### PR TITLE
[visionOS] Chrome missing after exiting spatial fullscreen on uploadvr.com

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -64,7 +64,8 @@ public:
     virtual void setVideoLayerFrame(FloatRect) = 0;
     virtual void setVideoLayerGravity(MediaPlayerEnums::VideoGravity) = 0;
     virtual void setVideoFullscreenFrame(FloatRect) = 0;
-    virtual void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) = 0;
+    enum class ShouldNotifyMediaElement { No, Yes };
+    virtual void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode, ShouldNotifyMediaElement) = 0;
 
     virtual FloatSize videoDimensions() const = 0;
     virtual bool hasVideo() const = 0;
@@ -125,6 +126,7 @@ public:
     virtual void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy) { }
     virtual void routingContextUIDChanged(const String&) { }
     virtual void hasBeenInteractedWith() { }
+    virtual void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -77,7 +77,7 @@ public:
     WEBCORE_EXPORT void setVideoLayerFrame(FloatRect) final;
     WEBCORE_EXPORT void setVideoLayerGravity(MediaPlayerEnums::VideoGravity) final;
     WEBCORE_EXPORT void setVideoFullscreenFrame(FloatRect) final;
-    WEBCORE_EXPORT void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) final;
+    WEBCORE_EXPORT void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode, ShouldNotifyMediaElement) final;
     FloatSize videoDimensions() const final { return m_videoDimensions; }
     bool hasVideo() const final { return m_hasVideo; }
     bool isChildOfElementFullscreen() const final { return m_isChildOfElementFullscreen; }

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -352,8 +352,9 @@ const AtomString& VideoPresentationModelVideoElement::eventNameAll()
     return sEventNameAll;
 }
 
-void VideoPresentationModelVideoElement::fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode)
+void VideoPresentationModelVideoElement::fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, ShouldNotifyMediaElement shouldNotifyMediaElement)
 {
+    ASSERT_UNUSED(shouldNotifyMediaElement, shouldNotifyMediaElement == ShouldNotifyMediaElement::Yes);
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoFullscreenMode);
     if (RefPtr videoElement = m_videoElement) {
         UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &videoElement->document());

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -72,7 +72,7 @@ public:
     void preparedToReturnToStandby() { }
     bool mayAutomaticallyShowVideoPictureInPicture() const { return false; }
     void applicationDidBecomeActive() { }
-    void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool) { }
+    void setMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement) { }
     HTMLMediaElementEnums::VideoFullscreenMode mode() const { return HTMLMediaElementEnums::VideoFullscreenModeNone; }
     bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }
     bool pictureInPictureWasStartedWhenEnteringBackground() const { return false; }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -170,8 +170,8 @@ public:
     WEBCORE_EXPORT virtual void prepareForPictureInPictureStopWithCompletionHandler(void (^)(BOOL));
     virtual bool isPlayingVideoInEnhancedFullscreen() const = 0;
 
-    WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool shouldNotifyModel);
-    void clearMode(HTMLMediaElementEnums::VideoFullscreenMode, bool shouldNotifyModel);
+    WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
+    void clearMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
     bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode mode) const { return m_currentMode.hasMode(mode); }
     WEBCORE_EXPORT UIViewController *presentingViewController();
     UIViewController *fullscreenViewController() const { return m_viewController.get(); }

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -135,6 +135,7 @@ private:
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override;
     void videoDimensionsChanged(const FloatSize&) override;
+    void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) override { }
 
     // PlaybackSessionModel
     void addClient(PlaybackSessionModelClient&) override;
@@ -209,7 +210,7 @@ private:
     void setVideoLayerFrame(FloatRect) override;
     void setVideoLayerGravity(MediaPlayerEnums::VideoGravity) override;
     void setVideoFullscreenFrame(FloatRect) override { }
-    void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) override;
+    void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode, ShouldNotifyMediaElement) override;
     bool hasVideo() const override;
     bool isChildOfElementFullscreen() const override;
     FloatSize videoDimensions() const override;
@@ -630,12 +631,15 @@ void VideoFullscreenControllerContext::setVideoLayerGravity(MediaPlayerEnums::Vi
     });
 }
 
-void VideoFullscreenControllerContext::fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode mode)
+void VideoFullscreenControllerContext::fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode mode, ShouldNotifyMediaElement shouldNotifyMediaElement)
 {
     ASSERT(isUIThread());
+    if (shouldNotifyMediaElement == ShouldNotifyMediaElement::No)
+        return;
+
     WebThreadRun([protectedThis = Ref { *this }, this, mode] {
         if (m_presentationModel)
-            m_presentationModel->fullscreenModeChanged(mode);
+            m_presentationModel->fullscreenModeChanged(mode, ShouldNotifyMediaElement::Yes);
     });
 }
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -102,8 +102,8 @@ public:
     HTMLMediaElementEnums::VideoFullscreenMode mode() const { return m_mode; }
     bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode mode) const { return m_mode & mode; }
     bool isMode(HTMLMediaElementEnums::VideoFullscreenMode mode) const { return m_mode == mode; }
-    WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool);
-    WEBCORE_EXPORT void clearMode(HTMLMediaElementEnums::VideoFullscreenMode);
+    WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
+    WEBCORE_EXPORT void clearMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
 
     WEBCORE_EXPORT bool isPlayingVideoInEnhancedFullscreen() const;
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -500,7 +500,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         model->setRequiresTextTrackRepresentation(false);
     }
 
-    videoPresentationInterfaceMac->clearMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture);
+    videoPresentationInterfaceMac->clearMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture, VideoPresentationModel::ShouldNotifyMediaElement::Yes);
 }
 
 - (void)pipActionPlay:(PIPViewController *)pip
@@ -584,7 +584,7 @@ void VideoPresentationInterfaceMac::setVideoPresentationModel(VideoPresentationM
         model->addClient(*this);
 }
 
-void VideoPresentationInterfaceMac::setMode(HTMLMediaElementEnums::VideoFullscreenMode mode, bool)
+void VideoPresentationInterfaceMac::setMode(HTMLMediaElementEnums::VideoFullscreenMode mode, VideoPresentationModel::ShouldNotifyMediaElement)
 {
     HTMLMediaElementEnums::VideoFullscreenMode newMode = m_mode | mode;
     if (m_mode == newMode)
@@ -600,7 +600,7 @@ void VideoPresentationInterfaceMac::setMode(HTMLMediaElementEnums::VideoFullscre
         return;
 
     if (model)
-        model->fullscreenModeChanged(m_mode);
+        model->fullscreenModeChanged(m_mode, VideoPresentationModel::ShouldNotifyMediaElement::Yes);
 }
 #if HAVE(PIP_SKIP_PREROLL)
 void VideoPresentationInterfaceMac::skipAd()
@@ -608,7 +608,7 @@ void VideoPresentationInterfaceMac::skipAd()
     m_playbackSessionInterface->skipAd();
 }
 #endif
-void VideoPresentationInterfaceMac::clearMode(HTMLMediaElementEnums::VideoFullscreenMode mode)
+void VideoPresentationInterfaceMac::clearMode(HTMLMediaElementEnums::VideoFullscreenMode mode, VideoPresentationModel::ShouldNotifyMediaElement)
 {
     HTMLMediaElementEnums::VideoFullscreenMode newMode = m_mode & ~mode;
     if (m_mode == newMode)
@@ -624,7 +624,7 @@ void VideoPresentationInterfaceMac::clearMode(HTMLMediaElementEnums::VideoFullsc
         return;
 
     if (model)
-        model->fullscreenModeChanged(m_mode);
+        model->fullscreenModeChanged(m_mode, VideoPresentationModel::ShouldNotifyMediaElement::Yes);
 }
 
 void VideoPresentationInterfaceMac::durationChanged(double duration)

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -336,8 +336,8 @@ void VideoPresentationInterfaceLMK::swapFullscreenModesWith(VideoPresentationInt
     auto currentMode = mode();
     auto previousMode = otherInterface.mode();
 
-    setMode(previousMode, true);
-    otherInterface.setMode(currentMode, true);
+    setMode(previousMode, WebCore::VideoPresentationModel::ShouldNotifyMediaElement::Yes);
+    otherInterface.setMode(currentMode, WebCore::VideoPresentationModel::ShouldNotifyMediaElement::Yes);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -90,7 +90,7 @@ private:
     void setVideoLayerFrame(WebCore::FloatRect) override;
     void setVideoLayerGravity(WebCore::MediaPlayerEnums::VideoGravity) override;
     void setVideoFullscreenFrame(WebCore::FloatRect) override;
-    void fullscreenModeChanged(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) override;
+    void fullscreenModeChanged(WebCore::HTMLMediaElementEnums::VideoFullscreenMode, ShouldNotifyMediaElement) override;
     bool hasVideo() const override { return m_hasVideo; }
     bool isChildOfElementFullscreen() const final { return m_isChildOfElementFullscreen; }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -26,7 +26,9 @@
 #if ENABLE(FULLSCREEN_API) && PLATFORM(IOS_FAMILY)
 
 #import <UIKit/UIViewController.h>
+#import <WebCore/PlatformVideoPresentationInterface.h>
 
+@class WKFullScreenViewController;
 @class WKWebView;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,6 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)requestExitFullScreen;
 - (void)showUI;
 - (void)hideUI;
+- (void)fullScreenViewControllerDidInvalidate:(WKFullScreenViewController *)fullScreenViewController;
+#if PLATFORM(VISION)
+- (void)fullScreenViewController:(WKFullScreenViewController *)fullScreenViewController bestVideoPresentationInterfaceDidChange:(nullable WebCore::PlatformVideoPresentationInterface*)bestVideoPresentationInterface;
+#endif
 @end
 
 @interface WKFullScreenViewController : UIViewController

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -65,6 +65,7 @@
 
 #if PLATFORM(VISION)
 - (void)toggleSceneDimming;
+- (void)bestVideoFullscreenModeChanged;
 #endif
 
 @end

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -638,7 +638,7 @@ void VideoPresentationManager::requestFullscreenMode(WebCore::MediaPlayerClientI
 void VideoPresentationManager::fullscreenModeChanged(WebCore::MediaPlayerClientIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode)
 {
     auto [model, interface] = ensureModelAndInterface(contextId);
-    model->fullscreenModeChanged(videoFullscreenMode);
+    model->fullscreenModeChanged(videoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement::Yes);
     interface->setFullscreenMode(videoFullscreenMode);
 }
 


### PR DESCRIPTION
#### dd4b8a6a214f6510433efd5b26267338a829157f
<pre>
[visionOS] Chrome missing after exiting spatial fullscreen on uploadvr.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=301851">https://bugs.webkit.org/show_bug.cgi?id=301851</a>
<a href="https://rdar.apple.com/159979195">rdar://159979195</a>

Reviewed by Jer Noble.

The following order of events can cause window chrome to be hidden in the WKWebView&apos;s window after
watching a video in spatial fullscreen:

1. The user enters element fullscreen; WKFullscreenWindowController saves the state of the
   WKWebView window’s chrome, then hides the chrome.
2. The user enters spatial fullscreen; LinearMediaKit saves the state of the WKWebView window’s
   chrome, then hides the chrome again.
3. The website calls document.exitFullscreen(); WKFullscreenWindowController closes the element
   fullscreen window and restores the saved state of the WKWebView window’s chrome.
4. The user exits spatial fullscreen; LinearMediaKit restores the saved state of the WKWebView
   window’s chrome.

Since when LinearMediaKit saved the state of the window chrome it was hidden, it is restored to a
hidden state in (4) even though it was previously made visible in (3).

Resolved this by checking if the native fullscreen-eligible video is in fullscreen when exiting
element fullscreen. If it is, WKFullscreenWindowController retains _parentWindowState so that it
can be later restored when native fullscreen exits. Made WKFullscreenWindowController a client of
the VideoPresentationModel that enters spatial fullscreen (or any other native fullscreen mode) so
that it can learn when the user exits native fullscreen (which required adding a new
VideoPresentationModelClient callback). and when they do, used _parentWindowState to restore window
chrome (as well as other state like ornaments and resizing behavior).

* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModelClient::fullscreenModeChanged):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::fullscreenModeChanged):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::enterFullscreenHandler):
(WebCore::VideoPresentationInterfaceIOS::exitFullscreenHandler):
(WebCore::VideoPresentationInterfaceIOS::didStartPictureInPicture):
(WebCore::VideoPresentationInterfaceIOS::failedToStartPictureInPicture):
(WebCore::VideoPresentationInterfaceIOS::didStopPictureInPicture):
(WebCore::VideoPresentationInterfaceIOS::setMode):
(WebCore::VideoPresentationInterfaceIOS::clearMode):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::fullscreenModeChanged):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::swapFullscreenModesWith):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::fullscreenModeChanged):
(WebKit::VideoPresentationManagerProxy::setVideoFullscreenMode):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController invalidate]):
(-[WKFullScreenViewController _bestVideoPresentationInterface]):
(-[WKFullScreenViewController configureEnvironmentPickerOrFullscreenVideoButtonView]):
(-[WKFullScreenViewController _playbackSessionInterface]):
(-[WKFullScreenViewController _enterVideoFullscreenAction:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController initWithWebView:]):
(-[WKFullScreenWindowController _completedExitFullScreen:]):
(-[WKFullScreenWindowController _isBestVideoInFullScreen]):
(-[WKFullScreenWindowController _shouldShowOrnaments]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
(-[WKFullScreenWindowController bestVideoFullscreenModeChanged]):
(-[WKFullScreenWindowController fullScreenViewControllerDidInvalidate:]):
(-[WKFullScreenWindowController fullScreenViewController:bestVideoPresentationInterfaceDidChange:]):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::fullscreenModeChanged):

Canonical link: <a href="https://commits.webkit.org/302506@main">https://commits.webkit.org/302506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1e98f5aa31fd9295f74018df35b39aa3d67c5b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80673 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/707a8bda-a460-40f4-bbd1-a5d61edb9bba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131153 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/1470 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98460 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66353 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e472896-f366-490a-a708-0b120a148f4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132229 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/1470 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115806 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79102 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d259aeac-b2f3-42fb-b5fe-508abb7ea91d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/1470 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33925 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79936 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/1470 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34431 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139131 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106989 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27203 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30663 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53951 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64757 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1219 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1255 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->