### PR TITLE
Migrate CoreAudioSharedUnit code to handle status bar in its own class

### DIFF
--- a/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.h
+++ b/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.h
@@ -28,35 +28,20 @@
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
 
 OBJC_CLASS WebCoreMediaCaptureStatusBarHandler;
 
 namespace WebCore {
-class MediaCaptureStatusBarManager;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaCaptureStatusBarManager> : std::true_type { };
-}
-
-namespace WebCore {
-
-class MediaCaptureStatusBarManager : public CanMakeWeakPtr<MediaCaptureStatusBarManager> {
-    WTF_MAKE_TZONE_ALLOCATED(MediaCaptureStatusBarManager);
+class MediaCaptureStatusBarManager : public RefCountedAndCanMakeWeakPtr<MediaCaptureStatusBarManager> {
 public:
     static bool hasSupport();
 
     using TapCallback = Function<void(CompletionHandler<void()>&&)>;
     using ErrorCallback = Function<void()>;
-    MediaCaptureStatusBarManager(TapCallback&& callback, ErrorCallback&& errorCallback)
-        : m_tapCallback(WTFMove(callback))
-        , m_errorCallback(WTFMove(errorCallback))
-    {
-    }
+    static Ref<MediaCaptureStatusBarManager> create(TapCallback&& tapCallback, ErrorCallback&& errorCallback) { return adoptRef(*new MediaCaptureStatusBarManager(WTFMove(tapCallback), WTFMove(errorCallback))); }
     ~MediaCaptureStatusBarManager();
 
     void start();
@@ -66,6 +51,12 @@ public:
     void didTap(CompletionHandler<void()>&& completionHandler) { m_tapCallback(WTFMove(completionHandler)); }
 
 private:
+    MediaCaptureStatusBarManager(TapCallback&& callback, ErrorCallback&& errorCallback)
+        : m_tapCallback(WTFMove(callback))
+        , m_errorCallback(WTFMove(errorCallback))
+    {
+    }
+
     RetainPtr<WebCoreMediaCaptureStatusBarHandler> m_handler;
     TapCallback m_tapCallback;
     ErrorCallback m_errorCallback;

--- a/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
@@ -32,7 +32,7 @@
 #include <pal/spi/ios/SBSStatusBarSPI.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/RuntimeApplicationChecks.h>
-#include <wtf/TZoneMallocInlines.h>
+#include <wtf/WeakPtr.h>
 
 #include <pal/cocoa/AVFoundationSoftLink.h>
 
@@ -88,8 +88,8 @@ using namespace WebCore;
         RELEASE_LOG_ERROR(WebRTC, "WebCoreMediaCaptureStatusBarHandler _acquireStatusBarOverride failed, code = %ld, description is '%s'", [error code], [error localizedDescription].UTF8String);
 
         callOnMainThread([self, strongSelf = retainPtr(self)] {
-            if (m_manager)
-                m_manager->didError();
+            if (RefPtr manager = m_manager.get())
+                manager->didError();
         });
     }];
 
@@ -98,13 +98,13 @@ using namespace WebCore;
         if (acquired)
             return;
         callOnMainThread([self, strongSelf = retainPtr(self)] {
-            if (m_manager)
-                m_manager->didError();
+            if (RefPtr manager = m_manager.get())
+                manager->didError();
         });
     } invalidationHandler:^{
         callOnMainThread([self, strongSelf = retainPtr(self)] {
-            if (m_manager)
-                m_manager->didError();
+            if (RefPtr manager = m_manager.get())
+                manager->didError();
         });
     }];
 }
@@ -128,9 +128,10 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     callOnMainThread([self, strongSelf = retainPtr(self), completion = makeBlockPtr(completion)]() mutable {
-        if (!m_manager)
+        RefPtr manager = m_manager.get();
+        if (!manager)
             return;
-        m_manager->didTap([completion = WTFMove(completion)] {
+        manager->didTap([completion = WTFMove(completion)] {
             completion.get()();
         });
     });
@@ -141,7 +142,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)statusBarCoordinator:(SBSStatusBarStyleOverridesCoordinator *)coordinator invalidatedRegistrationWithError:(NSError *)error
 {
     callOnMainThread([self, strongSelf = retainPtr(self)] {
-        if (m_manager)
+        if (RefPtr manager = m_manager.get())
             m_manager->didError();
     });
 }
@@ -149,8 +150,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 @end
 
 namespace WebCore {
-
-WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaCaptureStatusBarManager);
 
 bool MediaCaptureStatusBarManager::hasSupport()
 {

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -102,11 +102,12 @@ public:
     WEBCORE_EXPORT static void allowStarting();
 #endif
 
+    void captureFailed();
+
 protected:
     BaseAudioSharedUnit();
 
     void forEachClient(NOESCAPE const Function<void(CoreAudioCaptureSource&)>&) const;
-    void captureFailed();
 
     virtual void cleanupAudioUnit() = 0;
     virtual OSStatus startInternal() = 0;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -351,7 +351,7 @@ void CoreAudioCaptureSource::delaySamples(Seconds seconds)
 void CoreAudioCaptureSource::setIsInBackground(bool value)
 {
     if (isProducingData())
-        protectedUnit()->setIsInBackground(value);
+        CoreAudioSharedUnit::setIsInBackground(value);
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -932,33 +932,68 @@ void CoreAudioSharedUnit::willChangeCaptureDevice()
 }
 
 #if PLATFORM(IOS_FAMILY)
-void CoreAudioSharedUnit::setIsInBackground(bool isInBackground)
-{
-    if (!MediaCaptureStatusBarManager::hasSupport())
-        return;
-
-    if (!isInBackground) {
-        if (m_statusBarManager) {
-            m_statusBarManager->stop();
-            m_statusBarManager = nullptr;
-        }
-        return;
+class MicrophoneCaptureStatusBarManager {
+public:
+    static MicrophoneCaptureStatusBarManager& singleton()
+    {
+        static NeverDestroyed<MicrophoneCaptureStatusBarManager> singleton;
+        return singleton;
     }
 
-    if (m_statusBarManager)
-        return;
+    void setStatusBarWasTappedCallback(Function<void(CompletionHandler<void()>&&)>&& callback)
+    {
+        ASSERT(!m_statusBarWasTappedCallback);
+        m_statusBarWasTappedCallback = WTFMove(callback);
+    }
 
-    m_statusBarManager = makeUnique<MediaCaptureStatusBarManager>([this](CompletionHandler<void()>&& completionHandler) {
-        if (m_statusBarWasTappedCallback)
-            m_statusBarWasTappedCallback(WTFMove(completionHandler));
-    }, [this] {
-        RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit status bar failed");
-        auto statusBarManager = std::exchange(m_statusBarManager, { });
-        statusBarManager->stop();
-        if (isRunning())
-            captureFailed();
-    });
-    m_statusBarManager->start();
+    void setIsInBackground(bool isInBackground)
+    {
+        if (!MediaCaptureStatusBarManager::hasSupport())
+            return;
+
+        if (!isInBackground) {
+            if (m_statusBarManager) {
+                m_statusBarManager->stop();
+                m_statusBarManager = nullptr;
+            }
+            return;
+        }
+
+        if (m_statusBarManager)
+            return;
+
+        m_statusBarManager = MediaCaptureStatusBarManager::create([this](CompletionHandler<void()>&& completionHandler) {
+            if (m_statusBarWasTappedCallback)
+                m_statusBarWasTappedCallback(WTFMove(completionHandler));
+        }, [this] {
+            RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit status bar failed");
+            auto statusBarManager = std::exchange(m_statusBarManager, { });
+            statusBarManager->stop();
+
+            CoreAudioSharedUnit::forEach([](auto& unit) {
+                if (unit.isRunning())
+                    unit.captureFailed();
+            });
+        });
+        m_statusBarManager->start();
+    }
+
+private:
+    MicrophoneCaptureStatusBarManager() = default;
+    friend class NeverDestroyed<MicrophoneCaptureStatusBarManager>;
+
+    Function<void(CompletionHandler<void()>&&)> m_statusBarWasTappedCallback;
+    RefPtr<MediaCaptureStatusBarManager> m_statusBarManager;
+};
+
+void CoreAudioSharedUnit::setIsInBackground(bool isInBackground)
+{
+    MicrophoneCaptureStatusBarManager::singleton().setIsInBackground(isInBackground);
+}
+
+void CoreAudioSharedUnit::setStatusBarWasTappedCallback(Function<void(CompletionHandler<void()>&&)>&& callback)
+{
+    MicrophoneCaptureStatusBarManager::singleton().setStatusBarWasTappedCallback(WTFMove(callback));
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -97,8 +97,8 @@ public:
     void setSampleRateRange(LongCapabilityRange range) { m_sampleRateCapabilities = range; }
 
 #if PLATFORM(IOS_FAMILY)
-    void setIsInBackground(bool);
-    void setStatusBarWasTappedCallback(Function<void(CompletionHandler<void()>&&)>&& callback) { m_statusBarWasTappedCallback = WTFMove(callback); }
+    static void setIsInBackground(bool);
+    WEBCORE_EXPORT static void setStatusBarWasTappedCallback(Function<void(CompletionHandler<void()>&&)>&&);
 #endif
 
     bool canRenderAudio() const { return m_canRenderAudio; }
@@ -226,7 +226,7 @@ private:
     CoreAudioSpeakerSamplesProducer* m_speakerSamplesProducer WTF_GUARDED_BY_LOCK(m_speakerSamplesProducerLock) { nullptr };
 
 #if PLATFORM(IOS_FAMILY)
-    std::unique_ptr<MediaCaptureStatusBarManager> m_statusBarManager;
+    RefPtr<MediaCaptureStatusBarManager> m_statusBarManager;
     Function<void(CompletionHandler<void()>&&)> m_statusBarWasTappedCallback;
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -241,7 +241,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters,
     SandboxExtension::consumePermanently(parameters.microphoneSandboxExtensionHandle);
 #endif
 #if PLATFORM(IOS_FAMILY)
-    CoreAudioSharedUnit::defaultSingleton().setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
+    CoreAudioSharedUnit::setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
         if (RefPtr process = weakProcess.get())
             process->parentProcessConnection()->sendWithAsyncReply(Messages::GPUProcessProxy::StatusBarWasTapped(), [] { }, 0);
         completionHandler();


### PR DESCRIPTION
#### 991817191a30770aea4069d574e90d6a8dd20bf6
<pre>
Migrate CoreAudioSharedUnit code to handle status bar in its own class
<a href="https://rdar.apple.com/163922730">rdar://163922730</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301853">https://bugs.webkit.org/show_bug.cgi?id=301853</a>

Reviewed by Eric Carlson.

To reduce the class to CoreAudioSharedUnit::defaultSingleton(), we move the status bar logic in its own class, named MicrophoneCaptureStatusBarManager.
The logic remains the same as before, although the call from GPUProcess is now a call to a static method directly.
We also update MediaCaptureStatusBarManager to follow safer cpp guidelines.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/991817191a30770aea4069d574e90d6a8dd20bf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80810 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e349393-5026-48c0-9e59-d10b05732dfd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98553 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66444 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc0d6df1-e521-4e5f-a89f-3bd218299c98) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79204 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d325bf99-deca-4a5b-8a75-bb50045bd57c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80054 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109615 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34533 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139251 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107077 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106921 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30766 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54114 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64881 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->