### PR TITLE
Rename CoreAudioSharedUnit to CoreAudioCaptureUnit

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -62,7 +62,7 @@ platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
 platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 [ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
-[ iOS ] platform/mediastream/mac/CoreAudioSharedUnit.cpp
+[ iOS ] platform/mediastream/mac/CoreAudioCaptureUnit.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
 rendering/BackgroundPainter.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -67,7 +67,7 @@ platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
 platform/ios/WebAVPlayerController.mm
 platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
-platform/mediastream/mac/CoreAudioSharedUnit.mm
+platform/mediastream/mac/CoreAudioCaptureUnit.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -657,14 +657,14 @@ platform/mediastream/ios/ReplayKitCaptureSource.mm @nonARC @no-unify
 platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp
 platform/mediastream/mac/AVCaptureDeviceManager.mm @nonARC
 platform/mediastream/mac/AVVideoCaptureSource.mm @nonARC @no-unify
-platform/mediastream/mac/BaseAudioSharedUnit.cpp
+platform/mediastream/mac/BaseAudioCaptureUnit.cpp
 platform/mediastream/mac/CoreAudioCaptureDevice.cpp
 platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
 platform/mediastream/mac/CoreAudioCaptureSource.cpp
-platform/mediastream/mac/CoreAudioSharedUnit.cpp
+platform/mediastream/mac/CoreAudioCaptureUnit.cpp
 platform/mediastream/mac/DisplayCaptureManagerCocoa.cpp
 platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
-platform/mediastream/mac/MockAudioSharedUnit.mm @nonARC
+platform/mediastream/mac/MockAudioCaptureUnit.mm @nonARC
 platform/mediastream/mac/MockRealtimeVideoSourceMac.mm @nonARC
 platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm @nonARC

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -30,7 +30,7 @@
 
 #import "AVAudioSessionCaptureDevice.h"
 #import "AudioSession.h"
-#import "CoreAudioSharedUnit.h"
+#import "CoreAudioCaptureUnit.h"
 #import "Logging.h"
 #import "RealtimeMediaSourceCenter.h"
 #import <AVFoundation/AVAudioSession.h>
@@ -250,7 +250,7 @@ Vector<AVAudioSessionCaptureDevice> AVAudioSessionCaptureDeviceManager::retrieve
         if (currentInput != m_lastDefaultMicrophone.get()) {
             auto device = AVAudioSessionCaptureDevice::createInput(currentInput, currentInput);
             callOnWebThreadOrDispatchAsyncOnMainThread(makeBlockPtr([device = crossThreadCopy(WTFMove(device))] () mutable {
-                CoreAudioSharedUnit::forEach([&device](auto& unit) {
+                CoreAudioCaptureUnit::forEach([&device](auto& unit) {
                     unit.handleNewCurrentMicrophoneDevice(device);
                 });
             }).get());

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.h
@@ -39,7 +39,7 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-class BaseAudioSharedUnit;
+class BaseAudioCaptureUnit;
 }
 
 namespace WebCore {
@@ -49,9 +49,9 @@ class CaptureDevice;
 class CoreAudioCaptureSource;
 class PlatformAudioData;
 
-class BaseAudioSharedUnit : public RefCounted<BaseAudioSharedUnit>, public RealtimeMediaSourceCenterObserver {
+class BaseAudioCaptureUnit : public RefCounted<BaseAudioCaptureUnit>, public RealtimeMediaSourceCenterObserver {
 public:
-    virtual ~BaseAudioSharedUnit();
+    virtual ~BaseAudioCaptureUnit();
 
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
@@ -103,7 +103,7 @@ public:
 #endif
 
 protected:
-    BaseAudioSharedUnit();
+    BaseAudioCaptureUnit();
 
     void forEachClient(NOESCAPE const Function<void(CoreAudioCaptureSource&)>&) const;
     void captureFailed();

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureInternalUnit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,19 +27,35 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include <WebCore/CoreAudioSharedUnit.h>
+#include "CoreAudioCaptureUnit.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-namespace MockAudioSharedUnit {
-void enable();
-void disable();
-CoreAudioSharedUnit& singleton();
-void increaseBufferSize();
+class CoreAudioCaptureInternalUnit final :  public CoreAudioCaptureUnit::InternalUnit {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CoreAudioCaptureInternalUnit);
+public:
+    static Expected<UniqueRef<InternalUnit>, OSStatus> create(bool shouldUseVPIO);
+    CoreAudioCaptureInternalUnit(CoreAudioCaptureUnit::StoredAudioUnit&&, bool shouldUseVPIO);
+    ~CoreAudioCaptureInternalUnit() final;
 
-}
+private:
+    OSStatus initialize() final;
+    OSStatus uninitialize() final;
+    OSStatus start() final;
+    OSStatus stop() final;
+    OSStatus set(AudioUnitPropertyID, AudioUnitScope, AudioUnitElement, const void*, UInt32) final;
+    OSStatus get(AudioUnitPropertyID, AudioUnitScope, AudioUnitElement, void*, UInt32*) final;
+    OSStatus render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32, UInt32, AudioBufferList*) final;
+    OSStatus defaultInputDevice(uint32_t*) final;
+    OSStatus defaultOutputDevice(uint32_t*) final;
+    bool setVoiceActivityDetection(bool) final;
+    bool canRenderAudio() const final { return m_shouldUseVPIO; }
+
+    CoreAudioCaptureUnit::StoredAudioUnit m_audioUnit;
+    bool m_shouldUseVPIO { false };
+};
 
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)
-

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -33,7 +33,7 @@
 #include "AudioSession.h"
 #include "CoreAudioCaptureDevice.h"
 #include "CoreAudioCaptureDeviceManager.h"
-#include "CoreAudioSharedUnit.h"
+#include "CoreAudioCaptureUnit.h"
 #include "Logging.h"
 #include "PlatformMediaSessionManager.h"
 #include "Timer.h"
@@ -120,7 +120,7 @@ CoreAudioCaptureSourceFactory::~CoreAudioCaptureSourceFactory()
 void CoreAudioCaptureSourceFactory::beginInterruption()
 {
     ensureOnMainThread([] {
-        CoreAudioSharedUnit::forEach([](auto& unit) {
+        CoreAudioCaptureUnit::forEach([](auto& unit) {
             unit.suspend();
         });
     });
@@ -129,7 +129,7 @@ void CoreAudioCaptureSourceFactory::beginInterruption()
 void CoreAudioCaptureSourceFactory::endInterruption()
 {
     ensureOnMainThread([] {
-        CoreAudioSharedUnit::forEach([](auto& unit) {
+        CoreAudioCaptureUnit::forEach([](auto& unit) {
             unit.resume();
         });
     });
@@ -138,7 +138,7 @@ void CoreAudioCaptureSourceFactory::endInterruption()
 void CoreAudioCaptureSourceFactory::scheduleReconfiguration()
 {
     ensureOnMainThread([] {
-        CoreAudioSharedUnit::forEach([](auto& unit) {
+        CoreAudioCaptureUnit::forEach([](auto& unit) {
             unit.reconfigure();
         });
     });
@@ -169,37 +169,37 @@ const Vector<CaptureDevice>& CoreAudioCaptureSourceFactory::speakerDevices() con
 
 void CoreAudioCaptureSourceFactory::enableMutedSpeechActivityEventListener(Function<void()>&& callback)
 {
-    CoreAudioSharedUnit::defaultSingleton().enableMutedSpeechActivityEventListener(WTFMove(callback));
+    CoreAudioCaptureUnit::defaultSingleton().enableMutedSpeechActivityEventListener(WTFMove(callback));
 }
 
 void CoreAudioCaptureSourceFactory::disableMutedSpeechActivityEventListener()
 {
-    CoreAudioSharedUnit::defaultSingleton().disableMutedSpeechActivityEventListener();
+    CoreAudioCaptureUnit::defaultSingleton().disableMutedSpeechActivityEventListener();
 }
 
 void CoreAudioCaptureSourceFactory::registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
 {
-    CoreAudioSharedUnit::defaultSingleton().registerSpeakerSamplesProducer(producer);
+    CoreAudioCaptureUnit::defaultSingleton().registerSpeakerSamplesProducer(producer);
 }
 
 void CoreAudioCaptureSourceFactory::unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
 {
-    CoreAudioSharedUnit::defaultSingleton().unregisterSpeakerSamplesProducer(producer);
+    CoreAudioCaptureUnit::defaultSingleton().unregisterSpeakerSamplesProducer(producer);
 }
 
 bool CoreAudioCaptureSourceFactory::shouldAudioCaptureUnitRenderAudio()
 {
 #if PLATFORM(IOS_FAMILY)
-    return CoreAudioSharedUnit::defaultSingleton().isRunning();
+    return CoreAudioCaptureUnit::defaultSingleton().isRunning();
 #else
-    return CoreAudioSharedUnit::defaultSingleton().isRunning() && CoreAudioSharedUnit::defaultSingleton().canRenderAudio();
+    return CoreAudioCaptureUnit::defaultSingleton().isRunning() && CoreAudioCaptureUnit::defaultSingleton().canRenderAudio();
 #endif // PLATFORM(IOS_FAMILY)
 }
 
 CoreAudioCaptureSource::CoreAudioCaptureSource(const CaptureDevice& device, uint32_t captureDeviceID, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
     : RealtimeMediaSource(device, WTFMove(hashSalts), pageIdentifier)
     , m_captureDeviceID(captureDeviceID)
-    , m_unit(CoreAudioSharedUnit::defaultSingleton())
+    , m_unit(CoreAudioCaptureUnit::defaultSingleton())
 {
     // We ensure that we unsuspend ourselves on the constructor as a capture source
     // is created when getUserMedia grants access which only happens when the process is foregrounded.
@@ -212,12 +212,12 @@ CoreAudioCaptureSource::CoreAudioCaptureSource(const CaptureDevice& device, uint
     initializeVolume(unit->volume());
 }
 
-Ref<CoreAudioSharedUnit> CoreAudioCaptureSource::protectedUnit()
+Ref<CoreAudioCaptureUnit> CoreAudioCaptureSource::protectedUnit()
 {
     return m_unit;
 }
 
-Ref<const CoreAudioSharedUnit> CoreAudioCaptureSource::protectedUnit() const
+Ref<const CoreAudioCaptureUnit> CoreAudioCaptureSource::protectedUnit() const
 {
     return m_unit;
 }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -31,7 +31,7 @@
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreAudio/CoreAudioTypes.h>
 #include <WebCore/AudioSession.h>
-#include <WebCore/BaseAudioSharedUnit.h>
+#include <WebCore/BaseAudioCaptureUnit.h>
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CaptureDevice.h>
 #include <WebCore/RealtimeMediaSource.h>
@@ -49,7 +49,7 @@ namespace WebCore {
 
 class AudioSampleBufferList;
 class AudioSampleDataSource;
-class CoreAudioSharedUnit;
+class CoreAudioCaptureUnit;
 class CaptureDeviceInfo;
 class WebAudioSourceProviderAVFObjC;
 
@@ -75,8 +75,8 @@ protected:
     void setCanResumeAfterInterruption(bool value) { m_canResumeAfterInterruption = value; }
 
 private:
-    friend class BaseAudioSharedUnit;
-    friend class CoreAudioSharedUnit;
+    friend class BaseAudioCaptureUnit;
+    friend class CoreAudioCaptureUnit;
     friend class CoreAudioCaptureSourceFactory;
 
     bool isCaptureSource() const final { return true; }
@@ -106,11 +106,11 @@ private:
     ASCIILiteral logClassName() const override { return "CoreAudioCaptureSource"_s; }
 #endif
 
-    Ref<CoreAudioSharedUnit> protectedUnit();
-    Ref<const CoreAudioSharedUnit> protectedUnit() const;
+    Ref<CoreAudioCaptureUnit> protectedUnit();
+    Ref<const CoreAudioCaptureUnit> protectedUnit() const;
 
     uint32_t m_captureDeviceID { 0 };
-    Ref<CoreAudioSharedUnit> m_unit;
+    Ref<CoreAudioCaptureUnit> m_unit;
 
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
@@ -29,7 +29,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include <WebCore/AudioSampleDataSource.h>
-#include <WebCore/BaseAudioSharedUnit.h>
+#include <WebCore/BaseAudioCaptureUnit.h>
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CoreAudioCaptureSource.h>
 #include <WebCore/Timer.h>
@@ -61,7 +61,7 @@ class MediaCaptureStatusBarManager;
 
 class CoreAudioSpeakerSamplesProducer;
 
-class CoreAudioSharedUnit final : public BaseAudioSharedUnit {
+class CoreAudioCaptureUnit final : public BaseAudioCaptureUnit {
 public:
     class InternalUnit {
     public:
@@ -82,9 +82,9 @@ public:
     };
 
     // The default unit - the only one that may render audio when capturing
-    WEBCORE_EXPORT static CoreAudioSharedUnit& defaultSingleton();
-    WEBCORE_EXPORT static void forEach(NOESCAPE Function<void(CoreAudioSharedUnit&)>&&);
-    ~CoreAudioSharedUnit();
+    WEBCORE_EXPORT static CoreAudioCaptureUnit& defaultSingleton();
+    WEBCORE_EXPORT static void forEach(NOESCAPE Function<void(CoreAudioCaptureUnit&)>&&);
+    ~CoreAudioCaptureUnit();
 
     using CreationCallback = Function<Expected<UniqueRef<InternalUnit>, OSStatus>(bool enableEchoCancellation)>;
     void setInternalUnitCreationCallback(CreationCallback&& callback) { m_creationCallback = WTFMove(callback); }
@@ -132,11 +132,11 @@ public:
     void delaySamples(Seconds) final;
 
 private:
-    CoreAudioSharedUnit();
+    CoreAudioCaptureUnit();
 
-    friend class NeverDestroyed<CoreAudioSharedUnit>;
-    friend class MockAudioSharedInternalUnit;
-    friend class CoreAudioSharedInternalUnit;
+    friend class NeverDestroyed<CoreAudioCaptureUnit>;
+    friend class MockAudioCaptureInternalUnit;
+    friend class CoreAudioCaptureInternalUnit;
 
     static size_t preferredIOBufferSize();
 

--- a/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,35 +27,19 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include "CoreAudioSharedUnit.h"
-#include <wtf/TZoneMallocInlines.h>
+#include <WebCore/CoreAudioCaptureUnit.h>
 
 namespace WebCore {
 
-class CoreAudioSharedInternalUnit final :  public CoreAudioSharedUnit::InternalUnit {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(CoreAudioSharedInternalUnit);
-public:
-    static Expected<UniqueRef<InternalUnit>, OSStatus> create(bool shouldUseVPIO);
-    CoreAudioSharedInternalUnit(CoreAudioSharedUnit::StoredAudioUnit&&, bool shouldUseVPIO);
-    ~CoreAudioSharedInternalUnit() final;
+namespace MockAudioCaptureUnit {
+void enable();
+void disable();
+CoreAudioCaptureUnit& singleton();
+void increaseBufferSize();
 
-private:
-    OSStatus initialize() final;
-    OSStatus uninitialize() final;
-    OSStatus start() final;
-    OSStatus stop() final;
-    OSStatus set(AudioUnitPropertyID, AudioUnitScope, AudioUnitElement, const void*, UInt32) final;
-    OSStatus get(AudioUnitPropertyID, AudioUnitScope, AudioUnitElement, void*, UInt32*) final;
-    OSStatus render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32, UInt32, AudioBufferList*) final;
-    OSStatus defaultInputDevice(uint32_t*) final;
-    OSStatus defaultOutputDevice(uint32_t*) final;
-    bool setVoiceActivityDetection(bool) final;
-    bool canRenderAudio() const final { return m_shouldUseVPIO; }
-
-    CoreAudioSharedUnit::StoredAudioUnit m_audioUnit;
-    bool m_shouldUseVPIO { false };
-};
+}
 
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)
+

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -43,7 +43,7 @@
 #include <wtf/UUID.h>
 
 #if PLATFORM(COCOA)
-#include "MockAudioSharedUnit.h"
+#include "MockAudioCaptureUnit.h"
 #endif
 
 #if USE(GSTREAMER)
@@ -191,11 +191,11 @@ void MockRealtimeAudioSource::setIsInterrupted(bool isInterrupted)
     UNUSED_PARAM(isInterrupted);
 #if PLATFORM(COCOA)
     if (isInterrupted) {
-        CoreAudioSharedUnit::forEach([](auto& unit) {
+        CoreAudioCaptureUnit::forEach([](auto& unit) {
             unit.suspend();
         });
     } else {
-        CoreAudioSharedUnit::forEach([](auto& unit) {
+        CoreAudioCaptureUnit::forEach([](auto& unit) {
             unit.resume();
         });
     }

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -45,7 +45,7 @@
 #if PLATFORM(COCOA)
 #include "CoreAudioCaptureSource.h"
 #include "DisplayCaptureSourceCocoa.h"
-#include "MockAudioSharedUnit.h"
+#include "MockAudioCaptureUnit.h"
 #include "MockRealtimeVideoSourceMac.h"
 #endif
 
@@ -381,7 +381,7 @@ void MockRealtimeMediaSourceCenter::setMockRealtimeMediaSourceCenterEnabled(bool
     if (mock.m_isEnabled) {
         if (mock.m_isMockAudioCaptureEnabled) {
 #if PLATFORM(COCOA)
-            MockAudioSharedUnit::enable();
+            MockAudioCaptureUnit::enable();
 #endif
             center.setAudioCaptureFactory(mock.audioCaptureFactory());
         }
@@ -394,7 +394,7 @@ void MockRealtimeMediaSourceCenter::setMockRealtimeMediaSourceCenterEnabled(bool
 
     if (mock.m_isMockAudioCaptureEnabled) {
 #if PLATFORM(COCOA)
-        MockAudioSharedUnit::disable();
+        MockAudioCaptureUnit::disable();
 #endif
         center.unsetAudioCaptureFactory(mock.audioCaptureFactory());
     }
@@ -447,8 +447,8 @@ void MockRealtimeMediaSourceCenter::triggerMockCaptureConfigurationChange(bool f
     if (forMicrophone) {
         auto devices = audioCaptureDeviceManager().captureDevices();
         if (devices.size() > 1) {
-            MockAudioSharedUnit::increaseBufferSize();
-            CoreAudioSharedUnit::forEach([&devices](auto& unit) {
+            MockAudioCaptureUnit::increaseBufferSize();
+            CoreAudioCaptureUnit::forEach([&devices](auto& unit) {
                 unit.handleNewCurrentMicrophoneDevice(devices[1]);
             });
         }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -159,7 +159,7 @@
 #endif
 
 #if PLATFORM(MAC) && ENABLE(MEDIA_STREAM)
-#include <WebCore/CoreAudioSharedUnit.h>
+#include <WebCore/CoreAudioCaptureUnit.h>
 #endif
 
 #if ENABLE(MEDIA_STREAM)
@@ -1262,7 +1262,7 @@ void GPUConnectionToWebProcess::updateCaptureAccess(bool allowAudioCapture, bool
 {
 #if PLATFORM(MAC) && ENABLE(MEDIA_STREAM)
     if (allowAudioCapture)
-        CoreAudioSharedUnit::defaultSingleton().prewarmAudioUnitCreation([] { });
+        CoreAudioCaptureUnit::defaultSingleton().prewarmAudioUnitCreation([] { });
 #endif
 
     m_allowsAudioCapture |= allowAudioCapture;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -72,7 +72,7 @@
 
 #if PLATFORM(COCOA)
 #include "ArgumentCodersCocoa.h"
-#include <WebCore/CoreAudioSharedUnit.h>
+#include <WebCore/CoreAudioCaptureUnit.h>
 #include <WebCore/UTIUtilities.h>
 #include <WebCore/VP9UtilitiesCocoa.h>
 #endif
@@ -94,7 +94,7 @@ GPUProcess::GPUProcess()
 {
     RELEASE_LOG(Process, "%p - GPUProcess::GPUProcess:", this);
 #if ASSERT_ENABLED && PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    CoreAudioSharedUnit::allowStarting();
+    CoreAudioCaptureUnit::allowStarting();
 #endif
 }
 
@@ -241,7 +241,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters,
     SandboxExtension::consumePermanently(parameters.microphoneSandboxExtensionHandle);
 #endif
 #if PLATFORM(IOS_FAMILY)
-    CoreAudioSharedUnit::defaultSingleton().setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
+CoreAudioCaptureUnit::defaultSingleton().setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
         if (RefPtr process = weakProcess.get())
             process->parentProcessConnection()->sendWithAsyncReply(Messages::GPUProcessProxy::StatusBarWasTapped(), [] { }, 0);
         completionHandler();
@@ -434,7 +434,7 @@ void GPUProcess::setOrientationForMediaCapture(WebCore::IntDegrees orientation)
 void GPUProcess::enableMicrophoneMuteStatusAPI()
 {
 #if PLATFORM(COCOA)
-    CoreAudioSharedUnit::defaultSingleton().setMuteStatusChangedCallback([weakProcess = WeakPtr { *this }] (bool isMuting) {
+    CoreAudioCaptureUnit::defaultSingleton().setMuteStatusChangedCallback([weakProcess = WeakPtr { *this }] (bool isMuting) {
         if (RefPtr process = weakProcess.get())
             process->protectedParentProcessConnection()->send(Messages::GPUProcessProxy::MicrophoneMuteStatusChanged(isMuting), 0);
     });

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -44,7 +44,7 @@
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CARingBuffer.h>
 #include <WebCore/CoreAudioCaptureSource.h>
-#include <WebCore/CoreAudioSharedUnit.h>
+#include <WebCore/CoreAudioCaptureUnit.h>
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
@@ -314,7 +314,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitIsSt
 void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitHasStopped()
 {
     // Capture unit has stopped and audio will no longer be rendered through it so start the local unit.
-    if (m_isPlaying && !WebCore::CoreAudioSharedUnit::defaultSingleton().isSuspended())
+    if (m_isPlaying && !WebCore::CoreAudioCaptureUnit::defaultSingleton().isSuspended())
         protectedLocalUnit()->start();
 }
 
@@ -343,7 +343,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::endAudioSession
     if (!m_isPlaying)
         return;
 
-    if (m_shouldRegisterAsSpeakerSamplesProducer && (WebCore::CoreAudioSharedUnit::defaultSingleton().isRunning() || WebCore::CoreAudioSharedUnit::defaultSingleton().isSuspended()))
+    if (m_shouldRegisterAsSpeakerSamplesProducer && (WebCore::CoreAudioCaptureUnit::defaultSingleton().isRunning() || WebCore::CoreAudioCaptureUnit::defaultSingleton().isSuspended()))
         return;
 
     protectedLocalUnit()->start();


### PR DESCRIPTION
#### 864a5a91115161181c3d014fff9f6ed5d2e7b2f7
<pre>
Rename CoreAudioSharedUnit to CoreAudioCaptureUnit
<a href="https://rdar.apple.com/163922980">rdar://163922980</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301854">https://bugs.webkit.org/show_bug.cgi?id=301854</a>

Reviewed by Eric Carlson.

re rename CoreAudioSharedUnit to CoreAudioCaptureUnit as it will no longer solely be used as a singleton in a follow-up.
The plan is to create non shared core audio unit for microphone sources that do not need echo cancellation on macOS.

Canonical link: <a href="https://commits.webkit.org/302540@main">https://commits.webkit.org/302540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52bf538dce7226c21cbacc251720784074804630

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129420 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80833 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ad7c84b-68fc-41b8-af5c-b5b143e1c05e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131291 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1608 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98564 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68f9fb14-87bb-4047-87de-bd6f65e45ade) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79215 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6a9f91d2-4cb8-4f6f-9b30-13e859bfe2c2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80074 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139272 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107091 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27227 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1192 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54138 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1538 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64901 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1357 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1392 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->