### PR TITLE
Calling getUserMedia with echo cancellation disabled causes side effects for existing audio tracks acquired via getUserMedia

### DIFF
--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2.html
@@ -14,6 +14,10 @@ promise_test(async (t) => {
 
     assert_true(track.getSettings().echoCancellation);
 
+    // Currently, iOS platforms do not support capturing audio with and without echo cancellation.
+    if (!window.internals || internals.supportsMultiMicrophoneCaptureWithoutEchoCancellation())
+        return;
+
     let promise = new Promise((resolve, reject) => {
         track.onconfigurationchange = resolve;
         setTimeout(()=> reject("waited too long for configurationchange"), 5000);
@@ -28,12 +32,11 @@ promise_test(async (t) => {
     await promise;
     assert_false(track.getSettings().echoCancellation, "track");
 
-     promise = new Promise((resolve, reject) => {
+    promise = new Promise((resolve, reject) => {
         track2.onconfigurationchange = resolve;
         setTimeout(()=> reject("waited too long for configurationchange2"), 5000);
     });
 
-    // Currently, cocoa platforms do not support capturing audio with and without echo cancellation.
     track.applyConstraints({echoCancellation: true});
 
     await promise;

--- a/LayoutTests/fast/mediastream/microphone-with-and-without-echocancellation-expected.txt
+++ b/LayoutTests/fast/mediastream/microphone-with-and-without-echocancellation-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Capturing without echo cancellation shouldn't affect echo cancelled tracks of the same device
+PASS Capturing with echo cancellation shouldn't affect tracks without echo cancellation of the same device
+PASS Using applyConstraints for enabling/disabling echo cancellation should not interfere with another microphone track
+FAIL Using applyConstraints for enabling/disabling echo cancellation should not interfere with another cloned track assert_true: FIXME: support changing settings of cloned audio tracks - expected true got false
+

--- a/LayoutTests/fast/mediastream/microphone-with-and-without-echocancellation.html
+++ b/LayoutTests/fast/mediastream/microphone-with-and-without-echocancellation.html
@@ -1,0 +1,77 @@
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+promise_test(async (t) => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track1 = stream1.getAudioTracks()[0];
+    t.add_cleanup(() => track1.stop());
+    assert_true(track1.getSettings().echoCancellation, "test1");
+
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation:false } });
+    const track2 = stream2.getAudioTracks()[0];
+    t.add_cleanup(() => track2.stop());
+    assert_false(track2.getSettings().echoCancellation, "test2");
+
+    if (window.internals && !internals.supportsMultiMicrophoneCaptureWithoutEchoCancellation())
+        return;
+
+    await new Promise(resolve => t.step_timeout(resolve, 50));
+    assert_true(track1.getSettings().echoCancellation, "test3");
+}, "Capturing without echo cancellation shouldn't affect echo cancelled tracks of the same device");
+
+promise_test(async (t) => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation:false } });
+    const track1 = stream1.getAudioTracks()[0];
+    t.add_cleanup(() => track1.stop());
+    assert_false(track1.getSettings().echoCancellation, "test1");
+
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track2 = stream2.getAudioTracks()[0];
+    t.add_cleanup(() => track2.stop());
+    assert_true(track2.getSettings().echoCancellation, "test2");
+
+    if (window.internals && !internals.supportsMultiMicrophoneCaptureWithoutEchoCancellation())
+        return;
+
+    await new Promise(resolve => t.step_timeout(resolve, 50));
+    assert_false(track1.getSettings().echoCancellation, "test3");
+}, "Capturing with echo cancellation shouldn't affect tracks without echo cancellation of the same device");
+
+promise_test(async (t) => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation:false } });
+    const track1 = stream1.getAudioTracks()[0];
+    t.add_cleanup(() => track1.stop());
+    assert_false(track1.getSettings().echoCancellation, "test1");
+
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track2 = stream2.getAudioTracks()[0];
+    t.add_cleanup(() => track2.stop());
+    assert_true(track2.getSettings().echoCancellation, "test2");
+
+    if (window.internals && !internals.supportsMultiMicrophoneCaptureWithoutEchoCancellation())
+        return;
+
+    await track1.applyConstraints({ echoCancellation:true });
+    assert_true(track1.getSettings().echoCancellation, "test3");
+    assert_true(track2.getSettings().echoCancellation, "test4");
+
+    await track1.applyConstraints({ echoCancellation:false });
+    assert_false(track1.getSettings().echoCancellation, "test5");
+    assert_true(track2.getSettings().echoCancellation, "test6");
+}, "Using applyConstraints for enabling/disabling echo cancellation should not interfere with another microphone track");
+
+promise_test(async (t) => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation:false } });
+    const track1 = stream1.getAudioTracks()[0];
+    t.add_cleanup(() => track1.stop());
+    assert_false(track1.getSettings().echoCancellation, "test1");
+
+    const track2 = track1.clone();
+    t.add_cleanup(() => track2.stop());
+    assert_false(track2.getSettings().echoCancellation, "test2");
+
+    await track1.applyConstraints({ echoCancellation:true });
+    assert_true(track1.getSettings().echoCancellation, "test3");
+    assert_true(!track2.getSettings().echoCancellation, "FIXME: support changing settings of cloned audio tracks -");
+}, "Using applyConstraints for enabling/disabling echo cancellation should not interfere with another cloned track");
+</script>

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.cpp
@@ -40,8 +40,10 @@ namespace WebCore {
 
 constexpr Seconds voiceActivityThrottlingDuration = 5_s;
 
-BaseAudioCaptureUnit::BaseAudioCaptureUnit()
-    : m_sampleRate(AudioSession::singleton().sampleRate())
+BaseAudioCaptureUnit::BaseAudioCaptureUnit(CanEnableEchoCancellation canEnableEchoCancellation)
+    : m_canEnableEchoCancellation(canEnableEchoCancellation == CanEnableEchoCancellation::Yes)
+    , m_enableEchoCancellation(m_canEnableEchoCancellation)
+    , m_sampleRate(AudioSession::singleton().sampleRate())
 {
     RealtimeMediaSourceCenter::singleton().addDevicesChangedObserver(*this);
 }
@@ -49,6 +51,12 @@ BaseAudioCaptureUnit::BaseAudioCaptureUnit()
 BaseAudioCaptureUnit::~BaseAudioCaptureUnit()
 {
     RealtimeMediaSourceCenter::singleton().removeDevicesChangedObserver(*this);
+}
+
+void BaseAudioCaptureUnit::setEnableEchoCancellation(bool enableEchoCancellation)
+{
+    ASSERT(m_canEnableEchoCancellation || (!enableEchoCancellation && !m_enableEchoCancellation));
+    m_enableEchoCancellation = enableEchoCancellation;
 }
 
 void BaseAudioCaptureUnit::addClient(CoreAudioCaptureSource& client)

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.h
@@ -77,7 +77,7 @@ public:
 
     void setVolume(double volume) { m_volume = volume; }
     void setSampleRate(int sampleRate) { m_sampleRate = sampleRate; }
-    void setEnableEchoCancellation(bool enableEchoCancellation) { m_enableEchoCancellation = enableEchoCancellation; }
+    void setEnableEchoCancellation(bool);
 
     void addClient(CoreAudioCaptureSource&);
     void removeClient(CoreAudioCaptureSource&);
@@ -103,7 +103,8 @@ public:
 #endif
 
 protected:
-    BaseAudioCaptureUnit();
+    enum class CanEnableEchoCancellation : bool { No, Yes };
+    explicit BaseAudioCaptureUnit(CanEnableEchoCancellation);
 
     void forEachClient(NOESCAPE const Function<void(CoreAudioCaptureSource&)>&) const;
     void captureFailed();
@@ -153,6 +154,7 @@ private:
     void continueStartProducingData();
     void continueStopProducingData();
 
+    const bool m_canEnableEchoCancellation { true };
     bool m_enableEchoCancellation { true };
     double m_volume { 1 };
     int m_sampleRate;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -116,7 +116,7 @@ private:
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
 
     bool m_canResumeAfterInterruption { true };
-    bool m_isReadyToStart { false };
+    bool m_shouldInitializeAudioUnit { true };
     bool m_echoCancellationChanging { false };
 
     std::optional<bool> m_echoCancellationCapability;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
@@ -83,8 +83,11 @@ public:
 
     // The default unit - the only one that may render audio when capturing
     WEBCORE_EXPORT static CoreAudioCaptureUnit& defaultSingleton();
-    WEBCORE_EXPORT static void forEach(NOESCAPE Function<void(CoreAudioCaptureUnit&)>&&);
+    static Ref<CoreAudioCaptureUnit> createNonVPIOUnit();
     ~CoreAudioCaptureUnit();
+
+    WEBCORE_EXPORT static void forEach(NOESCAPE Function<void(CoreAudioCaptureUnit&)>&&);
+    static void forNewUnit(Function<void(CoreAudioCaptureUnit&)>&&);
 
     using CreationCallback = Function<Expected<UniqueRef<InternalUnit>, OSStatus>(bool enableEchoCancellation)>;
     void setInternalUnitCreationCallback(CreationCallback&& callback) { m_creationCallback = WTFMove(callback); }
@@ -132,7 +135,7 @@ public:
     void delaySamples(Seconds) final;
 
 private:
-    CoreAudioCaptureUnit();
+    explicit CoreAudioCaptureUnit(CanEnableEchoCancellation);
 
     friend class NeverDestroyed<CoreAudioCaptureUnit>;
     friend class MockAudioCaptureInternalUnit;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6450,6 +6450,15 @@ size_t Internals::audioCaptureSourceCount() const
     return false;
 }
 
+bool Internals::supportsMultiMicrophoneCaptureWithoutEchoCancellation() const
+{
+#if PLATFORM(MAC)
+    return true;
+#else
+    return false;
+#endif
+}
+
 bool Internals::isMediaStreamSourceInterrupted(MediaStreamTrack& track) const
 {
     return track.source().interrupted();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1025,6 +1025,7 @@ public:
     void setMediaStreamSourceInterrupted(MediaStreamTrack&, bool);
     const String& mediaStreamTrackPersistentId(const MediaStreamTrack&);
     size_t audioCaptureSourceCount() const;
+    bool supportsMultiMicrophoneCaptureWithoutEchoCancellation() const;
     bool isMediaStreamSourceInterrupted(MediaStreamTrack&) const;
     bool isMediaStreamSourceEnded(MediaStreamTrack&) const;
     bool isMockRealtimeMediaSourceCenterEnabled();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1202,6 +1202,7 @@ enum ContentsFormat {
     [Conditional=MEDIA_STREAM] boolean shouldAudioTrackPlay(AudioTrack track);
     [Conditional=MEDIA_STREAM] DOMString mediaStreamTrackPersistentId(MediaStreamTrack track);
     [Conditional=MEDIA_STREAM] unsigned long audioCaptureSourceCount();
+    [Conditional=MEDIA_STREAM] boolean supportsMultiMicrophoneCaptureWithoutEchoCancellation();
 
     [Conditional=WEB_RTC] readonly attribute DOMString rtcNetworkInterfaceName;
 


### PR DESCRIPTION
#### 9c7c6b9984936126323da202f62288548cc28fb0
<pre>
Calling getUserMedia with echo cancellation disabled causes side effects for existing audio tracks acquired via getUserMedia
<a href="https://rdar.apple.com/151143554">rdar://151143554</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292861">https://bugs.webkit.org/show_bug.cgi?id=292861</a>

Reviewed by Jean-Yves Avenard.

On macOS, we can run one VPIO unit and several HAL units in parallel.
This allows to use at the same time a microphone without echo cancellation (using HAL units) and with echo cancellation (using VPIO).

To do so, CoreAudioCaptureSource has its own CoreAudioCaptureUnit whenever echo cancellation is off.
CoreAudioCaptureSource uses CoreAudioCaptureUnit::defaultSingleton whenever echo cancellation is on.

We update BaseAudioCaptureUnit to take a boolean telling whether it supports echo cancellation.
This is used in BaseAudioCaptureUnit::setEnableEchoCancellation to validate we are not creating more than one VPIO unit.

CoreAudioCaptureSource, just before initializing its audio unit, will select its CoreAudioCaptureUnit based on echo cancellation.
The same principle is also done in CoreAudioCaptureSource::settingsDidChange, which happens when the web page calls MediaStreamTrack.applyConstraints.
The code path used for applyConstraints reuse the initialization code path, which requires to reset m_shouldInitializeAudioUnit to true.

It is possible to use applyConstraints to switch between HAL and VPIO units but all track clones are sharing the same CoreAudioCaptureUnit.
To get independent tracks, the web page will have to call getUserMedia twice.
A future patch should fix this limitation.

This is specific to macOS, no change to iOS behavior.

Now that we are creating potentially more than one CoreAudioCaptureUnit, we need to mock all of them.
We update our mock code so that we can iterate on existing CoreAudioCaptureUnit and update newly created.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/302582@main">https://commits.webkit.org/302582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd6ad5cd907b99134184b1aa5bce219e49e7d85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129583 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136969 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9284ed7d-840a-4a3a-a989-af193813ecae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1716 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98710 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/efb4a1a8-31c5-4db4-979a-4ff5d1f1986b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79373 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c56decac-c392-46b2-b112-5bdcb47dbebd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34200 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139449 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1559 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107074 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1331 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54349 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65064 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1521 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->