### PR TITLE
Relanding: Move FontPlatformSerializedAttributes off of using a CFArray for serialization

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -183,6 +183,13 @@ struct FontPlatformOpticalSize {
     Variant<RetainPtr<CFNumberRef>, String> opticalSize;
 };
 
+struct FontPlatformFeatureSetting {
+    std::optional<RetainPtr<CFNumberRef>> type;
+    std::optional<RetainPtr<CFNumberRef>> selector;
+    std::optional<RetainPtr<CFStringRef>> tag;
+    std::optional<RetainPtr<CFNumberRef>> value;
+};
+
 struct FontPlatformSerializedAttributes {
     static std::optional<FontPlatformSerializedAttributes> fromCF(CFDictionaryRef);
     RetainPtr<CFDictionaryRef> toCFDictionary() const;
@@ -211,8 +218,7 @@ struct FontPlatformSerializedAttributes {
     std::optional<FontPlatformOpticalSize> opticalSize;
     std::optional<FontPlatformSerializedTraits> traits;
 
-    // FIXME: featureSettings is an array of CFDictionaries whose layouts are highly variable
-    std::optional<RetainPtr<CFArrayRef>> featureSettings;
+    std::optional<Vector<FontPlatformFeatureSetting>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
     std::optional<RetainPtr<CFNumberRef>> additionalNumber;

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -110,6 +110,13 @@ header: <WebCore/FontPlatformData.h>
     Variant<RetainPtr<CFNumberRef>, String> opticalSize;
 };
 
+[CustomHeader] struct WebCore::FontPlatformFeatureSetting {
+    std::optional<RetainPtr<CFNumberRef>> type;
+    std::optional<RetainPtr<CFNumberRef>> selector;
+    std::optional<RetainPtr<CFStringRef>> tag;
+    std::optional<RetainPtr<CFNumberRef>> value;
+};
+
 [CustomHeader] struct WebCore::FontPlatformSerializedAttributes {
     String fontName;
     String descriptorLanguage;
@@ -135,7 +142,7 @@ header: <WebCore/FontPlatformData.h>
     std::optional<WebCore::FontPlatformOpticalSize> opticalSize;
     std::optional<WebCore::FontPlatformSerializedTraits> traits;
 
-    std::optional<RetainPtr<CFArrayRef>> featureSettings;
+    std::optional<Vector<WebCore::FontPlatformFeatureSetting>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
     std::optional<RetainPtr<CFNumberRef>> additionalNumber;

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -31,9 +31,6 @@
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFString()] CFStringRef wrapped by WTF::String {
 }
 
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFArray()] CFArrayRef wrapped by WebKit::CoreIPCCFArray {
-}
-
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFDictionary()] CFDictionaryRef wrapped by WebKit::CoreIPCCFDictionary {
 }
 


### PR DESCRIPTION
#### 836a24278f037486c21895cbdb42436a864adb8b
<pre>
Relanding: Move FontPlatformSerializedAttributes off of using a CFArray for serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=301567">https://bugs.webkit.org/show_bug.cgi?id=301567</a>
<a href="https://rdar.apple.com/163561063">rdar://163561063</a>

Reviewed by Brady Eidson.

Moves FontPlatformSerializedAttributes off of using a CFArray to serialize
it&apos;s featureSettings. Instead, we explicitly breakout the featureSettings to
expose it&apos;s inner structure. This was the last CFArray being directly serialized, so
we also removed the CFArray exposure to our .serialization.in files.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm

* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformSerializedAttributes::fromCF):
(WebCore::FontPlatformSerializedAttributes::toCFDictionary const):
* Source/WebKit/Shared/WebCoreFont.serialization.in:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(cfHolder):
(TEST(IPCSerialization, Basic)):
(TEST(CoreIPCCFDictionary, InsertDifferentValueTypes)):
(TEST(CoreIPCCFDictionary, InsertDifferentKeyTypes)):

Canonical link: <a href="https://commits.webkit.org/302799@main">https://commits.webkit.org/302799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32428e2e3375ba3c1cbbdc46fe98a9ba1fe2d6e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136633 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80648 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ed11b42f-8e07-4698-b5be-385582c76002) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66330 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2776217b-f701-4633-ae51-33d86c006a1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79081 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/21d6e020-8170-42ed-8ff1-ba9ef12357e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79912 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139106 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106960 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1078 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30641 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53925 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1376 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1299 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->