### PR TITLE
[Tahoe] Month/time input editable component tests are failing

### DIFF
--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-mouse-events.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -34,15 +35,17 @@ function mouseClickOn(x, y) {
 input.addEventListener("click", onClickEvent);
 const center = input.offsetHeight / 2;
 
+const shadowRoot = internals.shadowRoot(input);
+const monthField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-month-field");
+const yearField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-year-field");
+
 debug("Enabled Input\n");
 
-// Click on month field.
-mouseClickOn(20, center);
+UIHelper.activateElement(monthField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "2020-09");
 
-// Click on year field.
-mouseClickOn(60, center);
+UIHelper.activateElement(yearField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "0012-09");
@@ -64,10 +67,8 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-// Click on month field.
-mouseClickOn(20, center);
-// Click on year field.
-mouseClickOn(60, center);
+UIHelper.activateElement(monthField);
+UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -80,10 +81,8 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-// Click on month field.
-mouseClickOn(20, center);
-// Click on year field.
-mouseClickOn(60, center);
+UIHelper.activateElement(monthField);
+UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -92,7 +91,5 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 shouldBe("clickEventsFired", "3");
 
 </script>
-
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-mouse-events.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -34,21 +35,23 @@ function mouseClickOn(x, y) {
 input.addEventListener("click", onClickEvent);
 const center = input.offsetHeight / 2;
 
+const shadowRoot = internals.shadowRoot(input);
+const hourField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-hour-field");
+const minuteField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-minute-field");
+const meridiemField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-meridiem-field");
+
 debug("Enabled Input\n");
 
-// Click on hour field.
-mouseClickOn(20, center);
+UIHelper.activateElement(hourField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "09:30");
 
-// Click on minute field.
-mouseClickOn(60, center);
+UIHelper.activateElement(minuteField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "09:12");
 
-// Click on AM/PM field.
-mouseClickOn(120, center);
+UIHelper.activateElement(meridiemField);
 UIHelper.keyDown("upArrow");
 shouldBeEqualToString("input.value", "21:12");
 
@@ -69,12 +72,9 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-// Click on hour field.
-mouseClickOn(20, center);
-// Click on minute field.
-mouseClickOn(60, center);
-// Click on AM/PM field.
-mouseClickOn(120, center);
+UIHelper.activateElement(hourField);
+UIHelper.activateElement(minuteField);
+UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -87,12 +87,9 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-// Click on hour field.
-mouseClickOn(20, center);
-// Click on minute field.
-mouseClickOn(60, center);
-// Click on AM/PM field.
-mouseClickOn(120, center);
+UIHelper.activateElement(hourField);
+UIHelper.activateElement(minuteField);
+UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -101,7 +98,5 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 shouldBe("clickEventsFired", "4");
 
 </script>
-
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2409,6 +2409,3 @@ webkit.org/b/301566 [ Debug ] imported/w3c/web-platform-tests/custom-elements/re
 [ Tahoe Debug arm64 ] http/tests/media/hls/range-request-cross-origin.html [ Timeout ]
 [ Tahoe Debug arm64 ] http/tests/media/hls/track-in-band-multiple-cues.html [ Timeout ]
 [ Tahoe Debug arm64 ] http/tests/media/hls/track-webvtt-multitracks.html [ Timeout ]
-
-webkit.org/b/301700 [ Tahoe ] fast/forms/month/month-editable-components/month-editable-components-mouse-events.html [ Failure ]
-webkit.org/b/301700 [ Tahoe ] fast/forms/time/time-editable-components/time-editable-components-mouse-events.html [ Failure ]


### PR DESCRIPTION
#### 5f74aac61ffb90462a5ca1058c45c661d2a8cf2e
<pre>
[Tahoe] Month/time input editable component tests are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=301700">https://bugs.webkit.org/show_bug.cgi?id=301700</a>
<a href="https://rdar.apple.com/163718499">rdar://163718499</a>

Reviewed by Abrar Rahman Protyasha.

Mouse event tests for month/time inputs with editable components currently rely
on hardcoded coordinates for clicking. With the control redesign on macOS 26,
the introduction of padding has changed the position of editable components.
Consequently, the hardcoded coordinates are no longer correct.

Fix by obtaining the elements themselves from the shadow tree and clicking on
them after obtaining their position programmatically.

This was already done for date and datetimelocal in 297080@main.

* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-mouse-events.html:
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-mouse-events.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/302491@main">https://commits.webkit.org/302491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1513c13b2f9cea1e948c62abdcd2eb77e1d838c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136637 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80653 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69a295fc-2f8a-425c-a6d6-460e16d60b29) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98432 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66333 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e58cbc4-c969-43dd-9ff4-a7e87d190acb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79083 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07a2dfb9-1ac0-4c4b-b00e-38d9ad5e87d0) 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1060 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79916 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109513 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139110 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106800 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30646 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53931 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20180 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1380 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1203 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->