### PR TITLE
Fix the internal build when using some versions of the iOS SDK

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/UIFoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/UIFoundationSPI.h
@@ -54,3 +54,27 @@ DECLARE_SYSTEM_HEADER
 #endif // ENABLE(MULTI_REPRESENTATION_HEIC)
 
 #endif // USE(APPLE_INTERNAL_SDK)
+
+#if PLATFORM(MAC) && !__has_include(<UIFoundation/NSTextTable.h>)
+
+// Map new names to deprecated names so that we can build against older SDKs,
+// while referencing only the new enum value names.
+#define NSTextBlockValueTypeAbsolute                    NSTextBlockAbsoluteValueType
+#define NSTextBlockValueTypePercentage                  NSTextBlockPercentageValueType
+#define NSTextBlockDimensionWidth                       NSTextBlockWidth
+#define NSTextBlockDimensionMinimumWidth                NSTextBlockMinimumWidth
+#define NSTextBlockDimensionMaximumWidth                NSTextBlockMaximumWidth
+#define NSTextBlockDimensionHeight                      NSTextBlockHeight
+#define NSTextBlockDimensionMinimumHeight               NSTextBlockMinimumHeight
+#define NSTextBlockDimensionMaximumHeight               NSTextBlockMaximumHeight
+#define NSTextBlockLayerPadding                         NSTextBlockPadding
+#define NSTextBlockLayerBorder                          NSTextBlockBorder
+#define NSTextBlockLayerMargin                          NSTextBlockMargin
+#define NSTextBlockVerticalAlignmentTop                 NSTextBlockTopAlignment
+#define NSTextBlockVerticalAlignmentMiddle              NSTextBlockMiddleAlignment
+#define NSTextBlockVerticalAlignmentBottom              NSTextBlockBottomAlignment
+#define NSTextBlockVerticalAlignmentBaseline            NSTextBlockBaselineAlignment
+#define NSTextTableLayoutAlgorithmAutomatic             NSTextTableAutomaticLayoutAlgorithm
+#define NSTextTableLayoutAlgorithmFixed                 NSTextTableFixedLayoutAlgorithm
+
+#endif // PLATFORM(MAC) && !__has_include(<UIFoundation/NSTextTable.h>)

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -96,41 +96,41 @@ bool AttributedString::rangesAreSafe(const String& string, const Vector<std::pai
 
 inline static void configureNSTextBlockFromParagraphStyleCommonTableAttributes(NSTextBlock* table, const ParagraphStyleCommonTableAttributes& item)
 {
-    [table setValue:item.width type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockWidth];
-    [table setValue:item.minimumWidth type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMinimumWidth];
-    [table setValue:item.maximumWidth type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMaximumWidth];
-    [table setValue:item.minimumHeight type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMinimumHeight];
-    [table setValue:item.maximumHeight type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMaximumHeight];
+    [table setValue:item.width type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionWidth];
+    [table setValue:item.minimumWidth type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMinimumWidth];
+    [table setValue:item.maximumWidth type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMaximumWidth];
+    [table setValue:item.minimumHeight type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMinimumHeight];
+    [table setValue:item.maximumHeight type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMaximumHeight];
 
-    [table setWidth:item.paddingMinXEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMinXEdge];
-    [table setWidth:item.paddingMinYEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMinYEdge];
-    [table setWidth:item.paddingMaxXEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMaxXEdge];
-    [table setWidth:item.paddingMaxYEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMaxYEdge];
+    [table setWidth:item.paddingMinXEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinX];
+    [table setWidth:item.paddingMinYEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinY];
+    [table setWidth:item.paddingMaxXEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxX];
+    [table setWidth:item.paddingMaxYEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxY];
 
-    [table setWidth:item.borderMinXEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMinXEdge];
-    [table setWidth:item.borderMinYEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMinYEdge];
-    [table setWidth:item.borderMaxXEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMaxXEdge];
-    [table setWidth:item.borderMaxYEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMaxYEdge];
+    [table setWidth:item.borderMinXEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinX];
+    [table setWidth:item.borderMinYEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinY];
+    [table setWidth:item.borderMaxXEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxX];
+    [table setWidth:item.borderMaxYEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxY];
 
-    [table setWidth:item.marginMinXEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMinXEdge];
-    [table setWidth:item.marginMinYEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMinYEdge];
-    [table setWidth:item.marginMaxXEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMaxXEdge];
-    [table setWidth:item.marginMaxYEdge type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMaxYEdge];
+    [table setWidth:item.marginMinXEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinX];
+    [table setWidth:item.marginMinYEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinY];
+    [table setWidth:item.marginMaxXEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxX];
+    [table setWidth:item.marginMaxYEdge type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxY];
 
     if (item.backgroundColor)
         [table setBackgroundColor:item.backgroundColor.get()];
 
     if (item.borderMinXEdgeColor)
-        [table setBorderColor:item.borderMinXEdgeColor.get() forEdge:NSMinXEdge];
+        [table setBorderColor:item.borderMinXEdgeColor.get() forEdge:NSRectEdgeMinX];
 
     if (item.borderMinYEdgeColor)
-        [table setBorderColor:item.borderMinYEdgeColor.get() forEdge:NSMinYEdge];
+        [table setBorderColor:item.borderMinYEdgeColor.get() forEdge:NSRectEdgeMinY];
 
     if (item.borderMaxXEdgeColor)
-        [table setBorderColor:item.borderMaxXEdgeColor.get() forEdge:NSMaxXEdge];
+        [table setBorderColor:item.borderMaxXEdgeColor.get() forEdge:NSRectEdgeMaxX];
 
     if (item.borderMaxYEdgeColor)
-        [table setBorderColor:item.borderMaxYEdgeColor.get() forEdge:NSMaxYEdge];
+        [table setBorderColor:item.borderMaxYEdgeColor.get() forEdge:NSRectEdgeMaxY];
 }
 
 inline static NSTextAlignment reconstructNSTextAlignment(ParagraphStyleAlignment alignment)
@@ -155,28 +155,28 @@ inline static NSTextBlockVerticalAlignment reconstructNSTextBlockVerticalAlignme
 {
     switch (alignment) {
     case TextTableBlockVerticalAlignment::Top:
-        return NSTextBlockTopAlignment;
+        return NSTextBlockVerticalAlignmentTop;
     case TextTableBlockVerticalAlignment::Middle:
-        return NSTextBlockMiddleAlignment;
+        return NSTextBlockVerticalAlignmentMiddle;
     case TextTableBlockVerticalAlignment::Bottom:
-        return NSTextBlockBottomAlignment;
+        return NSTextBlockVerticalAlignmentBottom;
     case TextTableBlockVerticalAlignment::Baseline:
-        return NSTextBlockBaselineAlignment;
+        return NSTextBlockVerticalAlignmentBaseline;
     }
     ASSERT_NOT_REACHED();
-    return NSTextBlockTopAlignment;
+    return NSTextBlockVerticalAlignmentTop;
 }
 
 inline static NSTextTableLayoutAlgorithm reconstructNSTextTableLayoutAlgorithm(TextTableLayoutAlgorithm layout)
 {
     switch (layout) {
     case TextTableLayoutAlgorithm::Automatic:
-        return NSTextTableAutomaticLayoutAlgorithm;
+        return NSTextTableLayoutAlgorithmAutomatic;
     case TextTableLayoutAlgorithm::Fixed:
-        return NSTextTableFixedLayoutAlgorithm;
+        return NSTextTableLayoutAlgorithmFixed;
     }
     ASSERT_NOT_REACHED();
-    return NSTextTableAutomaticLayoutAlgorithm;
+    return NSTextTableLayoutAlgorithmAutomatic;
 }
 
 inline static NSWritingDirection reconstructNSWritingDirection(ParagraphStyleWritingDirection writingDirection)
@@ -501,13 +501,13 @@ inline static ParagraphStyleAlignment extractParagraphStyleAlignment(NSTextAlign
 inline static TextTableBlockVerticalAlignment extractTextTableBlockVerticalAlignment(NSTextBlockVerticalAlignment verticalAlignment)
 {
     switch (verticalAlignment) {
-    case NSTextBlockTopAlignment:
+    case NSTextBlockVerticalAlignmentTop:
         return TextTableBlockVerticalAlignment::Top;
-    case NSTextBlockMiddleAlignment:
+    case NSTextBlockVerticalAlignmentMiddle:
         return TextTableBlockVerticalAlignment::Middle;
-    case NSTextBlockBottomAlignment:
+    case NSTextBlockVerticalAlignmentBottom:
         return TextTableBlockVerticalAlignment::Bottom;
-    case NSTextBlockBaselineAlignment:
+    case NSTextBlockVerticalAlignmentBaseline:
         return TextTableBlockVerticalAlignment::Baseline;
     }
     ASSERT_NOT_REACHED();
@@ -517,9 +517,9 @@ inline static TextTableBlockVerticalAlignment extractTextTableBlockVerticalAlign
 inline static TextTableLayoutAlgorithm extractTextTableLayoutAlgorithm(NSTextTableLayoutAlgorithm layout)
 {
     switch (layout) {
-    case NSTextTableAutomaticLayoutAlgorithm:
+    case NSTextTableLayoutAlgorithmAutomatic:
         return TextTableLayoutAlgorithm::Automatic;
-    case NSTextTableFixedLayoutAlgorithm:
+    case NSTextTableLayoutAlgorithmFixed:
         return TextTableLayoutAlgorithm::Fixed;
     }
     ASSERT_NOT_REACHED();
@@ -591,32 +591,32 @@ inline static ParagraphStyle extractParagraphStyle(NSParagraphStyle *style, Tabl
         if (tableEnsureResults.isNewEntry) {
             newTextTables.append(TextTable {
                 {
-                    [nsTable valueForDimension:NSTextBlockWidth],
-                    [nsTable valueForDimension:NSTextBlockMinimumWidth],
-                    [nsTable valueForDimension:NSTextBlockMaximumWidth],
-                    [nsTable valueForDimension:NSTextBlockMinimumHeight],
-                    [nsTable valueForDimension:NSTextBlockMaximumHeight],
+                    [nsTable valueForDimension:NSTextBlockDimensionWidth],
+                    [nsTable valueForDimension:NSTextBlockDimensionMinimumWidth],
+                    [nsTable valueForDimension:NSTextBlockDimensionMaximumWidth],
+                    [nsTable valueForDimension:NSTextBlockDimensionMinimumHeight],
+                    [nsTable valueForDimension:NSTextBlockDimensionMaximumHeight],
 
-                    [nsTable widthForLayer:NSTextBlockPadding edge:NSMinXEdge],
-                    [nsTable widthForLayer:NSTextBlockPadding edge:NSMinYEdge],
-                    [nsTable widthForLayer:NSTextBlockPadding edge:NSMaxXEdge],
-                    [nsTable widthForLayer:NSTextBlockPadding edge:NSMaxYEdge],
+                    [nsTable widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinX],
+                    [nsTable widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinY],
+                    [nsTable widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxX],
+                    [nsTable widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxY],
 
-                    [nsTable widthForLayer:NSTextBlockBorder edge:NSMinXEdge],
-                    [nsTable widthForLayer:NSTextBlockBorder edge:NSMinYEdge],
-                    [nsTable widthForLayer:NSTextBlockBorder edge:NSMaxXEdge],
-                    [nsTable widthForLayer:NSTextBlockBorder edge:NSMaxYEdge],
+                    [nsTable widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinX],
+                    [nsTable widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinY],
+                    [nsTable widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxX],
+                    [nsTable widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxY],
 
-                    [nsTable widthForLayer:NSTextBlockMargin edge:NSMinXEdge],
-                    [nsTable widthForLayer:NSTextBlockMargin edge:NSMinYEdge],
-                    [nsTable widthForLayer:NSTextBlockMargin edge:NSMaxXEdge],
-                    [nsTable widthForLayer:NSTextBlockMargin edge:NSMaxYEdge],
+                    [nsTable widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinX],
+                    [nsTable widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinY],
+                    [nsTable widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxX],
+                    [nsTable widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxY],
 
                     [nsTable backgroundColor],
-                    [nsTable borderColorForEdge:NSMinXEdge],
-                    [nsTable borderColorForEdge:NSMinYEdge],
-                    [nsTable borderColorForEdge:NSMaxXEdge],
-                    [nsTable borderColorForEdge:NSMaxYEdge]
+                    [nsTable borderColorForEdge:NSRectEdgeMinX],
+                    [nsTable borderColorForEdge:NSRectEdgeMinY],
+                    [nsTable borderColorForEdge:NSRectEdgeMaxX],
+                    [nsTable borderColorForEdge:NSRectEdgeMaxY]
                 },
                 tableID,
                 [nsTable numberOfColumns],
@@ -629,32 +629,32 @@ inline static ParagraphStyle extractParagraphStyle(NSParagraphStyle *style, Tabl
         if (tableBlockEnsureResult.isNewEntry) {
             newTextTableBlocks.append(TextTableBlock {
                 {
-                    [item valueForDimension:NSTextBlockWidth],
-                    [item valueForDimension:NSTextBlockMinimumWidth],
-                    [item valueForDimension:NSTextBlockMaximumWidth],
-                    [item valueForDimension:NSTextBlockMinimumHeight],
-                    [item valueForDimension:NSTextBlockMaximumHeight],
+                    [item valueForDimension:NSTextBlockDimensionWidth],
+                    [item valueForDimension:NSTextBlockDimensionMinimumWidth],
+                    [item valueForDimension:NSTextBlockDimensionMaximumWidth],
+                    [item valueForDimension:NSTextBlockDimensionMinimumHeight],
+                    [item valueForDimension:NSTextBlockDimensionMaximumHeight],
 
-                    [item widthForLayer:NSTextBlockPadding edge:NSMinXEdge],
-                    [item widthForLayer:NSTextBlockPadding edge:NSMinYEdge],
-                    [item widthForLayer:NSTextBlockPadding edge:NSMaxXEdge],
-                    [item widthForLayer:NSTextBlockPadding edge:NSMaxYEdge],
+                    [item widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinX],
+                    [item widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinY],
+                    [item widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxX],
+                    [item widthForLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxY],
 
-                    [item widthForLayer:NSTextBlockBorder edge:NSMinXEdge],
-                    [item widthForLayer:NSTextBlockBorder edge:NSMinYEdge],
-                    [item widthForLayer:NSTextBlockBorder edge:NSMaxXEdge],
-                    [item widthForLayer:NSTextBlockBorder edge:NSMaxYEdge],
+                    [item widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinX],
+                    [item widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinY],
+                    [item widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxX],
+                    [item widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxY],
 
-                    [item widthForLayer:NSTextBlockMargin edge:NSMinXEdge],
-                    [item widthForLayer:NSTextBlockMargin edge:NSMinYEdge],
-                    [item widthForLayer:NSTextBlockMargin edge:NSMaxXEdge],
-                    [item widthForLayer:NSTextBlockMargin edge:NSMaxYEdge],
+                    [item widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinX],
+                    [item widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinY],
+                    [item widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxX],
+                    [item widthForLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxY],
 
                     [item backgroundColor],
-                    [item borderColorForEdge:NSMinXEdge],
-                    [item borderColorForEdge:NSMinYEdge],
-                    [item borderColorForEdge:NSMaxXEdge],
-                    [item borderColorForEdge:NSMaxYEdge]
+                    [item borderColorForEdge:NSRectEdgeMinX],
+                    [item borderColorForEdge:NSRectEdgeMinY],
+                    [item borderColorForEdge:NSRectEdgeMaxX],
+                    [item borderColorForEdge:NSRectEdgeMaxY]
                 },
                 tableBlockID,
                 tableID,

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -81,6 +81,7 @@
 #import "markup.h"
 #import <objc/runtime.h>
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
+#import <pal/spi/cocoa/UIFoundationSPI.h>
 #import <wtf/ASCIICType.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>
@@ -1397,63 +1398,63 @@ void HTMLConverter::_fillInBlock(NSTextBlock *block, Element& element, PlatformC
     RetainPtr width = element.getAttribute(widthAttr).createNSString();
     if ((width && [width length]) || !isTable) {
         if (_caches->floatPropertyValueForNode(element, CSSPropertyWidth, result))
-            [block setValue:result type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockWidth];
+            [block setValue:result type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionWidth];
     }
 
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMinWidth, result))
-        [block setValue:result type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMinimumWidth];
+        [block setValue:result type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMinimumWidth];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMaxWidth, result))
-        [block setValue:result type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMaximumWidth];
+        [block setValue:result type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMaximumWidth];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMinHeight, result))
-        [block setValue:result type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMinimumHeight];
+        [block setValue:result type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMinimumHeight];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMaxHeight, result))
-        [block setValue:result type:NSTextBlockAbsoluteValueType forDimension:NSTextBlockMaximumHeight];
+        [block setValue:result type:NSTextBlockValueTypeAbsolute forDimension:NSTextBlockDimensionMaximumHeight];
 
     if (_caches->floatPropertyValueForNode(element, CSSPropertyPaddingLeft, result))
-        [block setWidth:result + extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMinXEdge];
+        [block setWidth:result + extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinX];
     else
-        [block setWidth:extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMinXEdge];
+        [block setWidth:extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinX];
 
     if (_caches->floatPropertyValueForNode(element, CSSPropertyPaddingTop, result))
-        [block setWidth:result + extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMinYEdge];
+        [block setWidth:result + extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinY];
     else
-        [block setWidth:extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMinYEdge];
+        [block setWidth:extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMinY];
 
     if (_caches->floatPropertyValueForNode(element, CSSPropertyPaddingRight, result))
-        [block setWidth:result + extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMaxXEdge];
+        [block setWidth:result + extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxX];
     else
-        [block setWidth:extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMaxXEdge];
+        [block setWidth:extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxX];
 
     if (_caches->floatPropertyValueForNode(element, CSSPropertyPaddingBottom, result))
-        [block setWidth:result + extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMaxYEdge];
+        [block setWidth:result + extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxY];
     else
-        [block setWidth:extraPadding type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockPadding edge:NSMaxYEdge];
+        [block setWidth:extraPadding type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerPadding edge:NSRectEdgeMaxY];
 
     if (_caches->floatPropertyValueForNode(element, CSSPropertyBorderLeftWidth, result))
-        [block setWidth:result type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMinXEdge];
+        [block setWidth:result type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinX];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyBorderTopWidth, result))
-        [block setWidth:result type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMinYEdge];
+        [block setWidth:result type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinY];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyBorderRightWidth, result))
-        [block setWidth:result type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMaxXEdge];
+        [block setWidth:result type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxX];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyBorderBottomWidth, result))
-        [block setWidth:result type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockBorder edge:NSMaxYEdge];
+        [block setWidth:result type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerBorder edge:NSRectEdgeMaxY];
 
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMarginLeft, result))
-        [block setWidth:result + extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMinXEdge];
+        [block setWidth:result + extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinX];
     else
-        [block setWidth:extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMinXEdge];
+        [block setWidth:extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinX];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMarginTop, result))
-        [block setWidth:result + extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMinYEdge];
+        [block setWidth:result + extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinY];
     else
-        [block setWidth:extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMinYEdge];
+        [block setWidth:extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMinY];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMarginRight, result))
-        [block setWidth:result + extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMaxXEdge];
+        [block setWidth:result + extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxX];
     else
-        [block setWidth:extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMaxXEdge];
+        [block setWidth:extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxX];
     if (_caches->floatPropertyValueForNode(element, CSSPropertyMarginBottom, result))
-        [block setWidth:result + extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMaxYEdge];
+        [block setWidth:result + extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxY];
     else
-        [block setWidth:extraMargin type:NSTextBlockAbsoluteValueType forLayer:NSTextBlockMargin edge:NSMaxYEdge];
+        [block setWidth:extraMargin type:NSTextBlockValueTypeAbsolute forLayer:NSTextBlockLayerMargin edge:NSRectEdgeMaxY];
 
     RetainPtr<PlatformColor> color;
     if ((color = _colorForElement(element, CSSPropertyBackgroundColor)))
@@ -1462,14 +1463,14 @@ void HTMLConverter::_fillInBlock(NSTextBlock *block, Element& element, PlatformC
         [block setBackgroundColor:backgroundColor];
 
     if ((color = _colorForElement(element, CSSPropertyBorderLeftColor)))
-        [block setBorderColor:color.get() forEdge:NSMinXEdge];
+        [block setBorderColor:color.get() forEdge:NSRectEdgeMinX];
 
     if ((color = _colorForElement(element, CSSPropertyBorderTopColor)))
-        [block setBorderColor:color.get() forEdge:NSMinYEdge];
+        [block setBorderColor:color.get() forEdge:NSRectEdgeMinY];
     if ((color = _colorForElement(element, CSSPropertyBorderRightColor)))
-        [block setBorderColor:color.get() forEdge:NSMaxXEdge];
+        [block setBorderColor:color.get() forEdge:NSRectEdgeMaxX];
     if ((color = _colorForElement(element, CSSPropertyBorderBottomColor)))
-        [block setBorderColor:color.get() forEdge:NSMaxYEdge];
+        [block setBorderColor:color.get() forEdge:NSRectEdgeMaxY];
 }
 
 static inline BOOL read2DigitNumber(std::span<const char>& p, int8_t& outval)
@@ -1661,7 +1662,7 @@ void HTMLConverter::_addTableForElement(Element *tableElement)
     CGFloat cellSpacingVal = 1;
     CGFloat cellPaddingVal = 1;
     [table setNumberOfColumns:1];
-    [table setLayoutAlgorithm:NSTextTableAutomaticLayoutAlgorithm];
+    [table setLayoutAlgorithm:NSTextTableLayoutAlgorithmAutomatic];
     [table setCollapsesBorders:NO];
     [table setHidesEmptyCells:NO];
 
@@ -1685,7 +1686,7 @@ void HTMLConverter::_addTableForElement(Element *tableElement)
         if (_caches->propertyValueForNode(coreTableElement, CSSPropertyEmptyCells) == "hide"_s)
             [table setHidesEmptyCells:YES];
         if (_caches->propertyValueForNode(coreTableElement, CSSPropertyTableLayout) == "fixed"_s)
-            [table setLayoutAlgorithm:NSTextTableFixedLayoutAlgorithm];
+            [table setLayoutAlgorithm:NSTextTableLayoutAlgorithmFixed];
     }
 
     [_textTables addObject:table.get()];
@@ -1732,13 +1733,13 @@ void HTMLConverter::_addTableCellForElement(Element* element)
 
         _fillInBlock(block.get(), *element, color, cellSpacingVal / 2, 0, NO);
         if (verticalAlign == "middle"_s)
-            [block setVerticalAlignment:NSTextBlockMiddleAlignment];
+            [block setVerticalAlignment:NSTextBlockVerticalAlignmentMiddle];
         else if (verticalAlign == "bottom"_s)
-            [block setVerticalAlignment:NSTextBlockBottomAlignment];
+            [block setVerticalAlignment:NSTextBlockVerticalAlignmentBottom];
         else if (verticalAlign == "baseline"_s)
-            [block setVerticalAlignment:NSTextBlockBaselineAlignment];
+            [block setVerticalAlignment:NSTextBlockVerticalAlignmentBaseline];
         else if (verticalAlign == "top"_s)
-            [block setVerticalAlignment:NSTextBlockTopAlignment];
+            [block setVerticalAlignment:NSTextBlockVerticalAlignmentTop];
     } else {
         block = adoptNS([[PlatformNSTextTableBlock alloc] initWithTable:table startingRow:rowNumber rowSpan:rowSpan startingColumn:columnNumber columnSpan:colSpan]);
     }

--- a/Source/WebCore/platform/ios/wak/WAKAppKitStubs.h
+++ b/Source/WebCore/platform/ios/wak/WAKAppKitStubs.h
@@ -151,7 +151,8 @@ typedef CGSize NSSize;
 #define NSMaxY CGRectGetMaxY
 #endif
 
-typedef NS_ENUM(NSInteger, NSRectEdge) {
+#ifndef WK_HAS_DEFINED_NS_RECT_EDGE
+typedef NS_ENUM(NSUInteger, NSRectEdge) {
 #ifndef NSMinXEdge
     NSMinXEdge = CGRectMinXEdge,
 #endif
@@ -164,7 +165,13 @@ typedef NS_ENUM(NSInteger, NSRectEdge) {
 #ifndef NSMaxYEdge
     NSMaxYEdge = CGRectMaxYEdge,
 #endif
+    NSRectEdgeMinX = CGRectMinXEdge,
+    NSRectEdgeMinY = CGRectMinYEdge,
+    NSRectEdgeMaxX = CGRectMaxXEdge,
+    NSRectEdgeMaxY = CGRectMaxYEdge,
 };
+#define WK_HAS_DEFINED_NS_RECT_EDGE 1
+#endif // !defined(WK_HAS_DEFINED_NS_RECT_EDGE)
 
 @interface NSValue (NSGeometryDetails)
 + (NSValue *)valueWithPoint:(NSPoint)point;

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -28,6 +28,22 @@
 #import <UIKit/UIKit.h>
 
 #if USE(APPLE_INTERNAL_SDK)
+#import <Foundation/NSGeometry.h>
+#endif
+
+#ifndef WK_HAS_DEFINED_NS_RECT_EDGE
+#ifndef NSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES
+typedef NS_ENUM(NSUInteger, NSRectEdge) {
+    NSRectEdgeMinX = CGRectMinXEdge,
+    NSRectEdgeMinY = CGRectMinYEdge,
+    NSRectEdgeMaxX = CGRectMaxXEdge,
+    NSRectEdgeMaxY = CGRectMaxYEdge,
+};
+#define WK_HAS_DEFINED_NS_RECT_EDGE 1
+#endif // !defined(NSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES)
+#endif // !defined(WK_HAS_DEFINED_NS_RECT_EDGE)
+
+#if USE(APPLE_INTERNAL_SDK)
 
 #import <UIKit/NSParagraphStyle_Private.h>
 #import <UIKit/NSTextAlternatives.h>
@@ -536,14 +552,18 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionShouldBeginResult) {
 - (UITextInputArrowKeyHistory *)_moveToStartOfParagraph:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history;
 @end
 
+#if __has_include(<UIFoundation/NSTextTable.h>)
+#import <UIFoundation/NSTextTable.h>
+#else
+
 typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
-    NSTextBlockPadding  = -1,
-    NSTextBlockBorder   =  0,
-    NSTextBlockMargin   =  1
+    NSTextBlockLayerPadding  = -1,
+    NSTextBlockLayerBorder   =  0,
+    NSTextBlockLayerMargin   =  1
 };
 
 @interface NSTextBlock : NSObject
-- (CGFloat)widthForLayer:(NSTextBlockLayer)layer edge:(CGRectEdge)edge;
+- (CGFloat)widthForLayer:(NSTextBlockLayer)layer edge:(NSRectEdge)edge;
 @property (nonatomic, copy) UIColor *backgroundColor;
 @end
 
@@ -559,9 +579,11 @@ typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
 - (NSInteger)rowSpan;
 @end
 
-@interface NSParagraphStyle ()
+@interface NSParagraphStyle (TextBlocks)
 - (NSArray<NSTextBlock *> *)textBlocks;
 @end
+
+#endif // !__has_include(<UIFoundation/NSTextTable.h>)
 
 @interface UIResponder (Internal)
 - (void)_share:(id)sender;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -44,6 +44,10 @@
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/WTFString.h>
 
+#if PLATFORM(MAC) && !__has_include(<UIFoundation/NSTextTable.h>)
+#define NSTextBlockLayerBorder NSTextBlockBorder
+#endif
+
 @implementation WKWebView (WKWebViewGetContents)
 
 - (NSAttributedString *)_contentsAsAttributedString
@@ -339,12 +343,7 @@ TEST(WKWebView, AttributedStringFromTable)
         EXPECT_EQ(cell.columnSpan, static_cast<NSInteger>(1));
         EXPECT_EQ(cell.rowSpan, static_cast<NSInteger>(1));
         EXPECT_EQ(cell.table, expectedTable);
-#if PLATFORM(IOS_FAMILY)
-        auto leftEdge = CGRectMinXEdge;
-#else
-        auto leftEdge = NSRectEdgeMinX;
-#endif
-        EXPECT_EQ([cell widthForLayer:NSTextBlockBorder edge:leftEdge], expectedBorderWidth);
+        EXPECT_EQ([cell widthForLayer:NSTextBlockLayerBorder edge:NSRectEdgeMinX], expectedBorderWidth);
 
         if (!expectedBackgroundColor)
             EXPECT_NULL(cell.backgroundColor);


### PR DESCRIPTION
#### 5aac70aee6f520d2c9831649831c4929b1e4019f
<pre>
Fix the internal build when using some versions of the iOS SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=301867">https://bugs.webkit.org/show_bug.cgi?id=301867</a>
<a href="https://rdar.apple.com/163270786">rdar://163270786</a>

Reviewed by Abrar Rahman Protyasha.

Avoid build failures due to duplicate or conflicting SPI / IPI declarations, due to these symbols
being either moved around or renamed in the SDK.

No change in behavior.

* Source/WebCore/PAL/pal/spi/cocoa/UIFoundationSPI.h:

Add definitions to map each of the new API names back to shipping (deprecated) symbol names, to
ensure source compatibility when building with older SDKs on macOS (where these symbol names are
already public API anyways). This allows us to use only the newer names in our source code without
breaking older macOS builds.

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::configureNSTextBlockFromParagraphStyleCommonTableAttributes):
(WebCore::reconstructNSTextBlockVerticalAlignment):
(WebCore::reconstructNSTextTableLayoutAlgorithm):
(WebCore::extractTextTableBlockVerticalAlignment):
(WebCore::extractTextTableLayoutAlgorithm):
(WebCore::extractParagraphStyle):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_fillInBlock):
(HTMLConverter::_addTableForElement):
(HTMLConverter::_addTableCellForElement):
* Source/WebCore/platform/ios/wak/WAKAppKitStubs.h:

Make the type of `NSRectEdge` consistent with the definition in the SDK (as well as the new forward
declarations).

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TestWebKitAPI::TEST(WKWebView, AttributedStringFromTable)):

Canonical link: <a href="https://commits.webkit.org/302544@main">https://commits.webkit.org/302544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b30ddfcc057e2ba3b62379f2bd8a6edcb416d5b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80752 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94a0b696-9d33-4981-b381-ba5c774154c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66409 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2cc58611-46f2-4079-a15a-e0670cec6307) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79162 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3228b7f0-e5bb-4375-b41f-c568412225ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33984 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80007 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109574 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34485 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139203 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106881 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54040 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64834 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1288 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->