### PR TITLE
[Navigation API] Fire an abort signal when aborting a NavigateEvent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html
@@ -45,6 +45,7 @@ promise_test(async t => {
     ["currententrychange", "#1", { from, navigationType: "push" }],
     ["handler run", "#1", { from, navigationType: "push" }],
     ["promise microtask", "#1", { from, navigationType: "push" }],
+    ["AbortSignal abort", "#1", { from, navigationType: "push" }],
     ["navigateerror", "#1", { from, navigationType: "push" }],
     ["transition.finished rejected", "#1", null],
   ]);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html
@@ -44,6 +44,7 @@ promise_test(async t => {
     ["currententrychange", "", { from, navigationType: "traverse" }],
     ["handler run", "", { from, navigationType: "traverse" }],
     ["committed fulfilled", "", { from, navigationType: "traverse" }],
+    ["AbortSignal abort", "", { from, navigationType: "traverse" }],
     ["navigateerror", "", { from, navigationType: "traverse" }],
     ["finished rejected", "", null],
     ["transition.finished rejected", "", null]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject.html
@@ -41,6 +41,7 @@ promise_test(async t => {
     ["currententrychange", "#1", { from, navigationType: "push" }],
     ["handler run", "#1", { from, navigationType: "push" }],
     ["promise microtask", "#1", { from, navigationType: "push" }],
+    ["AbortSignal abort", "#1", { from, navigationType: "push" }],
     ["navigateerror", "#1", { from, navigationType: "push" }],
     ["transition.finished rejected", "#1", null],
   ]);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject.html
@@ -44,6 +44,7 @@ promise_test(async t => {
     ["committed fulfilled", "#1", { from, navigationType: "push" }],
     ["transition.committed fulfilled", "#1", { from, navigationType: "push" }],
     ["promise microtask", "#1", { from, navigationType: "push" }],
+    ["AbortSignal abort", "#1", { from, navigationType: "push" }],
     ["navigateerror", "#1", { from, navigationType: "push" }],
     ["finished rejected", "#1", null],
     ["transition.finished rejected", "#1", null],

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject.html
@@ -44,6 +44,7 @@ promise_test(async t => {
     ["committed fulfilled", "", { from, navigationType: "reload" }],
     ["transition.committed fulfilled", "", { from, navigationType: "reload" }],
     ["promise microtask", "", { from, navigationType: "reload" }],
+    ["AbortSignal abort", "", { from, navigationType: "reload" }],
     ["navigateerror", "", { from, navigationType: "reload" }],
     ["finished rejected", "", null],
     ["transition.finished rejected", "", null],

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1142,6 +1142,10 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
                 auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
                 protectedThis->protectedOngoingNavigateEvent()->finish(*document, InterceptionHandlersDidFulfill::No, focusChanged);
+
+                if (abortController)
+                    abortController->signal().signalAbort(result);
+
                 protectedThis->m_ongoingNavigateEvent = nullptr;
 
                 ErrorInformation errorInformation;


### PR DESCRIPTION
#### ee02162b1bf16993a15794e9bc70a03b130ca865
<pre>
[Navigation API] Fire an abort signal when aborting a NavigateEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=301883">https://bugs.webkit.org/show_bug.cgi?id=301883</a>
<a href="https://rdar.apple.com/163957784">rdar://163957784</a>

Reviewed by Tim Nguyen.

Step 2 of <a href="https://html.spec.whatwg.org/#abort-a-navigateevent">https://html.spec.whatwg.org/#abort-a-navigateevent</a> signals an abort
on the event&apos;s abort controller. We also change the tests to reflect this in
the same way that this WPT change proposal does:
web-platform-tests/wpt#55707

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject.html:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/302591@main">https://commits.webkit.org/302591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7aadce147ffa9c367f6c667b98162584fc2141d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80982 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e093bbd1-870a-4273-829a-1eea8bc0c552) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98678 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66537 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6bfb1c6-6ac7-4f99-9690-ae326c6b590f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79326 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9f62d648-c83d-4c66-8d61-d8d979dd4d34) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34165 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80207 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139407 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107200 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107044 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54296 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20220 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65030 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1487 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1521 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->