### PR TITLE
[Navigation API] NavigateEvent.sourceElement can be cross-window.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html
@@ -20,10 +20,10 @@ async_test(t => {
       assert_equals(new URL(e.destination.url).pathname,
                     "/navigation-api/navigate-event/foo.html");
       assert_false(e.destination.sameDocument);
-    assert_equals(e.destination.key, "");
-    assert_equals(e.destination.id, "");
+      assert_equals(e.destination.key, "");
+      assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      assert_equals(e.sourceElement, a);
       e.preventDefault();
     });
     a.click();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4426,11 +4426,6 @@ bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadR
 
     RefPtr sourceElement = event ? dynamicDowncast<Element>(event->target()) : nullptr;
 
-    // For non-form navigations, if sourceElement is from a different frame, it should be null.
-    // For form submissions, sourceElement can be from a different frame (when form has target attribute).
-    if (!formState && sourceElement && sourceElement->document().frame() != m_frame.ptr())
-        sourceElement = nullptr;
-
     return window->protectedNavigation()->dispatchPushReplaceReloadNavigateEvent(newURL, navigationType, isSameDocument, formState, classicHistoryAPIState, sourceElement.get());
 }
 


### PR DESCRIPTION
#### cb035d053e086d30e72ea1a6ca09438a5e777050
<pre>
[Navigation API] NavigateEvent.sourceElement can be cross-window.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301885">https://bugs.webkit.org/show_bug.cgi?id=301885</a>
<a href="https://rdar.apple.com/163962362">rdar://163962362</a>

Reviewed by Rupin Mittal.

NavigateEvent.sourceElement should be allowed to reference elements from
different browsing contexts (e.g., when an anchor in a parent window targets
an iframe). Since navigate events only fire for same-origin navigations, there
is no security risk in exposing the source element across windows.

This aligns WebKit&apos;s behavior with the HTML specification and matches Chromium&apos;s
implementation after their fix.

Spec:
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-push/replace/reload-navigate-event">https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-push/replace/reload-navigate-event</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html:
imported from <a href="https://github.com/web-platform-tests/wpt/pull/55760">https://github.com/web-platform-tests/wpt/pull/55760</a>

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::dispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/302504@main">https://commits.webkit.org/302504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fe87a5ca81923c4b17c6c33ce7a6d5b3dfddb13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80700 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/624bf43a-a43c-4f09-91a9-87d114aab0af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98480 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66380 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e90b0bca-bfeb-4389-85f8-922ba9994fd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79122 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e3dcc87-97d2-4948-b5d0-df1d0140c391) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33946 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79963 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139158 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107006 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106840 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27201 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1108 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53988 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1426 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64790 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1279 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1348 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->