### PR TITLE
Fix crash in style invalidation when element has no parent during removal

### DIFF
--- a/LayoutTests/fast/dom/Element/nth-child-of-popover-open-crash-expected.txt
+++ b/LayoutTests/fast/dom/Element/nth-child-of-popover-open-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash.
+
+X

--- a/LayoutTests/fast/dom/Element/nth-child-of-popover-open-crash.html
+++ b/LayoutTests/fast/dom/Element/nth-child-of-popover-open-crash.html
@@ -1,0 +1,16 @@
+<p>This test passes if WebKit does not crash.</p>
+<style></style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+document.styleSheets[0].insertRule(`@scope (:nth-last-child(1 of :popover-open)) { i { } }`);
+
+let element = document.createElement('div');
+document.body.append(element);
+
+element.popover = 'auto';
+element.showPopover();
+element.scrollIntoView();
+element.outerText = 'X';
+</script>

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1243,7 +1243,9 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
     if (isInTopLayer())
         removeFromTopLayer();
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::PopoverOpen, false);
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+    if (parentNode())
+        styleInvalidation.emplace(*this, CSSSelector::PseudoClass::PopoverOpen, false);
     popoverData()->setVisibilityState(PopoverVisibilityState::Hidden);
 
     if (fireEvents == FireEvents::Yes)

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -303,10 +303,8 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         break;
     case MatchElement::AnySibling:
         // :nth-last-child(even of .changed)
-        if (CheckedPtr parentNode = element.parentNode()) {
-            for (auto& parentChild : childrenOfType<Element>(*element.parentNode()))
-                invalidateIfNeeded(parentChild, nullptr);
-        }
+        for (auto& parentChild : childrenOfType<Element>(*element.parentNode()))
+            invalidateIfNeeded(parentChild, nullptr);
         break;
     case MatchElement::ParentSibling:
         // .changed ~ .a > .subject


### PR DESCRIPTION
#### 277383f502897a94b43f4302a56e922fdfa1876c
<pre>
Fix crash in style invalidation when element has no parent during removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=301879">https://bugs.webkit.org/show_bug.cgi?id=301879</a>
<a href="https://rdar.apple.com/163025404">rdar://163025404</a>

Reviewed by Antti Koivisto.

This is a fuzzer found bug that results in a crash.
When hidePopoverInternal() is called during element removal (due to outerText being set),
style invalidation runs even when parentNode is null. This is
incorrect. We shouldn&apos;t be entering style invalidation in this case at all.
While the rest of the cleanup in hidePopoverInternal() is necessary, style
invalidation is not here.

As a result, this fix adds a null check to only perform style invalidation
when elements are NOT being removed (aka its parent still exists). Since we
add this check, the existing null check further down in invalidateStyleWithMatchElement()
is redundant and no longer necessary.

There were 2 previous attempted fixes for this: 286644@main and 293967@main.
286644@main had an incorrect Style::InvalidationScope::Descendants. 293967@main didn&apos;t
add null checks to the other relevant cases in invalidateStyleWithMatchElement().
This PR correctly implements the full fix.

Test: fast/dom/Element/nth-child-of-popover-open-crash.html

* LayoutTests/fast/dom/Element/nth-child-of-popover-open-crash-expected.txt: Added.
* LayoutTests/fast/dom/Element/nth-child-of-popover-open-crash.html: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::hidePopoverInternal):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

Canonical link: <a href="https://commits.webkit.org/303507@main">https://commits.webkit.org/303507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb9096a873bc17c03566d6dd92b9584cd91551d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84280 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa90b9e2-5d4b-48a4-971f-7ab98e4bc9c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101162 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68438 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ad55602-9563-4b34-99f1-d13cb4418c55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81952 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e8612f2e-1d1e-456c-8202-c1667e58fda6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3442 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83074 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142500 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4499 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109539 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109717 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3408 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114811 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57775 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4553 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33178 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4385 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68003 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4644 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->