### PR TITLE
[JSC] Collect execution count in Wasm::BaselineData

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -428,7 +428,7 @@ end
 
     restoreWasmArgumentRegisters()
 
-    btpz ws0, .recover
+    btpz ws0, .continue
 
     restoreIPIntRegisters()
     restoreCallerPCAndCFR()
@@ -440,8 +440,6 @@ end
         jmp ws0, WasmEntryPtrTag
     end
 
-.recover:
-    loadp UnboxedWasmCalleeStackSlot[cfr], ws0
 .continue:
     if ARMv7
         break # FIXME: ipint support.
@@ -1238,10 +1236,14 @@ if ARMv7
 else
     ipintPrologueOSR(5)
 end
-    move sp, PL
+    move cfr, a1
+    operationCall(macro() cCall2(_ipint_extern_prepare_function_body) end)
+    move r0, ws0
 
+    move sp, PL
     loadp Wasm::IPIntCallee::m_bytecode[ws0], PC
     loadp Wasm::IPIntCallee::m_metadata + VectorBufferOffset[ws0], MC
+
     # Load memory
     ipintReloadMemory()
 

--- a/Source/JavaScriptCore/wasm/WasmBaselineData.h
+++ b/Source/JavaScriptCore/wasm/WasmBaselineData.h
@@ -48,11 +48,18 @@ public:
         return adoptRef(*new (fastMalloc(allocationSize(callee.numCallProfiles()))) BaselineData(callee.numCallProfiles()));
     }
 
+    uint32_t totalCount() const { return m_totalCount; }
+    void incrementTotalCount() { ++m_totalCount; }
+
+    static constexpr ptrdiff_t offsetOfTotalCount() { return OBJECT_OFFSETOF(BaselineData, m_totalCount); }
+
 private:
     BaselineData(unsigned size)
         : TrailingArrayType(size)
     {
     }
+
+    uint32_t m_totalCount { 0 };
 };
 
 } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -288,11 +288,6 @@ const RegisterAtOffsetList* IPIntCallee::calleeSaveRegistersImpl()
     return &RegisterAtOffsetList::ipintCalleeSaveRegisters();
 }
 
-bool IPIntCallee::needsProfiling() const
-{
-    return numCallProfiles();
-}
-
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 void OptimizingJITCallee::addCodeOrigin(unsigned firstInlineCSI, unsigned lastInlineCSI, const Wasm::ModuleInformation& info, uint32_t functionIndex)
 {

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -446,8 +446,6 @@ public:
     const Vector<FunctionSpaceIndex>& callTargets() const { return m_callTargets; }
     unsigned numCallProfiles() const { return m_callTargets.size(); }
 
-    bool needsProfiling() const;
-
     IPIntTierUpCounter& tierUpCounter() { return m_tierUpCounter; }
     const IPIntTierUpCounter& tierUpCounter() const { return m_tierUpCounter; }
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -165,26 +165,6 @@ RefPtr<JITCallee> CalleeGroup::tryGetReplacementConcurrently(FunctionCodeIndex f
 }
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
-RefPtr<BBQCallee> CalleeGroup::tryGetBBQCallee(FunctionCodeIndex functionIndex)
-{
-    if (m_optimizedCallees.isEmpty())
-        return nullptr;
-
-    // Do not use optimizedCalleesTuple. optimizedCalleesTuple adjusts the result with currently-installing Callee. But we do not want to handle it actually.
-    // We would like to peek the callee when it is stored into m_optimizedCallees without taking a lock.
-    auto* tuple = &m_optimizedCallees[functionIndex];
-
-    Locker bbqLocker { tuple->m_bbqCalleeLock };
-    RefPtr bbqCallee = tuple->m_bbqCallee.get();
-    if (!bbqCallee)
-        return nullptr;
-
-    if (tuple->m_bbqCallee.isStrong())
-        return bbqCallee;
-
-    return nullptr;
-}
-
 RefPtr<BBQCallee> CalleeGroup::tryGetBBQCalleeForLoopOSRConcurrently(VM& vm, FunctionCodeIndex functionIndex)
 {
     if (m_optimizedCallees.isEmpty())

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -135,7 +135,6 @@ public:
 
     RefPtr<JITCallee> tryGetReplacementConcurrently(FunctionCodeIndex functionIndex) const WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 #if ENABLE(WEBASSEMBLY_BBQJIT)
-    RefPtr<BBQCallee> tryGetBBQCallee(FunctionCodeIndex) WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     RefPtr<BBQCallee> tryGetBBQCalleeForLoopOSRConcurrently(VM&, FunctionCodeIndex) WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -930,6 +930,13 @@ WASM_IPINT_EXTERN_CPP_DECL(ref_cast, int32_t heapType, bool allowNull, EncodedJS
     IPINT_RETURN(value);
 }
 
+WASM_IPINT_EXTERN_CPP_DECL(prepare_function_body, CallFrame* callFrame)
+{
+    Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
+    instance->ensureBaselineData(callee->functionIndex()).incrementTotalCount();
+    WASM_RETURN_TWO(callee, nullptr);
+}
+
 /**
  * Given a function index, determine the pointer to its executable code.
  * Return a pair of the wasm instance pointer received as the first argument and the code pointer.

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -124,6 +124,7 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_cast, int32_t, bool, EncodedJSValue);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call);
 
 // We can't use FunctionSpaceIndex here since ARMv7 ABI always passes structs on th stack...
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_function_body, CallFrame*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call, CallFrame*, CallMetadata*, Register* callee);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call_ref, CallFrame*, CallRefMetadata*, IPIntStackEntry*);

--- a/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
@@ -147,7 +147,7 @@ void InliningNode::inlineNode(InliningDecision& decision)
 
             double relativeCallCount = 0;
             if (profile->totalCount())
-                relativeCallCount = callCount / profile->totalCount();
+                relativeCallCount = callCount / static_cast<double>(profile->totalCount());
             size_t wasmSize = decision.m_module.moduleInformation().functionWasmSizeImportSpace(candidateCallee->index());
             auto& child = decision.m_arena.alloc(target, this, callSite.size(), index, wasmSize, relativeCallCount);
             callSite.append(&child);

--- a/Source/JavaScriptCore/wasm/WasmMergedProfile.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMergedProfile.cpp
@@ -37,9 +37,8 @@ namespace JSC::Wasm {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MergedProfile);
 
-MergedProfile::MergedProfile(const IPIntCallee& callee, double totalCount)
+MergedProfile::MergedProfile(const IPIntCallee& callee)
     : m_callSites(callee.numCallProfiles())
-    , m_totalCount(totalCount)
 {
 }
 
@@ -132,6 +131,7 @@ auto MergedProfile::Candidates::finalize() const -> Candidates
 
 void MergedProfile::merge(const Module& module, const IPIntCallee& callee, BaselineData& data)
 {
+    m_totalCount += data.totalCount();
     m_merged = true;
     auto span = m_callSites.mutableSpan();
     RELEASE_ASSERT(data.size() == span.size());

--- a/Source/JavaScriptCore/wasm/WasmMergedProfile.h
+++ b/Source/JavaScriptCore/wasm/WasmMergedProfile.h
@@ -69,7 +69,7 @@ public:
         std::array<std::tuple<Callee*, uint32_t>, CallProfile::maxPolymorphicCallees> m_callees { };
     };
 
-    MergedProfile(const IPIntCallee&, double totalCount);
+    MergedProfile(const IPIntCallee&);
     unsigned size() const { return m_callSites.size(); }
     bool isCalled(size_t index) const { return m_callSites[index].isCalled(); }
     Candidates candidates(size_t index) const { return m_callSites[index].finalize(); }
@@ -77,11 +77,11 @@ public:
 
     void merge(const Module&, const IPIntCallee&, BaselineData&);
     bool merged() const { return m_merged; }
-    double totalCount() const { return m_totalCount; }
+    uint32_t totalCount() const { return m_totalCount; }
 
 private:
     Vector<Candidates> m_callSites;
-    double m_totalCount { 0 };
+    uint32_t m_totalCount { 0 };
     bool m_merged { false };
 };
 

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -150,17 +150,7 @@ Ref<Wasm::InstanceAnchor> Module::registerAnchor(JSWebAssemblyInstance* instance
 
 std::unique_ptr<MergedProfile> Module::createMergedProfile(const IPIntCallee& callee)
 {
-    double totalCount = callee.tierUpCounter().count();
-#if ENABLE(WEBASSEMBLY_BBQJIT)
-    for (unsigned i = 0; i < numberOfMemoryModes; ++i) {
-        if (RefPtr group = m_calleeGroups[i]) {
-            if (RefPtr bbq = group->tryGetBBQCallee(callee.functionIndex()))
-                totalCount += bbq->tierUpCounter().count();
-        }
-    }
-#endif
-
-    auto result = makeUnique<MergedProfile>(callee, totalCount);
+    auto result = makeUnique<MergedProfile>(callee);
     for (Ref anchor : m_anchors) {
         RefPtr<BaselineData> data;
         {


### PR DESCRIPTION
#### 483814a0b640f2817d12c0806d131d597e9daef3
<pre>
[JSC] Collect execution count in Wasm::BaselineData
<a href="https://bugs.webkit.org/show_bug.cgi?id=301886">https://bugs.webkit.org/show_bug.cgi?id=301886</a>
<a href="https://rdar.apple.com/163966362">rdar://163966362</a>

Reviewed by Yijia Huang.

We were using Callee&apos;s execution counter to collect total execution
count of the function in the inlining decision. But this is too fragile
and unstable as BBQCallee can go away. And we found some cases these
data is missing since OMG for that callee is already compiled and
installed. Let&apos;s collect it in Wasm::BaselineData, this is much more
consistent since the other CallProfile data is also obtained from
Wasm::BaselineData.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIncrementCallProfileCount):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoopOSREntrypoint):
* Source/JavaScriptCore/wasm/WasmBaselineData.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::needsProfiling const): Deleted.
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::tryGetBBQCallee): Deleted.
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Source/JavaScriptCore/wasm/WasmInliningDecision.cpp:
(JSC::Wasm::InliningNode::inlineNode):
* Source/JavaScriptCore/wasm/WasmMergedProfile.cpp:
(JSC::Wasm::MergedProfile::MergedProfile):
(JSC::Wasm::MergedProfile::merge):
* Source/JavaScriptCore/wasm/WasmMergedProfile.h:
(JSC::Wasm::MergedProfile::totalCount const):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::createMergedProfile):

Canonical link: <a href="https://commits.webkit.org/302505@main">https://commits.webkit.org/302505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62f4d6ade431e2747f9730d0b9f7bacb3ed12bcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80711 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/06fab621-43f3-422d-9316-bbe8ad7e9c46) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98489 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc2bf6ca-d8a4-4c17-864f-30b04f809ee9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132265 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79131 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9d8c41e-441e-4b9b-ba41-e89478bd079a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33956 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79972 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121310 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139167 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127770 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107015 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106859 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30692 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54000 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20186 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1435 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64799 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160784 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1253 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40119 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1288 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1357 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->