### PR TITLE
Remove checked scrollbar getters on ScrollerPairMac

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -96,11 +96,7 @@ public:
 
     // Only for use by WebScrollerImpPairDelegateMac. Do not use elsewhere!
     ScrollerMac& verticalScroller() { return m_verticalScroller.get(); }
-    CheckedRef<ScrollerMac> checkedVerticalScroller()  { return m_verticalScroller.get(); }
-    CheckedRef<const ScrollerMac> checkedVerticalScroller() const { return m_verticalScroller.get(); }
     ScrollerMac& horizontalScroller() { return m_horizontalScroller.get(); }
-    CheckedRef<ScrollerMac> checkedHorizontalScroller() { return m_horizontalScroller.get(); }
-    CheckedRef<const ScrollerMac> checkedHorizontalScroller() const { return m_horizontalScroller.get(); }
 
     String scrollbarStateForOrientation(ScrollbarOrientation) const;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -154,8 +154,8 @@ void ScrollerPairMac::init()
     m_scrollbarStyle = WebCore::scrollbarStyle(style);
     [m_scrollerImpPair setScrollerStyle:style];
 
-    checkedVerticalScroller()->attach();
-    checkedHorizontalScroller()->attach();
+    m_verticalScroller->attach();
+    m_horizontalScroller->attach();
 }
 
 ScrollerPairMac::~ScrollerPairMac()
@@ -163,10 +163,10 @@ ScrollerPairMac::~ScrollerPairMac()
     [m_scrollerImpPairDelegate invalidate];
     [m_scrollerImpPair setDelegate:nil];
 
-    checkedVerticalScroller()->detach();
-    checkedHorizontalScroller()->detach();
+    m_verticalScroller->detach();
+    m_horizontalScroller->detach();
 
-    ensureOnMainThread([scrollerImpPair = std::exchange(m_scrollerImpPair, nil), verticalScrollerImp = checkedVerticalScroller()->takeScrollerImp(), horizontalScrollerImp = checkedHorizontalScroller()->takeScrollerImp()] {
+    ensureOnMainThread([scrollerImpPair = std::exchange(m_scrollerImpPair, nil), verticalScrollerImp = m_verticalScroller->takeScrollerImp(), horizontalScrollerImp = m_horizontalScroller->takeScrollerImp()] {
     });
 }
 
@@ -265,8 +265,8 @@ void ScrollerPairMac::updateValues()
         m_lastScrollOffset = offset;
     }
 
-    checkedHorizontalScroller()->updateValues();
-    checkedVerticalScroller()->updateValues();
+    m_horizontalScroller->updateValues();
+    m_verticalScroller->updateValues();
 }
 
 FloatSize ScrollerPairMac::visibleSize() const
@@ -318,7 +318,7 @@ ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollbarOrientati
 
 bool ScrollerPairMac::hasScrollerImp()
 {
-    return checkedVerticalScroller()->hasScrollerImp() || checkedHorizontalScroller()->hasScrollerImp();
+    return m_verticalScroller->hasScrollerImp() || m_horizontalScroller->hasScrollerImp();
 }
 
 void ScrollerPairMac::releaseReferencesToScrollerImpsOnTheMainThread()
@@ -326,14 +326,14 @@ void ScrollerPairMac::releaseReferencesToScrollerImpsOnTheMainThread()
     if (hasScrollerImp()) {
         // FIXME: This is a workaround in place for the time being since NSScrollerImps cannot be deallocated
         // on a non-main thread. rdar://problem/24535055
-        WTF::callOnMainThread([verticalScrollerImp = checkedVerticalScroller()->takeScrollerImp(), horizontalScrollerImp = checkedHorizontalScroller()->takeScrollerImp()] {
+        WTF::callOnMainThread([verticalScrollerImp = m_verticalScroller->takeScrollerImp(), horizontalScrollerImp = m_horizontalScroller->takeScrollerImp()] {
         });
     }
 }
 
 String ScrollerPairMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
 {
-    return orientation == ScrollbarOrientation::Vertical ? checkedVerticalScroller()->scrollbarState() : checkedHorizontalScroller()->scrollbarState();
+    return orientation == ScrollbarOrientation::Vertical ? m_verticalScroller->scrollbarState() : m_horizontalScroller->scrollbarState();
 }
 
 void ScrollerPairMac::setVerticalScrollerImp(NSScrollerImp *scrollerImp)
@@ -411,16 +411,16 @@ void ScrollerPairMac::mouseIsInScrollbar(ScrollbarHoverState hoverState)
 {
     if (m_scrollbarHoverState.mouseIsOverVerticalScrollbar != hoverState.mouseIsOverVerticalScrollbar) {
         if (hoverState.mouseIsOverVerticalScrollbar)
-            checkedVerticalScroller()->mouseEnteredScrollbar();
+            m_verticalScroller->mouseEnteredScrollbar();
         else
-            checkedVerticalScroller()->mouseExitedScrollbar();
+            m_verticalScroller->mouseExitedScrollbar();
     }
 
     if (m_scrollbarHoverState.mouseIsOverHorizontalScrollbar != hoverState.mouseIsOverHorizontalScrollbar) {
         if (hoverState.mouseIsOverHorizontalScrollbar)
-            checkedHorizontalScroller()->mouseEnteredScrollbar();
+            m_horizontalScroller->mouseEnteredScrollbar();
         else
-            checkedHorizontalScroller()->mouseExitedScrollbar();
+            m_horizontalScroller->mouseExitedScrollbar();
     }
     m_scrollbarHoverState = hoverState;
 }
@@ -431,8 +431,8 @@ void ScrollerPairMac::setUseDarkAppearance(bool useDarkAppearance)
         return;
     m_useDarkAppearance = useDarkAppearance;
 
-    checkedHorizontalScroller()->setNeedsDisplay();
-    checkedVerticalScroller()->setNeedsDisplay();
+    m_horizontalScroller->setNeedsDisplay();
+    m_verticalScroller->setNeedsDisplay();
 }
 
 void ScrollerPairMac::setScrollbarWidth(ScrollbarWidth scrollbarWidth)
@@ -441,14 +441,14 @@ void ScrollerPairMac::setScrollbarWidth(ScrollbarWidth scrollbarWidth)
         return;
     m_scrollbarWidth = scrollbarWidth;
 
-    checkedHorizontalScroller()->updateScrollbarStyle();
-    checkedVerticalScroller()->updateScrollbarStyle();
+    m_horizontalScroller->updateScrollbarStyle();
+    m_verticalScroller->updateScrollbarStyle();
 }
 
 void ScrollerPairMac::scrollbarColorChanged(const std::optional<ScrollbarColor>& scrollbarColor)
 {
-    checkedHorizontalScroller()->scrollbarColorChanged(scrollbarColor);
-    checkedVerticalScroller()->scrollbarColorChanged(scrollbarColor);
+    m_horizontalScroller->scrollbarColorChanged(scrollbarColor);
+    m_verticalScroller->scrollbarColorChanged(scrollbarColor);
 }
 
 void ScrollerPairMac::updateScrollbarPainters()


### PR DESCRIPTION
#### 22adb02ed37cadc140b69d17d2f83424c148992d
<pre>
Remove checked scrollbar getters on ScrollerPairMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=301887">https://bugs.webkit.org/show_bug.cgi?id=301887</a>

Reviewed by Geoffrey Garen.

Remove checkedVerticalScroller and checkedHorizontalScroller from ScrollerPairMac after 302500@main.

No new tests since there should be no behavioral differences.

* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::verticalScroller):
(WebCore::ScrollerPairMac::horizontalScroller):
(WebCore::ScrollerPairMac::checkedVerticalScroller): Deleted.
(WebCore::ScrollerPairMac::checkedVerticalScroller const): Deleted.
(WebCore::ScrollerPairMac::checkedHorizontalScroller): Deleted.
(WebCore::ScrollerPairMac::checkedHorizontalScroller const): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::init):
(WebCore::ScrollerPairMac::~ScrollerPairMac):
(WebCore::ScrollerPairMac::updateValues):
(WebCore::ScrollerPairMac::hasScrollerImp):
(WebCore::ScrollerPairMac::releaseReferencesToScrollerImpsOnTheMainThread):
(WebCore::ScrollerPairMac::scrollbarStateForOrientation const):
(WebCore::ScrollerPairMac::mouseIsInScrollbar):
(WebCore::ScrollerPairMac::setUseDarkAppearance):
(WebCore::ScrollerPairMac::setScrollbarWidth):
(WebCore::ScrollerPairMac::scrollbarColorChanged):

Canonical link: <a href="https://commits.webkit.org/302515@main">https://commits.webkit.org/302515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eb97581b1a21b31a42e7439ee931a46cf6dc065

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80727 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/97ac10da-2f77-4e0d-8375-15a2c9d230ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98488 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66396 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e3602d7f-e4e9-4b92-9cea-400059acde03) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79129 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/935efe20-c40f-4b41-8d22-40a46d3dab99) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33955 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79975 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139170 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107013 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106847 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54004 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20188 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1439 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64802 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1256 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1292 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->