### PR TITLE
REGRESSION (300057@main): Content scripts are injected on the wrong pages.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1365,7 +1365,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
 
             auto scriptString = scriptStringResult.value();
 
-            Ref userScript = API::UserScript::create(WebCore::UserScript { WTFMove(scriptString), URL { m_baseURL, scriptPath }, WTFMove(includeMatchPatterns), WTFMove(excludeMatchPatterns), injectionTime, injectedFrames, matchParentFrame }, executionWorld);
+            Ref userScript = API::UserScript::create(WebCore::UserScript { WTFMove(scriptString), URL { m_baseURL, scriptPath }, Vector { includeMatchPatterns }, Vector { excludeMatchPatterns }, injectionTime, injectedFrames, matchParentFrame }, executionWorld);
             originInjectedScripts.append(userScript);
 
             for (Ref userContentController : userContentControllers)
@@ -1388,11 +1388,9 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
                 continue;
             }
 
-            auto styleSheetString = styleSheetStringResult.value();
+            auto styleSheetString = localizedResourceString(styleSheetStringResult.value(), "text/css"_s);
 
-            styleSheetString = localizedResourceString(styleSheetString, "text/css"_s);
-
-            Ref userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { WTFMove(styleSheetString), URL { m_baseURL, styleSheetPath }, WTFMove(includeMatchPatterns), WTFMove(excludeMatchPatterns), injectedFrames, matchParentFrame, styleLevel, std::nullopt }, executionWorld);
+            Ref userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { WTFMove(styleSheetString), URL { m_baseURL, styleSheetPath }, Vector { includeMatchPatterns }, Vector { excludeMatchPatterns }, injectedFrames, matchParentFrame, styleLevel, std::nullopt }, executionWorld);
             originInjectedStyleSheets.append(userStyleSheet);
 
             for (Ref userContentController : userContentControllers)
@@ -1559,6 +1557,7 @@ bool WebExtensionContext::purgeMatchedRulesFromBefore(const WallTime& startTime)
     }
 
     m_matchedRules = WTFMove(filteredMatchedRules);
+
     return !m_matchedRules.isEmpty();
 }
 


### PR DESCRIPTION
#### f86f0d4ad055cbbee47ff46eddfd0d7a3ee95154
<pre>
REGRESSION (300057@main): Content scripts are injected on the wrong pages.
<a href="https://webkit.org/b/301890">https://webkit.org/b/301890</a>
<a href="https://rdar.apple.com/162073778">rdar://162073778</a>

Reviewed by Brian Weinstein.

When an extension declares multiple content scripts with match patterns, only the first
script correctly respects the match patterns. Subsequent scripts in the list ignore the
patterns and inject on all pages, and stylesheets fail to inject at all.

The bug was introduced when converting from ObjC++ to C++ in 300057@main. The original
code used `makeVector&lt;String&gt;(array)` to create a new `Vector` from an `NSArray` on each
loop iteration. The converted code incorrectly used `WTFMove(includeMatchPatterns)` and
`WTFMove(excludeMatchPatterns)`, which moved the pattern vectors on the first iteration,
leaving them empty for all subsequent iterations.

With empty match patterns, WebCore&apos;s content script matching logic treats the patterns as
matching all pages, causing scripts to inject globally instead of on their intended targets.

The fix changes `WTFMove(patterns)` to `Vector { patterns }`, which creates a copy of the
pattern vectors for each script and stylesheet, matching the original behavior.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::addInjectedContent): Copy vectors instead of moving in the loop.
(WebKit::WebExtensionContext::purgeMatchedRulesFromBefore): Add a newline.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, MultipleContentScriptsInjectedWhenMatched)): Added.
(TestWebKitAPI::TEST(WKWebExtension, MultipleContentScriptsNotInjectedWhenNotMatched)): Added.

Canonical link: <a href="https://commits.webkit.org/302546@main">https://commits.webkit.org/302546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b5825665a94a06402d0f17be0d6bc122325eb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80737 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f644661a-46a0-4eab-864a-863ebe4ecb94) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98505 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66402 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cebac5df-0963-486d-a09f-97d8e4c359d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79155 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1c37bac-a485-4303-b400-c7b3cb1b5603) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33975 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79994 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139190 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106874 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54023 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20200 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64821 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1275 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1311 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->