### PR TITLE
[AutoFill Debugging] Add a way for text extraction clients to include additional node attributes

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -73,6 +73,7 @@ enum class EventListenerCategory : uint8_t {
 };
 
 struct Request {
+    HashMap<String, HashMap<JSHandleIdentifier, String>> clientNodeAttributes;
     std::optional<FloatRect> collectionRectInRootView;
     std::optional<JSHandleIdentifier> targetNodeHandleIdentifier;
     bool mergeParagraphs { false };
@@ -153,6 +154,7 @@ struct Item {
     OptionSet<EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;
+    HashMap<String, String> clientAttributes;
 };
 
 } // namespace TextExtraction

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -176,6 +176,13 @@ static Vector<String> eventListenerTypesToStringArray(OptionSet<TextExtraction::
     return result;
 }
 
+template<typename T> static Vector<String> sortedKeys(const HashMap<String, T>& dictionary)
+{
+    auto keys = copyToVector(dictionary.keys());
+    std::ranges::sort(keys, codePointCompareLessThan);
+    return keys;
+}
+
 static Vector<String> partsForItem(const TextExtraction::Item& item, const TextExtractionAggregator& aggregator)
 {
     Vector<String> parts;
@@ -198,11 +205,11 @@ static Vector<String> partsForItem(const TextExtraction::Item& item, const TextE
     if (!listeners.isEmpty())
         parts.append(makeString("events=["_s, commaSeparatedString(listeners), ']'));
 
-    auto attributeKeys = copyToVector(item.ariaAttributes.keys());
-    std::ranges::sort(attributeKeys, codePointCompareLessThan);
-
-    for (auto& key : attributeKeys)
+    for (auto& key : sortedKeys(item.ariaAttributes))
         parts.append(makeString(key, "='"_s, escapeString(item.ariaAttributes.get(key)), '\''));
+
+    for (auto& key : sortedKeys(item.clientAttributes))
+        parts.append(makeString(key, "='"_s, item.clientAttributes.get(key), '\''));
 
     return parts;
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6732,6 +6732,7 @@ header: <WebCore/TextExtractionTypes.h>
 
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Request {
+    HashMap<String, HashMap<WebCore::JSHandleIdentifier, String>> clientNodeAttributes;
     std::optional<WebCore::FloatRect> collectionRectInRootView;
     std::optional<WebCore::JSHandleIdentifier> targetNodeHandleIdentifier;
     bool mergeParagraphs;
@@ -6829,6 +6830,7 @@ header: <WebCore/TextExtractionTypes.h>
     OptionSet<WebCore::TextExtraction::EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;
+    HashMap<String, String> clientAttributes;
 };
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -84,6 +84,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  */
 @property (nonatomic, copy, nullable) _WKJSHandle *targetNode;
 
+/*!
+ Client-specified attributes and values to add when extracting DOM nodes.
+ Will appear as "attribute=value" in text extraction output.
+ */
+- (void)addClientAttribute:(NSString *)attributeName value:(NSString *)attributeValue forNode:(_WKJSHandle *)node;
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -27,6 +27,8 @@
 
 #import <WebKit/_WKTextExtraction.h>
 
+@class _WKJSHandle;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKTextExtractionConfiguration ()
@@ -48,6 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
  Defaults to `YES`.
  */
 @property (nonatomic) BOOL shouldFilterText;
+
+/*!
+ Iterates over all custom node attributes added via -addClientAttribute:value:forNode:.
+ */
+- (void)forEachClientNodeAttribute:(void(^)(NSString *attribute, NSString *value, _WKJSHandle *))block;
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -809,7 +809,7 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
 
 - (_WKJSHandle *)querySelector:(NSString *)selector frame:(WKFrameInfo *)frame world:(WKContentWorld *)world
 {
-    RetainPtr script = [NSString stringWithFormat:@"window.webkit.createJSHandle(document.querySelector('%@'))", selector];
+    RetainPtr script = [NSString stringWithFormat:@"window.webkit.createJSHandle(document.querySelector(`%@`))", selector];
     return dynamic_objc_cast<_WKJSHandle>([self objectByEvaluatingJavaScript:script.get() inFrame:frame inContentWorld:world]);
 }
 


### PR DESCRIPTION
#### 4bdaf7c934c05858d156f56ccd622a734986e9a5
<pre>
[AutoFill Debugging] Add a way for text extraction clients to include additional node attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=301895">https://bugs.webkit.org/show_bug.cgi?id=301895</a>
<a href="https://rdar.apple.com/163978127">rdar://163978127</a>

Reviewed by Abrar Rahman Protyasha.

Add support for new method on the text extraction configuration:

&gt; `-addClientAttribute:value:forNode:`

...which allows clients to append additional attributes for a given node (identified by JS handle).
These attributes are appended to the text extraction output as long as the given node is traversed
during the extraction process.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::nodeFromJSHandle):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::sortedKeys):
(WebKit::partsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(extractClientNodeAttributes):
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration addClientAttribute:value:forNode:]):

Maintain nested hashmaps of `[attribute_name : [node_id : attribute_value]]`, which are then
converted into nested hashmaps of `[node : [attribute_name : attribute_value]]` in the web process
during traversal (for fast lookup per element).

(-[_WKTextExtractionConfiguration forEachClientNodeAttribute:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, TargetNodeAndClientAttributes)):
(TestWebKitAPI::TEST(TextExtractionTests, TargetNode)): Deleted.
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView querySelector:frame:world:]):

Drive-by fix: use backticks (`) to wrap the query selector string, so that callers can use double or
single quotes without having to escape those characters.

Canonical link: <a href="https://commits.webkit.org/302519@main">https://commits.webkit.org/302519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce5548863e0c2a299b4eda896d057175a141e03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80747 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ffe9d94e-0e1d-472b-b16d-b06b966858f2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98510 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66408 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/75439e68-5cbe-468b-a516-2135bcef2a74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79160 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/79f95c9b-10ee-4bac-bc22-2c93d824f091) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33980 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80003 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139199 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1350 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107036 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54036 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64830 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1284 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1320 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->