### PR TITLE
Make it possible to track multiple pending frames in RemoteLayerTreeDrawingAreaProxy.

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -298,4 +298,5 @@ struct WebKit::RemoteLayerTreeCommitBundle {
     Vector<WebKit::RemoteLayerTreeCommitBundle::RootFrameData> transactions;
     WebKit::PageData pageData;
     std::optional<WebKit::MainFrameData> mainFrameData;
+    MonotonicTime startTime;
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -64,6 +64,7 @@ struct RemoteLayerTreeCommitBundle {
     Vector<RootFrameData> transactions;
     PageData pageData;
     std::optional<MainFrameData> mainFrameData;
+    MonotonicTime startTime;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -211,7 +211,7 @@ void DrawingAreaProxyCoordinatedGraphics::commitTransientZoom(double scale, Floa
 void DrawingAreaProxyCoordinatedGraphics::update(uint64_t, UpdateInfo&& updateInfo)
 {
     if (m_isWaitingForDidUpdateGeometry && updateInfo.viewSize != m_lastSentSize) {
-        send(Messages::DrawingArea::DisplayDidRefresh());
+        send(Messages::DrawingArea::DisplayDidRefresh(MonotonicTime::now()));
         return;
     }
 
@@ -222,7 +222,7 @@ void DrawingAreaProxyCoordinatedGraphics::update(uint64_t, UpdateInfo&& updateIn
 #endif
 
     if (!m_isWaitingForDidUpdateGeometry)
-        send(Messages::DrawingArea::DisplayDidRefresh());
+        send(Messages::DrawingArea::DisplayDidRefresh(MonotonicTime::now()));
 }
 
 void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(uint64_t, const LayerTreeContext& layerTreeContext)

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -79,7 +79,7 @@ void DrawingAreaProxyWC::update(uint64_t backingStoreStateID, UpdateInfo&& updat
 {
     if (backingStoreStateID == m_currentBackingStoreStateID)
         incorporateUpdate(WTFMove(updateInfo));
-    send(Messages::DrawingArea::DisplayDidRefresh());
+    send(Messages::DrawingArea::DisplayDidRefresh(MonotonicTime::now()));
 }
 
 void DrawingAreaProxyWC::enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -384,7 +384,7 @@ void DrawingAreaCoordinatedGraphics::updateGeometry(const IntSize& size, Complet
     completionHandler();
 }
 
-void DrawingAreaCoordinatedGraphics::displayDidRefresh()
+void DrawingAreaCoordinatedGraphics::displayDidRefresh(MonotonicTime)
 {
     // We might get didUpdate messages from the UI process even after we've
     // entered accelerated compositing mode. Ignore them.

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -92,7 +92,7 @@ private:
 
     // IPC message handlers.
     void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) override;
-    void displayDidRefresh() override;
+    void displayDidRefresh(MonotonicTime) override;
     void setDeviceScaleFactor(float, CompletionHandler<void()>&&) override;
     void forceUpdate() override;
     void didDiscardBackingStore() override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -233,7 +233,7 @@ private:
 #endif
 
     virtual void setDeviceScaleFactor(float, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
-    virtual void displayDidRefresh() { }
+    virtual void displayDidRefresh(MonotonicTime) { }
 
     // DisplayRefreshMonitorFactory.
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -32,7 +32,7 @@ messages -> DrawingArea {
 #endif
 
     SetDeviceScaleFactor(float deviceScaleFactor) -> ()
-    DisplayDidRefresh()
+    DisplayDidRefresh(MonotonicTime start)
 
 #if PLATFORM(COCOA)
     UpdateGeometry(WebCore::IntSize viewSize, bool flushSynchronously, MachSendRight fencePort) -> ()

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -414,7 +414,7 @@ RefPtr<ImageBuffer> DrawingAreaWC::createImageBuffer(FloatSize size, float devic
     return ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, deviceScaleFactor, DestinationColorSpace::SRGB(), { PixelFormat::BGRA8 }, RenderingPurpose::DOM, { });
 }
 
-void DrawingAreaWC::displayDidRefresh()
+void DrawingAreaWC::displayDidRefresh(MonotonicTime)
 {
     m_waitDidUpdate = false;
     didCompleteRenderingUpdateDisplay();

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -69,7 +69,7 @@ private:
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;
     void updatePreferences(const WebPreferencesStore&) override;
     bool shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView&) const override;
-    void displayDidRefresh() override;
+    void displayDidRefresh(MonotonicTime = MonotonicTime::now()) override;
     // GraphicsLayerWC::Observer
     void graphicsLayerAdded(GraphicsLayerWC&) override;
     void graphicsLayerRemoved(GraphicsLayerWC&) override;


### PR DESCRIPTION
#### 6dea3f8189126887699003d8aafa706c8d1e0c4e
<pre>
Make it possible to track multiple pending frames in RemoteLayerTreeDrawingAreaProxy.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301898">https://bugs.webkit.org/show_bug.cgi?id=301898</a>
&lt;<a href="https://rdar.apple.com/problem/163978742">rdar://problem/163978742</a>&gt;

Reviewed by Gerald Squelart.

Converts commitLayerTreeMessageState to be a Variant so that data that is specific to one state are restricted to that (like receivedCommitLayerTreePendingConfirmation).

Converts the receivedCommitLayerTreePendingConfirmation bool to two integers, counting the number of pending NotifyPendingCommitLayerTree and CommitLayerTree calls.

Folds the MissedCommit state into a subset flag of the CommitLayerTreePending state.

When receiving a notifyPendingCommitLayerTree message while Idle, move into the CommitLayerTreePending state. This simplifies the logic in waitForDidUpdateActivityState.

Round-trip the transaction startTime via the WebProcess, rather than storing it on the UI-process side.

There should be no behavior changes at this point.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::update):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::nextMainFrameLayerTreeTransactionID const): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxy::lastCommittedMainFrameLayerTreeTransactionID const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::nextMainFrameLayerTreeTransactionID const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::lastCommittedMainFrameLayerTreeTransactionID const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks):
(WebKit::operator&lt;&lt;):
(WebKit::RemoteLayerTreeDrawingAreaProxy::ProcessState::canSendDisplayDidRefresh):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp:
(WebKit::DrawingAreaProxyWC::update):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::displayDidRefresh):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::displayDidRefresh):
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::BackingStoreFlusher::hasPendingFlush const):
(WebKit::RemoteLayerTreeDrawingArea::BackingStoreFlusher::markHasPendingFlush):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
(WebKit::RemoteLayerTreeDrawingArea::BackingStoreFlusher::flush):
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::displayDidRefresh):
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:

Canonical link: <a href="https://commits.webkit.org/302734@main">https://commits.webkit.org/302734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13e4588fc862b530ed231a87219755f7c1b7d733

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81397 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/23bac7c7-9fc4-47e5-852a-f0653915952b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66766 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e3520864-79ba-47da-a110-07d2d17215d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79648 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c1b11ed9-a84b-40f8-a460-5d8850e6d2d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1539 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80571 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139782 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107463 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107349 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27353 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31166 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54765 "Hash 13e4588f for PR 53368 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65405 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1850 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1959 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->