### PR TITLE
[WPE] fatal error: wpe/WPEEnumTypes.h: No such file or directory

### DIFF
--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -103,13 +103,12 @@ set(WPEPlatform_PRIVATE_INCLUDE_DIRECTORIES
     "${WPEPlatform_DERIVED_SOURCES_DIR}/wpe"
     "${WEBKIT_DIR}/WPEPlatform"
     "${WEBKIT_DIR}/WPEPlatform/wpe"
-    "${WTF_FRAMEWORK_HEADERS_DIR}"
 )
 
 set(WPEPlatform_LIBRARIES
     Epoxy::Epoxy
     GLib::Gio
-    WTF
+    WebKit::WTF
     ${LIBXKBCOMMON_LIBRARIES}
 )
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -52,6 +52,7 @@ target_compile_options(WPEPlatformDRM PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatformDRM PRIVATE ${WPEPlatformDRM_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformDRM SYSTEM PRIVATE ${WPEPlatformDRM_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformDRM ${WPEPlatform_LIBRARIES} ${WPEPlatformDRM_LIBRARIES})
+add_dependencies(WPEPlatformDRM WPEPlatformGeneratedEnumTypesHeader)
 
 set_target_properties(WPEPlatformDRM PROPERTIES
     SOURCES_FOR_INTROSPECTION "${WPEPlatformDRM_SOURCES_FOR_INTROSPECTION}"

--- a/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_options(WPEPlatformHeadless PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatformHeadless PRIVATE ${WPEPlatformHeadless_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformHeadless SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformHeadless ${WPEPlatform_LIBRARIES})
+add_dependencies(WPEPlatformHeadless WPEPlatformGeneratedEnumTypesHeader)
 
 set_target_properties(WPEPlatformHeadless PROPERTIES
     SOURCES_FOR_INTROSPECTION "${WPEPlatformHeadless_SOURCES_FOR_INTROSPECTION}"

--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -203,6 +203,7 @@ target_compile_definitions(WPEPlatformWayland PRIVATE ${WPEPlatformWayland_DEFIN
 target_include_directories(WPEPlatformWayland PRIVATE ${WPEPlatformWayland_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformWayland SYSTEM PRIVATE ${WPEPlatformWayland_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformWayland ${WPEPlatformWayland_LIBRARIES})
+add_dependencies(WPEPlatformWayland WPEPlatformGeneratedEnumTypesHeader)
 
 set_target_properties(WPEPlatformWayland PROPERTIES
     SOURCES_FOR_INTROSPECTION "${WPEPlatformWayland_SOURCES_FOR_INTROSPECTION}"


### PR DESCRIPTION
#### fc4bb3101b4b48688597418b5ec17952c7841f44
<pre>
[WPE] fatal error: wpe/WPEEnumTypes.h: No such file or directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=301901">https://bugs.webkit.org/show_bug.cgi?id=301901</a>

Reviewed by Adrian Perez de Castro.

WPEEnumTypes.h wasn&apos;t generated when WPEPlatform backends were built. Added a
dependency of WPEPlatformGeneratedEnumTypesHeader to WPEPlatformDRM,
WPEPlatformHeadless and WPEPlatformWayland targets.

Added WebKit::WTF to WPEPlatform_LIBRARIES instead of WTF. WTF headers have to
be copied before building WPEPlatform.

* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/302525@main">https://commits.webkit.org/302525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ce3ed9261045d66789cb64551e22f6c07eead0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136767 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1523 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132337 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79193 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80044 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139241 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1385 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106912 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/1169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30757 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54095 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20194 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64871 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->