### PR TITLE
Adopt C++20 Concepts in JavaScriptCore/assembler

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -4305,10 +4305,8 @@ private:
     };
 
     struct Imm {
-        template<typename T>
-        using EnableIfInteger = std::enable_if_t<(std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t>)>;
-
-        template<typename ImmediateType, typename T, typename = EnableIfInteger<T>>
+        template<typename ImmediateType, typename T>
+            requires (std::same_as<T, int32_t> || std::same_as<T, int64_t>)
         static bool isValid(T value) { return ImmediateType::isValid(value); }
 
         using IType = RISCV64Assembler::IImmediate;
@@ -4489,14 +4487,14 @@ private:
     Jump branchForArithmeticOverflow(RegisterID op1, Op2Type op2, RegisterID dest)
     {
         static_assert(bitSize == 32 || bitSize == 64);
-        static_assert(std::is_same_v<Op2Type, RegisterID> || std::is_same_v<Op2Type, TrustedImm32>);
+        static_assert(std::same_as<Op2Type, RegisterID> || std::same_as<Op2Type, TrustedImm32>);
         auto temp = temps<Data, Memory>();
 
         if constexpr (bitSize == 32) {
             RELEASE_ASSERT(op1 == temp.data() || op1 != temp.memory());
             m_assembler.signExtend<32>(temp.data(), op1);
 
-            if constexpr (!std::is_same_v<Op2Type, TrustedImm32>) {
+            if constexpr (!std::same_as<Op2Type, TrustedImm32>) {
                 RELEASE_ASSERT(op2 == temp.memory() || op1 != temp.data());
                 m_assembler.signExtend<32>(temp.memory(), op2);
             } else
@@ -4533,7 +4531,7 @@ private:
         RELEASE_ASSERT(dest != temp.data() && dest != temp.memory());
 
         RegisterID rop2;
-        if constexpr (std::is_same_v<Op2Type, TrustedImm32>) {
+        if constexpr (std::same_as<Op2Type, TrustedImm32>) {
             loadImmediate(op2, temp.memory());
             rop2 = temp.memory();
         } else {

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2914,7 +2914,7 @@ public:
     template<typename LeftType, typename RightType>
     void moveDoubleConditionally32(RelationalCondition cond, LeftType left, RightType right, FPRegisterID thenCase, FPRegisterID elseCase, FPRegisterID dest)
     {
-        static_assert(!std::is_same<LeftType, FPRegisterID>::value && !std::is_same<RightType, FPRegisterID>::value, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
+        static_assert(!std::same_as<LeftType, FPRegisterID> && !std::same_as<RightType, FPRegisterID>, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
 
         if (thenCase != dest && elseCase != dest) {
             moveDouble(elseCase, dest);
@@ -2935,7 +2935,7 @@ public:
     template<typename TestType, typename MaskType>
     void moveDoubleConditionallyTest32(ResultCondition cond, TestType test, MaskType mask, FPRegisterID thenCase, FPRegisterID elseCase, FPRegisterID dest)
     {
-        static_assert(!std::is_same<TestType, FPRegisterID>::value && !std::is_same<MaskType, FPRegisterID>::value, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
+        static_assert(!std::same_as<TestType, FPRegisterID> && !std::same_as<MaskType, FPRegisterID>, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
 
         if (elseCase == dest && isInvertible(cond)) {
             Jump falseCase = branchTest32(invert(cond), test, mask);
@@ -6599,7 +6599,7 @@ public:
     template<typename LeftType, typename RightType>
     void moveDoubleConditionally64(RelationalCondition cond, LeftType left, RightType right, FPRegisterID thenCase, FPRegisterID elseCase, FPRegisterID dest)
     {
-        static_assert(!std::is_same<LeftType, FPRegisterID>::value && !std::is_same<RightType, FPRegisterID>::value, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
+        static_assert(!std::same_as<LeftType, FPRegisterID> && !std::same_as<RightType, FPRegisterID>, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
 
         if (thenCase != dest && elseCase != dest) {
             moveDouble(elseCase, dest);
@@ -6620,7 +6620,7 @@ public:
     template<typename TestType, typename MaskType>
     void moveDoubleConditionallyTest64(ResultCondition cond, TestType test, MaskType mask, FPRegisterID thenCase, FPRegisterID elseCase, FPRegisterID dest)
     {
-        static_assert(!std::is_same<TestType, FPRegisterID>::value && !std::is_same<MaskType, FPRegisterID>::value, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
+        static_assert(!std::same_as<TestType, FPRegisterID> && !std::same_as<MaskType, FPRegisterID>, "One of the tested argument could be aliased on dest. Use moveDoubleConditionallyDouble().");
 
         if (elseCase == dest && isInvertible(cond)) {
             Jump falseCase = branchTest64(invert(cond), test, mask);

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -134,8 +134,8 @@ using RegisterID = RISCV64Registers::RegisterID;
 using FPRegisterID = RISCV64Registers::FPRegisterID;
 
 template<typename T>
-auto registerValue(T registerID)
-    -> std::enable_if_t<(std::is_same_v<T, RegisterID> || std::is_same_v<T, FPRegisterID>), unsigned>
+    requires (std::same_as<T, RegisterID> || std::same_as<T, FPRegisterID>)
+unsigned registerValue(T registerID)
 {
     return unsigned(registerID) & ((1 << 5) - 1);
 }
@@ -188,8 +188,8 @@ struct ImmediateBase {
     }
 
     template<typename T>
-    static auto isValid(T immValue)
-        -> std::enable_if_t<(std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t>), bool>
+        requires (std::same_as<T, int32_t> || std::same_as<T, int64_t>)
+    static bool isValid(T immValue)
     {
         constexpr unsigned shift = sizeof(T) * 8 - immediateSize;
         return immValue == ((immValue << shift) >> shift);
@@ -313,7 +313,8 @@ struct JImmediate : ImmediateBase<21> {
 };
 
 struct ImmediateDecomposition {
-    template<typename T, typename = std::enable_if_t<(std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t>)>>
+    template<typename T>
+        requires (std::same_as<T, int32_t> || std::same_as<T, int64_t>)
     explicit ImmediateDecomposition(T immediate)
         : upper(UImmediate(0))
         , lower(IImmediate(0))
@@ -1954,8 +1955,8 @@ public:
     {
         using FCVTType = RISCV64Instructions::FCVTBase<ToType, FromType>;
         static_assert(FCVTType::valid);
-        static_assert(std::is_same_v<std::decay_t<RDType>, typename FCVTType::RDType>);
-        static_assert(std::is_same_v<std::decay_t<RS1Type>, typename FCVTType::RS1Type>);
+        static_assert(std::same_as<std::decay_t<RDType>, typename FCVTType::RDType>);
+        static_assert(std::same_as<std::decay_t<RS1Type>, typename FCVTType::RS1Type>);
 
         insn(FCVTType::construct(rd, rs1, RM));
     }
@@ -1971,8 +1972,8 @@ public:
     {
         using FMVType = RISCV64Instructions::FMVBase<ToType, FromType>;
         static_assert(FMVType::valid);
-        static_assert(std::is_same_v<std::decay_t<RDType>, typename FMVType::RDType>);
-        static_assert(std::is_same_v<std::decay_t<RS1Type>, typename FMVType::RS1Type>);
+        static_assert(std::same_as<std::decay_t<RDType>, typename FMVType::RDType>);
+        static_assert(std::same_as<std::decay_t<RS1Type>, typename FMVType::RS1Type>);
 
         insn(FMVType::construct(rd, rs1));
     }
@@ -2127,7 +2128,8 @@ public:
         signExtend<bitSize>(rd, rd);
     }
 
-    template<unsigned bitSize, typename = std::enable_if_t<bitSize == 8 || bitSize == 16 || bitSize == 32 || bitSize == 64>>
+    template<unsigned bitSize>
+        requires (bitSize == 8 || bitSize == 16 || bitSize == 32 || bitSize == 64)
     void signExtend(RegisterID rd, RegisterID rs)
     {
         if constexpr (bitSize == 64)
@@ -2148,7 +2150,8 @@ public:
         zeroExtend<bitSize>(rd, rd);
     }
 
-    template<unsigned bitSize, typename = std::enable_if_t<bitSize == 8 || bitSize == 16 || bitSize == 32 || bitSize == 64>>
+    template<unsigned bitSize>
+        requires (bitSize == 8 || bitSize == 16 || bitSize == 32 || bitSize == 64)
     void zeroExtend(RegisterID rd, RegisterID rs)
     {
         if constexpr (bitSize == 64)


### PR DESCRIPTION
#### 7c1f01e62617a8251dd8a6e1fd5c3d16aac7e544
<pre>
Adopt C++20 Concepts in JavaScriptCore/assembler
<a href="https://bugs.webkit.org/show_bug.cgi?id=301906">https://bugs.webkit.org/show_bug.cgi?id=301906</a>
<a href="https://rdar.apple.com/163984226">rdar://163984226</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::branchForArithmeticOverflow):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::moveDoubleConditionally32):
(JSC::MacroAssemblerX86_64::moveDoubleConditionallyTest32):
(JSC::MacroAssemblerX86_64::moveDoubleConditionally64):
(JSC::MacroAssemblerX86_64::moveDoubleConditionallyTest64):
* Source/JavaScriptCore/assembler/Printer.h:
(JSC::Printer::PrintRecord::PrintRecord):
(JSC::Printer::setPrinter):
* Source/JavaScriptCore/assembler/RISCV64Assembler.h:
(JSC::RISCV64Instructions::registerValue):
(JSC::RISCV64Instructions::ImmediateBase::isValid):
(JSC::RISCV64Assembler::fcvtInsn):
(JSC::RISCV64Assembler::fmvInsn):

Canonical link: <a href="https://commits.webkit.org/302539@main">https://commits.webkit.org/302539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5afc4f602558495819b6f1feadb2c84d577d1a50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80763 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98521 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66424 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33996 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80016 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121354 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139212 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127814 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107048 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106891 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27224 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1148 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30728 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54060 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64843 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160828 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1297 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40124 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->