### PR TITLE
Address remaining safer CPP warnings in WebKit/WebProcess/InjectedBundle

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4194,6 +4194,11 @@ HTMLElement* Document::bodyOrFrameset() const
     return nullptr;
 }
 
+RefPtr<HTMLElement> Document::protectedBodyOrFrameset() const
+{
+    return bodyOrFrameset();
+}
+
 ExceptionOr<void> Document::setBodyOrFrameset(RefPtr<HTMLElement>&& newBody)
 {
     if (!is<HTMLBodyElement>(newBody) && !is<HTMLFrameSetElement>(newBody))

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1241,6 +1241,7 @@ public:
     // This is the "body element" as defined by HTML5, the first body or frameset child of the
     // document element. See https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2.
     WEBCORE_EXPORT HTMLElement* bodyOrFrameset() const;
+    WEBCORE_EXPORT RefPtr<HTMLElement> protectedBodyOrFrameset() const;
     WEBCORE_EXPORT ExceptionOr<void> setBodyOrFrameset(RefPtr<HTMLElement>&&);
 
     Location* location() const;

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -49,10 +49,10 @@ public:
     WEBCORE_EXPORT ~Range();
 
     Node& startContainer() const final { return m_start.container(); }
-    Ref<Node> protectedStartContainer() const;
+    WEBCORE_EXPORT Ref<Node> protectedStartContainer() const;
     unsigned startOffset() const final { return m_start.offset(); }
     Node& endContainer() const final { return m_end.container(); }
-    Ref<Node> protectedEndContainer() const;
+    WEBCORE_EXPORT Ref<Node> protectedEndContainer() const;
     unsigned endOffset() const final { return m_end.offset(); }
     bool collapsed() const final { return m_start == m_end; }
     WEBCORE_EXPORT Node* commonAncestorContainer() const;

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -14,10 +14,6 @@ Platform/IPC/ArgumentCoders.h
 [ iOS ] UIProcess/ios/WKContentViewInteraction.mm
 [ iOS ] UIProcess/ios/WebPageProxyIOS.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
-WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
-WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
-WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
 [ iOS ] WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 [ iOS ] WebProcess/WebPage/WebFoundTextRangeController.cpp
 [ iOS ] WebProcess/WebPage/ios/FindControllerIOS.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -48,15 +48,6 @@ Platform/IPC/ArgumentCoders.h
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
 [ iOS ] WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
-WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
-WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
-[ Mac ] WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
-WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
-WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
-WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
-WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
 [ iOS ] WebProcess/Network/NetworkProcessConnection.cpp
 [ iOS ] WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 [ iOS ] WebProcess/WebCoreSupport/WebChromeClientCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -64,9 +64,6 @@
 [ iOS ] UIProcess/ios/forms/WKFormSelectPopover.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
-WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
 WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
 WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -73,7 +73,7 @@ void WKBundlePostSynchronousMessage(WKBundleRef bundleRef, WKStringRef messageNa
     RefPtr<API::Object> returnData;
     WebKit::toProtectedImpl(bundleRef)->postSynchronousMessage(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get(), returnData);
     if (returnRetainedDataRef)
-        SUPPRESS_UNCOUNTED_ARG *returnRetainedDataRef = WebKit::toAPI(returnData.leakRef());
+        *returnRetainedDataRef = WebKit::toAPILeakingRef(WTFMove(returnData));
 }
 
 void WKBundleGarbageCollectJavaScriptObjects(WKBundleRef bundleRef)
@@ -153,7 +153,7 @@ void WKBundleReleaseMemory(WKBundleRef)
 
 WKDataRef WKBundleCreateWKDataFromUInt8Array(WKBundleRef bundle, JSContextRef context, JSValueRef data)
 {
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&WebKit::toProtectedImpl(bundle)->createWebDataFromUint8Array(context, data).leakRef());
+    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(bundle)->createWebDataFromUint8Array(context, data));
 }
 
 int WKBundleNumberOfPages(WKBundleRef bundleRef, WKBundleFrameRef frameRef, double pageWidthInPixels, double pageHeightInPixels)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp
@@ -40,7 +40,7 @@ WKTypeID WKBundleDOMWindowExtensionGetTypeID()
 WKBundleDOMWindowExtensionRef WKBundleDOMWindowExtensionCreate(WKBundleFrameRef frame, WKBundleScriptWorldRef world)
 {
     RefPtr<WebKit::InjectedBundleDOMWindowExtension> extension = WebKit::InjectedBundleDOMWindowExtension::create(WebKit::toProtectedImpl(frame).get(), WebKit::toProtectedImpl(world).get());
-    SUPPRESS_UNCOUNTED_ARG return toAPI(extension.leakRef());
+    return toAPILeakingRef(WTFMove(extension));
 }
 
 WKBundleFrameRef WKBundleDOMWindowExtensionGetFrame(WKBundleDOMWindowExtensionRef extension)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -95,7 +95,7 @@ WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 
 WKArrayRef WKBundleFrameCopyChildFrames(WKBundleFrameRef frameRef)
 {
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&WebKit::toImpl(frameRef)->childFrames().leakRef());
+    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(frameRef)->childFrames());
 }
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContext(WKBundleFrameRef frameRef)
@@ -140,7 +140,7 @@ unsigned WKBundleFrameGetPendingUnloadCount(WKBundleFrameRef frameRef)
 
 WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toProtectedImpl(frameRef)->page());
+    return toAPI(WebKit::toProtectedImpl(frameRef)->protectedPage().get());
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)
@@ -270,7 +270,7 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
 WKBundleHitTestResultRef WKBundleFrameCreateHitTestResult(WKBundleFrameRef frameRef, WKPoint point)
 {
     ASSERT(frameRef);
-    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->hitTest(WebKit::toIntPoint(point)).leakRef());
+    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(frameRef)->hitTest(WebKit::toIntPoint(point)));
 }
 
 WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
@@ -42,13 +42,13 @@ WKTypeID WKBundleHitTestResultGetTypeID()
 WKBundleNodeHandleRef WKBundleHitTestResultCopyNodeHandle(WKBundleHitTestResultRef hitTestResultRef)
 {
     RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toProtectedImpl(hitTestResultRef)->nodeHandle();
-    SUPPRESS_UNCOUNTED_ARG return toAPI(nodeHandle.leakRef());
+    return toAPILeakingRef(WTFMove(nodeHandle));
 }
 
 WKBundleNodeHandleRef WKBundleHitTestResultCopyURLElementHandle(WKBundleHitTestResultRef hitTestResultRef)
 {
     RefPtr<WebKit::InjectedBundleNodeHandle> urlElementNodeHandle = WebKit::toProtectedImpl(hitTestResultRef)->urlElementHandle();
-    SUPPRESS_UNCOUNTED_ARG return toAPI(urlElementNodeHandle.leakRef());
+    return toAPILeakingRef(WTFMove(urlElementNodeHandle));
 }
 
 WKBundleFrameRef WKBundleHitTestResultGetFrame(WKBundleHitTestResultRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
@@ -82,13 +82,13 @@ WKTypeID WKBundleNodeHandleGetTypeID()
 WKBundleNodeHandleRef WKBundleNodeHandleCreate(JSContextRef contextRef, JSObjectRef objectRef)
 {
     RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::InjectedBundleNodeHandle::getOrCreate(contextRef, objectRef);
-    SUPPRESS_UNCOUNTED_ARG return toAPI(nodeHandle.leakRef());
+    return toAPILeakingRef(WTFMove(nodeHandle));
 }
 
 WKBundleNodeHandleRef WKBundleNodeHandleCopyDocument(WKBundleNodeHandleRef nodeHandleRef)
 {
     RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toProtectedImpl(nodeHandleRef)->document();
-    SUPPRESS_UNCOUNTED_ARG return toAPI(nodeHandle.leakRef());
+    return toAPILeakingRef(WTFMove(nodeHandle));
 }
 
 WKRect WKBundleNodeHandleGetRenderRect(WKBundleNodeHandleRef nodeHandleRef, bool* isReplaced)
@@ -100,7 +100,7 @@ WKRect WKBundleNodeHandleGetRenderRect(WKBundleNodeHandleRef nodeHandleRef, bool
 WKImageRef WKBundleNodeHandleCopySnapshotWithOptions(WKBundleNodeHandleRef nodeHandleRef, WKSnapshotOptions options)
 {
     RefPtr<WebKit::WebImage> image = WebKit::toProtectedImpl(nodeHandleRef)->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow);
-    SUPPRESS_UNCOUNTED_ARG return toAPI(image.leakRef());
+    return toAPILeakingRef(WTFMove(image));
 }
 
 WKBundleRangeHandleRef WKBundleNodeHandleCopyVisibleRange(WKBundleNodeHandleRef)
@@ -202,7 +202,7 @@ WKBundleNodeHandleRef WKBundleNodeHandleCopyHTMLTableCellElementCellAbove(WKBund
 WKBundleFrameRef WKBundleNodeHandleCopyDocumentFrame(WKBundleNodeHandleRef documentHandleRef)
 {
     RefPtr<WebKit::WebFrame> frame = WebKit::toProtectedImpl(documentHandleRef)->documentFrame();
-    SUPPRESS_UNCOUNTED_ARG return toAPI(frame.leakRef());
+    return toAPILeakingRef(WTFMove(frame));
 }
 
 WKBundleFrameRef WKBundleNodeHandleCopyHTMLFrameElementContentFrame(WKBundleNodeHandleRef htmlFrameElementHandleRef)
@@ -214,7 +214,7 @@ WKBundleFrameRef WKBundleNodeHandleCopyHTMLFrameElementContentFrame(WKBundleNode
 WKBundleFrameRef WKBundleNodeHandleCopyHTMLIFrameElementContentFrame(WKBundleNodeHandleRef htmlIFrameElementHandleRef)
 {
     RefPtr<WebKit::WebFrame> frame = WebKit::toProtectedImpl(htmlIFrameElementHandleRef)->htmlIFrameElementContentFrame();
-    SUPPRESS_UNCOUNTED_ARG return toAPI(frame.leakRef());
+    return toAPILeakingRef(WTFMove(frame));
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutofilled(WKBundleNodeHandleRef htmlInputElementHandleRef)
@@ -236,6 +236,6 @@ void WKBundleNodeHandleSetHTMLInputElementAutoFillButtonEnabled(WKBundleNodeHand
 WKBundleFrameRef WKBundleNodeHandleCopyOwningDocumentFrame(WKBundleNodeHandleRef documentHandleRef)
 {
     if (RefPtr document = WebKit::toProtectedImpl(documentHandleRef)->document())
-        SUPPRESS_UNCOUNTED_ARG return toAPI(document->documentFrame().leakRef());
+        return toAPILeakingRef(document->documentFrame());
     return nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -129,7 +129,7 @@ WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef pageRef)
 
 WKFrameHandleRef WKBundleFrameCreateFrameHandle(WKBundleFrameRef bundleFrameRef)
 {
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::FrameHandle::create(WebKit::toImpl(bundleFrameRef)->frameID()).leakRef());
+    return WebKit::toAPILeakingRef(API::FrameHandle::create(WebKit::toImpl(bundleFrameRef)->frameID()));
 }
 
 void WKBundlePageClickMenuItem(WKBundlePageRef pageRef, WKContextMenuItemRef item)
@@ -156,8 +156,7 @@ WKArrayRef WKBundlePageCopyContextMenuItems(WKBundlePageRef pageRef)
 {
 #if ENABLE(CONTEXT_MENUS)
     Ref contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenu();
-
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&contextMenuItems(contextMenu.get()).leakRef());
+    return WebKit::toAPILeakingRef(contextMenuItems(contextMenu.get()));
 #else
     UNUSED_PARAM(pageRef);
     return nullptr;
@@ -175,7 +174,7 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
     if (!contextMenu)
         return nullptr;
 
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&contextMenuItems(*contextMenu).leakRef());
+    return WebKit::toAPILeakingRef(contextMenuItems(*contextMenu));
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(point);
@@ -408,7 +407,7 @@ void WKBundlePageReplaceStringMatches(WKBundlePageRef pageRef, WKArrayRef matchI
 WKImageRef WKBundlePageCreateSnapshotWithOptions(WKBundlePageRef pageRef, WKRect rect, WKSnapshotOptions options)
 {
     RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::toSnapshotOptions(options));
-    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
+    return toAPILeakingRef(WTFMove(webImage));
 }
 
 WKImageRef WKBundlePageCreateSnapshotInViewCoordinates(WKBundlePageRef pageRef, WKRect rect, WKImageOptions options)
@@ -416,19 +415,19 @@ WKImageRef WKBundlePageCreateSnapshotInViewCoordinates(WKBundlePageRef pageRef, 
     auto snapshotOptions = WebKit::snapshotOptionsFromImageOptions(options);
     snapshotOptions.add(WebKit::SnapshotOption::InViewCoordinates);
     RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, snapshotOptions);
-    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
+    return toAPILeakingRef(WTFMove(webImage));
 }
 
 WKImageRef WKBundlePageCreateSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, WKImageOptions options)
 {
     RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::snapshotOptionsFromImageOptions(options));
-    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
+    return toAPILeakingRef(WTFMove(webImage));
 }
 
 WKImageRef WKBundlePageCreateScaledSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, double scaleFactor, WKImageOptions options)
 {
     RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), scaleFactor, WebKit::snapshotOptionsFromImageOptions(options));
-    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
+    return toAPILeakingRef(WTFMove(webImage));
 }
 
 double WKBundlePageGetBackingScaleFactor(WKBundlePageRef pageRef)
@@ -489,7 +488,7 @@ bool WKBundlePageIsTrackingRepaints(WKBundlePageRef pageRef)
 
 WKArrayRef WKBundlePageCopyTrackedRepaintRects(WKBundlePageRef pageRef)
 {
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&WebKit::toProtectedImpl(pageRef)->trackedRepaintRects().leakRef());
+    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(pageRef)->trackedRepaintRects());
 }
 
 void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData, WKArrayRef annotationData)
@@ -675,7 +674,7 @@ void WKBundlePagePostSynchronousMessageForTesting(WKBundlePageRef pageRef, WKStr
     RefPtr<API::Object> returnData;
     WebKit::toProtectedImpl(pageRef)->postSynchronousMessageForTesting(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get(), returnData);
     if (returnRetainedDataRef)
-        SUPPRESS_UNCOUNTED_ARG *returnRetainedDataRef = WebKit::toAPI(returnData.leakRef());
+        *returnRetainedDataRef = WebKit::toAPILeakingRef(WTFMove(returnData));
 }
 
 bool WKBundlePageIsSuspended(WKBundlePageRef pageRef)
@@ -725,7 +724,7 @@ WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPrefere
 {
 #if ENABLE(VIDEO)
     Ref captionPreferences = WebKit::toProtectedImpl(page)->protectedCorePage()->checkedGroup()->ensureCaptionPreferences();
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()).leakRef());
+    return WebKit::toAPILeakingRef(API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()));
 #else
     UNUSED_PARAM(page);
     return { };
@@ -744,5 +743,5 @@ void WKBundlePageSetSkipDecidePolicyForResponseIfPossible(WKBundlePageRef page, 
 
 WKStringRef WKBundlePageCopyFrameTextForTesting(WKBundlePageRef page, bool includeSubframes)
 {
-    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::String::create(WebKit::toProtectedImpl(page)->frameTextForTestingIncludingSubframes(includeSubframes)).leakRef());
+    return WebKit::toAPILeakingRef(API::String::create(WebKit::toProtectedImpl(page)->frameTextForTestingIncludingSubframes(includeSubframes)));
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
@@ -235,7 +235,7 @@ WKTypeID WKBundlePageOverlayGetTypeID()
 WKBundlePageOverlayRef WKBundlePageOverlayCreate(WKBundlePageOverlayClientBase* wkClient)
 {
     auto clientImpl = makeUnique<PageOverlayClientImpl>(wkClient);
-    SUPPRESS_UNCOUNTED_ARG return toAPI(&WebKit::WebPageOverlay::create(WTFMove(clientImpl)).leakRef());
+    return toAPILeakingRef(WebKit::WebPageOverlay::create(WTFMove(clientImpl)));
 }
 
 void WKBundlePageOverlaySetAccessibilityClient(WKBundlePageOverlayRef bundlePageOverlayRef, WKBundlePageOverlayAccessibilityClientBase* client)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
@@ -43,7 +43,7 @@ WKTypeID WKBundleRangeHandleGetTypeID()
 WKBundleRangeHandleRef WKBundleRangeHandleCreate(JSContextRef contextRef, JSObjectRef objectRef)
 {
     RefPtr<WebKit::InjectedBundleRangeHandle> rangeHandle = WebKit::InjectedBundleRangeHandle::getOrCreate(contextRef, objectRef);
-    SUPPRESS_UNCOUNTED_ARG return toAPI(rangeHandle.leakRef());
+    return toAPILeakingRef(WTFMove(rangeHandle));
 }
 
 WKRect WKBundleRangeHandleGetBoundingRectInWindowCoordinates(WKBundleRangeHandleRef rangeHandleRef)
@@ -55,11 +55,11 @@ WKRect WKBundleRangeHandleGetBoundingRectInWindowCoordinates(WKBundleRangeHandle
 WKImageRef WKBundleRangeHandleCopySnapshotWithOptions(WKBundleRangeHandleRef rangeHandleRef, WKSnapshotOptions options)
 {
     RefPtr<WebKit::WebImage> image = WebKit::toProtectedImpl(rangeHandleRef)->renderedImage(WebKit::toSnapshotOptions(options));
-    SUPPRESS_UNCOUNTED_ARG return toAPI(image.leakRef());
+    return toAPILeakingRef(WTFMove(image));
 }
 
 WKBundleFrameRef WKBundleRangeHandleCopyDocumentFrame(WKBundleRangeHandleRef rangeHandleRef)
 {
     RefPtr frame = WebKit::toProtectedImpl(rangeHandleRef)->document()->documentFrame();
-    SUPPRESS_UNCOUNTED_ARG return toAPI(frame.leakRef());
+    return toAPILeakingRef(WTFMove(frame));
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
@@ -38,7 +38,7 @@ WKTypeID WKBundleScriptWorldGetTypeID()
 WKBundleScriptWorldRef WKBundleScriptWorldCreateWorld()
 {
     RefPtr<WebKit::InjectedBundleScriptWorld> world = WebKit::InjectedBundleScriptWorld::create(WebKit::ContentWorldIdentifier::generate());
-    SUPPRESS_UNCOUNTED_ARG return toAPI(world.leakRef());
+    return toAPILeakingRef(WTFMove(world));
 }
 
 WKBundleScriptWorldRef WKBundleScriptWorldNormalWorld()

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
@@ -31,5 +31,5 @@
 
 id WKBundleGetParameters(WKBundleRef bundle)
 {
-    return WebKit::toImpl(bundle)->bundleParameters();
+    return WebKit::toProtectedImpl(bundle)->bundleParameters();
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
@@ -99,12 +99,12 @@ WKBundlePageBannerRef WKBundlePageBannerCreateBannerWithCALayer(CALayer *layer, 
         return 0;
 
     auto clientImpl = makeUnique<WebKit::PageBannerClientImpl>(wkClient);
-    return toAPI(&WebKit::PageBanner::create(layer, height, WTFMove(clientImpl)).leakRef());
+    return toAPILeakingRef(WebKit::PageBanner::create(layer, height, WTFMove(clientImpl)));
 }
 
 CALayer *WKBundlePageBannerGetLayer(WKBundlePageBannerRef pageBanner)
 {
-    return WebKit::toImpl(pageBanner)->layer();
+    return WebKit::toProtectedImpl(pageBanner)->layer();
 }
 
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
@@ -69,7 +69,7 @@
 
 - (WKDOMElement *)body
 {
-    return WebKit::toWKDOMElement(downcast<WebCore::Document>(*_impl).bodyOrFrameset());
+    return WebKit::toWKDOMElement(downcast<WebCore::Document>(*_impl).protectedBodyOrFrameset().get());
 }
 
 - (WKDOMNode *)createDocumentFragmentWithMarkupString:(NSString *)markupString baseURL:(NSURL *)baseURL

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
@@ -89,12 +89,14 @@ DOMCache<WebCore::Range*, __unsafe_unretained WKDOMRange *>& WKDOMRangeCache();
 // -- Node and classes derived from Node. --
 
 WebCore::Node* toWebCoreNode(WKDOMNode *);
+RefPtr<WebCore::Node> toProtectedWebCoreNode(WKDOMNode *);
 WKDOMNode *toWKDOMNode(WebCore::Node*);
 
 WebCore::Element* toWebCoreElement(WKDOMElement *);
 WKDOMElement *toWKDOMElement(WebCore::Element*);
 
 WebCore::Document* toWebCoreDocument(WKDOMDocument *);
+RefPtr<WebCore::Document> toProtectedWebCoreDocument(WKDOMDocument *);
 WKDOMDocument *toWKDOMDocument(WebCore::Document*);
 
 WebCore::Text* toWebCoreText(WKDOMText *);
@@ -103,6 +105,7 @@ WKDOMText *toWKDOMText(WebCore::Text*);
 // -- Range. --
 
 WebCore::Range* toWebCoreRange(WKDOMRange *);
+RefPtr<WebCore::Range> toProtectedWebCoreRange(WKDOMRange *);
 WKDOMRange *toWKDOMRange(WebCore::Range*);
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
@@ -64,7 +64,7 @@ DOMCache<WebCore::Range*, __unsafe_unretained WKDOMRange *>& WKDOMRangeCache()
 
 // -- Node and classes derived from Node. --
 
-static Class WKDOMNodeClass(WebCore::Node* impl)
+static Class WKDOMNodeClassSingleton(WebCore::Node* impl)
 {
     switch (impl->nodeType()) {
     case WebCore::Node::ELEMENT_NODE:
@@ -87,12 +87,17 @@ static Class WKDOMNodeClass(WebCore::Node* impl)
 
 static RetainPtr<WKDOMNode> createWrapper(WebCore::Node* impl)
 {
-    return adoptNS([[WKDOMNodeClass(impl) alloc] _initWithImpl:impl]);
+    return adoptNS([[WKDOMNodeClassSingleton(impl) alloc] _initWithImpl:impl]);
 }
 
 WebCore::Node* toWebCoreNode(WKDOMNode *wrapper)
 {
     return wrapper ? wrapper->_impl.get() : 0;
+}
+
+RefPtr<WebCore::Node> toProtectedWebCoreNode(WKDOMNode *wrapper)
+{
+    return toWebCoreNode(wrapper);
 }
 
 WKDOMNode *toWKDOMNode(WebCore::Node* impl)
@@ -113,6 +118,11 @@ WKDOMElement *toWKDOMElement(WebCore::Element* impl)
 WebCore::Document* toWebCoreDocument(WKDOMDocument *wrapper)
 {
     return wrapper ? downcast<WebCore::Document>(wrapper->_impl.get()) : 0;
+}
+
+RefPtr<WebCore::Document> toProtectedWebCoreDocument(WKDOMDocument *wrapper)
+{
+    return toWebCoreDocument(wrapper);
 }
 
 WKDOMDocument *toWKDOMDocument(WebCore::Document* impl)
@@ -137,9 +147,14 @@ static RetainPtr<WKDOMRange> createWrapper(WebCore::Range* impl)
     return adoptNS([[WKDOMRange alloc] _initWithImpl:impl]);
 }
 
-WebCore::Range* toWebCoreRange(WKDOMRange * wrapper)
+WebCore::Range* toWebCoreRange(WKDOMRange *wrapper)
 {
     return wrapper ? wrapper->_impl.get() : 0;
+}
+
+RefPtr<WebCore::Range> toProtectedWebCoreRange(WKDOMRange *wrapper)
+{
+    return toWebCoreRange(wrapper);
 }
 
 WKDOMRange *toWKDOMRange(WebCore::Range* impl)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -64,7 +64,7 @@
     if (!node)
         return;
 
-    _impl->insertBefore(*WebKit::toWebCoreNode(node), WebKit::toWebCoreNode(refNode));
+    _impl->insertBefore(*WebKit::toProtectedWebCoreNode(node).get(), WebKit::toProtectedWebCoreNode(refNode).get());
 }
 
 - (void)appendChild:(WKDOMNode *)node
@@ -72,7 +72,7 @@
     if (!node)
         return;
 
-    _impl->appendChild(*WebKit::toWebCoreNode(node));
+    _impl->appendChild(*WebKit::toProtectedWebCoreNode(node).get());
 }
 
 - (void)removeChild:(WKDOMNode *)node
@@ -80,42 +80,42 @@
     if (!node)
         return;
 
-    _impl->removeChild(*WebKit::toWebCoreNode(node));
+    _impl->removeChild(*WebKit::toProtectedWebCoreNode(node).get());
 }
 
 - (WKDOMDocument *)document
 {
-    return WebKit::toWKDOMDocument(&_impl->document());
+    return WebKit::toWKDOMDocument(_impl->protectedDocument().ptr());
 }
 
 - (WKDOMNode *)parentNode
 {
-    return WebKit::toWKDOMNode(_impl->parentNode());
+    return WebKit::toWKDOMNode(_impl->protectedParentNode().get());
 }
 
 - (WKDOMNode *)firstChild
 {
-    return WebKit::toWKDOMNode(_impl->firstChild());
+    return WebKit::toWKDOMNode(_impl->protectedFirstChild().get());
 }
 
 - (WKDOMNode *)lastChild
 {
-    return WebKit::toWKDOMNode(_impl->lastChild());
+    return WebKit::toWKDOMNode(_impl->protectedLastChild().get());
 }
 
 - (WKDOMNode *)previousSibling
 {
-    return WebKit::toWKDOMNode(_impl->previousSibling());
+    return WebKit::toWKDOMNode(_impl->protectedPreviousSibling().get());
 }
 
 - (WKDOMNode *)nextSibling
 {
-    return WebKit::toWKDOMNode(_impl->nextSibling());
+    return WebKit::toWKDOMNode(_impl->protectedNextSibling().get());
 }
 
 - (NSArray *)textRects
 {
-    _impl->document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
+    _impl->protectedDocument()->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     if (!_impl->renderer())
         return nil;
     return createNSArray(WebCore::RenderObject::absoluteTextRects(WebCore::makeRangeSelectingNodeContents(*_impl))).autorelease();
@@ -127,7 +127,7 @@
 
 - (WKBundleNodeHandleRef)_copyBundleNodeHandleRef
 {
-    return toAPI(WebKit::InjectedBundleNodeHandle::getOrCreate(_impl.get()).leakRef());
+    return toAPILeakingRef(WebKit::InjectedBundleNodeHandle::getOrCreate(_impl.get()));
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
@@ -53,7 +53,7 @@
 
 - (id)initWithDocument:(WKDOMDocument *)document
 {
-    return [self _initWithImpl:WebCore::Range::create(*WebKit::toWebCoreDocument(document)).ptr()];
+    return [self _initWithImpl:WebCore::Range::create(*WebKit::toProtectedWebCoreDocument(document)).ptr()];
 }
 
 - (void)dealloc
@@ -87,19 +87,19 @@
 {
     if (!node)
         return;
-    _impl->selectNode(*WebKit::toWebCoreNode(node));
+    _impl->selectNode(*WebKit::toProtectedWebCoreNode(node));
 }
 
 - (void)selectNodeContents:(WKDOMNode *)node
 {
     if (!node)
         return;
-    _impl->selectNodeContents(*WebKit::toWebCoreNode(node));
+    _impl->selectNodeContents(*WebKit::toProtectedWebCoreNode(node));
 }
 
 - (WKDOMNode *)startContainer
 {
-    return WebKit::toWKDOMNode(&_impl->startContainer());
+    return WebKit::toWKDOMNode(_impl->protectedStartContainer().ptr());
 }
 
 - (NSInteger)startOffset
@@ -109,7 +109,7 @@
 
 - (WKDOMNode *)endContainer
 {
-    return WebKit::toWKDOMNode(&_impl->endContainer());
+    return WebKit::toWKDOMNode(_impl->protectedEndContainer().ptr());
 }
 
 - (NSInteger)endOffset
@@ -120,7 +120,7 @@
 - (NSString *)text
 {
     auto range = makeSimpleRange(*_impl);
-    range.start.document().updateLayout();
+    range.start.protectedDocument()->updateLayout();
     return plainText(range).createNSString().autorelease();
 }
 
@@ -132,7 +132,7 @@
 - (NSArray *)textRects
 {
     auto range = makeSimpleRange(*_impl);
-    range.start.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
+    range.start.protectedDocument()->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     return createNSArray(WebCore::RenderObject::absoluteTextRects(range)).autorelease();
 }
 
@@ -150,7 +150,7 @@
 - (WKBundleRangeHandleRef)_copyBundleRangeHandleRef
 {
     auto rangeHandle = WebKit::InjectedBundleRangeHandle::getOrCreate(_impl.get());
-    return toAPI(rangeHandle.leakRef());
+    return toAPILeakingRef(WTFMove(rangeHandle));
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
@@ -48,7 +48,7 @@
     if (!range)
         return self;
 
-    _textIterator = makeUnique<WebCore::TextIterator>(makeSimpleRange(*WebKit::toWebCoreRange(range)));
+    _textIterator = makeUnique<WebCore::TextIterator>(makeSimpleRange(*WebKit::toProtectedWebCoreRange(range)));
     return self;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -83,13 +83,18 @@
     RetainPtr<_WKRemoteObjectRegistry> _remoteObjectRegistry;
 }
 
+static Ref<WebKit::WebPage> protectedPage(WKWebProcessPlugInBrowserContextController *controller)
+{
+    return *controller->_page;
+}
+
 static void didStartProvisionalLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userDataRef, const void *clientInfo)
 {
     auto pluginContextController = (__bridge WKWebProcessPlugInBrowserContextController *)clientInfo;
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didStartProvisionalLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didStartProvisionalLoadForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didStartProvisionalLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didReceiveServerRedirectForProvisionalLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef *userDataRef, const void *clientInfo)
@@ -98,7 +103,7 @@ static void didReceiveServerRedirectForProvisionalLoadForFrame(WKBundlePageRef p
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didReceiveServerRedirectForProvisionalLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didReceiveServerRedirectForProvisionalLoadForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didReceiveServerRedirectForProvisionalLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didFinishLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -107,7 +112,7 @@ static void didFinishLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFinishLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishLoadForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didClearWindowObjectForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -116,7 +121,7 @@ static void didClearWindowObjectForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
     
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didClearWindowObjectForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didClearWindowObjectForFrame:wrapper(*WebKit::toImpl(frame)) inScriptWorld:wrapper(*WebKit::toImpl(scriptWorld))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didClearWindowObjectForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
 }
 
 static void globalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -125,7 +130,7 @@ static void globalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameR
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:globalObjectIsAvailableForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController globalObjectIsAvailableForFrame:wrapper(*WebKit::toImpl(frame)) inScriptWorld:wrapper(*WebKit::toImpl(scriptWorld))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController globalObjectIsAvailableForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
 }
 
 static void serviceWorkerGlobalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -134,7 +139,7 @@ static void serviceWorkerGlobalObjectIsAvailableForFrame(WKBundlePageRef page, W
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:serviceWorkerGlobalObjectIsAvailableForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController serviceWorkerGlobalObjectIsAvailableForFrame:wrapper(*WebKit::toImpl(frame)) inScriptWorld:wrapper(*WebKit::toImpl(scriptWorld))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController serviceWorkerGlobalObjectIsAvailableForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
 }
 
 static void willInjectUserScriptForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -143,7 +148,7 @@ static void willInjectUserScriptForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:willInjectUserScriptForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController willInjectUserScriptForFrame:wrapper(*WebKit::toImpl(frame)) inScriptWorld:wrapper(*WebKit::toImpl(scriptWorld))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController willInjectUserScriptForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
 }
 
 static void didRemoveFrameFromHierarchy(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void* clientInfo)
@@ -152,7 +157,7 @@ static void didRemoveFrameFromHierarchy(WKBundlePageRef page, WKBundleFrameRef f
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didRemoveFrameFromHierarchy:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didRemoveFrameFromHierarchy:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didRemoveFrameFromHierarchy:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didCommitLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -161,7 +166,7 @@ static void didCommitLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didCommitLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didCommitLoadForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didCommitLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didFinishDocumentLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -170,7 +175,7 @@ static void didFinishDocumentLoadForFrame(WKBundlePageRef page, WKBundleFrameRef
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFinishDocumentLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishDocumentLoadForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishDocumentLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didFailProvisionalLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKErrorRef wkError, WKTypeRef* userData, const void *clientInfo)
@@ -179,7 +184,7 @@ static void didFailProvisionalLoadWithErrorForFrame(WKBundlePageRef page, WKBund
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFailProvisionalLoadWithErrorForFrame:error:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailProvisionalLoadWithErrorForFrame:wrapper(*WebKit::toImpl(frame)) error:wrapper(*WebKit::toImpl(wkError))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailProvisionalLoadWithErrorForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() error:protectedWrapper(*WebKit::toProtectedImpl(wkError)).get()];
 }
 
 static void didFailLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKErrorRef wkError, WKTypeRef* userData, const void *clientInfo)
@@ -188,7 +193,7 @@ static void didFailLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFailLoadWithErrorForFrame:error:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailLoadWithErrorForFrame:wrapper(*WebKit::toImpl(frame)) error:wrapper(*WebKit::toImpl(wkError))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailLoadWithErrorForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() error:protectedWrapper(*WebKit::toProtectedImpl(wkError)).get()];
 }
 
 static void didSameDocumentNavigationForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKSameDocumentNavigationType type, WKTypeRef* userData, const void *clientInfo)
@@ -197,11 +202,11 @@ static void didSameDocumentNavigationForFrame(WKBundlePageRef page, WKBundleFram
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didSameDocumentNavigation:forFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigation:toWKSameDocumentNavigationType(WebKit::toSameDocumentNavigationType(type)) forFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigation:toWKSameDocumentNavigationType(WebKit::toSameDocumentNavigationType(type)) forFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
     else {
         // FIXME: Remove this once clients switch to implementing the above delegate method.
         if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didSameDocumentNavigationForFrame:)])
-            [(NSObject *)loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigationForFrame:wrapper(*WebKit::toImpl(frame))];
+            [(NSObject *)loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigationForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
     }
 }
 
@@ -211,7 +216,7 @@ static void didLayoutForFrame(WKBundlePageRef page, WKBundleFrameRef frame, cons
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didLayoutForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didLayoutForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didLayoutForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didReachLayoutMilestone(WKBundlePageRef page, WKLayoutMilestones milestones, WKTypeRef* userData, const void *clientInfo)
@@ -241,7 +246,7 @@ static void didFirstVisuallyNonEmptyLayoutForFrame(WKBundlePageRef page, WKBundl
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFirstVisuallyNonEmptyLayoutForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFirstVisuallyNonEmptyLayoutForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFirstVisuallyNonEmptyLayoutForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef frame, const void* clientInfo)
@@ -250,7 +255,7 @@ static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didHandleOnloadEventsForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didHandleOnloadEventsForFrame:wrapper(*WebKit::toImpl(frame))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didHandleOnloadEventsForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
 }
 
 static void setUpPageLoaderClient(WKWebProcessPlugInBrowserContextController *contextController, WebKit::WebPage& page)
@@ -290,14 +295,14 @@ static WKURLRequestRef willSendRequestForFrame(WKBundlePageRef, WKBundleFrameRef
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequestForResource:request:redirectResponse:)]) {
         RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
-        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:wrapper(*WebKit::toImpl(frame)) willSendRequestForResource:resourceIdentifier
-            request:originalRequest.get() redirectResponse:WebKit::toImpl(redirectResponse)->resourceResponse().nsURLResponse()];
+        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() willSendRequestForResource:resourceIdentifier
+            request:originalRequest.get() redirectResponse:WebKit::toImpl(redirectResponse)->resourceResponse().protectedNSURLResponse().get()];
 
         if (substituteRequest != originalRequest.get())
             return substituteRequest ? WKURLRequestCreateWithNSURLRequest(substituteRequest.get()) : nullptr;
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequest:redirectResponse:)]) {
         RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
-        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:wrapper(*WebKit::toImpl(frame)) willSendRequest:originalRequest.get()
+        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() willSendRequest:originalRequest.get()
             redirectResponse:WebKit::toImpl(redirectResponse)->resourceResponse().protectedNSURLResponse().get()];
 
         if (substituteRequest != originalRequest.get())
@@ -314,10 +319,10 @@ static void didInitiateLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didInitiateLoadForResource:request:pageIsProvisionallyLoading:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:wrapper(*WebKit::toImpl(frame)) didInitiateLoadForResource:resourceIdentifier request:wrapper(*WebKit::toImpl(request))
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didInitiateLoadForResource:resourceIdentifier request:protectedWrapper(*WebKit::toProtectedImpl(request)).get()
             pageIsProvisionallyLoading:pageIsProvisionallyLoading];
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didInitiateLoadForResource:request:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:wrapper(*WebKit::toImpl(frame)) didInitiateLoadForResource:resourceIdentifier request:wrapper(*WebKit::toImpl(request))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didInitiateLoadForResource:resourceIdentifier request:protectedWrapper(*WebKit::toProtectedImpl(request)).get()];
     }
 }
 
@@ -327,7 +332,7 @@ static void didReceiveResponseForResource(WKBundlePageRef, WKBundleFrameRef fram
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didReceiveResponse:forResource:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:wrapper(*WebKit::toImpl(frame)) didReceiveResponse:WebKit::toImpl(response)->resourceResponse().protectedNSURLResponse().get() forResource:resourceIdentifier];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didReceiveResponse:WebKit::toImpl(response)->resourceResponse().protectedNSURLResponse().get() forResource:resourceIdentifier];
 }
 
 static void didFinishLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint64_t resourceIdentifier, const void* clientInfo)
@@ -336,7 +341,7 @@ static void didFinishLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, ui
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didFinishLoadForResource:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:wrapper(*WebKit::toImpl(frame)) didFinishLoadForResource:resourceIdentifier];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didFinishLoadForResource:resourceIdentifier];
     }
 }
 
@@ -346,7 +351,7 @@ static void didFailLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didFailLoadForResource:error:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:wrapper(*WebKit::toImpl(frame)) didFailLoadForResource:resourceIdentifier error:wrapper(*WebKit::toImpl(error))];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didFailLoadForResource:resourceIdentifier error:protectedWrapper(*WebKit::toProtectedImpl(error)).get()];
     }
 }
 
@@ -375,12 +380,13 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 {
     _loadDelegate = loadDelegate;
 
+    Ref page = *_page;
     if (loadDelegate) {
-        setUpPageLoaderClient(self, *_page);
-        setUpResourceLoadClient(self, *_page);
+        setUpPageLoaderClient(self, page);
+        setUpResourceLoadClient(self, page);
     } else {
-        WKBundlePageSetPageLoaderClient(toAPI(_page.get()), nullptr);
-        WKBundlePageSetResourceLoadClient(toAPI(_page.get()), nullptr);
+        WKBundlePageSetPageLoaderClient(toAPI(page.ptr()), nullptr);
+        WKBundlePageSetResourceLoadClient(toAPI(page.ptr()), nullptr);
     }
 }
 
@@ -392,23 +398,23 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
     if (_remoteObjectRegistry)
         [_remoteObjectRegistry _invalidate];
 
-    _page->~WebPage();
+    SUPPRESS_UNCOUNTED_ARG _page->~WebPage();
 
     [super dealloc];
 }
 
 - (WKDOMDocument *)mainFrameDocument
 {
-    RefPtr webCoreMainFrame = dynamicDowncast<WebCore::LocalFrame>(_page->mainFrame());
+    RefPtr webCoreMainFrame = dynamicDowncast<WebCore::LocalFrame>(protectedPage(self)->mainFrame());
     if (!webCoreMainFrame)
         return nil;
 
-    return WebKit::toWKDOMDocument(webCoreMainFrame->document());
+    return WebKit::toWKDOMDocument(webCoreMainFrame->protectedDocument().get());
 }
 
 - (WKDOMRange *)selectedRange
 {
-    auto range = _page->currentSelectionAsRange();
+    auto range = protectedPage(self)->currentSelectionAsRange();
     if (!range)
         return nil;
 
@@ -433,7 +439,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
 - (WKBundlePageRef)_bundlePageRef
 {
-    return toAPI(_page.get());
+    return toAPI(protectedPage(self).ptr());
 }
 
 - (WKBrowsingContextHandle *)handle
@@ -479,7 +485,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:didFocusTextField:inFrame:)])
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() didFocusTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:wrapper(*frame)];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() didFocusTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:protectedWrapper(*frame).get()];
         }
 
         void willSendSubmitEvent(WebKit::WebPage*, WebCore::HTMLFormElement* formElement, WebKit::WebFrame* targetFrame, WebKit::WebFrame* sourceFrame, const Vector<std::pair<String, String>>& values) final
@@ -493,8 +499,8 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
                 auto valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:values.size()]);
                 for (const auto& pair : values)
                     [valueMap setObject:pair.second.createNSString().get() forKey:pair.first.createNSString().get()];
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() willSendSubmitEventToForm:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get())
-                    inFrame:wrapper(*sourceFrame) targetFrame:wrapper(*targetFrame) values:valueMap.get()];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() willSendSubmitEventToForm:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get()).get()
+                    inFrame:protectedWrapper(*sourceFrame).get() targetFrame:protectedWrapper(*targetFrame).get() values:valueMap.get()];
             }
         }
 
@@ -509,7 +515,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
                 auto valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:values.size()]);
                 for (const auto& pair : values)
                     [valueMap setObject:pair.second.createNSString().get() forKey:pair.first.createNSString().get()];
-                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willSubmitForm:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get()) toFrame:wrapper(*frame) fromFrame:wrapper(*sourceFrame) withValues:valueMap.get()]);
+                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willSubmitForm:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get()).get() toFrame:protectedWrapper(*frame).get() fromFrame:protectedWrapper(*sourceFrame).get() withValues:valueMap.get()]);
             }
         }
 
@@ -521,7 +527,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:textDidChangeInTextField:inFrame:initiatedByUserTyping:)])
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() textDidChangeInTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:wrapper(*frame) initiatedByUserTyping:initiatedByUserTyping];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() textDidChangeInTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:protectedWrapper(*frame).get() initiatedByUserTyping:initiatedByUserTyping];
         }
 
         void willBeginInputSession(WebKit::WebPage*, WebCore::Element* element, WebKit::WebFrame* frame, bool userIsInteracting, RefPtr<API::Object>& userData) final
@@ -532,13 +538,13 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:willBeginInputSessionForElement:inFrame:userIsInteracting:)]) {
-                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element)) inFrame:wrapper(*frame) userIsInteracting:userIsInteracting]);
+                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element)).get() inFrame:protectedWrapper(*frame).get() userIsInteracting:userIsInteracting]);
             } else if (userIsInteracting && [formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:willBeginInputSessionForElement:inFrame:)]) {
                 // FIXME: We check userIsInteracting so that we don't begin an input session for a
                 // programmatic focus that doesn't cause the keyboard to appear. But this misses the case of
                 // a programmatic focus happening while the keyboard is already shown. Once we have a way to
                 // know the keyboard state in the Web Process, we should refine the condition.
-                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element)) inFrame:wrapper(*frame)]);
+                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element)).get() inFrame:protectedWrapper(*frame).get()]);
             }
         }
 
@@ -573,9 +579,9 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
     };
 
     if (formDelegate)
-        _page->setInjectedBundleFormClient(makeUnique<FormClient>(self));
+        protectedPage(self)->setInjectedBundleFormClient(makeUnique<FormClient>(self));
     else
-        _page->setInjectedBundleFormClient(nullptr);
+        protectedPage(self)->setInjectedBundleFormClient(nullptr);
 }
 
 - (id <WKWebProcessPlugInEditingDelegate>)_editingDelegate
@@ -615,7 +621,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
                 return true;
 
             RetainPtr controller = m_controller.get();
-            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() shouldInsertText:text.createNSString().get() replacingRange:wrapper(*WebKit::createHandle(rangeToReplace)) givenAction:toWK(action)];
+            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() shouldInsertText:text.createNSString().get() replacingRange:protectedWrapper(*WebKit::createHandle(rangeToReplace)).get() givenAction:toWK(action)];
         }
 
         bool shouldChangeSelectedRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>& fromRange, const std::optional<WebCore::SimpleRange>& toRange, WebCore::Affinity affinity, bool stillSelecting) final
@@ -656,7 +662,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
                 return;
 
             RetainPtr controller = m_controller.get();
-            [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() willWriteRangeToPasteboard:wrapper(WebKit::createHandle(range).get())];
+            [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() willWriteRangeToPasteboard:protectedWrapper(WebKit::createHandle(range).get()).get()];
         }
 
         void getPasteboardDataForRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final
@@ -665,7 +671,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
                 return;
 
             RetainPtr controller = m_controller.get();
-            RetainPtr dataByType = [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() pasteboardDataForRange:wrapper(WebKit::createHandle(range).get())];
+            RetainPtr dataByType = [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() pasteboardDataForRange:protectedWrapper(WebKit::createHandle(range).get()).get()];
             for (NSString *type in dataByType.get()) {
                 pasteboardTypes.append(type);
                 pasteboardData.append(WebCore::SharedBuffer::create(dataByType.get()[type]));
@@ -689,7 +695,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
             auto rangeHandle = WebKit::createHandle(range);
             auto nodeHandle = WebKit::InjectedBundleNodeHandle::getOrCreate(&fragment);
             RetainPtr controller = m_controller.get();
-            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() performTwoStepDrop:wrapper(*nodeHandle) atDestination:wrapper(*rangeHandle) isMove:isMove];
+            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() performTwoStepDrop:protectedWrapper(*nodeHandle).get() atDestination:protectedWrapper(*rangeHandle).get() isMove:isMove];
         }
 
         WeakObjCPtr<WKWebProcessPlugInBrowserContextController> m_controller;
@@ -716,9 +722,9 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
     };
 
     if (editingDelegate)
-        _page->setInjectedBundleEditorClient(makeUnique<Client>(self));
+        protectedPage(self)->setInjectedBundleEditorClient(makeUnique<Client>(self));
     else
-        _page->setInjectedBundleEditorClient(nullptr);
+        protectedPage(self)->setInjectedBundleEditorClient(nullptr);
 }
 
 - (BOOL)_defersLoading
@@ -732,7 +738,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
 
 - (BOOL)_usesNonPersistentWebsiteDataStore
 {
-    return _page->usesEphemeralSession();
+    return protectedPage(self)->usesEphemeralSession();
 }
 
 - (NSString *)_groupIdentifier


### PR DESCRIPTION
#### 7d39c09c5961edc9223b4d663c5b5e72c6e27889
<pre>
Address remaining safer CPP warnings in WebKit/WebProcess/InjectedBundle
<a href="https://bugs.webkit.org/show_bug.cgi?id=301909">https://bugs.webkit.org/show_bug.cgi?id=301909</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedBodyOrFrameset const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Range.h:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp:
(WKBundlePostSynchronousMessage):
(WKBundleCreateWKDataFromUInt8Array):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp:
(WKBundleDOMWindowExtensionCreate):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameCopyChildFrames):
(WKBundleFrameGetPage):
(WKBundleFrameCreateHitTestResult):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp:
(WKBundleHitTestResultCopyNodeHandle):
(WKBundleHitTestResultCopyURLElementHandle):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp:
(WKBundleNodeHandleCreate):
(WKBundleNodeHandleCopyDocument):
(WKBundleNodeHandleCopySnapshotWithOptions):
(WKBundleNodeHandleCopyDocumentFrame):
(WKBundleNodeHandleCopyHTMLIFrameElementContentFrame):
(WKBundleNodeHandleCopyOwningDocumentFrame):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundleFrameCreateFrameHandle):
(WKBundlePageCopyContextMenuItems):
(WKBundlePageCopyContextMenuAtPointInWindow):
(WKBundlePageCreateSnapshotWithOptions):
(WKBundlePageCreateSnapshotInViewCoordinates):
(WKBundlePageCreateSnapshotInDocumentCoordinates):
(WKBundlePageCreateScaledSnapshotInDocumentCoordinates):
(WKBundlePageCopyTrackedRepaintRects):
(WKBundlePagePostSynchronousMessageForTesting):
(WKBundlePageCreateCaptionUserPreferencesTestingModeToken):
(WKBundlePageCopyFrameTextForTesting):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp:
(WKBundlePageOverlayCreate):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp:
(WKBundleRangeHandleCreate):
(WKBundleRangeHandleCopySnapshotWithOptions):
(WKBundleRangeHandleCopyDocumentFrame):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp:
(WKBundleScriptWorldCreateWorld):
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm:
(WKBundleGetParameters):
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm:
(WKBundlePageBannerCreateBannerWithCALayer):
(WKBundlePageBannerGetLayer):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm:
(-[WKDOMDocument body]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm:
(WebKit::WKDOMNodeClassSingleton):
(WebKit::createWrapper):
(WebKit::toProtectedWebCoreNode):
(WebKit::toProtectedWebCoreDocument):
(WebKit::toWebCoreRange):
(WebKit::toProtectedWebCoreRange):
(WebKit::WKDOMNodeClass): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm:
(-[WKDOMNode insertNode:before:]):
(-[WKDOMNode appendChild:]):
(-[WKDOMNode removeChild:]):
(-[WKDOMNode document]):
(-[WKDOMNode parentNode]):
(-[WKDOMNode firstChild]):
(-[WKDOMNode lastChild]):
(-[WKDOMNode previousSibling]):
(-[WKDOMNode nextSibling]):
(-[WKDOMNode textRects]):
(-[WKDOMNode _copyBundleNodeHandleRef]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm:
(-[WKDOMRange initWithDocument:]):
(-[WKDOMRange selectNode:]):
(-[WKDOMRange selectNodeContents:]):
(-[WKDOMRange startContainer]):
(-[WKDOMRange endContainer]):
(-[WKDOMRange text]):
(-[WKDOMRange textRects]):
(-[WKDOMRange _copyBundleRangeHandleRef]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm:
(-[WKDOMTextIterator initWithRange:]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm:
(protectedBundle):
(-[WKWebProcessPlugInController dealloc]):
(didCreatePage):
(willDestroyPage):
(-[WKWebProcessPlugInController _setPrincipalClassInstance:]):
(-[WKWebProcessPlugInController parameters]):
(-[WKWebProcessPlugInController extendClassesForParameterCoder:]):
(-[WKWebProcessPlugInController _bundleRef]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(protectedPage):
(didStartProvisionalLoadForFrame):
(didReceiveServerRedirectForProvisionalLoadForFrame):
(didFinishLoadForFrame):
(didClearWindowObjectForFrame):
(globalObjectIsAvailableForFrame):
(serviceWorkerGlobalObjectIsAvailableForFrame):
(willInjectUserScriptForFrame):
(didRemoveFrameFromHierarchy):
(didCommitLoadForFrame):
(didFinishDocumentLoadForFrame):
(didFailProvisionalLoadWithErrorForFrame):
(didFailLoadWithErrorForFrame):
(didSameDocumentNavigationForFrame):
(didLayoutForFrame):
(didFirstVisuallyNonEmptyLayoutForFrame):
(didHandleOnloadEventsForFrame):
(willSendRequestForFrame):
(didInitiateLoadForResource):
(didReceiveResponseForResource):
(didFinishLoadForResource):
(didFailLoadForResource):
(-[WKWebProcessPlugInBrowserContextController setLoadDelegate:]):
(-[WKWebProcessPlugInBrowserContextController dealloc]):
(-[WKWebProcessPlugInBrowserContextController mainFrameDocument]):
(-[WKWebProcessPlugInBrowserContextController selectedRange]):
(-[WKWebProcessPlugInBrowserContextController _bundlePageRef]):
(-[WKWebProcessPlugInBrowserContextController _setFormDelegate:]):
(-[WKWebProcessPlugInBrowserContextController _setEditingDelegate:]):
(-[WKWebProcessPlugInBrowserContextController _usesNonPersistentWebsiteDataStore]):

Canonical link: <a href="https://commits.webkit.org/302531@main">https://commits.webkit.org/302531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82c48af1e676ebd72b89b7d58cb741d17bf8501a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136771 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a4ec044d-e1fe-4ab4-a9eb-802b0cfae425) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98548 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f3de2e5d-a892-4481-947f-69e2b64286d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132341 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79199 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc66a95c-9e39-4b9b-98b3-093efb0fec04) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34028 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80048 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139245 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1389 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107072 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106916 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54099 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64875 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1329 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1366 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->