### PR TITLE
WIP Make eventSender `mouseDown`, `mouseUp`, and `mouseMoveTo` wait for pending mouse events

### DIFF
--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3193,11 +3193,13 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
 
         if (WKStringIsEqualToUTF8CString(subMessageName, "MouseDown")) {
             m_eventSenderProxy->mouseDown(uint64Value(dictionary, "Button"), uint64Value(dictionary, "Modifiers"), stringValue(dictionary, "PointerType"));
+            m_eventSenderProxy->waitForPendingMouseEvents();
             return completionHandler(nullptr);
         }
 
         if (WKStringIsEqualToUTF8CString(subMessageName, "MouseUp")) {
             m_eventSenderProxy->mouseUp(uint64Value(dictionary, "Button"), uint64Value(dictionary, "Modifiers"), stringValue(dictionary, "PointerType"));
+            m_eventSenderProxy->waitForPendingMouseEvents();
             return completionHandler(nullptr);
         }
 
@@ -3213,6 +3215,7 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
 
         if (WKStringIsEqualToUTF8CString(subMessageName, "MouseMoveTo")) {
             m_eventSenderProxy->mouseMoveTo(doubleValue(dictionary, "X"), doubleValue(dictionary, "Y"), stringValue(dictionary, "PointerType"));
+            m_eventSenderProxy->waitForPendingMouseEvents();
             return completionHandler(nullptr);
         }
 


### PR DESCRIPTION
#### f33cbe46b3a4ccd69b93da1e01d9269dbe87ed78
<pre>
WIP Make eventSender `mouseDown`, `mouseUp`, and `mouseMoveTo` wait for pending mouse events
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP DO NOT REVIEW

* Tools/WebKitTestRunner/TestController.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f33cbe46b3a4ccd69b93da1e01d9269dbe87ed78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80771 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/791ff90b-2d37-4df6-8733-764b0141dc98) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66446 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/55b1b8ec-206f-4744-8526-733dcbff2780) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79173 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/447bf9b7-50b6-459c-bd8e-2f892b725b98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80021 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109584 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34498 "Found 6 new test failures: editing/mac/selection/word-thai-does-not-leak.html fast/forms/form-control-element-crash.html fast/forms/switch/click-animation-twice.html fast/scrolling/mac/stateless-user-scroll-scrollend.html fast/shadow-dom/mouseenter-mouseleave-across-shadow-boundary.html imported/w3c/web-platform-tests/uievents/mouse/synthetic-mouse-enter-leave-over-out-button-state-after-target-removed.tentative.html?buttonType=MIDDLE&button=1&buttons=4 (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139217 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1414 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1366 "Found 4 new test failures: editing/mac/selection/word-thai-does-not-leak.html fast/forms/form-control-element-crash.html fast/shadow-dom/mouseenter-mouseleave-across-shadow-boundary.html imported/w3c/web-platform-tests/uievents/mouse/synthetic-mouse-enter-leave-over-out-button-state-after-target-removed.tentative.html?buttonType=MIDDLE&button=1&buttons=4 (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106892 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1152 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30732 "Found 5 new test failures: editing/mac/selection/word-thai-does-not-leak.html fast/forms/form-control-element-crash.html fast/forms/switch/click-animation-twice.html fast/scrolling/mac/stateless-user-scroll-scrollend.html fast/shadow-dom/mouseenter-mouseleave-across-shadow-boundary.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54066 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1485 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->