### PR TITLE
[Model element] Support `stagemode` in GPU process model element

### DIFF
--- a/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
@@ -77,6 +77,7 @@ public:
     virtual void setScale(float) { }
     virtual void setCameraDistance(float) = 0;
     virtual void setStageMode(WebCore::StageModeOperation) { }
+    virtual void setRotation(float, float = 0.f, float = 0.f) { }
     virtual void play(bool) = 0;
 
     virtual void render() = 0;

--- a/Source/WebCore/Modules/model-element/DDModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.h
@@ -86,6 +86,7 @@ private:
     std::optional<TransformationMatrix> entityTransform() const final;
     void setEntityTransform(TransformationMatrix) final;
     bool supportsTransform(TransformationMatrix) override;
+    bool supportsMouseInteraction() override;
 
     const MachSendRight* displayBuffer() const;
     GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate();
@@ -94,6 +95,7 @@ private:
     void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) override;
     bool paused() const override;
     void play(bool);
+    void simulate(float elapsedTime);
 
     void ensureOnMainThreadWithProtectedThis(Function<void(Ref<DDModelPlayer>)>&& task);
     void setStageMode(WebCore::StageModeOperation) final;
@@ -117,6 +119,11 @@ private:
         Paused
     };
     PauseState m_pauseState { PauseState::None };
+    std::optional<LayoutPoint> m_currentPoint;
+    float m_yawAcceleration { 0.f };
+    float m_pitchAcceleration { 0.f };
+    float m_yaw { 0.f };
+    float m_pitch { 0.f };
 };
 
 }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -774,7 +774,11 @@ bool HTMLModelElement::isDraggableIgnoringAttributes() const
 
 bool HTMLModelElement::isInteractive() const
 {
+#if ENABLE(MODEL_ELEMENT_STAGE_MODE)
+    return canSetEntityTransform();
+#else
     return hasAttributeWithoutSynchronization(HTMLNames::interactiveAttr);
+#endif
 }
 
 void HTMLModelElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1286,7 +1286,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         return true;
     }
 
-#if ENABLE(MODEL_ELEMENT)
+#if ENABLE(MODEL_ELEMENT) && !ENABLE(GPU_PROCESS_MODEL)
     if (RefPtr modelElement = dynamicDowncast<HTMLModelElement>(state.source); modelElement && m_dragSourceAction.contains(DragSourceAction::Model)) {
         dragImage = DragImage { createDragImageForNode(src, *modelElement) };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
@@ -93,6 +93,9 @@ private:
     void setScale(float) final;
     void setCameraDistance(float) final;
     void setStageMode(WebCore::StageModeOperation) final;
+#if ENABLE(GPU_PROCESS_MODEL)
+    void setRotation(float yaw, float pitch, float roll) final;
+#endif
 
     const DDModelIdentifier m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;


### PR DESCRIPTION
#### 5c30c1699634bfa0fc870ec6bd117ec21fca50e8
<pre>
[Model element] Support `stagemode` in GPU process model element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299474">https://bugs.webkit.org/show_bug.cgi?id=299474</a>&gt;
<a href="https://rdar.apple.com/161268350">rdar://161268350</a>

Reviewed by Etienne Segonzac.

Support stageMode and the ability to rotate the model
via mouse / touch by changing its transform.

* Source/WebCore/Modules/Model/InternalAPI/DDMesh.h:
(WebCore::DDModel::DDMesh::setRotation):
* Source/WebCore/Modules/model-element/DDModelPlayer.h:
* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
(WebCore::DDModelPlayer::handleMouseDown):
(WebCore::DDModelPlayer::handleMouseMove):
(WebCore::DDModelPlayer::handleMouseUp):
(WebCore::DDModelPlayer::simulate):
(WebCore::DDModelPlayer::update):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::isInteractive const):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::startDrag):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.cpp:
(WebKit::DDModel::buildRotation):
(WebKit::DDModel::RemoteDDMeshProxy::setRotation):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h:

Canonical link: <a href="https://commits.webkit.org/302618@main">https://commits.webkit.org/302618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b58ac884711dca4b97977c3058ed3de6a30b45e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80990 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ced4b23-664d-499b-bf12-ddcd5596b20b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98685 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66542 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d96cbbef-3498-4a9f-9112-01826350558e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79336 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5d22c790-0c9b-43f7-8be2-8d70f63ee1b8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80215 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107207 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54306 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65037 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1494 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1528 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->