### PR TITLE
REGRESSION(302186@main): [WPE] Build broken when targeting Android

### DIFF
--- a/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
+++ b/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
@@ -40,7 +40,7 @@ RefPtr<GraphicsContextGLTextureMapperAndroid> GraphicsContextGLTextureMapperAndr
 
 bool GraphicsContextGLTextureMapperAndroid::platformInitializeExtensions()
 {
-    if (!enableExtensions(GCGLExtension::GL_OES_EGL_image))
+    if (!enableExtensionsImpl({ "GL_OES_EGL_image"_s }))
         return false;
 
     const auto& eglExtensions = PlatformDisplay::sharedDisplay().eglExtensions();
@@ -104,13 +104,13 @@ bool GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensions()
     if (!makeContextCurrent())
         return false;
 
-    return enableExtensions({
-        GCGLExtension::GL_OES_EGL_image,
-        GCGLExtension::GL_OES_EGL_image_external,
-        GCGLExtension::EGL_KHR_image_base,
-        GCGLExtension::EGL_KHR_surfaceless_context,
-        GCGLExtension::EGL_ANDROID_get_native_client_buffer,
-        GCGLExtension::EGL_ANDROID_image_native_buffer,
+    return enableExtensionsImpl({
+        "GL_OES_EGL_image"_s,
+        "GL_OES_EGL_image_external"_s,
+        "EGL_KHR_image_base"_s,
+        "EGL_KHR_surfaceless_context"_s,
+        "EGL_ANDROID_get_native_client_buffer"_s,
+        "EGL_ANDROID_image_native_buffer"_s,
     });
 }
 #endif // ENABLE(WEBXR)


### PR DESCRIPTION
#### 18722fb3ee051f9900dcde9e9f0581fa089ac498
<pre>
REGRESSION(302186@main): [WPE] Build broken when targeting Android
<a href="https://bugs.webkit.org/show_bug.cgi?id=301912">https://bugs.webkit.org/show_bug.cgi?id=301912</a>

Reviewed by Carlos Garcia Campos.

Use GraphicsContextGLANGLE::enableExtensionsImpl() for extension names
which do not have an enumeration value in GCGLExtension. This is the
same approach used in 302186@main inside other GraphicsContextGLANGLE
subclasses.

* Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp:
(WebCore::GraphicsContextGLTextureMapperAndroid::platformInitializeExtensions):
(WebCore::GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensions):

Canonical link: <a href="https://commits.webkit.org/302523@main">https://commits.webkit.org/302523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14dd3e05dd41883554fe7d5a0775f48949b75350

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136753 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1509 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132323 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34012 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80030 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139226 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1423 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106899 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1157 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54081 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64857 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->