### PR TITLE
Always allocate FrameSelection in heap

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1945,10 +1945,10 @@ VisiblePositionRange AccessibilityNodeObject::visiblePositionRangeForLine(unsign
     // make a caret selection for the marker position, then extend it to the line
     // NOTE: Ignores results of sel.modify because it returns false when starting at an empty line.
     // The resulting selection in that case will be a caret at position.
-    FrameSelection selection;
-    selection.setSelection(position);
-    selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Right, TextGranularity::LineBoundary);
-    return selection.selection();
+    auto selection = makeUniqueRef<FrameSelection>();
+    selection->setSelection(position);
+    selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Right, TextGranularity::LineBoundary);
+    return selection->selection();
 }
 
 bool AccessibilityNodeObject::isGenericFocusableElement() const

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -128,7 +128,7 @@ struct RevealSelectionOptions {
     OnlyAllowForwardScrolling onlyAllowForwardScrolling { OnlyAllowForwardScrolling::No };
 };
 
-class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr<FrameSelection, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr<FrameSelection> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(FrameSelection, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(FrameSelection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameSelection);

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -673,11 +673,11 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
 
         m_smartDelete = false;
 
-        FrameSelection selection;
-        selection.setSelection(endingSelection());
-        selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, granularity);
-        if (shouldAddToKillRing && selection.isCaret() && granularity != TextGranularity::CharacterGranularity)
-            selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, TextGranularity::CharacterGranularity);
+        auto selection = makeUniqueRef<FrameSelection>();
+        selection->setSelection(endingSelection());
+        selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, granularity);
+        if (shouldAddToKillRing && selection->isCaret() && granularity != TextGranularity::CharacterGranularity)
+            selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, TextGranularity::CharacterGranularity);
 
         const VisiblePosition& visibleStart = endingSelection().visibleStart();
         const VisiblePosition& previousPosition = visibleStart.previous(CannotCrossEditingBoundary);
@@ -712,7 +712,7 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
             if (isLastPositionBeforeTable(visibleStart))
                 return;
             // Extend the selection backward into the last cell, then deletion will handle the move.
-            selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, granularity);
+            selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, granularity);
         // If the caret is just after a table, select the table and don't delete anything.
         } else if (RefPtr table = isFirstPositionAfterTable(visibleStart)) {
             setEndingSelection(VisibleSelection(positionBeforeNode(table.get()), endingSelection().start(), Affinity::Downstream, endingSelection().directionality()));
@@ -720,7 +720,7 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
             return;
         }
 
-        selectionToDelete = selection.selection();
+        selectionToDelete = selection->selection();
 
         if (granularity == TextGranularity::CharacterGranularity && selectionToDelete.end().containerNode() == selectionToDelete.start().containerNode()
             && selectionToDelete.end().computeOffsetInContainerNode() - selectionToDelete.start().computeOffsetInContainerNode() > 1) {
@@ -792,13 +792,13 @@ void TypingCommand::forwardDeleteKeyPressed(TextGranularity granularity, bool sh
         // Handle delete at beginning-of-block case.
         // Do nothing in the case that the caret is at the start of a
         // root editable element or at the start of a document.
-        FrameSelection selection;
-        selection.setSelection(endingSelection());
-        selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Forward, granularity);
-        if (selection.isNone())
+        auto selection = makeUniqueRef<FrameSelection>();
+        selection->setSelection(endingSelection());
+        selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Forward, granularity);
+        if (selection->isNone())
             return;
-        if (shouldAddToKillRing && selection.isCaret() && granularity != TextGranularity::CharacterGranularity)
-            selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Forward, TextGranularity::CharacterGranularity);
+        if (shouldAddToKillRing && selection->isCaret() && granularity != TextGranularity::CharacterGranularity)
+            selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Forward, TextGranularity::CharacterGranularity);
 
         Position downstreamEnd = endingSelection().end().downstream();
         VisiblePosition visibleEnd = endingSelection().visibleEnd();
@@ -816,10 +816,10 @@ void TypingCommand::forwardDeleteKeyPressed(TextGranularity granularity, bool sh
         }
 
         // deleting to end of paragraph when at end of paragraph needs to merge the next paragraph (if any)
-        if (granularity == TextGranularity::ParagraphBoundary && selection.selection().isCaret() && isEndOfParagraph(selection.selection().visibleEnd()))
-            selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Forward, TextGranularity::CharacterGranularity);
+        if (granularity == TextGranularity::ParagraphBoundary && selection->selection().isCaret() && isEndOfParagraph(selection->selection().visibleEnd()))
+            selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Forward, TextGranularity::CharacterGranularity);
 
-        selectionToDelete = selection.selection();
+        selectionToDelete = selection->selection();
         if (!startingSelection().isRange() || selectionToDelete.base() != startingSelection().start())
             selectionAfterUndo = selectionToDelete;
         else {

--- a/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
@@ -81,9 +81,9 @@ using WebCore::VisiblePosition;
 {
     auto& range = *core(self);
 
-    WebCore::FrameSelection frameSelection;
-    frameSelection.setSelection(makeSimpleRange(range));
-    
+    auto frameSelection = makeUniqueRef<WebCore::FrameSelection>();
+    frameSelection->setSelection(makeSimpleRange(range));
+
     WebCore::TextGranularity granularity = WebCore::TextGranularity::CharacterGranularity;
     // Until WebKit supports vertical layout, "down" is equivalent to "forward by a line" and
     // "up" is equivalent to "backward by a line".
@@ -96,10 +96,10 @@ using WebCore::VisiblePosition;
     }
 
     for (UInt32 i = 0; i < amount; i++)
-        frameSelection.modify(WebCore::FrameSelection::Alteration::Move, (WebCore::SelectionDirection)direction, granularity);
+        frameSelection->modify(WebCore::FrameSelection::Alteration::Move, (WebCore::SelectionDirection)direction, granularity);
 
-    Position start = frameSelection.selection().start().parentAnchoredEquivalent();
-    Position end = frameSelection.selection().end().parentAnchoredEquivalent();
+    Position start = frameSelection->selection().start().parentAnchoredEquivalent();
+    Position end = frameSelection->selection().end().parentAnchoredEquivalent();
     if (start.containerNode())
         range.setStart(*start.containerNode(), start.offsetInContainerNode());
     if (end.containerNode())
@@ -110,14 +110,14 @@ using WebCore::VisiblePosition;
 {
     auto& range = *core(self);
 
-    WebCore::FrameSelection frameSelection;
-    frameSelection.setSelection(makeSimpleRange(range));
+    auto frameSelection = makeUniqueRef<WebCore::FrameSelection>();
+    frameSelection->setSelection(makeSimpleRange(range));
 
     for (UInt32 i = 0; i < amount; i++)
-        frameSelection.modify(WebCore::FrameSelection::Alteration::Extend, (WebCore::SelectionDirection)direction, WebCore::TextGranularity::CharacterGranularity);
+        frameSelection->modify(WebCore::FrameSelection::Alteration::Extend, (WebCore::SelectionDirection)direction, WebCore::TextGranularity::CharacterGranularity);
 
-    Position start = frameSelection.selection().start().parentAnchoredEquivalent();
-    Position end = frameSelection.selection().end().parentAnchoredEquivalent();
+    Position start = frameSelection->selection().start().parentAnchoredEquivalent();
+    Position end = frameSelection->selection().end().parentAnchoredEquivalent();
     if (start.containerNode())
         range.setStart(*start.containerNode(), start.offsetInContainerNode());
     if (end.containerNode())


### PR DESCRIPTION
#### 79f1ca3872b2f573e6c98a63becc6375804b66b1
<pre>
Always allocate FrameSelection in heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=301913">https://bugs.webkit.org/show_bug.cgi?id=301913</a>

Reviewed by Wenson Hsieh.

Always allocate FrameSelection in heap so that operator delete can destruct it.

No new tests since there should be no behavioral differences.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::modify):
(WebCore::FrameSelection::setSelectedRange):
(WebCore::FrameSelection::rangeByExtendingCurrentSelection const):
(WebCore::FrameSelection::wordSelectionContainingCaretSelection):
(WebCore::FrameSelection::rangeByAlteringCurrentSelection const):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::deleteKeyPressed):
(WebCore::TypingCommand::forwardDeleteKeyPressed):
* Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm:
(-[DOMRange move:inDirection:]):
(-[DOMRange extend:inDirection:]):

Canonical link: <a href="https://commits.webkit.org/302597@main">https://commits.webkit.org/302597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1de0ee34916b8153708cbf263241d5a9c6831805

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80993 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92c413a6-87c4-463c-a02a-4704e21944a7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98688 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66552 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0417d398-26e6-4082-8749-2cee232972f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79339 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/182eb6fd-0473-48ec-afb3-01689f82b7ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34176 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80218 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139417 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107055 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54309 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20224 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65040 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1497 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->