### PR TITLE
GPUP: ShapeDetection implementation should operate on NativeImages

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h
@@ -59,7 +59,7 @@ private:
     BarcodeDetectorImpl& operator=(const BarcodeDetectorImpl&) = delete;
     BarcodeDetectorImpl& operator=(BarcodeDetectorImpl&&) = delete;
 
-    void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) final;
+    void detect(const NativeImage&, CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) final;
 
     std::optional<BarcodeFormatSet> m_requestedBarcodeFormatSet;
 };

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
@@ -173,15 +173,9 @@ void BarcodeDetectorImpl::getSupportedFormats(CompletionHandler<void(Vector<Barc
     completionHandler(WTFMove(barcodeFormatsVector));
 }
 
-void BarcodeDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<DetectedBarcode>&&)>&& completionHandler)
+void BarcodeDetectorImpl::detect(const NativeImage& image, CompletionHandler<void(Vector<DetectedBarcode>&&)>&& completionHandler)
 {
-    auto nativeImage = imageBuffer->copyNativeImage();
-    if (!nativeImage) {
-        completionHandler({ });
-        return;
-    }
-
-    auto platformImage = nativeImage->platformImage();
+    auto platformImage = image.platformImage();
     if (!platformImage) {
         completionHandler({ });
         return;
@@ -207,14 +201,15 @@ void BarcodeDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandl
         return;
     }
 
+    auto imageSize = image.size();
     Vector<DetectedBarcode> results;
     results.reserveInitialCapacity(request.get().results.count);
     for (VNBarcodeObservation *observation in request.get().results) {
         results.append({
-            convertRectFromVisionToWeb(nativeImage->size(), observation.boundingBox),
+            convertRectFromVisionToWeb(imageSize, observation.boundingBox),
             observation.payloadStringValue,
             convertSymbology(observation.symbology),
-            convertCornerPoints(nativeImage->size(), observation),
+            convertCornerPoints(imageSize, observation),
         });
     }
 

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h
@@ -52,7 +52,7 @@ private:
     FaceDetectorImpl& operator=(const FaceDetectorImpl&) = delete;
     FaceDetectorImpl& operator=(FaceDetectorImpl&&) = delete;
 
-    void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedFace>&&)>&&) final;
+    void detect(const NativeImage&, CompletionHandler<void(Vector<DetectedFace>&&)>&&) final;
 
     uint16_t m_maxDetectedFaces { std::numeric_limits<uint16_t>::max() };
 };

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h
@@ -50,7 +50,7 @@ private:
     TextDetectorImpl& operator=(const TextDetectorImpl&) = delete;
     TextDetectorImpl& operator=(TextDetectorImpl&&) = delete;
 
-    void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedText>&&)>&&) final;
+    void detect(const NativeImage&, CompletionHandler<void(Vector<DetectedText>&&)>&&) final;
 };
 
 } // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
@@ -43,15 +43,9 @@ TextDetectorImpl::TextDetectorImpl() = default;
 
 TextDetectorImpl::~TextDetectorImpl() = default;
 
-void TextDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<DetectedText>&&)>&& completionHandler)
+void TextDetectorImpl::detect(const NativeImage& image, CompletionHandler<void(Vector<DetectedText>&&)>&& completionHandler)
 {
-    auto nativeImage = imageBuffer->copyNativeImage();
-    if (!nativeImage) {
-        completionHandler({ });
-        return;
-    }
-
-    auto platformImage = nativeImage->platformImage();
+    auto platformImage = image.platformImage();
     if (!platformImage) {
         completionHandler({ });
         return;
@@ -69,13 +63,14 @@ void TextDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<
         return;
     }
 
+    auto imageSize = image.size();
     Vector<DetectedText> results;
     results.reserveInitialCapacity(request.get().results.count);
     for (VNRecognizedTextObservation *observation in request.get().results) {
         results.append({
-            convertRectFromVisionToWeb(nativeImage->size(), observation.boundingBox),
+            convertRectFromVisionToWeb(imageSize, observation.boundingBox),
             [observation topCandidates:1][0].string,
-            convertCornerPoints(nativeImage->size(), observation),
+            convertCornerPoints(imageSize, observation),
         });
     }
 

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h
@@ -31,7 +31,7 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
-class ImageBuffer;
+class NativeImage;
 }
 
 namespace WebCore::ShapeDetection {
@@ -43,7 +43,7 @@ class BarcodeDetector : public RefCounted<BarcodeDetector> {
 public:
     virtual ~BarcodeDetector() = default;
 
-    virtual void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) = 0;
+    virtual void detect(const NativeImage&, CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) = 0;
 
 protected:
     BarcodeDetector() = default;

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h
@@ -31,7 +31,7 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
-class ImageBuffer;
+class NativeImage;
 }
 
 namespace WebCore::ShapeDetection {
@@ -42,7 +42,7 @@ class FaceDetector : public RefCounted<FaceDetector> {
 public:
     virtual ~FaceDetector() = default;
 
-    virtual void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedFace>&&)>&&) = 0;
+    virtual void detect(const NativeImage&, CompletionHandler<void(Vector<DetectedFace>&&)>&&) = 0;
 
 protected:
     FaceDetector() = default;

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h
@@ -31,7 +31,7 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
-class ImageBuffer;
+class NativeImage;
 }
 
 namespace WebCore::ShapeDetection {
@@ -42,7 +42,7 @@ class TextDetector : public RefCounted<TextDetector> {
 public:
     virtual ~TextDetector() = default;
 
-    virtual void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedText>&&)>&&) = 0;
+    virtual void detect(const NativeImage&, CompletionHandler<void(Vector<DetectedText>&&)>&&) = 0;
 
 protected:
     TextDetector() = default;

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
@@ -76,13 +76,14 @@ void TextDetector::detect(ScriptExecutionContext& scriptExecutionContext, ImageB
         }
 
         // FIXME: This is a safer cpp false positive (rdar://160082559).
-        SUPPRESS_UNCOUNTED_ARG auto imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
-        if (!imageBuffer) {
+        SUPPRESS_UNCOUNTED_ARG RefPtr imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
+        RefPtr<NativeImage> image = imageBuffer ? imageBuffer->copyNativeImage() : nullptr;
+        if (!image) {
             promise.resolve({ });
             return;
         }
 
-        backing->detect(imageBuffer.releaseNonNull(), [promise = WTFMove(promise)](Vector<ShapeDetection::DetectedText>&& detectedText) mutable {
+        backing->detect(*image, [promise = WTFMove(promise)](Vector<ShapeDetection::DetectedText>&& detectedText) mutable {
             promise.resolve(detectedText.map([](const auto& detectedText) {
                 return convertFromBacking(detectedText);
             }));

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
@@ -31,23 +31,22 @@
 #include "ArgumentCoders.h"
 #include "RemoteRenderingBackend.h"
 #include "RemoteResourceCache.h"
-#include "ShapeDetectionObjectHeap.h"
 #include "SharedPreferencesForWebProcess.h"
 #include <WebCore/BarcodeDetectorInterface.h>
 #include <WebCore/DetectedBarcodeInterface.h>
-#include <WebCore/ImageBuffer.h>
+#include <WebCore/NativeImage.h>
 #include <wtf/TZoneMallocInlines.h>
+
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_renderingBackend.get().streamConnection());
 
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBarcodeDetector);
 
-RemoteBarcodeDetector::RemoteBarcodeDetector(Ref<WebCore::ShapeDetection::BarcodeDetector>&& barcodeDetector, ShapeDetection::ObjectHeap& objectHeap, RemoteRenderingBackend& backend, ShapeDetectionIdentifier identifier, WebCore::ProcessIdentifier webProcessIdentifier)
+RemoteBarcodeDetector::RemoteBarcodeDetector(Ref<WebCore::ShapeDetection::BarcodeDetector>&& barcodeDetector, RemoteRenderingBackend& backend, ShapeDetectionIdentifier identifier)
     : m_backing(WTFMove(barcodeDetector))
-    , m_objectHeap(objectHeap)
-    , m_backend(backend)
+    , m_renderingBackend(backend)
     , m_identifier(identifier)
-    , m_webProcessIdentifier(webProcessIdentifier)
 {
 }
 
@@ -55,30 +54,18 @@ RemoteBarcodeDetector::~RemoteBarcodeDetector() = default;
 
 std::optional<SharedPreferencesForWebProcess> RemoteBarcodeDetector::sharedPreferencesForWebProcess() const
 {
-    return protectedBackend()->sharedPreferencesForWebProcess();
-}
-
-Ref<WebCore::ShapeDetection::BarcodeDetector> RemoteBarcodeDetector::protectedBacking() const
-{
-    return backing();
-}
-
-Ref<RemoteRenderingBackend> RemoteBarcodeDetector::protectedBackend() const
-{
-    return m_backend.get();
+    return Ref { m_renderingBackend.get() }->sharedPreferencesForWebProcess();
 }
 
 void RemoteBarcodeDetector::detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&& completionHandler)
 {
-    auto sourceImage = protectedBackend()->imageBuffer(renderingResourceIdentifier);
-    if (!sourceImage) {
-        completionHandler({ });
-        return;
-    }
-
-    protectedBacking()->detect(*sourceImage, WTFMove(completionHandler));
+    RefPtr sourceImage = m_renderingBackend.get().remoteResourceCache().cachedNativeImage(renderingResourceIdentifier);
+    MESSAGE_CHECK(sourceImage);
+    m_backing->detect(*sourceImage, WTFMove(completionHandler));
 }
 
 } // namespace WebKit
+
+#undef MESSAGE_CHECK
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
@@ -55,36 +55,26 @@ class ObjectHeap;
 class RemoteBarcodeDetector : public IPC::StreamMessageReceiver {
 public:
     WTF_MAKE_TZONE_ALLOCATED(RemoteBarcodeDetector);
+    WTF_MAKE_NONCOPYABLE(RemoteBarcodeDetector);
 public:
-    static Ref<RemoteBarcodeDetector> create(Ref<WebCore::ShapeDetection::BarcodeDetector>&& barcodeDetector, ShapeDetection::ObjectHeap& objectHeap, RemoteRenderingBackend& backend, ShapeDetectionIdentifier identifier, WebCore::ProcessIdentifier webProcessIdentifier)
+    static Ref<RemoteBarcodeDetector> create(Ref<WebCore::ShapeDetection::BarcodeDetector>&& barcodeDetector, RemoteRenderingBackend& renderingBackend, ShapeDetectionIdentifier identifier)
     {
-        return adoptRef(*new RemoteBarcodeDetector(WTFMove(barcodeDetector), objectHeap, backend, identifier, webProcessIdentifier));
+        return adoptRef(*new RemoteBarcodeDetector(WTFMove(barcodeDetector), renderingBackend, identifier));
     }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
     virtual ~RemoteBarcodeDetector();
 
 private:
-    RemoteBarcodeDetector(Ref<WebCore::ShapeDetection::BarcodeDetector>&&, ShapeDetection::ObjectHeap&, RemoteRenderingBackend&, ShapeDetectionIdentifier, WebCore::ProcessIdentifier);
-
-    RemoteBarcodeDetector(const RemoteBarcodeDetector&) = delete;
-    RemoteBarcodeDetector(RemoteBarcodeDetector&&) = delete;
-    RemoteBarcodeDetector& operator=(const RemoteBarcodeDetector&) = delete;
-    RemoteBarcodeDetector& operator=(RemoteBarcodeDetector&&) = delete;
-
-    WebCore::ShapeDetection::BarcodeDetector& backing() const { return m_backing; }
-    Ref<WebCore::ShapeDetection::BarcodeDetector> protectedBacking() const;
-    Ref<RemoteRenderingBackend> protectedBackend() const;
+    RemoteBarcodeDetector(Ref<WebCore::ShapeDetection::BarcodeDetector>&&, RemoteRenderingBackend&, ShapeDetectionIdentifier);
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&&);
 
-    Ref<WebCore::ShapeDetection::BarcodeDetector> m_backing;
-    WeakRef<ShapeDetection::ObjectHeap> m_objectHeap;
-    WeakRef<RemoteRenderingBackend> m_backend;
+    const Ref<WebCore::ShapeDetection::BarcodeDetector> m_backing;
+    const WeakRef<RemoteRenderingBackend> m_renderingBackend;
     const ShapeDetectionIdentifier m_identifier;
-    const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
@@ -55,10 +55,11 @@ class ObjectHeap;
 class RemoteFaceDetector : public IPC::StreamMessageReceiver {
 public:
     WTF_MAKE_TZONE_ALLOCATED(RemoteFaceDetector);
+    WTF_MAKE_NONCOPYABLE(RemoteFaceDetector);
 public:
-    static Ref<RemoteFaceDetector> create(Ref<WebCore::ShapeDetection::FaceDetector>&& faceDetector, ShapeDetection::ObjectHeap& objectHeap, RemoteRenderingBackend& backend, ShapeDetectionIdentifier identifier, WebCore::ProcessIdentifier webProcessIdentifier)
+    static Ref<RemoteFaceDetector> create(Ref<WebCore::ShapeDetection::FaceDetector>&& faceDetector, RemoteRenderingBackend& renderingBackend, ShapeDetectionIdentifier identifier)
     {
-        return adoptRef(*new RemoteFaceDetector(WTFMove(faceDetector), objectHeap, backend, identifier, webProcessIdentifier));
+        return adoptRef(*new RemoteFaceDetector(WTFMove(faceDetector), renderingBackend, identifier));
     }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
@@ -66,25 +67,15 @@ public:
     virtual ~RemoteFaceDetector();
 
 private:
-    RemoteFaceDetector(Ref<WebCore::ShapeDetection::FaceDetector>&&, ShapeDetection::ObjectHeap&, RemoteRenderingBackend&, ShapeDetectionIdentifier, WebCore::ProcessIdentifier);
-
-    RemoteFaceDetector(const RemoteFaceDetector&) = delete;
-    RemoteFaceDetector(RemoteFaceDetector&&) = delete;
-    RemoteFaceDetector& operator=(const RemoteFaceDetector&) = delete;
-    RemoteFaceDetector& operator=(RemoteFaceDetector&&) = delete;
-
-    WebCore::ShapeDetection::FaceDetector& backing() { return m_backing; }
-    Ref<RemoteRenderingBackend> protectedBackend() const { return m_backend.get(); }
+    RemoteFaceDetector(Ref<WebCore::ShapeDetection::FaceDetector>&&, RemoteRenderingBackend&, ShapeDetectionIdentifier);
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&);
 
-    Ref<WebCore::ShapeDetection::FaceDetector> m_backing;
-    WeakRef<ShapeDetection::ObjectHeap> m_objectHeap;
-    WeakRef<RemoteRenderingBackend> m_backend;
+    const Ref<WebCore::ShapeDetection::FaceDetector> m_backing;
+    const WeakRef<RemoteRenderingBackend> m_renderingBackend;
     const ShapeDetectionIdentifier m_identifier;
-    const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
@@ -54,10 +54,11 @@ class ObjectHeap;
 class RemoteTextDetector : public IPC::StreamMessageReceiver {
 public:
     WTF_MAKE_TZONE_ALLOCATED(RemoteTextDetector);
+    WTF_MAKE_NONCOPYABLE(RemoteTextDetector);
 public:
-    static Ref<RemoteTextDetector> create(Ref<WebCore::ShapeDetection::TextDetector>&& textDetector, ShapeDetection::ObjectHeap& objectHeap, RemoteRenderingBackend& backend, ShapeDetectionIdentifier identifier, WebCore::ProcessIdentifier webProcessIdentifier)
+    static Ref<RemoteTextDetector> create(Ref<WebCore::ShapeDetection::TextDetector>&& textDetector, RemoteRenderingBackend& renderingBackend, ShapeDetectionIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextDetector(WTFMove(textDetector), objectHeap, backend, identifier, webProcessIdentifier));
+        return adoptRef(*new RemoteTextDetector(WTFMove(textDetector), renderingBackend, identifier));
     }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
@@ -65,26 +66,15 @@ public:
     virtual ~RemoteTextDetector();
 
 private:
-    RemoteTextDetector(Ref<WebCore::ShapeDetection::TextDetector>&&, ShapeDetection::ObjectHeap&, RemoteRenderingBackend&, ShapeDetectionIdentifier, WebCore::ProcessIdentifier);
-
-    RemoteTextDetector(const RemoteTextDetector&) = delete;
-    RemoteTextDetector(RemoteTextDetector&&) = delete;
-    RemoteTextDetector& operator=(const RemoteTextDetector&) = delete;
-    RemoteTextDetector& operator=(RemoteTextDetector&&) = delete;
-
-    WebCore::ShapeDetection::TextDetector& backing() const { return m_backing; }
-    Ref<WebCore::ShapeDetection::TextDetector> protectedBacking() const;
-    Ref<RemoteRenderingBackend> protectedBackend() const;
+    RemoteTextDetector(Ref<WebCore::ShapeDetection::TextDetector>&&, RemoteRenderingBackend&, ShapeDetectionIdentifier);
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&&);
 
-    Ref<WebCore::ShapeDetection::TextDetector> m_backing;
-    WeakRef<ShapeDetection::ObjectHeap> m_objectHeap;
-    WeakRef<RemoteRenderingBackend> m_backend;
+    const Ref<WebCore::ShapeDetection::TextDetector> m_backing;
+    const WeakRef<RemoteRenderingBackend> m_renderingBackend;
     const ShapeDetectionIdentifier m_identifier;
-    const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -188,13 +188,13 @@ private:
     void createSnapshotRecorder(RemoteSnapshotRecorderIdentifier, RemoteSnapshotIdentifier);
     void sinkSnapshotRecorderIntoSnapshotFrame(RemoteSnapshotRecorderIdentifier, WebCore::FrameIdentifier, CompletionHandler<void(bool)>&&);
 
-    void createRemoteBarcodeDetector(ShapeDetectionIdentifier, const WebCore::ShapeDetection::BarcodeDetectorOptions&);
-    void releaseRemoteBarcodeDetector(ShapeDetectionIdentifier);
-    void getRemoteBarcodeDetectorSupportedFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>&&);
-    void createRemoteFaceDetector(ShapeDetectionIdentifier, const WebCore::ShapeDetection::FaceDetectorOptions&);
-    void releaseRemoteFaceDetector(ShapeDetectionIdentifier);
-    void createRemoteTextDetector(ShapeDetectionIdentifier);
-    void releaseRemoteTextDetector(ShapeDetectionIdentifier);
+    void createBarcodeDetector(ShapeDetectionIdentifier, const WebCore::ShapeDetection::BarcodeDetectorOptions&);
+    void releaseBarcodeDetector(ShapeDetectionIdentifier);
+    void supportedBarcodeDetectorBarcodeFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>&&);
+    void createFaceDetector(ShapeDetectionIdentifier, const WebCore::ShapeDetection::FaceDetectorOptions&);
+    void releaseFaceDetector(ShapeDetectionIdentifier);
+    void createTextDetector(ShapeDetectionIdentifier);
+    void releaseTextDetector(ShapeDetectionIdentifier);
 
     bool shouldUseLockdownFontParser() const;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -69,13 +69,13 @@ messages -> RemoteRenderingBackend Stream {
     CreateSnapshotRecorder(WebKit::RemoteSnapshotRecorderIdentifier identifier, WebKit::RemoteSnapshotIdentifier snapshotIdentifier)
     SinkSnapshotRecorderIntoSnapshotFrame(WebKit::RemoteSnapshotRecorderIdentifier identifier, WebCore::FrameIdentifier frameIdentifer) -> (bool success)
 
-    [EnabledBy=ShapeDetection] CreateRemoteBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::BarcodeDetectorOptions barcodeDetectorOptions) AllowedWhenWaitingForSyncReply
-    [EnabledBy=ShapeDetection] ReleaseRemoteBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
-    [EnabledBy=ShapeDetection] GetRemoteBarcodeDetectorSupportedFormats() -> (Vector<WebCore::ShapeDetection::BarcodeFormat> formats) Async
-    [EnabledBy=ShapeDetection] CreateRemoteFaceDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::FaceDetectorOptions faceDetectorOptions) AllowedWhenWaitingForSyncReply
-    [EnabledBy=ShapeDetection] ReleaseRemoteFaceDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
-    [EnabledBy=ShapeDetection] CreateRemoteTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
-    [EnabledBy=ShapeDetection] ReleaseRemoteTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] CreateBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::BarcodeDetectorOptions barcodeDetectorOptions) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] ReleaseBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] SupportedBarcodeDetectorBarcodeFormats() -> (Vector<WebCore::ShapeDetection::BarcodeFormat> formats) Async
+    [EnabledBy=ShapeDetection] CreateFaceDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::FaceDetectorOptions faceDetectorOptions) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] ReleaseFaceDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] CreateTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] ReleaseTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
@@ -25,12 +25,11 @@
 
 #pragma once
 
-#include "RemoteRenderingBackendIdentifier.h"
 #include "ShapeDetectionIdentifier.h"
 #include <WebCore/FaceDetectorInterface.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Identified.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,33 +41,26 @@ class StreamClientConnection;
 
 namespace WebCore::ShapeDetection {
 struct DetectedFace;
-struct FaceDetectorOptions;
+}
+
+namespace WebKit {
+class RemoteRenderingBackendProxy;
 }
 
 namespace WebKit::ShapeDetection {
 
-class RemoteFaceDetectorProxy : public WebCore::ShapeDetection::FaceDetector {
+class RemoteFaceDetectorProxy : public WebCore::ShapeDetection::FaceDetector, public Identified<ShapeDetectionIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteFaceDetectorProxy);
+    WTF_MAKE_NONCOPYABLE(RemoteFaceDetectorProxy);
 public:
-    static Ref<RemoteFaceDetectorProxy> create(Ref<IPC::StreamClientConnection>&&, RemoteRenderingBackendIdentifier, ShapeDetectionIdentifier, const WebCore::ShapeDetection::FaceDetectorOptions&);
-
+    static Ref<RemoteFaceDetectorProxy> create(RemoteRenderingBackendProxy&);
     virtual ~RemoteFaceDetectorProxy();
 
 private:
-    RemoteFaceDetectorProxy(Ref<IPC::StreamClientConnection>&&, RemoteRenderingBackendIdentifier, ShapeDetectionIdentifier);
+    RemoteFaceDetectorProxy(RemoteRenderingBackendProxy&);
+    void detect(const WebCore::NativeImage&, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&) final;
 
-    RemoteFaceDetectorProxy(const RemoteFaceDetectorProxy&) = delete;
-    RemoteFaceDetectorProxy(RemoteFaceDetectorProxy&&) = delete;
-    RemoteFaceDetectorProxy& operator=(const RemoteFaceDetectorProxy&) = delete;
-    RemoteFaceDetectorProxy& operator=(RemoteFaceDetectorProxy&&) = delete;
-
-    ShapeDetectionIdentifier backing() const { return m_backing; }
-
-    void detect(Ref<WebCore::ImageBuffer>&&, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&) final;
-
-    ShapeDetectionIdentifier m_backing;
-    const Ref<IPC::StreamClientConnection> m_streamClientConnection;
-    RemoteRenderingBackendIdentifier m_renderingBackendIdentifier;
+    WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;
 };
 
 } // namespace WebKit::ShapeDetection

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -35,7 +35,9 @@
 #include "ImageBufferShareableBitmapBackend.h"
 #include "Logging.h"
 #include "PrepareBackingStoreBuffersData.h"
+#include "RemoteBarcodeDetectorProxy.h"
 #include "RemoteDisplayListRecorderProxy.h"
+#include "RemoteFaceDetectorProxy.h"
 #include "RemoteImageBufferMessages.h"
 #include "RemoteImageBufferProxy.h"
 #include "RemoteImageBufferProxyMessages.h"
@@ -44,6 +46,7 @@
 #include "RemoteRenderingBackendProxyMessages.h"
 #include "RemoteSharedResourceCacheProxy.h"
 #include "RemoteSnapshotRecorderProxy.h"
+#include "RemoteTextDetectorProxy.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
@@ -699,6 +702,47 @@ Function<bool()> RemoteRenderingBackendProxy::flushImageBuffers()
 void RemoteRenderingBackendProxy::getImageBufferResourceLimitsForTesting(CompletionHandler<void(ImageBufferResourceLimits)>&& callback)
 {
     sendWithAsyncReply(Messages::RemoteRenderingBackend::GetImageBufferResourceLimitsForTesting(), WTFMove(callback));
+}
+
+Ref<ShapeDetection::RemoteBarcodeDetectorProxy> RemoteRenderingBackendProxy::createBarcodeDetector(const WebCore::ShapeDetection::BarcodeDetectorOptions& options)
+{
+    Ref instance = ShapeDetection::RemoteBarcodeDetectorProxy::create(*this);
+    send(Messages::RemoteRenderingBackend::CreateBarcodeDetector(instance->identifier(), options));
+    return instance;
+}
+
+void RemoteRenderingBackendProxy::releaseBarcodeDetector(ShapeDetection::RemoteBarcodeDetectorProxy& instance)
+{
+    send(Messages::RemoteRenderingBackend::ReleaseBarcodeDetector(instance.identifier()));
+}
+
+void RemoteRenderingBackendProxy::supportedBarcodeDetectorBarcodeFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)> completionHandler)
+{
+    sendWithAsyncReply(Messages::RemoteRenderingBackend::SupportedBarcodeDetectorBarcodeFormats(), WTFMove(completionHandler));
+}
+
+Ref<ShapeDetection::RemoteFaceDetectorProxy> RemoteRenderingBackendProxy::createFaceDetector(const WebCore::ShapeDetection::FaceDetectorOptions& options)
+{
+    Ref instance = ShapeDetection::RemoteFaceDetectorProxy::create(*this);
+    send(Messages::RemoteRenderingBackend::CreateFaceDetector(instance->identifier(), options));
+    return instance;
+}
+
+void RemoteRenderingBackendProxy::releaseFaceDetector(ShapeDetection::RemoteFaceDetectorProxy& instance)
+{
+    send(Messages::RemoteRenderingBackend::ReleaseFaceDetector(instance.identifier()));
+}
+
+Ref<ShapeDetection::RemoteTextDetectorProxy> RemoteRenderingBackendProxy::createTextDetector()
+{
+    Ref instance = ShapeDetection::RemoteTextDetectorProxy::create(*this);
+    send(Messages::RemoteRenderingBackend::CreateTextDetector(instance->identifier()));
+    return instance;
+}
+
+void RemoteRenderingBackendProxy::releaseTextDetector(ShapeDetection::RemoteTextDetectorProxy& instance)
+{
+    send(Messages::RemoteRenderingBackend::ReleaseTextDetector(instance.identifier()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -65,6 +65,9 @@ class PixelBuffer;
 enum class AlphaPremultiplication : uint8_t;
 enum class RenderingMode : uint8_t;
 
+namespace ShapeDetection {
+enum class BarcodeFormat : uint8_t;
+}
 }
 
 namespace WebKit {
@@ -76,9 +79,14 @@ class RemoteImageBufferProxy;
 class RemoteSerializedImageBufferProxy;
 class RemoteSharedResourceCacheProxy;
 class RemoteLayerBackingStore;
-
 class RemoteImageBufferProxyFlushState;
 class RemoteImageBufferSetProxy;
+
+namespace ShapeDetection {
+class RemoteBarcodeDetectorProxy;
+class RemoteTextDetectorProxy;
+class RemoteFaceDetectorProxy;
+}
 
 class RemoteRenderingBackendProxy
     : public IPC::Connection::Client, public RefCounted<RemoteRenderingBackendProxy>, SerialFunctionDispatcher {
@@ -129,6 +137,14 @@ public:
 
     UniqueRef<RemoteSnapshotRecorderProxy> createSnapshotRecorder(RemoteSnapshotIdentifier);
     void sinkSnapshotRecorderIntoSnapshotFrame(UniqueRef<RemoteSnapshotRecorderProxy>&&, WebCore::FrameIdentifier, CompletionHandler<void(bool)>&&);
+
+    Ref<ShapeDetection::RemoteBarcodeDetectorProxy> createBarcodeDetector(const WebCore::ShapeDetection::BarcodeDetectorOptions&);
+    void releaseBarcodeDetector(ShapeDetection::RemoteBarcodeDetectorProxy&);
+    void supportedBarcodeDetectorBarcodeFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>);
+    Ref<ShapeDetection::RemoteFaceDetectorProxy> createFaceDetector(const WebCore::ShapeDetection::FaceDetectorOptions&);
+    void releaseFaceDetector(ShapeDetection::RemoteFaceDetectorProxy&);
+    Ref<ShapeDetection::RemoteTextDetectorProxy> createTextDetector();
+    void releaseTextDetector(ShapeDetection::RemoteTextDetectorProxy&);
 
 #if USE(GRAPHICS_LAYER_WC)
     Function<bool()> flushImageBuffers();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1171,13 +1171,8 @@ RefPtr<WebCore::ShapeDetection::BarcodeDetector> WebChromeClient::createBarcodeD
     RefPtr page = m_page.get();
     if (!page)
         return nullptr;
-
-    Ref remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
-    RefPtr connection = remoteRenderingBackendProxy->connection();
-    if (!connection)
-        return nullptr;
-    return ShapeDetection::RemoteBarcodeDetectorProxy::create(connection.releaseNonNull(), remoteRenderingBackendProxy->renderingBackendIdentifier(), ShapeDetectionIdentifier::generate(), barcodeDetectorOptions);
+    Ref renderingBackend = page->ensureRemoteRenderingBackendProxy();
+    return renderingBackend->createBarcodeDetector(barcodeDetectorOptions);
 #elif HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
     return WebCore::ShapeDetection::BarcodeDetectorImpl::create(barcodeDetectorOptions);
 #else
@@ -1193,14 +1188,8 @@ void WebChromeClient::getBarcodeDetectorSupportedFormats(CompletionHandler<void(
         completionHandler({ });
         return;
     }
-    Ref remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
-    RefPtr connection = remoteRenderingBackendProxy->connection();
-    if (!connection) {
-        completionHandler({ });
-        return;
-    }
-    ShapeDetection::RemoteBarcodeDetectorProxy::getSupportedFormats(connection.releaseNonNull(), remoteRenderingBackendProxy->renderingBackendIdentifier(), WTFMove(completionHandler));
+    Ref renderingBackend = page->ensureRemoteRenderingBackendProxy();
+    renderingBackend->supportedBarcodeDetectorBarcodeFormats(WTFMove(completionHandler));
 #elif HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
     WebCore::ShapeDetection::BarcodeDetectorImpl::getSupportedFormats(WTFMove(completionHandler));
 #else
@@ -1214,13 +1203,8 @@ RefPtr<WebCore::ShapeDetection::FaceDetector> WebChromeClient::createFaceDetecto
     RefPtr page = m_page.get();
     if (!page)
         return nullptr;
-
-    Ref remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
-    RefPtr connection = remoteRenderingBackendProxy->connection();
-    if (!connection)
-        return nullptr;
-    return ShapeDetection::RemoteFaceDetectorProxy::create(connection.releaseNonNull(), remoteRenderingBackendProxy->renderingBackendIdentifier(), ShapeDetectionIdentifier::generate(), faceDetectorOptions);
+    Ref renderingBackend = page->ensureRemoteRenderingBackendProxy();
+    return renderingBackend->createFaceDetector(faceDetectorOptions);
 #elif HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
     return WebCore::ShapeDetection::FaceDetectorImpl::create(faceDetectorOptions);
 #else
@@ -1234,13 +1218,8 @@ RefPtr<WebCore::ShapeDetection::TextDetector> WebChromeClient::createTextDetecto
     RefPtr page = m_page.get();
     if (!page)
         return nullptr;
-
-    Ref remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
-    RefPtr connection = remoteRenderingBackendProxy->connection();
-    if (!connection)
-        return nullptr;
-    return ShapeDetection::RemoteTextDetectorProxy::create(connection.releaseNonNull(), remoteRenderingBackendProxy->renderingBackendIdentifier(), ShapeDetectionIdentifier::generate());
+    Ref renderingBackend = page->ensureRemoteRenderingBackendProxy();
+    return renderingBackend->createTextDetector();
 #elif HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
     return WebCore::ShapeDetection::TextDetectorImpl::create();
 #else


### PR DESCRIPTION
#### d0dc0c8cdd47bc8ff489ab515d4b3ad653067d6e
<pre>
GPUP: ShapeDetection implementation should operate on NativeImages
<a href="https://bugs.webkit.org/show_bug.cgi?id=301914">https://bugs.webkit.org/show_bug.cgi?id=301914</a>
<a href="https://rdar.apple.com/163993427">rdar://163993427</a>

Reviewed by Mike Wyrzykowski.

The input to shape detection is a bitmap image. This is represented by
WebCore::NativeImage. Change the ShapeDetection detector inputs to
NativeImage instead of ImageBuffers. This way the natural sources,
images, are directly passable to ShapeDetection instead of the lossy,
redundant conversion to ImageBuffers.

This change is a prerequisite to the target commit of doing similar
change to ImageBitmap, e.g. making ImageBitmap hold a NativeImage
directly for similar performance and correctness reasons. ShapeDetection
uses ImageBitmap as a implementation detail to obtain the image out of
various ImageBitmapSources. Before ImageBitmap can be made to hold
NativeImage, ShapeDetection must be able to input NativeImage.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp:
(WebCore::BarcodeDetector::detect):
* Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp:
(WebCore::FaceDetector::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm:
(WebCore::ShapeDetection::BarcodeDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm:
(WebCore::ShapeDetection::FaceDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm:
(WebCore::ShapeDetection::TextDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h:
* Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h:
* Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h:
* Source/WebCore/Modules/ShapeDetection/TextDetector.cpp:
(WebCore::TextDetector::detect):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp:
(WebKit::RemoteBarcodeDetector::RemoteBarcodeDetector):
(WebKit::RemoteBarcodeDetector::sharedPreferencesForWebProcess const):
(WebKit::RemoteBarcodeDetector::detect):
(WebKit::RemoteBarcodeDetector::protectedBacking const): Deleted.
(WebKit::RemoteBarcodeDetector::protectedBackend const): Deleted.
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h:
(WebKit::RemoteBarcodeDetector::create):
(WebKit::RemoteBarcodeDetector::backing const): Deleted.
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp:
(WebKit::RemoteFaceDetector::RemoteFaceDetector):
(WebKit::RemoteFaceDetector::sharedPreferencesForWebProcess const):
(WebKit::RemoteFaceDetector::detect):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h:
(WebKit::RemoteFaceDetector::create):
(WebKit::RemoteFaceDetector::backing): Deleted.
(WebKit::RemoteFaceDetector::protectedBackend const): Deleted.
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp:
(WebKit::RemoteTextDetector::RemoteTextDetector):
(WebKit::RemoteTextDetector::sharedPreferencesForWebProcess const):
(WebKit::RemoteTextDetector::detect):
(WebKit::RemoteTextDetector::protectedBacking const): Deleted.
(WebKit::RemoteTextDetector::protectedBackend const): Deleted.
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h:
(WebKit::RemoteTextDetector::create):
(WebKit::RemoteTextDetector::backing const): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::createBarcodeDetector):
(WebKit::RemoteRenderingBackend::releaseBarcodeDetector):
(WebKit::RemoteRenderingBackend::supportedBarcodeDetectorBarcodeFormats):
(WebKit::RemoteRenderingBackend::createFaceDetector):
(WebKit::RemoteRenderingBackend::releaseFaceDetector):
(WebKit::RemoteRenderingBackend::createTextDetector):
(WebKit::RemoteRenderingBackend::releaseTextDetector):
(WebKit::RemoteRenderingBackend::createRemoteBarcodeDetector): Deleted.
(WebKit::RemoteRenderingBackend::releaseRemoteBarcodeDetector): Deleted.
(WebKit::RemoteRenderingBackend::getRemoteBarcodeDetectorSupportedFormats): Deleted.
(WebKit::RemoteRenderingBackend::createRemoteFaceDetector): Deleted.
(WebKit::RemoteRenderingBackend::releaseRemoteFaceDetector): Deleted.
(WebKit::RemoteRenderingBackend::createRemoteTextDetector): Deleted.
(WebKit::RemoteRenderingBackend::releaseRemoteTextDetector): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::create):
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::RemoteBarcodeDetectorProxy):
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::~RemoteBarcodeDetectorProxy):
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::detect):
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::getSupportedFormats): Deleted.
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h:
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::backing const): Deleted.
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::create):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::RemoteFaceDetectorProxy):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h:
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::backing const): Deleted.
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteTextDetectorProxy::create):
(WebKit::ShapeDetection::RemoteTextDetectorProxy::RemoteTextDetectorProxy):
(WebKit::ShapeDetection::RemoteTextDetectorProxy::~RemoteTextDetectorProxy):
(WebKit::ShapeDetection::RemoteTextDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h:
(WebKit::ShapeDetection::RemoteTextDetectorProxy::backing const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createBarcodeDetector):
(WebKit::RemoteRenderingBackendProxy::releaseBarcodeDetector):
(WebKit::RemoteRenderingBackendProxy::supportedBarcodeDetectorBarcodeFormats):
(WebKit::RemoteRenderingBackendProxy::createFaceDetector):
(WebKit::RemoteRenderingBackendProxy::releaseFaceDetector):
(WebKit::RemoteRenderingBackendProxy::createTextDetector):
(WebKit::RemoteRenderingBackendProxy::releaseTextDetector):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createBarcodeDetector const):
(WebKit::WebChromeClient::getBarcodeDetectorSupportedFormats const):
(WebKit::WebChromeClient::createFaceDetector const):
(WebKit::WebChromeClient::createTextDetector const):

Canonical link: <a href="https://commits.webkit.org/302786@main">https://commits.webkit.org/302786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c0a724963d44a27f2e23932244a1e62f14d4171

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137179 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81265 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41793697-7b84-4aaf-bf86-58204550cbfe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98873 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66691 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c7a8d83-ef53-44c0-adc1-76c3e4e603f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79553 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0877ec63-c9e0-41ed-89ad-fcbbbb4af646) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34377 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80452 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109923 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34879 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139662 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107380 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107256 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27386 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31079 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65287 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1732 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1841 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->