### PR TITLE
Address safer CPP failures in WebKit/WebProcess/Plugins

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1197,7 +1197,7 @@ public:
 
     AccessibilityObjectWrapper* wrapper() const { return m_wrapper.get(); }
 #if PLATFORM(COCOA)
-    RetainPtr<AccessibilityObjectWrapper> protectedWrapper() const;
+    WEBCORE_EXPORT RetainPtr<AccessibilityObjectWrapper> protectedWrapper() const;
 #endif
     void setWrapper(AccessibilityObjectWrapper* wrapper) { m_wrapper = wrapper; }
     void detachWrapper(AccessibilityDetachmentType);

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -64,11 +64,6 @@
 [ iOS ] UIProcess/ios/forms/WKFormSelectPopover.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
-WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
-WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
-WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
-WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
-WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 [ iOS ] WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 [ iOS ] WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -804,7 +804,7 @@ void PDFIncrementalLoader::threadEntry(Ref<PDFIncrementalLoader>&& protectedLoad
     BinarySemaphore firstPageSemaphore;
     auto firstPageQueue = WorkQueue::create("PDF first page work queue"_s);
 
-    [m_backgroundThreadDocument preloadDataOfPagesInRange:NSMakeRange(0, 1) onQueue:firstPageQueue->dispatchQueue() completion:[&firstPageSemaphore, protectedThis = Ref { *this }] (NSIndexSet *) mutable {
+    [m_backgroundThreadDocument preloadDataOfPagesInRange:NSMakeRange(0, 1) onQueue:firstPageQueue->protectedDispatchQueue().get() completion:[&firstPageSemaphore, protectedThis = Ref { *this }] (NSIndexSet *) mutable {
         callOnMainRunLoop([protectedThis] {
             protectedThis->transitionToMainThreadDocument();
         });

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -55,6 +55,7 @@ public:
 
     WebCore::Element* element() const { return m_element.get(); }
     PDFAnnotation *annotation() const { return m_annotation.get(); }
+    RetainPtr<PDFAnnotation> protectedAnnotation() const { return m_annotation; }
     PDFPluginBase* plugin() const { return m_plugin.get(); }
 
     RefPtr<WebCore::Element> protectedElement() const { return element(); }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -54,12 +54,12 @@ void PDFPluginChoiceAnnotation::updateGeometry()
     PDFPluginAnnotation::updateGeometry();
 
     Ref styledElement = downcast<StyledElement>(*element());
-    styledElement->setInlineStyleProperty(CSSPropertyFontSize, annotation().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
+    styledElement->setInlineStyleProperty(CSSPropertyFontSize, protectedAnnotation().get().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
 }
 
 void PDFPluginChoiceAnnotation::commit()
 {
-    annotation().widgetStringValue = downcast<HTMLSelectElement>(protectedElement())->value().createNSString().get();
+    protectedAnnotation().get().widgetStringValue = downcast<HTMLSelectElement>(protectedElement())->value().createNSString().get();
 
     PDFPluginAnnotation::commit();
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -106,12 +106,12 @@ void PDFPluginTextAnnotation::updateGeometry()
     PDFPluginAnnotation::updateGeometry();
 
     Ref styledElement = downcast<StyledElement>(*element());
-    styledElement->setInlineStyleProperty(CSSPropertyFontSize, annotation().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
+    styledElement->setInlineStyleProperty(CSSPropertyFontSize, protectedAnnotation().get().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
 }
 
 void PDFPluginTextAnnotation::commit()
 {
-    annotation().widgetStringValue = value().createNSString().get();
+    protectedAnnotation().get().widgetStringValue = value().createNSString().get();
     PDFPluginAnnotation::commit();
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -146,7 +146,7 @@
 {
     if (RefPtr plugin = _pdfPlugin.get()) {
         if (auto coreObject = plugin->accessibilityCoreObject())
-            [coreObject->wrapper() accessibilityScroll:direction];
+            [coreObject->protectedWrapper() accessibilityScroll:direction];
     }
     return YES;
 }
@@ -165,7 +165,7 @@
             if (CheckedPtr existingCache = plugin->axObjectCache()) {
                 if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->protectedElement().get())) {
                 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-                    return [object->wrapper() accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
+                    return [object->protectedWrapper() accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
                 ALLOW_DEPRECATED_DECLARATIONS_END
                 }
             }
@@ -225,7 +225,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         callOnMainRunLoopAndWait([protectedSelf] {
             if (CheckedPtr axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
                 if (RefPtr pluginAxObject = axObjectCache->exportedGetOrCreate(RefPtr { protectedSelf->_pluginElement.get() }.get()))
-                    protectedSelf->_parent = pluginAxObject->wrapper();
+                    protectedSelf->_parent = pluginAxObject->protectedWrapper().get();
             }
         });
     }


### PR DESCRIPTION
#### 6e0255e88064448c301f85a5c29f6d6c3ced780a
<pre>
Address safer CPP failures in WebKit/WebProcess/Plugins
<a href="https://bugs.webkit.org/show_bug.cgi?id=301916">https://bugs.webkit.org/show_bug.cgi?id=301916</a>

Reviewed by Darin Adler.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::threadEntry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
(WebKit::PDFPluginAnnotation::protectedAnnotation const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::updateGeometry):
(WebKit::PDFPluginChoiceAnnotation::commit):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(WebKit::PDFPluginTextAnnotation::updateGeometry):
(WebKit::PDFPluginTextAnnotation::commit):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityScroll:]):
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityParent]):

Canonical link: <a href="https://commits.webkit.org/302532@main">https://commits.webkit.org/302532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cffa305b5d9cd865febc3a18b84a367afad31775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136784 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54195069-aa2f-4abf-bfb9-484edbc3a288) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1540 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3d9b647-34ec-4bd0-9539-e356fc3eebed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132354 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115907 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79208 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/801405ed-454f-49c7-aff5-7928698815c2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/34038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80061 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139258 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106925 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1186 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54120 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64888 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1342 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1447 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->