### PR TITLE
[masonry] WPT Import Nov 2nd - 3rd

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/row-auto-placement-min-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/row-auto-placement-min-content-expected.html
@@ -10,20 +10,14 @@ html,body {
 .grid {
     display: grid;
     grid-template-rows: 15px auto auto;
-    width: min-content;
+    width: max-content;
+    background: gray;
     align-items: start;
     padding: 10px;
-}
-
-#gray-bg {
-    background: gray;
-    position: absolute;
-    z-index: -1;
 }
 </style>
 <body>
   <p>Ensure that masonry containers are sized correctly under min-content constraints even if the items do not have the min-content style.</p>
-  <div id="gray-bg"></div>
   <div id="shown-items" class="grid">
     <div style="background: lightskyblue; width: max-content; grid-row: 1; grid-column: 1;">
         Number 1

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/row-auto-placement-min-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/row-auto-placement-min-content-ref.html
@@ -10,20 +10,14 @@ html,body {
 .grid {
     display: grid;
     grid-template-rows: 15px auto auto;
-    width: min-content;
+    width: max-content;
+    background: gray;
     align-items: start;
     padding: 10px;
-}
-
-#gray-bg {
-    background: gray;
-    position: absolute;
-    z-index: -1;
 }
 </style>
 <body>
   <p>Ensure that masonry containers are sized correctly under min-content constraints even if the items do not have the min-content style.</p>
-  <div id="gray-bg"></div>
   <div id="shown-items" class="grid">
     <div style="background: lightskyblue; width: max-content; grid-row: 1; grid-column: 1;">
         Number 1

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html
@@ -36,8 +36,7 @@
   </div>
 </div>
 <script>
-  test_computed_value("grid-template-rows", 'none', 'none');
-  test_computed_value("grid-template-columns", 'none', 'none'); // "none" without #child
+  test_computed_value("grid-template-columns", 'none', '300px'); // "none" without #child
 
   // track-size <fixed-breadth> = <length-percentage> | <flex> | min-content | max-content | auto
   test_computed_value("grid-template-columns", '20%', '60px'); // 20% * width
@@ -76,7 +75,7 @@
   // <auto-repeat> = repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )
   test_computed_value("grid-template-columns", 'repeat(auto-fill, 200px)', '200px');
   test_computed_value("grid-template-columns", 'repeat(auto-fit, [one] 20%)',
-          '[one] 60px [one] 60px [one] 60px [one] 60px [one] 60px');
+          '[one] 60px [one] 0px [one] 0px [one] 0px [one] 0px');
   test_computed_value("grid-template-columns", 'repeat(auto-fill, minmax(100px, 5fr) [two])',
           '100px [two] 100px [two] 100px [two]');
   test_computed_value("grid-template-columns", 'repeat(auto-fit, [three] minmax(max-content, 6em) [four])',


### PR DESCRIPTION
#### 155764b4dbbacc8aae6304dc24857b73d7ace9ad
<pre>
[masonry] WPT Import Nov 2nd - 3rd
<a href="https://bugs.webkit.org/show_bug.cgi?id=301921">https://bugs.webkit.org/show_bug.cgi?id=301921</a>
<a href="https://rdar.apple.com/problem/164000587">rdar://problem/164000587</a>

Reviewed by Tim Nguyen.

Import CSS Masonry changes from WPT Nov 2nd - 3rd.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/cff0b18c201d3a5b94d8c5d0b2a5e0a2c76aa423">https://github.com/web-platform-tests/wpt/commit/cff0b18c201d3a5b94d8c5d0b2a5e0a2c76aa423</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/row-auto-placement-min-content-expected.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/row-auto-placement-min-content-ref.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html

Canonical link: <a href="https://commits.webkit.org/302538@main">https://commits.webkit.org/302538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4ee10ab9acfbd3b42910ea4188f9d76e5d931da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80808 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98551 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66442 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79202 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34031 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80052 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139249 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107076 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27226 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54108 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1516 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1333 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->