### PR TITLE
[WebAuthn] Pin Protocol 2 support

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -22,4 +22,6 @@ PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platf
 PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator. 2
 PASS PublicKeyCredential's [[create]] with excludeCredentials - verify preflighted credentials not sent in main request.
+PASS PublicKeyCredential's [[create]] with PIN Protocol 2 support in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with PIN Protocol 1 fallback in a mock hid authenticator.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -7,7 +7,7 @@
 <script>
     // Default mock configuration. Tests need to override if they need different configuration.
     if (window.internals)
-        internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64], pinProtocols: [1] } });
 
     promise_test(t => {
     const options = {
@@ -607,5 +607,80 @@
             checkCtapMakeCredentialResult(credential, true, ["usb"]);
         });
     }, "PublicKeyCredential's [[create]] with excludeCredentials - verify preflighted credentials not sent in main request.");
+
+    promise_test(t => {
+        let config = {
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                pinProtocols: [1, 2],
+                payloadBase64: [testCreationMessageBase64],
+                validateExpectedCommands: true,
+                expectedCommandsBase64: [
+                    "AaQBWCAa2kobC+fJlf+RMJIo/kN+6IXwkpjr76haP2Ha5BcxtQKiYmlkaWxvY2FsaG9zdGRuYW1laWxvY2FsaG9zdAOjYmlkSgABAgMEBQYHCAlkbmFtZW5Kb2huIEFwcGxlc2VlZGtkaXNwbGF5TmFtZWlBcHBsZXNlZWQEgaJjYWxnJmR0eXBlanB1YmxpYy1rZXk="
+                ]
+            }
+        };
+
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 1000
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with PIN Protocol 2 support in a mock hid authenticator.");
+
+    promise_test(t => {
+        let config = {
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                payloadBase64: [testCreationMessageBase64],
+                validateExpectedCommands: true,
+                expectedCommandsBase64: [
+                    "AaQBWCAa2kobC+fJlf+RMJIo/kN+6IXwkpjr76haP2Ha5BcxtQKiYmlkaWxvY2FsaG9zdGRuYW1laWxvY2FsaG9zdAOjYmlkSgABAgMEBQYHCAlkbmFtZW5Kb2huIEFwcGxlc2VlZGtkaXNwbGF5TmFtZWlBcHBsZXNlZWQEgaJjYWxnJmR0eXBlanB1YmxpYy1rZXk="
+                ]
+            }
+        };
+
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 1000
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with PIN Protocol 1 fallback in a mock hid authenticator.");
 
 </script>

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -60,7 +60,7 @@ AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setMaxMsgSize(uint32
     return *this;
 }
 
-AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setPinProtocols(Vector<uint8_t>&& pinProtocols)
+AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setPinProtocols(StdSet<PINUVAuthProtocol>&& pinProtocols)
 {
     m_pinProtocols = WTFMove(pinProtocols);
     return *this;
@@ -129,8 +129,12 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
     if (response.maxMsgSize())
         deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMaxMsgSizeKey), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
 
-    if (response.pinProtocol())
-        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey), toArrayValue(*response.pinProtocol()));
+    if (response.pinProtocol()) {
+        CBORValue::ArrayValue protocols;
+        for (auto protocol : *response.pinProtocol())
+            protocols.append(CBORValue(static_cast<int64_t>(protocol)));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey), CBORValue(WTFMove(protocols)));
+    }
     
     if (response.transports()) {
         auto transports = *response.transports();

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
@@ -51,7 +51,7 @@ public:
     AuthenticatorGetInfoResponse& operator=(AuthenticatorGetInfoResponse&& other) = default;
 
     AuthenticatorGetInfoResponse& setMaxMsgSize(uint32_t);
-    AuthenticatorGetInfoResponse& setPinProtocols(Vector<uint8_t>&&);
+    AuthenticatorGetInfoResponse& setPinProtocols(StdSet<PINUVAuthProtocol>&&);
     AuthenticatorGetInfoResponse& setExtensions(Vector<String>&&);
     AuthenticatorGetInfoResponse& setOptions(AuthenticatorSupportedOptions&&);
     AuthenticatorGetInfoResponse& setTransports(Vector<WebCore::AuthenticatorTransport>&&);
@@ -64,7 +64,7 @@ public:
     const StdSet<ProtocolVersion>& versions() const { return m_versions; }
     const Vector<uint8_t>& aaguid() const { return m_aaguid; }
     const std::optional<uint32_t>& maxMsgSize() const { return m_maxMsgSize; }
-    const std::optional<Vector<uint8_t>>& pinProtocol() const { return m_pinProtocols; }
+    const std::optional<StdSet<PINUVAuthProtocol>>& pinProtocol() const { return m_pinProtocols; }
     const std::optional<Vector<String>>& extensions() const { return m_extensions; }
     const AuthenticatorSupportedOptions& options() const { return m_options; }
     AuthenticatorSupportedOptions& mutableOptions() { return m_options; }
@@ -79,7 +79,7 @@ private:
     StdSet<ProtocolVersion> m_versions;
     Vector<uint8_t> m_aaguid;
     std::optional<uint32_t> m_maxMsgSize;
-    std::optional<Vector<uint8_t>> m_pinProtocols;
+    std::optional<StdSet<PINUVAuthProtocol>> m_pinProtocols;
     std::optional<uint32_t> m_maxCredentialCountInList;
     std::optional<uint32_t> m_maxCredentialIdLength;
     std::optional<Vector<String>> m_extensions;

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -316,12 +316,17 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         if (!it->second.isArray())
             return std::nullopt;
 
-        Vector<uint8_t> supportedPinProtocols;
+        StdSet<PINUVAuthProtocol> supportedPinProtocols;
         for (const auto& protocol : it->second.getArray()) {
             if (!protocol.isUnsigned())
                 return std::nullopt;
 
-            supportedPinProtocols.append(protocol.getUnsigned());
+            auto value = protocol.getUnsigned();
+            if (value == static_cast<uint8_t>(PINUVAuthProtocol::kPinProtocol1))
+                supportedPinProtocols.insert(PINUVAuthProtocol::kPinProtocol1);
+            else if (value == static_cast<uint8_t>(PINUVAuthProtocol::kPinProtocol2))
+                supportedPinProtocols.insert(PINUVAuthProtocol::kPinProtocol2);
+            // Ignore unknown protocols
         }
         response.setPinProtocols(WTFMove(supportedPinProtocols));
     }

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
@@ -36,6 +36,11 @@
 
 namespace fido {
 
+enum class PINUVAuthProtocol : uint8_t {
+    kPinProtocol1 = 1,
+    kPinProtocol2 = 2,
+};
+
 enum class ProtocolVersion {
     kCtap2,
     kCtap21,
@@ -177,6 +182,10 @@ constexpr size_t kHidInitNonceLength = 8;
 constexpr uint8_t kHidMaxLockSeconds = 10;
 
 constexpr size_t kPINMaxSizeInBytes = 63;
+
+// HKDF info strings for PIN/UV Auth Protocol 2 key derivation (CTAP 2.1 spec 6.5.7)
+constexpr std::array<uint8_t, 14> kHKDFInfoHMACKey { 'C', 'T', 'A', 'P', '2', ' ', 'H', 'M', 'A', 'C', ' ', 'k', 'e', 'y' };
+constexpr std::array<uint8_t, 13> kHKDFInfoAESKey { 'C', 'T', 'A', 'P', '2', ' ', 'A', 'E', 'S', ' ', 'k', 'e', 'y' };
 
 // Messages are limited to an initiation packet and 128 continuation packets.
 constexpr size_t kHidMaxMessageSize = 7609;

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -37,10 +37,13 @@
 #include "CryptoAlgorithmAESCBC.h"
 #include "CryptoAlgorithmAesCbcCfbParams.h"
 #include "CryptoAlgorithmECDH.h"
+#include "CryptoAlgorithmHKDF.h"
 #include "CryptoAlgorithmHMAC.h"
+#include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyAES.h"
 #include "CryptoKeyEC.h"
 #include "CryptoKeyHMAC.h"
+#include "CryptoKeyRaw.h"
 #include "DeviceResponseConverter.h"
 #include "ExceptionOr.h"
 #include "WebAuthenticationConstants.h"
@@ -49,6 +52,7 @@
 #include <pal/PALSwift.h>
 #endif
 #include <pal/crypto/CryptoDigest.h>
+#include <wtf/CryptographicallyRandomNumber.h>
 
 namespace fido {
 using namespace WebCore;
@@ -65,14 +69,18 @@ static bool hasAtLeastFourCodepoints(const String& pin)
     return pin.length() >= 4;
 }
 
-// makePinAuth returns `LEFT(HMAC-SHA-256(secret, data), 16)`.
-static Vector<uint8_t> makePinAuth(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
+static Vector<uint8_t> authenticateForProtocol(PINUVAuthProtocol protocol, const CryptoKeyHMAC& key, const Vector<uint8_t>& message)
 {
-    auto result = CryptoAlgorithmHMAC::platformSign(key, data);
+    auto result = CryptoAlgorithmHMAC::platformSign(key, message);
     ASSERT(!result.hasException());
-    auto pinAuth = result.releaseReturnValue();
-    pinAuth.shrink(16);
-    return pinAuth;
+    auto signature = result.releaseReturnValue();
+
+    // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto1
+    // Pin Protocol 1 should trim to 16 bytes, Pin Protocol 2 uses full 32.
+    if (protocol == PINUVAuthProtocol::kPinProtocol1)
+        signature.shrink(16);
+
+    return signature;
 }
 
 std::optional<CString> validateAndConvertToUTF8(const String& pin)
@@ -88,10 +96,10 @@ std::optional<CString> validateAndConvertToUTF8(const String& pin)
 // encodePINCommand returns a CTAP2 PIN command for the operation |subcommand|.
 // Additional elements of the top-level CBOR map can be added with the optional
 // |addAdditional| callback.
-static Vector<uint8_t> encodePinCommand(Subcommand subcommand, Function<void(CBORValue::MapValue*)> addAdditional = nullptr)
+static Vector<uint8_t> encodePinCommand(Subcommand subcommand, PINUVAuthProtocol protocol, Function<void(CBORValue::MapValue*)> addAdditional = nullptr)
 {
     CBORValue::MapValue map;
-    map.emplace(static_cast<int64_t>(RequestKey::kProtocol), kProtocolVersion);
+    map.emplace(static_cast<int64_t>(RequestKey::kProtocol), static_cast<int64_t>(protocol));
     map.emplace(static_cast<int64_t>(RequestKey::kSubcommand), static_cast<int64_t>(subcommand));
 
     if (addAdditional)
@@ -198,7 +206,7 @@ TokenResponse::TokenResponse(Ref<WebCore::CryptoKeyHMAC>&& token)
 {
 }
 
-std::optional<TokenResponse> TokenResponse::parse(const WebCore::CryptoKeyAES& sharedKey, const Vector<uint8_t>& inBuffer)
+std::optional<TokenResponse> TokenResponse::parse(PINUVAuthProtocol protocol, const WebCore::CryptoKeyAES& sharedKey, const Vector<uint8_t>& inBuffer)
 {
     auto decodedMap = decodeResponseMap(inBuffer);
     if (!decodedMap)
@@ -210,10 +218,36 @@ std::optional<TokenResponse> TokenResponse::parse(const WebCore::CryptoKeyAES& s
         return std::nullopt;
     const auto& encryptedToken = it->second.getByteString();
 
-    auto tokenResult = CryptoAlgorithmAESCBC::platformDecrypt({ }, sharedKey, encryptedToken, CryptoAlgorithmAESCBC::Padding::No);
-    if (tokenResult.hasException())
-        return std::nullopt;
-    auto token = tokenResult.releaseReturnValue();
+    Vector<uint8_t> token;
+    if (protocol == PINUVAuthProtocol::kPinProtocol2) {
+        // CTAP 2.1 spec 6.5.7: Protocol 2 decrypt
+        // Split ciphertext into IV (first 16 bytes) and ct (remaining bytes)
+        if (encryptedToken.size() < 16) {
+            LOG_ERROR("TokenResponse::parse: Protocol 2 encrypted token too short (%zu bytes)", encryptedToken.size());
+            return std::nullopt;
+        }
+
+        Vector<uint8_t> iv(encryptedToken.subspan(0, 16));
+        Vector<uint8_t> ciphertext(encryptedToken.subspan(16));
+
+        CryptoAlgorithmAesCbcCfbParams params;
+        params.iv = BufferSource(iv);
+
+        auto tokenResult = CryptoAlgorithmAESCBC::platformDecrypt(params, sharedKey, ciphertext, CryptoAlgorithmAESCBC::Padding::No);
+        if (tokenResult.hasException()) {
+            LOG_ERROR("TokenResponse::parse: Protocol 2 decryption failed");
+            return std::nullopt;
+        }
+        token = tokenResult.releaseReturnValue();
+    } else {
+        // CTAP 2.1 spec 6.5.6: Protocol 1 decrypt with zero IV
+        auto tokenResult = CryptoAlgorithmAESCBC::platformDecrypt({ }, sharedKey, encryptedToken, CryptoAlgorithmAESCBC::Padding::No);
+        if (tokenResult.hasException()) {
+            LOG_ERROR("TokenResponse::parse: Protocol 1 decryption failed");
+            return std::nullopt;
+        }
+        token = tokenResult.releaseReturnValue();
+    }
 
     auto tokenKey = CryptoKeyHMAC::importRaw(token.size() * 8, CryptoAlgorithmIdentifier::SHA_256, WTFMove(token), true, CryptoKeyUsageSign);
     ASSERT(tokenKey);
@@ -221,9 +255,9 @@ std::optional<TokenResponse> TokenResponse::parse(const WebCore::CryptoKeyAES& s
     return TokenResponse(tokenKey.releaseNonNull());
 }
 
-Vector<uint8_t> TokenResponse::pinAuth(const Vector<uint8_t>& clientDataHash) const
+Vector<uint8_t> TokenResponse::pinAuth(PINUVAuthProtocol protocol, const Vector<uint8_t>& clientDataHash) const
 {
-    return makePinAuth(m_token, clientDataHash);
+    return authenticateForProtocol(protocol, m_token, clientDataHash);
 }
 
 const Vector<uint8_t>& TokenResponse::token() const
@@ -231,17 +265,80 @@ const Vector<uint8_t>& TokenResponse::token() const
     return m_token->key();
 }
 
-Vector<uint8_t> encodeAsCBOR(const RetriesRequest&)
+Vector<uint8_t> encodeAsCBOR(const RetriesRequest& request)
 {
-    return encodePinCommand(Subcommand::kGetRetries);
+    return encodePinCommand(Subcommand::kGetRetries, request.protocol);
 }
 
-Vector<uint8_t> encodeAsCBOR(const KeyAgreementRequest&)
+Vector<uint8_t> encodeAsCBOR(const KeyAgreementRequest& request)
 {
-    return encodePinCommand(Subcommand::kGetKeyAgreement);
+    return encodePinCommand(Subcommand::kGetKeyAgreement, request.protocol);
 }
 
-std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const CryptoKeyEC& peerKey)
+static Vector<uint8_t> deriveProtocolSharedSecret(PINUVAuthProtocol protocol, Vector<uint8_t>&& ecdhResult)
+{
+    // CTAP spec 6.5.6 (Protocol 1) and 6.5.7 (Protocol 2).
+    Vector<uint8_t> sharedSecret;
+    if (protocol == PINUVAuthProtocol::kPinProtocol1) {
+        auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+        crypto->addBytes(ecdhResult.span());
+        sharedSecret = crypto->computeHash();
+    } else if (protocol == PINUVAuthProtocol::kPinProtocol2) {
+        sharedSecret.reserveInitialCapacity(64);
+        auto hkdfKey = CryptoKeyRaw::create(CryptoAlgorithmIdentifier::HKDF, WTFMove(ecdhResult), CryptoKeyUsageDeriveBits);
+
+        CryptoAlgorithmHkdfParams hmacHkdfParams;
+        hmacHkdfParams.hashIdentifier = CryptoAlgorithmIdentifier::SHA_256;
+        Vector<uint8_t> hkdfSalt(32, 0);
+        hmacHkdfParams.salt = toBufferSource(hkdfSalt.span());
+        hmacHkdfParams.info = toBufferSource(std::span { kHKDFInfoHMACKey });
+
+        auto hmacKeyMaterial = CryptoAlgorithmHKDF::deriveBits(hmacHkdfParams, hkdfKey.get(), 32 * 8);
+        if (hmacKeyMaterial.hasException())
+            return { };
+        sharedSecret.appendVector(hmacKeyMaterial.releaseReturnValue());
+
+        CryptoAlgorithmHkdfParams aesHkdfParams;
+        aesHkdfParams.hashIdentifier = CryptoAlgorithmIdentifier::SHA_256;
+        aesHkdfParams.salt = toBufferSource(hkdfSalt.span());
+        aesHkdfParams.info = toBufferSource(std::span { kHKDFInfoAESKey });
+
+        auto aesKeyMaterial = CryptoAlgorithmHKDF::deriveBits(aesHkdfParams, hkdfKey.get(), 32 * 8);
+        if (aesKeyMaterial.hasException())
+            return { };
+        sharedSecret.appendVector(aesKeyMaterial.releaseReturnValue());
+    } else {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+    return sharedSecret;
+}
+
+static Vector<uint8_t> encryptForProtocol(PINUVAuthProtocol protocol, const CryptoKeyAES& key, const Vector<uint8_t>& plaintext)
+{
+    if (protocol == PINUVAuthProtocol::kPinProtocol2) {
+        Vector<uint8_t> iv(16);
+        cryptographicallyRandomValues(iv.mutableSpan());
+
+        CryptoAlgorithmAesCbcCfbParams params;
+        params.iv = BufferSource(iv);
+
+        auto result = CryptoAlgorithmAESCBC::platformEncrypt(params, key, plaintext, CryptoAlgorithmAESCBC::Padding::No);
+        ASSERT(!result.hasException());
+
+        Vector<uint8_t> output;
+        output.reserveInitialCapacity(iv.size() + result.returnValue().size());
+        output.appendVector(iv);
+        output.appendVector(result.releaseReturnValue());
+        return output;
+    }
+
+    auto result = CryptoAlgorithmAESCBC::platformEncrypt({ }, key, plaintext, CryptoAlgorithmAESCBC::Padding::No);
+    ASSERT(!result.hasException());
+    return result.releaseReturnValue();
+}
+
+std::optional<TokenRequest> TokenRequest::tryCreate(PINUVAuthProtocol protocol, const CString& pin, const CryptoKeyEC& peerKey)
 {
     // The following implements Section 5.5.4 Getting sharedSecret from Authenticator.
     // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#gettingSharedSecret
@@ -250,16 +347,23 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
     ASSERT(!keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
-    // 2. Use ECDH and SHA-256 to compute the shared AES-CBC key.
+    // 2. Use ECDH to compute the shared secret, then apply protocol-specific KDF.
     auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), peerKey);
     if (!sharedKeyResult)
         return std::nullopt;
 
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(sharedKeyResult->span());
-    auto sharedKeyHash = crypto->computeHash();
+    auto sharedSecret = deriveProtocolSharedSecret(protocol, WTFMove(*sharedKeyResult));
+    if (sharedSecret.isEmpty())
+        return std::nullopt;
 
-    auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(sharedKeyHash), true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);
+    Vector<uint8_t> aesKeyMaterial;
+    if (protocol == PINUVAuthProtocol::kPinProtocol2) {
+        ASSERT(sharedSecret.size() == 64);
+        aesKeyMaterial = Vector<uint8_t>(sharedSecret.span().last(32));
+    } else
+        aesKeyMaterial = sharedSecret;
+
+    auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(aesKeyMaterial), true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);
     ASSERT(sharedKey);
 
     // The following encodes the public key of the above key pair into COSE format.
@@ -268,26 +372,28 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
     auto coseKey = encodeCOSEPublicKey(rawPublicKeyResult.returnValue());
 
     // The following calculates a SHA-256 digest of the PIN, and shrink to the left 16 bytes.
-    crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(byteCast<uint8_t>(pin.span()));
     auto pinHash = crypto->computeHash();
     pinHash.shrink(16);
 
-    return TokenRequest(sharedKey.releaseNonNull(), WTFMove(coseKey), WTFMove(pinHash));
+    return TokenRequest(sharedKey.releaseNonNull(), WTFMove(coseKey), WTFMove(pinHash), protocol);
 }
 
-TokenRequest::TokenRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& pinHash)
+TokenRequest::TokenRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& pinHash, PINUVAuthProtocol protocol)
     : m_sharedKey(WTFMove(sharedKey))
     , m_coseKey(WTFMove(coseKey))
     , m_pinHash(WTFMove(pinHash))
+    , m_protocol(protocol)
 {
 }
 
-SetPinRequest::SetPinRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& newPinEnc, Vector<uint8_t>&& pinUvAuthParam)
+SetPinRequest::SetPinRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& newPinEnc, Vector<uint8_t>&& pinUvAuthParam, PINUVAuthProtocol protocol)
     : m_sharedKey(WTFMove(sharedKey))
     , m_coseKey(WTFMove(coseKey))
     , m_newPinEnc(WTFMove(newPinEnc))
     , m_pinUvAuthParam(WTFMove(pinUvAuthParam))
+    , m_protocol(protocol)
 {
 }
 
@@ -296,7 +402,7 @@ const Vector<uint8_t>& SetPinRequest::pinAuth() const
     return m_pinUvAuthParam;
 }
 
-std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, const WebCore::CryptoKeyEC& peerKey)
+std::optional<SetPinRequest> SetPinRequest::tryCreate(PINUVAuthProtocol protocol, const String& inputPin, const WebCore::CryptoKeyEC& peerKey)
 {
     std::optional<CString> newPin = validateAndConvertToUTF8(inputPin);
     if (!newPin)
@@ -309,16 +415,25 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
     ASSERT(!keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
-    // 2. Use ECDH and SHA-256 to compute the shared AES-CBC key.
     auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), peerKey);
     if (!sharedKeyResult)
         return std::nullopt;
 
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(sharedKeyResult->span());
-    auto sharedKeyHash = crypto->computeHash();
+    auto sharedSecret = deriveProtocolSharedSecret(protocol, WTFMove(*sharedKeyResult));
+    if (sharedSecret.isEmpty())
+        return std::nullopt;
 
-    auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, Vector { sharedKeyHash }, true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);
+    Vector<uint8_t> hmacKeyMaterial, aesKeyMaterial;
+    if (protocol == PINUVAuthProtocol::kPinProtocol2) {
+        ASSERT(sharedSecret.size() == 64);
+        hmacKeyMaterial = Vector<uint8_t>(sharedSecret.span().first(32));
+        aesKeyMaterial = Vector<uint8_t>(sharedSecret.span().last(32));
+    } else {
+        hmacKeyMaterial = sharedSecret;
+        aesKeyMaterial = sharedSecret;
+    }
+
+    auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(aesKeyMaterial), true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);
     ASSERT(sharedKey);
 
     // The following encodes the public key of the above key pair into COSE format.
@@ -333,23 +448,20 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
     for (int i = paddedPin.size(); i < 64; i++)
         paddedPin.append('\0');
 
-    auto hmacKey = CryptoKeyHMAC::importRaw(sharedKeyHash.size() * 8 /* lengthInBits */, CryptoAlgorithmIdentifier::SHA_256, WTFMove(sharedKeyHash), true, CryptoKeyUsageSign);
+    auto hmacKey = CryptoKeyHMAC::importRaw(hmacKeyMaterial.size() * 8 /* lengthInBits */, CryptoAlgorithmIdentifier::SHA_256, WTFMove(hmacKeyMaterial), true, CryptoKeyUsageSign);
 
-    auto newPinEnc = CryptoAlgorithmAESCBC::platformEncrypt({ }, *sharedKey, paddedPin, CryptoAlgorithmAESCBC::Padding::No);
-    ASSERT(!newPinEnc.hasException());
+    auto newPinEnc = encryptForProtocol(protocol, *sharedKey, paddedPin);
 
-    auto pinUvAuthParam = CryptoAlgorithmHMAC::platformSign(*hmacKey, newPinEnc.returnValue());
-    ASSERT(!pinUvAuthParam.hasException());
+    auto pinUvAuthParam = authenticateForProtocol(protocol, *hmacKey, newPinEnc);
 
-    return SetPinRequest(sharedKey.releaseNonNull(), WTFMove(coseKey), newPinEnc.releaseReturnValue(), pinUvAuthParam.releaseReturnValue());
+    return SetPinRequest(sharedKey.releaseNonNull(), WTFMove(coseKey), WTFMove(newPinEnc), WTFMove(pinUvAuthParam), protocol);
 }
 
 Vector<uint8_t> encodeAsCBOR(const TokenRequest& request)
 {
-    auto result = CryptoAlgorithmAESCBC::platformEncrypt({ }, request.sharedKey(), request.m_pinHash, CryptoAlgorithmAESCBC::Padding::No);
-    ASSERT(!result.hasException());
+    auto encryptedPin = encryptForProtocol(request.m_protocol, request.sharedKey(), request.m_pinHash);
 
-    return encodePinCommand(Subcommand::kGetPinToken, [coseKey = WTFMove(request.m_coseKey), encryptedPin = result.releaseReturnValue()] (CBORValue::MapValue* map) mutable {
+    return encodePinCommand(Subcommand::kGetPinToken, request.m_protocol, [coseKey = WTFMove(request.m_coseKey), encryptedPin = WTFMove(encryptedPin)] (CBORValue::MapValue* map) mutable {
         map->emplace(static_cast<int64_t>(RequestKey::kKeyAgreement), WTFMove(coseKey));
         map->emplace(static_cast<int64_t>(RequestKey::kPinHashEnc), WTFMove(encryptedPin));
     });
@@ -357,7 +469,7 @@ Vector<uint8_t> encodeAsCBOR(const TokenRequest& request)
 
 Vector<uint8_t> encodeAsCBOR(const SetPinRequest& request)
 {
-    return encodePinCommand(Subcommand::kSetPin, [coseKey = WTFMove(request.m_coseKey), encryptedPin = request.m_newPinEnc, pinUvAuthParam = request.m_pinUvAuthParam] (CBORValue::MapValue* map) mutable {
+    return encodePinCommand(Subcommand::kSetPin, request.m_protocol, [coseKey = WTFMove(request.m_coseKey), encryptedPin = request.m_newPinEnc, pinUvAuthParam = request.m_pinUvAuthParam] (CBORValue::MapValue* map) mutable {
         map->emplace(static_cast<int64_t>(RequestKey::kKeyAgreement), WTFMove(coseKey));
         map->emplace(static_cast<int64_t>(RequestKey::kNewPinEnc), WTFMove(encryptedPin));
         map->emplace(static_cast<int64_t>(RequestKey::kPinAuth), WTFMove(pinUvAuthParam));

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
@@ -80,5 +80,10 @@ ExceptionOr<std::optional<size_t>> CryptoAlgorithmHKDF::getKeyLength(const Crypt
 {
     return std::optional<size_t>();
 }
-    
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
+{
+    return platformDeriveBits(parameters, key, length);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
@@ -46,6 +46,10 @@ private:
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
+public:
+    static ExceptionOr<Vector<uint8_t>> deriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t);
+
+private:
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t);
 };
 

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
@@ -92,6 +92,7 @@ struct MockWebAuthenticationConfiguration {
         bool expectCancel { false };
         bool supportClientPin { false };
         bool supportInternalUV { false };
+        Vector<uint8_t> pinProtocols;
         int64_t maxCredentialCountInList { 1 };
         int64_t maxCredentialIdLength { 64 };
     };

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -106,6 +106,7 @@
     boolean expectCancel = false;
     boolean supportClientPin = false;
     boolean supportInternalUV = false;
+    sequence<octet> pinProtocols;
     long maxCredentialCountInList = 1;
     long maxCredentialIdLength = 64;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6243,6 +6243,7 @@ header: <WebCore/ISOVTTCue.h>
     bool expectCancel;
     bool supportClientPin;
     bool supportInternalUV;
+    Vector<uint8_t> pinProtocols;
     int64_t maxCredentialCountInList;
     int64_t maxCredentialIdLength;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -230,7 +230,18 @@ void MockHidConnection::feedReports()
             AuthenticatorGetInfoResponse infoResponse({ ProtocolVersion::kCtap2 }, Vector<uint8_t>(aaguidLength, 0u));
             AuthenticatorSupportedOptions options;
             if (m_configuration.hid->supportClientPin) {
-                infoResponse.setPinProtocols({ pin::kProtocolVersion });
+                StdSet<PINUVAuthProtocol> protocols;
+                if (!m_configuration.hid->pinProtocols.isEmpty()) {
+                    for (auto protocol : m_configuration.hid->pinProtocols) {
+                        if (protocol == static_cast<uint8_t>(PINUVAuthProtocol::kPinProtocol1))
+                            protocols.insert(PINUVAuthProtocol::kPinProtocol1);
+                        else if (protocol == static_cast<uint8_t>(PINUVAuthProtocol::kPinProtocol2))
+                            protocols.insert(PINUVAuthProtocol::kPinProtocol2);
+                    }
+                } else
+                    protocols.insert(PINUVAuthProtocol::kPinProtocol1);
+
+                infoResponse.setPinProtocols(WTFMove(protocols));
                 options.setClientPinAvailability(AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet);
             }
             if (m_configuration.hid->supportInternalUV)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -131,7 +131,7 @@ void CtapAuthenticator::makeCredential()
         m_currentBatch = 0;
         std::optional<PinParameters> pinParameters;
         if (!m_pinAuth.isEmpty())
-            pinParameters = PinParameters { pin::kProtocolVersion, m_pinAuth };
+            pinParameters = PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth };
         Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rp.id, requestData().hash, m_batches[m_currentBatch], pinParameters);
         protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
             ASSERT(RunLoop::isMain());
@@ -173,7 +173,7 @@ void CtapAuthenticator::continueSilentlyCheckCredentials(Vector<uint8_t>&& data,
     auto response = readCTAPGetAssertionResponse(data, AuthenticatorAttachment::CrossPlatform);
     std::optional<PinParameters> pinParameters;
     if (!m_pinAuth.isEmpty())
-        pinParameters = PinParameters { pin::kProtocolVersion, m_pinAuth };
+        pinParameters = PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth };
     WTF::switchOn(requestData().options, [&](const PublicKeyCredentialCreationOptions& options) {
         cborCmd = encodeSilentGetAssertion(options.rp.id, requestData().hash, m_batches[m_currentBatch], pinParameters);
     }, [&](const PublicKeyCredentialRequestOptions& options) {
@@ -216,7 +216,7 @@ void CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials(bool
     if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && (!options.authenticatorSelection || options.authenticatorSelection->userVerification() != UserVerificationRequirement::Discouraged) && m_pinAuth.isEmpty())
         cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, std::nullopt, m_info.algorithms(), WTFMove(overrideExcludeCredentials));
     else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet)
-        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth }, m_info.algorithms(), WTFMove(overrideExcludeCredentials));
+        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth }, m_info.algorithms(), WTFMove(overrideExcludeCredentials));
     else
         cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, std::nullopt, m_info.algorithms(), WTFMove(overrideExcludeCredentials));
     CTAP_RELEASE_LOG("makeCredential: Sending %s", base64EncodeToString(cborCmd).utf8().data());
@@ -298,7 +298,7 @@ void CtapAuthenticator::getAssertion()
         m_currentBatch = 0;
         std::optional<PinParameters> pinParameters;
         if (!m_pinAuth.isEmpty())
-            pinParameters = PinParameters { pin::kProtocolVersion, m_pinAuth };
+            pinParameters = PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth };
         Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rpId, requestData().hash, m_batches[m_currentBatch], pinParameters);
         protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
             ASSERT(RunLoop::isMain());
@@ -315,7 +315,7 @@ void CtapAuthenticator::getAssertion()
     } else if (options.allowCredentials.size() == 1 && canDowngradeToU2f()) {
         std::optional<PinParameters> pinParameters;
         if (!m_pinAuth.isEmpty())
-            pinParameters = PinParameters { pin::kProtocolVersion, m_pinAuth };
+            pinParameters = PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth };
         Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rpId, requestData().hash, options.allowCredentials, pinParameters);
         protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
             ASSERT(RunLoop::isMain());
@@ -346,7 +346,7 @@ void CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials()
     if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && options.userVerification() != UserVerificationRequirement::Discouraged && m_pinAuth.isEmpty())
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideAllowCredentials));
     else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet && options.userVerification() != UserVerificationRequirement::Discouraged)
-        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth }, WTFMove(overrideAllowCredentials));
+        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth }, WTFMove(overrideAllowCredentials));
     else
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideAllowCredentials));
     if (m_info.maxMsgSize() && cborCmd.size() >= *m_info.maxMsgSize())
@@ -457,7 +457,7 @@ void CtapAuthenticator::continueGetNextAssertionAfterResponseReceived(Vector<uin
 
 void CtapAuthenticator::getRetries()
 {
-    auto cborCmd = encodeAsCBOR(pin::RetriesRequest { });
+    auto cborCmd = encodeAsCBOR(pin::RetriesRequest { selectPinProtocol() });
     CTAP_RELEASE_LOG("getRetries: Sending %s", base64EncodeToString(cborCmd).utf8().data());
     protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
@@ -480,7 +480,7 @@ void CtapAuthenticator::continueGetKeyAgreementAfterGetRetries(Vector<uint8_t>&&
         return;
     }
 
-    auto cborCmd = encodeAsCBOR(pin::KeyAgreementRequest { });
+    auto cborCmd = encodeAsCBOR(pin::KeyAgreementRequest { selectPinProtocol() });
     CTAP_RELEASE_LOG("continueGetKeyAgreementAfterGetRetries: Sending %s", base64EncodeToString(cborCmd).utf8().data());
     protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, retries = retries->retries] (Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
@@ -531,7 +531,7 @@ void CtapAuthenticator::continueGetPinTokenAfterRequestPin(const String& pin, co
         tryRestartPin(CtapDeviceResponseCode::kCtap2ErrPinInvalid);
         return;
     }
-    auto tokenRequest = pin::TokenRequest::tryCreate(*pinUTF8, peerKey);
+    auto tokenRequest = pin::TokenRequest::tryCreate(selectPinProtocol(), *pinUTF8, peerKey);
     if (!tokenRequest) {
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, "Cannot create a TokenRequest."_s });
         return;
@@ -552,7 +552,7 @@ void CtapAuthenticator::continueGetPinTokenAfterRequestPin(const String& pin, co
 void CtapAuthenticator::continueRequestAfterGetPinToken(Vector<uint8_t>&& data, const fido::pin::TokenRequest& tokenRequest)
 {
     CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived");
-    auto token = pin::TokenResponse::parse(tokenRequest.sharedKey(), data);
+    auto token = pin::TokenResponse::parse(selectPinProtocol(), tokenRequest.sharedKey(), data);
     if (!token) {
         auto error = getResponseCode(data);
 
@@ -573,7 +573,7 @@ void CtapAuthenticator::continueRequestAfterGetPinToken(Vector<uint8_t>&& data, 
     if (RefPtr observer = this->observer())
         observer->authenticatorStatusUpdated(toStatus(CtapDeviceResponseCode::kSuccess));
 
-    m_pinAuth = token->pinAuth(requestData().hash);
+    m_pinAuth = token->pinAuth(selectPinProtocol(), requestData().hash);
     WTF::switchOn(requestData().options, [&](const PublicKeyCredentialCreationOptions& options) {
         makeCredential();
     }, [&](const PublicKeyCredentialRequestOptions& options) {
@@ -647,6 +647,22 @@ bool CtapAuthenticator::isUVSetup() const
     return m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet || m_info.options().userVerificationAvailability() == AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured;
 }
 
+fido::PINUVAuthProtocol CtapAuthenticator::selectPinProtocol() const
+{
+    if (auto& protocols = m_info.pinProtocol()) {
+        CTAP_RELEASE_LOG("selectPinProtocol: Authenticator supports %zu protocols", protocols->size());
+        for (auto protocol : *protocols)
+            CTAP_RELEASE_LOG("selectPinProtocol: Available protocol %hhu", static_cast<uint8_t>(protocol));
+
+        if (protocols->contains(fido::PINUVAuthProtocol::kPinProtocol2)) {
+            CTAP_RELEASE_LOG("selectPinProtocol: Selected Protocol 2");
+            return fido::PINUVAuthProtocol::kPinProtocol2;
+        }
+    }
+    CTAP_RELEASE_LOG("selectPinProtocol: Defaulting to Protocol 1");
+    return fido::PINUVAuthProtocol::kPinProtocol1;
+}
+
 void CtapAuthenticator::continueSetupPinAfterCommand(Vector<uint8_t>&& data, const String& pin, Ref<WebCore::CryptoKeyEC> peerKey)
 {
     auto error = getResponseCode(data);
@@ -662,7 +678,7 @@ void CtapAuthenticator::continueSetupPinAfterCommand(Vector<uint8_t>&& data, con
         protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::PinInvalid);
         return;
     }
-    auto tokenRequest = pin::TokenRequest::tryCreate(*pinUTF8, peerKey);
+    auto tokenRequest = pin::TokenRequest::tryCreate(selectPinProtocol(), *pinUTF8, peerKey);
     if (!tokenRequest) {
         CTAP_RELEASE_LOG("continueSetupPinAfterCommand: Failed to create TokenRequest.");
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, "Cannot create a TokenRequest."_s });
@@ -690,7 +706,7 @@ void CtapAuthenticator::continueSetupPinAfterGetKeyAgreement(Vector<uint8_t>&& d
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, makeString("Unknown internal error. Error code: "_s, static_cast<uint8_t>(error)) });
         return;
     }
-    auto setPinRequest = pin::SetPinRequest::tryCreate(pin, keyAgreement->peerKey);
+    auto setPinRequest = pin::SetPinRequest::tryCreate(selectPinProtocol(), pin, keyAgreement->peerKey);
     if (!setPinRequest) {
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, "Cannot create a SetPinRequest."_s });
         return;
@@ -727,7 +743,7 @@ void CtapAuthenticator::setupPin()
             protectedThis->performAuthenticatorSelectionForSetupPin();
             return;
         }
-        auto cborCmd = encodeAsCBOR(pin::KeyAgreementRequest { });
+        auto cborCmd = encodeAsCBOR(pin::KeyAgreementRequest { protectedThis->selectPinProtocol() });
         CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "setupPin: Sending %s", base64EncodeToString(cborCmd).utf8().data());
         protectedThis->protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WTFMove(weakThis), pin] (Vector<uint8_t>&& data) {
             ASSERT(RunLoop::isMain());

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -75,6 +75,7 @@ private:
 
     String aaguidForDebugging() const;
 
+    fido::PINUVAuthProtocol selectPinProtocol() const;
     bool isUVSetup() const;
 
     void continueSetupPinAfterCommand(Vector<uint8_t>&&, const String& pin, Ref<WebCore::CryptoKeyEC> peerKey);

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -83,11 +83,11 @@ TEST(CtapPinTest, TestSetPinRequest)
 
     String pin = "1234"_s;
 
-    auto request = SetPinRequest::tryCreate(pin, downcast<CryptoKeyEC>(*keyPair.publicKey));
+    auto request = SetPinRequest::tryCreate(PINUVAuthProtocol::kPinProtocol1, pin, downcast<CryptoKeyEC>(*keyPair.publicKey));
     EXPECT_TRUE(request);
     auto result = encodeAsCBOR(*request);
 
-    EXPECT_EQ(result.size(), 187u);
+    EXPECT_EQ(result.size(), 170u);
     EXPECT_EQ(result[0], static_cast<uint8_t>(CtapRequestCommand::kAuthenticatorClientPin));
 
     // Decode the CBOR binary to check if each field is encoded correctly.
@@ -154,17 +154,17 @@ TEST(CtapPinTest, TestSetPinRequest)
     EXPECT_TRUE(equalSpans(newPinEnc.span(), std::span { expectedNewPinEnc }));
 
     String pin2 = "123"_s;
-    auto request2 = SetPinRequest::tryCreate(pin2, downcast<CryptoKeyEC>(*keyPair.publicKey));
+    auto request2 = SetPinRequest::tryCreate(PINUVAuthProtocol::kPinProtocol1, pin2, downcast<CryptoKeyEC>(*keyPair.publicKey));
     EXPECT_FALSE(request2);
 
     String pin3 = "01234567891011121314151617181920212223242526272829303132333435363738394041424344454647484950"_s;
-    auto request3 = SetPinRequest::tryCreate(pin3, downcast<CryptoKeyEC>(*keyPair.publicKey));
+    auto request3 = SetPinRequest::tryCreate(PINUVAuthProtocol::kPinProtocol1, pin3, downcast<CryptoKeyEC>(*keyPair.publicKey));
     EXPECT_FALSE(request3);
 }
 
 TEST(CtapPinTest, TestRetriesRequest)
 {
-    auto result = encodeAsCBOR(RetriesRequest { });
+    auto result = encodeAsCBOR(RetriesRequest { PINUVAuthProtocol::kPinProtocol1 });
     EXPECT_EQ(result.size(), sizeof(TestData::kCtapClientPinRetries));
     EXPECT_TRUE(equalSpans(result.span(), std::span { TestData::kCtapClientPinRetries }));
 }
@@ -194,7 +194,7 @@ TEST(CtapPinTest, TestRetriesResponse)
 
 TEST(CtapPinTest, TestKeyAgreementRequest)
 {
-    auto result = encodeAsCBOR(KeyAgreementRequest { });
+    auto result = encodeAsCBOR(KeyAgreementRequest { PINUVAuthProtocol::kPinProtocol1 });
     EXPECT_EQ(result.size(), sizeof(TestData::kCtapClientPinKeyAgreement));
     EXPECT_TRUE(equalSpans(result.span(), std::span { TestData::kCtapClientPinKeyAgreement }));
 }
@@ -271,7 +271,7 @@ TEST(CtapPinTest, TestTokenRequest)
 
     CString pin = "1234";
 
-    auto token = TokenRequest::tryCreate(pin, downcast<CryptoKeyEC>(*keyPair.publicKey));
+    auto token = TokenRequest::tryCreate(PINUVAuthProtocol::kPinProtocol1, pin, downcast<CryptoKeyEC>(*keyPair.publicKey));
     EXPECT_TRUE(token);
     auto result = encodeAsCBOR(*token);
 
@@ -352,22 +352,22 @@ TEST(CtapPinTest, TestTokenResponse)
     ASSERT_TRUE(sharedKey);
 
     // Failure cases
-    auto result = TokenResponse::parse(*sharedKey, { });
+    auto result = TokenResponse::parse(PINUVAuthProtocol::kPinProtocol1, *sharedKey, { });
     EXPECT_FALSE(result);
 
     constexpr std::array<uint8_t, 1> testData1 { 0x05 }; // wrong response code
-    result = TokenResponse::parse(*sharedKey, std::span { testData1 });
+    result = TokenResponse::parse(PINUVAuthProtocol::kPinProtocol1, *sharedKey, std::span { testData1 });
     EXPECT_FALSE(result);
 
     constexpr std::array<uint8_t, 2> testData2 { 0x00, 0x00 }; // wrong CBOR map
-    result = TokenResponse::parse(*sharedKey, std::span { testData2 });
+    result = TokenResponse::parse(PINUVAuthProtocol::kPinProtocol1, *sharedKey, std::span { testData2 });
     EXPECT_FALSE(result);
 
-    result = TokenResponse::parse(*sharedKey, std::span { TestData::kCtapClientPinKeyAgreementResponse }); // wrong response
+    result = TokenResponse::parse(PINUVAuthProtocol::kPinProtocol1, *sharedKey, std::span { TestData::kCtapClientPinKeyAgreementResponse }); // wrong response
     EXPECT_FALSE(result);
 
     // Success cases
-    result = TokenResponse::parse(*sharedKey, std::span { TestData::kCtapClientPinTokenResponse });
+    result = TokenResponse::parse(PINUVAuthProtocol::kPinProtocol1, *sharedKey, std::span { TestData::kCtapClientPinTokenResponse });
     EXPECT_TRUE(result);
     constexpr std::array<uint8_t, 16> expectedToken { 0x03, 0xac, 0x67, 0x42, 0x16, 0xf3, 0xe1, 0x5c, 0x76, 0x1e, 0xe1, 0xa5, 0xe2, 0x55, 0xf0, 0x67 };
     EXPECT_EQ(result->token().size(), 16u);
@@ -384,14 +384,159 @@ TEST(CtapPinTest, TestPinAuth)
         0xEF, 0x0A, 0x6C, 0x67, 0xA7, 0x2B, 0xB5, 0x0F, };
     auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, std::span { sharedKeyData }, true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);
     ASSERT_TRUE(sharedKey);
-    auto result = TokenResponse::parse(*sharedKey, std::span { TestData::kCtapClientPinTokenResponse });
+    auto result = TokenResponse::parse(PINUVAuthProtocol::kPinProtocol1, *sharedKey, std::span { TestData::kCtapClientPinTokenResponse });
     ASSERT_TRUE(result);
 
     // 2. Generate the pinAuth.
-    auto pinAuth = result->pinAuth(std::span { sharedKeyData }); // sharedKeyData pretends to be clientDataHash
+    auto pinAuth = result->pinAuth(PINUVAuthProtocol::kPinProtocol1, std::span { sharedKeyData }); // sharedKeyData pretends to be clientDataHash
     constexpr std::array<uint8_t, 16> expectedPinAuth { 0x0b, 0xec, 0x9d, 0xba, 0x69, 0xb0, 0x0f, 0x45, 0x0b, 0xec, 0x66, 0xb4, 0x75, 0x7f, 0x93, 0x85 };
     EXPECT_EQ(pinAuth.size(), 16u);
     EXPECT_TRUE(equalSpans(pinAuth.span(), std::span { expectedPinAuth }));
+}
+
+TEST(CtapPinTest, TestSetPinRequestProtocol2)
+{
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
+    ASSERT_FALSE(keyPairResult.hasException());
+    auto keyPair = keyPairResult.releaseReturnValue();
+
+    String pin = "1234"_s;
+
+    auto request = SetPinRequest::tryCreate(PINUVAuthProtocol::kPinProtocol2, pin, downcast<CryptoKeyEC>(*keyPair.publicKey));
+    EXPECT_TRUE(request);
+    auto result = encodeAsCBOR(*request);
+
+    EXPECT_EQ(result.size(), 203u);
+    EXPECT_EQ(result[0], static_cast<uint8_t>(CtapRequestCommand::kAuthenticatorClientPin));
+
+    Vector<uint8_t> buffer;
+    buffer.append(result.subspan(1));
+    auto decodedResponse = cbor::CBORReader::read(buffer);
+    EXPECT_TRUE(decodedResponse);
+    EXPECT_TRUE(decodedResponse->isMap());
+    const auto& responseMap = decodedResponse->getMap();
+
+    const auto& it1 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kProtocol)));
+    EXPECT_NE(it1, responseMap.end());
+    EXPECT_EQ(it1->second.getInteger(), static_cast<int64_t>(PINUVAuthProtocol::kPinProtocol2));
+
+    const auto& it2 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kSubcommand)));
+    EXPECT_NE(it2, responseMap.end());
+    EXPECT_EQ(it2->second.getInteger(), static_cast<uint8_t>(Subcommand::kSetPin));
+
+    // COSE key validation
+    auto it = responseMap.find(CBORValue(static_cast<int>(RequestKey::kKeyAgreement)));
+    EXPECT_NE(it, responseMap.end());
+    EXPECT_TRUE(it->second.isMap());
+    const auto& coseKey = it->second.getMap();
+
+    const auto& it3 = coseKey.find(CBORValue(COSE::kty));
+    EXPECT_NE(it3, coseKey.end());
+    EXPECT_EQ(it3->second.getInteger(), COSE::EC2);
+
+    const auto& it4 = coseKey.find(CBORValue(COSE::alg));
+    EXPECT_NE(it4, coseKey.end());
+    EXPECT_EQ(it4->second.getInteger(), COSE::ECDH256);
+
+    const auto& it5 = coseKey.find(CBORValue(COSE::crv));
+    EXPECT_NE(it5, coseKey.end());
+    EXPECT_EQ(it5->second.getInteger(), COSE::P_256);
+
+    const auto& it6 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kNewPinEnc)));
+    EXPECT_NE(it6, responseMap.end());
+    EXPECT_TRUE(it6->second.isByteString());
+    EXPECT_EQ(it6->second.getByteString().size(), 80u);
+
+    const auto& it7 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kPinAuth)));
+    EXPECT_NE(it7, responseMap.end());
+    EXPECT_TRUE(it7->second.isByteString());
+    EXPECT_GT(it7->second.getByteString().size(), 0u);
+}
+
+TEST(CtapPinTest, TestTokenRequestProtocol2)
+{
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
+    ASSERT_FALSE(keyPairResult.hasException());
+    auto keyPair = keyPairResult.releaseReturnValue();
+
+    CString pin = "1234";
+
+    auto token = TokenRequest::tryCreate(PINUVAuthProtocol::kPinProtocol2, pin, downcast<CryptoKeyEC>(*keyPair.publicKey));
+    EXPECT_TRUE(token);
+    auto result = encodeAsCBOR(*token);
+
+    EXPECT_EQ(result.size(), 120u);
+    EXPECT_EQ(result[0], static_cast<uint8_t>(CtapRequestCommand::kAuthenticatorClientPin));
+
+    Vector<uint8_t> buffer;
+    buffer.append(result.subspan(1));
+    auto decodedResponse = cbor::CBORReader::read(buffer);
+    EXPECT_TRUE(decodedResponse);
+    EXPECT_TRUE(decodedResponse->isMap());
+    const auto& responseMap = decodedResponse->getMap();
+
+    const auto& it1 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kProtocol)));
+    EXPECT_NE(it1, responseMap.end());
+    EXPECT_EQ(it1->second.getInteger(), static_cast<int64_t>(PINUVAuthProtocol::kPinProtocol2));
+
+    const auto& it2 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kSubcommand)));
+    EXPECT_NE(it2, responseMap.end());
+    EXPECT_EQ(it2->second.getInteger(), static_cast<uint8_t>(Subcommand::kGetPinToken));
+
+    // COSE key validation
+    auto it = responseMap.find(CBORValue(static_cast<int>(RequestKey::kKeyAgreement)));
+    EXPECT_NE(it, responseMap.end());
+    EXPECT_TRUE(it->second.isMap());
+    const auto& coseKey = it->second.getMap();
+
+    const auto& it3 = coseKey.find(CBORValue(COSE::kty));
+    EXPECT_NE(it3, coseKey.end());
+    EXPECT_EQ(it3->second.getInteger(), COSE::EC2);
+
+    const auto& it4 = coseKey.find(CBORValue(COSE::alg));
+    EXPECT_NE(it4, coseKey.end());
+    EXPECT_EQ(it4->second.getInteger(), COSE::ECDH256);
+
+    const auto& it5 = coseKey.find(CBORValue(COSE::crv));
+    EXPECT_NE(it5, coseKey.end());
+    EXPECT_EQ(it5->second.getInteger(), COSE::P_256);
+
+    // Verify encrypted PIN hash is present
+    const auto& it6 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kPinHashEnc)));
+    EXPECT_NE(it6, responseMap.end());
+    EXPECT_TRUE(it6->second.isByteString());
+    EXPECT_EQ(it6->second.getByteString().size(), 32u);
+}
+
+TEST(CtapPinTest, TestProtocol2HKDFKeyDerivation)
+{
+    constexpr std::array<uint8_t, 32> testECDHResult {
+        0x87, 0x6e, 0x3d, 0x99, 0x2c, 0x5a, 0x1b, 0x84,
+        0x6f, 0x2d, 0x87, 0x62, 0xaa, 0x38, 0x92, 0x7c,
+        0x4e, 0x5c, 0x3b, 0x23, 0x1d, 0xe6, 0x89, 0x45,
+        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0
+    };
+
+    constexpr std::array<uint8_t, 32> expectedHMACKey {
+        0x88, 0x1f, 0xc7, 0x93, 0xc8, 0x34, 0xdb, 0x80,
+        0x4f, 0xd5, 0x8d, 0x96, 0xb2, 0xbd, 0x85, 0xac,
+        0x21, 0xf7, 0xe7, 0x4b, 0xeb, 0x23, 0x36, 0x5b,
+        0xd2, 0x67, 0xe4, 0x96, 0x21, 0x9b, 0xfb, 0x29
+    };
+
+    constexpr std::array<uint8_t, 32> expectedAESKey {
+        0x31, 0x3b, 0x20, 0xaf, 0x5e, 0x3f, 0x60, 0x05,
+        0x17, 0xa6, 0xdc, 0xda, 0xbf, 0xae, 0xa2, 0xbf,
+        0x49, 0x08, 0xe8, 0x36, 0x2a, 0x1c, 0x3a, 0x5b,
+        0xaa, 0xce, 0x11, 0x8e, 0x3e, 0x72, 0x49, 0xd2
+    };
+
+    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    crypto->addBytes(std::span { testECDHResult });
+    auto protocol1Key = crypto->computeHash();
+
+    EXPECT_FALSE(equalSpans(protocol1Key.span(), std::span { expectedHMACKey }));
+    EXPECT_FALSE(equalSpans(protocol1Key.span(), std::span { expectedAESKey }));
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
@@ -647,7 +647,7 @@ TEST(CTAPResponseTest, TestSerializeGetInfoResponse)
     options.setUserVerificationAvailability(AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured);
     response.setOptions(WTFMove(options));
     response.setMaxMsgSize(1200);
-    response.setPinProtocols({ 1 });
+    response.setPinProtocols({ PINUVAuthProtocol::kPinProtocol1 });
 
     auto responseAsCBOR = encodeAsCBOR(response);
     EXPECT_EQ(responseAsCBOR.size(), sizeof(TestData::kTestGetInfoResponsePlatformDevice) - 1);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -2507,6 +2507,126 @@ TEST(WebAuthenticationPanel, ImportMalformedCredential)
     EXPECT_EQ(credentialId, nil);
 }
 
+TEST(WebAuthenticationPanel, MakeCredentialPinProtocol2)
+{
+    reset();
+
+    NSString *html = @"<input type='text' id='input'>"
+    "<script>"
+    "const testCtapPinAuthInvalidErrorBase64 = 'Mw==';"
+    "const testPinGetRetriesResponseBase64 = 'AKEDCA==';"
+    "const testPinGetKeyAgreementResponseBase64 = 'AKEBpQECAzgYIAEhWCDodiWJbuTkbcAydm6Ah5YvNt+d/otWfzdjAVsZkKYOFCJYICfeYS1mQYvaGVBYHrxcjB2tcQyxTCL4yXBF9GEvsgyR';"
+    "const testPinGetPinTokenResponseBase64 = 'AKECUBOk7rcOyRrqAB6TFvYeQfc=';"
+    "const testCreationMessageBase64 ="
+    "    'AKMBZnBhY2tlZAJYxEbMf7lnnVWy25CS4cjZ5eHQK3WA8LSBLHcJYuHkj1rYQQAA' +"
+    "    'AE74oBHzjApNFYAGFxEfntx9AEAoCK3O6P5OyXN6V/f+9nAga0NA2Cgp4V3mgSJ5' +"
+    "    'jOHLMDrmxp/S0rbD+aihru1C0aAN3BkiM6GNy5nSlDVqOgTgpQECAyYgASFYIEFb' +"
+    "    'he3RkNud6sgyraBGjlh1pzTlCZehQlL/b18HZ6WGIlggJgfUd/en9p5AIqMQbUni' +"
+    "    'nEeXdFLkvW0/zV5BpEjjNxADo2NhbGcmY3NpZ1hHMEUCIQDKg+ZBmEBtf0lWq4Re' +"
+    "    'dH4/i/LOYqOR4uR2NAj2zQmw9QIgbTXb4hvFbj4T27bv/rGrc+y+0puoYOBkBk9P' +"
+    "    'mCewWlNjeDVjgVkCwjCCAr4wggGmoAMCAQICBHSG/cIwDQYJKoZIhvcNAQELBQAw' +"
+    "    'LjEsMCoGA1UEAxMjWXViaWNvIFUyRiBSb290IENBIFNlcmlhbCA0NTcyMDA2MzEw' +"
+    "    'IBcNMTQwODAxMDAwMDAwWhgPMjA1MDA5MDQwMDAwMDBaMG8xCzAJBgNVBAYTAlNF' +"
+    "    'MRIwEAYDVQQKDAlZdWJpY28gQUIxIjAgBgNVBAsMGUF1dGhlbnRpY2F0b3IgQXR0' +"
+    "    'ZXN0YXRpb24xKDAmBgNVBAMMH1l1YmljbyBVMkYgRUUgU2VyaWFsIDE5NTUwMDM4' +"
+    "    'NDIwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASVXfOt9yR9MXXv/ZzE8xpOh466' +"
+    "    '4YEJVmFQ+ziLLl9lJ79XQJqlgaUNCsUvGERcChNUihNTyKTlmnBOUjvATevto2ww' +"
+    "    'ajAiBgkrBgEEAYLECgIEFTEuMy42LjEuNC4xLjQxNDgyLjEuMTATBgsrBgEEAYLl' +"
+    "    'HAIBAQQEAwIFIDAhBgsrBgEEAYLlHAEBBAQSBBD4oBHzjApNFYAGFxEfntx9MAwG' +"
+    "    'A1UdEwEB/wQCMAAwDQYJKoZIhvcNAQELBQADggEBADFcSIDmmlJ+OGaJvWn9Cqhv' +"
+    "    'SeueToVFQVVvqtALOgCKHdwB+Wx29mg2GpHiMsgQp5xjB0ybbnpG6x212FxESJ+G' +"
+    "    'inZD0ipchi7APwPlhIvjgH16zVX44a4e4hOsc6tLIOP71SaMsHuHgCcdH0vg5d2s' +"
+    "    'c006WJe9TXO6fzV+ogjJnYpNKQLmCXoAXE3JBNwKGBIOCvfQDPyWmiiG5bGxYfPt' +"
+    "    'y8Z3pnjX+1MDnM2hhr40ulMxlSNDnX/ZSnDyMGIbk8TOQmjTF02UO8auP8k3wt5D' +"
+    "    '1rROIRU9+FCSX5WQYi68RuDrGMZB8P5+byoJqbKQdxn2LmE1oZAyohPAmLcoPO4=';"
+    "if (window.internals) {"
+    "    internals.setMockWebAuthenticationConfiguration({"
+    "        hid: {"
+    "            supportClientPin: true,"
+    "            pinProtocols: [1, 2],"
+    "            payloadBase64: [testCtapPinAuthInvalidErrorBase64, testPinGetRetriesResponseBase64, testPinGetKeyAgreementResponseBase64, testPinGetPinTokenResponseBase64, testCreationMessageBase64]"
+    "        }"
+    "    });"
+    "    internals.withUserGesture(() => { input.focus(); });"
+    "}"
+    "const options = {"
+    "    publicKey: {"
+    "        rp: { name: 'localhost' },"
+    "        user: {"
+    "            name: 'John Appleseed',"
+    "            id: new Uint8Array(16),"
+    "            displayName: 'Appleseed'"
+    "        },"
+    "        challenge: new Uint8Array(16),"
+    "        pubKeyCredParams: [{ type: 'public-key', alg: -7 }]"
+    "    }"
+    "};"
+    "navigator.credentials.create(options).then(credential => {"
+    "    window.webkit.messageHandlers.testHandler.postMessage('Succeeded!');"
+    "}, error => {"
+    "    window.webkit.messageHandlers.testHandler.postMessage(error.message);"
+    "});"
+    "</script>";
+
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
+    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+    [webView focus];
+
+    webAuthenticationPanelPin = "1234"_s;
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://localhost:443"]];
+    [webView waitForMessage:@"Succeeded!"];
+}
+
+TEST(WebAuthenticationPanel, GetAssertionPinProtocol2)
+{
+    reset();
+
+    NSString *html = @"<input type='text' id='input'>"
+    "<script>"
+    "const testCtapPinAuthInvalidErrorBase64 = 'Mw==';"
+    "const testPinGetRetriesResponseBase64 = 'AKEDCA==';"
+    "const testPinGetKeyAgreementResponseBase64 = 'AKEBpQECAzgYIAEhWCDodiWJbuTkbcAydm6Ah5YvNt+d/otWfzdjAVsZkKYOFCJYICfeYS1mQYvaGVBYHrxcjB2tcQyxTCL4yXBF9GEvsgyR';"
+    "const testPinGetPinTokenResponseBase64 = 'AKECUBOk7rcOyRrqAB6TFvYeQfc=';"
+    "const testAssertionMessageBase64 ="
+    "    'AKMBomJpZFhAKAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2' +"
+    "    'w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4GR0eXBlanB1YmxpYy1rZXkCWCVGzH+5' +"
+    "    'Z51VstuQkuHI2eXh0Ct1gPC0gSx3CWLh5I9a2AEAAABQA1hHMEUCIQCSFTuuBWgB' +"
+    "    '4/F0VB7DlUVM09IHPmxe1MzHUwRoCRZbCAIgGKov6xoAx2MEf6/6qNs8OutzhP2C' +"
+    "    'QoJ1L7Fe64G9uBc=';"
+    "if (window.internals) {"
+    "    internals.setMockWebAuthenticationConfiguration({"
+    "        hid: {"
+    "            supportClientPin: true,"
+    "            pinProtocols: [1, 2],"
+    "            payloadBase64: [testCtapPinAuthInvalidErrorBase64, testPinGetRetriesResponseBase64, testPinGetKeyAgreementResponseBase64, testPinGetPinTokenResponseBase64, testAssertionMessageBase64]"
+    "        }"
+    "    });"
+    "    internals.withUserGesture(() => { input.focus(); });"
+    "}"
+    "const options = {"
+    "    publicKey: {"
+    "        challenge: new Uint8Array(16),"
+    "        timeout: 100"
+    "    }"
+    "};"
+    "navigator.credentials.get(options).then(credential => {"
+    "    window.webkit.messageHandlers.testHandler.postMessage('Succeeded!');"
+    "}, error => {"
+    "    window.webkit.messageHandlers.testHandler.postMessage(error.message);"
+    "});"
+    "</script>";
+
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
+    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+    [webView focus];
+
+    webAuthenticationPanelPin = "1234"_s;
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://localhost:443"]];
+    [webView waitForMessage:@"Succeeded!"];
+}
+
 TEST(WebAuthenticationPanel, DeleteOneCredential)
 {
     reset();


### PR DESCRIPTION
#### fb4149ed5439527c905c46ee3ec16f9421c0a7ef
<pre>
[WebAuthn] Pin Protocol 2 support
<a href="https://rdar.apple.com/157884782">rdar://157884782</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301922">https://bugs.webkit.org/show_bug.cgi?id=301922</a>

Reviewed by Brent Fulgham.

Add support for CTAP PIN/UV Auth Protocol 2, which uses HKDF-SHA-256
for key derivation instead of SHA-256. This is required for FIPS
certification of authenticators per the CTAP 2.1 specification. Currently
these authenticators will not work over NFC.

The implementation:
- Uses HKDF to derive separate 32-byte HMAC and AES keys (Protocol 2)
  vs. SHA-256 for a single 32-byte key (Protocol 1)
- Encodes the selected protocol in authenticatorClientPIN commands
- Selects Protocol 2 when authenticator reports support for both

This also corrects Protocol 1 pinAuth to return 16-bytes instead of
32 bytes per spec. I updated CtapPinTest expectations for new behavior.

Spec: <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2">https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2</a>

Tests: Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
       Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm

* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::readCTAPGetInfoResponse):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.h:
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::encodePinCommand):
(fido::pin::encodeAsCBOR):
(fido::pin::deriveProtocolSharedSecret):
(fido::pin::TokenRequest::tryCreate):
(fido::pin::TokenRequest::TokenRequest):
(fido::pin::SetPinRequest::SetPinRequest):
(fido::pin::SetPinRequest::tryCreate):
* Source/WebCore/Modules/webauthn/fido/Pin.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp:
(WebCore::CryptoAlgorithmHKDF::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp:
(WebKit::MockHidConnection::feedReports):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueSilentlyCheckCredentials):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):
(WebKit::CtapAuthenticator::getAssertion):
(WebKit::CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials):
(WebKit::CtapAuthenticator::continueGetPinTokenAfterRequestPin):
(WebKit::CtapAuthenticator::selectPinProtocol const):
(WebKit::CtapAuthenticator::continueSetupPinAfterCommand):
(WebKit::CtapAuthenticator::continueSetupPinAfterGetKeyAgreement):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST(CtapPinTest, TestSetPinRequest)):
(TestWebKitAPI::TEST(CtapPinTest, TestTokenRequest)):
(TestWebKitAPI::TEST(CtapPinTest, TestSetPinRequestProtocol2)):
(TestWebKitAPI::TEST(CtapPinTest, TestTokenRequestProtocol2)):
(TestWebKitAPI::TEST(CtapPinTest, TestProtocol2HKDFKeyDerivation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialPinProtocol2)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinProtocol2)):

Canonical link: <a href="https://commits.webkit.org/302574@main">https://commits.webkit.org/302574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa1c63cd963e722a9df4ac0a6f00b195d25dcd61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129555 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136939 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/949744b7-7eb6-4e1a-988d-aaee5030f6c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1688 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/212acd14-004e-4a57-a6da-ea0b2bb53ac6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132502 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79335 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/36d75fc6-a7aa-4a67-be06-7e835f0a3bfd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80214 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139413 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1530 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107051 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27254 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54303 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65036 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1493 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->