### PR TITLE
[JSC] Remove `@neverInline` attribute

### DIFF
--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
@@ -136,8 +136,6 @@ class BuiltinsGenerator:
         inlineAttribute = "None"
         if function.is_always_inline:
             inlineAttribute = "Always"
-        elif function.is_never_inline:
-            inlineAttribute = "Never"
 
         return {
             'codeName': BuiltinsGenerator.mangledNameForFunction(function) + 'Code',

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
@@ -45,7 +45,6 @@ _FRAMEWORK_CONFIG_MAP = {
 functionHeadRegExp = re.compile(r"(?:@[\w|=\[\] \"\.]+\s*\n)*(?:async\s+)?function\s+\w+\s*\(.*?\)", re.MULTILINE | re.DOTALL)
 functionLinkTimeConstantRegExp = re.compile(r".*^@linkTimeConstant", re.MULTILINE | re.DOTALL)
 functionAlwaysInlineRegExp = re.compile(r".*^@alwaysInline", re.MULTILINE | re.DOTALL)
-functionNeverInlineRegExp = re.compile(r".*^@neverInline", re.MULTILINE | re.DOTALL)
 functionVisibilityRegExp = re.compile(r".*^@visibility=(\w+)", re.MULTILINE | re.DOTALL)
 functionNakedConstructorRegExp = re.compile(r".*^@nakedConstructor", re.MULTILINE | re.DOTALL)
 functionIntrinsicRegExp = re.compile(r".*^@intrinsic=(\w+)", re.MULTILINE | re.DOTALL)
@@ -106,7 +105,7 @@ class BuiltinObject:
 
 
 class BuiltinFunction:
-    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, is_never_inline, intrinsic, visibility, overridden_name):
+    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, intrinsic, visibility, overridden_name):
         self.function_name = function_name
         self.function_source = function_source
         self.parameters = parameters
@@ -114,7 +113,6 @@ class BuiltinFunction:
         self.is_constructor = is_constructor
         self.is_naked_constructor = is_naked_constructor
         self.is_always_inline = is_always_inline
-        self.is_never_inline = is_never_inline
         self.is_link_time_constant = is_link_time_constant
         self.intrinsic = intrinsic
         self.visibility = visibility
@@ -153,7 +151,6 @@ class BuiltinFunction:
         is_link_time_constant = functionLinkTimeConstantRegExp.match(function_source) != None
         is_naked_constructor = functionNakedConstructorRegExp.match(function_source) != None
         is_always_inline = functionAlwaysInlineRegExp.match(function_source) != None
-        is_never_inline = functionNeverInlineRegExp.match(function_source) is not None
         if is_naked_constructor:
             is_constructor = True
 
@@ -179,7 +176,7 @@ class BuiltinFunction:
         if overridden_name[-1] == "\"":
             overridden_name += "_s"
 
-        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, is_never_inline, intrinsic, visibility, overridden_name)
+        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, intrinsic, visibility, overridden_name)
 
     def __str__(self):
         interface = "%s(%s)" % (self.function_name, ', '.join(self.parameters))

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -203,9 +203,6 @@ FunctionExecutable* UnlinkedFunctionExecutable::link(VM& vm, ScriptExecutable* t
     if (overrideLineNumber)
         result->setOverrideLineNumber(*overrideLineNumber);
 
-    if (inlineAttribute() == InlineAttribute::Never)
-        result->setNeverInline(true);
-
     if (hasFunctionOverride) [[unlikely]]
         result->overrideInfo(overrideInfo);
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -311,7 +311,7 @@ private:
     LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures;
     uint8_t m_functionMode : 2; // FunctionMode
     uint8_t m_derivedContextType : 2;
-    uint8_t m_inlineAttribute : 2;
+    uint8_t m_inlineAttribute : 1;
 
     union {
         WriteBarrier<UnlinkedFunctionCodeBlock> m_unlinkedCodeBlockForCall;

--- a/Source/JavaScriptCore/runtime/InlineAttribute.h
+++ b/Source/JavaScriptCore/runtime/InlineAttribute.h
@@ -30,7 +30,6 @@ namespace JSC {
 enum class InlineAttribute : uint8_t {
     None,
     Always,
-    Never,
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2150,7 +2150,6 @@ static JSC_DECLARE_HOST_FUNCTION(functionCpuClflush);
 static JSC_DECLARE_HOST_FUNCTION(functionLLintTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionBaselineJITTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionNoInline);
-static JSC_DECLARE_HOST_FUNCTION(functionIsNeverInline);
 static JSC_DECLARE_HOST_FUNCTION(functionTriggerMemoryPressure);
 static JSC_DECLARE_HOST_FUNCTION(functionGC);
 static JSC_DECLARE_HOST_FUNCTION(functionEdenGC);
@@ -2614,24 +2613,6 @@ JSC_DEFINE_HOST_FUNCTION(functionNoInline, (JSGlobalObject*, CallFrame* callFram
         executable->setNeverInline(true);
     
     return JSValue::encode(jsUndefined());
-}
-
-// Check that the argument function is never inlined (set by $vm.noInline or the @neverInline attribute)
-// Usage:
-// function f() {}
-// $vm.isNeverInline(f);
-JSC_DEFINE_HOST_FUNCTION(functionIsNeverInline, (JSGlobalObject*, CallFrame* callFrame))
-{
-    DollarVMAssertScope assertScope;
-    if (callFrame->argumentCount() < 1)
-        return JSValue::encode(jsBoolean(false));
-
-    JSValue theFunctionValue = callFrame->uncheckedArgument(0);
-
-    if (FunctionExecutable* executable = getExecutableForFunction(theFunctionValue))
-        return JSValue::encode(jsBoolean(executable->neverInline()));
-
-    return JSValue::encode(jsBoolean(false));
 }
 
 // Runs a full GC synchronously.
@@ -4373,7 +4354,6 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "baselineJITTrue"_s, functionBaselineJITTrue, 0);
 
     addFunction(vm, "noInline"_s, functionNoInline, 1);
-    addFunction(vm, "isNeverInline"_s, functionIsNeverInline, 1);
 
     addFunction(vm, "triggerMemoryPressure"_s, functionTriggerMemoryPressure, 0);
     addFunction(vm, "gc"_s, functionGC, 0);


### PR DESCRIPTION
#### f923f67dd39633b0b4489d924c2f5293b0a433bc
<pre>
[JSC] Remove `@neverInline` attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=301927">https://bugs.webkit.org/show_bug.cgi?id=301927</a>

Reviewed by Justin Michaud.

We added `@neverInline` attribute by <a href="https://commits.webkit.org/299245@main.">https://commits.webkit.org/299245@main.</a>
It&apos;s no longer used, and using it is not a good practice.

So this patch changed to remove `@neverInline` attribute.

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py:
(BuiltinsGenerator.generate_embedded_code_data_for_function):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py:
(BuiltinFunction.__init__):
(BuiltinFunction.fromString):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::link):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/runtime/InlineAttribute.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSDollarVM::finishCreation):

Canonical link: <a href="https://commits.webkit.org/302562@main">https://commits.webkit.org/302562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc4a2ee18e8e286bcfa64e90498129b340aa0aa1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98569 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66460 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34049 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80073 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121411 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109629 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34549 "Found 2 new test failures: fast/images/page-wide-animation-toggle.html http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139270 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127871 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106938 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54137 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64900 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160885 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1354 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40129 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->