### PR TITLE
[CSS @starting-style] entry animation is only respected on first transition

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/after-change-style-inherited-try-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/after-change-style-inherited-try-fallback-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Position fallback correctly applied to after-change style assert_equals: Transitioning from !important width to fallback width expected 250 but got 200
+FAIL Position fallback correctly applied to after-change style assert_equals: #inner halfway between black and lime expected "rgb(0, 128, 0)" but got "rgb(64, 64, 0)"
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -762,6 +762,11 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
 
     std::unique_ptr<RenderStyle> startingStyle;
 
+    // The style of the styleable is constantly in flux during anchor resolution and/or trying
+    // position options. Hence we skip updating/applying animations until both processes are
+    // complete and the style is stable.
+    auto skipAnimationForAnchorPosition = hasUnresolvedAnchorPosition(styleable) || isTryingPositionOption(styleable);
+
     auto* oldStyle = [&]() -> const RenderStyle* {
         if (auto* styleBefore = beforeResolutionStyle(element, styleable.pseudoElementIdentifier))
             return styleBefore;
@@ -775,8 +780,14 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         return nullptr;
     }();
 
+    if (skipAnimationForAnchorPosition) {
+        // A styleable gets its style resolved multiple times for anchor positioning.
+        // Therefore when updating animation is deferred, save the old style so it's restored
+        // (using beforeResolutionStyle) and can be used when animation is finally updated/applied.
+        saveBeforeResolutionStyleForInterleaving(styleable.element, oldStyle);
+    }
+
     auto unanimatedDisplay = resolvedStyle.style->display();
-    auto hasUnresolvedAnchorPosition = this->hasUnresolvedAnchorPosition(styleable);
 
     WeakStyleOriginatedAnimations newStyleOriginatedAnimations;
 
@@ -784,7 +795,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         if (document.backForwardCacheState() != Document::NotInBackForwardCache || document.printing())
             return;
 
-        if (hasUnresolvedAnchorPosition)
+        if (skipAnimationForAnchorPosition)
             return;
 
         if (oldStyle && (oldStyle->hasTransitions() || resolvedStyle.style->hasTransitions()))
@@ -809,7 +820,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
     };
 
     auto applyAnimations = [&]() -> std::pair<std::unique_ptr<RenderStyle>, OptionSet<AnimationImpact>> {
-        if (hasUnresolvedAnchorPosition) {
+        if (skipAnimationForAnchorPosition) {
             auto newStyle = WTF::move(resolvedStyle.style);
             ASSERT(newStyle);
 
@@ -1449,7 +1460,6 @@ std::unique_ptr<Update> TreeResolver::resolve()
         if (elementAndState.value->stage < AnchorPositionResolutionStage::Resolved) {
             const_cast<Element&>(*elementAndState.key.first).invalidateForResumingAnchorPositionedElementResolution();
             m_needsInterleavedLayout = true;
-            saveBeforeResolutionStyleForInterleaving(*elementAndState.key.first);
         }
     }
 
@@ -1458,7 +1468,6 @@ std::unique_ptr<Update> TreeResolver::resolve()
             ASSERT(styleable.first);
             const_cast<Element&>(*styleable.first).invalidateForResumingAnchorPositionedElementResolution();
             m_needsInterleavedLayout = true;
-            saveBeforeResolutionStyleForInterleaving(*styleable.first);
         }
     }
 
@@ -1848,13 +1857,9 @@ const RenderStyle* TreeResolver::beforeResolutionStyle(const Element& element, s
     return resolvePseudoStyle(element.renderOrDisplayContentsStyle());
 }
 
-void TreeResolver::saveBeforeResolutionStyleForInterleaving(const Element& element)
+void TreeResolver::saveBeforeResolutionStyleForInterleaving(const Element& element, const RenderStyle* style)
 {
-    m_savedBeforeResolutionStylesForInterleaving.ensure(element, [&]() -> std::unique_ptr<RenderStyle> {
-        if (auto* style = element.renderOrDisplayContentsStyle())
-            return makeUnique<RenderStyle>(RenderStyle::cloneIncludingPseudoElements(*style));
-        return { };
-    });
+    m_savedBeforeResolutionStylesForInterleaving.add(element, style ? RenderStyle::clonePtr(*style) : nullptr);
 }
 
 bool TreeResolver::hasUnresolvedAnchorPosition(const Styleable& styleable) const
@@ -1871,6 +1876,14 @@ bool TreeResolver::hasResolvedAnchorPosition(const Styleable& styleable) const
     auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
     if (anchorPositionedState && anchorPositionedState->stage >= AnchorPositionResolutionStage::Resolved)
         return true;
+
+    return false;
+}
+
+bool TreeResolver::isTryingPositionOption(const Styleable& styleable) const
+{
+    if (auto it = m_positionOptions.find({ styleable.element, styleable.pseudoElementIdentifier }); it != m_positionOptions.end())
+        return !it->value.chosen;
 
     return false;
 }

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -184,10 +184,13 @@ private:
     // This returns the style that was in effect (applied to the render tree) before we started the style resolution.
     // Layout interleaving may cause different styles to be applied during the style resolution.
     const RenderStyle* beforeResolutionStyle(const Element&, std::optional<PseudoElementIdentifier>);
-    void saveBeforeResolutionStyleForInterleaving(const Element&);
+    void saveBeforeResolutionStyleForInterleaving(const Element&, const RenderStyle*);
 
     bool hasUnresolvedAnchorPosition(const Styleable&) const;
     bool hasResolvedAnchorPosition(const Styleable&) const;
+    // Returns true if (1) the styleable specifies position fallbacks and
+    // (2) we're in the middle of trying position options.
+    bool isTryingPositionOption(const Styleable&) const;
 
     void collectChangedAnchorNames(const RenderStyle&, const RenderStyle* currentStyle);
 


### PR DESCRIPTION
#### d9149b628100da7d3164b71bf473f9ba99db6c41
<pre>
[CSS @starting-style] entry animation is only respected on first transition
<a href="https://rdar.apple.com/163928932">rdar://163928932</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301510">https://bugs.webkit.org/show_bug.cgi?id=301510</a>

Reviewed by Antti Koivisto.

Fixed some issues with the interaction between CSS animations/transitions and
anchor positioning:

* The style to be saved when deferring updating/applying animations should also
  be the starting style, in addition to the previous render style.
* Updating/applying animations should be deferred until a position option is
  chosen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/after-change-style-inherited-try-fallback-expected.txt:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::saveBeforeResolutionStyleForInterleaving):
(WebCore::Style::TreeResolver::isTryingPositionOption const):
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/305371@main">https://commits.webkit.org/305371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfac8efd3f87398381d89a89909d64d75517f574

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91065 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105610 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77057 "2 flakes 9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86461 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7948 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5706 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6447 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148873 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10137 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114020 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114352 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7879 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64861 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10183 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38040 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73751 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10124 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9975 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->