### PR TITLE
[GTK][WPE] WebGL support broken when there is no access to /dev/dri since GPU process was enabled by default at 301939@main

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -42,6 +42,20 @@
 
 namespace WebCore {
 
+bool GraphicsContextGLTextureMapperGBM::checkRequirements()
+{
+    auto& display = PlatformDisplay::sharedDisplay();
+    if (display.type() != PlatformDisplay::Type::GBM)
+        return false;
+
+    const auto& eglExtensions = display.eglExtensions();
+    if (!eglExtensions.KHR_image_base || !eglExtensions.EXT_image_dma_buf_import)
+        return false;
+
+    static const char* disableGBM = getenv("WEBKIT_WEBGL_DISABLE_GBM");
+    return !disableGBM || *disableGBM == '0';
+}
+
 RefPtr<GraphicsContextGLTextureMapperGBM> GraphicsContextGLTextureMapperGBM::create(GraphicsContextGLAttributes&& attributes, RefPtr<GraphicsLayerContentsDisplayDelegate>&& delegate)
 {
     auto context = adoptRef(new GraphicsContextGLTextureMapperGBM(WTFMove(attributes), WTFMove(delegate)));

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
@@ -41,6 +41,8 @@ public:
     static RefPtr<GraphicsContextGLTextureMapperGBM> create(GraphicsContextGLAttributes&&, RefPtr<GraphicsLayerContentsDisplayDelegate>&& = nullptr);
     virtual ~GraphicsContextGLTextureMapperGBM();
 
+    static bool checkRequirements();
+
     WTF::UnixFileDescriptor createExportedFence() const;
     void prepareForDisplayWithFinishedSignal(Function<void()>&&);
     DMABufBuffer* displayBuffer() { return m_displayBuffer.dmabuf.get(); }

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -166,15 +166,11 @@ RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContex
             eglExtensions.ANDROID_get_native_client_buffer ? "found" : "missing", eglExtensions.ANDROID_image_native_buffer ? "found" : "missing");
     }
 #elif USE(GBM)
-    auto& display = PlatformDisplay::sharedDisplay();
-    if (display.type() == PlatformDisplay::Type::GBM && display.eglExtensions().KHR_image_base && display.eglExtensions().EXT_image_dma_buf_import) {
-        static const char* disableGBM = getenv("WEBKIT_WEBGL_DISABLE_GBM");
-        if (!disableGBM || *disableGBM == '0') {
-            RefPtr delegate = GraphicsLayerContentsDisplayDelegateCoordinated::create();
-            if (auto context = GraphicsContextGLTextureMapperGBM::create(GraphicsContextGLAttributes { attributes }, WTFMove(delegate)))
-                return context;
-            WTFLogAlways("Failed to create a graphics context for WebGL using GBM, falling back to textures");
-        }
+    if (GraphicsContextGLTextureMapperGBM::checkRequirements()) {
+        RefPtr delegate = GraphicsLayerContentsDisplayDelegateCoordinated::create();
+        if (auto context = GraphicsContextGLTextureMapperGBM::create(GraphicsContextGLAttributes { attributes }, WTFMove(delegate)))
+            return context;
+        WTFLogAlways("Failed to create a graphics context for WebGL using GBM, falling back to textures");
     }
 #endif
     return GraphicsContextGLTextureMapperANGLE::create(GraphicsContextGLAttributes { attributes });

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -259,6 +259,10 @@
 #import <wtf/spi/darwin/SandboxSPI.h>
 #endif
 
+#if ENABLE(GPU_PROCESS) && ENABLE(WEBGL) && USE(COORDINATED_GRAPHICS) && USE(GBM)
+#include <WebCore/GraphicsContextGLTextureMapperGBM.h>
+#endif
+
 #undef WEBPROCESS_RELEASE_LOG
 #define RELEASE_LOG_SESSION_ID (m_sessionID ? m_sessionID->toUInt64() : 0)
 #if RELEASE_LOG_DISABLED
@@ -2552,7 +2556,15 @@ void WebProcess::setUseGPUProcessForWebGL(bool useGPUProcessForWebGL)
 
 bool WebProcess::shouldUseRemoteRenderingForWebGL() const
 {
+#if USE(COORDINATED_GRAPHICS)
+#if USE(GBM)
+    return m_useGPUProcessForWebGL && WebCore::GraphicsContextGLTextureMapperGBM::checkRequirements();
+#else
+    return false;
+#endif
+#else
     return m_useGPUProcessForWebGL;
+#endif
 }
 #endif // ENABLE(WEBGL)
 


### PR DESCRIPTION
#### 92a7e4d46e5157e46eec55a8242328287792e116
<pre>
[GTK][WPE] WebGL support broken when there is no access to /dev/dri since GPU process was enabled by default at 301939@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=301923">https://bugs.webkit.org/show_bug.cgi?id=301923</a>

Reviewed by Carlos Alberto Lopez Perez.

GBM and DMA-BUF support is required to run WebGL in the GPU process, so
we need to check that we can actually use the GPU process too.

Canonical link: <a href="https://commits.webkit.org/302579@main">https://commits.webkit.org/302579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ceda11d4b71f5fc7ff236ad1269a12487ea1df6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129422 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98566 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34050 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139274 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107093 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106936 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27257 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54140 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64903 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->