### PR TITLE
[libpas] Fix guard for BENABLE use in pas_mte_config.h

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -157,10 +157,12 @@ void pas_mte_ensure_initialized(void);
 #define PAS_MTE_INITIALIZE_IN_WTF_CONFIG \
     pas_mte_ensure_initialized()
 
-#if defined(PAS_BMALLOC) && BENABLE(LIBPAS)
+#if defined(PAS_BMALLOC)
+#if BENABLE(LIBPAS)
 #if BENABLE_MTE != PAS_ENABLE_MTE
 #error "cannot enable MTE in libpas without enabling it in bmalloc, or vice versa"
-#endif
+#endif // BENABLE(LIBPAS)
+#endif // defined(PAS_BMALLOC)
 
 #define BMALLOC_VM_MTE PAS_VM_MTE
 #define BMALLOC_USE_MTE PAS_USE_MTE


### PR DESCRIPTION
#### eb706fcd89ff0b8e3b467975f5589503a470f687
<pre>
[libpas] Fix guard for BENABLE use in pas_mte_config.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=301933">https://bugs.webkit.org/show_bug.cgi?id=301933</a>
<a href="https://rdar.apple.com/164009557">rdar://164009557</a>

Reviewed by Dan Hecht.

In pas_mte_config.h, previously we would do:
```
```
but we should actually do
```
```
so that the BENABLE(LIBPAS) is only evaluated if
we have bmalloc in the build.

Canonical link: <a href="https://commits.webkit.org/302545@main">https://commits.webkit.org/302545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f641c37f0258211734fd203dd3f110bf54464369

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80841 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/921254f4-096c-43aa-b871-f8c547edbf11) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98572 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ff9c0d8-e558-4ba6-bd1b-2a2a911445eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1259 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79225 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ce81681-e43c-460f-b2f4-71baaded181f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34056 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80080 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121418 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139278 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127878 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107098 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27234 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30789 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54145 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1544 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160892 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1362 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40131 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1398 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->