### PR TITLE
[threaded-animations] opt animations associated with progress-based timelines into acceleration

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -122,6 +122,7 @@ overlay-region [ Skip ]
 pdf [ Skip ]
 ipc/mac [ Skip ]
 ipc/restrictedendpoints/mac [ Skip ]
+webanimations/threaded-animations [ Skip ]
 
 # Requires async overflow scrolling
 compositing/shared-backing/overflow-scroll [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -28,6 +28,7 @@ remote-layer-tree [ Pass ]
 swipe [ Pass ]
 http/tests/swipe [ Pass ]
 fast/page-color-sampling [ Pass ]
+webanimations/threaded-animations [ Pass ]
 
 webkit.org/b/271780 fast/dom/Orientation/no-orientation-change-event-when-unparenting-view.html [ Pass Timeout ] # change back to pass when bug resolved
 fast/events/ios [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -47,6 +47,7 @@ tiled-drawing [ Pass ]
 ipc/mac [ Pass ]
 ipc/restrictedendpoints/mac [ Pass ]
 fast/page-color-sampling [ Pass ]
+[ Sequoia+ ] webanimations/threaded-animations [ Pass ]
 
 fast/events/autoscroll-when-zoomed.html [ Pass ]
 fast/events/autoscroll-main-document.html [ Pass ]

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A scroll-driven CSS animation can be accelerated.
+

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<body>
+<style>
+
+body {
+    height: 2000px;
+}
+
+@keyframes slide {
+    to { translate: 100px }
+}
+
+.target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+
+    animation: slide auto linear;
+    animation-timeline: scroll();
+    will-change: translate;
+}
+
+</style>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script>
+
+promise_test(async t => {
+    const target = createDiv(t);
+    target.className = "target";
+    await new Promise(requestAnimationFrame);
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1);
+}, "A scroll-driven CSS animation can be accelerated.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -135,8 +135,6 @@ AcceleratedTimeline& AnimationTimeline::acceleratedRepresentation()
 
 Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation()
 {
-    // Until we implement accelerated representations of other timeline types,
-    // we should only ever call DocumentTimeline::createAcceleratedRepresentation().
     ASSERT_NOT_REACHED();
     return AcceleratedTimeline::create(m_acceleratedTimelineIdentifier, 0_s);
 }

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -103,6 +103,9 @@ private:
     explicit ScrollTimeline(Scroller, ScrollAxis);
 
     bool isScrollTimeline() const final { return true; }
+#if ENABLE(THREADED_ANIMATIONS)
+    Ref<AcceleratedTimeline> createAcceleratedRepresentation() override;
+#endif
 
     void animationTimingDidChange(WebAnimation&) override;
 

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -216,6 +216,7 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const Timelin
     if (RefPtr animation = effect.animation()) {
         m_paused = animation->playState() == WebAnimation::PlayState::Paused;
         m_playbackRate = animation->playbackRate();
+        ASSERT(!animation->pending());
         ASSERT(animation->holdTime() || animation->startTime());
         m_holdTime = animation->holdTime();
         m_startTime = animation->startTime();


### PR DESCRIPTION
#### b64ace980799e0c233591c32097c537ed1ccb725
<pre>
[threaded-animations] opt animations associated with progress-based timelines into acceleration
<a href="https://bugs.webkit.org/show_bug.cgi?id=301934">https://bugs.webkit.org/show_bug.cgi?id=301934</a>
<a href="https://rdar.apple.com/164009759">rdar://164009759</a>

Reviewed by Dean Jackson.

In 302282@main we added the code to allow progress-based timelines to be uploaded to the remote
layer tree, but we didn&apos;t have any code that would actually make use of this new facility.

Working towards the goal of having qualifying scroll-driven animations being resolved in the
remote layer tree on Cocoa ports, we take another step by allowing effects associated with a
ready [0] animation to be accelerated – if the recently-introduced `ThreadedScrollDrivenAnimationsEnabled`
flag is indeed enabled.

We also override the `AnimationTimeline::createAcceleratedRepresentation()` method on
`ScrollTimeline` to provide the correct metrics for both scroll and view timelines, which
is a requirement of the threaded animations code.

Note that this code only works with CSS Animations, a followup patch will also enable this for
JS-originated scroll-driven animations.

[0] <a href="https://drafts.csswg.org/web-animations-1/#ready">https://drafts.csswg.org/web-animations-1/#ready</a>

Test: webanimations/threaded-animations/scroll-driven-animations.html

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html: Added.
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::createAcceleratedRepresentation):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canBeAccelerated const):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::createAcceleratedRepresentation):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::AcceleratedEffect):

Canonical link: <a href="https://commits.webkit.org/302580@main">https://commits.webkit.org/302580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0edc3fc64cb83a3af473040a5c6dc0f4a6f66c12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81005 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/723ace3d-b14b-40f0-bf7d-304dddfcecc4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98698 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b657dbc-eaf1-4bd8-892f-7a9f4bd18d04) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79348 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/486f6292-5018-42e8-b90a-0fafe23fd46e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34186 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80228 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139427 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107219 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107064 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30909 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54333 "Hash 0edc3fc6 for PR 53398 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20215 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65050 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1507 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->