### PR TITLE
[libpas] Fix MARTests.cpp build

### DIFF
--- a/Source/bmalloc/libpas/src/test/MARTests.cpp
+++ b/Source/bmalloc/libpas/src/test/MARTests.cpp
@@ -53,7 +53,7 @@ void testRetrieval()
 
     auto result = pas_mar_get_allocation_record(&registry, address);
     CHECK(result.is_valid);
-    CHECK_EQUAL(result.allocation_size, 32);
+    CHECK_EQUAL(result.allocation_size_bytes, 32);
     CHECK_EQUAL(result.allocation_trace.num_frames, 8);
     CHECK_EQUAL(result.allocation_trace.backtrace_buffer[0], backtrace[0]);
 }
@@ -76,12 +76,12 @@ void testRetrievalAfterCycling()
 
     pas_mar_record_allocation(&registry, address, 32, 8, backtrace);
 
-    for (unsigned long i = 1; i < MARTrackedAllocations; ++i)
+    for (unsigned long i = 1; i < PAS_MAR_TRACKED_ALLOCATIONS; ++i)
         pas_mar_record_allocation(&registry, (void*)i, 32, 8, backtrace);
 
     auto result = pas_mar_get_allocation_record(&registry, address);
     CHECK(result.is_valid);
-    CHECK_EQUAL(result.allocation_size, 32);
+    CHECK_EQUAL(result.allocation_size_bytes, 32);
     CHECK_EQUAL(result.allocation_trace.num_frames, 8);
     CHECK_EQUAL(result.allocation_trace.backtrace_buffer[0], backtrace[0]);
 }
@@ -99,17 +99,17 @@ void testRetrievalAfterMultipleCycles()
 
     void* address = (void*)0x11223344;
 
-    for (unsigned long i = 0; i < 3 * MARTrackedAllocations; ++i)
+    for (unsigned long i = 0; i < 3 * PAS_MAR_TRACKED_ALLOCATIONS; ++i)
         pas_mar_record_allocation(&registry, (void*)i, 32, 8, backtrace);
 
     pas_mar_record_allocation(&registry, address, 32, 8, backtrace);
 
-    for (unsigned long i = 1; i < MARTrackedAllocations; ++i)
+    for (unsigned long i = 1; i < PAS_MAR_TRACKED_ALLOCATIONS; ++i)
         pas_mar_record_allocation(&registry, (void*)i, 32, 8, backtrace);
 
     auto result = pas_mar_get_allocation_record(&registry, address);
     CHECK(result.is_valid);
-    CHECK_EQUAL(result.allocation_size, 32);
+    CHECK_EQUAL(result.allocation_size_bytes, 32);
     CHECK_EQUAL(result.allocation_trace.num_frames, 8);
     CHECK_EQUAL(result.allocation_trace.backtrace_buffer[0], backtrace[0]);
 }


### PR DESCRIPTION
#### 7ee0c3619c152b33bd38a05a50fb1086ac4f7384
<pre>
[libpas] Fix MARTests.cpp build
<a href="https://bugs.webkit.org/show_bug.cgi?id=301935">https://bugs.webkit.org/show_bug.cgi?id=301935</a>
<a href="https://rdar.apple.com/164010546">rdar://164010546</a>

Reviewed by Keith Miller, Daniel Liu, and Dan Hecht.

Fixes some outdated identifiers --
  - s/MARTrackedAllocations/PAS_MAR_TRACKED_ALLOCATIONS/
  - s/allocation_size/&amp;_bytes/

Canonical link: <a href="https://commits.webkit.org/302740@main">https://commits.webkit.org/302740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75f341e045a94aad78f295e5a2303aa8646d884f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80845 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b74d1772-4ec7-42c9-b6a2-31f5505a4589) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98575 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66468 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cff53ec4-185e-4fac-997f-d35b652228e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79227 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c6d3950-31b6-475d-b3d6-a26906711159) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34055 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80083 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121421 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109641 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34555 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139282 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107103 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106947 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54148 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20289 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1547 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160895 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1365 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40133 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1469 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->