### PR TITLE
Reduce unsafeness in WebCore (more smart pointers; reduce unsafeGet/Ptr usage)

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -49,7 +49,6 @@ accessibility/cocoa/AccessibilityObjectCocoa.mm
 [ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 animation/AnimationTimelinesController.cpp
 animation/BlendingKeyframes.cpp
-animation/DocumentTimeline.cpp
 animation/ElementAnimationRareData.cpp
 animation/KeyframeEffect.cpp
 animation/ScrollTimeline.cpp
@@ -114,7 +113,6 @@ dom/ContainerNode.cpp
 dom/ContainerNodeAlgorithms.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CurrentScriptIncrementer.h
-dom/DataTransfer.cpp
 dom/DeviceMotionController.cpp
 dom/DeviceOrientationController.cpp
 dom/Document.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -128,7 +128,6 @@ editing/cocoa/WebContentReaderCocoa.mm
 [ Mac ] editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
 history/CachedFrame.cpp
-html/Autofill.cpp
 html/CachedHTMLCollectionInlines.h
 html/CollectionTraversalInlines.h
 html/FormAssociatedCustomElement.cpp
@@ -287,7 +286,6 @@ page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
 page/text-extraction/TextExtraction.cpp
 page/writing-tools/WritingToolsController.mm
-platform/CaretAnimator.cpp
 platform/DictationCaretAnimator.cpp
 platform/DragImage.cpp
 platform/ScrollView.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -195,7 +195,6 @@ editing/cocoa/NodeHTMLConverter.mm
 [ Mac ] editing/mac/FrameSelectionMac.mm
 history/CachedFrame.cpp
 history/CachedPage.cpp
-html/Autofill.cpp
 html/CachedHTMLCollectionInlines.h
 html/CollectionTraversalInlines.h
 html/FormAssociatedCustomElement.cpp
@@ -255,13 +254,11 @@ layout/layouttree/LayoutTreeBuilder.cpp
 loader/ApplicationManifestLoader.cpp
 loader/EmptyClients.cpp
 mathml/MathMLSelectElement.cpp
-page/BarProp.cpp
 page/CaptionUserPreferences.cpp
 [ iOS ] page/Chrome.cpp
 [ Mac ] page/ContextMenuController.cpp
 page/DebugPageOverlays.cpp
 page/DeviceController.cpp
-page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
 page/FocusController.cpp
@@ -316,7 +313,6 @@ page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
 page/scrolling/ScrollingTreePositionedNode.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp
 page/text-extraction/TextExtraction.cpp
-platform/CaretAnimator.cpp
 platform/DictationCaretAnimator.cpp
 platform/KeyboardScrollingAnimator.cpp
 platform/ScrollAnimator.cpp

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -115,8 +115,8 @@ Ref<DataTransfer> DataTransfer::create()
 DataTransfer::~DataTransfer()
 {
 #if ENABLE(DRAG_SUPPORT)
-    if (m_dragImageLoader && m_dragImage)
-        m_dragImageLoader->stopLoading(m_dragImage);
+    if (CheckedPtr dragImageLoader = m_dragImageLoader.get(); dragImageLoader && m_dragImage)
+        dragImageLoader->stopLoading(m_dragImage);
 #endif
 }
 
@@ -561,13 +561,13 @@ void DataTransfer::setDragImage(Ref<Element>&& element, int x, int y)
     m_dragLocation = IntPoint(x, y);
 
     Ref document = element->document();
-    if (m_dragImageLoader && m_dragImage)
-        m_dragImageLoader->stopLoading(m_dragImage);
+    if (CheckedPtr dragImageLoader = m_dragImageLoader.get(); dragImageLoader && m_dragImage)
+        dragImageLoader->stopLoading(m_dragImage);
     m_dragImage = image;
     if (m_dragImage) {
         if (!m_dragImageLoader)
             m_dragImageLoader = makeUnique<DragImageLoader>(*this, document);
-        m_dragImageLoader->startLoading(m_dragImage);
+        CheckedRef { *m_dragImageLoader }->startLoading(m_dragImage);
     }
 
     if (image)
@@ -771,8 +771,8 @@ void DataTransfer::moveDragState(Ref<DataTransfer>&& other)
     m_dragImage = other->m_dragImage;
     m_dragImageElement = WTFMove(other->m_dragImageElement);
     m_dragImageLoader = WTFMove(other->m_dragImageLoader);
-    if (m_dragImageLoader)
-        m_dragImageLoader->moveToDataTransfer(*this);
+    if (CheckedPtr dragImageLoader = m_dragImageLoader.get())
+        dragImageLoader->moveToDataTransfer(*this);
     m_fileList = WTFMove(other->m_fileList);
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10797,6 +10797,11 @@ AnimationTimelinesController& Document::ensureTimelinesController()
     return *m_timelinesController.get();
 }
 
+CheckedRef<AnimationTimelinesController> Document::ensureCheckedTimelinesController()
+{
+    return ensureTimelinesController();
+}
+
 StyleOriginatedTimelinesController& Document::ensureStyleOriginatedTimelinesController()
 {
     if (!m_styleOriginatedTimelinesController)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1840,6 +1840,7 @@ public:
     Vector<RefPtr<WebAnimation>> matchingAnimations(NOESCAPE const Function<bool(Element&)>&);
     AnimationTimelinesController* timelinesController() const { return m_timelinesController.get(); }
     WEBCORE_EXPORT AnimationTimelinesController& ensureTimelinesController();
+    WEBCORE_EXPORT CheckedRef<AnimationTimelinesController> ensureCheckedTimelinesController();
     StyleOriginatedTimelinesController* styleOriginatedTimelinesController() { return m_styleOriginatedTimelinesController.get(); }
     StyleOriginatedTimelinesController& ensureStyleOriginatedTimelinesController();
     void keyframesRuleDidChange(const String& name);

--- a/Source/WebCore/html/Autofill.cpp
+++ b/Source/WebCore/html/Autofill.cpp
@@ -167,7 +167,7 @@ AutofillData AutofillData::createFromHTMLFormControlElement(const HTMLFormContro
         if (element.autofillMantle() == AutofillMantle::Anchor)
             return { emptyAtom(), emptyString(), NonAutofillCredentialType::None };
         
-        auto form = element.form();
+        RefPtr form = element.form();
         if (form && form->autocomplete() == offAtom())
             return { offAtom(), emptyString(), NonAutofillCredentialType::None };
         return { onAtom(), emptyString(), NonAutofillCredentialType::None };

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -151,9 +151,9 @@ static Touch* findTouchWithIdentifier(TouchList& list, unsigned identifier)
 {
     unsigned length = list.length();
     for (unsigned i = 0; i < length; ++i) {
-        RefPtr touch = list.item(i);
+        auto* touch = list.item(i);
         if (touch->identifier() == identifier)
-            return touch.unsafeGet();
+            return touch;
     }
     return nullptr;
 }

--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -35,10 +35,10 @@ FormAssociatedElement::FormAssociatedElement(HTMLFormElement* form)
 {
 }
 
-HTMLFormElement* FormAssociatedElement::formForBindings() const
+RefPtr<HTMLFormElement> FormAssociatedElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(asHTMLElement().retargetReferenceTargetForBindings(form())).unsafeGet();
+    return dynamicDowncast<HTMLFormElement>(asHTMLElement().retargetReferenceTargetForBindings(form()));
 }
 
 void FormAssociatedElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -39,7 +39,7 @@ public:
     virtual void formWillBeDestroyed() { m_form = nullptr; }
 
     HTMLFormElement* form() const { return m_form.get(); }
-    virtual HTMLFormElement* formForBindings() const;
+    virtual RefPtr<HTMLFormElement> formForBindings() const;
 
     void setForm(RefPtr<HTMLFormElement>&&);
     virtual void elementInsertedIntoAncestor(Element&, Node::InsertionType);

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -105,10 +105,10 @@ HTMLFormElement* HTMLLabelElement::form() const
     return nullptr;
 }
 
-HTMLFormElement* HTMLLabelElement::formForBindings() const
+RefPtr<HTMLFormElement> HTMLLabelElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).unsafeGet();
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form()));
 }
 
 void HTMLLabelElement::setActive(bool down, Style::InvalidationScope invalidationScope)

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -36,9 +36,9 @@ public:
     static Ref<HTMLLabelElement> create(Document&);
 
     WEBCORE_EXPORT RefPtr<HTMLElement> control() const;
-    WEBCORE_EXPORT RefPtr<HTMLElement> controlForBindings() const;
+    RefPtr<HTMLElement> controlForBindings() const;
     WEBCORE_EXPORT HTMLFormElement* form() const;
-    WEBCORE_EXPORT HTMLFormElement* formForBindings() const;
+    RefPtr<HTMLFormElement> formForBindings() const;
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
     void updateLabel(TreeScope&, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue);

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -56,10 +56,10 @@ HTMLFormElement* HTMLLegendElement::form() const
     return fieldset ? fieldset->form() : nullptr;
 }
 
-HTMLFormElement* HTMLLegendElement::formForBindings() const
+RefPtr<HTMLFormElement> HTMLLegendElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).unsafeGet();
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form()));
 }
     
 } // namespace

--- a/Source/WebCore/html/HTMLLegendElement.h
+++ b/Source/WebCore/html/HTMLLegendElement.h
@@ -35,7 +35,7 @@ public:
     static Ref<HTMLLegendElement> create(const QualifiedName&, Document&);
 
     WEBCORE_EXPORT HTMLFormElement* form() const;
-    WEBCORE_EXPORT HTMLFormElement* formForBindings() const;
+    RefPtr<HTMLFormElement> formForBindings() const;
 
 private:
     HTMLLegendElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -178,10 +178,10 @@ HTMLFormElement* HTMLOptionElement::form() const
     return nullptr;
 }
 
-HTMLFormElement* HTMLOptionElement::formForBindings() const
+RefPtr<HTMLFormElement> HTMLOptionElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).unsafeGet();
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form()));
 }
 
 int HTMLOptionElement::index() const

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -44,7 +44,7 @@ public:
     void setText(String&&);
 
     WEBCORE_EXPORT HTMLFormElement* form() const;
-    WEBCORE_EXPORT HTMLFormElement* formForBindings() const;
+    RefPtr<HTMLFormElement> formForBindings() const;
 
     WEBCORE_EXPORT int index() const;
 

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -415,13 +415,14 @@ void SliderThumbElement::clearExclusiveTouchIdentifier()
     m_exclusiveTouchIdentifier = NoIdentifier;
 }
 
+// FIXME: Share these functions with CheckboxInputType somehow?
 static Touch* findTouchWithIdentifier(TouchList& list, unsigned identifier)
 {
     unsigned length = list.length();
     for (unsigned i = 0; i < length; ++i) {
-        RefPtr<Touch> touch = list.item(i);
+        auto* touch = list.item(i);
         if (touch->identifier() == identifier)
-            return touch.unsafeGet();
+            return touch;
     }
     return nullptr;
 }
@@ -459,7 +460,7 @@ void SliderThumbElement::handleTouchMove(TouchEvent& touchEvent)
     if (!targetTouches)
         return;
 
-    RefPtr<Touch> touch = findTouchWithIdentifier(*targetTouches, identifier);
+    RefPtr touch = findTouchWithIdentifier(*targetTouches, identifier);
     if (!touch)
         return;
 
@@ -479,7 +480,7 @@ void SliderThumbElement::handleTouchEndAndCancel(TouchEvent& touchEvent)
         return;
     // If our exclusive touch still exists, it was not the touch
     // that ended, so we should not stop dragging.
-    RefPtr<Touch> exclusiveTouch = findTouchWithIdentifier(*targetTouches, identifier);
+    RefPtr exclusiveTouch = findTouchWithIdentifier(*targetTouches, identifier);
     if (exclusiveTouch)
         return;
 

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -84,22 +84,22 @@ AudioTrack* AudioTrackList::firstEnabled() const
     return nullptr;
 }
 
-AudioTrack* AudioTrackList::getTrackById(const AtomString& id) const
+RefPtr<AudioTrack> AudioTrackList::getTrackById(const AtomString& id) const
 {
     for (auto& inbandTrack : m_inbandTracks) {
         Ref track = downcast<AudioTrack>(*inbandTrack);
         if (track->id() == id)
-            return track.unsafePtr();
+            return track;
     }
     return nullptr;
 }
 
-AudioTrack* AudioTrackList::getTrackById(TrackID id) const
+RefPtr<AudioTrack> AudioTrackList::getTrackById(TrackID id) const
 {
     for (auto& inbandTrack : m_inbandTracks) {
         Ref track = downcast<AudioTrack>(*inbandTrack);
         if (track->trackId() == id)
-            return track.unsafePtr();
+            return track;
     }
     return nullptr;
 }

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -43,8 +43,8 @@ public:
     }
     virtual ~AudioTrackList();
 
-    AudioTrack* getTrackById(const AtomString&) const;
-    AudioTrack* getTrackById(TrackID) const;
+    RefPtr<AudioTrack> getTrackById(const AtomString&) const;
+    RefPtr<AudioTrack> getTrackById(TrackID) const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
     AudioTrack* item(unsigned index) const;

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -122,7 +122,7 @@ TextTrack* TextTrackList::item(unsigned index) const
     return nullptr;
 }
 
-TextTrack* TextTrackList::getTrackById(const AtomString& id) const
+RefPtr<TextTrack> TextTrackList::getTrackById(const AtomString& id) const
 {
     // 4.8.10.12.5 Text track API
     // The getTrackById(id) method must return the first TextTrack in the
@@ -131,19 +131,19 @@ TextTrack* TextTrackList::getTrackById(const AtomString& id) const
     for (unsigned i = 0; i < length(); ++i) {
         Ref track = *item(i);
         if (track->id() == id)
-            return track.unsafePtr();
+            return track;
     }
 
     // When no tracks match the given argument, the method must return null.
     return nullptr;
 }
 
-TextTrack* TextTrackList::getTrackById(TrackID id) const
+RefPtr<TextTrack> TextTrackList::getTrackById(TrackID id) const
 {
     for (unsigned i = 0; i < length(); ++i) {
         Ref track = *item(i);
         if (track->trackId() == id)
-            return track.unsafePtr();
+            return track;
     }
     return nullptr;
 }

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -52,8 +52,8 @@ public:
     bool contains(TrackBase&) const override;
 
     TextTrack* item(unsigned index) const;
-    TextTrack* getTrackById(const AtomString&) const;
-    TextTrack* getTrackById(TrackID) const;
+    RefPtr<TextTrack> getTrackById(const AtomString&) const;
+    RefPtr<TextTrack> getTrackById(TrackID) const;
     TextTrack* lastItem() const { return item(length() - 1); }
 
     void append(Ref<TextTrack>&&);

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -67,22 +67,22 @@ VideoTrack* VideoTrackList::item(unsigned index) const
     return nullptr;
 }
 
-VideoTrack* VideoTrackList::getTrackById(const AtomString& id) const
+RefPtr<VideoTrack> VideoTrackList::getTrackById(const AtomString& id) const
 {
     for (auto& inbandTracks : m_inbandTracks) {
         Ref track = downcast<VideoTrack>(*inbandTracks);
         if (track->id() == id)
-            return track.unsafePtr();
+            return track;
     }
     return nullptr;
 }
 
-VideoTrack* VideoTrackList::getTrackById(TrackID id) const
+RefPtr<VideoTrack> VideoTrackList::getTrackById(TrackID id) const
 {
     for (auto& inbandTracks : m_inbandTracks) {
-        auto& track = downcast<VideoTrack>(*inbandTracks);
-        if (track.trackId() == id)
-            return &track;
+        Ref track = downcast<VideoTrack>(*inbandTracks);
+        if (track->trackId() == id)
+            return track;
     }
     return nullptr;
 }

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -43,8 +43,8 @@ public:
     }
     virtual ~VideoTrackList();
 
-    VideoTrack* getTrackById(const AtomString&) const;
-    VideoTrack* getTrackById(TrackID) const;
+    RefPtr<VideoTrack> getTrackById(const AtomString&) const;
+    RefPtr<VideoTrack> getTrackById(TrackID) const;
     int selectedIndex() const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }

--- a/Source/WebCore/page/BarProp.cpp
+++ b/Source/WebCore/page/BarProp.cpp
@@ -47,7 +47,7 @@ BarProp::BarProp(LocalDOMWindow& window, Type type)
 
 bool BarProp::visible() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
     RefPtr page = frame->page();

--- a/Source/WebCore/platform/CaretAnimator.cpp
+++ b/Source/WebCore/platform/CaretAnimator.cpp
@@ -53,7 +53,7 @@ bool CaretAnimator::determinePrefersNonBlinkingCursor() const
 
 Page* CaretAnimator::page() const
 {
-    if (auto* document = m_client.document())
+    if (RefPtr document = m_client.document())
         return document->page();
     
     return nullptr;


### PR DESCRIPTION
#### 36b47718a2a214c7506e41a2b0b126b2f6a8c3a0
<pre>
Reduce unsafeness in WebCore (more smart pointers; reduce unsafeGet/Ptr usage)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301937">https://bugs.webkit.org/show_bug.cgi?id=301937</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/302576@main">https://commits.webkit.org/302576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9061e6789d6f2c2d4f7feab27a527b6219fa24df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136950 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff1574bc-9dbb-4193-a52a-1679b46495fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1699 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01f211bb-e9cb-4121-b373-33feab88a462) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132513 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1f229166-fdff-4b94-928a-7096b9bf7e31) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80225 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139424 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1540 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107063 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1316 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54326 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20213 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65047 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1504 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->