### PR TITLE
Remove unsafeGet from ScrollingTreeScrollingNodeDelegate

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -621,7 +621,6 @@ page/scrolling/ScrollingCoordinator.cpp
 [ Mac ] page/scrolling/ScrollingTreeGestureState.cpp
 [ Mac ] page/scrolling/ThreadedScrollingCoordinator.cpp
 [ Mac ] page/scrolling/mac/ScrollingCoordinatorMac.mm
-[ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 page/text-extraction/TextExtraction.cpp
 page/writing-tools/WritingToolsController.mm
 platform/DragImage.cpp

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
@@ -45,27 +45,27 @@ ScrollingTreeScrollingNodeDelegate::~ScrollingTreeScrollingNodeDelegate() = defa
 
 RefPtr<ScrollingTree> ScrollingTreeScrollingNodeDelegate::scrollingTree() const
 {
-    return protectedScrollingNode()->scrollingTree();
+    return scrollingNode()->scrollingTree();
 }
 
 FloatPoint ScrollingTreeScrollingNodeDelegate::lastCommittedScrollPosition() const
 {
-    return protectedScrollingNode()->lastCommittedScrollPosition();
+    return scrollingNode()->lastCommittedScrollPosition();
 }
 
 FloatSize ScrollingTreeScrollingNodeDelegate::totalContentsSize()
 {
-    return protectedScrollingNode()->totalContentsSize();
+    return scrollingNode()->totalContentsSize();
 }
 
 FloatSize ScrollingTreeScrollingNodeDelegate::reachableContentsSize()
 {
-    return protectedScrollingNode()->reachableContentsSize();
+    return scrollingNode()->reachableContentsSize();
 }
 
 IntPoint ScrollingTreeScrollingNodeDelegate::scrollOrigin() const
 {
-    return protectedScrollingNode()->scrollOrigin();
+    return scrollingNode()->scrollOrigin();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -39,10 +39,9 @@ public:
     WEBCORE_EXPORT explicit ScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
     WEBCORE_EXPORT virtual ~ScrollingTreeScrollingNodeDelegate();
 
-    RefPtr<ScrollingTreeScrollingNode> protectedScrollingNode() const { return m_scrollingNode.get(); }
-    ScrollingTreeScrollingNode& scrollingNode() { return  *protectedScrollingNode().unsafeGet(); }
-    const ScrollingTreeScrollingNode& scrollingNode() const { return  *protectedScrollingNode().unsafeGet(); }
-    
+    Ref<ScrollingTreeScrollingNode> scrollingNode() { return m_scrollingNode.get().releaseNonNull(); }
+    Ref<const ScrollingTreeScrollingNode> scrollingNode() const { return m_scrollingNode.get().releaseNonNull(); }
+
     virtual bool startAnimatedScrollToPosition(FloatPoint) = 0;
     virtual void stopAnimatedScroll() = 0;
 
@@ -72,18 +71,18 @@ protected:
     WEBCORE_EXPORT FloatSize reachableContentsSize();
     WEBCORE_EXPORT IntPoint scrollOrigin() const;
 
-    FloatPoint currentScrollPosition() const { return protectedScrollingNode()->currentScrollPosition(); }
-    FloatPoint minimumScrollPosition() const { return protectedScrollingNode()->minimumScrollPosition(); }
-    FloatPoint maximumScrollPosition() const { return protectedScrollingNode()->maximumScrollPosition(); }
+    FloatPoint currentScrollPosition() const { return scrollingNode()->currentScrollPosition(); }
+    FloatPoint minimumScrollPosition() const { return scrollingNode()->minimumScrollPosition(); }
+    FloatPoint maximumScrollPosition() const { return scrollingNode()->maximumScrollPosition(); }
 
-    FloatSize scrollableAreaSize() const { return protectedScrollingNode()->scrollableAreaSize(); }
-    FloatSize totalContentsSize() const { return protectedScrollingNode()->totalContentsSize(); }
+    FloatSize scrollableAreaSize() const { return scrollingNode()->scrollableAreaSize(); }
+    FloatSize totalContentsSize() const { return scrollingNode()->totalContentsSize(); }
 
-    bool allowsHorizontalScrolling() const { return protectedScrollingNode()->allowsHorizontalScrolling(); }
-    bool allowsVerticalScrolling() const { return protectedScrollingNode()->allowsVerticalScrolling(); }
+    bool allowsHorizontalScrolling() const { return scrollingNode()->allowsHorizontalScrolling(); }
+    bool allowsVerticalScrolling() const { return scrollingNode()->allowsVerticalScrolling(); }
 
-    ScrollElasticity horizontalScrollElasticity() const { return protectedScrollingNode()->horizontalScrollElasticity(); }
-    ScrollElasticity verticalScrollElasticity() const { return protectedScrollingNode()->verticalScrollElasticity(); }
+    ScrollElasticity horizontalScrollElasticity() const { return scrollingNode()->horizontalScrollElasticity(); }
+    ScrollElasticity verticalScrollElasticity() const { return scrollingNode()->verticalScrollElasticity(); }
 
 private:
     ThreadSafeWeakPtr<ScrollingTreeScrollingNode> m_scrollingNode; // m_scrollingNode is expected never be null

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -74,7 +74,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::updateUserScrollInProgressForEv
     m_scrollController.updateGestureInProgressState(wheelEvent);
     bool isInUserScroll = m_scrollController.isUserScrollInProgress();
     if (isInUserScroll != wasInUserScroll)
-        protectedScrollingNode()->setUserScrollInProgress(isInUserScroll);
+        scrollingNode()->setUserScrollInProgress(isInUserScroll);
 }
 
 bool ThreadedScrollingTreeScrollingNodeDelegate::startAnimatedScrollToPosition(FloatPoint destinationPosition)
@@ -97,20 +97,20 @@ void ThreadedScrollingTreeScrollingNodeDelegate::serviceScrollAnimation(Monotoni
 std::unique_ptr<ScrollingEffectsControllerTimer> ThreadedScrollingTreeScrollingNodeDelegate::createTimer(Function<void()>&& function)
 {
     // This is only used for a scroll snap timer.
-    return WTF::makeUnique<ScrollingEffectsControllerTimer>(RunLoop::currentSingleton(), [function = WTFMove(function), protectedNode = Ref { scrollingNode() }] {
-        Locker locker { protectedNode->scrollingTree()->treeLock() };
+    return WTF::makeUnique<ScrollingEffectsControllerTimer>(RunLoop::currentSingleton(), [function = WTFMove(function), scrollingNode = this->scrollingNode()] {
+        Locker locker { scrollingNode->scrollingTree()->treeLock() };
         function();
     });
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::startAnimationCallback(ScrollingEffectsController&)
 {
-    protectedScrollingNode()->setScrollAnimationInProgress(true);
+    scrollingNode()->setScrollAnimationInProgress(true);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::stopAnimationCallback(ScrollingEffectsController&)
 {
-    protectedScrollingNode()->setScrollAnimationInProgress(false);
+    scrollingNode()->setScrollAnimationInProgress(false);
 }
 
 bool ThreadedScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling() const
@@ -125,7 +125,7 @@ bool ThreadedScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling() const
 
 void ThreadedScrollingTreeScrollingNodeDelegate::immediateScrollBy(const FloatSize& delta, ScrollClamping clamping)
 {
-    protectedScrollingNode()->scrollBy(delta, clamping);
+    scrollingNode()->scrollBy(delta, clamping);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::adjustScrollPositionToBoundsIfNecessary()
@@ -152,32 +152,32 @@ float ThreadedScrollingTreeScrollingNodeDelegate::pageScaleFactor() const
 
 void ThreadedScrollingTreeScrollingNodeDelegate::willStartAnimatedScroll()
 {
-    protectedScrollingNode()->willStartAnimatedScroll();
+    scrollingNode()->willStartAnimatedScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopAnimatedScroll()
 {
-    protectedScrollingNode()->didStopAnimatedScroll();
+    scrollingNode()->didStopAnimatedScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::willStartWheelEventScroll()
 {
-    protectedScrollingNode()->willStartWheelEventScroll();
+    scrollingNode()->willStartWheelEventScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopWheelEventScroll()
 {
-    protectedScrollingNode()->didStopWheelEventScroll();
+    scrollingNode()->didStopWheelEventScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::willStartScrollSnapAnimation()
 {
-    protectedScrollingNode()->setScrollSnapInProgress(true);
+    scrollingNode()->setScrollSnapInProgress(true);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopScrollSnapAnimation()
 {
-    protectedScrollingNode()->setScrollSnapInProgress(false);
+    scrollingNode()->setScrollSnapInProgress(false);
     didStopAnimatedScroll();
 }
 
@@ -196,7 +196,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::deferWheelEventTestCompletionFo
         return;
 
     // Just use the scrolling node ID as the identifier, since we know this is coming from a ScrollingEffectsController associated with this node.
-    scrollingTree()->deferWheelEventTestCompletionForReason(scrollingNode().scrollingNodeID(), reason);
+    scrollingTree()->deferWheelEventTestCompletionForReason(scrollingNode()->scrollingNodeID(), reason);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason reason) const
@@ -205,7 +205,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::removeWheelEventTestCompletionD
         return;
 
     // Just use the scrolling node ID as the identifier, since we know this is coming from a ScrollingEffectsController associated with this node.
-    scrollingTree()->removeWheelEventTestCompletionDeferralForReason(scrollingNode().scrollingNodeID(), reason);
+    scrollingTree()->removeWheelEventTestCompletionDeferralForReason(scrollingNode()->scrollingNodeID(), reason);
 }
 
 FloatPoint ThreadedScrollingTreeScrollingNodeDelegate::adjustedScrollPosition(const FloatPoint& position) const
@@ -230,7 +230,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::handleKeyboardScrollRequest(con
 
 ScrollingNodeID ThreadedScrollingTreeScrollingNodeDelegate::scrollingNodeIDForTesting() const
 {
-    return scrollingNode().scrollingNodeID();
+    return scrollingNode()->scrollingNodeID();
 }
 
 

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeScrollingNodeDelegateCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeScrollingNodeDelegateCoordinated.cpp
@@ -47,7 +47,7 @@ void ScrollingTreeScrollingNodeDelegateCoordinated::updateVisibleLengths()
 
 bool ScrollingTreeScrollingNodeDelegateCoordinated::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 {
-    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
+    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *scrollingTree(), scrollingNode()->scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
 
     updateUserScrollInProgressForEvent(wheelEvent);
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -137,7 +137,7 @@ bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent(const PlatformWheel
     if (wasInMomentumPhase != m_inMomentumPhase)
         m_scrollerPair->setUsePresentationValues(m_inMomentumPhase);
 
-    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
+    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *scrollingTree(), scrollingNode()->scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
 
     updateUserScrollInProgressForEvent(wheelEvent);
 
@@ -292,23 +292,23 @@ bool ScrollingTreeScrollingNodeDelegateMac::isPinnedOnSide(BoxSide side) const
 
 RectEdges<bool> ScrollingTreeScrollingNodeDelegateMac::edgePinnedState() const
 {
-    return scrollingNode().edgePinnedState();
+    return scrollingNode()->edgePinnedState();
 }
 
 bool ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide(BoxSide side) const
 {
-    return scrollingNode().shouldRubberBandOnSide(side, edgePinnedState());
+    return scrollingNode()->shouldRubberBandOnSide(side, edgePinnedState());
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::didStopRubberBandAnimation()
 {
     // Since the rubberband timer has stopped, totalContentsSizeForRubberBand can be synchronized with totalContentsSize.
-    scrollingNode().setTotalContentsSizeForRubberBand(totalContentsSize());
+    scrollingNode()->setTotalContentsSizeForRubberBand(totalContentsSize());
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged(bool inRubberBand)
 {
-    scrollingTree()->setRubberBandingInProgressForNode(scrollingNode().scrollingNodeID(), inRubberBand);
+    scrollingTree()->setRubberBandingInProgressForNode(scrollingNode()->scrollingNodeID(), inRubberBand);
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters()


### PR DESCRIPTION
#### 502be055da550621e61e4a48ba7273fb718f37e2
<pre>
Remove unsafeGet from ScrollingTreeScrollingNodeDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=301941">https://bugs.webkit.org/show_bug.cgi?id=301941</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/302583@main">https://commits.webkit.org/302583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e0842f2b657eee97df2de275cc41f9d21a770f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81017 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/498204a1-2962-4fc6-84de-3e84e8578382) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98705 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ceed8d46-0836-4f1f-ab4e-39b4a4990060) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79366 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a55d9d88-ec4d-45be-b5a2-c591f6e6bbc3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34191 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80238 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139442 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107225 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107070 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1326 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54344 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20217 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1517 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->