### PR TITLE
Bring up macOS API Debug queue in EWS

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/buildbot.py
+++ b/Tools/CISupport/ews-app/ews/common/buildbot.py
@@ -46,6 +46,7 @@ class Buildbot():
         'ios-wk2': 'ios-sim',
         'ios-wk2-wpt': 'ios-sim',
         'api-mac': 'mac',
+        'api-mac-debug': 'mac',
         'mac-wk1': 'mac',
         'mac-wk2': 'mac',
         'mac-intel-wk2': 'mac',

--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -212,13 +212,13 @@ class GitHubEWS(GitHub):
     STATUS_BUBBLE_ROWS = [['style', 'ios', 'mac', 'wpe', 'win'],  # FIXME: generate this list dynamically to have merge queue show up on top
                           ['bindings', 'ios-sim', 'mac-AS-debug', 'wpe-wk2', 'win-tests'],
                           ['webkitperl', 'ios-wk2', 'api-mac', 'api-wpe', ''],
-                          ['webkitpy', 'ios-wk2-wpt', 'mac-wk1', 'wpe-cairo', ''],
-                          ['jsc', 'api-ios', 'mac-wk2', 'gtk', ''],
-                          ['jsc-arm64', 'vision', 'mac-AS-debug-wk2', 'gtk-wk2', ''],
-                          ['services', 'vision-sim', 'mac-wk2-stress', 'api-gtk', ''],
-                          ['merge', 'vision-wk2', 'mac-intel-wk2', 'playstation', ''],
-                          ['unsafe-merge', 'tv', 'mac-safer-cpp', 'jsc-armv7', ''],
-                          ['', 'tv-sim', '', 'jsc-armv7-tests', ''],
+                          ['webkitpy', 'ios-wk2-wpt', 'api-mac-debug', 'wpe-cairo', ''],
+                          ['jsc', 'api-ios', 'mac-wk1', 'gtk', ''],
+                          ['jsc-arm64', 'vision', 'mac-wk2', 'gtk-wk2', ''],
+                          ['services', 'vision-sim', 'mac-AS-debug-wk2', 'api-gtk', ''],
+                          ['merge', 'vision-wk2', 'mac-wk2-stress', 'playstation', ''],
+                          ['unsafe-merge', 'tv', 'mac-intel-wk2', 'jsc-armv7', ''],
+                          ['', 'tv-sim', 'mac-safer-cpp', 'jsc-armv7-tests', ''],
                           ['', 'watch', '', '', ''],
                           ['', 'watch-sim', '', '', '']]
     approved_user_list_for_apple_internal_builds = []

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -45,7 +45,7 @@ class StatusBubble(View):
     # Note: This list is sorted in the order of which bubbles appear in bugzilla.
     ALL_QUEUES = ['style', 'ios', 'ios-sim', 'mac', 'mac-AS-debug', 'vision', 'vision-sim', 'tv', 'tv-sim', 'watch', 'watch-sim', 'gtk', 'wpe', 'wpe-cairo', 'playstation', 'win', 'win-tests',
                   'ios-wk2', 'ios-wk2-wpt', 'mac-wk1', 'mac-wk2', 'mac-wk2-stress', 'mac-intel-wk2', 'mac-AS-debug-wk2', 'mac-safer-cpp', 'vision-wk2', 'gtk-wk2', 'wpe-wk2', 'api-ios', 'api-mac',
-                  'api-gtk', 'api-wpe', 'bindings', 'jsc', 'jsc-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services']
+                  'api-mac-debug', 'api-gtk', 'api-wpe', 'bindings', 'jsc', 'jsc-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services']
 
     DAYS_TO_CHECK_QUEUE_POSITION = 0.5
     DAYS_TO_HIDE_BUBBLE = 7

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -162,6 +162,14 @@
     { "name": "ews200", "platform": "mac-sonoma" },
     { "name": "ews205", "platform": "mac-sonoma" },
     { "name": "ews206", "platform": "mac-sonoma" },
+    { "name": "ews207", "platform": "mac-tahoe" },
+    { "name": "ews208", "platform": "mac-tahoe" },
+    { "name": "ews209", "platform": "mac-tahoe" },
+    { "name": "ews210", "platform": "mac-tahoe" },
+    { "name": "ews211", "platform": "mac-tahoe" },
+    { "name": "ews212", "platform": "mac-tahoe" },
+    { "name": "ews213", "platform": "mac-tahoe" },
+    { "name": "ews214", "platform": "mac-tahoe" },
     { "name": "ews201", "platform": "mac-sonoma" },
     { "name": "ews202", "platform": "mac-sonoma" },
     { "name": "ews203", "platform": "mac-sonoma" },
@@ -269,8 +277,15 @@
       "name": "macOS-Tahoe-Debug-Build-EWS", "shortname": "mac-AS-debug", "icon": "buildOnly",
       "factory": "macOSBuildOnlyFactory", "platform": "mac-tahoe",
       "configuration": "debug", "architectures": ["arm64"],
-      "triggers": ["macos-tahoe-debug-wk2-tests-ews"],
+      "triggers": ["macos-tahoe-debug-api-tests-ews", "macos-tahoe-debug-wk2-tests-ews"],
       "workernames": ["ews171", "ews172", "ews173", "ews174"]
+    },
+    {
+      "name": "macOS-Tahoe-Debug-API-Tests-EWS", "shortname": "api-mac-debug", "icon": "testOnly",
+      "factory": "APITestsFactory", "platform": "mac-tahoe",
+      "configuration": "debug",
+      "triggered_by": ["macos-tahoe-debug-build-ews"],
+      "workernames": ["ews207", "ews208", "ews209", "ews210", "ews211", "ews212", "ews213", "ews214"]
     },
     {
       "name": "macOS-Tahoe-Debug-WK2-Tests-EWS", "shortname": "mac-AS-debug-wk2", "icon": "testOnly",
@@ -564,6 +579,10 @@
     {
       "type": "Triggerable", "name": "macos-tahoe-debug-build-ews",
       "builderNames": ["macOS-Tahoe-Debug-Build-EWS"]
+    },
+    {
+      "type": "Triggerable", "name": "macos-tahoe-debug-api-tests-ews",
+      "builderNames": ["macOS-Tahoe-Debug-API-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "macos-tahoe-debug-wk2-tests-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -182,6 +182,25 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
+        'macOS-Tahoe-Debug-API-Tests-EWS': [
+            'configure-build',
+            'validate-change',
+            'configuration',
+            'clean-up-git-repo',
+            'prune-coresymbolicationd-cache-if-too-large',
+            'set-credential-helper',
+            'checkout-source',
+            'fetch-branch-references',
+            'checkout-specific-revision',
+            'show-identifier',
+            'apply-patch',
+            'checkout-pull-request',
+            'kill-old-processes',
+            'download-built-product',
+            'extract-built-product',
+            'run-api-tests',
+            'set-build-summary'
+        ],
         'macOS-Tahoe-Debug-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2636,7 +2636,7 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
     flunkOnFailure = False
     haltOnFailure = False
     EMBEDDED_CHECKS = ['ios', 'ios-sim', 'ios-wk2', 'ios-wk2-wpt', 'api-ios', 'vision', 'vision-sim', 'vision-wk2', 'tv', 'tv-sim', 'watch', 'watch-sim']
-    MACOS_CHECKS = ['mac', 'mac-AS-debug', 'api-mac', 'mac-wk1', 'mac-wk2', 'mac-AS-debug-wk2', 'mac-wk2-stress', 'mac-safer-cpp', 'jsc', 'jsc-arm64']
+    MACOS_CHECKS = ['mac', 'mac-AS-debug', 'api-mac', 'api-mac-debug', 'mac-wk1', 'mac-wk2', 'mac-AS-debug-wk2', 'mac-wk2-stress', 'mac-safer-cpp', 'jsc', 'jsc-arm64']
     LINUX_CHECKS = ['gtk', 'gtk-wk2', 'api-gtk', 'wpe', 'wpe-cairo', 'wpe-wk2', 'api-wpe']
     WINDOWS_CHECKS = ['win']
     EWS_WEBKIT_FAILED = 0

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6440,6 +6440,7 @@ class TestRetrievePRDataFromLabel(BuildStepMixinAdditions, unittest.TestCase):
                         {'context': 'api-gtk', 'state': 'SUCCESS'},
                         {'context': 'api-ios', 'state': 'SUCCESS'},
                         {'context': 'api-mac', 'state': 'SUCCESS'},
+                        {'context': 'api-mac-debug', 'state': 'SUCCESS'},
                         {'context': 'bindings', 'state': 'SUCCESS'},
                         {'context': 'gtk', 'state': 'SUCCESS'},
                         {'context': 'gtk-wk2', 'state': 'SUCCESS'},


### PR DESCRIPTION
#### d53d6486394ec68bf6a31ebb97370389cd5e9d6c
<pre>
Bring up macOS API Debug queue in EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=301948">https://bugs.webkit.org/show_bug.cgi?id=301948</a>
<a href="https://rdar.apple.com/144877898">rdar://144877898</a>

Reviewed by Ryan Haddad and Aakash Jain.

Change the config file to bring up a new macOS API Debug tests in Tahoe.

* Tools/CISupport/ews-app/ews/common/buildbot.py:
(Buildbot):
* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS):
* Tools/CISupport/ews-app/ews/views/statusbubble.py:
(StatusBubble):
* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/ews-build/steps.py:
(CheckStatusOfPR):
* Tools/CISupport/ews-build/steps_unittest_disabled.py:

Canonical link: <a href="https://commits.webkit.org/303016@main">https://commits.webkit.org/303016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df16c0eb0c104f0eb3ad23623c42ae9475177919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130918 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/3242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132789 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/138360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/140852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130347 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/3031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20384 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/3053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->