### PR TITLE
[macOS] Allow multi-microphone capture

### DIFF
--- a/LayoutTests/fast/mediastream/multi-microphone-expected.txt
+++ b/LayoutTests/fast/mediastream/multi-microphone-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Capturing with different microphones should move previous capture out of echo cancellation
+PASS Enable echo cancellation with applyConstraints should disallow echo cancellation for other device tracks
+PASS Enable echo cancellation with applyConstraints should disallow echo cancellation for the other track again
+PASS Stopping tracks
+

--- a/LayoutTests/fast/mediastream/multi-microphone.html
+++ b/LayoutTests/fast/mediastream/multi-microphone.html
@@ -1,0 +1,59 @@
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+let track1, track2;
+
+promise_test(async () => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    track1 = stream1.getAudioTracks()[0];
+    assert_true(track1.getSettings().echoCancellation, "test1");
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const microphones = devices.filter(device => device.kind === "audioinput");
+
+    assert_greater_than(devices.length, 1);
+
+    const configurationChangePromise = new Promise(resolve => track1.onconfigurationchange = resolve);
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio: { deviceId:microphones[microphones.length - 1].deviceId } });
+    track2 = stream2.getAudioTracks()[0];
+    assert_true(track2.getSettings().echoCancellation, "test2");
+
+    if (window.internals && !internals.supportsMultiMicrophoneCaptureWithoutEchoCancellation()) {
+        if (track1.readyState === "ended")
+            return;
+        return new Promise(resolve => track1.onended = resolve);
+    }
+
+    await configurationChangePromise;
+    assert_false(track1.getSettings().echoCancellation, "test3");
+}, "Capturing with different microphones should move previous capture out of echo cancellation");
+
+promise_test(async (t) => {
+    if (window.internals && !internals.supportsMultiMicrophoneCaptureWithoutEchoCancellation())
+        return;
+
+    const configurationChangePromise = new Promise(resolve => track2.onconfigurationchange = resolve);
+    const applyPromise = track1.applyConstraints({ echoCancellation: true });
+    await Promise.all([applyPromise, configurationChangePromise]);
+
+    assert_true(track1.getSettings().echoCancellation, "test1");
+    assert_false(track2.getSettings().echoCancellation, "test2");
+}, "Enable echo cancellation with applyConstraints should disallow echo cancellation for other device tracks");
+
+promise_test(async (t) => {
+    if (window.internals && !internals.supportsMultiMicrophoneCaptureWithoutEchoCancellation())
+        return;
+
+    const configurationChangePromise = new Promise(resolve => track1.onconfigurationchange = resolve);
+    const applyPromise = track2.applyConstraints({ echoCancellation: true });
+    await Promise.all([applyPromise, configurationChangePromise]);
+
+    assert_false(track1.getSettings().echoCancellation, "test1");
+    assert_true(track2.getSettings().echoCancellation, "test2");
+}, "Enable echo cancellation with applyConstraints should disallow echo cancellation for the other track again");
+
+promise_test(async () => {
+    track1.stop();
+    track2.stop();
+}, "Stopping tracks");
+</script>

--- a/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
+++ b/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
@@ -35,8 +35,8 @@
                 if (originInfo[device.deviceId] != device.kind)
                     testFailed(`: duplicate device IDs for ${device.kind} and ${originInfo[device.deviceId]} in ${origin}/${self.origin}`);
 
-                if (Object.keys(originInfo).length > 9)
-                    testFailed(`: more than eight unique device IDs in ${origin}/${self.origin}`);
+                if (Object.keys(originInfo).length > 10)
+                    testFailed(`: more than ten unique device IDs in ${origin}/${self.origin}`);
             }
 
             let eventCount = 0;

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2147,6 +2147,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-eleme
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/adopt-from-image-document.html [ Pass ImageOnlyFailure ]
 
 fast/mediastream/camera-powerEfficient-track.html [ Failure ]
+fast/mediastream/multi-microphone.html [ Skip ]
 
 webkit.org/b/208182 fast/repaint/backgroundSizeRepaint.html [ ImageOnlyFailure Pass ]
 

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.cpp
@@ -53,11 +53,13 @@ BaseAudioCaptureUnit::~BaseAudioCaptureUnit()
     RealtimeMediaSourceCenter::singleton().removeDevicesChangedObserver(*this);
 }
 
+#if !PLATFORM(MAC)
 void BaseAudioCaptureUnit::setEnableEchoCancellation(bool enableEchoCancellation)
 {
     ASSERT(m_canEnableEchoCancellation || (!enableEchoCancellation && !m_enableEchoCancellation));
     m_enableEchoCancellation = enableEchoCancellation;
 }
+#endif
 
 void BaseAudioCaptureUnit::addClient(CoreAudioCaptureSource& client)
 {
@@ -188,7 +190,7 @@ void BaseAudioCaptureUnit::setCaptureDevice(String&& persistentID, uint32_t capt
 {
     bool hasChanged = this->persistentID() != persistentID || this->captureDeviceID() != captureDeviceID || m_isCapturingWithDefaultMicrophone != isDefault;
     if (hasChanged)
-        willChangeCaptureDevice();
+        willChangeCaptureDeviceTo(persistentID);
 
     m_capturingDevice = { WTFMove(persistentID), captureDeviceID };
     m_isCapturingWithDefaultMicrophone = isDefault;

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioCaptureUnit.h
@@ -77,7 +77,9 @@ public:
 
     void setVolume(double volume) { m_volume = volume; }
     void setSampleRate(int sampleRate) { m_sampleRate = sampleRate; }
+#if !PLATFORM(MAC)
     void setEnableEchoCancellation(bool);
+#endif
 
     void addClient(CoreAudioCaptureSource&);
     void removeClient(CoreAudioCaptureSource&);
@@ -145,7 +147,7 @@ private:
     OSStatus startUnit();
     bool shouldContinueRunning() const { return m_producingCount || m_isRenderingAudio || hasClients(); }
 
-    virtual void willChangeCaptureDevice() { };
+    virtual void willChangeCaptureDeviceTo(const String&) { };
 
     // RealtimeMediaSourceCenterObserver
     void devicesChanged() final;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -63,6 +63,9 @@ public:
     CMClockRef timebaseClock();
 
     void handleNewCurrentMicrophoneDevice(const CaptureDevice&);
+#if PLATFORM(MAC)
+    void vpioUnitWillChangeCaptureDeviceTo(const String&);
+#endif
     void echoCancellationChanged();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
@@ -101,6 +104,10 @@ private:
 
     void initializeToStartProducingData();
     void audioUnitWillStart();
+
+#if PLATFORM(MAC)
+    void changeAudioUnit();
+#endif
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const override { return "CoreAudioCaptureSource"_s; }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
@@ -162,7 +162,7 @@ private:
 #endif
     void resetSampleRate();
 
-    void willChangeCaptureDevice() final;
+    void willChangeCaptureDeviceTo(const String&) final;
 
     OSStatus configureSpeakerProc(int sampleRate);
     OSStatus configureMicrophoneProc(int sampleRate);

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -67,6 +67,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
         MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 1"_s, { }, true, MockMicrophoneProperties { 44100 , { }, 1 } },
         MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 2"_s, { }, false, MockMicrophoneProperties { 48000, { false }, 2 } },
         MockMediaDevice { "239c24b1-3b15-11e3-8224-0800200c9a66"_s, "Mock audio device 3"_s, { }, false, MockMicrophoneProperties { 96000, { true }, 3 } },
+        MockMediaDevice { "239c24b1-3b15-21e3-8224-0800200c9a66"_s, "Mock audio device 4"_s, { }, true, MockMicrophoneProperties { 44100 , { }, 4 } },
 
         MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 1"_s, { }, true, MockSpeakerProperties { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, 44100 } },
         MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 2"_s, { }, false, MockSpeakerProperties { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, 48000 } },

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
@@ -147,7 +147,9 @@ private:
     Ref<GenericPromise> m_pendingAction { GenericPromise::createAndResolve() };
 
     struct PageSources {
+#if PLATFORM(IOS_FAMILY)
         ThreadSafeWeakPtr<WebCore::RealtimeMediaSource> microphoneSource;
+#endif
         ThreadSafeWeakHashSet<WebCore::RealtimeMediaSource> cameraSources;
     };
     HashMap<WebCore::PageIdentifier, PageSources> m_pageSources;


### PR DESCRIPTION
#### f8af49f640cc922f066d0e349ff119a5ea6a7eb2
<pre>
[macOS] Allow multi-microphone capture
<a href="https://rdar.apple.com/163945062">rdar://163945062</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301870">https://bugs.webkit.org/show_bug.cgi?id=301870</a>

Reviewed by Jean-Yves Avenard.

On macOS, only one VPIO unit can run at a time.
This means that we can capture with echo cancellation only one microphone at a time.
To support multi-capture, we do the following heuristic:
1. Whenever getUserMedia is called by default, echo cancellation remains on by default except if web page explicitly asks for echo cancellation to be turned on.
2. If starting to capture with echo cancellation, and VPIO is not in use, business is done as usual: the CoreAudioCaptureUnit::defaultSingleton() is used as normal.
3. If starting to capture with echo cancellation, and VPIO is in use, the CoreAudioCaptureSource(s) using the CoreAudioCaptureUnit::defaultSingleton() are migrated to a non VPIO HAL unit.
   This is being exposed to the web page by firing configurationchange event on the track.
   The new capture will start with echo cancellation on.

To implement this heurisitc, we add a willChangeCaptureDeviceTo callback from CoreAudioCaptureUnit to CoreAudioCaptureSource.
We reuse the same approach as the applyConstraints code path, except if the source is not capturing, in which case we ignore the change.

On iOS, CoreAudioCaptureUnit::defaultSingleton() is still in use and responsible to change between VPIO and RemoteIO unit.
To make this clearer, CoreAudioCaptureUnit::setEnableEchoCancellation is now only defined in IOS.

To support testing with mocks, we add a second device that supports w/o echo cancellation.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/303113@main">https://commits.webkit.org/303113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d5225469a1d72f6ff3395eaba4a9a45c44d76b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83095 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8d6cfb79-3524-43a2-ac04-4431d74786fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100079 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67825 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/08e9ee31-f80a-4938-a621-cc6d080677b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8fcb70c0-33f4-48a5-8bff-39708680ffd1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2575 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/312 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82036 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141286 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108597 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2586 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3478 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32322 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66886 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3500 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->