### PR TITLE
[WKCI] `architectures` for queues should be concatenated with `-`, not space.

### DIFF
--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -33,7 +33,7 @@ class Factory(factory.BuildFactory):
 
     def __init__(self, platform, configuration, architectures, buildOnly, additionalArguments, device_model, triggers=None):
         factory.BuildFactory.__init__(self)
-        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architecture=" ".join(architectures), buildOnly=buildOnly, additionalArguments=additionalArguments, device_model=device_model, triggers=triggers))
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architecture='-'.join(architectures), buildOnly=buildOnly, additionalArguments=additionalArguments, device_model=device_model, triggers=triggers))
         self.addStep(PrintConfiguration())
         self.addStep(CheckOutSource())
         self.addStep(CheckOutSpecificRevision())

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -668,7 +668,7 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
             self.platform = platform.split('-', 1)[0]
         self.fullPlatform = platform
         self.configuration = configuration
-        self.architecture = ' '.join(architectures) if architectures else None
+        self.architecture = '-'.join(architectures) if architectures else None
         self.buildOnly = buildOnly
         self.triggers = triggers
         self.triggered_by = triggered_by

--- a/Tools/Scripts/bisect-builds
+++ b/Tools/Scripts/bisect-builds
@@ -88,17 +88,17 @@ class QueueDescriptor(object):
             architectures_and_configuration = descriptor_string[platform_name_end_index + 1:]
         architectures_end_index = architectures_and_configuration.find('-')
         if architectures_end_index == -1:
-            self.architectures = set(architectures_and_configuration.split(' '))
+            self.architectures = set(architectures_and_configuration.split('-'))
             return
         configuration_start_index = architectures_end_index + 1
-        self.architectures = set(architectures_and_configuration[:architectures_end_index].split(' '))
+        self.architectures = set(architectures_and_configuration[:architectures_end_index].split('-'))
         self.configuration = architectures_and_configuration[configuration_start_index:]
 
     def pretty_string(self):
         result = self.platform_name
         if self.version:
             result += '-' + self.version
-        result += ' (' + ' '.join(self.architectures)
+        result += ' (' + '/'.join(self.architectures)
         result += ', ' + self.configuration + ')'
         return result
 

--- a/Websites/webkit.org/wp-content/themes/webkit/build-archives.php
+++ b/Websites/webkit.org/wp-content/themes/webkit/build-archives.php
@@ -10,9 +10,9 @@ class WebKitBuildArchives {
     private static $object = null;
 
     public static $platforms = array(
-        'mac-tahoe-x86_64%20arm64'      => 'Tahoe',
-        'mac-sequoia-x86_64%20arm64'    => 'Sequoia',
-        'mac-sonoma-x86_64%20arm64'     => 'Sonoma',
+        'mac-tahoe-x86_64-arm64'      => 'Tahoe',
+        'mac-sequoia-x86_64-arm64'    => 'Sequoia',
+        'mac-sonoma-x86_64-arm64'     => 'Sonoma',
     );
 
     public static function object() {


### PR DESCRIPTION
#### 3447e887008ca6b66e1a2ea663490d6651510a17
<pre>
[WKCI] `architectures` for queues should be concatenated with `-`, not space.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301952">https://bugs.webkit.org/show_bug.cgi?id=301952</a>
<a href="https://rdar.apple.com/164027693">rdar://164027693</a>

Reviewed by Jonathan Bedard.

When uploading build products from CI to S3, if there are multiple
architectures specified in the queue information, we upload with a space in the
file name (as the concatenator of the architectures) instead of a dash.

This PR changes this to avoid issues with spaces in file names.

* Tools/CISupport/build-webkit-org/factories.py:
    (Factory.__init__): Change space to `-`.
* Tools/CISupport/ews-build/steps.py:
    (ConfigureBuild.__init__): Ditto.
* Tools/Scripts/bisect-builds:
    (QueueDescriptor):
        -&gt; (__init__): Ditto.
        -&gt; (pretty_string): Ditto, but to `/` instead.
* Websites/webkit.org/wp-content/themes/webkit/build-archives.php: Replace `%20` with `-` in `$platforms`.

Canonical link: <a href="https://commits.webkit.org/302748@main">https://commits.webkit.org/302748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9396edf4d7a40aeeaa640b4f8e2d3fdd367d1734

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81395 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/73b1f4cc-ead9-464d-93b6-e1fc6ccbc9df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98952 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66775 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/55157ad5-3138-465a-9e28-00f9b15be0ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79643 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34473 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80569 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139780 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107462 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/129336 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107348 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1569 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54763 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20293 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2034 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1848 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->