### PR TITLE
[AutoFill Debugging] Add the ability to redact or replace the contents of AutoFilled text fields

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -135,6 +135,7 @@ addEventListener("load", async () => {
         includeNodeIdentifiers: true,
         includeEventListeners: true,
         includeAccessibilityAttributes: true,
+        includeTextInAutoFilledControls: true,
     });
 
     testRunner.notifyDone();

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
@@ -36,6 +36,7 @@
             includeNodeIdentifiers: true,
             includeEventListeners: true,
             includeAccessibilityAttributes: true,
+            includeTextInAutoFilledControls: true,
         });
 
         error1 = await UIHelper.performTextExtractionInteraction("highlightText", {

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
@@ -1,0 +1,4 @@
+root
+	textFormControl,'email',placeholder='Enter your email'
+	textFormControl,'password',placeholder='Enter your password',secure
+	textFormControl,'number',placeholder='Security code','123456'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+input {
+    font-size: 18px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div><input type="email" placeholder="Enter your email"></div>
+<div><input type="password" placeholder="Enter your password"></div>
+<div><input type="number" placeholder="Security code"></div>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const emailField = document.querySelector("input[type='email']");
+    const passwordField = document.querySelector("input[type='password']");
+    const numberField = document.querySelector("input[type='number']");
+
+    emailField.value = "test@webkit.org";
+    passwordField.value = "hunter2";
+    numberField.value = "123456";
+
+    internals.setAutofilled(emailField, true);
+    internals.setAutofilledAndViewable(passwordField, true);
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        includeRects: false,
+        includeURLs: false,
+        includeNodeIdentifiers: false,
+        includeTextInAutoFilledControls: false,
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -81,6 +81,7 @@ struct Request {
     bool includeNodeIdentifiers { false };
     bool includeEventListeners { false };
     bool includeAccessibilityAttributes { false };
+    bool includeTextInAutoFilledControls { false };
 };
 
 struct Editable {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -59,19 +59,22 @@ struct TextExtractionOptions {
     TextExtractionOptions(TextExtractionOptions&& other)
         : filterCallback(WTFMove(other.filterCallback))
         , nativeMenuItems(WTFMove(other.nativeMenuItems))
+        , replacementStrings(WTFMove(other.replacementStrings))
         , flags(other.flags)
     {
     }
 
-    TextExtractionOptions(TextExtractionFilterCallback&& filter, Vector<String>&& items, TextExtractionOptionFlags flags)
+    TextExtractionOptions(TextExtractionFilterCallback&& filter, Vector<String>&& items, HashMap<String, String>&& replacementStrings, TextExtractionOptionFlags flags)
         : filterCallback(WTFMove(filter))
         , nativeMenuItems(WTFMove(items))
+        , replacementStrings(WTFMove(replacementStrings))
         , flags(flags)
     {
     }
 
     TextExtractionFilterCallback filterCallback;
     Vector<String> nativeMenuItems;
+    HashMap<String, String> replacementStrings;
     TextExtractionOptionFlags flags;
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6740,6 +6740,7 @@ header: <WebCore/TextExtractionTypes.h>
     bool includeNodeIdentifiers;
     bool includeEventListeners;
     bool includeAccessibilityAttributes;
+    bool includeTextInAutoFilledControls;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -73,6 +73,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic) BOOL includeAccessibilityAttributes;
 
 /*!
+ Include text content underneath form controls that have been modified via AutoFill.
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL includeTextInAutoFilledControls;
+
+/*!
  Max number of words to include per paragraph; remaining text is truncated with an ellipsis (…).
  The default value is `NSUIntegerMax`.
  */
@@ -89,6 +95,14 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  Will appear as "attribute=value" in text extraction output.
  */
 - (void)addClientAttribute:(NSString *)attributeName value:(NSString *)attributeValue forNode:(_WKJSHandle *)node;
+
+/*!
+ A mapping of strings to replace in text extraction output.
+ Each key represents a string that should be replaced, and the corresponding
+ value represents the string to replace it with.
+ The default value is `nil`.
+ */
+@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *replacementStrings;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -34,6 +34,7 @@
 @implementation _WKTextExtractionConfiguration {
     RetainPtr<_WKJSHandle> _targetNode;
     HashMap<RetainPtr<NSString>, HashMap<RetainPtr<_WKJSHandle>, RetainPtr<NSString>>> _clientNodeAttributes;
+    RetainPtr<NSDictionary<NSString *, NSString *>> _replacementStrings;
 }
 
 - (instancetype)init
@@ -47,6 +48,7 @@
     _includeNodeIdentifiers = YES;
     _includeEventListeners = YES;
     _includeAccessibilityAttributes = YES;
+    _includeTextInAutoFilledControls = YES;
     _targetRect = CGRectNull;
     _maxWordsPerParagraph = NSUIntegerMax;
     return self;
@@ -75,6 +77,16 @@
         for (auto [handle, value] : values)
             block(attribute.get(), value.get(), handle.get());
     }
+}
+
+- (NSDictionary<NSString *, NSString *> *)replacementStrings
+{
+    return _replacementStrings.get();
+}
+
+- (void)setReplacementStrings:(NSDictionary<NSString *, NSString *> *)replacementStrings
+{
+    _replacementStrings = adoptNS([replacementStrings copy]);
 }
 
 @end

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -50,6 +50,7 @@ dictionary TextExtractionTestOptions {
     boolean includeNodeIdentifiers = false;
     boolean includeEventListeners = false;
     boolean includeAccessibilityAttributes = false;
+    boolean includeTextInAutoFilledControls = false;
     boolean mergeParagraphs = false;
     boolean skipNearlyTransparentContent = false;
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -65,6 +65,7 @@ struct TextExtractionTestOptions {
     bool includeNodeIdentifiers { false };
     bool includeEventListeners { false };
     bool includeAccessibilityAttributes { false };
+    bool includeTextInAutoFilledControls { false };
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -76,6 +76,7 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.includeURLs = booleanProperty(context, (JSObjectRef)argument, "includeURLs", false);
     options.includeEventListeners = booleanProperty(context, (JSObjectRef)argument, "includeEventListeners", false);
     options.includeAccessibilityAttributes = booleanProperty(context, (JSObjectRef)argument, "includeAccessibilityAttributes", false);
+    options.includeTextInAutoFilledControls = booleanProperty(context, (JSObjectRef)argument, "includeTextInAutoFilledControls", false);
     options.wordLimit = static_cast<unsigned>(numericProperty(context, (JSObjectRef)argument, "wordLimit"));
     options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
     options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -348,6 +348,7 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     [configuration setIncludeNodeIdentifiers:options && options->includeNodeIdentifiers];
     [configuration setIncludeEventListeners:options && options->includeEventListeners];
     [configuration setIncludeAccessibilityAttributes:options && options->includeAccessibilityAttributes];
+    [configuration setIncludeTextInAutoFilledControls:options && options->includeTextInAutoFilledControls];
     if (auto wordLimit = options ? options->wordLimit : 0)
         [configuration setMaxWordsPerParagraph:static_cast<NSUInteger>(wordLimit)];
     [configuration setTargetRect:extractionRect];


### PR DESCRIPTION
#### 3fc2c409c17ec3bd8743ddcb6df38e3f160ed417
<pre>
[AutoFill Debugging] Add the ability to redact or replace the contents of AutoFilled text fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=301956">https://bugs.webkit.org/show_bug.cgi?id=301956</a>
<a href="https://rdar.apple.com/163650051">rdar://163650051</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Add support for a couple new properties, which allow clients to:

- Automatically replace all occurrences of any given set of strings with another set of strings.
- Avoid extracting text from all text inputs that have been modified via AutoFill.

Tests: fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html
       TextExtractionTests.ReplacementStrings

Tests: fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::hasEnclosingAutoFilledInput):
(WebCore::TextExtraction::collectText):
(WebCore::TextExtraction::extractItem):

Add plumbing to avoid extracting text from text nodes inside input elements that have been
AutoFilled.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::applyReplacements):

Honor the new `replacementStrings` dictionary here, by swapping out all replacement text after
filtering. Importantly, this happens after filtering so that the results of OCR-based filtering
don&apos;t result in false positives due to replacement text being significantly different from the DOM
text.

(WebKit::addPartsForText):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(extractReplacementStrings):
(-[WKWebView _debugTextWithConfiguration:completionHandler:]):
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration init]):
(-[_WKTextExtractionConfiguration replacementStrings]):
(-[_WKTextExtractionConfiguration setReplacementStrings:]):

Add the new properties here.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, ReplacementStrings)):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/302561@main">https://commits.webkit.org/302561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7de438c6deefd2549e92f5d624af09abe4800358

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80911 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9e0af0f8-5052-4198-bac6-a5bf962443fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98628 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66498 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8d3e23c9-1998-4f16-8483-a2aa283aa1c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/77a6906f-1296-441c-8867-5ecd9a42e4ba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34110 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80142 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109689 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139340 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1471 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107153 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27244 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54225 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1606 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1426 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->