### PR TITLE
[Site Isolation] Drag & drop within a remote frame does not drop

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -57,6 +57,7 @@
 #include "EmptyBadgeClient.h"
 #include "EmptyFrameLoaderClient.h"
 #include "FormState.h"
+#include "FrameIdentifier.h"
 #include "FrameNetworkingContext.h"
 #include "HTMLFormElement.h"
 #include "HistoryItem.h"
@@ -266,7 +267,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyDiagnosticLoggingClient);
 #if ENABLE(DRAG_SUPPORT)
 
 class EmptyDragClient final : public DragClient {
-    void willPerformDragDestinationAction(DragDestinationAction, const DragData&) final { }
+    void willPerformDragDestinationAction(DragDestinationAction, const DragData&, std::optional<FrameIdentifier>, CompletionHandler<void()>&& completionHandler) final { completionHandler(); }
     void willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&) final { }
     OptionSet<DragSourceAction> dragSourceActionMaskForPoint(const IntPoint&) final { return { }; }
     void startDrag(DragItem, DataTransfer&, Frame&, const std::optional<NodeIdentifier>&) final { }

--- a/Source/WebCore/page/DragClient.h
+++ b/Source/WebCore/page/DragClient.h
@@ -29,6 +29,7 @@
 #include <WebCore/DragData.h>
 #include <WebCore/DragItem.h>
 #include <WebCore/FloatPoint.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntPoint.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -55,7 +56,7 @@ class DragClient {
 public:
     virtual bool useLegacyDragClient() { return true; }
 
-    virtual void willPerformDragDestinationAction(DragDestinationAction, const DragData&) = 0;
+    virtual void willPerformDragDestinationAction(DragDestinationAction, const DragData&, std::optional<FrameIdentifier>, CompletionHandler<void()>&&) = 0;
     virtual void willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&) = 0;
     virtual void didConcludeEditDrag() { }
     virtual OptionSet<DragSourceAction> dragSourceActionMaskForPoint(const IntPoint& rootViewPoint) = 0;

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -239,30 +239,32 @@ inline static bool dragIsHandledByDocument(DragHandlingMethod dragHandlingMethod
     return dragHandlingMethod != DragHandlingMethod::None && dragHandlingMethod != DragHandlingMethod::PageLoad;
 }
 
-bool DragController::performDragOperation(DragData&& dragData)
+void DragController::performDragOperation(DragData&& dragData, LocalFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!m_droppedImagePlaceholders.isEmpty() && m_droppedImagePlaceholderRange && tryToUpdateDroppedImagePlaceholders(dragData)) {
         m_droppedImagePlaceholders.clear();
         m_droppedImagePlaceholderRange = std::nullopt;
         m_documentUnderMouse = nullptr;
         clearDragCaret();
-        return true;
+        completionHandler(true);
+        return;
     }
 
     removeAllDroppedImagePlaceholders();
 
     SetForScope isPerformingDrop(m_isPerformingDrop, true);
-    RefPtr focusedOrMainFrame = m_page->focusController().focusedOrMainFrame();
-    if (!focusedOrMainFrame)
-        return false;
+    RefPtr ignoreSelectionChangesFrame = &frame;
 
-    IgnoreSelectionChangeForScope ignoreSelectionChanges { *focusedOrMainFrame };
+    IgnoreSelectionChangeForScope ignoreSelectionChanges { *ignoreSelectionChangesFrame };
 
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (!localMainFrame)
-        return false;
+    IntPoint point = frame.protectedView()->windowToContents(dragData.clientPosition());
+    HitTestResult hitTestResult = HitTestResult(point);
 
-    m_documentUnderMouse = localMainFrame->documentAtPoint(dragData.clientPosition());
+    if (frame.contentRenderer()) {
+        static constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
+        hitTestResult = frame.eventHandler().hitTestResultAtPoint(point, hitType);
+    }
+    m_documentUnderMouse = hitTestResult.innerNode() ? &hitTestResult.innerNode()->document() : nullptr;
 
     disallowFileAccessIfNeeded(dragData);
 
@@ -270,43 +272,73 @@ bool DragController::performDragOperation(DragData&& dragData)
     if (RefPtr document = m_documentUnderMouse)
         shouldOpenExternalURLsPolicy = document->shouldOpenExternalURLsPolicyToPropagate();
 
-    if ((m_dragDestinationActionMask.contains(DragDestinationAction::DHTML)) && dragIsHandledByDocument(m_dragHandlingMethod)) {
-        client().willPerformDragDestinationAction(DragDestinationAction::DHTML, dragData);
-        bool preventedDefault = false;
-        if (localMainFrame->view())
-            preventedDefault = localMainFrame->eventHandler().performDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
+    auto continuePerformDrag = [weakThis = WeakPtr { *this }, this, completionHandler = WTFMove(completionHandler), dragData, weakFrame = WeakPtr { frame }, shouldOpenExternalURLsPolicy](bool preventedDefault) mutable {
+        if (!weakThis || !weakFrame) {
+            completionHandler(false);
+            return;
+        }
         if (preventedDefault) {
             clearDragCaret();
             m_documentUnderMouse = nullptr;
-            return true;
+            completionHandler(true);
+            return;
         }
-    }
+        if ((m_dragDestinationActionMask.contains(DragDestinationAction::Edit)) && concludeEditDrag(dragData)) {
+            client().didConcludeEditDrag();
+            m_documentUnderMouse = nullptr;
+            clearDragCaret();
+            completionHandler(true);
+            return;
+        }
 
-    if ((m_dragDestinationActionMask.contains(DragDestinationAction::Edit)) && concludeEditDrag(dragData)) {
-        client().didConcludeEditDrag();
         m_documentUnderMouse = nullptr;
         clearDragCaret();
-        return true;
+
+        if (!operationForLoad(dragData)) {
+            completionHandler(false);
+            return;
+        }
+        auto frameID = weakFrame->frameID();
+        client().willPerformDragDestinationAction(DragDestinationAction::Load, dragData, frameID, [weakThis = WTFMove(weakThis), completionHandler = WTFMove(completionHandler), weakFrame = WTFMove(weakFrame), shouldOpenExternalURLsPolicy, dragData] mutable {
+            RefPtr strongFrame = weakFrame.get();
+            if (!weakThis || !strongFrame) {
+                completionHandler(false);
+                return;
+            }
+
+            auto urlString = dragData.asURL();
+            if (urlString.isEmpty()) {
+                completionHandler(false);
+                return;
+            }
+
+            ResourceRequest resourceRequest { URL { urlString } };
+            resourceRequest.setIsAppInitiated(false);
+            FrameLoadRequest frameLoadRequest { *strongFrame, WTFMove(resourceRequest) };
+            frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
+            frameLoadRequest.setIsRequestFromClientOrUserInput();
+            strongFrame->loader().load(WTFMove(frameLoadRequest));
+            completionHandler(true);
+        });
+    };
+    RefPtr subframe = EventHandler::subframeForTargetNode(hitTestResult.protectedTargetNode().get());
+    RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe);
+    if ((remoteFrame || ((m_dragDestinationActionMask.contains(DragDestinationAction::DHTML)) && dragIsHandledByDocument(m_dragHandlingMethod))) && frame.view()) {
+        if (remoteFrame) {
+            frame.eventHandler().performDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles(), hitTestResult, WTFMove(continuePerformDrag));
+            return;
+        }
+        client().willPerformDragDestinationAction(DragDestinationAction::DHTML, dragData, frame.frameID(), [dragData = WTFMove(dragData), weakFrame = WeakPtr { frame }, hitTestResult = WTFMove(hitTestResult), continuePerformDrag = WTFMove(continuePerformDrag)] mutable {
+            RefPtr strongFrame = weakFrame.get();
+            if (!strongFrame) {
+                continuePerformDrag(false);
+                return;
+            }
+            strongFrame->eventHandler().performDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles(), hitTestResult, WTFMove(continuePerformDrag));
+        });
+        return;
     }
-
-    m_documentUnderMouse = nullptr;
-    clearDragCaret();
-
-    if (!operationForLoad(dragData))
-        return false;
-
-    auto urlString = dragData.asURL();
-    if (urlString.isEmpty())
-        return false;
-
-    client().willPerformDragDestinationAction(DragDestinationAction::Load, dragData);
-    ResourceRequest resourceRequest { WTFMove(urlString) };
-    resourceRequest.setIsAppInitiated(false);
-    FrameLoadRequest frameLoadRequest { *localMainFrame, WTFMove(resourceRequest) };
-    frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
-    frameLoadRequest.setIsRequestFromClientOrUserInput();
-    localMainFrame->loader().load(WTFMove(frameLoadRequest));
-    return true;
+    continuePerformDrag(false);
 }
 
 void DragController::mouseMovedIntoDocument(RefPtr<Document>&& newDocument)
@@ -601,7 +633,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         style->setProperty(CSSPropertyColor, serializationForHTML(color));
         if (!innerFrame->protectedEditor()->shouldApplyStyle(style, *innerRange))
             return false;
-        client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData);
+        client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData, std::nullopt, [] () {});
         innerFrame->protectedEditor()->applyStyle(style.ptr(), EditAction::SetColor);
         return true;
     }
@@ -637,7 +669,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         if (!fragment || !editor->shouldInsertFragment(*fragment, range, EditorInsertAction::Dropped))
             return false;
 
-        client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData);
+        client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData, std::nullopt,  [] () {});
 
         if (editor->client() && editor->client()->performTwoStepDrop(*fragment, *range, isMove))
             return true;
@@ -663,7 +695,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         if (text.isEmpty() || !editor->shouldInsertText(text, *range, EditorInsertAction::Dropped))
             return false;
 
-        client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData);
+        client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData, std::nullopt, [] () {});
         Ref fragment = createFragmentFromText(*range, text);
         if (editor->client() && editor->client()->performTwoStepDrop(fragment.get(), *range, isMove))
             return true;

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -58,7 +58,7 @@ struct DragState;
 struct PromisedAttachmentInfo;
 struct RemoteUserInputEventData;
 
-class DragController {
+class DragController : public CanMakeSingleThreadWeakPtr<DragController> {
     WTF_MAKE_TZONE_ALLOCATED(DragController);
     WTF_MAKE_NONCOPYABLE(DragController);
 public:
@@ -69,7 +69,7 @@ public:
 
     WEBCORE_EXPORT Variant<std::optional<DragOperation>, RemoteUserInputEventData> dragEnteredOrUpdated(LocalFrame&, DragData&&);
     WEBCORE_EXPORT void dragExited(LocalFrame&, DragData&&);
-    WEBCORE_EXPORT bool performDragOperation(DragData&&);
+    WEBCORE_EXPORT void performDragOperation(DragData&&, LocalFrame&, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT void dragCancelled();
 
     bool mouseIsOverFileInput() const { return m_fileInputElementUnderMouse; }
@@ -110,6 +110,7 @@ public:
     static const int DragIconRightInset;
     static const int DragIconBottomInset;
     static const float DragImageAlpha;
+    DragClient& client() const { return *m_client; }
 
 private:
     void updateSupportedTypeIdentifiersForDragHandlingMethod(DragHandlingMethod, const DragData&) const;
@@ -142,8 +143,6 @@ private:
         return true;
 #endif
     }
-
-    DragClient& client() const { return *m_client; }
 
     bool tryToUpdateDroppedImagePlaceholders(const DragData&);
     void removeAllDroppedImagePlaceholders();

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -104,6 +104,7 @@
 #include "PseudoClassChangeInvalidation.h"
 #include "Range.h"
 #include "RemoteFrame.h"
+#include "RemoteFrameClient.h"
 #include "RemoteFrameGeometryTransformer.h"
 #include "RemoteFrameView.h"
 #include "RemoteUserInputEventData.h"
@@ -2696,13 +2697,13 @@ bool EventHandler::canDropCurrentlyDraggedImageAsFile() const
     return !sourceOrigin || m_frame->document()->protectedSecurityOrigin()->canReceiveDragData(*sourceOrigin);
 }
 
-static std::pair<bool, RefPtr<LocalFrame>> contentFrameForNode(Node* target)
+static std::pair<bool, RefPtr<Frame>> contentFrameForNode(Node* target)
 {
     RefPtr frameElement = dynamicDowncast<HTMLFrameElementBase>(target);
     if (!frameElement)
         return { false, nullptr };
 
-    return { true, dynamicDowncast<LocalFrame>(frameElement->contentFrame()) };
+    return { true, frameElement->contentFrame() };
 }
 
 static std::optional<DragOperation> convertDropZoneOperationToDragOperation(const String& dragOperation)
@@ -2808,8 +2809,8 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
         //
         // Moreover, this ordering conforms to section 7.9.4 of the HTML 5 spec. <http://dev.w3.org/html5/spec/Overview.html#drag-and-drop-processing-model>.
         if (auto [isFrameOwner, targetFrame] = contentFrameForNode(newTarget.get()); isFrameOwner) {
-            if (targetFrame)
-                response = targetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
+            if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrame))
+                response = localTargetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
         } else if (newTarget) {
             // As per section 7.9.4 of the HTML 5 spec., we must always fire a drag event before firing a dragenter, dragleave, or dragover event.
             dispatchEventToDragSourceElement(eventNames().dragEvent, event);
@@ -2818,8 +2819,8 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
 
         if (auto [isFrameOwner, targetFrame] = contentFrameForNode(m_dragTarget.copyRef().get()); isFrameOwner) {
             // FIXME: Recursing again here doesn't make sense if the newTarget and m_dragTarget were in the same frame.
-            if (targetFrame)
-                response = targetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
+            if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrame))
+                response = localTargetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
         } else if (RefPtr dragTarget = m_dragTarget) {
             auto dataTransfer = DataTransfer::createForUpdatingDropTarget(dragTarget->protectedDocument(), makePasteboard(), sourceOperationMask, draggingFiles);
             dispatchDragEvent(eventNames().dragleaveEvent, *dragTarget, event, dataTransfer.get());
@@ -2833,13 +2834,14 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
         }
     } else {
         if (auto [isFrameOwner, targetFrame] = contentFrameForNode(newTarget.get()); isFrameOwner) {
-            if (targetFrame)
-                response = targetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
+            if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrame))
+                response = localTargetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
         } else if (newTarget) {
             // Note, when dealing with sub-frames, we may need to fire only a dragover event as a drag event may have been fired earlier.
             if (!m_shouldOnlyFireDragOverEvent)
                 dispatchEventToDragSourceElement(eventNames().dragEvent, event);
             response = dispatchDragEnterOrDragOverEvent(eventNames().dragoverEvent, *newTarget, event, makePasteboard(), sourceOperationMask, draggingFiles);
+
             m_shouldOnlyFireDragOverEvent = false;
         }
     }
@@ -2852,8 +2854,8 @@ void EventHandler::cancelDragAndDrop(const PlatformMouseEvent& event, std::uniqu
     Ref frame = m_frame.get();
 
     if (auto [isFrameOwner, targetFrame] = contentFrameForNode(m_dragTarget.copyRef().get()); isFrameOwner) {
-        if (targetFrame)
-            targetFrame->eventHandler().cancelDragAndDrop(event, WTFMove(pasteboard), sourceOperationMask, draggingFiles);
+        if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrame))
+            localTargetFrame->eventHandler().cancelDragAndDrop(event, WTFMove(pasteboard), sourceOperationMask, draggingFiles);
     } else if (RefPtr dragTarget = m_dragTarget) {
         dispatchEventToDragSourceElement(eventNames().dragEvent, event);
 
@@ -2864,21 +2866,44 @@ void EventHandler::cancelDragAndDrop(const PlatformMouseEvent& event, std::uniqu
     clearDragState();
 }
 
-bool EventHandler::performDragAndDrop(const PlatformMouseEvent& event, std::unique_ptr<Pasteboard>&& pasteboard, OptionSet<DragOperation> sourceOperationMask, bool draggingFiles)
+void EventHandler::performDragAndDrop(const PlatformMouseEvent& event, std::unique_ptr<Pasteboard>&& pasteboard, OptionSet<DragOperation> sourceOperationMask, bool draggingFiles, const HitTestResult& result, CompletionHandler<void(bool)>&& completionHandler)
 {
     Ref frame = m_frame.get();
 
     bool preventedDefault = false;
+    RefPtr subframe = EventHandler::subframeForTargetNode(result.protectedTargetNode().get());
+    auto afterDragAndDrop = [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](bool preventedDefault) mutable {
+        CheckedPtr checkedThis = weakThis.get();
+        if (checkedThis)
+            checkedThis->clearDragState();
+        completionHandler(preventedDefault);
+    };
+
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+    if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe)) {
+        if (auto remoteUserInputEventData = userInputEventDataForRemoteFrame(remoteFrame.get(), result.roundedPointInInnerNodeFrame())) {
+            remoteFrame->client().propagateDragAndDrop(frame->frameID(), *remoteUserInputEventData, WTFMove(afterDragAndDrop));
+            return;
+        }
+    }
+#endif
     if (auto [isFrameOwner, targetFrame] = contentFrameForNode(m_dragTarget.copyRef().get()); isFrameOwner) {
-        if (targetFrame)
-            preventedDefault = targetFrame->eventHandler().performDragAndDrop(event, WTFMove(pasteboard), sourceOperationMask, draggingFiles);
+        if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrame)) {
+            localTargetFrame->eventHandler().performDragAndDrop(event, WTFMove(pasteboard), sourceOperationMask, draggingFiles, result, WTFMove(afterDragAndDrop));
+            return;
+        }
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+        if (RefPtr remoteTargetFrame = dynamicDowncast<RemoteFrame>(targetFrame)) {
+            auto remoteUserInputEventData = userInputEventDataForRemoteFrame(remoteTargetFrame.get(), result.roundedPointInInnerNodeFrame());
+            remoteTargetFrame->client().propagateDragAndDrop(frame->frameID(), *remoteUserInputEventData, WTFMove(afterDragAndDrop));
+        }
+#endif
     } else if (RefPtr dragTarget = m_dragTarget) {
         Ref dataTransfer = DataTransfer::createForDrop(dragTarget->protectedDocument(), WTFMove(pasteboard), sourceOperationMask, draggingFiles);
         preventedDefault = dispatchDragEvent(eventNames().dropEvent, *dragTarget, event, dataTransfer);
         dataTransfer->makeInvalidForSecurity();
     }
-    clearDragState();
-    return preventedDefault;
+    afterDragAndDrop(preventedDefault);
 }
 
 void EventHandler::clearDragState()

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -136,7 +136,7 @@ extern const unsigned InvalidTouchIdentifier;
 enum AppendTrailingWhitespace { ShouldAppendTrailingWhitespace, DontAppendTrailingWhitespace };
 enum CheckDragHysteresis { ShouldCheckDragHysteresis, DontCheckDragHysteresis };
 
-class EventHandler final : public CanMakeCheckedPtr<EventHandler> {
+class EventHandler final : public CanMakeCheckedPtr<EventHandler>, public CanMakeWeakPtr<EventHandler> {
     WTF_MAKE_TZONE_ALLOCATED(EventHandler);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventHandler);
 public:
@@ -185,7 +185,7 @@ public:
     };
     DragTargetResponse updateDragAndDrop(const PlatformMouseEvent&, const std::function<std::unique_ptr<Pasteboard>()>&, OptionSet<DragOperation>, bool draggingFiles);
     void cancelDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
-    bool performDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
+    void performDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles, const HitTestResult&, CompletionHandler<void(bool)>&&);
     void updateDragStateAfterEditDragIfNeeded(Element& rootEditableElement);
     static Element* draggedElement();
     static RefPtr<Element> protectedDraggedElement();

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -44,6 +44,7 @@ enum class RenderAsTextFlag : uint16_t;
 
 struct FocusEventData;
 struct MessageWithMessagePorts;
+struct RemoteUserInputEventData;
 
 class RemoteFrameClient : public FrameLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteFrameClient);
@@ -61,6 +62,9 @@ public:
     virtual void unbindRemoteAccessibilityFrames(int) = 0;
     virtual void focus() = 0;
     virtual void unfocus() = 0;
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+    virtual void propagateDragAndDrop(FrameIdentifier, WebCore::RemoteUserInputEventData, CompletionHandler<void(bool)>&&) = 0;
+#endif
     virtual void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) = 0;
     virtual void updateScrollingMode(ScrollbarMode scrollingMode) = 0;
     virtual void reportMixedContentViolation(bool blocked, const URL& target) = 0;

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -238,6 +238,18 @@ std::optional<IPC::AsyncReplyID> WebPageProxy::grantAccessToCurrentPasteboardDat
     return WebPasteboardProxy::singleton().grantAccessToCurrentData(m_legacyMainFrameProcess, pasteboardName, WTFMove(completionHandler));
 }
 
+void WebPageProxy::grantAccessToCurrentPasteboardData(const String& pasteboardName, std::optional<FrameIdentifier> frameID)
+{
+    if (!hasRunningProcess())
+        return;
+    if (RefPtr frame = WebFrameProxy::webFrame(frameID)) {
+        WebPasteboardProxy::singleton().grantAccessToCurrentData(frame->protectedProcess(), pasteboardName, [] { });
+        return;
+    }
+
+    WebPasteboardProxy::singleton().grantAccessToCurrentData(m_legacyMainFrameProcess, pasteboardName, [] { });
+}
+
 void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navigation, bool forMainFrameNavigation)
 {
 #if HAVE(SAFE_BROWSING)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3804,30 +3804,61 @@ void WebPageProxy::dragExited(DragData& dragData)
     performDragControllerAction(DragControllerAction::Exited, dragData);
 }
 
-void WebPageProxy::performDragOperation(DragData& dragData, const String& dragStorageName, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsForUpload)
+#if PLATFORM(COCOA)
+void WebPageProxy::propagateDragAndDrop(IPC::Connection& connection, FrameIdentifier frameID, RemoteUserInputEventData remoteUserInputEventData, CompletionHandler<void(bool)>&& completionHandler)
+{
+    auto& currentOperation = internals().currentDragOperationData;
+    if (!currentOperation) {
+        ASSERT_NOT_REACHED();
+        completionHandler(false);
+        return;
+    }
+    MESSAGE_CHECK_BASE(!currentOperation->lastFrameID ||  currentOperation->lastFrameID == frameID, &connection);
+    currentOperation->lastFrameID = remoteUserInputEventData.targetFrameID;
+
+    sendWithAsyncReplyToProcessContainingFrame(remoteUserInputEventData.targetFrameID, Messages::WebPage::PerformDragOperation(remoteUserInputEventData.targetFrameID, currentOperation->dragData), [completionHandler = WTFMove(completionHandler)](bool handled) mutable {
+        completionHandler(handled);
+    });
+}
+
+void WebPageProxy::fetchSandboxExtensionsForDragAction(IPC::Connection& connection, FrameIdentifier frameID, CompletionHandler<void(SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&)>&& completionHandler)
+{
+    auto& currentOperation = internals().currentDragOperationData;
+    if (!currentOperation) {
+        ASSERT_NOT_REACHED();
+        completionHandler({ }, { });
+        return;
+    }
+
+    RefPtr frame = WebFrameProxy::webFrame(frameID);
+    if (!frame) {
+        ASSERT_NOT_REACHED();
+        completionHandler({ }, { });
+        return;
+    }
+
+    MESSAGE_CHECK_BASE(!currentOperation->lastFrameID ||  currentOperation->lastFrameID == frameID, &connection);
+    grantAccessToCurrentPasteboardData(currentOperation->dragStorageName, [] () { }, frameID);
+    completionHandler(WTFMove(currentOperation->sandboxExtensionHandle), WTFMove(currentOperation->sandboxExtensionsForUpload));
+}
+#endif
+
+void WebPageProxy::performDragOperation(DragData& dragData, const String& dragStorageName, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsForUpload, std::optional<WebCore::FrameIdentifier> frameID)
 {
     if (!hasRunningProcess())
         return;
 
 #if PLATFORM(GTK)
-    URL url { dragData.asURL() };
-    if (url.protocolIsFile())
-        protectedLegacyMainFrameProcess()->assumeReadAccessToBaseURL(*this, url.string(), [] { });
-    else if (!dragData.fileNames().isEmpty())
-        protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(siteIsolatedProcess().coreProcessIdentifier(), dragData.fileNames()), [] { });
-
     performDragControllerAction(DragControllerAction::PerformDragOperation, dragData);
-#elif PLATFORM(COCOA)
-    grantAccessToCurrentPasteboardData(dragStorageName, [this, protectedThis = Ref { *this }, dragStorageName, dragData = WTFMove(dragData), sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), sandboxExtensionsForUpload = WTFMove(sandboxExtensionsForUpload)] () mutable {
-        sendWithAsyncReply(Messages::WebPage::PerformDragOperation(dragData, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload)), [this, protectedThis = Ref { *this }] (bool handled) {
-            if (RefPtr pageClient = this->pageClient())
-                pageClient->didPerformDragOperation(handled);
-        });
-    });
 #else
-    sendWithAsyncReply(Messages::WebPage::PerformDragOperation(dragData, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload)), [this, protectedThis = Ref { *this }] (bool handled) {
-        if (RefPtr pageClient = this->pageClient())
-            pageClient->didPerformDragOperation(handled);
+    if (!hasRunningProcess())
+        return;
+    if (!frameID)
+        internals().currentDragOperationData = { dragData, dragStorageName, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload), std::nullopt };
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDragOperation(frameID, internals().currentDragOperationData->dragData), [this, protectedThis = Ref { *this }, frameID] (bool handled) mutable {
+        if (!frameID)
+            internals().currentDragOperationData = std::nullopt;
+        protectedPageClient()->didPerformDragOperation(handled);
     });
 #endif
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1672,7 +1672,7 @@ public:
     void dragEntered(WebCore::DragData&, const String& dragStorageName = String());
     void dragUpdated(WebCore::DragData&, const String& dragStorageName = String());
     void dragExited(WebCore::DragData&);
-    void performDragOperation(WebCore::DragData&, const String& dragStorageName, SandboxExtensionHandle&&, Vector<SandboxExtensionHandle>&&);
+    void performDragOperation(WebCore::DragData&, const String& dragStorageName, SandboxExtensionHandle&&, Vector<SandboxExtensionHandle>&&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 
     void didPerformDragControllerAction(std::optional<WebCore::DragOperation>, WebCore::DragHandlingMethod, bool mouseIsOverFileInput, unsigned numberOfItemsToBeAccepted, const WebCore::IntRect& insertionRect, const WebCore::IntRect& editableElementRect);
     void dragEnded(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragOperation>, const std::optional<WebCore::FrameIdentifier>& = std::nullopt);
@@ -1680,6 +1680,8 @@ public:
     void dragCancelled();
     void setDragCaretRect(const WebCore::IntRect&);
 #if PLATFORM(COCOA)
+    void propagateDragAndDrop(IPC::Connection&, WebCore::FrameIdentifier, WebCore::RemoteUserInputEventData, CompletionHandler<void(bool)>&&);
+    void fetchSandboxExtensionsForDragAction(IPC::Connection&, WebCore::FrameIdentifier, CompletionHandler<void(SandboxExtensionHandle&&, Vector<SandboxExtensionHandle>&&)>&&);
     void startDrag(const WebCore::DragItem&, WebCore::ShareableBitmapHandle&& dragImageHandle, const std::optional<WebCore::NodeIdentifier>&);
     void setPromisedDataForImage(IPC::Connection&, const String& pasteboardName, WebCore::SharedMemoryHandle&& imageHandle, const String& filename, const String& extension,
         const String& title, const String& url, const String& visibleURL, WebCore::SharedMemoryHandle&& archiveHandle, const String& originIdentifier);
@@ -2347,6 +2349,7 @@ public:
         
 #if PLATFORM(COCOA)
     std::optional<IPC::AsyncReplyID> grantAccessToCurrentPasteboardData(const String& pasteboardName, CompletionHandler<void()>&&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
+    void grantAccessToCurrentPasteboardData(const String& pasteboardName, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -317,6 +317,8 @@ messages -> WebPageProxy {
 
     # Drag and drop messages
 #if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+    PropagateDragAndDrop(WebCore::FrameIdentifier frameID, struct WebCore::RemoteUserInputEventData remoteUserInputData) -> (bool handled)
+    FetchSandboxExtensionsForDragAction(WebCore::FrameIdentifier frameID) -> (WebKit::SandboxExtensionHandle sandboxExtensionHandle, Vector<WebKit::SandboxExtensionHandle> sandboxExtensionsForUpload)
     StartDrag(struct WebCore::DragItem dragItem, WebCore::ShareableBitmapHandle dragImage, std::optional<WebCore::NodeIdentifier> nodeID)
     SetPromisedDataForImage(String pasteboardName, WebCore::SharedMemory::Handle imageHandle, String filename, String extension, String title, String url, String visibleURL, WebCore::SharedMemory::Handle archiveHandle, String originIdentifier)
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -56,7 +56,9 @@
 #endif
 
 #if ENABLE(DRAG_SUPPORT)
+#include "SandboxExtension.h"
 #include <WebCore/DragActions.h>
+#include <WebCore/DragData.h>
 #endif
 
 #if PLATFORM(MACCATALYST)
@@ -339,9 +341,17 @@ public:
     RefPtr<WebDataListSuggestionsDropdown> dataListSuggestionsDropdown;
 
 #if ENABLE(DRAG_SUPPORT)
+    struct DragOperationData {
+        WebCore::DragData dragData;
+        String dragStorageName;
+        SandboxExtension::Handle sandboxExtensionHandle;
+        Vector<SandboxExtension::Handle> sandboxExtensionsForUpload;
+        std::optional<WebCore::FrameIdentifier> lastFrameID;
+    };
     WebCore::IntRect currentDragCaretEditableElementRect;
     WebCore::IntRect currentDragCaretRect;
     WebCore::DragHandlingMethod currentDragHandlingMethod { WebCore::DragHandlingMethod::None };
+    std::optional<DragOperationData> currentDragOperationData;
 #endif
 
     RefPtr<WebColorPicker> colorPicker;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
@@ -36,12 +36,27 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDragClient);
 
-void WebDragClient::willPerformDragDestinationAction(DragDestinationAction action, const DragData&)
+void WebDragClient::willPerformDragDestinationAction(DragDestinationAction action, const DragData& dragData, std::optional<FrameIdentifier> frameID, CompletionHandler<void()>&& completionHandler)
 {
-    if (action == DragDestinationAction::Load)
-        protectedPage()->willPerformLoadDragDestinationAction();
-    else
-        protectedPage()->mayPerformUploadDragDestinationAction(); // Upload can happen from a drop event handler, so we should prepare early.
+#if PLATFORM(COCOA)
+    if (frameID) {
+        protectedPage()->fetchSandboxExtensionsForDragAction(frameID.value(), [page = RefPtr { m_page.get() }, action, completionHandler = WTFMove(completionHandler)] () mutable {
+            if (action == DragDestinationAction::Load)
+                page->willPerformLoadDragDestinationAction();
+            else
+                page->mayPerformUploadDragDestinationAction();
+            completionHandler();
+        });
+    } else {
+        if (action == DragDestinationAction::Load)
+            protectedPage()->willPerformLoadDragDestinationAction();
+        else
+            protectedPage()->mayPerformUploadDragDestinationAction(); // Upload can happen from a drop event handler, so we should prepare early.
+        completionHandler();
+    }
+#else
+    completionHandler();
+#endif
 }
 
 void WebDragClient::willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&) override;
+    void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void()>&&) override;
     void willPerformDragSourceAction(WebCore::DragSourceAction, const WebCore::IntPoint&, WebCore::DataTransfer&) override;
     OptionSet<WebCore::DragSourceAction> dragSourceActionMaskForPoint(const WebCore::IntPoint& windowPoint) override;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/NodeDocument.h>
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/RemoteFrame.h>
+#include <WebCore/RemoteUserInputEventData.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -228,6 +229,16 @@ void WebRemoteFrameClient::applyWebsitePolicies(WebsitePoliciesData&& websitePol
     coreFrame->setCustomNavigatorPlatform(WTFMove(websitePolicies.customNavigatorPlatform));
     coreFrame->setAutoplayPolicy(core(websitePolicies.autoplayPolicy));
 }
+
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+void WebRemoteFrameClient::propagateDragAndDrop(FrameIdentifier frameID, WebCore::RemoteUserInputEventData remoteUserInputEventData, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (RefPtr page = m_frame->page())
+        page->sendWithAsyncReply(Messages::WebPageProxy::PropagateDragAndDrop(frameID, WTFMove(remoteUserInputEventData)), WTFMove(completionHandler));
+    else
+        completionHandler(false);
+}
+#endif
 
 void WebRemoteFrameClient::updateScrollingMode(ScrollbarMode scrollingMode)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -52,6 +52,9 @@ private:
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>&&, CompletionHandler<void(Vector<uint8_t>, int)>&&) final;
     void unbindRemoteAccessibilityFrames(int) final;
     void updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint) final;
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+    void propagateDragAndDrop(WebCore::FrameIdentifier, WebCore::RemoteUserInputEventData, CompletionHandler<void(bool)>&&) final;
+#endif
     bool isWebRemoteFrameClient() const final { return true; }
 
     void closePage() final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5511,8 +5511,10 @@ void WebPage::performDragControllerAction(DragControllerAction action, const Int
         return completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
 
     case DragControllerAction::PerformDragOperation: {
-        m_page->dragController().performDragOperation(WTFMove(dragData));
-        return completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
+        m_page->dragController().performDragOperation(WTFMove(dragData), *localMainFrame, [completionHandler = WTFMove(completionHandler)] (bool) mutable {
+            completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
+        });
+        return;
     }
     }
     ASSERT_NOT_REACHED();
@@ -5526,12 +5528,14 @@ void WebPage::performDragControllerAction(std::optional<FrameIdentifier> frameID
     RefPtr frame = frameID ? WebProcess::singleton().webFrame(*frameID) : &mainWebFrame();
     if (!frame) {
         ASSERT_NOT_REACHED();
+        completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
         return;
     }
 
     RefPtr localFrame = frame->coreLocalFrame();
     if (!localFrame) {
         ASSERT_NOT_REACHED();
+        completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
         return;
     }
 
@@ -5553,24 +5557,26 @@ void WebPage::performDragControllerAction(std::optional<FrameIdentifier> frameID
     ASSERT_NOT_REACHED();
 }
 
-void WebPage::performDragOperation(WebCore::DragData&& dragData, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsHandleArray, CompletionHandler<void(bool)>&& completionHandler)
+void WebPage::performDragOperation(std::optional<WebCore::FrameIdentifier> frameID, WebCore::DragData&& dragData, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(!m_pendingDropSandboxExtension);
 
-    m_pendingDropSandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
-    for (size_t i = 0; i < sandboxExtensionsHandleArray.size(); i++) {
-        if (auto extension = SandboxExtension::create(WTFMove(sandboxExtensionsHandleArray[i])))
-            m_pendingDropExtensionsForFileUpload.append(extension);
+    RefPtr frame = frameID ? WebProcess::singleton().webFrame(*frameID) : &mainWebFrame();
+
+    if (!frame) {
+        ASSERT_NOT_REACHED();
+        completionHandler(false);
+        return;
     }
 
-    bool handled = m_page->dragController().performDragOperation(WTFMove(dragData));
+    RefPtr localFrame = frame->coreLocalFrame();
+    if (!localFrame) {
+        ASSERT_NOT_REACHED();
+        completionHandler(false);
+        return;
+    }
 
-    // If we started loading a local file, the sandbox extension tracker would have adopted this
-    // pending drop sandbox extension. If not, we'll play it safe and clear it.
-    m_pendingDropSandboxExtension = nullptr;
-
-    m_pendingDropExtensionsForFileUpload.clear();
-    completionHandler(handled);
+    m_page->dragController().performDragOperation(WTFMove(dragData), *localFrame, WTFMove(completionHandler));
 }
 #endif
 
@@ -5612,6 +5618,25 @@ void WebPage::mayPerformUploadDragDestinationAction()
         extension->consumePermanently();
     m_pendingDropExtensionsForFileUpload.clear();
 }
+
+#if PLATFORM(COCOA)
+void WebPage::fetchSandboxExtensionsForDragAction(FrameIdentifier frameID, CompletionHandler<void()>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::WebPageProxy::FetchSandboxExtensionsForDragAction(frameID), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsHandleArray) mutable {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis) {
+            completionHandler();
+            return;
+        }
+        strongThis->m_pendingDropSandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
+        for (size_t i = 0; i < sandboxExtensionsHandleArray.size(); i++) {
+            if (auto extension = SandboxExtension::create(WTFMove(sandboxExtensionsHandleArray[i])))
+                strongThis->m_pendingDropExtensionsForFileUpload.append(extension);
+        }
+        completionHandler();
+    });
+}
+#endif
 
 void WebPage::didStartDrag()
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1336,7 +1336,7 @@ public:
 
 #if ENABLE(DRAG_SUPPORT) && !PLATFORM(GTK)
     void performDragControllerAction(std::optional<WebCore::FrameIdentifier>, DragControllerAction, WebCore::DragData&&, CompletionHandler<void(std::optional<WebCore::DragOperation>, WebCore::DragHandlingMethod, bool, unsigned, WebCore::IntRect, WebCore::IntRect, std::optional<WebCore::RemoteUserInputEventData>)>&&);
-    void performDragOperation(WebCore::DragData&&, SandboxExtensionHandle&&, Vector<SandboxExtensionHandle>&&, CompletionHandler<void(bool)>&&);
+    void performDragOperation(std::optional<WebCore::FrameIdentifier>, WebCore::DragData&&, CompletionHandler<void(bool)>&&);
 #endif
 
 #if ENABLE(DRAG_SUPPORT)
@@ -1344,7 +1344,9 @@ public:
 
     void willPerformLoadDragDestinationAction();
     void mayPerformUploadDragDestinationAction();
-
+#if PLATFORM(COCOA)
+    void fetchSandboxExtensionsForDragAction(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
+#endif
     void willStartDrag() { ASSERT(!m_isStartingDrag); m_isStartingDrag = true; }
     void didStartDrag();
     void dragCancelled();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -361,7 +361,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 #if !PLATFORM(GTK) && ENABLE(DRAG_SUPPORT)
     PerformDragControllerAction(std::optional<WebCore::FrameIdentifier> frameID, enum:uint8_t WebKit::DragControllerAction action, WebCore::DragData dragData) -> (enum:uint8_t std::optional<WebCore::DragOperation> dragOperation, enum:uint8_t WebCore::DragHandlingMethod dragHandlingMethod, bool mouseIsOverFileInput, unsigned numberOfItemsToBeAccepted, WebCore::IntRect insertionRect, WebCore::IntRect editableElementRect, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
-    PerformDragOperation(WebCore::DragData dragData, WebKit::SandboxExtensionHandle sandboxExtensionHandle, Vector<WebKit::SandboxExtensionHandle> sandboxExtensionsForUpload) -> (bool handled)
+    PerformDragOperation(std::optional<WebCore::FrameIdentifier> frameID, WebCore::DragData dragData) -> (bool handled)
 #endif
 #if ENABLE(DRAG_SUPPORT)
     DidStartDrag()

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -761,7 +761,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
     WebHitTestResultData immediateActionResult(hitTestResult, { });
 
     auto subframe = EventHandler::subframeForTargetNode(hitTestResult.protectedTargetNode().get());
-    if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe).get()) {
+    if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe)) {
         if (RefPtr remoteFrameView = remoteFrame->view()) {
             immediateActionResult.remoteUserInputEventData = RemoteUserInputEventData {
                 remoteFrame->frameID(),

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h
@@ -37,7 +37,7 @@ public:
 
     bool useLegacyDragClient() override;
 
-    void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&) override;
+    void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void()>&&) override;
     void willPerformDragSourceAction(WebCore::DragSourceAction, const WebCore::IntPoint&, WebCore::DataTransfer&) override;
     OptionSet<WebCore::DragSourceAction> dragSourceActionMaskForPoint(const WebCore::IntPoint& windowPoint) override;
     void startDrag(WebCore::DragItem, WebCore::DataTransfer&, WebCore::Frame&, const std::optional<WebCore::NodeIdentifier>&) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -63,6 +63,7 @@
 #import <WebCore/PagePasteboardContext.h>
 #import <WebCore/Pasteboard.h>
 #import <WebCore/PasteboardWriter.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
@@ -124,12 +125,6 @@ static WebHTMLView *getTopHTMLView(LocalFrame* frame)
     return (WebHTMLView*)[[kit(dynamicDowncast<WebCore::LocalFrame>(frame->page()->mainFrame())) frameView] documentView];
 }
 
-void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction action, const WebCore::DragData& dragData)
-{
-    [[m_webView _UIDelegateForwarder] webView:m_webView willPerformDragDestinationAction:kit(action) forDraggingInfo:dragData.platformData()];
-}
-
-
 OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint& rootViewPoint)
 {
     NSPoint viewPoint = [m_webView _convertPointFromRootView:rootViewPoint];
@@ -139,6 +134,14 @@ OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint
 void WebDragClient::willPerformDragSourceAction(WebCore::DragSourceAction action, const WebCore::IntPoint& mouseDownPoint, WebCore::DataTransfer& dataTransfer)
 {
     [[m_webView _UIDelegateForwarder] webView:m_webView willPerformDragSourceAction:kit(action) fromPoint:mouseDownPoint withPasteboard:[NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()]];
+}
+
+void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction action, const DragData& dragData, std::optional<WebCore::FrameIdentifier> frameID, CompletionHandler<void()>&& completionHandler)
+{
+    if (!frameID) {
+        [[m_webView _UIDelegateForwarder] webView:m_webView willPerformDragDestinationAction:kit(action) forDraggingInfo:dragData.platformData()];
+    }
+    completionHandler();
 }
 
 void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Frame& frame, const std::optional<NodeIdentifier>& nodeID)
@@ -223,8 +226,9 @@ void WebDragClient::didConcludeEditDrag()
 {
 }
 
-void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&)
+void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void()>&& completionHandler)
 {
+    completionHandler();
 }
 
 OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint&)
@@ -258,8 +262,9 @@ bool WebDragClient::useLegacyDragClient()
     return true;
 }
 
-void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&)
+void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void()>&& completionHandler)
 {
+    completionHandler();
 }
 
 OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint&)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -344,6 +344,10 @@
 #import <wtf/FastMalloc.h>
 #endif
 
+#if ENABLE(DRAG_SUPPORT)
+#import <wtf/Box.h>
+#endif
+
 #if ENABLE(REMOTE_INSPECTOR)
 #import <JavaScriptCore/RemoteInspector.h>
 #if PLATFORM(IOS_FAMILY)
@@ -1983,9 +1987,17 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 
 - (BOOL)_tryToPerformDataInteraction:(id <UIDropSession>)session client:(CGPoint)clientPosition global:(CGPoint)globalPosition operation:(uint64_t)operation
 {
+    RefPtr localMainFrame = [self _mainCoreFrame];
+    if (!localMainFrame)
+        return NO;
+
     WebThreadLock();
     auto dragData = [self dragDataForSession:session client:clientPosition global:globalPosition operation:operation];
-    return _private->page->dragController().performDragOperation(WTFMove(dragData));
+    auto preventedDefault = Box<bool>::create(false);
+    _private->page->dragController().performDragOperation(WTFMove(dragData), *localMainFrame, [preventedDefault] (bool dragPreventedDefault) mutable {
+        *preventedDefault = dragPreventedDefault;
+    });
+    return *preventedDefault;
 }
 
 - (void)_endedDataInteraction:(CGPoint)clientPosition global:(CGPoint)globalPosition
@@ -6358,7 +6370,8 @@ static bool needsWebViewInitThreadWorkaround()
                     fileNames->append(path.get());
                     if (fileNames->size() == fileCount) {
                         dragData->setFileNames(*fileNames);
-                        core(self)->dragController().performDragOperation(WebCore::DragData { *dragData });
+                        RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(_private->page->mainFrame());
+                        core(self)->dragController().performDragOperation(WebCore::DragData { *dragData }, *localMainFrame, [] (bool) mutable { });
                         delete dragData;
                         delete fileNames;
                     }
@@ -6368,10 +6381,13 @@ static bool needsWebViewInitThreadWorkaround()
 
         return true;
     }
-    bool returnValue = core(self)->dragController().performDragOperation(WebCore::DragData { *dragData });
+    RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(_private->page->mainFrame());
+    auto returnValue = Box<bool>::create(false);
+    core(self)->dragController().performDragOperation(WebCore::DragData { *dragData }, *localMainFrame, [returnValue](bool value) {
+        *returnValue = value;
+    });
     delete dragData;
-
-    return returnValue;
+    return *returnValue;
 }
 
 - (NSView *)_hitTest:(NSPoint *)point dragTypes:(NSSet *)types

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -2125,6 +2125,111 @@ TEST(SiteIsolation, PasteGIF)
 
 #endif
 
+#if ENABLE(DRAG_SUPPORT) && !PLATFORM(MACCATALYST)
+TEST(SiteIsolation, DragAndDropWithoutNavigation)
+{
+    auto mainframeHTML = "<!DOCTYPE html>"
+    "<html>"
+    "    <head>"
+    "        <meta charset='utf8'>"
+    "        <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>"
+    "        <style>"
+    "            body {"
+    "                width: 100%;"
+    "                height: 100%;"
+    "                margin: 0;"
+    "                background-color: antiquewhite;"
+    "            }"
+    "        </style>"
+    "    </head>"
+    "    <body>"
+    "        <iframe src='https://domain2.com/subframe' style='width: 600px; height: 600px;'></iframe>"
+    "    </body>"
+    "</html>"_s;
+
+    auto subframeHTML = "<!DOCTYPE html>"
+    "<html>"
+    "    <head>"
+    "    <meta charset='utf8'>"
+    "    <meta name='viewport' content='width=device-width, initial-scale=1' />"
+    "    <style>"
+    "        body {"
+    "            margin: 0;"
+    "        }"
+    "       #draggable {"
+    "           background-color: cyan;"
+    "           width: 200px;"
+    "           height: 200px;"
+    "           border: 1px black dotted;"
+    "       }"
+    "       #dropzone {"
+    "           background-color: pink;"
+    "           width: 200px;"
+    "           height: 200px;"
+    "           border: 1px black dotted;"
+    "       }"
+    "    </style>"
+    "    </head>"
+    "    <body>"
+    "       <div draggable='true' id='draggable'>Hello World</div>"
+    "       <div id='dropzone'></div>"
+    "    <script>"
+    "        window.dropCount = 0;"
+    "        const draggable = document.getElementById('draggable');"
+    "        draggable.addEventListener('dragstart', function(e) {"
+    "               e.dataTransfer.setData('text/plain', 'hello world');"
+    "           });"
+    "       const dropzone = document.getElementById('dropzone');"
+    "       dropzone.addEventListener('dragenter', e => e.preventDefault());"
+    "       dropzone.addEventListener('dragover', e => e.preventDefault());"
+    "       dropzone.addEventListener('drop', function(e) {"
+    "           e.preventDefault();"
+    "           const data = e.dataTransfer.getData('text/plain');"
+    "           window.dropCount = 1;"
+    "       });"
+    "    </script>"
+    "    </body>"
+    "</html>"_s;
+
+    HTTPServer server({
+        { "/mainframe"_s, { { { "Content-Type"_s, "text/html "_s } }, mainframeHTML } },
+        { "/subframe"_s, { { { "Content-Type"_s, "text/html "_s } }, subframeHTML } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration.get());
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr webView = [simulator webView];
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+    [simulator runFrom:CGPointMake(72, 92) to:CGPointMake(86, 274)];
+
+    __block bool didDecideNavigationPolicy = false;
+    [navigationDelegate setDecidePolicyForNavigationAction:^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+        didDecideNavigationPolicy = true;
+    }];
+
+    __block bool done = false;
+    __block int windowDropCount = 0;
+    [webView evaluateJavaScript:@"window.dropCount" inFrame:[webView firstChildFrame] completionHandler:^(id resultValue, NSError *error) {
+        EXPECT_NULL(error);
+        done = true;
+        windowDropCount = [resultValue intValue];
+    }];
+
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_FALSE(didDecideNavigationPolicy);
+    EXPECT_EQ(windowDropCount, 1);
+}
+#endif
+
 TEST(SiteIsolation, ShutDownFrameProcessesAfterNavigation)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 0ca1973b0daee30ec610b5510add2503495e4b5e
<pre>
[Site Isolation] Drag &amp; drop within a remote frame does not drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=301963">https://bugs.webkit.org/show_bug.cgi?id=301963</a>
<a href="https://rdar.apple.com/160806781">rdar://160806781</a>

Reviewed by NOBODY (OOPS!).

Original patch by pascoej.

Currently on iOS and macOS, dragging and dropping elements within an
iframe does not work. That is, dropping never finishes and succeeds.
Particularly on iOS, the page navigates and populates
the search bar with the text/content of the element to be dropped.
To fix the navigating issue, make dropping in a remote frame work.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/DragClient.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::performDragOperation):
(WebCore::DragController::concludeEditDrag):
* Source/WebCore/page/DragController.h:
(WebCore::DragController::client const):
Add hit testing for remote frames and traverse until the correct
target frame is reached.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::contentFrameForNode):
(WebCore::EventHandler::updateDragAndDrop):
(WebCore::EventHandler::cancelDragAndDrop):
(WebCore::EventHandler::performDragAndDrop):
* Source/WebCore/page/EventHandler.h:
If there is a remote frame, get the RemoteUserInputEventData
and propagate drag &amp; drop until the current frame is the target frame.

* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::grantAccessToCurrentPasteboardData):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::propagateDragAndDrop):
(WebKit::WebPageProxy::fetchSandboxExtensionsForDragAction):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp:
(WebKit::WebDragClient::willPerformDragDestinationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::propagateDragAndDrop):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::performDragControllerAction):
(WebKit::WebPage::performDragOperation):
(WebKit::WebPage::fetchSandboxExtensionsForDragAction):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
(WebDragClient::willPerformDragDestinationAction):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _tryToPerformDataInteraction:client:global:operation:]):
(-[WebView performDragOperation:]):
Send an IPC message to performDragOperation on the correct frame,
passing the frame identifier.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, DragAndDropWithoutNavigation)):
Add a test that tests dragging and dropping within an iframe. This should
be allowed since dragging and dropping is within a single frame aka
same origin.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ca1973b0daee30ec610b5510add2503495e4b5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130489 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82089 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99418 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67294 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80117 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81166 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110507 "Found 2 new API test failures: TestWebKitAPI.WKAttachmentTestsIOS.TargetedPreviewsWhenDroppingImages, TestWebKitAPI.WKAttachmentTestsIOS.TargetedPreviewIsClippedWhenDroppingTallImage (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140386 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107931 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107841 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55528 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2620 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66008 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2439 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2641 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->