### PR TITLE
Web Inspector: extra scripts who don't define global functions are not available in devtools.

### DIFF
--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -222,8 +222,7 @@ UnlinkedFunctionExecutable* UnlinkedFunctionExecutable::fromGlobalCode(
     OptionSet<CodeGenerationMode> codeGenerationMode = globalObject->defaultCodeGenerationMode();
     UnlinkedFunctionExecutable* executable = codeCache->getUnlinkedGlobalFunctionExecutable(vm, name, source, lexicallyScopedFeatures, codeGenerationMode, functionConstructorParametersEndPosition, error);
 
-    if (globalObject->hasDebugger())
-        globalObject->debugger()->sourceParsed(globalObject, source.provider(), error.line(), error.message());
+    globalObject->sourceParsed(source.provider(), error.line(), error.message());
 
     if (error.isValid()) {
         exception = error.toErrorObject(globalObject, source, overrideLineNumber);

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -170,25 +170,6 @@ void Debugger::attach(JSGlobalObject* globalObject)
     m_globalObjects.add(globalObject);
 
     m_vm.setShouldBuildPCToCodeOriginMapping();
-
-    // Call `sourceParsed` after iterating because it will execute JavaScript in Web Inspector.
-    UncheckedKeyHashSet<RefPtr<SourceProvider>> sourceProviders;
-    {
-        JSLockHolder locker(m_vm);
-        HeapIterationScope iterationScope(m_vm.heap);
-        m_vm.heap.objectSpace().forEachLiveCell(iterationScope, [&] (HeapCell* heapCell, HeapCell::Kind kind) {
-            if (isJSCellKind(kind)) {
-                auto* cell = static_cast<JSCell*>(heapCell);
-                if (auto* function = jsDynamicCast<JSFunction*>(cell)) {
-                    if (function->scope()->globalObject() == globalObject && function->executable()->isFunctionExecutable() && !function->isHostOrBuiltinFunction())
-                        sourceProviders.add(jsCast<FunctionExecutable*>(function->executable())->source().provider());
-                }
-            }
-            return IterationStatus::Continue;
-        });
-    }
-    for (auto& sourceProvider : sourceProviders)
-        sourceParsed(globalObject, sourceProvider.get(), -1, nullString());
 }
 
 void Debugger::detach(JSGlobalObject* globalObject, ReasonForDetach reason)

--- a/Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp
@@ -55,8 +55,7 @@ DirectEvalExecutable* DirectEvalExecutable::create(JSGlobalObject* globalObject,
     // We don't bother with CodeCache here because direct eval uses a specialized DirectEvalCodeCache.
     UnlinkedEvalCodeBlock* unlinkedEvalCode = generateUnlinkedCodeBlockForDirectEval(vm, executable, executable->source(), JSParserScriptMode::Classic, codeGenerationMode, error, evalContextType, variablesUnderTDZ, privateNameEnvironment);
 
-    if (globalObject->hasDebugger())
-        globalObject->debugger()->sourceParsed(globalObject, executable->source().provider(), error.line(), error.message());
+    globalObject->sourceParsed(executable->source().provider(), error.line(), error.message());
 
     if (error.isValid()) {
         throwVMError(globalObject, scope, error.toErrorObject(globalObject, executable->source()));

--- a/Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp
@@ -56,8 +56,7 @@ inline IndirectEvalExecutable* IndirectEvalExecutable::createImpl(JSGlobalObject
     UnlinkedEvalCodeBlock* unlinkedEvalCode = vm.codeCache()->getUnlinkedEvalCodeBlock(
         vm, executable, executable->source(), codeGenerationMode, error, evalContextType);
 
-    if (globalObject->hasDebugger())
-        globalObject->debugger()->sourceParsed(globalObject, executable->source().provider(), error.line(), error.message());
+    globalObject->sourceParsed(executable->source().provider(), error.line(), error.message());
 
     if (error.isValid()) {
         errorHandler(executable->source(), &error);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -245,6 +245,7 @@
 #include "ShadowRealmObjectInlines.h"
 #include "ShadowRealmPrototypeInlines.h"
 #include "SourceCodeKey.h"
+#include "SourceProvider.h"
 #include "StrictEvalActivationInlines.h"
 #include "StringConstructorInlines.h"
 #include "StringIteratorPrototypeInlines.h"
@@ -3612,8 +3613,11 @@ WeakPtr<ConsoleClient> JSGlobalObject::consoleClient() const
 void JSGlobalObject::setDebugger(Debugger* debugger)
 {
     m_debugger = debugger;
-    if (debugger)
+    if (debugger) {
         vm().ensureShadowChicken();
+        for (auto& sourceProvider : m_sourceProviders)
+            debugger->sourceParsed(this, sourceProvider.get(), -1, nullString());
+    }
 }
 
 bool JSGlobalObject::hasInteractiveDebugger() const 
@@ -3762,5 +3766,12 @@ Ref<JSGlobalObjectDebuggable> JSGlobalObject::protectedInspectorDebuggable()
     return inspectorDebuggable();
 }
 #endif
+
+void JSGlobalObject::sourceParsed(RefPtr<SourceProvider> sourceProvider, int errorLine, const String& errorMessage)
+{
+    m_sourceProviders.add(sourceProvider);
+    if (m_debugger)
+        m_debugger->sourceParsed(this, sourceProvider.get(), errorLine, errorMessage);
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/Watchpoint.h>
 #include <JavaScriptCore/WeakGCSet.h>
 #include <wtf/FixedVector.h>
+#include <wtf/HashSet.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -115,6 +116,7 @@ class ShadowRealmConstructor;
 class ShadowRealmPrototype;
 class SourceCodeKey;
 class SourceOrigin;
+class SourceProvider;
 class StringConstructor;
 class WrapperMap;
 class WrapForValidIteratorPrototype;
@@ -677,6 +679,8 @@ public:
 
     std::optional<unsigned> stackTraceLimit() const { return m_stackTraceLimit; }
     void setStackTraceLimit(std::optional<unsigned> value) { m_stackTraceLimit = value; }
+
+    void sourceParsed(RefPtr<SourceProvider>, int errorLine, const String& errorMessage);
 
     JS_EXPORT_PRIVATE void startSignpost(String&&);
     JS_EXPORT_PRIVATE void stopSignpost(String&&);
@@ -1246,6 +1250,8 @@ private:
 #ifdef JSC_GLIB_API_ENABLED
     std::unique_ptr<WrapperMap> m_wrapperMap;
 #endif
+
+    HashSet<RefPtr<SourceProvider>> m_sourceProviders;
 };
 
 inline JSObject* JSScope::globalThis()

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
@@ -55,8 +55,7 @@ UnlinkedModuleProgramCodeBlock* ModuleProgramExecutable::getUnlinkedCodeBlock(JS
     OptionSet<CodeGenerationMode> codeGenerationMode = globalObject->defaultCodeGenerationMode();
     unlinkedModuleProgramCode = vm.codeCache()->getUnlinkedModuleProgramCodeBlock(vm, this, source(), codeGenerationMode, error);
 
-    if (globalObject->hasDebugger())
-        globalObject->debugger()->sourceParsed(globalObject, source().provider(), error.line(), error.message());
+    globalObject->sourceParsed(source().provider(), error.line(), error.message());
 
     if (error.isValid()) {
         throwVMError(globalObject, throwScope, error.toErrorObject(globalObject, source()));

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -94,8 +94,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
     UnlinkedProgramCodeBlock* unlinkedCodeBlock = vm.codeCache()->getUnlinkedProgramCodeBlock(
         vm, this, source(), codeGenerationMode, error);
 
-    if (globalObject->hasDebugger())
-        globalObject->debugger()->sourceParsed(globalObject, source().provider(), error.line(), error.message());
+    globalObject->sourceParsed(source().provider(), error.line(), error.message());
 
     if (error.isValid())
         return error.toErrorObject(globalObject, source());


### PR DESCRIPTION
#### 8347dbef461c871d06130076a18ed37429bc80b8
<pre>
Web Inspector: extra scripts who don&apos;t define global functions are not available in devtools.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301970">https://bugs.webkit.org/show_bug.cgi?id=301970</a>
<a href="https://rdar.apple.com/164039465">rdar://164039465</a>

Reviewed by NOBODY (OOPS!).

Instead of relying on some heuristic to try to gather the list of source
provider when needed, we store references to all source providers on the
global object. When a debugger is attached, we can just iterate trought
that list, and expose them to the debugger.

No new tests (OOPS!).

* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::fromGlobalCode):
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::attach):
* Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp:
(JSC::DirectEvalExecutable::create):
* Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp:
(JSC::IndirectEvalExecutable::createImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::setDebugger):
(JSC::JSGlobalObject::sourceParsed):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp:
(JSC::ModuleProgramExecutable::getUnlinkedCodeBlock):
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8347dbef461c871d06130076a18ed37429bc80b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80947 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db314664-4cc9-4cde-9faf-b71cc0802ebf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98659 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66529 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d269d170-2769-4e93-965a-d8eba0b4f7c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132465 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1327 "Found 2 new test failures: fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79307 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ce74c29-2ac7-456a-a7ec-040ed0422e14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1248 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34139 "Found 1 new test failure: inspector/debugger/scriptParsed.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80175 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121510 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109718 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34637 "Found 1 new test failure: inspector/debugger/scriptParsed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139375 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127970 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1565 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1500 "Found 1 new test failure: inspector/debugger/scriptParsed.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107174 "Found 1 new test failure: inspector/debugger/scriptParsed.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107015 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1276 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30867 "Found 1 new test failure: inspector/debugger/scriptParsed.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54257 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64999 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160984 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1456 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40155 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1490 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1558 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->