### PR TITLE
[JSC] GreedyRegAlloc: handle use/def count overflow gracefully

### DIFF
--- a/JSTests/wasm/stress/deeply-nested-loops-use-counts.js
+++ b/JSTests/wasm/stress/deeply-nested-loops-use-counts.js
@@ -1,0 +1,85 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+function generateNestedLoops(depth, numAccumulators) {
+    let wat = `(module
+  (func (export "nestedLoops") (param $iterations i32) (result i32)
+`;
+
+    // Declare local variables for loop counters
+    for (let i = 0; i < depth; i++)
+        wat += `    (local $i${i} i32)\n`;
+
+    // Declare accumulator variables for register pressure
+    for (let i = 0; i < numAccumulators; i++)
+        wat += `    (local $acc${i} i32)\n`;
+    wat += `\n`;
+
+    let loopCode = '';
+
+    // Generate opening of all nested loops
+    for (let i = 0; i < depth; i++)
+        loopCode += `    ${'  '.repeat(i)}(loop $loop${i}\n`;
+
+    // Generate innermost body - increment all accumulators with different amounts
+    for (let i = 0; i < numAccumulators; i++)
+        loopCode += `    ${'  '.repeat(depth)}(local.set $acc${i} (i32.add (local.get $acc${i}) (i32.const ${i + 1})))\n`;
+
+    // Generate closing of all nested loops (in reverse)
+    for (let i = depth - 1; i >= 0; i--) {
+        // Increment counter
+        loopCode += `    ${'  '.repeat(i)}  (local.set $i${i} (i32.add (local.get $i${i}) (i32.const 1)))\n`;
+        // Loop condition - continue if counter < iterations
+        loopCode += `    ${'  '.repeat(i)}  (br_if $loop${i} (i32.lt_u (local.get $i${i}) (local.get $iterations)))\n`;
+        // Reset counter for next outer loop iteration (except for the outermost loop)
+        if (i > 0)
+            loopCode += `    ${'  '.repeat(i)}  (local.set $i${i} (i32.const 0))\n`;
+        // Close the loop
+        loopCode += `    ${'  '.repeat(i)})\n`;
+    }
+
+    wat += loopCode;
+
+    // Return the sum of all accumulators
+    if (numAccumulators === 0)
+        wat += `    (i32.const 0)\n`;
+    else if (numAccumulators === 1)
+        wat += `    (local.get $acc0)\n`;
+    else {
+        // Generate a left-associative nested chain of additions
+        // ((acc0 + acc1) + acc2) + acc3) ...
+        wat += `    `;
+        for (let i = 1; i < numAccumulators; i++) {
+            wat += `(i32.add `;
+        }
+        wat += `(local.get $acc0)`;
+        for (let i = 1; i < numAccumulators; i++) {
+            wat += ` (local.get $acc${i}))`;
+        }
+        wat += `\n`;
+    }
+
+    wat += `  )
+)`;
+    return wat;
+}
+
+async function test() {
+    const depth = 50;
+    const numAccumulators = 40;
+ 
+    const wat = generateNestedLoops(depth, numAccumulators);
+
+    // Compile and instantiate the module
+    const instance = await instantiate(wat, {}, {});
+
+    // Calculate expected result: sum of 1+2+3+...+numAccumulators = n*(n+1)/2
+    const expectedSum = (numAccumulators * (numAccumulators + 1)) / 2;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        const result1 = instance.exports.nestedLoops(1);
+        assert.eq(result1, expectedSum);
+    }
+}
+
+await assert.asyncTest(test());


### PR DESCRIPTION
#### 59f3afb044ea756dd8beaaca10ebd6262ce10646
<pre>
[JSC] GreedyRegAlloc: handle use/def count overflow gracefully
<a href="https://rdar.apple.com/163797828">rdar://163797828</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301962">https://bugs.webkit.org/show_bug.cgi?id=301962</a>

Reviewed by Yusuke Suzuki.

B3::Air::UseCounts stores its counts in a float array. The basic
block frequency estimator code uses a factor of 10 for each level
of loop nesting. So, if a function has more than around 40 levels
of nested loops, the use/def counts can overflow and become infinity.

This inf value flows into the register allocator&apos;s spill cost heuristic,
causing the spill cost to be inf. Inf is used to represent the cost
of unspillable Tmps, so if there is enough register pressure, the
register allocator can get confused and decide it&apos;s run out of
registers and fail.

To fix this, cap the maximum spill cost of spillable Tmps.

Bonus fix: due to how the high 64-bit clobbers of SIMD vector registers
are modeled, these clobbers are not represented as true live ranges.
This caused an assert to trigger when trying to dump the register
allocator state in the above situation. The assert is not valid
for register Tmps for that reason - a register Tmp can have no live
ranges yet still conflict because of these high 64 vector clobbers.
Move the assert slightly for this reason.

Bonus cleanup: remove the !spillCostDivideBySize heuristic; there&apos;s no need
to keep the other side of this experiment around.

Test: JSTests/wasm/stress/deeply-nested-loops-use-counts.js
* JSTests/wasm/stress/deeply-nested-loops-use-counts.js: Added.
(generateNestedLoops):
(async test):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::TmpData::spillCost):

Canonical link: <a href="https://commits.webkit.org/302588@main">https://commits.webkit.org/302588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b349f5cf239e80dd629776e8bd2fe8ddba8f4b59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80951 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5d847f93-db64-45da-9640-7914accd1b74) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98654 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66523 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d21da1be-d3ac-4c01-a586-9dd54022b648) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79301 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/27f5d867-68c2-4766-86fd-186fa298b65e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80178 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121513 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139378 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127973 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107178 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107019 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54260 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20218 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65002 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160987 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1459 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40156 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1561 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->