### PR TITLE
[WIP] script injected with evaluateJavaScript in an uncommited frame is not cleared when the document gets created.

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -322,6 +322,7 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
         return;
 
     m_documentIsBeingReplaced = true;
+    resetScript();
 
     if (isMainFrame()) {
         if (RefPtr page = this->page())


### PR DESCRIPTION
#### 49afe2d3fa33d7a0313ca559ab53a626699155f4
<pre>
[WIP] script injected with evaluateJavaScript in an uncommited frame is not cleared when the document gets created.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301978">https://bugs.webkit.org/show_bug.cgi?id=301978</a>
<a href="https://rdar.apple.com/164053681">rdar://164053681</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::setDocument):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49afe2d3fa33d7a0313ca559ab53a626699155f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80961 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c75d90f6-ef0f-4d96-86a9-8dc0a48d9457) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1662 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98671 "Failure limit exceed. At least found 118 new test failures: fast/dom/Window/dom-access-from-closure-iframe.html fast/dom/Window/dom-access-from-closure-window-with-gc.html fast/dom/Window/dom-access-from-closure-window.html fast/dom/Window/window-access-after-navigation.html fast/dom/Window/window-open-self-as-opener.html fast/events/pagehide-timeout.html fast/events/pagehide-xhr-open.html fast/events/pageshow-pagehide-on-back-cached-with-frames.html fast/events/suspend-timers.html fast/forms/autocomplete-off-with-default-value-does-not-clear.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66526 "Found 60 new test failures: fast/dom/Window/dom-access-from-closure-iframe.html fast/dom/Window/dom-access-from-closure-window-with-gc.html fast/dom/Window/dom-access-from-closure-window.html fast/dom/Window/window-access-after-navigation.html fast/dom/Window/window-open-self-as-opener.html fast/dom/frame-src-javascript-url-async.html fast/dom/javascript-url-crash-function.html fast/dom/null-document-location-href-put-crash.html fast/dom/null-document-location-replace-crash.html fast/dom/null-inline-style.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc66d62e-97ff-4190-a418-628bd5590989) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132476 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1331 "Found 60 new test failures: contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-will-send-request-then-deny-unblock.html editing/selection/ios/become-first-responder-after-relinquishing-focus.html fast/canvas/canvas-drawImage-detached-leak.html fast/dom/Window/dom-access-from-closure-iframe.html fast/dom/Window/dom-access-from-closure-window-with-gc.html fast/dom/Window/dom-access-from-closure-window.html fast/dom/Window/window-access-after-navigation.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116018 "Found 12 new API test failures: TestWebKitAPI.DeviceScaleFactorOnBack.WebKit, TestWebKitAPI.ProcessSwap.NavigateCrossOriginWithOpener, TestWebKitAPI.SiteIsolation.NavigateOpener, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup4, TestWebKitAPI.WebKit.KeepPermissionForWebAppSameOriginNavigations, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup3, TestWebKitAPI.WebKitLegacy.JSDOMWindowWrapperBeforeOriginInitialization, TestWebKitAPI.WKWebExtensionAPITabs.SendMessageBackAndForwardNavigation, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup2, TestWebKitAPI.DeviceScaleFactorOnBack.WebKit2 ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79308 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b7f86c6-8a4a-4972-9af0-7b400c49876c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1252 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window.html imported/w3c/web-platform-tests/IndexedDB/database-names-by-origin.html imported/w3c/web-platform-tests/IndexedDB/idb-partitioned-coverage.sub.html imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-url-inherits-from-initiator.sub.html imported/w3c/web-platform-tests/content-security-policy/inheritance/iframe-all-local-schemes-inherit-self.sub.html imported/w3c/web-platform-tests/content-security-policy/inheritance/iframe-all-local-schemes.sub.html imported/w3c/web-platform-tests/content-security-policy/inheritance/inheritance-from-initiator.sub.html imported/w3c/web-platform-tests/content-security-policy/inheritance/javascript-url-srcdoc-cross-origin-iframe-inheritance.html imported/w3c/web-platform-tests/content-security-policy/inheritance/location-reload.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34149 "Found 60 new test failures: animations/animation-timeline-does-not-leak.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-will-send-request-then-deny-unblock.html editing/mac/input/unconfirmed-text-navigation-with-page-cache.html editing/mac/selection/word-thai-does-not-leak.html fast/canvas/canvas-gradient-can-outlive-context.html fast/css/contain-intrinsic-size-does-not-leak.html fast/css/content-visibility-zoom.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80186 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109722 "Found 7 new API test failures: TestWebKitAPI.SiteIsolation.NavigateOpener, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup4, TestWebKitAPI.WebKit.KeepPermissionForWebAppSameOriginNavigations, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup2, TestWebKitAPI.WKWebExtensionAPITabs.SendMessageBackAndForwardNavigation, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup3, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34647 "Found 60 new test failures: accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html accessibility/mac/replaced-element-text-selection.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-will-send-request-then-deny-unblock.html fast/css/aspect-ratio-min-height-replaced.html fast/dom/Window/dom-access-from-closure-iframe.html fast/dom/Window/dom-access-from-closure-window-with-gc.html fast/dom/Window/dom-access-from-closure-window.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139386 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1576 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1506 "Found 60 new test failures: accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-will-send-request-then-deny-unblock.html css3/filters/backdrop/effect-hw.html fast/canvas/webgl/debug-messages-to-console.html fast/dom/Window/dom-access-from-closure-iframe.html fast/dom/Window/dom-access-from-closure-window-with-gc.html fast/dom/Window/dom-access-from-closure-window.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107184 "Found 163 new test failures: fast/dom/Window/dom-access-from-closure-iframe.html fast/dom/Window/dom-access-from-closure-window-with-gc.html fast/dom/Window/dom-access-from-closure-window.html fast/dom/Window/window-access-after-navigation.html fast/dom/Window/window-open-self-as-opener.html fast/dom/javascript-url-crash-function.html fast/dom/set-dom-window-without-page.html fast/events/frame-programmatic-focus.html fast/events/pagehide-timeout.html fast/events/pagehide-xhr-open.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107025 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1283 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30874 "Found 60 new test failures: accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-will-send-request-then-deny-unblock.html css3/flexbox/flex-item-margin-top-no-crash.html fast/dom/Window/dom-access-from-closure-iframe.html fast/dom/Window/dom-access-from-closure-window-with-gc.html fast/dom/Window/dom-access-from-closure-window.html fast/dom/Window/window-access-after-navigation.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65010 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1467 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1501 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1569 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->