### PR TITLE
REGRESSION (298476@main): [AX] Crash under WebCore::Editor::respondToChangedContents when VoiceOver is enabled

### DIFF
--- a/LayoutTests/accessibility/crash-when-deleting-hidden-element-expected.txt
+++ b/LayoutTests/accessibility/crash-when-deleting-hidden-element-expected.txt
@@ -1,0 +1,4 @@
+ successfullyParsed is true
+
+TEST COMPLETE
+PASS

--- a/LayoutTests/accessibility/crash-when-deleting-hidden-element.html
+++ b/LayoutTests/accessibility/crash-when-deleting-hidden-element.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script>
+window.accessibilityController?.enableEnhancedAccessibility(true);
+
+addEventListener("load", () => {
+    document.execCommand("SelectAll");
+    const span = document.getElementsByTagName("span")[0];
+    span.contentEditable = true;
+    span.textContent = "bar";
+    document.execCommand("InsertText", false, "b");
+    document.body.textContent = "PASS";
+});
+</script>
+
+<style>
+* {
+    visibility: visible;
+}
+
+.inline {
+    display: inline;
+}
+
+* :only-child {
+    visibility: hidden;
+}
+</style>
+</head>
+<body>
+    <table>
+    <tr><td><span><table></table><span></span></span></td></tr>
+    <tr><td><td style="height: 100px;" class="inline">a</td></tr>
+    </table>
+</body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -838,9 +838,10 @@ bool Editor::shouldInsertText(const String& text, const std::optional<SimpleRang
 void Editor::respondToChangedContents(const VisibleSelection& endingSelection)
 {
     if (AXObjectCache::accessibilityEnabled()) {
-        RefPtr node = endingSelection.start().deprecatedNode();
-        if (AXObjectCache* cache = document().existingAXObjectCache())
-            cache->onEditableTextValueChanged(*node.get());
+        if (RefPtr node = endingSelection.start().deprecatedNode()) {
+            if (AXObjectCache* cache = document().existingAXObjectCache())
+                cache->onEditableTextValueChanged(*node.get());
+        }
     }
 
     updateMarkersForWordsAffectedByEditing(true);


### PR DESCRIPTION
#### 8bc3a0eefb4fd0e2bf42c27c8d7ca409fd631cd0
<pre>
REGRESSION (298476@main): [AX] Crash under WebCore::Editor::respondToChangedContents when VoiceOver is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=301982">https://bugs.webkit.org/show_bug.cgi?id=301982</a>
<a href="https://rdar.apple.com/163230929">rdar://163230929</a>

Reviewed by Abrar Rahman Protyasha.

Restore a null check for `node` in `Editor::respondToChangedContents` that was (effectively) removed
in 298476@main. Prior to that patch, we only passed a pointer into `AXObjectCache::postNotification`,
which would become a no-op if the `node` was null. After that change, we now (incorrectly) assume
the `node` is non-null and dereference it.

The selection start node might be null in the case where, while processing the editing command, we
mutated the DOM in such a way that the selection anchor is no longer connected or editable.

Test: accessibility/crash-when-deleting-hidden-element.html

* LayoutTests/accessibility/crash-when-deleting-hidden-element-expected.txt: Added.
* LayoutTests/accessibility/crash-when-deleting-hidden-element.html: Added.

Add a layout test to exercise the fix by verifying that we don&apos;t crash when accessibility is
enabled, under this codepath.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::respondToChangedContents):

Canonical link: <a href="https://commits.webkit.org/302581@main">https://commits.webkit.org/302581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8519ad7f5b71a00dd00c75c0739949bf28430419

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80991 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c6be663e-2b1b-4ee6-9a22-c9165992ae19) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98686 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66543 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c1b49532-c700-4238-94bb-2660661b8d97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dcbdb70e-b1a6-488c-bf61-a6fa2f5e427b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34175 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80216 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139415 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107208 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27259 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54307 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65038 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1529 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->