### PR TITLE
Address Safer CPP warning in WKView.h

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -343,7 +343,11 @@
 /* WK_UNUSED_INSTANCE_VARIABLE */
 
 #if !defined(WK_UNUSED_INSTANCE_VARIABLE)
+#if COMPILER_HAS_ATTRIBUTE(suppress)
+#define WK_UNUSED_INSTANCE_VARIABLE [[clang::suppress]] __attribute__((unused))
+#else
 #define WK_UNUSED_INSTANCE_VARIABLE __attribute__((unused))
+#endif
 #endif
 
 /* UNUSED_FUNCTION */

--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,4 +1,3 @@
-[ Mac ] UIProcess/API/Cocoa/WKView.h
 [ iOS ] Platform/ios/PaymentAuthorizationController.mm
 [ iOS ] UIProcess/API/Cocoa/WKPreviewActionItem.h
 [ iOS ] UIProcess/API/Cocoa/WKSnapshotConfiguration.h

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,3 +1,11 @@
+WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+WebCoreSupport/WebCryptoClient.h
+[ iOS ] ios/Misc/WebGeolocationProviderIOS.mm
+[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
+[ iOS ] ios/WebCoreSupport/WebGeolocationPrivate.h
+[ iOS ] ios/WebView/WebPDFViewIOS.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.h
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
 [ Mac ] mac/DefaultDelegates/WebDefaultUIDelegate.h
 mac/History/BackForwardList.h
 mac/History/WebBackForwardList.h
@@ -5,7 +13,6 @@ mac/History/WebHistory.h
 mac/History/WebHistoryItem.h
 mac/Misc/WebDownload.h
 mac/Misc/WebElementDictionary.h
-[ Mac ] mac/Misc/WebIconDatabase.h
 mac/Misc/WebLocalizableStrings.h
 [ Mac ] mac/Misc/WebSharingServicePickerController.h
 mac/Misc/WebUserContentURLPattern.h
@@ -29,12 +36,14 @@ mac/WebCoreSupport/WebProgressTrackerClient.h
 mac/WebCoreSupport/WebValidationMessageClient.h
 mac/WebInspector/WebInspector.h
 mac/WebInspector/WebNodeHighlight.h
-mac/WebInspector/WebNodeHighlighter.h
 mac/WebInspector/WebNodeHighlightView.h
+mac/WebInspector/WebNodeHighlighter.h
 mac/WebView/WebArchive.h
+[ iOS ] mac/WebView/WebDataSource.mm
 mac/WebView/WebDeviceOrientation.h
 mac/WebView/WebDeviceOrientationProviderMock.h
 mac/WebView/WebDocumentLoaderMac.h
+[ iOS ] mac/WebView/WebFeature.h
 mac/WebView/WebFrame.h
 mac/WebView/WebFrameView.h
 mac/WebView/WebFrameView.mm
@@ -44,6 +53,7 @@ mac/WebView/WebHTMLRepresentation.h
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.h
 mac/WebView/WebHTMLView.mm
+[ iOS ] mac/WebView/WebIndicateLayer.h
 mac/WebView/WebNavigationData.h
 mac/WebView/WebNotification.h
 [ Mac ] mac/WebView/WebPDFView.h
@@ -59,17 +69,6 @@ mac/WebView/WebTextIterator.h
 mac/WebView/WebView.h
 mac/WebView/WebView.mm
 mac/WebView/WebViewData.h
-[ Mac ] mac/WebView/WebWindowAnimation.h
-WebCoreSupport/SocketStreamHandleImplCFNet.cpp
-WebCoreSupport/WebCryptoClient.h
-[ iOS ] ios/Misc/WebGeolocationProviderIOS.mm
-[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
-[ iOS ] ios/WebCoreSupport/WebGeolocationPrivate.h
-[ iOS ] ios/WebView/WebPDFViewIOS.mm
-[ iOS ] ios/WebView/WebPDFViewPlaceholder.h
-[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
-[ iOS ] mac/WebView/WebDataSource.mm
-[ iOS ] mac/WebView/WebFeature.h
-[ iOS ] mac/WebView/WebIndicateLayer.h
 [ iOS ] mac/WebView/WebViewPrivate.h
 [ iOS ] mac/WebView/WebViewRenderingUpdateScheduler.h
+[ Mac ] mac/WebView/WebWindowAnimation.h


### PR DESCRIPTION
#### e54a6839fd1cd171a308108f780daac5a0f48ac4
<pre>
Address Safer CPP warning in WKView.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=301986">https://bugs.webkit.org/show_bug.cgi?id=301986</a>

Reviewed by Ryosuke Niwa.

WKView.h has an unused instance variable that is flagged as unsafe by safer cpp
due to using a raw pointer. However, I cannot modify this header due to backward
compatibility. Also, the code is not truly unsafe since this instance variable
is unused. To silence the warning I am adding `[[clang::suppress]]` to
`WK_UNUSED_INSTANCE_VARIABLE` to ignore compiler warnings on unused instance
variables.

* Source/WTF/wtf/Compiler.h:
* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/302619@main">https://commits.webkit.org/302619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dc3b793259cb1e35025f256b556596e8dcd1ee9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129578 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81016 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1cda796-5725-4360-8f6b-178ec263d800) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98704 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66559 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79368 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2096ee32-df91-4aa8-8182-daf93351125d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80237 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121570 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139436 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128030 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107224 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54343 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65059 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161044 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1516 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40168 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->