### PR TITLE
Make AVTrackPrivateAVFObjCImpl be a ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
@@ -35,9 +35,9 @@
 #include "VideoTrackPrivate.h"
 #include <wtf/Observer.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS AVAssetTrack;
 OBJC_CLASS AVPlayerItem;
@@ -55,7 +55,7 @@ struct PlatformVideoTrackConfiguration;
 struct PlatformAudioTrackConfiguration;
 struct VideoProjectionMetadata;
 
-class AVTrackPrivateAVFObjCImpl final : public RefCountedAndCanMakeWeakPtr<AVTrackPrivateAVFObjCImpl> {
+class AVTrackPrivateAVFObjCImpl final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AVTrackPrivateAVFObjCImpl, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(AVTrackPrivateAVFObjCImpl);
 public:
     static Ref<AVTrackPrivateAVFObjCImpl> create(AVPlayerItemTrack* track) { return adoptRef(*new AVTrackPrivateAVFObjCImpl(track)); }
@@ -74,24 +74,24 @@ public:
     VideoTrackPrivate::Kind videoKind() const;
     InbandTextTrackPrivate::Kind textKind() const;
 
-    static InbandTextTrackPrivate::Kind textKindForAVAssetTrack(const AVAssetTrack*);
-    static InbandTextTrackPrivate::Kind textKindForAVMediaSelectionOption(const AVMediaSelectionOption*);
+    static InbandTextTrackPrivate::Kind textKindForAVAssetTrack(const AVAssetTrack *);
+    static InbandTextTrackPrivate::Kind textKindForAVMediaSelectionOption(const AVMediaSelectionOption *);
 
     int index() const;
     TrackID id() const;
     String label() const;
     String language() const;
 
-    static String languageForAVAssetTrack(AVAssetTrack*);
-    static String languageForAVMediaSelectionOption(AVMediaSelectionOption *);
+    static String languageForAVAssetTrack(const AVAssetTrack *);
+    static String languageForAVMediaSelectionOption(const AVMediaSelectionOption *);
 
     PlatformVideoTrackConfiguration videoTrackConfiguration() const;
     using VideoTrackConfigurationObserver = Observer<void()>;
-    void setVideoTrackConfigurationObserver(VideoTrackConfigurationObserver& observer) { m_videoTrackConfigurationObserver = observer; }
+    void setVideoTrackConfigurationObserver(VideoTrackConfigurationObserver&);
 
     PlatformAudioTrackConfiguration audioTrackConfiguration() const;
     using AudioTrackConfigurationObserver = Observer<void()>;
-    void setAudioTrackConfigurationObserver(AudioTrackConfigurationObserver& observer) { m_audioTrackConfigurationObserver = observer; }
+    void setAudioTrackConfigurationObserver(AudioTrackConfigurationObserver&);
 
 private:
     AVTrackPrivateAVFObjCImpl(AVPlayerItemTrack*);

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
@@ -31,9 +31,9 @@
 #include <wtf/HashMap.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
 OBJC_CLASS AVAssetTrack;
@@ -45,7 +45,7 @@ namespace WebCore {
 
 class MediaSelectionGroupAVFObjC;
 
-class MediaSelectionOptionAVFObjC : public RefCountedAndCanMakeWeakPtr<MediaSelectionOptionAVFObjC> {
+class MediaSelectionOptionAVFObjC : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaSelectionOptionAVFObjC, WTF::DestructionThread::Main> {
 public:
     static Ref<MediaSelectionOptionAVFObjC> create(MediaSelectionGroupAVFObjC&, AVMediaSelectionOption *);
 
@@ -54,7 +54,7 @@ public:
 
     int index() const;
 
-    AVMediaSelectionOption *avMediaSelectionOption() const { return m_mediaSelectionOption.get(); }
+    RetainPtr<AVMediaSelectionOption> avMediaSelectionOption() const { return m_mediaSelectionOption; }
     AVAssetTrack *assetTrack() const;
     AVPlayerItem *playerItem() const;
 
@@ -64,17 +64,17 @@ private:
 
     void clearGroup() { m_group = nullptr; }
 
-    WeakPtr<MediaSelectionGroupAVFObjC> m_group;
+    ThreadSafeWeakPtr<MediaSelectionGroupAVFObjC> m_group;
     RetainPtr<AVMediaSelectionOption> m_mediaSelectionOption;
 };
 
-class MediaSelectionGroupAVFObjC : public RefCountedAndCanMakeWeakPtr<MediaSelectionGroupAVFObjC> {
+class MediaSelectionGroupAVFObjC : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaSelectionGroupAVFObjC, WTF::DestructionThread::Main> {
 public:
     static Ref<MediaSelectionGroupAVFObjC> create(AVPlayerItem*, AVMediaSelectionGroup*, const Vector<String>& characteristics);
     ~MediaSelectionGroupAVFObjC();
 
     void setSelectedOption(MediaSelectionOptionAVFObjC*);
-    MediaSelectionOptionAVFObjC* selectedOption() const { return m_selectedOption.get(); }
+    RefPtr<MediaSelectionOptionAVFObjC> selectedOption() const { return m_selectedOption.get(); }
 
     void updateOptions(const Vector<String>& characteristics);
 
@@ -92,7 +92,7 @@ private:
     RetainPtr<AVPlayerItem> m_playerItem;
     RetainPtr<AVMediaSelectionGroup> m_mediaSelectionGroup;
     OptionContainer m_options;
-    WeakPtr<MediaSelectionOptionAVFObjC> m_selectedOption;
+    ThreadSafeWeakPtr<MediaSelectionOptionAVFObjC> m_selectedOption;
     Timer m_selectionTimer;
     bool m_shouldSelectOptionAutomatically { true };
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2357,8 +2357,10 @@ void MediaPlayerPrivateAVFoundationObjC::tracksChanged()
         updateAudioTracks();
         updateVideoTracks();
 
-        hasAudio |= (m_audibleGroup && m_audibleGroup->selectedOption());
-        hasVideo |= (m_visualGroup && m_visualGroup->selectedOption());
+        RefPtr audibleGroup = m_audibleGroup;
+        RefPtr visualGroup = m_visualGroup;
+        hasAudio |= (audibleGroup && audibleGroup->selectedOption());
+        hasVideo |= (visualGroup && visualGroup->selectedOption());
 
         // HLS streams will occasionally recreate all their tracks; during seek and after
         // buffering policy changes. "debounce" notifications which result in no enabled
@@ -2485,7 +2487,7 @@ void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* 
     for (auto& option : group->options()) {
         if (!option)
             continue;
-        AVMediaSelectionOption* avOption = option->avMediaSelectionOption();
+        RetainPtr avOption = option->avMediaSelectionOption();
         if (!avOption)
             continue;
         newSelectionOptions.add(option);


### PR DESCRIPTION
#### 70946f63bb9c058cbd94a2d29ebbae260e5ce105
<pre>
Make AVTrackPrivateAVFObjCImpl be a ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=301988">https://bugs.webkit.org/show_bug.cgi?id=301988</a>
<a href="https://rdar.apple.com/164063921">rdar://164063921</a>

Reviewed by Youenn Fablet.

Similar with its companions MediaSelectionOptionAVFObjC and MediaSelectionGroupAVFObjC.
We also update it for modern coding style.

No change in observable behaviour.

Canonical link: <a href="https://commits.webkit.org/302656@main">https://commits.webkit.org/302656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba118b39e600053637d100dd2093a0390f5dba60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81285 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f3e13e0f-b6fa-4761-9b1b-f669a0d564e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98886 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c26d8f9-77f4-4a0b-9bae-831cdda6927d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79567 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c83f956b-6c2f-4756-a737-d987ad2c4504) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80472 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139681 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107394 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107271 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1501 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54651 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65306 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1751 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->