### PR TITLE
[JSC] Do not zero clear all pages for wasm memory initially

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -112,6 +112,7 @@ static RefPtr<BufferMemoryHandle> tryAllocateResizableMemory(VM* vm, size_t size
     constexpr bool readable = false;
     constexpr bool writable = false;
     OSAllocator::protect(slowMemory + initialBytes, maximumBytes - initialBytes, readable, writable);
+    Gigacage::vmZeroAndPurge(slowMemory, initialBytes);
     return adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, maximumBytes, PageCount::fromBytes(initialBytes), PageCount::fromBytes(maximumBytes), MemorySharingMode::Shared, MemoryMode::BoundsChecking));
 }
 
@@ -519,8 +520,8 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
             size_t desiredSize = newPageCount.bytes();
             RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
 
-            if (desiredSize > memoryHandle->size()) {
-                size_t bytesToAdd = desiredSize - memoryHandle->size();
+            if (desiredSize > oldPageCount.bytes()) {
+                size_t bytesToAdd = desiredSize - oldPageCount.bytes();
                 ASSERT(bytesToAdd);
                 ASSERT(roundUpToMultipleOf<PageCount::pageSize>(bytesToAdd) == bytesToAdd);
                 bool allocationSuccess = tryAllocate(&vm,
@@ -534,14 +535,19 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
                 RELEASE_ASSERT(memory);
 
                 // Signaling memory must have been pre-allocated virtually.
-                uint8_t* startAddress = static_cast<uint8_t*>(memory) + memoryHandle->size();
+                uint8_t* startAddress = static_cast<uint8_t*>(memory) + oldPageCount.bytes();
 
                 dataLogLnIf(ArrayBufferInternal::verbose, "Marking memory's ", RawPointer(memory), " as read+write in range [", RawPointer(startAddress), ", ", RawPointer(startAddress + bytesToAdd), ")");
                 constexpr bool readable = true;
                 constexpr bool writable = true;
                 OSAllocator::protect(startAddress, bytesToAdd, readable, writable);
+                Gigacage::vmZeroAndPurge(startAddress, bytesToAdd);
+
+                // oldPageCount -> newPageCount ranges are already zero-cleared via Gigacage::vmZeroAndPurge.
+                if (m_contents.m_sizeInBytes < oldPageCount.bytes())
+                    memset(std::bit_cast<uint8_t*>(data()) + m_contents.m_sizeInBytes, 0, oldPageCount.bytes() - m_contents.m_sizeInBytes);
             } else {
-                size_t bytesToSubtract = memoryHandle->size() - desiredSize;
+                size_t bytesToSubtract = oldPageCount.bytes() - desiredSize;
                 ASSERT(bytesToSubtract);
                 ASSERT(roundUpToMultipleOf<PageCount::pageSize>(bytesToSubtract) == bytesToSubtract);
                 BufferMemoryManager::singleton().freePhysicalBytes(bytesToSubtract);
@@ -558,10 +564,11 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
                 OSAllocator::protect(startAddress, bytesToSubtract, readable, writable);
             }
             memoryHandle->updateSize(desiredSize);
+        } else {
+            // If oldPageCount and newPageCount are the same, only different part should be zero-cleared.
+            if (m_contents.m_sizeInBytes < newByteLength)
+                memset(std::bit_cast<uint8_t*>(data()) + m_contents.m_sizeInBytes, 0, newByteLength - m_contents.m_sizeInBytes);
         }
-
-        if (m_contents.m_sizeInBytes < newByteLength)
-            memset(std::bit_cast<uint8_t*>(data()) + m_contents.m_sizeInBytes, 0, newByteLength - m_contents.m_sizeInBytes);
 
         m_contents.m_sizeInBytes = newByteLength;
     }
@@ -646,13 +653,15 @@ Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(const Abstract
         uint8_t* startAddress = static_cast<uint8_t*>(memory) + memoryHandle->size();
 
         dataLogLnIf(ArrayBufferInternal::verbose, "Marking memory's ", RawPointer(memory), " as read+write in range [", RawPointer(startAddress), ", ", RawPointer(startAddress + extraBytes), ")");
+
+        // Zero clear backing content before calling OSAllocator::protect. We may access to these page region from the concurrent thread (including wasm).
+        // Need to ensure that newly accessible pages are zeroed even from concurrent threads.
+        Gigacage::vmZeroAndPurge(startAddress, extraBytes);
         constexpr bool readable = true;
         constexpr bool writable = true;
         OSAllocator::protect(startAddress, extraBytes, readable, writable);
         memoryHandle->updateSize(desiredSize);
     }
-
-    memset(std::bit_cast<uint8_t*>(data()) + sizeInBytes, 0, newByteLength - sizeInBytes);
 
     updateSize(newByteLength);
     return deltaByteLength;

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -79,7 +79,7 @@ BufferMemoryResult BufferMemoryManager::tryAllocateFastMemory()
         if (m_fastMemories.size() >= m_maxFastMemoryCount)
             return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
 
-        void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, BufferMemoryHandle::fastMappedBytes());
+        void* result = Gigacage::tryAllocateVirtualPages(Gigacage::Primitive, BufferMemoryHandle::fastMappedBytes());
         if (!result)
             return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
 
@@ -110,7 +110,7 @@ BufferMemoryResult BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory(
 {
     BufferMemoryResult result = [&] {
         Locker locker { m_lock };
-        void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, mappedCapacity);
+        void* result = Gigacage::tryAllocateVirtualPages(Gigacage::Primitive, mappedCapacity);
         if (!result)
             return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
 

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -190,6 +190,7 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         constexpr bool readable = false;
         constexpr bool writable = false;
         OSAllocator::protect(fastMemory + initialBytes, BufferMemoryHandle::fastMappedBytes() - initialBytes, readable, writable);
+        Gigacage::vmZeroAndPurge(fastMemory, initialBytes);
         switch (sharingMode) {
         case MemorySharingMode::Default: {
             return Memory::create(vm, adoptRef(*new BufferMemoryHandle(fastMemory, initialBytes, BufferMemoryHandle::fastMappedBytes(), initial, maximum, MemorySharingMode::Default, MemoryMode::Signaling)), WTFMove(growSuccessCallback));
@@ -239,6 +240,7 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         constexpr bool readable = false;
         constexpr bool writable = false;
         OSAllocator::protect(slowMemory + initialBytes, maximumBytes - initialBytes, readable, writable);
+        Gigacage::vmZeroAndPurge(slowMemory, initialBytes);
 
         auto handle = adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, maximumBytes, initial, maximum, MemorySharingMode::Shared, MemoryMode::BoundsChecking));
         auto span = handle->mutableSpan();
@@ -383,6 +385,7 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
         constexpr bool readable = true;
         constexpr bool writable = true;
         OSAllocator::protect(startAddress, extraBytes, readable, writable);
+        Gigacage::vmZeroAndPurge(startAddress, extraBytes);
         m_handle->updateSize(desiredSize);
         return success();
     }

--- a/Source/WTF/wtf/Gigacage.cpp
+++ b/Source/WTF/wtf/Gigacage.cpp
@@ -49,6 +49,41 @@ void* tryRealloc(Kind, void* pointer, size_t size)
     return FastMalloc::tryRealloc(pointer, size);
 }
 
+void* tryAllocateVirtualPages(Kind, size_t requestedSize)
+{
+    size_t size = roundUpToMultipleOf(WTF::pageSize(), requestedSize);
+    RELEASE_ASSERT(size >= requestedSize);
+    void* result = OSAllocator::tryReserveAndCommit(size);
+    return result;
+}
+
+void vmZeroAndPurge(void* p, size_t size)
+{
+    if (!p) [[unlikely]]
+        return;
+
+    if (!size) [[unlikely]]
+        return;
+
+#if OS(WINDOWS)
+    // Guarantees the memory is zeroed. This will also cause
+    // page faults on accesses to this range following this
+    DWORD result = DiscardVirtualMemory(p, size);
+    RELEASE_BASSERT(result == ERROR_SUCCESS);
+#elif OS(DARWIN)
+#error bmalloc needs to be enabled. System malloc can be used via environment variable.
+#else
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0
+#endif
+    int flags = MAP_PRIVATE | MAP_ANON | MAP_FIXED | MAP_NORESERVE;
+    // MAP_ANON guarantees the memory is zeroed. This will also cause
+    // page faults on accesses to this range following this call.
+    void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, flags, -1, 0);
+    RELEASE_BASSERT(result == p);
+#endif
+}
+
 void* tryAllocateZeroedVirtualPages(Kind, size_t requestedSize)
 {
     size_t size = roundUpToMultipleOf(WTF::pageSize(), requestedSize);
@@ -128,12 +163,25 @@ void free(Kind kind, void* p)
     WTF::compilerFence();
 }
 
+void* tryAllocateVirtualPages(Kind kind, size_t size)
+{
+    void* result = bmalloc::api::tryLargeMemalignVirtual(WTF::pageSize(), size, bmalloc::CompactAllocationMode::Compact, bmalloc::heapKind(kind));
+    BPROFILE_TRY_ALLOCATION(GIGACAGE, kind, result, size);
+    WTF::compilerFence();
+    return result;
+}
+
 void* tryAllocateZeroedVirtualPages(Kind kind, size_t size)
 {
     void* result = bmalloc::api::tryLargeZeroedMemalignVirtual(WTF::pageSize(), size, bmalloc::CompactAllocationMode::Compact, bmalloc::heapKind(kind));
     BPROFILE_TRY_ALLOCATION(GIGACAGE, kind, result, size);
     WTF::compilerFence();
     return result;
+}
+
+void vmZeroAndPurge(void* result, size_t size)
+{
+    bmalloc::api::vmZeroAndPurge(result, size);
 }
 
 void freeVirtualPages(Kind kind, void* basePtr, size_t size)

--- a/Source/WTF/wtf/Gigacage.h
+++ b/Source/WTF/wtf/Gigacage.h
@@ -77,8 +77,10 @@ WTF_EXPORT_PRIVATE void* tryZeroedMalloc(Kind, size_t);
 WTF_EXPORT_PRIVATE void* tryRealloc(Kind, void*, size_t);
 inline void free(Kind, void* p) { fastFree(p); }
 
+WTF_EXPORT_PRIVATE void* tryAllocateVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void* tryAllocateZeroedVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void freeVirtualPages(Kind, void* basePtr, size_t size);
+WTF_EXPORT_PRIVATE void vmZeroAndPurge(void*, size_t);
 
 } // namespace Gigacage
 #else
@@ -93,8 +95,10 @@ WTF_EXPORT_PRIVATE void* tryZeroedMalloc(Kind, size_t);
 WTF_EXPORT_PRIVATE void* tryRealloc(Kind, void*, size_t);
 WTF_EXPORT_PRIVATE void free(Kind, void*);
 
+WTF_EXPORT_PRIVATE void* tryAllocateVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void* tryAllocateZeroedVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void freeVirtualPages(Kind, void* basePtr, size_t size);
+WTF_EXPORT_PRIVATE void vmZeroAndPurge(void*, size_t);
 
 } // namespace Gigacage
 #endif

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -67,7 +67,7 @@ void freeOutOfLine(void* object, HeapKind kind)
     free(object, kind);
 }
 
-void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSize, CompactAllocationMode mode, HeapKind kind)
+void* tryLargeMemalignVirtual(size_t requiredAlignment, size_t requestedSize, CompactAllocationMode mode, HeapKind kind)
 {
     RELEASE_BASSERT(isPowerOfTwo(requiredAlignment));
 
@@ -100,9 +100,26 @@ void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSi
 #endif
     }
 
-    if (result)
-        vmZeroAndPurge(result, size);
+    return result;
+}
 
+void vmZeroAndPurge(void* result, size_t size)
+{
+    if (!result) [[unlikely]]
+        return;
+
+    if (!size) [[unlikely]]
+        return;
+
+    bmalloc::vmZeroAndPurge(result, size);
+}
+
+void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSize, CompactAllocationMode mode, HeapKind kind)
+{
+    size_t pageSize = vmPageSize();
+    size_t size = roundUpToMultipleOf(pageSize, requestedSize);
+    auto* result = tryLargeMemalignVirtual(requiredAlignment, requestedSize, mode, kind);
+    vmZeroAndPurge(result, size);
     return result;
 }
 

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -212,6 +212,8 @@ BINLINE void* realloc(void* object, size_t newSize, CompactAllocationMode mode, 
 // will page fault on first access. It returns to you memory that initially only
 // uses up virtual address space, not `size` bytes of physical memory.
 BEXPORT void* tryLargeZeroedMemalignVirtual(size_t alignment, size_t size, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary);
+BEXPORT void* tryLargeMemalignVirtual(size_t alignment, size_t size, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary);
+BEXPORT void vmZeroAndPurge(void*, size_t size);
 
 BINLINE void free(void* object, HeapKind kind = HeapKind::Primary)
 {


### PR DESCRIPTION
#### 504799402c83518d117fe63f249dfe99cc96c15a
<pre>
[JSC] Do not zero clear all pages for wasm memory initially
<a href="https://bugs.webkit.org/show_bug.cgi?id=301989">https://bugs.webkit.org/show_bug.cgi?id=301989</a>
<a href="https://rdar.apple.com/164065023">rdar://164065023</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::tryAllocateResizableMemory):
(JSC::ArrayBuffer::resize):
(JSC::SharedArrayBufferContents::grow):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryManager::tryAllocateFastMemory):
(JSC::BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::grow):
* Source/WTF/wtf/Gigacage.cpp:
(Gigacage::tryAllocateVirtualPages):
(Gigacage::vmZeroAndPurge):
* Source/WTF/wtf/Gigacage.h:
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::tryLargeMemalignVirtual):
(bmalloc::api::vmZeroAndPurge):
(bmalloc::api::tryLargeZeroedMemalignVirtual):
* Source/bmalloc/bmalloc/bmalloc.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/504799402c83518d117fe63f249dfe99cc96c15a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129633 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81088 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f34cc670-7a21-4022-b969-e481f8e8885d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1766 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66600 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bf2bbab3-ef61-4292-b010-63ae7d6fe6b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132580 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116122 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dfe4f18d-bf5e-4131-82ba-88770bbb9b83) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80293 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121625 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139499 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128085 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107268 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107121 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54437 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65114 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161099 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1571 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40183 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1614 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1673 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->