### PR TITLE
iPad: Google Search Suggestions require tapping twice to activate in Safari

### DIFF
--- a/LayoutTests/fast/events/touch/ios/content-observation/visibility-toggles-off-and-back-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/content-observation/visibility-toggles-off-and-back-expected.txt
@@ -1,0 +1,2 @@
+PASS if 'clicked' text is shown below.
+ clicked

--- a/LayoutTests/fast/events/touch/ios/content-observation/visibility-toggles-off-and-back.html
+++ b/LayoutTests/fast/events/touch/ios/content-observation/visibility-toggles-off-and-back.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<title>This tests the case when visible content change goes from visible -> hidden -> visible</title>
+<script src="../../../../../resources/basic-gestures.js"></script>
+<style>
+#tapthis {
+    width: 400px;
+    height: 400px;
+    border: 1px solid green;
+}
+
+#becomesTemporarilyInvisible {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    display: inline-block;
+}
+</style>
+<script>
+async function test() {
+    if (!window.testRunner || !testRunner.runUIScript)
+        return;
+    if (window.internals)
+        internals.settings.setContentChangeObserverEnabled(true);
+
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+
+    let rect = tapthis.getBoundingClientRect();
+    let x = rect.left + rect.width / 2;
+    let y = rect.top + rect.height / 2;
+
+    await tapAtPoint(x, y);
+}
+</script>
+</head>
+<body onload="test()">
+<div id=tapthis>PASS if 'clicked' text is shown below.</div>
+<div id=becomesTemporarilyInvisible></div>
+<pre id=result></pre>
+<script>
+tapthis.addEventListener("mousemove", function(event) {
+    // 1. Trigger "became invisible", so the element is eligible to become visible.
+    becomesTemporarilyInvisible.style.opacity = "0";
+    document.body.offsetHeight;
+
+    // 2. Install a nested timer with visibility change. This should not result
+    // in hover even though it "became visible", because it was originally visible.
+    setTimeout(function() {
+        becomesTemporarilyInvisible.style.opacity = "1";
+    }, 0);
+}, false);
+
+tapthis.addEventListener("click", function(event) {   
+    result.innerHTML = "clicked";
+    document.body.offsetHeight;
+    testRunner.notifyDone();
+}, false);
+
+becomesTemporarilyInvisible.addEventListener("click", function(event) {   
+    // The hovered element just needs to respond to click events so the change isn't ignored.
+}, false);
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -221,6 +221,8 @@ private:
     };
     void adjustObservedState(Event);
 
+    enum class ElementVisibility : bool { Hidden, Visible };
+
     const CheckedRef<Document> m_document;
     Timer m_contentObservationTimer;
     WeakHashSet<const DOMTimer> m_DOMTimerList;
@@ -230,6 +232,7 @@ private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_hiddenTouchTargetElement;
     WeakPtr<Node, WeakPtrImplWithEventTargetData> m_clickTarget;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_visibilityCandidateList;
+    WeakHashMap<Element, ElementVisibility, WeakPtrImplWithEventTargetData> m_initialElementVisibility;
     bool m_touchEventIsBeingDispatched { false };
     bool m_isWaitingForStyleRecalc { false };
     bool m_isInObservedStyleRecalc { false };


### PR DESCRIPTION
#### 833e930831b0b2d0e8658ec69b469e6c775b4118
<pre>
iPad: Google Search Suggestions require tapping twice to activate in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=301995">https://bugs.webkit.org/show_bug.cgi?id=301995</a>
<a href="https://rdar.apple.com/162155695">rdar://162155695</a>

Reviewed by Alan Baradlay.

When tapping on a Google Search suggestion, content change observation code
currently observes a single element transitioning from visible -&gt; hidden -&gt; visible.
The second transition triggers a relevant content change, and invokes two-step
hover instead of synthesizing a click, despite not actually resulting in any
visible change on the page.

Test: fast/events/touch/ios/content-observation/visibility-toggles-off-and-back.html

* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::reset):
(WebCore::ContentChangeObserver::elementDidBecomeVisible):
(WebCore::ContentChangeObserver::elementDidBecomeHidden):
* Source/WebCore/page/ios/ContentChangeObserver.h:
Keep track of the initial visibility state of any element that changes visibility during a
given content change observation session; ignore any transitions to &apos;visible&apos; that
happen to elements that started out originally being visible.

* LayoutTests/fast/events/touch/ios/content-observation/visibility-toggles-off-and-back-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/content-observation/visibility-toggles-off-and-back.html: Added.

Canonical link: <a href="https://commits.webkit.org/302590@main">https://commits.webkit.org/302590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ef43d9a4f34c42a42f3712ffc5359693fd426b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81002 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d5942992-1f9c-4930-973b-902ce4101488) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98695 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66550 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79345 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bd3674e5-3d55-4f73-9de3-f47954875eff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34181 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80226 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107216 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107061 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54327 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65048 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1505 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1539 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->