### PR TITLE
Reduce unsafeness in DeviceController classes

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -1,9 +1,5 @@
 Modules/websockets/WorkerThreadableWebSocketChannel.h
 [ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.h
-[ iOS ] page/ios/ContentChangeObserver.h
-[ iOS ] platform/ios/DeviceMotionClientIOS.h
-[ iOS ] platform/ios/DeviceOrientationClientIOS.h
-[ iOS ] rendering/ios/RenderThemeIOS.mm
 bindings/js/JSLazyEventListener.cpp
 css/CSSToLengthConversionData.h
 css/SelectorChecker.h
@@ -35,9 +31,11 @@ loader/DocumentThreadableLoader.h
 loader/WorkerThreadableLoader.h
 page/FrameSnapshotting.cpp
 page/UndoManager.h
+[ iOS ] page/ios/ContentChangeObserver.h
 platform/graphics/TextRunIterator.h
 platform/graphics/ca/TileCoverageMap.h
-platform/mock/DeviceOrientationClientMock.h
+[ iOS ] platform/ios/DeviceMotionClientIOS.h
+[ iOS ] platform/ios/DeviceOrientationClientIOS.h
 rendering/BackgroundPainter.h
 rendering/GlyphDisplayListCache.cpp
 rendering/GridTrackSizingAlgorithm.h
@@ -74,6 +72,7 @@ rendering/RenderText.cpp
 rendering/TableLayout.h
 rendering/TextBoxPainter.h
 rendering/TextDecorationPainter.h
+[ iOS ] rendering/ios/RenderThemeIOS.mm
 rendering/line/BreakingContext.h
 rendering/line/LineBreaker.h
 rendering/line/LineWidth.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -113,8 +113,6 @@ dom/ContainerNode.cpp
 dom/ContainerNodeAlgorithms.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CurrentScriptIncrementer.h
-dom/DeviceMotionController.cpp
-dom/DeviceOrientationController.cpp
 dom/Document.cpp
 dom/DocumentFullscreen.cpp
 dom/Element.cpp
@@ -462,7 +460,6 @@ platform/ios/PlaybackSessionInterfaceIOS.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
 platform/ios/WebAVPlayerController.mm
 [ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
-platform/mock/DeviceOrientationClientMock.cpp
 platform/mock/MockRealtimeVideoSource.cpp
 platform/text/cocoa/LocalizedDateCache.mm
 rendering/AccessibilityRegionContext.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -72,8 +72,6 @@ dom/ComposedTreeIterator.cpp
 dom/ComposedTreeIterator.h
 dom/ContainerNodeAlgorithms.cpp
 dom/CustomElementReactionQueue.cpp
-dom/DeviceMotionController.cpp
-dom/DeviceOrientationController.cpp
 dom/Document.cpp
 dom/Element.cpp
 dom/ElementAndTextDescendantIterator.h
@@ -244,7 +242,6 @@ page/AutoscrollController.cpp
 [ iOS ] page/Chrome.cpp
 [ Mac ] page/ContextMenuController.cpp
 [ iOS ] page/DOMTimer.cpp
-page/DeviceController.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -722,7 +722,6 @@ platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
 platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
-platform/mock/GeolocationClientMock.cpp
 platform/mock/MockRealtimeVideoSource.cpp
 platform/mock/RTCNotifiersMock.cpp
 platform/mock/mediasource/MockMediaSourcePrivate.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -258,7 +258,6 @@ page/CaptionUserPreferences.cpp
 [ iOS ] page/Chrome.cpp
 [ Mac ] page/ContextMenuController.cpp
 page/DebugPageOverlays.cpp
-page/DeviceController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
 page/FocusController.cpp

--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -70,12 +70,12 @@ void DeviceMotionController::didChangeDeviceMotion(DeviceMotionData* deviceMotio
 
 bool DeviceMotionController::hasLastData()
 {
-    return m_client->lastMotion();
+    return checkedClient()->lastMotion();
 }
 
 RefPtr<Event> DeviceMotionController::getLastEvent()
 {
-    RefPtr lastMotion = m_client->lastMotion();
+    RefPtr lastMotion = checkedClient()->lastMotion();
     return DeviceMotionEvent::create(eventNames().devicemotionEvent, lastMotion.get());
 }
 
@@ -86,12 +86,17 @@ DeviceMotionController* DeviceMotionController::from(Page* page)
 
 bool DeviceMotionController::isActiveAt(Page* page)
 {
-    if (DeviceMotionController* self = DeviceMotionController::from(page))
+    if (CheckedPtr self = DeviceMotionController::from(page))
         return self->isActive();
     return false;
 }
 
 DeviceClient& DeviceMotionController::client()
+{
+    return m_client.get();
+}
+
+CheckedRef<DeviceMotionClient> DeviceMotionController::checkedClient()
 {
     return m_client.get();
 }

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -63,6 +63,8 @@ private:
     static ASCIILiteral supplementName() { return "DeviceMotionController"_s; }
     bool isDeviceMotionController() const final { return true; }
 
+    CheckedRef<DeviceMotionClient> checkedClient();
+
     WeakRef<DeviceMotionClient> m_client;
 };
 

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -71,12 +71,12 @@ void DeviceOrientationController::resumeUpdates()
 
 bool DeviceOrientationController::hasLastData()
 {
-    return m_client->lastOrientation();
+    return checkedClient()->lastOrientation();
 }
 
 RefPtr<Event> DeviceOrientationController::getLastEvent()
 {
-    RefPtr orientation = m_client->lastOrientation();
+    RefPtr orientation = checkedClient()->lastOrientation();
     return DeviceOrientationEvent::create(eventNames().deviceorientationEvent, orientation.get());
 }
 
@@ -89,12 +89,17 @@ DeviceOrientationController* DeviceOrientationController::from(Page* page)
 
 bool DeviceOrientationController::isActiveAt(Page* page)
 {
-    if (DeviceOrientationController* self = DeviceOrientationController::from(page))
+    if (CheckedPtr self = DeviceOrientationController::from(page))
         return self->isActive();
     return false;
 }
 
 DeviceClient& DeviceOrientationController::client()
+{
+    return m_client.get();
+}
+
+CheckedRef<DeviceOrientationClient> DeviceOrientationController::checkedClient()
 {
     return m_client.get();
 }

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -64,6 +64,8 @@ private:
     static ASCIILiteral supplementName() { return "DeviceOrientationController"_s; }
     bool isDeviceOrientationController() const final { return true; }
 
+    CheckedRef<DeviceOrientationClient> checkedClient();
+
     WeakRef<DeviceOrientationClient> m_client;
 };
 

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -97,7 +97,7 @@ void DeviceController::fireDeviceEvent()
     auto listenerVector = copyToVector(m_lastEventListeners.values());
     m_lastEventListeners.clear();
     for (auto& listener : listenerVector) {
-        auto document = listener->document();
+        RefPtr document = listener->document();
         if (document && !document->activeDOMObjectsAreSuspended() && !document->activeDOMObjectsAreStopped()) {
             if (RefPtr lastEvent = getLastEvent())
                 listener->dispatchEvent(*lastEvent);

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
@@ -34,11 +34,11 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceOrientationClientMock);
 
 DeviceOrientationClientMock::DeviceOrientationClientMock()
-    : m_controller(0)
-    , m_timer(*this, &DeviceOrientationClientMock::timerFired)
-    , m_isUpdating(false)
+    : m_timer(*this, &DeviceOrientationClientMock::timerFired)
 {
 }
+
+DeviceOrientationClientMock::~DeviceOrientationClientMock() = default;
 
 void DeviceOrientationClientMock::setController(DeviceOrientationController* controller)
 {
@@ -68,7 +68,7 @@ void DeviceOrientationClientMock::setOrientation(RefPtr<DeviceOrientationData>&&
 void DeviceOrientationClientMock::timerFired()
 {
     m_timer.stop();
-    m_controller->didChangeDeviceOrientation(m_orientation.get());
+    CheckedPtr { m_controller }->didChangeDeviceOrientation(m_orientation.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -23,8 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DeviceOrientationClientMock_h
-#define DeviceOrientationClientMock_h
+#pragma once
 
 #include <WebCore/DeviceOrientationClient.h>
 #include <WebCore/DeviceOrientationData.h>
@@ -45,6 +44,7 @@ class DeviceOrientationClientMock final : public DeviceOrientationClient {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClientMock);
 public:
     WEBCORE_EXPORT DeviceOrientationClientMock();
+    ~DeviceOrientationClientMock();
 
     // DeviceOrientationClient
     WEBCORE_EXPORT void setController(DeviceOrientationController*) override;
@@ -59,11 +59,9 @@ private:
     void timerFired();
 
     RefPtr<DeviceOrientationData> m_orientation;
-    DeviceOrientationController* m_controller;
+    CheckedPtr<DeviceOrientationController> m_controller;
     Timer m_timer;
-    bool m_isUpdating;
+    bool m_isUpdating { false };
 };
 
 } // namespace WebCore
-
-#endif // DeviceOrientationClientMock_h

--- a/Source/WebCore/platform/mock/GeolocationClientMock.cpp
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.cpp
@@ -109,14 +109,13 @@ void GeolocationClientMock::permissionTimerFired()
 {
     ASSERT(m_permissionState != PermissionStateUnset);
     bool allowed = m_permissionState == PermissionStateAllowed;
-    GeolocationSet::iterator end = m_pendingPermission.end();
 
     // Once permission has been set (or denied) on a Geolocation object, there can be
     // no further requests for permission to the mock. Consequently the callbacks
     // which fire synchronously from Geolocation::setIsAllowed() cannot reentrantly modify
     // m_pendingPermission.
-    for (GeolocationSet::iterator it = m_pendingPermission.begin(); it != end; ++it)
-        (*it)->setIsAllowed(allowed, { });
+    for (RefPtr permission : m_pendingPermission)
+        permission->setIsAllowed(allowed, { });
     m_pendingPermission.clear();
 }
 


### PR DESCRIPTION
#### 8e11110eadb783c1d43fee94e4e3997c8ebf053c
<pre>
Reduce unsafeness in DeviceController classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=301997">https://bugs.webkit.org/show_bug.cgi?id=301997</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/302584@main">https://commits.webkit.org/302584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfda42fcd40331c43ceb027b2476c4b6686676bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81028 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9714281e-ebb9-4f4f-97ac-251a2ba4fdf5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98711 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76609ad6-155b-4496-97e6-a38f96cb7f00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e7b7dca8-29a9-47e6-a78d-08904e7876e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34199 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80247 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139452 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107231 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107076 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54353 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1705 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65068 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->