### PR TITLE
Rename static_pointer_cast() / static_reference_cast() to unsafeRefPtrDowncast() / unsafeRefDowncast()

### DIFF
--- a/Source/JavaScriptCore/bytecode/MetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/MetadataTable.h
@@ -129,7 +129,7 @@ public:
 
     void validate() const;
 
-    RefPtr<UnlinkedMetadataTable> unlinkedMetadata() const { return static_reference_cast<UnlinkedMetadataTable>(linkingData().unlinkedMetadata); }
+    RefPtr<UnlinkedMetadataTable> unlinkedMetadata() const { return linkingData().unlinkedMetadata.copyRef(); }
 
     SUPPRESS_ASAN bool isDestroyed() const
     {

--- a/Source/JavaScriptCore/inspector/InspectorProtocolTypes.h
+++ b/Source/JavaScriptCore/inspector/InspectorProtocolTypes.h
@@ -56,7 +56,7 @@ template<typename T> struct BindingTraits<JSON::ArrayOf<T>> {
         auto array = value->asArray();
         BindingTraits<JSON::ArrayOf<T>>::assertValueHasExpectedType(array.get());
         static_assert(sizeof(JSON::ArrayOf<T>) == sizeof(JSON::Array), "type cast problem");
-        return static_reference_cast<JSON::ArrayOf<T>>(static_reference_cast<JSON::ArrayBase>(array.releaseNonNull()));
+        return unsafeRefDowncast<JSON::ArrayOf<T>>(upcast<JSON::ArrayBase>(array.releaseNonNull()));
     }
 
     static void assertValueHasExpectedType(JSON::Value* value)

--- a/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
@@ -245,6 +245,6 @@ ${constructorExample}
     auto result = value->asObject();
     BindingTraits<${objectType}>::assertValueHasExpectedType(result.get());
     static_assert(sizeof(${objectType}) == sizeof(JSON::ObjectBase), "type cast problem");
-    return static_reference_cast<${objectType}>(static_reference_cast<JSON::ObjectBase>(result.releaseNonNull()));
+    return unsafeRefDowncast<${objectType}>(upcast<JSON::ObjectBase>(result.releaseNonNull()));
 }
 """)

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -787,7 +787,7 @@ Ref<Protocol::Test::TypeNeedingCast> BindingTraits<Protocol::Test::TypeNeedingCa
     auto result = value->asObject();
     BindingTraits<Protocol::Test::TypeNeedingCast>::assertValueHasExpectedType(result.get());
     static_assert(sizeof(Protocol::Test::TypeNeedingCast) == sizeof(JSON::ObjectBase), "type cast problem");
-    return static_reference_cast<Protocol::Test::TypeNeedingCast>(static_reference_cast<JSON::ObjectBase>(result.releaseNonNull()));
+    return unsafeRefDowncast<Protocol::Test::TypeNeedingCast>(upcast<JSON::ObjectBase>(result.releaseNonNull()));
 }
 
 

--- a/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,5 +1,3 @@
-wtf/Ref.h
-wtf/RefPtr.h
 wtf/ThreadSpecific.h
 wtf/text/AtomStringImpl.cpp
 wtf/text/SymbolRegistry.cpp

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -193,13 +193,13 @@ private:
 
 template<typename T, typename U, typename WeakPtrImpl> inline WeakPtrImpl* weak_ptr_impl_cast(WeakPtrImpl* impl)
 {
-    static_assert(std::is_same_v<typename T::WeakValueType, typename U::WeakValueType>, "Invalid weak pointer cast");
+    static_assert(std::same_as<typename T::WeakValueType, typename U::WeakValueType>, "Invalid weak pointer cast");
     return impl;
 }
 
 template<typename T, typename U, typename WeakPtrImpl> inline WeakPtrImpl& weak_ptr_impl_cast(WeakPtrImpl& impl)
 {
-    static_assert(std::is_same_v<typename T::WeakValueType, typename U::WeakValueType>, "Invalid weak pointer cast");
+    static_assert(std::same_as<typename T::WeakValueType, typename U::WeakValueType>, "Invalid weak pointer cast");
     return impl;
 }
 
@@ -299,20 +299,20 @@ inline bool is(const WeakPtr<ArgType, WeakPtrImpl, PtrTraits>& source)
 template<typename Target, typename Source, typename WeakPtrImpl, typename PtrTraits>
 inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> downcast(WeakPtr<Source, WeakPtrImpl, PtrTraits> source)
 {
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    static_assert(!std::same_as<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::derived_from<Target, Source>, "Should be a downcast");
     RELEASE_ASSERT(!source || is<Target>(*source));
-    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> { static_pointer_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
+    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> { unsafeRefPtrDowncast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 
 template<typename Target, typename Source, typename WeakPtrImpl, typename PtrTraits>
 inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> dynamicDowncast(WeakPtr<Source, WeakPtrImpl, PtrTraits> source)
 {
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    static_assert(!std::same_as<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::derived_from<Target, Source>, "Should be a downcast");
     if (!is<Target>(source))
         return nullptr;
-    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> { static_pointer_cast<match_constness_t<Source, Target>, WeakPtrImpl>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
+    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> { unsafeRefPtrDowncast<match_constness_t<Source, Target>, WeakPtrImpl>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 
 template<typename T, typename U, typename WeakPtrImpl, typename PtrTraits> inline bool operator==(const WeakPtr<T, WeakPtrImpl, PtrTraits>& a, const WeakPtr<U, WeakPtrImpl, PtrTraits>& b)

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -201,20 +201,20 @@ inline bool is(const WeakRef<ArgType, WeakPtrImpl>& source)
 template<typename Target, typename Source, typename WeakPtrImpl>
 inline WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> downcast(WeakRef<Source, WeakPtrImpl> source)
 {
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    static_assert(!std::same_as<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::derived_from<Target, Source>, "Should be a downcast");
     RELEASE_ASSERT(is<Target>(source));
-    return WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> { static_reference_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
+    return WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> { unsafeRefDowncast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 
 template<typename Target, typename Source, typename WeakPtrImpl>
 inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> dynamicDowncast(WeakRef<Source, WeakPtrImpl> source)
 {
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    static_assert(!std::same_as<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::derived_from<Target, Source>, "Should be a downcast");
     if (!is<Target>(source))
         return nullptr;
-    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> { static_reference_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
+    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> { unsafeRefDowncast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -61,7 +61,7 @@ public:
 
     // FIXME: What guarantees this isn't a SymbolImpl rather than an AtomStringImpl?
     AtomStringImpl* impl() const LIFETIME_BOUND { SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<AtomStringImpl*>(m_string.impl()); }
-    RefPtr<AtomStringImpl> releaseImpl() { return static_pointer_cast<AtomStringImpl>(m_string.releaseImpl()); }
+    RefPtr<AtomStringImpl> releaseImpl() { return uncheckedDowncast<AtomStringImpl>(m_string.releaseImpl()); }
 
     bool is8Bit() const { return m_string.is8Bit(); }
     std::span<const Latin1Character> span8() const LIFETIME_BOUND { return m_string.span8(); }

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -406,7 +406,7 @@ Ref<AtomStringImpl> AtomStringImpl::addSlowCase(Ref<StringImpl>&& string)
     if (addResult.isNewEntry) {
         ASSERT(addResult.iterator->get() == string.ptr());
         string->setIsAtom(true);
-        return static_reference_cast<AtomStringImpl>(WTFMove(string));
+        return uncheckedDowncast<AtomStringImpl>(WTFMove(string));
     }
 
     return *static_cast<AtomStringImpl*>(addResult.iterator->get());

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -130,9 +130,9 @@ ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(StringImpl& string)
 
 ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(Ref<StringImpl>&& string)
 {
-    if (string->isAtom()) {
+    if (is<AtomStringImpl>(string)) {
         ASSERT_WITH_MESSAGE(!string->length() || isInAtomStringTable(string.ptr()), "The atom string comes from an other thread!");
-        return static_reference_cast<AtomStringImpl>(WTFMove(string));
+        return uncheckedDowncast<AtomStringImpl>(WTFMove(string));
     }
     return addSlowCase(WTFMove(string));
 }

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -46,7 +46,6 @@ dom/NodeRareData.h
 domjit/DOMJITHelpers.h
 domjit/JSDocumentDOMJIT.cpp
 domjit/JSNodeDOMJIT.cpp
-editing/TypingCommand.cpp
 html/InputType.cpp
 html/track/TextTrackCueGeneric.cpp
 inspector/CommandLineAPIModule.cpp

--- a/Source/WebCore/bindings/js/JSDOMWrapperCache.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapperCache.h
@@ -189,8 +189,10 @@ template<typename DOMClass, typename T> inline auto createWrapper(JSDOMGlobalObj
         auto* wrapper = WrapperClass::create(getDOMStructure<WrapperClass>(globalObject->vm(), *globalObject), globalObject, WTFMove(domObject));
         cacheWrapper(globalObject->world(), domObjectPtr, wrapper);
         return wrapper;
-    } else
-        return createWrapper<DOMClass>(globalObject, static_reference_cast<DOMClass>(WTFMove(domObject)));
+    } else {
+        // FIXME: Use downcast<>() once all the casted types support it.
+        return createWrapper<DOMClass>(globalObject, unsafeRefDowncast<DOMClass>(WTFMove(domObject)));
+    }
 }
 
 template<typename DOMClass> inline JSC::JSValue wrap(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, DOMClass& domObject)

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -72,12 +72,12 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSNumericValue);
 template<typename T> static ExceptionOr<Ref<CSSNumericValue>> convertToExceptionOrNumericValue(ExceptionOr<Ref<T>>&& input)
 {
     CSS_NUMERIC_RETURN_IF_EXCEPTION(result, WTFMove(input));
-    return static_reference_cast<CSSNumericValue>(WTFMove(result));
+    return upcast<CSSNumericValue>(WTFMove(result));
 }
 
 template<typename T> static ExceptionOr<Ref<CSSNumericValue>> convertToExceptionOrNumericValue(Ref<T>&& input)
 {
-    return static_reference_cast<CSSNumericValue>(WTFMove(input));
+    return upcast<CSSNumericValue>(WTFMove(input));
 }
 
 static ExceptionOr<Vector<Ref<CSSNumericValue>>> reifyMathExpressions(const CSSCalc::Children& nodes)

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -192,7 +192,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
             auto result = CSSNumericValue::reifyMathExpression(calcValue->tree());
             if (result.hasException())
                 return result.releaseException();
-            return static_reference_cast<CSSStyleValue>(result.releaseReturnValue());
+            return upcast<CSSStyleValue>(result.releaseReturnValue());
         }
         switch (primitiveValue->primitiveType()) {
         case CSSUnitType::CSS_NUMBER:
@@ -285,7 +285,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
             // Per the specification, the CSSKeywordValue's value slot should be set to the serialization
             // of the identifier. As a result, the identifier will be lowercase:
             // https://drafts.css-houdini.org/css-typed-om-1/#reify-ident
-            return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(primitiveValue->cssText(CSS::defaultSerializationContext())));
+            return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(primitiveValue->cssText(CSS::defaultSerializationContext())));
         default:
             break;
         }
@@ -316,7 +316,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
     } else if (RefPtr property = dynamicDowncast<CSSFilterValue>(cssValue)) {
         return WTF::switchOn(property->filter(),
             [&](CSS::Keyword::None) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
+                return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
                 return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
@@ -325,7 +325,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
     } else if (RefPtr property = dynamicDowncast<CSSAppleColorFilterValue>(cssValue)) {
         return WTF::switchOn(property->filter(),
             [&](CSS::Keyword::None) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
+                return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
                 return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
@@ -334,7 +334,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
     } else if (RefPtr property = dynamicDowncast<CSSBoxShadowPropertyValue>(cssValue)) {
         return WTF::switchOn(property->shadow(),
             [&](CSS::Keyword::None) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
+                return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
                 return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
@@ -343,7 +343,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
     } else if (RefPtr property = dynamicDowncast<CSSTextShadowPropertyValue>(cssValue)) {
         return WTF::switchOn(property->shadow(),
             [&](CSS::Keyword::None) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
+                return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
                 return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
@@ -352,7 +352,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
     } else if (RefPtr property = dynamicDowncast<CSSEasingFunctionValue>(cssValue)) {
         return WTF::switchOn(property->easingFunction(),
             [&]<CSSValueID keyword>(Constant<keyword>) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(keyword)));
+                return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(keyword)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
                 return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -441,7 +441,7 @@ RefPtr<Element> TreeScope::elementFromPoint(double clientX, double clientY, HitT
         node = retargetToScope(*node);
     }
 
-    return static_pointer_cast<Element>(WTFMove(node));
+    return uncheckedDowncast<Element>(WTFMove(node));
 }
 
 Vector<RefPtr<Element>> TreeScope::elementsFromPoint(double clientX, double clientY, HitTestSource source)
@@ -490,7 +490,7 @@ Vector<RefPtr<Element>> TreeScope::elementsFromPoint(double clientX, double clie
         if (node == lastNode)
             continue;
 
-        elements.append(static_pointer_cast<Element>(node));
+        elements.append(uncheckedDowncast<Element>(node));
         lastNode = node;
     }
 

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -489,14 +489,16 @@ RefPtr<HTMLElement> ApplyStyleCommand::splitAncestorsWithUnicodeBidi(Node* node,
 
     RefPtr<HTMLElement> unsplitAncestor;
 
-    if (allowedDirection != WritingDirection::Natural && highestAncestorUnicodeBidi != CSSValueBidiOverride && is<HTMLElement>(*highestAncestorWithUnicodeBidi)) {
-        auto highestAncestorDirection = EditingStyle::create(highestAncestorWithUnicodeBidi.get(), EditingStyle::PropertiesToInclude::AllProperties)->textDirection();
-        if (highestAncestorDirection && *highestAncestorDirection == allowedDirection) {
-            if (!nextHighestAncestorWithUnicodeBidi)
-                return static_pointer_cast<HTMLElement>(WTFMove(highestAncestorWithUnicodeBidi));
+    if (allowedDirection != WritingDirection::Natural && highestAncestorUnicodeBidi != CSSValueBidiOverride) {
+        if (RefPtr highestAncestorElementWithUnicodeBidi = dynamicDowncast<HTMLElement>(*highestAncestorWithUnicodeBidi)) {
+            auto highestAncestorDirection = EditingStyle::create(highestAncestorElementWithUnicodeBidi.get(), EditingStyle::PropertiesToInclude::AllProperties)->textDirection();
+            if (highestAncestorDirection && *highestAncestorDirection == allowedDirection) {
+                if (!nextHighestAncestorWithUnicodeBidi)
+                    return highestAncestorElementWithUnicodeBidi;
 
-            unsplitAncestor = static_pointer_cast<HTMLElement>(WTFMove(highestAncestorWithUnicodeBidi));
-            highestAncestorWithUnicodeBidi = nextHighestAncestorWithUnicodeBidi;
+                unsplitAncestor = WTFMove(highestAncestorElementWithUnicodeBidi);
+                highestAncestorWithUnicodeBidi = nextHighestAncestorWithUnicodeBidi;
+            }
         }
     }
 

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -116,10 +116,8 @@ static RefPtr<HTMLElement> firstInSpecialElement(const Position& position)
             continue;
         VisiblePosition visiblePosition = position;
         VisiblePosition firstInElement = firstPositionInOrBeforeNode(node.get());
-        if ((isRenderedTable(node.get()) && visiblePosition == firstInElement.next()) || visiblePosition == firstInElement) {
-            RELEASE_ASSERT(is<HTMLElement>(node));
-            return static_pointer_cast<HTMLElement>(WTFMove(node));
-        }
+        if ((isRenderedTable(node.get()) && visiblePosition == firstInElement.next()) || visiblePosition == firstInElement)
+            return downcast<HTMLElement>(WTFMove(node));
     }
     return nullptr;
 }
@@ -132,10 +130,8 @@ static RefPtr<HTMLElement> lastInSpecialElement(const Position& position)
             continue;
         VisiblePosition visiblePosition = position;
         VisiblePosition lastInElement = lastPositionInOrAfterNode(node.get());
-        if ((isRenderedTable(node.get()) && visiblePosition == lastInElement.previous()) || visiblePosition == lastInElement) {
-            RELEASE_ASSERT(is<HTMLElement>(node));
-            return static_pointer_cast<HTMLElement>(WTFMove(node));
-        }
+        if ((isRenderedTable(node.get()) && visiblePosition == lastInElement.previous()) || visiblePosition == lastInElement)
+            return downcast<HTMLElement>(WTFMove(node));
     }
     return nullptr;
 }

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2589,8 +2589,8 @@ void Editor::setComposition(const String& text, const Vector<CompositionUnderlin
         RefPtr extentNode = extent.deprecatedNode();
         unsigned extentOffset = extent.deprecatedEditingOffset();
 
-        if (is<Text>(baseNode) && baseNode == extentNode && baseOffset + text.length() == extentOffset) {
-            m_compositionNode = static_pointer_cast<Text>(baseNode);
+        if (RefPtr baseTextNode = dynamicDowncast<Text>(baseNode); baseTextNode && baseNode == extentNode && baseOffset + text.length() == extentOffset) {
+            m_compositionNode = baseTextNode;
             m_compositionStart = baseOffset;
             m_compositionEnd = extentOffset;
             m_customCompositionUnderlines = underlines;
@@ -2610,12 +2610,12 @@ void Editor::setComposition(const String& text, const Vector<CompositionUnderlin
                     range.location += baseOffset;
             }
 
-            if (auto renderer = baseNode->renderer())
+            if (auto renderer = baseTextNode->renderer())
                 renderer->repaint();
 
             unsigned start = std::min(baseOffset + selectionStart, extentOffset);
             unsigned end = std::min(std::max(start, baseOffset + selectionEnd), extentOffset);
-            auto range = SimpleRange { { *baseNode, start }, { *baseNode, end } };
+            auto range = SimpleRange { { *baseTextNode, start }, { *baseTextNode, end } };
             document->selection().setSelectedRange(range, Affinity::Downstream, FrameSelection::ShouldCloseTyping::No);
         }
     }

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1002,7 +1002,7 @@ void ReplaceSelectionCommand::handleStyleSpans(InsertedNodes& insertedNodes)
     // so search for the top level style span instead of assuming it's at the top.
     for (RefPtr node = insertedNodes.firstNodeInserted(); node; node = NodeTraversal::next(*node)) {
         if (isLegacyAppleStyleSpan(node.get())) {
-            wrappingStyleSpan = static_pointer_cast<HTMLElement>(WTFMove(node));
+            wrappingStyleSpan = downcast<HTMLElement>(WTFMove(node));
             break;
         }
     }

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -314,11 +314,10 @@ void TypingCommand::insertParagraphSeparator(Ref<Document>&& document, OptionSet
 
 RefPtr<TypingCommand> TypingCommand::lastTypingCommandIfStillOpenForTyping(Document& document)
 {
-    RefPtr lastEditCommand = document.editor().lastEditCommand();
-    if (!lastEditCommand || !lastEditCommand->isTypingCommand() || !static_cast<TypingCommand*>(lastEditCommand.get())->isOpenForMoreTyping())
+    RefPtr lastEditCommand = dynamicDowncast<TypingCommand>(document.editor().lastEditCommand());
+    if (!lastEditCommand || !lastEditCommand->isOpenForMoreTyping())
         return nullptr;
-
-    return static_pointer_cast<TypingCommand>(WTFMove(lastEditCommand));
+    return lastEditCommand;
 }
 
 bool TypingCommand::shouldDeferWillApplyCommandUntilAddingTypingCommand() const

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -259,7 +259,7 @@ void InspectorCanvas::finalizeFrame()
     appendActionSnapshotIfNeeded();
 
     if (m_frames && m_frames->length() && !m_currentFrameStartTime.isNaN()) {
-        auto currentFrame = static_reference_cast<Inspector::Protocol::Recording::Frame>(m_frames->get(m_frames->length() - 1));
+        auto currentFrame = unsafeRefDowncast<Inspector::Protocol::Recording::Frame>(m_frames->get(m_frames->length() - 1));
         currentFrame->setDuration((MonotonicTime::now() - m_currentFrameStartTime).milliseconds());
 
         m_currentFrameStartTime = MonotonicTime::nan();
@@ -273,7 +273,7 @@ void InspectorCanvas::markCurrentFrameIncomplete()
     if (!m_currentActions || !m_frames || !m_frames->length())
         return;
 
-    auto currentFrame = static_reference_cast<Inspector::Protocol::Recording::Frame>(m_frames->get(m_frames->length() - 1));
+    auto currentFrame = unsafeRefDowncast<Inspector::Protocol::Recording::Frame>(m_frames->get(m_frames->length() - 1));
     currentFrame->setIncomplete(true);
 }
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2793,10 +2793,10 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
     RefPtr<Element> newTarget;
     if (RefPtr targetNode = mouseEvent.targetNode()) {
         // Drag events should never go to non-element nodes (following IE, and proper mouseover/out dispatch)
-        if (!is<Element>(*targetNode))
-            newTarget = targetNode->parentOrShadowHostElement();
+        if (is<Element>(*targetNode))
+            newTarget = uncheckedDowncast<Element>(WTFMove(targetNode));
         else
-            newTarget = static_pointer_cast<Element>(WTFMove(targetNode));
+            newTarget = targetNode->parentOrShadowHostElement();
     }
 
     m_autoscrollController->updateDragAndDrop(newTarget.get(), flooredIntPoint(event.position()), event.timestamp());

--- a/Source/WebCore/page/ImageOverlayController.cpp
+++ b/Source/WebCore/page/ImageOverlayController.cpp
@@ -82,10 +82,7 @@ void ImageOverlayController::selectionQuadsDidChange(LocalFrame& frame, const Ve
         if (!ImageOverlay::isInsideOverlay(*selectedRange))
             return nullptr;
 
-        if (RefPtr host = selectedRange->startContainer().shadowHost(); is<HTMLElement>(host))
-            return static_pointer_cast<HTMLElement>(WTFMove(host));
-
-        return nullptr;
+        return dynamicDowncast<HTMLElement>(selectedRange->startContainer().shadowHost());
     })();
 
     if (!overlayHost) {

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -50,7 +50,7 @@ void ThreadedScrollingCoordinator::pageDestroyed()
     AsyncScrollingCoordinator::pageDestroyed();
 
     // Invalidating the scrolling tree will break the reference cycle between the ScrollingCoordinator and ScrollingTree objects.
-    RefPtr scrollingTree = static_pointer_cast<ThreadedScrollingTree>(releaseScrollingTree());
+    RefPtr scrollingTree = downcast<ThreadedScrollingTree>(releaseScrollingTree());
     ScrollingThread::dispatch([scrollingTree = WTFMove(scrollingTree)] {
         scrollingTree->invalidate();
     });

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -197,7 +197,8 @@ std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(std::spa
             if (audioTrack.track) {
                 duration = init.duration;
                 audioTrackId = audioTrack.track->id();
-                track = static_pointer_cast<AudioTrackPrivateWebM>(audioTrack.track);
+                // FIXME: Use downcast instead.
+                track = unsafeRefPtrDowncast<AudioTrackPrivateWebM>(audioTrack.track);
                 return;
             }
         }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1178,7 +1178,8 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
     RefPtr player = m_player.get();
     for (auto videoTrackInfo : segment.videoTracks) {
         if (videoTrackInfo.track) {
-            auto track = static_pointer_cast<VideoTrackPrivateWebM>(videoTrackInfo.track);
+            // FIXME: Use downcast instead.
+            auto track = unsafeRefPtrDowncast<VideoTrackPrivateWebM>(videoTrackInfo.track);
 #if PLATFORM(IOS_FAMILY)
             if (shouldCheckHardwareSupport() && (videoTrackInfo.description->codec() == "vp8"_s || (videoTrackInfo.description->codec() == "vp9"_s && !(canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9))))) {
                 m_errored = true;
@@ -1216,7 +1217,8 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
 
     for (auto audioTrackInfo : segment.audioTracks) {
         if (audioTrackInfo.track) {
-            auto track = static_pointer_cast<AudioTrackPrivateWebM>(audioTrackInfo.track);
+            // FIXME: Use downcast instead.
+            auto track = unsafeRefPtrDowncast<AudioTrackPrivateWebM>(audioTrackInfo.track);
             addTrackBuffer(track->id(), WTFMove(audioTrackInfo.description));
 
             track->setEnabledChangedCallback([weakThis = ThreadSafeWeakPtr { *this }] (AudioTrackPrivate& track, bool enabled) {

--- a/Source/WebCore/rendering/RenderPtr.h
+++ b/Source/WebCore/rendering/RenderPtr.h
@@ -43,9 +43,13 @@ template<typename T, class... Args> inline RenderPtr<T> createRenderer(Args&&...
     return RenderPtr<T>(new T(std::forward<Args>(args)...));
 }
 
-template<typename T, typename U> inline RenderPtr<T> static_pointer_cast(RenderPtr<U>&& p)
+} // namespace WebCore
+
+namespace WTF {
+
+template<typename T, typename U> inline WebCore::RenderPtr<T> downcast(WebCore::RenderPtr<U>&& p)
 {
-    return RenderPtr<T>(downcast<T>(p.release()));
+    return WebCore::RenderPtr<T>(downcast<T>(p.release()));
 }
 
-} // namespace WebCore
+} // namespace WTF

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
@@ -85,8 +85,8 @@ RefPtr<StyleCrossfadeImage> StyleCrossfadeImage::blend(const StyleCrossfadeImage
 
 Ref<CSSValue> StyleCrossfadeImage::computedStyleValue(const RenderStyle& style) const
 {
-    auto fromComputedValue = m_from ? m_from->computedStyleValue(style) : static_reference_cast<CSSValue>(CSSPrimitiveValue::create(CSSValueNone));
-    auto toComputedValue = m_to ? m_to->computedStyleValue(style) : static_reference_cast<CSSValue>(CSSPrimitiveValue::create(CSSValueNone));
+    auto fromComputedValue = m_from ? m_from->computedStyleValue(style) : upcast<CSSValue>(CSSPrimitiveValue::create(CSSValueNone));
+    auto toComputedValue = m_to ? m_to->computedStyleValue(style) : upcast<CSSValue>(CSSPrimitiveValue::create(CSSValueNone));
     return CSSCrossfadeValue::create(WTFMove(fromComputedValue), WTFMove(toComputedValue), CSSPrimitiveValue::create(m_percentage), m_isPrefixed);
 }
 

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -80,7 +80,7 @@ Ref<CSSValue> StyleFilterImage::computedStyleValue(const RenderStyle& style) con
 {
     RefPtr image = m_image;
     return CSSFilterImageValue::create(
-        image ? image->computedStyleValue(style) : static_reference_cast<CSSValue>(CSSPrimitiveValue::create(CSSValueNone)),
+        image ? image->computedStyleValue(style) : upcast<CSSValue>(CSSPrimitiveValue::create(CSSValueNone)),
         Style::toCSS(m_filter, style)
     );
 }

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -187,15 +187,14 @@ void SVGFEImageElement::notifyFinished(CachedResource&, const NetworkLoadMetrics
 
 std::tuple<RefPtr<ImageBuffer>, FloatRect> SVGFEImageElement::imageBufferForEffect(const GraphicsContext& destinationContext) const
 {
-    auto target = SVGURIReference::targetElementFromIRIString(href(), const_cast<SVGFEImageElement&>(*this).treeScopeForSVGReferences());
-    if (!is<SVGElement>(target.element))
+    auto targetElement = dynamicDowncast<SVGElement>(SVGURIReference::targetElementFromIRIString(href(), const_cast<SVGFEImageElement&>(*this).treeScopeForSVGReferences()).element);
+    if (!targetElement)
         return { };
 
-    if (isShadowIncludingDescendantOf(target.element.get()))
+    if (isShadowIncludingDescendantOf(targetElement.get()))
         return { };
 
-    RefPtr contextNode = static_pointer_cast<SVGElement>(target.element);
-    CheckedPtr renderer = contextNode->renderer();
+    CheckedPtr renderer = targetElement->renderer();
     if (!renderer)
         return { };
 

--- a/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
@@ -51,7 +51,7 @@ public:
     template<typename... Arguments>
     SVGPrimitivePropertyAnimator(const QualifiedName& attributeName, Ref<SVGProperty>&& property, Arguments&&... arguments)
         : Base(attributeName, std::forward<Arguments>(arguments)...)
-        , m_property(static_reference_cast<ValuePropertyType>(WTFMove(property)))
+        , m_property(unsafeRefDowncast<ValuePropertyType>(WTFMove(property)))
     {
     }
 

--- a/Source/WebCore/svg/properties/SVGValuePropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyAnimator.h
@@ -41,7 +41,7 @@ public:
     template<typename... Arguments>
     SVGValuePropertyAnimator(const QualifiedName& attributeName, Ref<SVGProperty>&& property, Arguments&&... arguments)
         : Base(attributeName, std::forward<Arguments>(arguments)...)
-        , m_property(static_reference_cast<PropertyType>(WTFMove(property)))
+        , m_property(unsafeRefDowncast<PropertyType>(WTFMove(property)))
     {
     }
 

--- a/Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h
@@ -41,7 +41,7 @@ public:
     template<typename... Arguments>
     SVGValuePropertyListAnimator(const QualifiedName& attributeName, Ref<SVGProperty>&& property, Arguments&&... arguments)
         : Base(attributeName, std::forward<Arguments>(arguments)...)
-        , m_list(static_reference_cast<ListType>(WTFMove(property)))
+        , m_list(unsafeRefDowncast<ListType>(WTFMove(property)))
     {
     }
 

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -75,9 +75,8 @@ public:
     unsigned removeAllOfTypeMatching(NOESCAPE const MatchFunction& matchFunction)
     {
         return m_elements.removeAllMatching([&] (const RefPtr<Object>& object) -> bool {
-            if (object->type() != T::APIType)
-                return false;
-            return matchFunction(static_pointer_cast<T>(object));
+            RefPtr objectAsT = dynamicDowncast<T>(*object);
+            return objectAsT && matchFunction(objectAsT.releaseNonNull());
         });
     }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
@@ -139,9 +139,8 @@ G_DEFINE_BOXED_TYPE(WebKitFeature, webkit_feature, webkit_feature_ref, webkit_fe
 
 static WebKitFeature* webkitFeatureCreate(const RefPtr<API::Object>& apiFeature)
 {
-    ASSERT(apiFeature->type() == API::Object::Type::Feature);
     WebKitFeature* feature = static_cast<WebKitFeature*>(fastMalloc(sizeof(WebKitFeature)));
-    new (feature) WebKitFeature(static_pointer_cast<API::Feature>(apiFeature));
+    new (feature) WebKitFeature(downcast<API::Feature>(apiFeature));
     return feature;
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
@@ -109,9 +109,8 @@ WebKitWebExtensionMatchPattern* webkitWebExtensionMatchPatternCreate(const RefPt
     if (!apiMatchPattern)
         return nullptr;
 
-    ASSERT(API::Object::unwrap(static_cast<void*>(apiMatchPattern.get()))->type() == API::Object::Type::WebExtensionMatchPattern);
     WebKitWebExtensionMatchPattern* matchPattern = static_cast<WebKitWebExtensionMatchPattern*>(fastMalloc(sizeof(WebKitWebExtensionMatchPattern)));
-    new (matchPattern) WebKitWebExtensionMatchPattern(static_pointer_cast<WebExtensionMatchPattern>(apiMatchPattern));
+    new (matchPattern) WebKitWebExtensionMatchPattern(apiMatchPattern.copyRef());
     return matchPattern;
 }
 

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -97,7 +97,7 @@ const Vector<RefPtr<API::Object>>& WebPreferences::experimentalFeatures()
     static auto experimentalFeatures = NeverDestroyed([]() {
         Vector<RefPtr<API::Object>> result;
         for (auto& object : features()) {
-            API::FeatureStatus status = static_pointer_cast<API::Feature>(object)->status();
+            API::FeatureStatus status = downcast<API::Feature>(object)->status();
             if (status == API::FeatureStatus::Developer || status == API::FeatureStatus::Testable || status == API::FeatureStatus::Preview || status == API::FeatureStatus::Stable)
                 result.append(object);
         }
@@ -111,7 +111,7 @@ const Vector<RefPtr<API::Object>>& WebPreferences::internalDebugFeatures()
     static auto internalDebugFeatures = NeverDestroyed([]() {
         Vector<RefPtr<API::Object>> result;
         for (auto& object : features()) {
-            API::FeatureStatus status = static_pointer_cast<API::Feature>(object)->status();
+            API::FeatureStatus status = downcast<API::Feature>(object)->status();
             if (status == API::FeatureStatus::Unstable || status == API::FeatureStatus::Internal)
                 result.append(object);
         }

--- a/Tools/TestWebKitAPI/Tests/WTF/Ref.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Ref.cpp
@@ -279,7 +279,7 @@ TEST(WTF_Ref, StaticReferenceCastFromConstReference)
     {
         DerivedRefCheckingRefLogger a("a");
         const Ref<DerivedRefCheckingRefLogger> ref(a);
-        auto ref2 = static_reference_cast<RefCheckingRefLogger>(ref);
+        auto ref2 = upcast<RefCheckingRefLogger>(ref);
     }
     EXPECT_STREQ("ref(a) ref(a) deref(a) deref(a) ", takeLogStr().c_str());
 }
@@ -289,7 +289,7 @@ TEST(WTF_Ref, StaticReferenceCastFromRValueReference)
     {
         DerivedRefCheckingRefLogger a("a");
         Ref<DerivedRefCheckingRefLogger> ref(a);
-        auto ref2 = static_reference_cast<RefCheckingRefLogger>(WTFMove(ref));
+        auto ref2 = upcast<RefCheckingRefLogger>(WTFMove(ref));
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
 }


### PR DESCRIPTION
#### ee6d739d218f27a98346d64c683e4b1bcd3c6b84
<pre>
Rename static_pointer_cast() / static_reference_cast() to unsafeRefPtrDowncast() / unsafeRefDowncast()
<a href="https://bugs.webkit.org/show_bug.cgi?id=301991">https://bugs.webkit.org/show_bug.cgi?id=301991</a>

Reviewed by Darin Adler.

Rename static_pointer_cast() / static_reference_cast() to unsafeRefPtrDowncast()
/ unsafeRefDowncast() to make it clear they are unsafe and reduce their use in
the codebase by leveraging:
1. downcast&lt;&gt;() which is truly safe and supports smart pointers nowadays
2. uncheckedDowncast&lt;&gt;() which is not ideal but better since it will at least validate
   the cast in debug builds.
3. New upcast() functions which are safe since it is safe to use static_cast for upcasts.

* Source/JavaScriptCore/bytecode/MetadataTable.h:
(JSC::MetadataTable::unlinkedMetadata const):
* Source/JavaScriptCore/inspector/InspectorProtocolTypes.h:
(Inspector::Protocol::BindingTraits&lt;JSON::ArrayOf&lt;T&gt;&gt;::runtimeCast):
* Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result:
* Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WTF/wtf/Ref.h:
(WTF::upcast):
(WTF::unsafeRefDowncast):
(WTF::uncheckedDowncast):
(WTF::downcast):
(WTF::dynamicDowncast):
(WTF::static_reference_cast): Deleted.
* Source/WTF/wtf/RefPtr.h:
(WTF::upcast):
(WTF::unsafeRefPtrDowncast):
(WTF::uncheckedDowncast):
(WTF::downcast):
(WTF::dynamicDowncast):
(WTF::static_pointer_cast): Deleted.
* Source/WTF/wtf/WeakPtr.h:
(WTF::weak_ptr_impl_cast):
(WTF::downcast):
(WTF::dynamicDowncast):
* Source/WTF/wtf/WeakRef.h:
(WTF::downcast):
(WTF::dynamicDowncast):
* Source/WTF/wtf/text/AtomString.h:
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringImpl::addSlowCase):
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::add):
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/bindings/js/JSDOMWrapperCache.h:
(WebCore::createWrapper):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::convertToExceptionOrNumericValue):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::elementFromPoint):
(WebCore::TreeScope::elementsFromPoint):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::splitAncestorsWithUnicodeBidi):
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::firstInSpecialElement):
(WebCore::lastInSpecialElement):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::setComposition):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::handleStyleSpans):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::lastTypingCommandIfStillOpenForTyping):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::finalizeFrame):
(WebCore::InspectorCanvas::markCurrentFrameIncomplete):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateDragAndDrop):
* Source/WebCore/page/ImageOverlayController.cpp:
(WebCore::ImageOverlayController::selectionQuadsDidChange):
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp:
(WebCore::ThreadedScrollingCoordinator::pageDestroyed):
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
* Source/WebCore/rendering/RenderPtr.h:
(WTF::downcast):
(WebCore::static_pointer_cast): Deleted.
* Source/WebCore/rendering/style/StyleCrossfadeImage.cpp:
(WebCore::StyleCrossfadeImage::computedStyleValue const):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::computedStyleValue const):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::imageBufferForEffect const):
* Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h:
(WebCore::SVGPrimitivePropertyAnimator::SVGPrimitivePropertyAnimator):
* Source/WebCore/svg/properties/SVGValuePropertyAnimator.h:
(WebCore::SVGValuePropertyAnimator::SVGValuePropertyAnimator):
* Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h:
(WebCore::SVGValuePropertyListAnimator::SVGValuePropertyListAnimator):
* Source/WebKit/Shared/API/APIArray.h:
* Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp:
(webkitFeatureCreate):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp:
(webkitWebExtensionMatchPatternCreate):
* Source/WebKit/UIProcess/WebPreferences.cpp:
(WebKit::WebPreferences::experimentalFeatures):
(WebKit::WebPreferences::internalDebugFeatures):
* Tools/TestWebKitAPI/Tests/WTF/Ref.cpp:
(TestWebKitAPI::TEST(WTF_Ref, StaticReferenceCastFromConstReference)):
(TestWebKitAPI::TEST(WTF_Ref, StaticReferenceCastFromRValueReference)):

Canonical link: <a href="https://commits.webkit.org/302695@main">https://commits.webkit.org/302695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c268e2513feb55c7691f924646a08fad376cff0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81226 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/16ef8398-39cb-496a-bb69-09978b463296) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66680 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/08b4b120-c8aa-4902-88b8-cfc2b1d22192) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79533 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c5077311-70f2-4d4e-aa26-717889c2518b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80419 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121749 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139629 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128209 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107359 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107234 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31055 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54566 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1885 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65254 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161223 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1699 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40201 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1734 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->