### PR TITLE
GPUP: Avoid message check failures on failure to send NativeImages to GPUP

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -145,8 +145,8 @@ private:
     void endPage() final;
     void setURLForRect(const URL&, const WebCore::FloatRect&) final;
 
-    bool recordResourceUse(WebCore::NativeImage&);
-    bool recordResourceUse(WebCore::ImageBuffer&);
+    [[nodiscard]] bool recordResourceUse(WebCore::NativeImage&);
+    [[nodiscard]] bool recordResourceUse(WebCore::ImageBuffer&);
     bool recordResourceUse(const WebCore::SourceImage&);
     bool recordResourceUse(WebCore::Font&);
     std::optional<RemoteGradientIdentifier> recordResourceUse(WebCore::Gradient&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -62,7 +62,7 @@ public:
 
     Ref<RemoteNativeImageProxy> createNativeImage(const WebCore::IntSize&, WebCore::PlatformColorSpace&&, bool hasAlpha);
 
-    void recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
+    [[nodiscard]] bool recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
     void recordFontUse(WebCore::Font&);
     RemoteGradientIdentifier recordGradientUse(WebCore::Gradient&);
     void recordFilterUse(WebCore::Filter&);


### PR DESCRIPTION
#### 4cd951ea3ba224fde4b4228fc5fadf89bb21aa44
<pre>
GPUP: Avoid message check failures on failure to send NativeImages to GPUP
<a href="https://bugs.webkit.org/show_bug.cgi?id=301999">https://bugs.webkit.org/show_bug.cgi?id=301999</a>
<a href="https://rdar.apple.com/164076543">rdar://164076543</a>

Reviewed by Mike Wyrzykowski.

NativeImage send to GPUP might fail due to resource exhausition (memory,
file handles) or due to the image not existing due to previous GPUP
crash.

Add return value to recordResourceUse() to check if the image was sent
successfully, and only issue the respective RemoteGraphicsContext
rendering command in case it was.

* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::clipToImageBuffer):
(WebKit::RemoteGraphicsContextProxy::drawNativeImage):
(WebKit::RemoteGraphicsContextProxy::drawSystemImage):
(WebKit::RemoteGraphicsContextProxy::drawPattern):
(WebKit::RemoteGraphicsContextProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/302636@main">https://commits.webkit.org/302636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3d1b7d7a2935d1f9530db4d5798d76e47e7cbd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81024 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cfa0487c-14a8-4f66-acc4-1a569b6d3c52) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98707 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66562 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0322bd6-26b4-433b-8481-83fffb5b5b1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116070 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79370 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0f1ea91-9c9c-47d8-9974-51d0568514c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1293 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80243 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139448 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107227 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65065 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1522 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->