### PR TITLE
[threaded-animations] add support for JS-originated animations associated with progress-based timelines

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt
@@ -1,3 +1,4 @@
 
 PASS A scroll-driven CSS animation can be accelerated.
+PASS A scroll-driven JS-originated animation can be accelerated.
 

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
@@ -14,10 +14,6 @@ body {
     width: 100px;
     height: 100px;
     background-color: black;
-
-    animation: slide auto linear;
-    animation-timeline: scroll();
-    will-change: translate;
 }
 
 </style>
@@ -26,12 +22,37 @@ body {
 <script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
 <script>
 
-promise_test(async t => {
+const make_target = t => {
     const target = createDiv(t);
     target.className = "target";
-    await new Promise(requestAnimationFrame);
+    return target;
+};
+
+const animationAcceleration = async animation => {
+    // An animation must be ready to be considered for acceleration.
+    await animation.ready;
+    // We only need to wait for the next JS run loop here
+    // because composition will happen during the animation frame,
+    // but after the requestAnimationFrame callbacks have been serviced.
+    await new Promise(setTimeout);
+};
+
+promise_test(async t => {
+    const target = make_target(t);
+    target.style.animation = "slide auto linear";
+    target.style.animationTimeline = "scroll()";
+    const animation = document.getAnimations()[0];
+    await animationAcceleration(animation);
     assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1);
 }, "A scroll-driven CSS animation can be accelerated.");
+
+promise_test(async t => {
+    const target = make_target(t);
+    const timeline = new ScrollTimeline({ source: document.documentElement });
+    const animation = target.animate({ translate: '100px' }, { timeline });
+    await animationAcceleration(animation);
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1);
+}, "A scroll-driven JS-originated animation can be accelerated.");
 
 </script>
 </body>

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -65,6 +65,7 @@ public:
     void transitionDidComplete(Ref<CSSTransition>&&);
 
     void animationAcceleratedRunningStateDidChange(WebAnimation&);
+    void runPostRenderingUpdateTasks();
     void detachFromDocument() override;
 
     void enqueueAnimationEvent(AnimationEventBase&);

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2087,6 +2087,11 @@ void KeyframeEffect::animationDidTick()
     invalidate();
     updateAcceleratedActions();
 
+#if ENABLE(THREADED_ANIMATIONS)
+    if (threadedAnimationsEnabled())
+        updateAcceleratedAnimationIfNecessary();
+#endif
+
     if (RefPtr viewTimeline = activeViewTimeline())
         computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline.get(), animation());
 }

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1617,8 +1617,24 @@ void WebAnimation::setSuspended(bool isSuspended)
 
 void WebAnimation::acceleratedStateDidChange()
 {
-    if (RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline))
-        documentTimeline->animationAcceleratedRunningStateDidChange(*this);
+    // FIXME: this would not be necessary if we didn't go through DocumentTimeline to
+    // schedule accelerated animations.
+    auto documentTimeline = [&]() -> DocumentTimeline* {
+        if (auto* timeline = dynamicDowncast<DocumentTimeline>(m_timeline.get()))
+            return timeline;
+        if (RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(m_timeline.get())) {
+            if (RefPtr source = scrollTimeline->source())
+                return &source->protectedDocument()->timeline();
+        }
+        if (RefPtr keyframeEffect = this->keyframeEffect()) {
+            if (RefPtr target = keyframeEffect->target())
+                return &target->protectedDocument()->timeline();
+        }
+        return nullptr;
+    };
+
+    if (RefPtr timeline = documentTimeline())
+        timeline->animationAcceleratedRunningStateDidChange(*this);
 }
 
 WebAnimation& WebAnimation::readyPromiseResolve()

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10819,8 +10819,10 @@ void Document::updateAnimationsAndSendEvents()
         timelinesController->updateAnimationsAndSendEvents(window->frozenNowTimestamp());
 }
 
-void Document::updateStaleScrollTimelines()
+void Document::runPostRenderingUpdateAnimationTasks()
 {
+    if (m_timeline)
+        m_timeline->runPostRenderingUpdateTasks();
     if (CheckedPtr timelinesController = this->timelinesController())
         timelinesController->updateStaleScrollTimelines();
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1833,7 +1833,7 @@ public:
     WEBCORE_EXPORT static const Logger& sharedLogger();
 
     void updateAnimationsAndSendEvents();
-    void updateStaleScrollTimelines();
+    void runPostRenderingUpdateAnimationTasks();
     WEBCORE_EXPORT DocumentTimeline& timeline();
     DocumentTimeline* existingTimeline() const { return m_timeline.get(); }
     Vector<RefPtr<WebAnimation>> getAnimations();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2295,7 +2295,7 @@ void Page::updateRendering()
 
     // https://drafts.csswg.org/scroll-animations-1/#event-loop
     forEachDocument([] (Document& document) {
-        document.updateStaleScrollTimelines();
+        document.runPostRenderingUpdateAnimationTasks();
     });
 
     runProcessingStep(RenderingUpdateStep::FocusFixup, [&] (Document& document) {


### PR DESCRIPTION
#### d88f62b700cb0df20a27ebbec498ba3b30ad4aee
<pre>
[threaded-animations] add support for JS-originated animations associated with progress-based timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=302000">https://bugs.webkit.org/show_bug.cgi?id=302000</a>
<a href="https://rdar.apple.com/164077999">rdar://164077999</a>

Reviewed by Simon Fraser.

In 302580@main we added support for CSS Animations associated with progress-based timelines
to be uploaded to the remote layer tree. However, JS-originated animations were not yet
supported because they are initially marked pending and thus `KeyframeEffect::canBeAccelerated()`
would return false.

We add support for JS-originated animations associated with progress-based timelines by making sure
that when such animations are marked as ready [0] in `KeyframeEffect::animationDidTick()` we
call into `updateAcceleratedAnimationIfNecessary()` which will make these animations be reconsidered
for upload to the remote layer tree.

This required a bit of a hack as it stands because this system relies on the timeline being a monotonic
timeline and the relevant code being on `DocumentTimeline`. We will address that later in a refactor
to move this logic to `AnimationTimelinesController`.

We also change the system we use to process animations pending consideration to be uploaded to the
remote layer tree from what has been historically used with animations accelerated on Cocoa platforms
by Core Animation. We now modify the existing `Document::updateStaleScrollTimelines()` method called
after layout in `Page::updateRendering()` to more generically run post-layout tasks for animations,
and thus renamed to `Document::runPostRenderingUpdateAnimationTasks()`.

In this method, we now also trigger the mechanism to process such pending animations so that animations
marked as ready are immediately uploaded to the remote layer tree instead of waiting for the next frame.

As a result, in the modified `webanimations/threaded-animations/scroll-driven-animations.html` layout
test, we introduce a new test function to wait until an animation should have been uploaded to the remote
layer tree as follows:

```
const animationAcceleration = async animation =&gt; {
    // An animation must be ready to be considered for acceleration.
    await animation.ready;
    // We only need to wait for the next JS run loop here
    // because composition will happen during the animation frame,
    // but after the requestAnimationFrame callbacks have been serviced.
    await new Promise(setTimeout);
};
```

We also add a new test to check that a JS-originated animation has indeed been marked as accelerated.

A future patch will add testing facilities on the remote end via `UIScriptController` to allow the
retrieval of a JSON description of animations associated with a remote layer tree node such that we
can validate the uploaded animation, timeline and effect data.

[0] <a href="https://drafts.csswg.org/web-animations-1/#ready">https://drafts.csswg.org/web-animations-1/#ready</a>

* LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt:
* LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::runPostRenderingUpdateTasks):
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationDidTick):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::acceleratedStateDidChange):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::runPostRenderingUpdateAnimationTasks):
(WebCore::Document::updateStaleScrollTimelines): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):

Canonical link: <a href="https://commits.webkit.org/302634@main">https://commits.webkit.org/302634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6f390e7ae92250c8d0969cab801b6a783f9df67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137143 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b23c973-8af7-4233-bfa5-a11c9205e609) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98848 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/198ecdb2-7d28-4701-b58f-4f3647717c3a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132701 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79526 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/22ef3a77-f4a4-4f41-bfb1-f651b26b2ce5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34344 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80416 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139626 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107355 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107230 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31050 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54563 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20242 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65251 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1696 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->