### PR TITLE
Implement a Debug Overlay for Enhanced Security

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		5157AE072B23CD8100C0E095 /* ContactsSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 5157AE062B23CD8100C0E095 /* ContactsSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		57F1C90A25DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57F1C90825DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm */; };
 		57FD318A22B3593E008D0E8B /* AppSSOSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57FD318922B3593E008D0E8B /* AppSSOSoftLink.mm */; };
+		58E7ACFA2EB3CE2C00DEFC26 /* EnhancedSecurityCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 58E7ACF62EB3CE1900DEFC26 /* EnhancedSecurityCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		58E7ACFC2EB3CE4600DEFC26 /* EnhancedSecurityCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 58E7ACFB2EB3CE3400DEFC26 /* EnhancedSecurityCocoa.mm */; };
 		5C7C787423AC3E770065F47E /* ManagedConfigurationSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C7C787223AC3E770065F47E /* ManagedConfigurationSoftLink.mm */; };
 		5CB898B2286274FA00CA3485 /* QuarantineSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CB898B1286274FA00CA3485 /* QuarantineSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CF869ED29D266AE0045F0D2 /* NSKeyedUnarchiverSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF869EC29D266AE0045F0D2 /* NSKeyedUnarchiverSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -643,6 +645,8 @@
 		57F1C90825DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CryptoKitPrivateSoftLink.mm; sourceTree = "<group>"; };
 		57FD318822B3592F008D0E8B /* AppSSOSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppSSOSoftLink.h; sourceTree = "<group>"; };
 		57FD318922B3593E008D0E8B /* AppSSOSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AppSSOSoftLink.mm; sourceTree = "<group>"; };
+		58E7ACF62EB3CE1900DEFC26 /* EnhancedSecurityCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecurityCocoa.h; sourceTree = "<group>"; };
+		58E7ACFB2EB3CE3400DEFC26 /* EnhancedSecurityCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EnhancedSecurityCocoa.mm; sourceTree = "<group>"; };
 		5C7C787123AC3E770065F47E /* ManagedConfigurationSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ManagedConfigurationSoftLink.h; sourceTree = "<group>"; };
 		5C7C787223AC3E770065F47E /* ManagedConfigurationSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ManagedConfigurationSoftLink.mm; sourceTree = "<group>"; };
 		5C7C787523AC3E850065F47E /* ManagedConfigurationSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ManagedConfigurationSPI.h; sourceTree = "<group>"; };
@@ -1131,6 +1135,8 @@
 				57F1C90825DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm */,
 				F4DDD01A264DC69E00EF1B91 /* DataDetectorsCoreSoftLink.h */,
 				F4DDD019264DC69E00EF1B91 /* DataDetectorsCoreSoftLink.mm */,
+				58E7ACF62EB3CE1900DEFC26 /* EnhancedSecurityCocoa.h */,
+				58E7ACFB2EB3CE3400DEFC26 /* EnhancedSecurityCocoa.mm */,
 				F44291661FA52705002CC93E /* FileSizeFormatterCocoa.mm */,
 				F47471EC2ACA17AF00E0D4AB /* LinkPresentationSoftLink.h */,
 				F47471ED2ACA17AF00E0D4AB /* LinkPresentationSoftLink.mm */,
@@ -1452,6 +1458,7 @@
 				DD20DE4427BC90D80093D175 /* DefaultSearchProvider.h in Headers */,
 				44B1A8682A7C5BAD00DC80A6 /* Device.h in Headers */,
 				DD20DE4E27BC90D80093D175 /* EncodingTables.h in Headers */,
+				58E7ACFA2EB3CE2C00DEFC26 /* EnhancedSecurityCocoa.h in Headers */,
 				DD20DE5E27BC90D80093D175 /* ExportMacros.h in Headers */,
 				DD20DDE527BC90D70093D175 /* FeatureFlagsSPI.h in Headers */,
 				DD20DDE627BC90D70093D175 /* FilePortSPI.h in Headers */,
@@ -1784,6 +1791,7 @@
 				A1175B581F6B470500C4B9F0 /* DefaultSearchProvider.cpp in Sources */,
 				44B1A8642A7C334F00DC80A6 /* Device.cpp in Sources */,
 				1C5C57D427571626003B540D /* EncodingTables.cpp in Sources */,
+				58E7ACFC2EB3CE4600DEFC26 /* EnhancedSecurityCocoa.mm in Sources */,
 				F44291641FA52670002CC93E /* FileSizeFormatter.cpp in Sources */,
 				F44291681FA52705002CC93E /* FileSizeFormatterCocoa.mm in Sources */,
 				A30D41221F0DD0EA00B71954 /* KillRing.cpp in Sources */,

--- a/Source/WebCore/PAL/pal/cocoa/EnhancedSecurityCocoa.h
+++ b/Source/WebCore/PAL/pal/cocoa/EnhancedSecurityCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,16 +25,16 @@
 
 #pragma once
 
-namespace WebCore {
+#include <wtf/Platform.h>
 
-enum class DebugOverlayRegions : uint8_t {
-    NonFastScrollableRegion = 1 << 0,
-    WheelEventHandlerRegion = 1 << 1,
-    TouchActionRegion = 1 << 2,
-    EditableElementRegion = 1 << 3,
-    InteractionRegion = 1 << 4,
-    // We must leave 1 << 5 empty due to prior use by SiteIsolation.
-    EnhancedSecurity = 1 << 6,
-};
+#if PLATFORM(COCOA)
 
-}
+namespace PAL {
+
+PAL_EXPORT bool isEnhancedSecurityEnabledForCurrentProcess();
+
+PAL_EXPORT void setEnhancedSecurityEnabledForCurrentProcess(bool);
+
+} // namespace PAL
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/PAL/pal/cocoa/EnhancedSecurityCocoa.mm
+++ b/Source/WebCore/PAL/pal/cocoa/EnhancedSecurityCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,18 +23,31 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import "config.h"
+#import "EnhancedSecurityCocoa.h"
 
-namespace WebCore {
+#if PLATFORM(COCOA)
 
-enum class DebugOverlayRegions : uint8_t {
-    NonFastScrollableRegion = 1 << 0,
-    WheelEventHandlerRegion = 1 << 1,
-    TouchActionRegion = 1 << 2,
-    EditableElementRegion = 1 << 3,
-    InteractionRegion = 1 << 4,
-    // We must leave 1 << 5 empty due to prior use by SiteIsolation.
-    EnhancedSecurity = 1 << 6,
-};
+#import <wtf/NeverDestroyed.h>
 
+namespace PAL {
+
+static std::optional<bool>& isEnhancedSecurityEnabledForCurrentProcessCached()
+{
+    static NeverDestroyed<std::optional<bool>> cachedIsEnhancedSecurityEnabledForCurrentProcess;
+    return cachedIsEnhancedSecurityEnabledForCurrentProcess;
 }
+
+bool isEnhancedSecurityEnabledForCurrentProcess()
+{
+    return isEnhancedSecurityEnabledForCurrentProcessCached().value_or(false);
+}
+
+void setEnhancedSecurityEnabledForCurrentProcess(bool isEnhancedSecurityEnabled)
+{
+    isEnhancedSecurityEnabledForCurrentProcessCached() = isEnhancedSecurityEnabled;
+}
+
+} // namespace PAL
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -46,8 +46,10 @@ public:
         WheelEventHandlers,
         NonFastScrollableRegion,
         InteractionRegion,
+        EnhancedSecurity,
     };
-    static constexpr unsigned NumberOfRegionTypes = static_cast<unsigned>(RegionType::InteractionRegion) + 1;
+
+    static constexpr unsigned NumberOfRegionTypes = static_cast<unsigned>(RegionType::EnhancedSecurity) + 1;
 
     static void didLayout(LocalFrame&);
     static void didChangeEventHandlers(LocalFrame&);
@@ -117,6 +119,7 @@ inline void DebugPageOverlays::doAfterUpdateRendering(Page& page)
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::WheelEventHandlers);
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::NonFastScrollableRegion);
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::InteractionRegion);
+    sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::EnhancedSecurity);
 }
 
 inline bool DebugPageOverlays::shouldPaintOverlayIntoLayerForRegionType(Page& page, RegionType regionType)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -39,6 +39,7 @@ typedef NS_OPTIONS(NSUInteger, _WKDebugOverlayRegions) {
     _WKEditableElementRegion = 1 << 3,
     _WKInteractionRegion WK_API_AVAILABLE(macos(13.0), ios(16.0)) = 1 << 4,
     _WKSiteIsolationRegion WK_API_DEPRECATED_WITH_REPLACEMENT("ShowFrameProcessBordersEnabled", macos(15.0, WK_MAC_TBA), ios(18.0, WK_IOS_TBA), visionos(2.0, WK_XROS_TBA)) = 1 << 5,
+    _WKEnhancedSecurityRegion WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 6,
 } WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
 typedef NS_OPTIONS(NSUInteger, _WKJavaScriptRuntimeFlags) {

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -255,6 +255,10 @@
 #import <pal/cocoa/LockdownModeCocoa.h>
 #endif
 
+#if PLATFORM(COCOA)
+#import <pal/cocoa/EnhancedSecurityCocoa.h>
+#endif
+
 #if PLATFORM(MAC)
 #import <wtf/spi/darwin/SandboxSPI.h>
 #endif
@@ -669,6 +673,10 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
 #if ENABLE(LOCKDOWN_MODE_API)
     PAL::setLockdownModeEnabledForCurrentProcess(isLockdownModeEnabled());
+#endif
+
+#if PLATFORM(COCOA)
+    PAL::setEnhancedSecurityEnabledForCurrentProcess(enhancedSecurityEnabled());
 #endif
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -384,6 +384,7 @@ public:
 
     void isJITEnabled(CompletionHandler<void(bool)>&&);
     void isEnhancedSecurityEnabled(CompletionHandler<void(bool)>&&);
+    bool enhancedSecurityEnabled() const { return m_isEnhancedSecurityEnabled.value_or(false); }
 
     RefPtr<API::Object> transformHandlesToObjects(API::Object*);
     static RefPtr<API::Object> transformObjectsToHandles(API::Object*);

--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -50,6 +50,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
 @property (nonatomic, readonly) BOOL nonFastScrollableRegionOverlayVisible;
 @property (nonatomic, readonly) BOOL wheelEventHandlerRegionOverlayVisible;
 @property (nonatomic, readonly) BOOL interactionRegionOverlayVisible;
+@property (nonatomic, readonly) BOOL enhancedSecurityOverlayVisible;
 @property (nonatomic, readonly) BOOL useUISideCompositing;
 @property (nonatomic, readonly) BOOL perWindowWebProcessesDisabled;
 @property (nonatomic, readonly) BOOL acceleratedDrawingEnabled;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -57,6 +57,7 @@ static NSString * const ResourceLoadStatisticsEnabledPreferenceKey = @"ResourceL
 static NSString * const NonFastScrollableRegionOverlayVisiblePreferenceKey = @"NonFastScrollableRegionOverlayVisible";
 static NSString * const WheelEventHandlerRegionOverlayVisiblePreferenceKey = @"WheelEventHandlerRegionOverlayVisible";
 static NSString * const InteractionRegionOverlayVisiblePreferenceKey = @"InteractionRegionOverlayVisible";
+static NSString * const EnhancedSecurityOverlayVisiblePreferenceKey = @"EnhancedSecurityOverlayVisible";
 
 static NSString * const UseTransparentWindowsPreferenceKey = @"UseTransparentWindows";
 static NSString * const UsePaginatedModePreferenceKey = @"UsePaginatedMode";
@@ -85,6 +86,7 @@ typedef NS_ENUM(NSInteger, DebugOverylayMenuItemTag) {
     NonFastScrollableRegionOverlayTag = 100,
     WheelEventHandlerRegionOverlayTag,
     InteractionRegionOverlayTag,
+    EnhancedSecurityOverlayTag,
     ExperimentalFeatureTag,
     InternalDebugFeatureTag,
 };
@@ -225,6 +227,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItemToMenu(debugOverlaysMenu, @"Non-fast Scrollable Region", @selector(toggleDebugOverlay:), NO, NonFastScrollableRegionOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Wheel Event Handler Region", @selector(toggleDebugOverlay:), NO, WheelEventHandlerRegionOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Interaction Region", @selector(toggleDebugOverlay:), NO, InteractionRegionOverlayTag);
+    addItemToMenu(debugOverlaysMenu, @"Enhanced Security", @selector(toggleDebugOverlay:), NO, EnhancedSecurityOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Resource Usage", @selector(toggleShowResourceUsageOverlay:), NO, 0);
 
     NSMenu *experimentalFeaturesMenu = addSubmenu(@"Experimental Features");
@@ -813,6 +816,11 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     return [[NSUserDefaults standardUserDefaults] boolForKey:InteractionRegionOverlayVisiblePreferenceKey];
 }
 
+- (BOOL)enhancedSecurityOverlayVisible
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:EnhancedSecurityOverlayVisiblePreferenceKey];
+}
+
 - (NSString *)preferenceKeyForRegionOverlayTag:(NSUInteger)tag
 {
     switch (tag) {
@@ -824,6 +832,9 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 
     case InteractionRegionOverlayTag:
         return InteractionRegionOverlayVisiblePreferenceKey;
+
+    case EnhancedSecurityOverlayTag:
+        return EnhancedSecurityOverlayVisiblePreferenceKey;
     }
     return nil;
 }

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -588,7 +588,9 @@ static BOOL areEssentiallyEqual(double a, double b)
         visibleOverlayRegions |= _WKWheelEventHandlerRegion;
     if (settings.interactionRegionOverlayVisible)
         visibleOverlayRegions |= _WKInteractionRegion;
-    
+    if (settings.enhancedSecurityOverlayVisible)
+        visibleOverlayRegions |= _WKEnhancedSecurityRegion;
+
     preferences._visibleDebugOverlayRegions = visibleOverlayRegions;
 
     int headerBannerHeight = [settings isSpaceReservedForBanners] ? testHeaderBannerHeight : 0;


### PR DESCRIPTION
#### 06ca3f825ac470ac38ec38a3bf6fba4220fd9654
<pre>
Implement a Debug Overlay for Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=302001">https://bugs.webkit.org/show_bug.cgi?id=302001</a>
<a href="https://rdar.apple.com/164079715">rdar://164079715</a>

Reviewed by Per Arne Vollan.

Adds a Debug Overlay that indicates if a site has Enhanced Security enabled.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/cocoa/EnhancedSecurityCocoa.h: Copied from Source/WebCore/page/DebugOverlayRegions.h.
* Source/WebCore/PAL/pal/cocoa/EnhancedSecurityCocoa.mm: Copied from Source/WebCore/page/DebugOverlayRegions.h.
(PAL::isEnhancedSecurityEnabledForCurrentProcessCached):
(PAL::isEnhancedSecurityEnabledForCurrentProcess):
(PAL::setEnhancedSecurityEnabledForCurrentProcess):
* Source/WebCore/page/DebugOverlayRegions.h:
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::EnhancedSecurityOverlay::drawRect):
(WebCore::RegionOverlay::create):
(WebCore::DebugPageOverlays::updateOverlayRegionVisibility):
* Source/WebCore/page/DebugPageOverlays.h:
(WebCore::DebugPageOverlays::doAfterUpdateRendering):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
* Source/WebKit/WebProcess/WebProcess.h:
* Tools/MiniBrowser/mac/SettingsController.h:
* Tools/MiniBrowser/mac/SettingsController.m:
(-[SettingsController _populateMenu:]):
(-[SettingsController enhancedSecurityOverlayVisible]):
(-[SettingsController preferenceKeyForRegionOverlayTag:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController didChangeSettings]):

Canonical link: <a href="https://commits.webkit.org/302863@main">https://commits.webkit.org/302863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e2e0b859fe9a8bd4a4d4a7f102364173dfd353f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137892 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e6c10a29-8887-422f-a084-1b263084af4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133421 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80104 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0ef7e95e-5f17-4f64-abe5-d76de1de4cb0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34961 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81151 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140371 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107919 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31615 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55513 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65993 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2424 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->