### PR TITLE
[WPE] MiniBrowser: implement --fullscreen and --maximized for the old API too

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
@@ -80,4 +80,4 @@ class WPEMiniBrowserLegacyAPIDriver(WPEMiniBrowserBaseDriver):
     browser_name = 'minibrowser-wpe-legacy'
 
     def _extra_wpe_minibrowser_args(self):
-        return ['--use-legacy-api']
+        return ['--use-legacy-api', '--fullscreen']

--- a/Tools/wpe/backends/ViewBackend.cpp
+++ b/Tools/wpe/backends/ViewBackend.cpp
@@ -99,4 +99,14 @@ void ViewBackend::notifyAccessibilityKeyEventListeners(struct wpe_input_keyboard
 }
 #endif
 
+void ViewBackend::setFullscreen(bool fullscreen)
+{
+    m_fullscreen = fullscreen;
+}
+
+void ViewBackend::setMaximized(bool maximized)
+{
+    m_maximized = maximized;
+}
+
 } // namespace WPEToolingBackends

--- a/Tools/wpe/backends/ViewBackend.h
+++ b/Tools/wpe/backends/ViewBackend.h
@@ -57,6 +57,12 @@ public:
     void addActivityState(uint32_t);
     void removeActivityState(uint32_t);
 
+    virtual void setFullscreen(bool);
+    virtual void setMaximized(bool);
+
+    bool isFullscreen() const { return m_fullscreen; }
+    bool isMaximized() const { return m_maximized; }
+
 protected:
     ViewBackend(uint32_t width, uint32_t height);
 
@@ -72,6 +78,8 @@ protected:
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
     std::unique_ptr<InputClient> m_inputClient;
+    bool m_fullscreen { false };
+    bool m_maximized { false };
 };
 
 } // namespace WPEToolingBackends


### PR DESCRIPTION
#### 5665fa94d65d7d6a6523383b5bc360da232b414c
<pre>
[WPE] MiniBrowser: implement --fullscreen and --maximized for the old API too
<a href="https://bugs.webkit.org/show_bug.cgi?id=302002">https://bugs.webkit.org/show_bug.cgi?id=302002</a>

Reviewed by Adrian Perez de Castro.

This way we can run the benchmarks in fullscreen mode like we do for the new API.

Canonical link: <a href="https://commits.webkit.org/302640@main">https://commits.webkit.org/302640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90798b60c27fba01cc45f6cc69fd728f25d601a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129591 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98716 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66570 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79379 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/128941 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139456 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107235 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107080 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30928 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54362 "Hash 90798b60 for PR 53448 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20244 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1709 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1563 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->