### PR TITLE
System UI Font Extraction should use CTFontGetUIFontType as opposed to the "." internal postfix name

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -71,5 +71,5 @@ selectors = [
 request = "rdar://161241270"
 cleanup = "rdar://161241477"
 symbols = [
-    "CTFontDescriptorCreateMatchingFontDescriptorsWithOptions",
+    "CTFontGetUIFontType",
 ]

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -244,7 +244,7 @@ bool CTFontIsAppleColorEmoji(CTFontRef);
 CTFontRef CTFontCreateForCharacters(CTFontRef currentFont, const UTF16Char *characters, CFIndex length, CFIndex *coveredLength);
 CGFloat CTFontGetSbixImageSizeForGlyphAndContentsScale(CTFontRef, const CGGlyph, CGFloat contentsScale);
 
-CFArrayRef _Nullable CTFontDescriptorCreateMatchingFontDescriptorsWithOptions(CTFontDescriptorRef, CFSetRef _Nullable, CTFontDescriptorMatchingOptions);
+CTFontUIFontType CTFontGetUIFontType(CTFontRef);
 CTFontDescriptorOptions CTFontDescriptorGetOptions(CTFontDescriptorRef);
 
 CFBitVectorRef CTFontCopyColorGlyphCoverage(CTFontRef);

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -171,6 +171,9 @@ struct FontPlatformDataAttributes {
 
 #if USE(CORE_TEXT)
 
+using SystemUIFontType = uint32_t;
+#define SystemUIFontTypeNone UINT32_MAX
+
 struct FontPlatformSerializedTraits {
     static std::optional<FontPlatformSerializedTraits> fromCF(CFDictionaryRef);
     RetainPtr<CFDictionaryRef> toCFDictionary() const;
@@ -248,6 +251,12 @@ struct FontMetadata {
 };
 
 struct InstalledFont {
+    struct SystemUIFont {
+        SystemUIFontType systemUIFontType { SystemUIFontTypeNone };
+        String language;
+        RetainPtr<CTFontRef> toCTFont(double pointSize) const;
+    };
+
     struct PostScriptFont {
         String postScriptName;
         CTFontDescriptorOptions fontDescriptorOptions;
@@ -255,7 +264,7 @@ struct InstalledFont {
         RetainPtr<CTFontRef> toCTFont(double pointSize) const;
     };
 
-    Variant<PostScriptFont> font;
+    Variant<SystemUIFont, PostScriptFont> font;
     FontMetadata metadata;
     WEBCORE_EXPORT RetainPtr<CTFontRef> toCTFont() const;
     Ref<Font> toFont() const;

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -1029,6 +1029,17 @@ std::optional<InstalledFont> Font::toSerializableInstalledFont() const
         platformData().syntheticOblique()
     };
 
+    SystemUIFontType fontType = CTFontGetUIFontType(ctFont.get());
+    if (fontType != SystemUIFontTypeNone) {
+        return InstalledFont {
+            InstalledFont::SystemUIFont {
+                fontType,
+                adoptCF(checked_cf_cast<CFStringRef>(CTFontCopyAttribute(ctFont.get(), kCTFontDescriptorLanguageAttribute))).get()
+            },
+            fontData
+        };
+    }
+
     RetainPtr fontDescriptor = adoptCF(CTFontCopyFontDescriptor(ctFont.get()));
     RetainPtr attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
     return InstalledFont {

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -167,6 +167,13 @@ header: <WebCore/FontPlatformData.h>
     bool syntheticOblique;
 }
 
+using WebCore::SystemUIFontType = uint32_t;
+
+[CustomHeader, Nested] struct WebCore::InstalledFont::SystemUIFont {
+    WebCore::SystemUIFontType systemUIFontType;
+    String language;
+}
+
 [CustomHeader, Nested] struct WebCore::InstalledFont::PostScriptFont {
     String postScriptName;
     CTFontDescriptorOptions fontDescriptorOptions;
@@ -174,7 +181,7 @@ header: <WebCore/FontPlatformData.h>
 }
 
 [CustomHeader] struct WebCore::InstalledFont {
-    Variant<WebCore::InstalledFont::PostScriptFont> font;
+    Variant<WebCore::InstalledFont::SystemUIFont, WebCore::InstalledFont::PostScriptFont> font;
     WebCore::FontMetadata metadata;
 }
 


### PR DESCRIPTION
#### 3b5afeaaf5da200e9becf2136000d85c63eafcad
<pre>
System UI Font Extraction should use CTFontGetUIFontType as opposed to the &quot;.&quot; internal postfix name
<a href="https://rdar.apple.com/164085378">rdar://164085378</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302004">https://bugs.webkit.org/show_bug.cgi?id=302004</a>

Reviewed by Brent Fulgham and Vitor Roriz.

Ports resolution of System fonts to us the SystemUI font name as
opposed to the internal &quot;.&quot; postfix name. We introduce a new
SystemUIFont InstalledFont type in order to handle serialization
in this manner.

* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::toSerializableInstalledFont const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::InstalledFont::SystemUIFont::toCTFont const):
(WebCore::InstalledFont::PostScriptFont::toCTFont const):
(WebCore::InstalledFont::toCTFont const):
(WebCore::InstalledFont::toFont const):
* Source/WebKit/Shared/WebCoreFont.serialization.in:

Canonical link: <a href="https://commits.webkit.org/304099@main">https://commits.webkit.org/304099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff1893cfb69d9e192cee74d783cf404c6a85fc47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86304 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a841bfd2-2916-4213-9e94-5f0ea8ad7832) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102659 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69931 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a1cb570-ff4c-47b8-a63b-37d361c951df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83452 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49d7554d-a1f7-453f-b05d-c29e0be60ac1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5007 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2608 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114241 "Found 2 new API test failures: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently, TestWebKitAPI.ProcessSwap.PageOverlayLayerPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144480 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111043 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4835 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60224 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6487 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34818 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70051 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6565 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->