### PR TITLE
Microphone capture can be muted when capturing with and without echo cancellation and using applyConstraints to switch dynamically between the two

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.cpp
@@ -754,7 +754,13 @@ void CoreAudioCaptureUnit::updateMutedState(SyncUpdate syncUpdate)
         auto error = m_ioUnit->set(kAUVoiceIOProperty_MuteOutput, kAudioUnitScope_Global, outputBus, &muteUplinkOutput, sizeof(muteUplinkOutput));
         RELEASE_LOG_ERROR_IF(error, WebRTC, "CoreAudioCaptureUnit::updateMutedState(%p) unable to set kAUVoiceIOProperty_MuteOutput, error %d (%.4s)", this, (int)error, (char*)&error);
     }
-    setMutedState(muteUplinkOutput);
+
+    auto isAnyUnitCapturing = [] {
+        return std::ranges::any_of(allCoreAudioCaptureUnits(), [](auto& unit) {
+            return unit.isProducingData();
+        });
+    };
+    setMutedState(muteUplinkOutput && !isAnyUnitCapturing());
 }
 
 void CoreAudioCaptureUnit::updateMutedStateTimerFired()


### PR DESCRIPTION
#### a1aedbea4cfe885239f6af96b937de0f2c995b2e
<pre>
Microphone capture can be muted when capturing with and without echo cancellation and using applyConstraints to switch dynamically between the two
<a href="https://rdar.apple.com/164086015">rdar://164086015</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302005">https://bugs.webkit.org/show_bug.cgi?id=302005</a>

Reviewed by Eric Carlson.

When a web page has two tracks, one with echo cancellation and one without echo cancellation on the same device,
the web page is running two CoreAudioCaptureUnits.
If it renders audio, the VPIO unit may also be rendering audio.

If the VPIO unit is stopping to capture (both tracks go to no echo cancellation), it will continue running to render audio.
It will then mute capture as it does not need to capture and to remove the OS microphone capture indicator.
But, this prevents the other unit to actually capture.

We update CoreAudioCaptureUnit::updateMutedState by making sure to set muted to true only if there is no other audio unit doing capture.
We also update CoreAudioCaptureUnit::updateMutedState to only set kAUVoiceIOProperty_MuteOutput on the VPIO unit since it fails with non VPIO units.

Manually tested.

Canonical link: <a href="https://commits.webkit.org/302637@main">https://commits.webkit.org/302637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a329afbd65a867a2429ac822bffc4d03eaee7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81104 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98759 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66604 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79431 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1346 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34256 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80307 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109819 "Found 4 new API test failures: TestWebKitAPI.WebKit2.NoCrashWhenInitializeWebViewWhenChangingUserDefaults, TestWebKitAPI.WebAuthenticationPanel.MakeCredentialPinProtocol2, TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently, TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinProtocol2 (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139517 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107277 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27295 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54452 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65128 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1589 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1693 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->