### PR TITLE
[WPE] Add an Android platform display

### DIFF
--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -57,7 +57,9 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/glib/SystemSettings.h
 
     platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h
+    platform/graphics/android/PlatformDisplayAndroid.h
 
+    platform/graphics/egl/PlatformDisplayDefault.h
     platform/graphics/egl/PlatformDisplaySurfaceless.h
 
     platform/graphics/gbm/GBMVersioning.h

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -70,8 +70,8 @@ platform/graphics/glib/IconGLib.cpp
 platform/graphics/glib/ImageAdapterGLib.cpp
 platform/graphics/glib/SystemFontDatabaseGLib.cpp
 
-platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h @no-unify
 platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp @no-unify
+platform/graphics/android/PlatformDisplayAndroid.cpp @no-unify
 
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
@@ -80,6 +80,7 @@ platform/graphics/egl/GLDisplay.cpp @no-unify
 platform/graphics/egl/GLFence.cpp @no-unify
 platform/graphics/egl/GLFenceEGL.cpp @no-unify
 platform/graphics/egl/GLFenceGL.cpp @no-unify
+platform/graphics/egl/PlatformDisplayDefault.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/DMABufBuffer.cpp

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -74,7 +74,10 @@ public:
 #if USE(GBM)
         GBM,
 #endif
-#if PLATFORM(GTK)
+#if OS(ANDROID)
+        Android,
+#endif
+#if PLATFORM(GTK) || OS(ANDROID)
         Default,
 #endif
     };

--- a/Source/WebCore/platform/graphics/android/PlatformDisplayAndroid.h
+++ b/Source/WebCore/platform/graphics/android/PlatformDisplayAndroid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,40 +23,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "PlatformDisplayDefault.h"
+#pragma once
 
-#if PLATFORM(GTK) || OS(ANDROID)
+#if OS(ANDROID)
 
-#include "GLContext.h"
-#include <epoxy/egl.h>
+#include "PlatformDisplay.h"
 
 namespace WebCore {
 
-std::unique_ptr<PlatformDisplayDefault> PlatformDisplayDefault::create()
-{
-    auto glDisplay = GLDisplay::create(eglGetDisplay(EGL_DEFAULT_DISPLAY));
-    if (!glDisplay) {
-        WTFLogAlways("Could not create default EGL display: %s. Aborting...", GLContext::lastErrorString());
-        CRASH();
-    }
+class PlatformDisplayAndroid final : public PlatformDisplay {
+public:
+    static std::unique_ptr<PlatformDisplayAndroid> create();
 
-    return std::unique_ptr<PlatformDisplayDefault>(new PlatformDisplayDefault(glDisplay.releaseNonNull()));
-}
+    virtual ~PlatformDisplayAndroid();
 
-PlatformDisplayDefault::PlatformDisplayDefault(Ref<GLDisplay>&& glDisplay)
-    : PlatformDisplay(WTFMove(glDisplay))
-{
-#if ENABLE(WEBGL)
-    m_anglePlatform = 0;
-    m_angleNativeDisplay = EGL_DEFAULT_DISPLAY;
-#endif
-}
+private:
+    explicit PlatformDisplayAndroid(Ref<GLDisplay>&&);
 
-PlatformDisplayDefault::~PlatformDisplayDefault()
-{
-}
+    Type type() const override { return PlatformDisplay::Type::Android; }
+};
 
 } // namespace WebCore
 
-#endif // PLATFORM(GTK) || OS(ANDROID)
+#endif // OS(ANDROID)

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.h
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || OS(ANDROID)
 
 #include "PlatformDisplay.h"
 
@@ -44,4 +44,4 @@ private:
 
 } // namespace WebCore
 
-#endif // PLATFORM(GTK)
+#endif // PLATFORM(GTK) || OS(ANDROID)

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
@@ -39,6 +39,8 @@
 
 #if USE(LIBDRM)
 #include <drm_fourcc.h>
+#elif OS(ANDROID)
+#include <drm/drm_fourcc.h>
 #endif
 
 #if USE(SKIA)

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -278,6 +278,11 @@ void WebPage::getRenderProcessInfo(CompletionHandler<void(RenderProcessInfo&&)>&
         break;
 #endif
 #endif
+#if OS(ANDROID)
+    case PlatformDisplay::Type::Android:
+        info.platform = "Android"_s;
+        break;
+#endif
 #if USE(WPE_RENDERER)
     case PlatformDisplay::Type::WPE:
         info.platform = "WPE"_s;
@@ -291,18 +296,16 @@ void WebPage::getRenderProcessInfo(CompletionHandler<void(RenderProcessInfo&&)>&
     info.msaaSampleCount = display->msaaSampleCount();
 #endif
 
+#if USE(GBM)
     if (info.platform != "WPE"_s) {
         info.supportedBufferFormats = display->bufferFormats().map([](const auto& format) -> RendererBufferFormat::Format {
             return {
                 format.fourcc.value,
-#if USE(GBM)
                 format.modifiers,
-#else
-                { },
-#endif
             };
         });
     }
+#endif // USE(GBM)
 
     static_cast<DrawingAreaCoordinatedGraphics*>(m_drawingArea.get())->fillGLInformation(WTFMove(info), WTFMove(completionHandler));
 }

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -65,7 +65,11 @@
 #include <WebCore/PlatformDisplaySurfaceless.h>
 #endif
 
-#if PLATFORM(GTK)
+#if OS(ANDROID)
+#include <WebCore/PlatformDisplayAndroid.h>
+#endif
+
+#if PLATFORM(GTK) || OS(ANDROID)
 #include <WebCore/PlatformDisplayDefault.h>
 #endif
 
@@ -160,12 +164,19 @@ void WebProcess::initializePlatformDisplayIfNeeded() const
     }
 #endif
 
+#if OS(ANDROID)
+    if (auto display = PlatformDisplayAndroid::create()) {
+        PlatformDisplay::setSharedDisplay(WTFMove(display));
+        return;
+    }
+#endif
+
     if (auto display = PlatformDisplaySurfaceless::create()) {
         PlatformDisplay::setSharedDisplay(WTFMove(display));
         return;
     }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || OS(ANDROID)
     if (auto display = PlatformDisplayDefault::create()) {
         PlatformDisplay::setSharedDisplay(WTFMove(display));
         return;


### PR DESCRIPTION
#### 42598486e6ea5601655b984c536e8f9197a369e7
<pre>
[WPE] Add an Android platform display
<a href="https://bugs.webkit.org/show_bug.cgi?id=301939">https://bugs.webkit.org/show_bug.cgi?id=301939</a>

Reviewed by Carlos Garcia Campos.

Add a new PlatformDisplayAndroid that tries using EGL_PLATFORM_ANDROID_KHR,
and also enable PlatformDisplayDefault as fallback. The fallback is needed
because it is common for the corresponding EGL_KHR_platform_android extension
to not be available, and also that some devices may not provide EGL 1.5,
which is required by the extension.

Loosely based on an initial patch by Felipe Erias &lt;felipeerias@igalia.com&gt;.

* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/android/PlatformDisplayAndroid.cpp: Added.
(WebCore::PlatformDisplayAndroid::create):
(WebCore::PlatformDisplayAndroid::PlatformDisplayAndroid):
* Source/WebCore/platform/graphics/android/PlatformDisplayAndroid.h: Added.
* Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.cpp: Build
for Android.
* Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.h: Ditto.
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp: Add the
correct header inclusion for drm_fourcc.h on Android.
* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
(WebKit::WebPage::getRenderProcessInfo): Handle the Android display
type, and extend an USE(GBM) guard to account for display buffer formats
not yet being exposed on Android.
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::initializePlatformDisplayIfNeeded const): Try using
the newly added PlatformDisplayAndroid, enable trying PlatformDisplayDefault
as last resort.

Canonical link: <a href="https://commits.webkit.org/302638@main">https://commits.webkit.org/302638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/077d05589fd4ba6a294d8be821ccc4c4b6e5164a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98757 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34247 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80303 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107274 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107127 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30968 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54447 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65124 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1585 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->