### PR TITLE
[threaded-animations] remove extraneous ref-churn in `RemoteAnimation::apply()`

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp
@@ -47,7 +47,7 @@ RemoteAnimation::RemoteAnimation(const WebCore::AcceleratedEffect& effect, const
 
 void RemoteAnimation::apply(WebCore::AcceleratedEffectValues& values)
 {
-    Ref { m_effect }->apply(values, m_timeline->currentTime(), m_timeline->duration());
+    m_effect->apply(values, m_timeline->currentTime(), m_timeline->duration());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
@@ -50,8 +50,8 @@ public:
 private:
     RemoteAnimation(const WebCore::AcceleratedEffect&, const RemoteAnimationTimeline&);
 
-    Ref<const WebCore::AcceleratedEffect> m_effect;
-    Ref<const RemoteAnimationTimeline> m_timeline;
+    const Ref<const WebCore::AcceleratedEffect> m_effect;
+    const Ref<const RemoteAnimationTimeline> m_timeline;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### daa49cf14304b10bef2970a945e8dc4d8477970b
<pre>
[threaded-animations] remove extraneous ref-churn in `RemoteAnimation::apply()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302015">https://bugs.webkit.org/show_bug.cgi?id=302015</a>
<a href="https://rdar.apple.com/164097428">rdar://164097428</a>

Reviewed by Alan Baradlay, Brent Fulgham, and Vitor Roriz.

Adopt the advice to &quot;mark data members that are smart pointers as const if
they never get reassigned&quot; [0] for both `Ref` members of `RemoteAnimation`.
This allows us to remove the extra `Ref` in the `apply()` method.

[0] <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#mark-data-members-that-are-smart-pointers-as-const-if-they-never-get-reassigned">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#mark-data-members-that-are-smart-pointers-as-const-if-they-never-get-reassigned</a>

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp:
(WebKit::RemoteAnimation::apply):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h:

Canonical link: <a href="https://commits.webkit.org/302623@main">https://commits.webkit.org/302623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c78feee2d6d8638d4a873e1ac6063877450f09f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81107 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ddfd1333-e57c-45f3-993a-744eca25ed07) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98761 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66607 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2a1e3764-9cd2-4f30-be07-6e3185fc5c9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79433 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7cb3f732-2e9b-4534-b99a-6dfe947a4e96) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1368 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139520 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107278 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107136 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30986 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54455 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20236 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65164 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1592 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1698 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->