### PR TITLE
Optimize common newline regex

### DIFF
--- a/LayoutTests/fast/regex/script-tests/string-split-newline.js
+++ b/LayoutTests/fast/regex/script-tests/string-split-newline.js
@@ -1,0 +1,56 @@
+description(
+'This test checks the SIMD-optimized newline splitting patterns for correctness.'
+);
+
+// Test the optimized patterns: /\r\n?|\n/ and /\n|\r\n?/
+// These patterns match LF (\n), CR (\r), and CRLF (\r\n)
+
+var newlinePatterns = [/\r\n?|\n/, /\n|\r\n?/];
+var newlineTypes = ["\\n", "\\r", "\\r\\n"];
+
+newlinePatterns.forEach(function(pattern, patternIndex) {
+    shouldBe(`"".split(newlinePatterns[${patternIndex}])`, '[""]');
+    shouldBe(`"no newlines".split(newlinePatterns[${patternIndex}])`, '["no newlines"]');
+    shouldBe(`"abc".split(newlinePatterns[${patternIndex}])`, '["abc"]');
+    shouldBe(`"Line1\\r\\nLine2\\nLine3\\rLine4".split(newlinePatterns[${patternIndex}])`, '["Line1", "Line2", "Line3", "Line4"]');
+    newlineTypes.forEach(function(nl) {
+        shouldBe(`"${nl}".split(newlinePatterns[${patternIndex}])`, '["", ""]');
+        shouldBe(`"${nl}text".split(newlinePatterns[${patternIndex}])`, '["", "text"]');
+        shouldBe(`"a${nl}b".split(newlinePatterns[${patternIndex}])`, '["a", "b"]');
+        shouldBe(`"a${nl}b${nl}c".split(newlinePatterns[${patternIndex}])`, '["a", "b", "c"]');
+        shouldBe(`"text${nl}".split(newlinePatterns[${patternIndex}])`, '["text", ""]');
+        shouldBe(`"${nl}${nl}".split(newlinePatterns[${patternIndex}])`, '["", "", ""]');
+        shouldBe(`"a${nl}${nl}b".split(newlinePatterns[${patternIndex}])`, '["a", "", "b"]');
+        shouldBe(`"a${nl}b${nl}c".split(newlinePatterns[${patternIndex}], 2)`, '["a", "b"]');
+        shouldBe(`"a${nl}b${nl}".split(newlinePatterns[${patternIndex}], 2)`, '["a", "b"]');
+        shouldBe(`"a${nl}b${nl}c${nl}".split(newlinePatterns[${patternIndex}], 3)`, '["a", "b", "c"]');
+        shouldBe(`"This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function${nl}Second line".split(newlinePatterns[${patternIndex}])`, '["This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function", "Second line"]');
+    });
+});
+
+/(test)(123)/.exec("test123");
+shouldBe('RegExp.$1', '"test"');
+shouldBe('RegExp.$2', '"123"');
+
+"".split(/\r\n?|\n/);
+shouldBe('RegExp.$1', '"test"');
+shouldBe('RegExp.$2', '"123"');
+
+"a\nb\nc".split(/\r\n?|\n/);
+shouldBe('RegExp.$1', '""');
+shouldBe('RegExp.$2', '""');
+
+/(foo)(bar)/.exec("foobar");
+shouldBe('RegExp.$1', '"foo"');
+shouldBe('RegExp.$2', '"bar"');
+
+"x\ny\nz".split(/\n|\r\n?/);
+shouldBe('RegExp.$1', '""');
+shouldBe('RegExp.$2', '""');
+
+"hello\nworld".split(/\r\n?|\n/);
+shouldBe('RegExp.lastMatch', '"\\n"');
+"hello\r\nworld".split(/\r\n?|\n/);
+shouldBe('RegExp.lastMatch', '"\\r\\n"');
+"hello\rworld".split(/\r\n?|\n/);
+shouldBe('RegExp.lastMatch', '"\\r"');

--- a/LayoutTests/fast/regex/string-split-newline-expected.txt
+++ b/LayoutTests/fast/regex/string-split-newline-expected.txt
@@ -1,0 +1,96 @@
+This test checks the SIMD-optimized newline splitting patterns for correctness.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS "".split(newlinePatterns[0]) is [""]
+PASS "no newlines".split(newlinePatterns[0]) is ["no newlines"]
+PASS "abc".split(newlinePatterns[0]) is ["abc"]
+PASS "Line1\r\nLine2\nLine3\rLine4".split(newlinePatterns[0]) is ["Line1", "Line2", "Line3", "Line4"]
+PASS "\n".split(newlinePatterns[0]) is ["", ""]
+PASS "\ntext".split(newlinePatterns[0]) is ["", "text"]
+PASS "a\nb".split(newlinePatterns[0]) is ["a", "b"]
+PASS "a\nb\nc".split(newlinePatterns[0]) is ["a", "b", "c"]
+PASS "text\n".split(newlinePatterns[0]) is ["text", ""]
+PASS "\n\n".split(newlinePatterns[0]) is ["", "", ""]
+PASS "a\n\nb".split(newlinePatterns[0]) is ["a", "", "b"]
+PASS "a\nb\nc".split(newlinePatterns[0], 2) is ["a", "b"]
+PASS "a\nb\n".split(newlinePatterns[0], 2) is ["a", "b"]
+PASS "a\nb\nc\n".split(newlinePatterns[0], 3) is ["a", "b", "c"]
+PASS "This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function\nSecond line".split(newlinePatterns[0]) is ["This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function", "Second line"]
+PASS "\r".split(newlinePatterns[0]) is ["", ""]
+PASS "\rtext".split(newlinePatterns[0]) is ["", "text"]
+PASS "a\rb".split(newlinePatterns[0]) is ["a", "b"]
+PASS "a\rb\rc".split(newlinePatterns[0]) is ["a", "b", "c"]
+PASS "text\r".split(newlinePatterns[0]) is ["text", ""]
+PASS "\r\r".split(newlinePatterns[0]) is ["", "", ""]
+PASS "a\r\rb".split(newlinePatterns[0]) is ["a", "", "b"]
+PASS "a\rb\rc".split(newlinePatterns[0], 2) is ["a", "b"]
+PASS "a\rb\r".split(newlinePatterns[0], 2) is ["a", "b"]
+PASS "a\rb\rc\r".split(newlinePatterns[0], 3) is ["a", "b", "c"]
+PASS "This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function\rSecond line".split(newlinePatterns[0]) is ["This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function", "Second line"]
+PASS "\r\n".split(newlinePatterns[0]) is ["", ""]
+PASS "\r\ntext".split(newlinePatterns[0]) is ["", "text"]
+PASS "a\r\nb".split(newlinePatterns[0]) is ["a", "b"]
+PASS "a\r\nb\r\nc".split(newlinePatterns[0]) is ["a", "b", "c"]
+PASS "text\r\n".split(newlinePatterns[0]) is ["text", ""]
+PASS "\r\n\r\n".split(newlinePatterns[0]) is ["", "", ""]
+PASS "a\r\n\r\nb".split(newlinePatterns[0]) is ["a", "", "b"]
+PASS "a\r\nb\r\nc".split(newlinePatterns[0], 2) is ["a", "b"]
+PASS "a\r\nb\r\n".split(newlinePatterns[0], 2) is ["a", "b"]
+PASS "a\r\nb\r\nc\r\n".split(newlinePatterns[0], 3) is ["a", "b", "c"]
+PASS "This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function\r\nSecond line".split(newlinePatterns[0]) is ["This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function", "Second line"]
+PASS "".split(newlinePatterns[1]) is [""]
+PASS "no newlines".split(newlinePatterns[1]) is ["no newlines"]
+PASS "abc".split(newlinePatterns[1]) is ["abc"]
+PASS "Line1\r\nLine2\nLine3\rLine4".split(newlinePatterns[1]) is ["Line1", "Line2", "Line3", "Line4"]
+PASS "\n".split(newlinePatterns[1]) is ["", ""]
+PASS "\ntext".split(newlinePatterns[1]) is ["", "text"]
+PASS "a\nb".split(newlinePatterns[1]) is ["a", "b"]
+PASS "a\nb\nc".split(newlinePatterns[1]) is ["a", "b", "c"]
+PASS "text\n".split(newlinePatterns[1]) is ["text", ""]
+PASS "\n\n".split(newlinePatterns[1]) is ["", "", ""]
+PASS "a\n\nb".split(newlinePatterns[1]) is ["a", "", "b"]
+PASS "a\nb\nc".split(newlinePatterns[1], 2) is ["a", "b"]
+PASS "a\nb\n".split(newlinePatterns[1], 2) is ["a", "b"]
+PASS "a\nb\nc\n".split(newlinePatterns[1], 3) is ["a", "b", "c"]
+PASS "This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function\nSecond line".split(newlinePatterns[1]) is ["This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function", "Second line"]
+PASS "\r".split(newlinePatterns[1]) is ["", ""]
+PASS "\rtext".split(newlinePatterns[1]) is ["", "text"]
+PASS "a\rb".split(newlinePatterns[1]) is ["a", "b"]
+PASS "a\rb\rc".split(newlinePatterns[1]) is ["a", "b", "c"]
+PASS "text\r".split(newlinePatterns[1]) is ["text", ""]
+PASS "\r\r".split(newlinePatterns[1]) is ["", "", ""]
+PASS "a\r\rb".split(newlinePatterns[1]) is ["a", "", "b"]
+PASS "a\rb\rc".split(newlinePatterns[1], 2) is ["a", "b"]
+PASS "a\rb\r".split(newlinePatterns[1], 2) is ["a", "b"]
+PASS "a\rb\rc\r".split(newlinePatterns[1], 3) is ["a", "b", "c"]
+PASS "This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function\rSecond line".split(newlinePatterns[1]) is ["This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function", "Second line"]
+PASS "\r\n".split(newlinePatterns[1]) is ["", ""]
+PASS "\r\ntext".split(newlinePatterns[1]) is ["", "text"]
+PASS "a\r\nb".split(newlinePatterns[1]) is ["a", "b"]
+PASS "a\r\nb\r\nc".split(newlinePatterns[1]) is ["a", "b", "c"]
+PASS "text\r\n".split(newlinePatterns[1]) is ["text", ""]
+PASS "\r\n\r\n".split(newlinePatterns[1]) is ["", "", ""]
+PASS "a\r\n\r\nb".split(newlinePatterns[1]) is ["a", "", "b"]
+PASS "a\r\nb\r\nc".split(newlinePatterns[1], 2) is ["a", "b"]
+PASS "a\r\nb\r\n".split(newlinePatterns[1], 2) is ["a", "b"]
+PASS "a\r\nb\r\nc\r\n".split(newlinePatterns[1], 3) is ["a", "b", "c"]
+PASS "This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function\r\nSecond line".split(newlinePatterns[1]) is ["This is a very long string that exceeds 32 chars to test vectorMatch in the SIMD-optimized function", "Second line"]
+PASS RegExp.$1 is "test"
+PASS RegExp.$2 is "123"
+PASS RegExp.$1 is "test"
+PASS RegExp.$2 is "123"
+PASS RegExp.$1 is ""
+PASS RegExp.$2 is ""
+PASS RegExp.$1 is "foo"
+PASS RegExp.$2 is "bar"
+PASS RegExp.$1 is ""
+PASS RegExp.$2 is ""
+PASS RegExp.lastMatch is "\n"
+PASS RegExp.lastMatch is "\r\n"
+PASS RegExp.lastMatch is "\r"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/regex/string-split-newline.html
+++ b/LayoutTests/fast/regex/string-split-newline.html
@@ -1,0 +1,3 @@
+<!DOCTYPE HTML>
+<script src='../../resources/js-test.js'></script>
+<script src='script-tests/string-split-newline.js'></script>

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1117,6 +1117,7 @@ static ALWAYS_INLINE JSString* tryTrimSpaces(VM& vm, JSGlobalObject* globalObjec
     case Yarr::SpecificPattern::TrailingSpacesStar:
     case Yarr::SpecificPattern::LeadingSpacesStar:
     case Yarr::SpecificPattern::Atom:
+    case Yarr::SpecificPattern::Newlines:
     case Yarr::SpecificPattern::None:
         break;
     }
@@ -1300,6 +1301,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
             break;
         }
         case Yarr::SpecificPattern::Atom:
+        case Yarr::SpecificPattern::Newlines:
         case Yarr::SpecificPattern::None:
             break;
         }

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -82,6 +82,7 @@ enum class SpecificPattern : uint8_t {
     LeadingSpacesPlus,
     TrailingSpacesStar,
     TrailingSpacesPlus,
+    Newlines,
 };
 
 struct BytecodePattern;


### PR DESCRIPTION
#### cbb2ba2c0577f5eca058938242c4ab363130c56d
<pre>
Optimize common newline regex
<a href="https://bugs.webkit.org/show_bug.cgi?id=302014">https://bugs.webkit.org/show_bug.cgi?id=302014</a>
<a href="https://rdar.apple.com/163958152">rdar://163958152</a>

Reviewed by Yusuke Suzuki.

The regular expression \r\n?|\n is a very common syntax for newline splitting.
This patch adds an entry for this to Yarr::SpecificPattern and uses SIMD to further optimize
this case.

* LayoutTests/fast/regex/script-tests/string-split-newline.js: Added.
(newlinePatterns.forEach):
* LayoutTests/fast/regex/string-split-newline-expected.txt: Added.
* LayoutTests/fast/regex/string-split-newline.html: Added.
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::tryTrimSpaces):
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::extractSpecificPattern):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::findNextNewline):

Canonical link: <a href="https://commits.webkit.org/302933@main">https://commits.webkit.org/302933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d64eef496a02fb27d3bc08026873bf2bb393c2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82166 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35039 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81230 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122556 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129006 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107975 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27477 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2024 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55592 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66073 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162021 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2503 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40399 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->