### PR TITLE
add parallel-safety functionality to run-api-tests for testing parallelization

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -145,6 +145,8 @@ def parse_args(args):
                              help='Force all tests to run in parallel (without grouping shards)'),
         optparse.make_option('--additional-env-var', type='string', action='append', default=[],
                              help='Passes that environment variable to the tests (--additional-env-var=NAME=VALUE)'),
+        optparse.make_option('--test-parallel-safety', type='string', action='append', default=[],
+                             help='Run specified test(s) constantly in parallel against all allowlist tests to test parallel safety'),
 
         optparse.make_option('--site-isolation', action='store_true', default=False,
                              help='Enable Site Isolation'),

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -45,12 +45,31 @@ def run_shard(name, *tests):
     return _Worker.instance.run(name, *tests)
 
 
+def run_test_parallel_safety_single_iteration(test_name):
+    """Run a single iteration of test-parallel-safety. TaskPool will handle repeat looping."""
+    # Check if worker is ready - repeat tasks can start before setup completes
+    if _Worker.instance is None:
+        # Worker not ready yet, return early (TaskPool will retry)
+        not_ready = f'Worker not ready for {test_name}, skipping iteration'
+        _log.debug(not_ready)
+        return not_ready
+
+    binary_name = test_name.split('.')[0]
+    test_suffix = '.'.join(test_name.split('.')[1:])
+
+    try:
+        _Worker.instance._run_single_test(binary_name, test_suffix)
+        return f"Test-parallel-safety iteration completed for {test_name}"
+    except Exception as e:
+        _log.error(f'Error in test-parallel-safety iteration for {test_name}: {e}')
+        raise  # Re-raise so TaskPool can handle the error appropriately
+
 def report_result(worker, test, status, output, elapsed=None):
     if elapsed < Runner.ELAPSED_THRESHOLD and status == Runner.STATUS_PASSED and (not output or Runner.instance.port.get_option('quiet')):
-        Runner.instance.printer.write_update('{} {} {}'.format(worker, test, Runner.NAME_FOR_STATUS[status]))
+        Runner.instance.printer.write_update(f'{worker} {test} {Runner.NAME_FOR_STATUS[status]}')
     else:
-        elapsed_log = ' (took {} seconds)'.format(round(elapsed, 1)) if elapsed > Runner.ELAPSED_THRESHOLD else ''
-        Runner.instance.printer.writeln('{} {} {}{}'.format(worker, test, Runner.NAME_FOR_STATUS[status], elapsed_log))
+        elapsed_log = f' (took {round(elapsed, 1)} seconds)' if elapsed > Runner.ELAPSED_THRESHOLD else ''
+        Runner.instance.printer.writeln(f'{worker} {test} {Runner.NAME_FOR_STATUS[status]}{elapsed_log}')
     if test in Runner.instance.results:
         existing_status = Runner.instance.results[test][0]
         if status > existing_status or (status == existing_status and status != Runner.STATUS_PASSED):
@@ -111,7 +130,7 @@ class Runner(object):
             assert port.DEVICE_MANAGER.INITIALIZED_DEVICES
             return ['/usr/bin/xcrun', 'simctl', 'spawn', port.DEVICE_MANAGER.INITIALIZED_DEVICES[0].udid] + args
         elif 'device' in port.port_name:
-            raise RuntimeError('Running api tests on {} is not supported'.format(port.port_name))
+            raise RuntimeError(f'Running api tests on {port.port_name} is not supported')
         elif port.host.platform.is_win():
             args[0] = os.path.splitext(args[0])[0] + '.exe'
         return args
@@ -134,6 +153,9 @@ class Runner(object):
         if not tests:
             return
 
+        if self.port.get_option('fully_parallel') and self.port.get_option('test_parallel_safety'):
+            raise RuntimeError(f'Running api tests fully parallel is not compatible with test_parallel_safety')
+
         self.printer.write_update('Sharding tests ...')
         shards = Runner._shard_tests(tests, self.port.get_option('fully_parallel'))
 
@@ -146,7 +168,6 @@ class Runner(object):
             Runner.instance = self
             mutually_exclusive_groups = list(self.port.sharding_groups(suite='api-tests').keys())
             workers = (num_workers if num_workers and num_workers >= self._num_workers else max(self.port.default_child_processes() or self._num_workers, self._num_workers) if mutually_exclusive_groups else self._num_workers)
-            self._num_workers = min(workers, len(shards))
 
             devices = None
             if getattr(self.port, 'DEVICE_MANAGER', None):
@@ -155,7 +176,30 @@ class Runner(object):
                     initialized_devices=self.port.DEVICE_MANAGER.INITIALIZED_DEVICES,
                 )
 
-            # Separate system and non-system shards
+            supplied_tests_raw = self.port.get_option('test_parallel_safety')
+            # Reserve 1/3 of workers for repeat tasks
+            max_repeat_workers = max(1, workers // 3)
+            supplied_tests = []
+            test_parallel_safety_batches = []
+            # Calculate batching for test-parallel-safety tasks to prevent overwhelming workers
+            if supplied_tests_raw:
+                for test_arg in supplied_tests_raw:
+                    supplied_tests.extend(test_arg.split())
+                _log.info(f'Test-parallel-safety mode: creating repeat loop tasks for tests: {supplied_tests}')
+
+                if len(supplied_tests) <= max_repeat_workers:
+                    # All tasks fit in one batch
+                    test_parallel_safety_batches = [supplied_tests]
+                else:
+                    # Split into batches of max_repeat_workers
+                    for i in range(0, len(supplied_tests), max_repeat_workers):
+                        batch = supplied_tests[i:i + max_repeat_workers]
+                        test_parallel_safety_batches.append(batch)
+                    _log.info(f'Test-parallel-safety batching: {len(supplied_tests)} tasks split into {len(test_parallel_safety_batches)} batches of max {max_repeat_workers} tasks each')
+
+            # For minimum worker calculation, use current batch size (first batch or all if unbatched)
+            self._num_workers = min(workers, max(len(shards) + (len(test_parallel_safety_batches[0]) if test_parallel_safety_batches else 0), 1))
+
             system_shards = {}
             non_system_shards = {}
 
@@ -166,33 +210,55 @@ class Runner(object):
                 else:
                     non_system_shards[name] = tests
 
-            # Run non-system tests first
-            if non_system_shards:
+            # Process test-parallel-safety batches sequentially
+            for batch_index, test_parallel_safety_batch in enumerate(test_parallel_safety_batches if test_parallel_safety_batches else [[]]):
+                if test_parallel_safety_batch:
+                    _log.info(f'Running batch {batch_index + 1}/{len(test_parallel_safety_batches)}: {len(non_system_shards)} regular shards with {len(test_parallel_safety_batch)} test-parallel-safety repeat tasks')
+
                 non_system_groups = [group for group in mutually_exclusive_groups if group != 'system']
+                test_parallel_safety_groups = []
+                if test_parallel_safety_batch:
+                    # Create unique groups for each test-parallel-safety task so they get separate workers
+                    for i, test_name in enumerate(test_parallel_safety_batch):
+                        test_parallel_safety_group = f'test-parallel-safety-{i}'
+                        test_parallel_safety_groups.append(test_parallel_safety_group)
+                        non_system_groups.append(test_parallel_safety_group)
+                    batch_test_parallel_safety_count = len(test_parallel_safety_batch)
+                    batch_effective_work_count = len(non_system_shards) + batch_test_parallel_safety_count
+                    batch_workers = min(workers, max(batch_effective_work_count, 1))
+                else:
+                    batch_workers = self._num_workers
+
                 with TaskPool(
-                    workers=self._num_workers,
+                    workers=batch_workers,
                     mutually_exclusive_groups=non_system_groups,
                     setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices, log_limit=self.log_limit), teardown=teardown_shard,
                 ) as pool:
-                    was_sent = set()
 
-                    # Dispatch shards from non-system groups first
-                    for name, tests in iteritems(non_system_shards):
-                        group = self.port.group_for_shard(type('Shard', (), {'name': name})(), suite='api-tests')
-                        if group and group != 'system' and not self.port.get_option('fully_parallel'):
-                            was_sent.add(name)
-                            pool.do(run_shard, name, *tests, group=group)
+                    if test_parallel_safety_batch:
+                        for i, test_name in enumerate(test_parallel_safety_batch):
+                            test_parallel_safety_group = test_parallel_safety_groups[i]
+                            _log.info(f'Dispatching repeat test-parallel-safety task for {test_name} to group {test_parallel_safety_group} (batch {batch_index + 1}/{len(test_parallel_safety_batches)})')
+                            pool.do(run_test_parallel_safety_single_iteration, test_name, repeat=True, group=test_parallel_safety_group)
 
-                    # Dispatch remaining non-system shards
+                    # Run regular shards with each batch - this is the whole point of test-parallel-safety testing
                     for name, tests in iteritems(non_system_shards):
-                        if name in was_sent:
+                        if name.startswith('test-parallel-safety.'):
                             continue
-                        pool.do(run_shard, name, *tests)
+
+                        group = self.port.group_for_shard(type('Shard', (), {'name': name})(), suite='api-tests')
+                        if test_parallel_safety_batches and group == 'system':
+                            continue
+
+                        if group and group != 'system' and not self.port.get_option('fully_parallel'):
+                            pool.do(run_shard, name, *tests, group=group)
+                        else:
+                            pool.do(run_shard, name, *tests)
 
                     pool.wait()
 
-            # Run system tests after all non-system tests complete
-            if system_shards:
+            # Run system tests after all non-system tests complete (unless in test-parallel-safety mode)
+            if system_shards and not self.port.get_option('test_parallel_safety'):
                 with TaskPool(
                     workers=1,  # System tests run with single worker to avoid conflicts
                     mutually_exclusive_groups=[],
@@ -202,6 +268,8 @@ class Runner(object):
                         pool.do(run_shard, name, *tests)
 
                     pool.wait()
+            elif self.port.get_option('test_parallel_safety'):
+                _log.info('Test-parallel-safety mode: skipping all system shard execution')
 
         finally:
             server_process_logger.setLevel(original_level)
@@ -247,7 +315,7 @@ class _Worker(object):
     def _run_single_test(self, binary_name, test):
         server_process = ServerProcess(
             self._port, binary_name,
-            Runner.command_for_port(self._port, [self._port.path_to_api_test(binary_name), '--gtest_filter={}'.format(test)]),
+            Runner.command_for_port(self._port, [self._port.path_to_api_test(binary_name), f'--gtest_filter={test}']),
             env=self._port.environment_for_api_tests())
 
         status = Runner.STATUS_RUNNING
@@ -322,7 +390,7 @@ class _Worker(object):
 
         TaskPool.Process.queue.send(TaskPool.Task(
             report_result, None, TaskPool.Process.name,
-            '{}.{}'.format(binary_name, test),
+            f'{binary_name}.{test}',
             status,
             self._filter_noisy_output(output_buffer),
             elapsed=time.time() - started,
@@ -338,7 +406,7 @@ class _Worker(object):
             server_process = ServerProcess(
                 self._port, binary_name,
                 Runner.command_for_port(self._port, [
-                    self._port.path_to_api_test(binary_name), '--gtest_filter={}'.format(':'.join(remaining_tests))
+                    self._port.path_to_api_test(binary_name), f'--gtest_filter={":".join(remaining_tests)}'
                 ]), env=self._port.environment_for_api_tests())
 
             try:
@@ -382,7 +450,7 @@ class _Worker(object):
                         line_count = 0
                         TaskPool.Process.queue.send(TaskPool.Task(
                             report_result, None, TaskPool.Process.name,
-                            '{}.{}'.format(binary_name, last_test),
+                            f'{binary_name}.{last_test}',
                             last_status, buffer,
                             elapsed=time.time() - started,
                         ))
@@ -415,7 +483,7 @@ class _Worker(object):
 
                     TaskPool.Process.queue.send(TaskPool.Task(
                         report_result, None, TaskPool.Process.name,
-                        '{}.{}'.format(binary_name, last_test),
+                        f'{binary_name}.{last_test}',
                         last_status,
                         self._filter_noisy_output(buffer),
                         elapsed=time.time() - started,

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -77,10 +77,12 @@ class DarwinPort(ApplePort):
 
     def sharding_groups(self, suite=None):
         if suite == 'api-tests':
-            return {
-                'system': lambda shard: self._should_use_system_shard(shard.name),
-                'system': lambda shard: self._should_use_system_shard(shard.name),
-            }
+            groups = {}
+
+            # Add system group - test-parallel-safety groups will be created dynamically in runner.py
+            groups['system'] = lambda shard: '__WEBKIT_TEST_PARALLEL_SAFETY_SHARD_' not in shard.name and self._should_use_system_shard(shard.name)
+
+            return groups
         return {
             'media': lambda shard: 'media' in shard.name or 'webaudio' in shard.name,
         }


### PR DESCRIPTION
#### 94022d76e6266c7acb456b43779eaf36a753cc6d
<pre>
add parallel-safety functionality to run-api-tests for testing parallelization
<a href="https://bugs.webkit.org/show_bug.cgi?id=302018">https://bugs.webkit.org/show_bug.cgi?id=302018</a>
<a href="https://rdar.apple.com/164101543">rdar://164101543</a>

Reviewed by Jonathan Bedard.

This adds functionality for testing parallelization on a given test.

* Tools/Scripts/run-api-tests:
(parse_args):
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/runner.py:
(run_parallel_safety_single_iteration):
(Runner.run):
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.sharding_groups):

Canonical link: <a href="https://commits.webkit.org/304306@main">https://commits.webkit.org/304306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b98f32e9ac714d1b4aff325e74cc27d234d9d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142713 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7447 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5875 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84178 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/134555 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3304 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145410 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7281 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7325 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112062 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28431 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5507 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7335 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7091 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7311 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->