### PR TITLE
[WebGPU+Swift] Factor some unsafe code into StdLibExtras.swift

### DIFF
--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0DD5FD352C66947B004AF552 /* XRProjectionLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DD5FD332C66947B004AF552 /* XRProjectionLayer.h */; };
 		0DD5FD362C66947B004AF552 /* XRProjectionLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DD5FD342C66947B004AF552 /* XRProjectionLayer.mm */; };
 		0DE2BFAD2C150DF700D04AEB /* ShaderStage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DE2BFAC2C150DF700D04AEB /* ShaderStage.h */; };
+		14C834402EBA7CBB003B591A /* StdLibExtras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8343F2EBA7CBB003B591A /* StdLibExtras.swift */; };
 		1C0F41EE280940650005886D /* HardwareCapabilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C0F41EC280940650005886D /* HardwareCapabilities.mm */; };
 		1C2CEDEE271E8A7300EDC16F /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C2CEDED271E8A7300EDC16F /* Metal.framework */; };
 		1C582FF927E04131009B40F0 /* CommandsMixin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C582FF727E04131009B40F0 /* CommandsMixin.mm */; };
@@ -316,6 +317,7 @@
 		0DD5FD332C66947B004AF552 /* XRProjectionLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XRProjectionLayer.h; sourceTree = "<group>"; };
 		0DD5FD342C66947B004AF552 /* XRProjectionLayer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = XRProjectionLayer.mm; sourceTree = "<group>"; };
 		0DE2BFAC2C150DF700D04AEB /* ShaderStage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShaderStage.h; sourceTree = "<group>"; };
+		14C8343F2EBA7CBB003B591A /* StdLibExtras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdLibExtras.swift; sourceTree = "<group>"; };
 		1C0F41EC280940650005886D /* HardwareCapabilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = HardwareCapabilities.mm; sourceTree = "<group>"; };
 		1C0F41ED280940650005886D /* HardwareCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HardwareCapabilities.h; sourceTree = "<group>"; };
 		1C2CEDED271E8A7300EDC16F /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
@@ -700,6 +702,7 @@
 				1CEBD80D2716C3D800A5254D /* ShaderModule.h */,
 				1C5ACAB0273A426D0095F8D5 /* ShaderModule.mm */,
 				0DE2BFAC2C150DF700D04AEB /* ShaderStage.h */,
+				14C8343F2EBA7CBB003B591A /* StdLibExtras.swift */,
 				1C5ACA99273A426D0095F8D5 /* Texture.h */,
 				1C5ACAB1273A426D0095F8D5 /* Texture.mm */,
 				0D164A392E8EE14700864EA1 /* TextureOrTextureView.h */,
@@ -1358,6 +1361,7 @@
 				1C5ACAB6273A426D0095F8D5 /* RenderPipeline.mm in Sources */,
 				1C5ACAE9273A55FD0095F8D5 /* Sampler.mm in Sources */,
 				1C5ACACE273A426E0095F8D5 /* ShaderModule.mm in Sources */,
+				14C834402EBA7CBB003B591A /* StdLibExtras.swift in Sources */,
 				1C5ACACF273A426E0095F8D5 /* Texture.mm in Sources */,
 				1C5ACAEB273A560D0095F8D5 /* TextureView.mm in Sources */,
 				0D078E942E737C0500A9B266 /* UsdModelRenderer.swift in Sources */,

--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -26,13 +26,12 @@
 import WebGPU_Internal
 
 extension WebGPU.Buffer {
-    func copy(from data: Span<UInt8>, offset: Int) {
-        // FIXME: Use a bounds-checking implementation when one is available.
-        var bufferContents = unsafe MutableSpan<UInt8>(_unsafeCxxSpan: getBufferContents());
-        precondition(bufferContents.count >= offset + data.count)
-        for i in 0..<data.count {
-            bufferContents[offset + i] = data[i]
-        }
+    func copy(from source: Span<UInt8>, offset: Int) {
+        // FIXME (rdar://161274084): Swift doesn't have a lifetime-safe way to return a borrowed value from a refcounted object yet.
+        let bufferContents = unsafe MutableSpan(_unsafeCxxSpan: getBufferContents())
+
+        var destination = bufferContents._consumingExtracting(droppingFirst: offset)
+        destination.copyMemory(from: source)
     }
 }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -554,8 +554,7 @@ extension WebGPU.CommandEncoder {
         }
 
         // https://gpuweb.github.io/gpuweb/#abstract-opdef-set-of-subresources-for-texture-copy
-        // FIXME(rdar://130765784): we should be able use === here once the radar lands
-        if unsafe unsafeBitCast(source.texture, to: UnsafeRawPointer.self) == unsafeBitCast(destination.texture, to: UnsafeRawPointer.self) {
+        if source.texture === destination.texture {
             // Mip levels are never ranges.
             if source.mipLevel == destination.mipLevel {
                 switch WebGPU.fromAPI(source.texture).dimension() {

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -29,7 +29,8 @@ private let largeBufferSize = 32 * 1024 * 1024
 
 @_expose(Cxx)
 public func Queue_writeBuffer_thunk(queue: WebGPU.Queue, buffer: MTLBuffer, bufferOffset: UInt64, data: SpanUInt8) {
-    queue.writeBuffer(buffer: buffer, bufferOffset: bufferOffset, data: unsafe MutableSpan<UInt8>(_unsafeCxxSpan: data)) // FIXME (rdar://161269480): We should be able to declare 'data' as MutableSpan<UInt8>, which will remove this use of 'unsafe'.
+    // FIXME (rdar://161269480): We should be able to declare 'data' as MutableSpan<UInt8>, which will remove this use of 'unsafe'.
+    queue.writeBuffer(buffer: buffer, bufferOffset: bufferOffset, data: unsafe MutableSpan(_unsafeCxxSpan: data))
 }
 
 extension WebGPU.Queue {
@@ -44,7 +45,8 @@ extension WebGPU.Queue {
 
         let count = data.count
         let noCopy = data.count >= largeBufferSize
-        let bufferWithOffset = unsafe newTemporaryBufferWithBytes(SpanUInt8(data), noCopy) // FIXME: 'bufferWithOffset' may extend the lifetime of 'data', but we drop that information here
+        // FIXME: 'bufferWithOffset' may extend the lifetime of 'data', but we drop that information here
+        let bufferWithOffset = unsafe newTemporaryBufferWithBytes(SpanUInt8(data), noCopy)
         let temporaryBuffer = unsafe bufferWithOffset.first
         let temporaryBufferOffset = unsafe bufferWithOffset.second
 

--- a/Source/WebGPU/WebGPU/StdLibExtras.swift
+++ b/Source/WebGPU/WebGPU/StdLibExtras.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// FIXME (rdar://164119356): Move StdLibExtras.swift from WebGPU to WTF
+
+// FIXME (rdar://162375123): This should be in the standard library.
+extension MutableSpan where Element: BitwiseCopyable {
+    @_lifetime(self: copy self)
+    mutating func copyMemory(from source: Span<Element>) {
+        // Safety: This is lifetime safe because we have exclusive access to 'self' and we don't escape 'selfBuffer'
+        unsafe withUnsafeMutableBufferPointer { selfBuffer in
+            // Safety: This is lifetime safe because we have exclusive access to 'source' and we don't escape 'sourceBuffer'
+            unsafe source.withUnsafeBufferPointer { sourceBuffer in
+                // Safety: This is bounds safe because we do a manual bounds check
+                // Safety: This is type safe because we statically declare that our element types match and are BitwiseCopyable
+                precondition(sourceBuffer.count <= selfBuffer.count)
+                _ = unsafe memcpy(selfBuffer.baseAddress, sourceBuffer.baseAddress, sourceBuffer.count)
+            }
+        }
+    }
+}
+
+// FIXME(rdar://130765784): We should be able use the built-in ===, but AnyObject currently excludes foreign reference types
+func === (_ lhs: WGPUTexture, _ rhs: WGPUTexture) -> Bool {
+    // Safety: Swift represents all reference types, including foreign reference types, as raw pointers
+    unsafe unsafeBitCast(lhs, to: UnsafeRawPointer.self) == unsafeBitCast(rhs, to: UnsafeRawPointer.self)
+}


### PR DESCRIPTION
#### 59fd40b9b902e6c949ecefa27c7f832b9c8c92b2
<pre>
[WebGPU+Swift] Factor some unsafe code into StdLibExtras.swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=302024">https://bugs.webkit.org/show_bug.cgi?id=302024</a>
<a href="https://rdar.apple.com/164104484">rdar://164104484</a>

Reviewed by Richard Robinson and Mike Wyrzykowski.

These operations are safe in fact, even though they use &apos;unsafe&apos; in their
implementations.

Factoring them into a separate file helps clarify which pieces of WebGPU still
have safety work left to do.

* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/Buffer.swift:
(WebGPU.copy(from:offset:)): It&apos;s now a bit clearer that the memory copy is in
fact safe; it&apos;s the lifetime of the buffer that&apos;s unsafe.

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.errorValidatingCopyTextureToTexture(_:destination:copySize:)): It&apos;s now
a bit clearer that this code is perfectly safe.

* Source/WebGPU/WebGPU/Queue.swift:
(Queue_writeBuffer_thunk(_:buffer:bufferOffset:data:)):
(WebGPU.writeBuffer(_:bufferOffset:data:)):
* Source/WebGPU/WebGPU/StdLibExtras.swift: Added. Holding tank for functionality
that has agreement in principle to be added to Swift or the Swift standard library,
but hasn&apos;t been added yet.
(MutableSpan.copyMemory(from:)):

Canonical link: <a href="https://commits.webkit.org/302614@main">https://commits.webkit.org/302614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e92e04e1d7b0695a0925c82ebdb2161002c6761f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137080 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/287444fd-57b4-4745-ab7d-110f743ad866) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98796 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea70081b-8a9c-475c-8d1b-617d9ef5a273) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132639 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79470 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e792298b-99f2-4c2d-8639-5cb375b111e2) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80352 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139562 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107308 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107175 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31002 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54497 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65189 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1634 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1741 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->