### PR TITLE
[iOS] Remove use of `-[UIScreen mainScreen]` in API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RenderedImageWithOptions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RenderedImageWithOptions.mm
@@ -28,6 +28,7 @@
 #import "RenderedImageWithOptionsProtocol.h"
 #import "TestNSBundleExtras.h"
 #import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
 #import "Utilities.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKWebViewPrivate.h>
@@ -41,7 +42,7 @@ using namespace TestWebKitAPI;
 static void runTestWithWidth(NSNumber *width, CGSize expectedSize)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"RenderedImageWithOptionsPlugIn"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
 
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(RenderedImageWithOptionsProtocol)];
     auto remoteObject = retainPtr([[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface]);
@@ -52,7 +53,7 @@ static void runTestWithWidth(NSNumber *width, CGSize expectedSize)
     __block bool testFinished = false;
     [remoteObject renderImageWithWidth:width completionHandler:^(CGSize imageSize) {
 #if PLATFORM(IOS_FAMILY)
-        CGFloat scale = [UIScreen mainScreen].scale;
+        CGFloat scale = [webView window].screen.scale;
 #elif PLATFORM(MAC)
         CGFloat scale = [NSScreen mainScreen].backingScaleFactor;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
@@ -59,10 +59,7 @@ TEST(ElementFullscreen, ScrollViewSetToInitialScale)
     [fullscreenDelegate waitForDidEnterElementFullscreen];
     [webView waitForNextPresentationUpdate];
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
-    CGFloat expectedScale = std::min<CGFloat>(UIScreen.mainScreen.bounds.size.width / 1000, 1);
-ALLOW_DEPRECATED_DECLARATIONS_END
+    CGFloat expectedScale = std::min<CGFloat>([webView window].screen.bounds.size.width / 1000, 1);
 
     EXPECT_EQ([webView scrollView].zoomScale, expectedScale);
     EXPECT_EQ([webView scrollView].minimumZoomScale, expectedScale);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -242,10 +242,7 @@ TEST(WKWebExtension, MultipleIconSizes)
 
     auto screenScale = 1.0;
 #if PLATFORM(IOS_FAMILY)
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
-    screenScale = UIScreen.mainScreen.scale;
-ALLOW_DEPRECATED_DECLARATIONS_END
+    screenScale = UITraitCollection.currentTraitCollection.displayScale;
 #else
     screenScale = NSScreen.mainScreen.backingScaleFactor;
 #endif

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1377,10 +1377,7 @@ TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedA
     CGImagePixelReader snapshotReaderExpected { expected.get() };
     CGImagePixelReader snapshotReaderActual { actual.get() };
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
-    auto scale = UIScreen.mainScreen.scale;
-ALLOW_DEPRECATED_DECLARATIONS_END
+    auto scale = UITraitCollection.currentTraitCollection.displayScale;
 
     for (int x = 0; x < frame.size.width * scale; ++x) {
         for (int y = 0; y < frame.size.height * scale; ++y)


### PR DESCRIPTION
#### e4bb4f6943e28eb5d0b26e86c7642406420f198c
<pre>
[iOS] Remove use of `-[UIScreen mainScreen]` in API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=302023">https://bugs.webkit.org/show_bug.cgi?id=302023</a>
<a href="https://rdar.apple.com/164104315">rdar://164104315</a>

Reviewed by Abrar Rahman Protyasha and Timothy Hatcher.

`-[UIScreen mainScreen]` was deprecated in iOS 26. Work towards removing its
use in WebKit.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/RenderedImageWithOptions.mm:
(runTestWithWidth):

Use `TestWKWebView`, so that a `UIWindow` (and `UIScreen`) can be obtained.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm:
(TEST(ElementFullscreen, ScrollViewSetToInitialScale)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, MultipleIconSizes)):

Get the display scale from the current trait collection. This uses UIKit&apos;s fallback
trait collection mechanism.

* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedAncestorColorProperty)):

Get the display scale from the current trait collection.

Canonical link: <a href="https://commits.webkit.org/302660@main">https://commits.webkit.org/302660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6144ac13c6984145bbba1e2a22d9f162cf96f7be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81111 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/087ba279-829d-431f-a15b-201e42e80736) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98765 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66610 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/77499d5b-b96c-4a1c-85d7-ee2d64657bf0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79437 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0891d0ff-2eb4-413c-a79e-8c324751d7c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80314 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139524 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107281 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107141 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1386 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54459 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20250 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1781 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1596 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1631 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->