### PR TITLE
Crunchyroll video controls reappear continuously even when the mouse is stationary

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4673,7 +4673,10 @@ void LocalFrameView::performPostLayoutTasks()
     resnapAfterLayout();
 
     m_frame->document()->scheduleDeferredAXObjectCacheUpdate();
-    m_frame->eventHandler().scheduleMouseEventTargetUpdateAfterLayout();
+
+    RefPtr document = m_frame->document();
+    if (document && !document->quirks().needsSuppressPostLayoutBoundaryEventsQuirk())
+        m_frame->eventHandler().scheduleMouseEventTargetUpdateAfterLayout();
 }
 
 void LocalFrameView::dequeueScrollableAreaForScrollAnchoringUpdate(ScrollableArea& scrollableArea)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2025,6 +2025,11 @@ bool Quirks::needsNowPlayingFullscreenSwapQuirk() const
     return needsQuirks() && m_quirksData.needsNowPlayingFullscreenSwapQuirk;
 }
 
+bool Quirks::needsSuppressPostLayoutBoundaryEventsQuirk() const
+{
+    return needsQuirks() && m_quirksData.needsSuppressPostLayoutBoundaryEventsQuirk;
+}
+
 // tiktok.com rdar://149712691
 std::optional<Quirks::TikTokOverflowingContentQuirkType> Quirks::needsTikTokOverflowingContentQuirk(const Element& element, const RenderStyle& parentStyle) const
 {
@@ -3176,6 +3181,13 @@ static void handleCapitalGroupQuirks(QuirksData& quirksData, const URL&, const S
     quirksData.shouldDelayReloadWhenRegisteringServiceWorker = true;
 }
 
+static void handleCrunchyRollQuirks(QuirksData& quirksData, const URL&, const String& quirksDomainString, const URL&)
+{
+    if (quirksDomainString != "crunchyroll.com"_s)
+        return;
+    quirksData.needsSuppressPostLayoutBoundaryEventsQuirk = true;
+}
+
 void Quirks::determineRelevantQuirks()
 {
     RELEASE_ASSERT(m_document);
@@ -3233,6 +3245,7 @@ void Quirks::determineRelevantQuirks()
         { "digitaltrends"_s, &handleDigitalTrendsQuirks },
         { "steampowered"_s, &handleSteamQuirks },
 #endif
+        { "crunchyroll"_s, &handleCrunchyRollQuirks },
         { "t-mobile"_s, &handleTMobileQuirks },
         { "descript"_s, &handleDescriptQuirks },
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -296,6 +296,8 @@ public:
 
     bool shouldDisableDOMAudioSessionQuirk() const;
 
+    bool needsSuppressPostLayoutBoundaryEventsQuirk() const;
+
     void determineRelevantQuirks();
 
 private:

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -207,6 +207,8 @@ struct WEBCORE_EXPORT QuirksData {
 #if HAVE(PIP_SKIP_PREROLL)
     bool shouldDisableAdSkippingInPip : 1 { false };
 #endif
+
+    bool needsSuppressPostLayoutBoundaryEventsQuirk : 1 { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f4a651a644be9e98d6d28b59043a4d8279ac48e8
<pre>
Crunchyroll video controls reappear continuously even when the mouse is stationary
<a href="https://bugs.webkit.org/show_bug.cgi?id=302026">https://bugs.webkit.org/show_bug.cgi?id=302026</a>
<a href="https://rdar.apple.com/163908769">rdar://163908769</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

Crunchyroll&apos;s video player contains an element which is always present with a
mouseover listener attached. This listener inserts an element containing the
video player controls, and the controls disappear after a few seconds. After
the controls disappear, mouseover fires again on the other element, causing
controls to reappear.

To fix this, we disable boundary events on layout change on crunchyroll.com.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::performPostLayoutTasks):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsSuppressPostLayoutBoundaryEventsQuirk const):
(WebCore::handleCrunchyRollQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/302633@main">https://commits.webkit.org/302633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df2070ebd96a3b1fde2a8a58149524768078c1bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81133 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f7fb2a31-528c-4f33-b9ca-d21fc62c4d4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66620 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94352e76-8786-4a93-90ac-3fdd86c24bcd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79454 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b64603e-da3e-42b7-9075-8c38bab1109f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1364 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34278 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80333 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139543 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107297 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107158 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54478 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20241 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65170 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1650 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1722 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->