### PR TITLE
[build.webkit.org] Switch macOS Debug JSC stress test queue to O3 debug builds

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -361,8 +361,7 @@
                   "platform": "mac-sonoma", "configuration": "debug", "architectures": ["x86_64", "arm64"],
                   "triggers": [
                       "sonoma-debug-tests-test262", "sonoma-debug-tests-wk1", "sonoma-debug-tests-wk2",
-                      "sonoma-debug-applesilicon-tests-wk1", "sonoma-debug-applesilicon-tests-wk2",
-                      "sonoma-applesilicon-debug-tests-jsc"
+                      "sonoma-debug-applesilicon-tests-wk1", "sonoma-debug-applesilicon-tests-wk2"
                   ],
                   "workernames": ["bot247", "bot248"]
                   },
@@ -390,8 +389,8 @@
                     "platform": "mac-sonoma", "configuration": "debug", "architectures": ["x86_64", "arm64"],
                     "workernames": ["bot603"]
                   },
-                  { "name": "Apple-Sonoma-AppleSilicon-Debug-JSC-Tests", "factory": "TestJSCFactory",
-                    "platform": "mac-sonoma", "configuration": "debug", "architectures": ["x86_64", "arm64"],
+                  { "name": "Apple-Sonoma-AppleSilicon-O3-Debug-JSC-BuildAndTest", "factory": "BuildO3AndJSCTestsFactory",
+                    "platform": "mac-sonoma", "configuration": "debug", "architectures": ["arm64"],
                     "workernames": ["bot105"]
                   },
                   {
@@ -844,7 +843,7 @@
                   "builderNames": ["Apple-Sequoia-Debug-AppleSilicon-WK2-Tests"]
                   },
                   { "type": "PlatformSpecificScheduler", "platform": "mac-sonoma", "branch": "main", "treeStableTimer": 45.0,
-                  "builderNames": ["Apple-Sonoma-Release-Build", "Apple-Sonoma-Debug-Build"]
+                  "builderNames": ["Apple-Sonoma-Release-Build", "Apple-Sonoma-Debug-Build", "Apple-Sonoma-AppleSilicon-O3-Debug-JSC-BuildAndTest"]
                   },
                   { "type": "Triggerable", "name": "sonoma-release-tests-wk1",
                   "builderNames": ["Apple-Sonoma-Release-WK1-Tests"]
@@ -875,9 +874,6 @@
                   },
                   { "type": "Triggerable", "name": "sonoma-release-tests-test262",
                     "builderNames": ["Apple-Sonoma-Release-Test262-Tests"]
-                  },
-                  { "type": "Triggerable", "name": "sonoma-applesilicon-debug-tests-jsc",
-                    "builderNames": ["Apple-Sonoma-AppleSilicon-Debug-JSC-Tests"]
                   },
                   { "type": "Triggerable", "name": "sonoma-applesilicon-release-tests-jsc",
                     "builderNames": ["Apple-Sonoma-AppleSilicon-Release-JSC-Tests"]

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -166,6 +166,14 @@ class BuildAndJSCTests32Factory(Factory):
         self.addStep(RunJavaScriptCoreTests(timeout=60 * 60))
 
 
+class BuildO3AndJSCTestsFactory(Factory):
+    def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None):
+        Factory.__init__(self, platform, configuration, architectures, False, additionalArguments, device_model)
+        self.addStep(SetO3OptimizationLevel())
+        self.addStep(CompileJSCOnly(timeout=60 * 60))
+        self.addStep(RunJavaScriptCoreTests(timeout=60 * 60))
+
+
 class TestAllButJSCFactory(TestFactory):
     JSCTestClass = None
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -852,7 +852,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'test262-test'
         ],
-        'Apple-Sonoma-AppleSilicon-Debug-JSC-Tests': [
+        'Apple-Sonoma-AppleSilicon-O3-Debug-JSC-BuildAndTest': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -862,8 +862,8 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
-            'download-built-product',
-            'extract-built-product',
+            'set-o3-optimization-level',
+            'compile-jsc',
             'jscore-test'
         ],
         'Apple-Sonoma-AppleSilicon-Release-JSC-Tests': [

--- a/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
+++ b/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
@@ -66,7 +66,7 @@ WebKitBuildbot = function()
         "Apple-Sonoma JSC": {platform: Dashboard.Platform.macOSSonoma, heading: "JavaScript", combinedQueues: {
             "Apple-Sonoma-Debug-Test262-Tests": {heading: "Debug Test262 (Tests)"},
             "Apple-Sonoma-Release-Test262-Tests": {heading: "Release Test262 (Tests)"},
-            "Apple-Sonoma-AppleSilicon-Debug-JSC-Tests": {heading: "Debug arm64 JSC (Tests)"},
+            "Apple-Sonoma-AppleSilicon-O3-Debug-JSC-BuildAndTest": {heading: "O3 Debug arm64 JSC (BuildAndTest)"},
             "Apple-Sonoma-AppleSilicon-Release-JSC-Tests": {heading: "Release arm64 JSC (Tests)"},
             "Apple-Sonoma-Intel-Release-JSC-Tests": {heading: "Release x86_64 JSC (Tests)"},
         }},

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -2324,3 +2324,10 @@ class RebootWithUpdatedCrossTargetImage(shell.ShellCommand):
         if rc == SUCCESS:
             self.build.buildFinished(['Rebooting with updated image, retrying build'], RETRY)
         defer.returnValue(rc)
+
+
+class SetO3OptimizationLevel(shell.ShellCommand):
+    command = ["Tools/Scripts/set-webkit-configuration", "--force-optimization-level=O3"]
+    name = "set-o3-optimization-level"
+    description = ["set O3 optimization level"]
+    descriptionDone = ["set O3 optimization level"]


### PR DESCRIPTION
#### c658e38c091d211f78c30a83421aaea6abe41e0b
<pre>
[build.webkit.org] Switch macOS Debug JSC stress test queue to O3 debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=302031">https://bugs.webkit.org/show_bug.cgi?id=302031</a>
<a href="https://rdar.apple.com/159975242">rdar://159975242</a>

Reviewed by Jonathan Bedard.

Switching this queue to O3 debug builds will increase its throughput and test result granularity.
This change brings test runtime down from 11 hours to about an hour on the same hardware. If this
queue proves to be reliable, we may switch the JSC-Tests-arm64-EWS queue to this configuration in
order to catch assertion failures on JSC pull requests.

In order to limit the scope of O3 builds to JSC tests, this test queue must now compile JSC
itself rather than being triggered by the same debug builder that triggers all macOS debug
style tests.

* Tools/CISupport/build-webkit-org/config.json: Update the queue name to reflect that it is
now a build and test queue, and switch it to the new factory.
* Tools/CISupport/build-webkit-org/factories.py:
(BuildO3AndJSCTestsFactory): Create a new factory that will include the step to set the
optimization level.
(BuildO3AndJSCTestsFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps): Update unit tests.
* Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js:
(WebKitBuildbot): Update the queue name on the dashboard.
* Tools/CISupport/build-webkit-org/steps.py:
(SetO3OptimizationLevel): New step to run `set-webkit-configuration` to enable the O3 optimization
level before building JSC.

Canonical link: <a href="https://commits.webkit.org/302930@main">https://commits.webkit.org/302930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a25543b6e69c95d3840acda530bc9a9f7bb783c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130672 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/2943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41627 "Build is in progress. Recent messages:") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f731876e-a3bb-44ce-9a25-27b557f22865) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132543 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/2959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/2836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/138095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dfdfd9b0-3723-4265-8254-ce600497fcaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133619 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/2959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/41627 "Build is in progress. Recent messages:") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4bdd0be7-1c72-42e5-941b-2f37993365f2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/2959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/41627 "Build is in progress. Recent messages:") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/2959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/41627 "Build is in progress. Recent messages:") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140573 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/2836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/140573 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130102 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/41627 "Build is in progress. Recent messages:") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140573 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/41627 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20345 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/2803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->