### PR TITLE
Incorrect date passed when removing expired permission match patterns

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -271,7 +271,6 @@ void WebExtensionContext::setGrantedPermissions(PermissionsMap&& grantedPermissi
         }
 
         addedPermissions.add(entry.key);
-        addedPermissions.add(entry.key);
     }
 
     if (addedPermissions.isEmpty() && removedPermissions.isEmpty())
@@ -328,7 +327,7 @@ void WebExtensionContext::setGrantedPermissionMatchPatterns(PermissionMatchPatte
         removedMatchPatterns.add(entry.key);
 
     m_nextGrantedPermissionMatchPatternsExpirationDate = WallTime::nan();
-    m_grantedPermissionMatchPatterns = removeExpired(grantedPermissionMatchPatterns, m_nextGrantedPermissionsExpirationDate);
+    m_grantedPermissionMatchPatterns = removeExpired(grantedPermissionMatchPatterns, m_nextGrantedPermissionMatchPatternsExpirationDate);
 
     MatchPatternSet addedMatchPatterns;
     for (auto& entry : m_grantedPermissionMatchPatterns) {
@@ -881,7 +880,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
         m_cachedPermissionURLs.appendOrMoveToLast(url);
         m_cachedPermissionStates.set(url, result);
 
-        ASSERT(m_cachedPermissionURLs.size() == m_cachedPermissionURLs.size());
+        ASSERT(m_cachedPermissionURLs.size() == m_cachedPermissionStates.size());
 
         if (m_cachedPermissionURLs.size() <= maximumCachedPermissionResults)
             return result;
@@ -889,7 +888,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
         URL firstCachedURL = m_cachedPermissionURLs.takeFirst();
         m_cachedPermissionStates.remove(firstCachedURL);
 
-        ASSERT(m_cachedPermissionURLs.size() == m_cachedPermissionURLs.size());
+        ASSERT(m_cachedPermissionURLs.size() == m_cachedPermissionStates.size());
 
         return result;
     };


### PR DESCRIPTION
#### 3bef62dc303f5cb30176b8c028691814a5300bea
<pre>
Incorrect date passed when removing expired permission match patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=302029">https://bugs.webkit.org/show_bug.cgi?id=302029</a>
<a href="https://rdar.apple.com/164108150">rdar://164108150</a>

Reviewed by Timothy Hatcher and Brian Weinstein.

We should be using m_nextGrantedPermissionMatchPatternsExpirationDate
instead of m_nextGrantedPermissionsExpirationDate.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::setGrantedPermissions):
Remove duplicate call for adding the permission.
(WebKit::WebExtensionContext::setGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::permissionState):
Fix asserts. They&apos;ll always pass.

Canonical link: <a href="https://commits.webkit.org/302610@main">https://commits.webkit.org/302610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b686903c15fd020679cb99390837bd021ea545e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137055 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d54f2071-2f91-4f39-80ae-ebbc3454af9c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98773 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eadedf44-88e2-4085-9d4e-a020cfa41ba9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116132 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79446 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/63030b9b-3c7d-47c2-b06d-f3bba2968467) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1355 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80327 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139537 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107288 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107149 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54472 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20230 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65161 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1609 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1716 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->