### PR TITLE
WebExtensionDeclarativeNetRequestSQLiteStore::addRules returns without calling the completion handler

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
@@ -96,9 +96,10 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
         Vector<double> rulesIDs;
         for (Ref ruleValue : rules.get()) {
             RefPtr rule = ruleValue->asObject();
-
-            if (!rule || !rule->size())
-                return;
+            if (!rule || !rule->size()) {
+                ASSERT_NOT_REACHED();
+                continue;
+            }
 
             auto ruleID = rule->getInteger("id"_s);
             ASSERT(ruleID);
@@ -131,9 +132,10 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
 
         for (Ref ruleValue : rules.get()) {
             RefPtr rule = ruleValue->asObject();
-
-            if (!rule || !rule->size())
-                return;
+            if (!rule || !rule->size()) {
+                ASSERT_NOT_REACHED();
+                continue;
+            }
 
             errorMessage = protectedThis->insertRule(*rule, *(protectedThis->database()));
             if (!errorMessage.isEmpty())


### PR DESCRIPTION
#### ecae3c1e15aef06d783240fb4b4c574e29324a51
<pre>
WebExtensionDeclarativeNetRequestSQLiteStore::addRules returns without calling the completion handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=302032">https://bugs.webkit.org/show_bug.cgi?id=302032</a>
<a href="https://rdar.apple.com/164109895">rdar://164109895</a>

Reviewed by Timothy Hatcher and Brian Weinstein.

We shouldn&apos;t be returning here without calling the completion handler. We wouldn&apos;t hit this case
for empty rules since we have checks in place before we reach this point. I think the only way we&apos;d
hit this is if we somehow get a corrupted value back after we parse the JSON. We could return
here and call the completion handler with an error, but I think a continue is sufficient.

* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp:
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::addRules):

Canonical link: <a href="https://commits.webkit.org/302609@main">https://commits.webkit.org/302609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ff657b908514f29a2d7bda4ec6cbe275b2274e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137057 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9f02c1b-2e3f-4267-9b2f-04069d81646d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d26438e0-4d62-48c2-b511-3dcab70215f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132616 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79449 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1360 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80329 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139539 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107291 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107152 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30992 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54474 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20231 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65157 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1611 "Failed to checkout and rebase branch from PR 53475") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->