### PR TITLE
Add UserDefault to override EnhancedSecurity

### DIFF
--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
@@ -85,6 +85,16 @@ bool WebsitePolicies::lockdownModeEnabled() const
     return m_lockdownModeEnabled ? *m_lockdownModeEnabled : WebKit::lockdownModeEnabledBySystem();
 }
 
+bool WebsitePolicies::enhancedSecurityEnabled() const
+{
+#if PLATFORM(COCOA)
+    if (WebKit::enhancedSecurityEnabledByUserDefault())
+        return true;
+#endif
+
+    return m_enhancedSecurityEnabled;
+}
+
 const WebCore::ResourceRequest& WebsitePolicies::alternateRequest() const
 {
     return m_data.alternateRequest;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -113,7 +113,7 @@ public:
     WebCore::AllowsContentJavaScript allowsContentJavaScript() const { return m_data.allowsContentJavaScript; }
     void setAllowsContentJavaScript(WebCore::AllowsContentJavaScript allows) { m_data.allowsContentJavaScript = allows; }
 
-    bool enhancedSecurityEnabled() const { return m_enhancedSecurityEnabled; }
+    bool enhancedSecurityEnabled() const;
     void setEnhancedSecurityEnabled(bool enabled) { m_enhancedSecurityEnabled = enabled; }
 
     bool lockdownModeEnabled() const;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1234,6 +1234,11 @@ void setLockdownModeEnabledGloballyForTesting(std::optional<bool> enabledForTest
         processPool->lockdownModeStateChanged();
 }
 
+bool enhancedSecurityEnabledByUserDefault()
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"WebKitOverrideEnhancedSecurity"];
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 void WebProcessPool::applicationIsAboutToSuspend()

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -150,6 +150,7 @@ void addLockdownModeObserver(LockdownModeObserver&);
 void removeLockdownModeObserver(LockdownModeObserver&);
 bool lockdownModeEnabledBySystem();
 void setLockdownModeEnabledGloballyForTesting(std::optional<bool>);
+bool enhancedSecurityEnabledByUserDefault();
 
 enum class CallDownloadDidStart : bool;
 enum class ProcessSwapRequestedByClient : bool;


### PR DESCRIPTION
#### 1d60ad506d44f3b9f33d957194694508d3021ede
<pre>
Add UserDefault to override EnhancedSecurity
<a href="https://bugs.webkit.org/show_bug.cgi?id=302034">https://bugs.webkit.org/show_bug.cgi?id=302034</a>
<a href="https://rdar.apple.com/164111075">rdar://164111075</a>

Reviewed by NOBODY (OOPS!).

Allow EnhancedSecurity to be overriden by a UserDefault.
This provides an easy way to test the feature on potential adopters.

* Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp:
(API::WebsitePolicies::enhancedSecurityEnabled const):
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::enhancedSecurityEnabledByUserDefault):
* Source/WebKit/UIProcess/WebProcessPool.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d60ad506d44f3b9f33d957194694508d3021ede

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81130 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/acbd2752-7d29-444e-92bc-5d11a01546f4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98779 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66619 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8fbb14d3-c843-4993-9204-7b191de8f47d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79452 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/52fbe4c6-2431-41f2-b061-45b235085794) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1365 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80331 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139541 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107296 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107157 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54476 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1799 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65167 "Found 2 new failures in UIProcess/API/Cocoa/WKWebpagePreferences.mm") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1613 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->