### PR TITLE
Unreviewed, reverting 302598@main (e9a617fae98b)

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -1348,7 +1348,7 @@ bool AsyncScrollingCoordinator::scrollAnimatorEnabled() const
     return settings.scrollAnimatorEnabled();
 }
 
-UniqueRef<ScrollingStateTree> AsyncScrollingCoordinator::commitTreeStateForRootFrameID(FrameIdentifier rootFrameID, LayerRepresentation::Type type)
+std::unique_ptr<ScrollingStateTree> AsyncScrollingCoordinator::commitTreeStateForRootFrameID(FrameIdentifier rootFrameID, LayerRepresentation::Type type)
 {
     auto& scrollingStateTree = ensureScrollingStateTreeForRootFrameID(rootFrameID);
     return scrollingStateTree.commit(type);

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -89,7 +89,7 @@ public:
     WEBCORE_EXPORT CheckedRef<ScrollingStateTree> ensureCheckedScrollingStateTreeForRootFrameID(FrameIdentifier);
     const ScrollingStateTree* existingScrollingStateTreeForRootFrameID(std::optional<FrameIdentifier>) const;
     ScrollingStateTree* stateTreeForNodeID(std::optional<ScrollingNodeID>) const;
-    UniqueRef<ScrollingStateTree> commitTreeStateForRootFrameID(FrameIdentifier, LayerRepresentation::Type);
+    std::unique_ptr<ScrollingStateTree> commitTreeStateForRootFrameID(FrameIdentifier, LayerRepresentation::Type);
 
     WEBCORE_EXPORT void scrollableAreaWillBeDetached(ScrollableArea&) override;
 

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -31,7 +31,6 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/UniqueRef.h>
  
 namespace WebCore {
 
@@ -43,12 +42,12 @@ class ScrollingStateFrameScrollingNode;
 // will be informed and will schedule a timer that will clone the new state tree and send it over to
 // the scrolling thread, avoiding locking. 
 
-class ScrollingStateTree final : public CanMakeCheckedPtr<ScrollingStateTree> {
+class ScrollingStateTree final : public CanMakeCheckedPtr<ScrollingStateTree, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingStateTree, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollingStateTree);
     friend class ScrollingStateNode;
 public:
-    WEBCORE_EXPORT static std::optional<UniqueRef<ScrollingStateTree>> createAfterReconstruction(bool, bool, RefPtr<ScrollingStateFrameScrollingNode>&&);
+    WEBCORE_EXPORT static std::optional<ScrollingStateTree> createAfterReconstruction(bool, bool, RefPtr<ScrollingStateFrameScrollingNode>&&);
     WEBCORE_EXPORT ScrollingStateTree(AsyncScrollingCoordinator* = nullptr);
     WEBCORE_EXPORT ScrollingStateTree(ScrollingStateTree&&);
     WEBCORE_EXPORT ~ScrollingStateTree();
@@ -64,7 +63,7 @@ public:
     void clear();
 
     // Copies the current tree state and clears the changed properties mask in the original.
-    WEBCORE_EXPORT UniqueRef<ScrollingStateTree> commit(LayerRepresentation::Type preferredLayerRepresentation);
+    WEBCORE_EXPORT std::unique_ptr<ScrollingStateTree> commit(LayerRepresentation::Type preferredLayerRepresentation);
 
     WEBCORE_EXPORT void attachDeserializedNodes();
 
@@ -99,8 +98,6 @@ public:
     void setRootFrameIdentifier(std::optional<FrameIdentifier> frameID) { m_rootFrameIdentifier = frameID; }
 
 private:
-    template<typename T, class... Args> friend WTF::UniqueRef<T> WTF::makeUniqueRefWithoutFastMallocCheck(Args&&...);
-
     ScrollingStateTree(bool hasNewRootStateNode, bool hasChangedProperties, RefPtr<ScrollingStateFrameScrollingNode>&&);
 
     void setRootStateNode(Ref<ScrollingStateFrameScrollingNode>&&);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -70,7 +70,7 @@ void ThreadedScrollingCoordinator::commitTreeStateIfNeeded()
 
         auto stateTree = commitTreeStateForRootFrameID(key, LayerRepresentation::PlatformLayerRepresentation);
         stateTree->setRootFrameIdentifier(key);
-        scrollingTree()->commitTreeState(stateTree.moveToUniquePtr());
+        scrollingTree()->commitTreeState(WTFMove(stateTree));
     });
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -49,15 +49,15 @@ using namespace WebCore;
 
 RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
 
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::optional<UniqueRef<WebCore::ScrollingStateTree>>&& scrollingStateTree, bool clearScrollLatching, std::optional<WebCore::FrameIdentifier> frameID, FromDeserialization fromDeserialization)
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching, std::optional<WebCore::FrameIdentifier> frameID, FromDeserialization fromDeserialization)
     : m_scrollingStateTree(WTFMove(scrollingStateTree))
     , m_clearScrollLatching(clearScrollLatching)
     , m_rootFrameID(frameID)
 {
     if (!m_scrollingStateTree)
-        m_scrollingStateTree = makeUniqueRef<WebCore::ScrollingStateTree>();
+        m_scrollingStateTree = makeUnique<WebCore::ScrollingStateTree>();
     if (fromDeserialization == FromDeserialization::Yes)
-        CheckedRef { m_scrollingStateTree->get() }->attachDeserializedNodes();
+        CheckedRef { *m_scrollingStateTree }->attachDeserializedNodes();
 }
 
 RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&) = default;
@@ -314,10 +314,10 @@ String RemoteScrollingCoordinatorTransaction::description() const
     ts << "scrolling state tree"_s;
 
     if (m_scrollingStateTree) {
-        if (!m_scrollingStateTree->get().hasChangedProperties())
+        if (!m_scrollingStateTree->hasChangedProperties())
             ts << " - no changes"_s;
         else
-            WebKit::dump(ts, m_scrollingStateTree->get(), true);
+            WebKit::dump(ts, *m_scrollingStateTree.get(), true);
     } else
         ts << " - none"_s;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -28,7 +28,6 @@
 #if ENABLE(UI_SIDE_COMPOSITING)
 
 #include <WebCore/FrameIdentifier.h>
-#include <wtf/UniqueRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -41,13 +40,13 @@ class RemoteScrollingCoordinatorTransaction {
 public:
     enum class FromDeserialization : bool { No, Yes };
     RemoteScrollingCoordinatorTransaction();
-    RemoteScrollingCoordinatorTransaction(std::optional<UniqueRef<WebCore::ScrollingStateTree>>&&, bool, std::optional<WebCore::FrameIdentifier> = std::nullopt, FromDeserialization = FromDeserialization::Yes);
+    RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&&, bool, std::optional<WebCore::FrameIdentifier> = std::nullopt, FromDeserialization = FromDeserialization::Yes);
     RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&);
     RemoteScrollingCoordinatorTransaction& operator=(RemoteScrollingCoordinatorTransaction&&);
     ~RemoteScrollingCoordinatorTransaction();
 
-    std::optional<UniqueRef<WebCore::ScrollingStateTree>>& scrollingStateTree() { return m_scrollingStateTree; }
-    const std::optional<UniqueRef<WebCore::ScrollingStateTree>>& scrollingStateTree() const { return m_scrollingStateTree; }
+    std::unique_ptr<WebCore::ScrollingStateTree>& scrollingStateTree() { return m_scrollingStateTree; }
+    const std::unique_ptr<WebCore::ScrollingStateTree>& scrollingStateTree() const { return m_scrollingStateTree; }
 
     std::optional<WebCore::FrameIdentifier> rootFrameIdentifier() const { return m_rootFrameID; }
     void setFrameIdentifier(WebCore::FrameIdentifier identifier) { m_rootFrameID = identifier; }
@@ -60,8 +59,8 @@ public:
 #endif
 
 private:
-    std::optional<UniqueRef<WebCore::ScrollingStateTree>> m_scrollingStateTree;
-
+    std::unique_ptr<WebCore::ScrollingStateTree> m_scrollingStateTree;
+    
     // Data encoded here should be "imperative" (valid just for one transaction). Stateful things should live on scrolling tree nodes.
     // Maybe RequestedScrollData should move here.
     bool m_clearScrollLatching { false };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -23,12 +23,12 @@
 headers: <WebCore/ScrollingStateTree.h> <WebCore/ScrollingStateFrameScrollingNode.h>
 
 class WebKit::RemoteScrollingCoordinatorTransaction {
-    std::optional<UniqueRef<WebCore::ScrollingStateTree>> scrollingStateTree()
+    std::unique_ptr<WebCore::ScrollingStateTree> scrollingStateTree()
     bool clearScrollLatching()
     std::optional<WebCore::FrameIdentifier> rootFrameIdentifier()
 }
 
-[UniqueRef, CreateUsing=createAfterReconstruction] class WebCore::ScrollingStateTree {
+[CreateUsing=createAfterReconstruction] class WebCore::ScrollingStateTree {
     bool hasNewRootStateNode()
     bool hasChangedProperties()
     RefPtr<WebCore::ScrollingStateFrameScrollingNode> rootStateNode()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -100,11 +100,11 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
         return { };
     }
 
-    CheckedRef { stateTree->get() }->setRootFrameIdentifier(transaction.rootFrameIdentifier());
+    stateTree->setRootFrameIdentifier(transaction.rootFrameIdentifier());
 
     ASSERT(stateTree);
-    connectStateNodeLayers(CheckedRef { stateTree->get() }.get(), *layerTreeHost);
-    bool succeeded = m_scrollingTree->commitTreeState(stateTree->moveToUniquePtr(), identifier);
+    connectStateNodeLayers(*stateTree, *layerTreeHost);
+    bool succeeded = m_scrollingTree->commitTreeState(WTFMove(stateTree), identifier);
 
     MESSAGE_CHECK_WITH_RETURN_VALUE(succeeded, std::nullopt);
 


### PR DESCRIPTION
#### 1e813887c655ed18530e29d6960065b48863283b
<pre>
Unreviewed, reverting 302598@main (e9a617fae98b)
<a href="https://rdar.apple.com/164110355">rdar://164110355</a>

revert 302598@main broke the builds

Reverted change:

    Always allocate ScrollingStateTree in heap
    <a href="https://bugs.webkit.org/show_bug.cgi?id=301911">https://bugs.webkit.org/show_bug.cgi?id=301911</a>
    302598@main (e9a617fae98b)

Canonical link: <a href="https://commits.webkit.org/302602@main">https://commits.webkit.org/302602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8177a0ba02def198819b8aeee6a939a208fb4df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129674 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/1935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137062 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131545 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/1881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/1824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132621 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/1881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/79455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/1881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80334 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/1881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139544 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/1824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/1774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/107159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20226 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/1802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/65171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/1723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->