### PR TITLE
REGRESSION (300911@main): Card layout on archidekt.com is incorrect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=301873">
+<style>
+  .cardStack {
+    display: grid;
+    width: 100px;
+  }
+  .card {
+    height: 100px;
+  }
+  #card1 { 
+    background-color: lightpink;
+    margin-top: 50%;
+  }
+  #card2 { 
+    background-color: lightgreen;
+  }
+</style>
+</head>
+<body>
+  <div class="cardStack">
+    <div id="card1" class="card"></div>
+    <div id="card2" class="card"></div>
+  </div>
+</body> 
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=301873">
+<style>
+  .cardStack {
+    display: grid;
+    width: 100px;
+  }
+  .card {
+    height: 100px;
+  }
+  #card1 { 
+    background-color: lightpink;
+    margin-top: 50%;
+  }
+  #card2 { 
+    background-color: lightgreen;
+  }
+</style>
+</head>
+<body>
+  <div class="cardStack">
+    <div id="card1" class="card"></div>
+    <div id="card2" class="card"></div>
+  </div>
+</body> 
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=301873">
+<link rel="match" href="grid-calc-margin-ref.html">
+<style>
+  .cardStack {
+    display: grid;
+    width: 100px;
+  }
+  .card {
+    height: 100px;
+  }
+  #card1 { 
+    background-color: lightpink;
+    margin-top: calc(50% - 0px);
+  }
+  #card2 { 
+    background-color: lightgreen;
+  }
+</style>
+</head>
+<body>
+  <div class="cardStack">
+    <div id="card1" class="card"></div>
+    <div id="card2" class="card"></div>
+  </div>
+</body> 
+</html>

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -51,10 +51,13 @@ static inline bool marginEndIsAuto(const RenderBox& gridItem, Style::GridTrackSi
 
 static bool gridItemHasMargin(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
 {
-    // `isPossiblyZero` returns true for 'auto' margins, which is aligned with the purpose of this function.
+    auto hasMarginEdge = [](auto& edge) {
+        return !edge.isKnownZero() && !edge.isAuto();
+    };
+
     if (direction == Style::GridTrackSizingDirection::Columns)
-        return !gridItem.style().marginStart().isPossiblyZero() || !gridItem.style().marginEnd().isPossiblyZero();
-    return !gridItem.style().marginBefore().isPossiblyZero() || !gridItem.style().marginAfter().isPossiblyZero();
+        return hasMarginEdge(gridItem.style().marginStart()) || hasMarginEdge(gridItem.style().marginEnd());
+    return hasMarginEdge(gridItem.style().marginBefore()) || hasMarginEdge(gridItem.style().marginAfter());
 }
 
 LayoutUnit computeMarginLogicalSizeForGridItem(const RenderGrid& grid, Style::GridTrackSizingDirection direction, const RenderBox& gridItem)


### PR DESCRIPTION
#### 44b22eb1df105edd3c9ce77888e752a3138919a7
<pre>
REGRESSION (300911@main): Card layout on archidekt.com is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=301873">https://bugs.webkit.org/show_bug.cgi?id=301873</a>

Reviewed by Brandon Stewart and Sammy Gill.

Fixes logic in GridLayoutFunctions&apos;s `gridItemHasMargin` back to
what it was prior to 300911@main.

It had been considering a margin as being there (and is again) based on:
    - YES: fixed and not 0
    - YES: percentage and not 0
    - YES: auto
    - NO: calc()

300911@main changed the check to:
    - YES: fixed and not 0
    - YES: percentage and not 0
    - YES: auto
    - YES: calc()

Test: imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-calc-margin.html: Added.
* Source/WebCore/rendering/GridLayoutFunctions.cpp:

Canonical link: <a href="https://commits.webkit.org/302744@main">https://commits.webkit.org/302744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3ed023ae21bb7dccab54a57db55f475367f3ccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137440 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132992 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1684 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 8 new passes 35 flakes 1 failures; Uploaded test results; layout-tests (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80712 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139919 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107565 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1680 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65542 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2022 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->