### PR TITLE
[Swift in WebKit] Fix inconsistent use of `extern` in wtf/spi

### DIFF
--- a/Source/WTF/wtf/spi/cf/CFPrivSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFPrivSPI.h
@@ -35,8 +35,8 @@ DECLARE_SYSTEM_HEADER
 
 #endif
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 CF_EXPORT const char *_CFProcessPath(void);
 
-}
+WTF_EXTERN_C_END

--- a/Source/WTF/wtf/spi/cf/CFRunLoopSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFRunLoopSPI.h
@@ -35,8 +35,8 @@ DECLARE_SYSTEM_HEADER
 
 #endif
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 CF_EXPORT Boolean _CFRunLoopSetPerCalloutAutoreleasepoolEnabled(Boolean enabled) API_AVAILABLE(macos(10.16), ios(14.0), watchos(7.0), tvos(14.0));
 
-}
+WTF_EXTERN_C_END

--- a/Source/WTF/wtf/spi/cf/CFStringSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFStringSPI.h
@@ -36,7 +36,7 @@ DECLARE_SYSTEM_HEADER
 
 #else
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 typedef CF_ENUM(CFIndex, CFStringCharacterClusterType)
 {
@@ -45,14 +45,14 @@ typedef CF_ENUM(CFIndex, CFStringCharacterClusterType)
     kCFStringBackwardDeletionCluster = 4
 };
 
-}
+WTF_EXTERN_C_END
 
 #endif
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 CFRange CFStringGetRangeOfCharacterClusterAtIndex(CFStringRef, CFIndex charIndex, CFStringCharacterClusterType);
 void _CFStringGetUserDefaultEncoding(UInt32* scriptValue, UInt32* regionValue);
 
-}
+WTF_EXTERN_C_END
 

--- a/Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h
+++ b/Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h
@@ -43,6 +43,8 @@
 #    endif
 #endif
 
+#ifdef __cplusplus
+
 struct ProcessMemoryFootprint {
 public:
     uint64_t current;
@@ -74,5 +76,7 @@ public:
 #endif
     }
 };
+
+#endif
 
 #endif


### PR DESCRIPTION
#### 601c7d72bdedf29ca56a62aee6fc9de94062a31c
<pre>
[Swift in WebKit] Fix inconsistent use of `extern` in wtf/spi
<a href="https://bugs.webkit.org/show_bug.cgi?id=302036">https://bugs.webkit.org/show_bug.cgi?id=302036</a>
<a href="https://rdar.apple.com/164114471">rdar://164114471</a>

Reviewed by Aditya Keerthi.

All files in wtf/spi are Objective-C and Objective-C++ compliant in spirit, however there are a few header files
that do not use compile guards as needed unlike the others.

Fix by adding the appropriate guards so these files compile as intended.

* Source/WTF/wtf/spi/cf/CFPrivSPI.h:
* Source/WTF/wtf/spi/cf/CFRunLoopSPI.h:
* Source/WTF/wtf/spi/cf/CFStringSPI.h:
* Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h:

Canonical link: <a href="https://commits.webkit.org/302624@main">https://commits.webkit.org/302624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a38b5cf020185bce74a848147c30d25103533bc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/261ce571-0dd1-4b7a-80e2-d2593fb6783b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98787 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff313e48-ceee-40c3-8af7-ccc4e9fca97b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1447 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116146 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79460 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa59bb85-2fe0-4046-b0db-e7953961f653) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80339 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121671 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139549 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128131 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107302 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107163 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1411 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54484 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1807 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65176 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161145 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1621 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40188 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1656 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->