### PR TITLE
[WPE] WIP: Use WebKitImage to implement web view snapshot

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -169,6 +169,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationManager.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitHitTestResult.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitImage.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInputMethodContext.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInstallMissingMediaPluginsPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -185,6 +185,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationManager.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitHitTestResult.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitImage.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInputMethodContext.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInstallMissingMediaPluginsPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -148,6 +148,7 @@ UIProcess/API/glib/WebKitFormSubmissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationManager.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitIconLoadingClient.cpp @no-unify
+UIProcess/API/glib/WebKitImage.cpp @no-unify
 UIProcess/API/glib/WebKitInitialize.cpp @no-unify
 UIProcess/API/glib/WebKitInjectedBundleClient.cpp @no-unify
 UIProcess/API/glib/WebKitInputMethodContext.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -149,6 +149,7 @@ UIProcess/API/glib/WebKitFormClient.cpp @no-unify
 UIProcess/API/glib/WebKitFormSubmissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationManager.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp @no-unify
+UIProcess/API/glib/WebKitImage.cpp @no-unify
 UIProcess/API/glib/WebKitInitialize.cpp @no-unify
 UIProcess/API/glib/WebKitInjectedBundleClient.cpp @no-unify
 UIProcess/API/glib/WebKitInputMethodContext.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
@@ -1,0 +1,447 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebKitImage.h"
+
+#include "WebKitImagePrivate.h"
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkData.h>
+#include <skia/core/SkImage.h>
+#include <skia/core/SkImageInfo.h>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Skia port
+#include <skia/encode/SkPngEncoder.h>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#else
+#include <WebCore/NotImplemented.h>
+#endif
+#include <wtf/Assertions.h>
+#include <wtf/Hasher.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GSpanExtras.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+
+static void webkit_image_gicon_interface_init(GIconIface*);
+static void webkit_image_gloadable_icon_interface_init(GLoadableIconIface*);
+
+struct _WebKitImagePrivate {
+    int width;
+    int height;
+    unsigned stride;
+    CompletionHandler<GRefPtr<GBytes>(WebKitImage*)> createBytesFn;
+
+    GRefPtr<GBytes> bytes;
+};
+
+/**
+ * WebKitImage:
+ *
+ * Represents an image as a buffer containing pixel data.
+ *
+ * Image objects are always created by WebKit, and considered immutable:
+ * a copy of the image data needs to be made before modifying the image.
+ * Pixel data can be obtained with [id@webkit_image_as_rgba_bytes].
+ *
+ * Since: 2.52
+ */
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitImage, webkit_image, G_TYPE_OBJECT, GObject,
+    G_IMPLEMENT_INTERFACE(G_TYPE_ICON, webkit_image_gicon_interface_init)
+    G_IMPLEMENT_INTERFACE(G_TYPE_LOADABLE_ICON, webkit_image_gloadable_icon_interface_init))
+
+
+enum {
+    PROP_0,
+
+    PROP_WIDTH,
+    PROP_HEIGHT,
+    PROP_STRIDE,
+
+    N_PROPERTIES
+};
+
+static constexpr uint8_t RGBA8BytesPerPixel = 4;
+
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
+
+static void webkitImageSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
+{
+    auto* image = WEBKIT_IMAGE(object);
+
+    switch (propId) {
+    case PROP_WIDTH:
+        image->priv->width = g_value_get_int(value);
+        break;
+    case PROP_HEIGHT:
+        image->priv->height = g_value_get_int(value);
+        break;
+    case PROP_STRIDE:
+        image->priv->stride = g_value_get_uint(value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void webkitImageGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
+{
+    auto* image = WEBKIT_IMAGE(object);
+
+    switch (propId) {
+    case PROP_WIDTH:
+        g_value_set_int(value, webkit_image_get_width(image));
+        break;
+    case PROP_HEIGHT:
+        g_value_set_int(value, webkit_image_get_height(image));
+        break;
+    case PROP_STRIDE:
+        g_value_set_uint(value, webkit_image_get_stride(image));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void webkit_image_class_init(WebKitImageClass* imageClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(imageClass);
+    objectClass->set_property = webkitImageSetProperty;
+    objectClass->get_property = webkitImageGetProperty;
+
+    /**
+     * WebKitImage:width: (getter get_width) (attributes org.gtk.Property.get=webkit_image_get_width):
+     *
+     * The image width in pixels.
+     *
+     * Since: 2.52
+     */
+    sObjProperties[PROP_WIDTH] =
+    g_param_spec_int(
+        "width",
+        nullptr, nullptr,
+        1, G_MAXINT, 1,
+        static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WebKitImage:height: (getter get_height) (attributes org.gtk.Property.get=webkit_image_get_height):
+     *
+     * The image height in pixels.
+     *
+     * Since: 2.52
+     */
+    sObjProperties[PROP_HEIGHT] =
+    g_param_spec_int(
+        "height",
+        nullptr, nullptr,
+        1, G_MAXINT, 1,
+        static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WebKitImage:stride: (getter get_stride) (attributes org.gtk.Property.get=webkit_image_get_stride):
+     *
+     * The image stride, in bytes. This value indicates the amount of
+     * memory occupied by each row of pixels in the image. Note that
+     * the stride may be larger than the image width multiplied by the
+     * amount of bytes used to represent each pixel.
+     *
+     * Since: 2.52
+     */
+    sObjProperties[PROP_STRIDE] =
+    g_param_spec_uint(
+        "stride",
+        nullptr, nullptr,
+        RGBA8BytesPerPixel, G_MAXUINT, 4,
+        static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
+}
+
+// When instantiating this class and providing a CompletionHandler to instantiate the bytes, make sure
+// this uses #CompletionHandlerCallThread::AnyThread if you first instantiate the class bytes asynchronously.
+WebKitImage* webkitImageNew(int width, int height, guint stride, CompletionHandler<GRefPtr<GBytes>(WebKitImage*)>&& createBytesFn)
+{
+    RELEASE_ASSERT(createBytesFn);
+    RELEASE_ASSERT(static_cast<gsize>(width) * RGBA8BytesPerPixel <= stride);
+
+    auto* image = WEBKIT_IMAGE(g_object_new(WEBKIT_TYPE_IMAGE,
+        "width", width,
+        "height", height,
+        "stride", stride,
+        nullptr));
+    image->priv->createBytesFn = WTFMove(createBytesFn);
+
+    return image;
+}
+
+/**
+ * webkit_image_get_width: (get-property width):
+ * @image: a #WebKitImage
+ *
+ * Get the @image width in pixels.
+ *
+ * Returns: the image width
+ *
+ * Since: 2.52
+ */
+int webkit_image_get_width(WebKitImage* image)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(image), 0);
+    return image->priv->width;
+}
+
+/**
+ * webkit_image_get_height: (get-property height):
+ * @image: a #WebKitImage
+ *
+ * Get the @image height in pixels.
+ *
+ * Returns: the image height
+ *
+ * Since: 2.52
+ */
+int webkit_image_get_height(WebKitImage* image)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(image), 0);
+    return image->priv->height;
+}
+
+/**
+ * webkit_image_get_stride: (get-property stride):
+ * @image: a #WebKitImage
+ *
+ * Get the @image stride.
+ *
+ * Returns: the image stride
+ *
+ * Since: 2.52
+ */
+guint webkit_image_get_stride(WebKitImage* image)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(image), 0);
+    return image->priv->stride;
+}
+
+/**
+ * webkit_image_as_rgba_bytes:
+ * @image: a #WebKitImage
+ *
+ * Get the @image pixel data as an array of bytes.
+ *
+ * The pixel format for the returned byte buffer is 32-bit per pixel
+ * with 8-bit premultiplied alpha, in the preferred byte order for
+ * the architecture (typically ABGR8888 on little-endian hosts, and
+ * RGBA8888 on big-endian ones).
+ *
+ * Returns: (transfer none): a #GBytes
+ *
+ * Since: 2.52
+ */
+GBytes* webkit_image_as_rgba_bytes(WebKitImage* image)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(image), nullptr);
+
+    if (!image->priv->bytes) {
+        ASSERT(image->priv->createBytesFn);
+        image->priv->bytes = image->priv->createBytesFn(image);
+    }
+    ASSERT(image->priv->bytes);
+
+    return image->priv->bytes.get();
+}
+
+static guint webkitImageHash(GIcon* icon)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(icon), 0);
+
+    auto* image = WEBKIT_IMAGE(icon);
+
+    Hasher hasher;
+
+    auto* bytes = webkit_image_as_rgba_bytes(image);
+    auto dataSpan = span(bytes);
+
+    gsize rowBytes = image->priv->width * RGBA8BytesPerPixel;
+
+    ASSERT(dataSpan.size() >= image->priv->stride * (image->priv->height - 1) + rowBytes);
+
+    for (int y = 0; y < image->priv->height; ++y) {
+        auto row = consumeSpan(dataSpan, image->priv->stride);
+        WTF::add(hasher, row.first(rowBytes));
+    }
+
+    WTF::add(hasher, image->priv->width, image->priv->height);
+    return hasher.hash();
+}
+
+static gboolean webkitImageEqual(GIcon* icon1, GIcon* icon2)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(icon1), false);
+
+    if (!WEBKIT_IS_IMAGE(icon2))
+        return false;
+
+    auto* image1 = WEBKIT_IMAGE(icon1);
+    auto* image2 = WEBKIT_IMAGE(icon2);
+
+    if (image1->priv->width != image2->priv->width
+        || image1->priv->height != image2->priv->height)
+        return false;
+
+    auto* bytes1 = webkit_image_as_rgba_bytes(image1);
+    auto* bytes2 = webkit_image_as_rgba_bytes(image2);
+
+    auto dataSpan1 = span(bytes1);
+    auto dataSpan2 = span(bytes2);
+
+    gsize rowBytes = image1->priv->width * RGBA8BytesPerPixel;
+
+    ASSERT(dataSpan1.size() >= image1->priv->stride * (image1->priv->height - 1) + rowBytes);
+    ASSERT(dataSpan2.size() >= image2->priv->stride * (image1->priv->height - 1) + rowBytes);
+
+    for (int y = 0; y < image1->priv->height; ++y) {
+        auto row1 = consumeSpan(dataSpan1, image1->priv->stride);
+        auto row2 = consumeSpan(dataSpan2, image2->priv->stride);
+
+        if (!equalSpans(row1.first(rowBytes), row2.first(rowBytes)))
+            return false;
+    }
+
+    return true;
+}
+
+static GInputStream* webkitImageLoad(GLoadableIcon* icon, int size, char** type, GCancellable* cancellable, GError** error)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(icon), nullptr);
+
+    auto* image = WEBKIT_IMAGE(icon);
+    auto* bytes = webkit_image_as_rgba_bytes(image);
+    if (!bytes) {
+        LOG_ERROR("Failed to retrieve image RGBA bytes");
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Failed to encode image as PNG");
+        return nullptr;
+    }
+
+#if USE(SKIA)
+    gsize dataSize = 0;
+    auto* data = g_bytes_get_data(bytes,  &dataSize);
+    sk_sp<SkData> skData = SkData::MakeWithoutCopy(data, dataSize);
+    SkImageInfo info = SkImageInfo::Make(
+        image->priv->width,
+        image->priv->height,
+        kRGBA_8888_SkColorType,
+        kUnpremul_SkAlphaType
+    );
+
+    sk_sp<SkImage> skImage = SkImages::RasterFromData(info, skData, image->priv->stride);
+
+    if (!skImage) {
+        LOG_ERROR("Failed to create SkImage from data");
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Failed to encode image as PNG");
+        return nullptr;
+    }
+
+    sk_sp<SkData> pngData = SkPngEncoder::Encode(nullptr, skImage.get(), { });
+    if (!pngData) {
+        LOG_ERROR("Failed to encode SkImage as PNG");
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Failed to encode image as PNG");
+        return nullptr;
+    }
+
+    pngData->ref();
+    GRefPtr<GBytes> pngBytes = adoptGRef(g_bytes_new_with_free_func(
+        pngData->data(),
+        pngData->size(),
+        [](gpointer userData) {
+            static_cast<SkData*>(userData)->unref();
+        },
+        pngData.get()
+    ));
+
+    GInputStream* stream = g_memory_input_stream_new_from_bytes(pngBytes.get());
+
+    if (type)
+        *type = g_strdup("image/png"_s);
+
+    return stream;
+#else
+    notImplemented();
+    g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Operation unimplemented");
+    return nullptr;
+#endif
+}
+
+struct LoadTaskData {
+    int size;
+    GLoadableIcon* icon;
+};
+WEBKIT_DEFINE_ASYNC_DATA_STRUCT(LoadTaskData)
+
+static void webkitImageLoadAsync(GLoadableIcon* icon, int size, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
+{
+    auto taskData = createLoadTaskData();
+    taskData->icon = icon;
+    taskData->size = size;
+    GRefPtr<GTask> task = adoptGRef(g_task_new(icon, cancellable, callback, userData));
+    GTaskThreadFunc taskHandler = [](GTask* task, gpointer, gpointer taskData, GCancellable* cancellable) {
+        if (g_task_return_error_if_cancelled(task))
+            return;
+
+        auto* data = static_cast<LoadTaskData*>(taskData);
+        GUniqueOutPtr<GError> error;
+        GRefPtr<GInputStream> stream = webkitImageLoad(data->icon, data->size, nullptr, cancellable, &error.outPtr());
+        if (error)
+            g_task_return_error(task, error.release());
+        else
+            g_task_return_pointer(task, stream.leakRef(), g_object_unref);
+    };
+    g_task_set_task_data(task.get(), taskData, reinterpret_cast<GDestroyNotify>(destroyLoadTaskData));
+    g_task_run_in_thread(task.get(), taskHandler);
+}
+
+static GInputStream* webkitImageLoadFinish(GLoadableIcon* icon, GAsyncResult* res, char** type, GError** error)
+{
+    g_return_val_if_fail(WEBKIT_IS_IMAGE(icon), nullptr);
+
+    if (type)
+        *type = g_strdup("image/png"_s);
+    return G_INPUT_STREAM(g_task_propagate_pointer(G_TASK(res), error));
+}
+
+static void webkit_image_gicon_interface_init(GIconIface* iface)
+{
+    iface->hash = webkitImageHash;
+    iface->equal = webkitImageEqual;
+}
+
+static void webkit_image_gloadable_icon_interface_init(GLoadableIconIface* iface)
+{
+    iface->load = webkitImageLoad;
+    iface->load_async = webkitImageLoadAsync;
+    iface->load_finish = webkitImageLoadFinish;
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitImage.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImage.h.in
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitImage_h
+#define WebKitImage_h
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_IMAGE                          (webkit_image_get_type())
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitImage, webkit_image, WEBKIT, IMAGE, GObject)
+
+WEBKIT_API int          webkit_image_get_width     (WebKitImage *image);
+WEBKIT_API int          webkit_image_get_height    (WebKitImage *image);
+WEBKIT_API guint        webkit_image_get_stride    (WebKitImage *image);
+WEBKIT_API GBytes      *webkit_image_as_rgba_bytes (WebKitImage *image);
+
+G_END_DECLS
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitImagePrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImagePrivate.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebKitImage.h"
+#include <WebKit/WKBase.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/glib/GRefPtr.h>
+
+WK_EXPORT WebKitImage* webkitImageNew(int width, int height, guint stride, CompletionHandler<GRefPtr<GBytes>(WebKitImage*)>&& createBytesFn);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5121,6 +5121,9 @@ gboolean webkit_web_view_get_tls_info(WebKitWebView* webView, GTlsCertificate** 
 #else
 #define SNAPSHOT_TYPE cairo_surface_t*
 #endif
+#else
+#define SNAPSHOT_TYPE WebKitImage*
+#endif
 
 /**
  * webkit_web_view_get_snapshot:
@@ -5162,6 +5165,7 @@ void webkit_web_view_get_snapshot(WebKitWebView* webView, WebKitSnapshotRegion r
     getPage(webView).takeSnapshotLegacy({ }, { }, snapshotOptions, [task = WTFMove(task)](std::optional<ShareableBitmap::Handle>&& handle) {
         if (handle) {
             if (auto bitmap = ShareableBitmap::create(WTFMove(*handle), SharedMemory::Protection::ReadOnly)) {
+#if PLATFORM(GTK)
 #if USE(GTK4)
                 if (auto texture = PLATFORM_IMAGE_TO_TEXTURE(bitmap->createPlatformImage(BackingStoreCopy::DontCopyBackingStore).get())) {
                     g_task_return_pointer(task.get(), texture.leakRef(), g_object_unref);
@@ -5177,6 +5181,21 @@ void webkit_web_view_get_snapshot(WebKitWebView* webView, WebKitSnapshotRegion r
                     g_task_return_pointer(task.get(), surface.leakRef(), reinterpret_cast<GDestroyNotify>(cairo_surface_destroy));
                     return;
                 }
+#endif
+#else
+                RELEASE_ASSERT(bitmap->bytesPerRow() <= std::numeric_limits<guint>::max());
+                const auto imageSize = bitmap->size();
+                auto* image = webkitImageNew(bitmapSize.width(), bitmapSize.height(), bitmap->bytesPerRow(),
+                    [bitmap = WTFMove(bitmap)](WebKitImage*) {
+                        auto* b = bitmap.leakRef();
+                        return adoptGRef(g_bytes_new_with_free_func(b->span().data(), b->span().size(),
+                            [](void* data) {
+                                reinterpret_cast<ShareableBitmap*>(data)->deref();
+                            },
+                            b));
+                    });
+                g_task_return_pointer(task.get(), image, g_object_unref);
+                return;
 #endif
             }
         }
@@ -5207,7 +5226,6 @@ SNAPSHOT_TYPE webkit_web_view_get_snapshot_finish(WebKitWebView* webView, GAsync
         g_set_error_literal(error, WEBKIT_SNAPSHOT_ERROR, WEBKIT_SNAPSHOT_ERROR_FAILED_TO_CREATE, _("There was an error creating the snapshot"));
     return nullptr;
 }
-#endif // PLATFORM(GTK)
 
 void webkitWebViewWebProcessTerminated(WebKitWebView* webView, WebKitWebProcessTerminationReason reason)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -186,7 +186,6 @@ typedef enum {
     WEBKIT_INSECURE_CONTENT_DISPLAYED
 } WebKitInsecureContentEvent;
 
-#if PLATFORM(GTK)
 /**
  * WebKitSnapshotOptions:
  * @WEBKIT_SNAPSHOT_OPTIONS_NONE: Do not include any special options.
@@ -217,7 +216,6 @@ typedef enum {
   WEBKIT_SNAPSHOT_REGION_VISIBLE = 0,
   WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT,
 } WebKitSnapshotRegion;
-#endif
 
 /**
  * WebKitWebProcessTerminationReason:
@@ -777,7 +775,6 @@ webkit_web_view_get_tls_info                         (WebKitWebView             
                                                       GTlsCertificate          **certificate,
                                                       GTlsCertificateFlags      *errors);
 
-#if PLATFORM(GTK)
 WEBKIT_API void
 webkit_web_view_get_snapshot                         (WebKitWebView             *web_view,
                                                       WebKitSnapshotRegion       region,
@@ -785,6 +782,7 @@ webkit_web_view_get_snapshot                         (WebKitWebView             
                                                       GCancellable              *cancellable,
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
+#if PLATFORM(GTK)
 #if USE(GTK4)
 WEBKIT_API GdkTexture *
 webkit_web_view_get_snapshot_finish                  (WebKitWebView             *web_view,
@@ -796,6 +794,11 @@ webkit_web_view_get_snapshot_finish                  (WebKitWebView             
                                                       GAsyncResult              *result,
                                                       GError                   **error);
 #endif
+#else
+WEBKIT_API WebKitImage *
+webkit_web_view_get_snapshot_finish                  (WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                   **error);
 #endif
 
 WEBKIT_API WebKitUserContentManager *

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -73,6 +73,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitGeolocationManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitGeolocationPermissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitHitTestResult.h>
+#include <@API_INCLUDE_PREFIX@/WebKitImage.h>
 #include <@API_INCLUDE_PREFIX@/WebKitInputMethodContext.h>
 #include <@API_INCLUDE_PREFIX@/WebKitInstallMissingMediaPluginsPermissionRequest.h>
 #if !ENABLE(2022_GLIB_API)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "TestMain.h"
+#include <WebKitImagePrivate.h>
+#include <span>
+#include <wtf/glib/GUniquePtr.h>
+
+class WebKitImageTest : public Test {
+public:
+    MAKE_GLIB_TEST_FIXTURE(WebKitImageTest);
+
+    static void asyncLoadFinishedCallback(GObject* source, GAsyncResult* result, gpointer userData)
+    {
+        auto* test = static_cast<WebKitImageTest*>(userData);
+        GUniqueOutPtr<char> type;
+        GUniqueOutPtr<GError> error;
+        GInputStream* stream = g_loadable_icon_load_finish(G_LOADABLE_ICON(source),
+        result, &type.outPtr(), &error.outPtr());
+
+        g_assert_no_error(error.get());
+        g_assert_nonnull(stream);
+        g_assert_cmpstr(type.get(), ==, "image/png");
+
+        gsize bytes_read;
+        unsigned char buffer[8];
+        gboolean success = g_input_stream_read_all(stream, buffer, sizeof(buffer),
+            &bytes_read, nullptr, &error.outPtr());
+
+        g_assert_no_error(error.get());
+        g_assert_true(success);
+        g_assert_cmpuint(bytes_read, ==, 8);
+        g_assert_cmpint(buffer[0], ==, 0x89);
+        g_assert_cmpint(buffer[1], ==, 'P');
+        g_assert_cmpint(buffer[2], ==, 'N');
+        g_assert_cmpint(buffer[3], ==, 'G');
+        g_assert_cmpint(buffer[4], ==, 0x0D);
+        g_assert_cmpint(buffer[5], ==, 0x0A);
+        g_assert_cmpint(buffer[6], ==, 0x1A);
+        g_assert_cmpint(buffer[7], ==, 0x0A);
+
+        g_main_loop_quit(test->m_mainLoop);
+    }
+
+    WebKitImageTest()
+        : m_mainLoop(g_main_loop_new(nullptr, TRUE))
+    {
+
+    }
+    ~WebKitImageTest()
+    {
+        g_main_loop_unref(m_mainLoop);
+    }
+
+    GMainLoop* m_mainLoop;
+};
+
+static void testWebKitImagePropertiesConstruct(WebKitImageTest*, gconstpointer)
+{
+    auto completionHandler = [](WebKitImage*) -> GRefPtr<GBytes> {
+        return adoptGRef(g_bytes_new_static("test_data", 9));
+    };
+    GRefPtr<WebKitImage> image = adoptGRef(webkitImageNew(1, 2, 4, WTFMove(completionHandler)));
+
+    int width, height;
+    GUniqueOutPtr<char> type;
+    guint stride;
+
+    g_object_get(image.get(),
+        "width", &width,
+        "height", &height,
+        "stride", &stride,
+        nullptr);
+
+    GBytes* retrieved_data = webkit_image_as_rgba_bytes(image.get());
+
+    g_assert_cmpint(width, ==, 1);
+    g_assert_cmpint(height, ==, 2);
+    g_assert_cmpuint(stride, ==, 4);
+    GRefPtr<GBytes> data = adoptGRef(g_bytes_new_static("test_data", 9));
+    g_assert_true(g_bytes_equal(data.get(), retrieved_data));
+}
+
+static void testWebKitImageIconInterface(WebKitImageTest*, gconstpointer)
+{
+    auto makeRGBAData = [](int width, int height, int stride, uint8_t fillValue) -> GRefPtr<GBytes> {
+        gsize size = stride * height;
+        auto* data = static_cast<uint8_t*>(g_malloc(size));
+        auto span = std::span<uint8_t>(data, size);
+        memsetSpan(span, fillValue);
+        return adoptGRef(g_bytes_new_take(data, size));
+    };
+
+    auto fn1 = [&](WebKitImage*) {
+        return makeRGBAData(2, 2, 8, 0xAA);
+    };
+    auto fn2 = [&](WebKitImage*) {
+        return makeRGBAData(2, 2, 8, 0xAA);
+    };
+    GRefPtr<WebKitImage> image1 = adoptGRef(webkitImageNew(2, 2, 8, WTFMove(fn1)));
+    GRefPtr<WebKitImage> image2 = adoptGRef(webkitImageNew(2, 2, 8, WTFMove(fn2)));
+
+    auto* icon1 = G_ICON(image1.get());
+    auto* icon2 = G_ICON(image2.get());
+    g_assert_true(g_icon_equal(icon1, icon2));
+
+    guint hash1 = g_icon_hash(icon1);
+    guint hash2 = g_icon_hash(icon2);
+    g_assert_cmpuint(hash1, ==, hash2);
+
+    auto fn3 = [&](WebKitImage*) {
+        return makeRGBAData(2, 2, 12, 0xAA);
+    };
+    GRefPtr<WebKitImage> image3 = adoptGRef(webkitImageNew(2, 2, 12, WTFMove(fn3)));
+
+    auto* icon3 = G_ICON(image3.get());
+    g_assert_true(g_icon_equal(icon1, icon3));
+
+    guint hash3 = g_icon_hash(icon3);
+    g_assert_cmpuint(hash1, ==, hash3);
+
+    auto fn4 = [&](WebKitImage*) {
+        return makeRGBAData(2, 2, 8, 0xBB);
+    };
+    GRefPtr<WebKitImage> image4 = adoptGRef(webkitImageNew(2, 2, 8, WTFMove(fn4)));
+
+    auto* icon4 = G_ICON(image4.get());
+    g_assert_false(g_icon_equal(icon1, icon4));
+
+    guint hash4 = g_icon_hash(icon4);
+    g_assert_cmpuint(hash1, !=, hash4);
+
+    auto fn5 = [&](WebKitImage*) {
+        return makeRGBAData(3, 3, 16, 0xCC);
+    };
+    GRefPtr<WebKitImage> image5 = adoptGRef(webkitImageNew(3, 3, 16, WTFMove(fn5)));
+
+    auto* icon5 = G_ICON(image5.get());
+    g_assert_false(g_icon_equal(icon1, icon5));
+
+    guint hash5 = g_icon_hash(icon5);
+    g_assert_cmpuint(hash1, !=, hash5);
+}
+
+static void testWebKitImageLoadableIconLoadSync(WebKitImageTest*, gconstpointer)
+{
+    auto makeSingleRedPixel = [](WebKitImage*) -> GRefPtr<GBytes> {
+        uint8_t pixel[] = { 255, 0, 0, 255 };
+        return adoptGRef(g_bytes_new(pixel, sizeof(pixel)));
+    };
+    GRefPtr<WebKitImage> image = webkitImageNew(1, 1, 4, WTFMove(makeSingleRedPixel));
+    auto* icon = G_LOADABLE_ICON(image.get());
+
+    GUniqueOutPtr<GError> error;
+    GUniqueOutPtr<char> type;
+
+    GRefPtr<GInputStream> stream = adoptGRef(g_loadable_icon_load(icon, 0, &type.outPtr(), nullptr, &error.outPtr()));
+
+    g_assert_no_error(error.get());
+    g_assert_nonnull(stream);
+    g_assert_cmpstr(type.get(), ==, "image/png");
+
+    gsize bytes_read;
+    unsigned char buffer[8];
+    gboolean success = g_input_stream_read_all(stream.get(), buffer, sizeof(buffer),
+        &bytes_read, nullptr, &error.outPtr());
+
+    g_assert_no_error(error.get());
+    g_assert_true(success);
+    g_assert_cmpuint(bytes_read, ==, 8);
+    g_assert_cmpint(buffer[0], ==, 0x89);
+    g_assert_cmpint(buffer[1], ==, 'P');
+    g_assert_cmpint(buffer[2], ==, 'N');
+    g_assert_cmpint(buffer[3], ==, 'G');
+    g_assert_cmpint(buffer[4], ==, 0x0D);
+    g_assert_cmpint(buffer[5], ==, 0x0A);
+    g_assert_cmpint(buffer[6], ==, 0x1A);
+    g_assert_cmpint(buffer[7], ==, 0x0A);
+}
+
+static void testWebKitImageLoadableIconLoadAsync(WebKitImageTest* test, gconstpointer)
+{
+    CompletionHandler<GRefPtr<GBytes>(WebKitImage*)> makeSingleRedPixel { [](WebKitImage*) -> GRefPtr<GBytes> {
+        uint8_t pixel[] = { 255, 0, 0, 255 };
+        return adoptGRef(g_bytes_new(pixel, sizeof(pixel)));
+    }, CompletionHandlerCallThread::AnyThread };
+    GRefPtr<WebKitImage> image = webkitImageNew(1, 1, 4, WTFMove(makeSingleRedPixel));
+    auto* icon = G_LOADABLE_ICON(image.get());
+
+    g_loadable_icon_load_async(icon, 0, nullptr, WebKitImageTest::asyncLoadFinishedCallback, test);
+
+    g_main_loop_run(test->m_mainLoop);
+}
+
+void beforeAll()
+{
+    WebKitImageTest::add("WebKitImage", "create-and-get", testWebKitImagePropertiesConstruct);
+    WebKitImageTest::add("WebKitImage", "icon-interface", testWebKitImageIconInterface);
+    WebKitImageTest::add("WebKitImage", "loadable-icon-interface-sync-load", testWebKitImageLoadableIconLoadSync);
+    WebKitImageTest::add("WebKitImage", "loadable-icon-interface-async-load", testWebKitImageLoadableIconLoadAsync);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -150,6 +150,7 @@ ADD_WK2_TEST(TestResources ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestResou
 ADD_WK2_TEST(TestSSL ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp)
 ADD_WK2_TEST(TestUIClient ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp)
 ADD_WK2_TEST(TestWebProcessExtensions ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp)
+ADD_WK2_TEST(TestWebKitImage ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp)
 ADD_WK2_TEST(TestWebKitPolicyClient ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp)
 ADD_WK2_TEST(TestWebKitSecurityOrigin ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSecurityOrigin.cpp)
 ADD_WK2_TEST(TestWebKitSettings ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp)


### PR DESCRIPTION
#### e782ba9994664957d903c6b1e3797dc182c398cf
<pre>
[WPE] WIP: Use WebKitImage to implement web view snapshot
Need a short description (OOPS!).
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
</pre>
----------------------------------------------------------------------
#### fdee3b285abe803eb74d5b5be384bbf5e9811465
<pre>
Add WebKitImage utility class to the public API <a href="https://bugs.webkit.org/show_bug.cgi?id=301089">https://bugs.webkit.org/show_bug.cgi?id=301089</a>

Reviewed by NOBODY (OOPS!).

Added a new WebKitImage utility class. This exposes width, height,
stride and image type properties, and allows accessing the native bytes
as well as a GdkTexture for convenience if under PLATFORM(GTK).

This class implements the GIcon and GLoadableIcon interfaces, and has
tests exercising its API as well as the interface implementations.

Tests: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
       Tools/TestWebKitAPI/glib/CMakeLists.txt
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitImage.cpp: Added.
(webkitImageSetProperty):
(webkitImageGetProperty):
(webkit_image_class_init):
(webkitImageNew):
(webkit_image_get_width):
(webkit_image_get_height):
(webkit_image_get_stride):
(webkit_image_as_rgba_bytes):
(webkitImageHash):
(webkitImageEqual):
(webkitImageLoad):
(webkitImageLoadAsync):
(webkitImageLoadFinish):
(webkit_image_gicon_interface_init):
(webkit_image_gloadable_icon_interface_init):
* Source/WebKit/UIProcess/API/glib/WebKitImage.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitImagePrivate.h: Added.
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp: Added.
(WebKitImageTest::asyncLoadFinishedCallback):
(WebKitImageTest::WebKitImageTest):
(WebKitImageTest::~WebKitImageTest):
(testWebKitImagePropertiesConstruct):
(testWebKitImageIconInterface):
(testWebKitImageLoadableIconLoadSync):
(testWebKitImageLoadableIconLoadAsync):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e782ba9994664957d903c6b1e3797dc182c398cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129682 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/1943 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/40538 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137070 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81142 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/131553 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/1891 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/1832 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/137070 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81142 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/132629 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/1891 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/40538 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137070 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/1891 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/40538 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/80342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/1891 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/40538 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/139552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1737 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/1832 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/139552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/1782 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/40538 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/139552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/40538 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54487 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/1810 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/65179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1624 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1659 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/1731 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->