### PR TITLE
AX: frameLoadingEventNotification calls getOrCreate even when it's unnecessary and potentially unsafe (e.g. when layout is dirty)

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -622,7 +622,7 @@ protected:
     void postPlatformAnnouncementNotification(const String&) { }
 #endif
 
-    void frameLoadingEventPlatformNotification(AccessibilityObject*, AXLoadingEvent);
+    void frameLoadingEventPlatformNotification(RenderView*, AXLoadingEvent);
     void handleLabelChanged(AccessibilityObject*);
 
     // CharacterOffset functions.

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -237,15 +237,16 @@ void AXObjectCache::postTextReplacementPlatformNotification(AccessibilityObject*
         wrapper->textInserted(insertedText, position);
 }
 
-void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* coreObject, AXLoadingEvent loadingEvent)
+void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView, AXLoadingEvent loadingEvent)
 {
-    if (!coreObject)
+    if (!renderView)
         return;
 
-    if (coreObject->role() != AccessibilityRole::WebArea)
+    RefPtr object = getOrCreate(*renderView);
+    if (!object || object->role() != AccessibilityRole::WebArea)
         return;
 
-    auto* wrapper = coreObject->wrapper();
+    auto* wrapper = object->wrapper();
     if (!wrapper)
         return;
 

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -663,16 +663,20 @@ void AXObjectCache::postTextReplacementPlatformNotificationForTextControl(Access
         postUserInfoForChanges(*root, *axObject, changes.get());
 }
 
-void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* axFrameObject, AXLoadingEvent loadingEvent)
+void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView, AXLoadingEvent loadingEvent)
 {
-    if (!axFrameObject)
+    if (!renderView)
         return;
 
     if (loadingEvent == AXLoadingEvent::Finished) {
-        if (axFrameObject->document() == axFrameObject->topDocument())
-            postNotification(axFrameObject, axFrameObject->document(), AXNotification::LoadComplete);
+        // It's not always safe to call getOrCreate (e.g. if layout is dirty), so
+        // only do so if necessary based on the loading event type.
+        RefPtr axWebArea = getOrCreate(*renderView);
+        RefPtr document = axWebArea ? axWebArea->document() : nullptr;
+        if (document.get() == axWebArea->topDocument())
+            postNotification(axWebArea.get(), document.get(), AXNotification::LoadComplete);
         else
-            postNotification(axFrameObject, axFrameObject->document(), AXNotification::FrameLoadComplete);
+            postNotification(axWebArea.get(), document.get(), AXNotification::FrameLoadComplete);
     }
 }
 

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -120,17 +120,20 @@ void AXObjectCache::nodeTextChangePlatformNotification(AccessibilityObject* obje
     client.postAccessibilityNodeTextChangeNotification(object, textChange, offset, text);
 }
 
-void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* object, AXLoadingEvent loadingEvent)
+void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView, AXLoadingEvent loadingEvent)
 {
-    if (!document()
-        || !object
+    if (!renderView || !document())
+        return;
+
+    RefPtr object = getOrCreate(*renderView);
+    if (!object
         || !object->document()
         || !object->document()->view()
         || object->document()->view()->layoutContext().layoutState()
         || object->document()->childNeedsStyleRecalc())
         return;
     ChromeClient& client = document()->frame()->page()->chrome().client();
-    client.postAccessibilityFrameLoadingEventNotification(object, loadingEvent);
+    client.postAccessibilityFrameLoadingEventNotification(object.get(), loadingEvent);
 }
 
 void AXObjectCache::handleScrolledToAnchor(const Node& scrolledToNode)


### PR DESCRIPTION
#### 1523cf6f4b3c5d8ff2a5c65d2b83372135eeb66c
<pre>
AX: frameLoadingEventNotification calls getOrCreate even when it&apos;s unnecessary and potentially unsafe (e.g. when layout is dirty)
<a href="https://bugs.webkit.org/show_bug.cgi?id=302035">https://bugs.webkit.org/show_bug.cgi?id=302035</a>
<a href="https://rdar.apple.com/164059225">rdar://164059225</a>

Reviewed by Joshua Hoffman.

On Cocoa ports, we have found CheckedPtr crashes stemming from the getOrCreate(RenderObject&amp;) performed by:

FrameLoader::prepareForLoadStart() -&gt; AXObjectCache::frameLoadingEventNotification

This probably means layout is dirty when we&apos;re calling this getOrCreate, but I can&apos;t say for sure because I haven&apos;t been
able to reproduce this crash. Workaround the issue for now by avoiding the getOrCreate if the AXLoadingEvent type is
one that the platform is going to ignore anyways.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::frameLoadingEventNotification):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):

Canonical link: <a href="https://commits.webkit.org/302668@main">https://commits.webkit.org/302668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01db056bb0507763ac4d20f481538cab1b926967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81308 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6a13cee6-6548-47e4-b4e7-4a5e0d3d7982) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/60980146-cd0a-4cf6-b732-19f7d43ec086) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79584 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a9a47e76-4301-4d12-9f2c-2c3f0c9bc3b0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34414 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80491 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109963 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34916 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139700 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107411 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107291 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/1523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54676 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20254 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1956 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65325 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->