### PR TITLE
In JSWebAssemblyInstance.cpp, replace the blanket "using namespace Wasm" directive with specific using declarations

### DIFF
--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -55,7 +55,22 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
-using namespace Wasm;
+using Wasm::CalleeGroup;
+using Wasm::CompilationMode;
+using Wasm::CreationMode;
+using Wasm::Element;
+using Wasm::Global;
+using Wasm::GlobalInformation;
+using Wasm::Memory;
+using Wasm::ModuleInformation;
+using Wasm::RTTKind;
+using Wasm::Table;
+using Wasm::Tag;
+using Wasm::Type;
+using Wasm::TypeIndex;
+using Wasm::TypeInformation;
+using Wasm::FunctionSpaceIndex;
+using Wasm::isRefType;
 
 const ClassInfo JSWebAssemblyInstance::s_info = { "WebAssembly.Instance"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblyInstance) };
 


### PR DESCRIPTION
#### b17bfa757d0cb010585bc9baac8bda50da1e5ee9
<pre>
In JSWebAssemblyInstance.cpp, replace the blanket &quot;using namespace Wasm&quot; directive with specific using declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=302041">https://bugs.webkit.org/show_bug.cgi?id=302041</a>
<a href="https://rdar.apple.com/164119670">rdar://164119670</a>

Reviewed by Daniel Liu and Dan Hecht.

Because of the unified source build mechanism, the &quot;using namespace Wasm&quot; directive in the
JSC namespace in JSWebAssemblyInstance.cpp can cause a random build failure if a source
file that uses a name from JSC which is also defined in Wasm is included in the unified
source following JSWebAssemblyInstance.cpp.

One such name is InternalFunction. There is JSC::InternalFunction, and also
JSC::Wasm::InternalFunction. JSC::InternalFunction is used by its unqualified name as a
superclass of many classes in JSC. The &quot;using namespace Wasm&quot; directive in
JSWebAssemblyInstance.cpp brings JSC::Wasm::InternalFunction into the namespace JSC as a
second definition associated with that unqualified name. This duplicate definition is then
present in any namespace JSC definition appearing after JSWebAssemblyInstance.cpp in the
unified source. Any file included into the unified source afterwards and defining a
subclass of InternalFunction will then fail with an ambiguous reference error.

To avoid this fragility, JSWebAssemblyInstance.cpp should use specific using declarations
for the Wasm names it needs.

Tests: not directly testable.
Canonical link: <a href="https://commits.webkit.org/302625@main">https://commits.webkit.org/302625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18a4d6676c9e5718fbd8dd7088ec7e6ced9aafe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81155 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6665a938-44fd-40b1-95c1-695c5d657078) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66626 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1ef85141-a234-4da7-b781-fa05c7503d6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1454 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79469 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f75ca3b-1ee3-4c21-a83f-2bfb6cf30a36) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80355 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139565 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128147 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107307 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107174 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27290 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1410 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54500 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65192 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161161 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1637 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40192 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1744 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->