### PR TITLE
[iOS] fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html is a constant failure

### DIFF
--- a/LayoutTests/fast/events/ios/do-not-show-keyboard-when-focusing-after-blur-expected.txt
+++ b/LayoutTests/fast/events/ios/do-not-show-keyboard-when-focusing-after-blur-expected.txt
@@ -1,4 +1,4 @@
-PASS inputBounds.top is >= screenHeight
+PASS inputBounds.top === null || inputBounds.top >= screenHeight is true
 PASS inputBounds.height is 0
 PASS document.activeElement is field
 PASS successfullyParsed is true

--- a/LayoutTests/fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html
+++ b/LayoutTests/fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html
@@ -40,7 +40,7 @@ addEventListener("load", async () => {
     screenHeight = screen.height;
 
     // Verify that the keyboard is positioned off-screen.
-    shouldBeGreaterThanOrEqual("inputBounds.top", "screenHeight");
+    shouldBeTrue("inputBounds.top === null || inputBounds.top >= screenHeight");
     shouldBe("inputBounds.height", "0");
     shouldBe("document.activeElement", "field");
     finishJSTest();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8369,5 +8369,3 @@ fast/forms/ios/focus-input-via-button.html [ Failure ]
 fast/forms/ios/focus-long-textarea.html [ Failure ]
 fast/forms/ios/zoom-after-input-tap-wide-input.html [ Failure ]
 fast/forms/ios/zoom-after-input-tap.html [ Failure ]
-
-webkit.org/b/301957 fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html [ Failure ]


### PR DESCRIPTION
#### 1cab0780a43c937bf6bf3d4e1a3ad4e18cadf41a
<pre>
[iOS] fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=301957">https://bugs.webkit.org/show_bug.cgi?id=301957</a>
<a href="https://rdar.apple.com/164033597">rdar://164033597</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Adjust this test to be robust in the case where the keyboard no longer animates down below the
bottom edge of the screen after dismissing — in iOS 26, instead of reporting an offscreen rect after
dismissal, the keyboard now reports `CGRectNull` instead (with no difference in end user
experience).

* LayoutTests/fast/events/ios/do-not-show-keyboard-when-focusing-after-blur-expected.txt:
* LayoutTests/fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/302654@main">https://commits.webkit.org/302654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cd8237fb9c9bf424a92ae5689b2a3b362dbff47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81219 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5756d160-45d3-4b79-81f9-da65d1f43292) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98842 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66670 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c8ae717c-46be-4990-b8fc-aac58b78f715) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/45a55b5c-0124-4532-be9f-33d98ed33d93) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80411 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139621 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107348 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27303 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54559 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1878 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1692 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->