### PR TITLE
Re-entrant navigation commits wrong DocumentLoader

### DIFF
--- a/LayoutTests/loader/child-frame-navigation-during-commit-expected.txt
+++ b/LayoutTests/loader/child-frame-navigation-during-commit-expected.txt
@@ -1,0 +1,1 @@
+PASS: Successfully navigated to second navigation (GoodBye)

--- a/LayoutTests/loader/child-frame-navigation-during-commit.html
+++ b/LayoutTests/loader/child-frame-navigation-during-commit.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function load() {
+    window.navigation.navigate("data:,Hello%2C%20World%21");
+}
+
+function load2() {
+    // Navigate to the data URL that contains the test completion logic.
+    var testCode = '<script>' +
+        'if (window.testRunner) {' +
+        '  document.write("PASS: Successfully navigated to second navigation (GoodBye)");' +
+        '  testRunner.notifyDone();' +
+        '}' +
+        '<\/script>';
+    window.navigation.navigate("data:text/html," + encodeURIComponent(testCode));
+}
+</script>
+</head>
+<body>
+<style onload="load()"></style>
+<embed src="data:text/html,foo">
+<svg onload="load2()"></svg>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2402,7 +2402,7 @@ void FrameLoader::commitProvisionalLoad()
     if (!cachedPage && !m_stateMachine.creatingInitialEmptyDocument())
         m_client->makeRepresentation(pdl.get());
 
-    transitionToCommitted(cachedPage.get());
+    transitionToCommitted(pdl.get(), cachedPage.get());
 
     if (pdl && m_documentLoader) {
         // Check if the destination page is allowed to access the previous page's timing information.
@@ -2531,13 +2531,17 @@ IGNORE_GCC_WARNINGS_END
     }
 }
 
-void FrameLoader::transitionToCommitted(CachedPage* cachedPage)
+void FrameLoader::transitionToCommitted(DocumentLoader* provisionalLoader, CachedPage* cachedPage)
 {
     ASSERT(m_client->hasWebView());
     ASSERT(m_state == FrameState::Provisional);
 
     if (m_state != FrameState::Provisional)
         return;
+
+    // Ensure we're committing the loader that was originally captured
+    ASSERT(provisionalLoader);
+    ASSERT(provisionalLoader->isCommitted());
 
     if (RefPtr view = m_frame->view()) {
         if (auto* scrollAnimator = view->existingScrollAnimator())
@@ -2550,10 +2554,9 @@ void FrameLoader::transitionToCommitted(CachedPage* cachedPage)
     // The call to closeURL() invokes the unload event handler, which can execute arbitrary
     // JavaScript. If the script initiates a new load, we need to abandon the current load,
     // or the two will stomp each other.
-    RefPtr originalProvisionalDocumentLoader = m_provisionalDocumentLoader;
     if (m_documentLoader)
         closeURL();
-    if (originalProvisionalDocumentLoader != m_provisionalDocumentLoader)
+    if (provisionalLoader != m_provisionalDocumentLoader)
         return;
 
     if (RefPtr documentLoader = m_documentLoader)
@@ -2564,10 +2567,11 @@ void FrameLoader::transitionToCommitted(CachedPage* cachedPage)
     // Setting our document loader invokes the unload event handler of our child frames.
     // Script can do anything. If the script initiates a new load, we need to abandon the
     // current load or the two will stomp each other.
-    setDocumentLoader(m_provisionalDocumentLoader.copyRef());
-    if (originalProvisionalDocumentLoader != m_provisionalDocumentLoader)
+    // Use the captured provisionalLoader parameter, not m_provisionalDocumentLoader
+    setDocumentLoader(RefPtr { provisionalLoader });
+    if (provisionalLoader != m_provisionalDocumentLoader)
         return;
-    FRAMELOADER_RELEASE_LOG_FORWARDABLE(FRAMELOADER_TRANSITIONTOCOMMITTED, (uint64_t)m_provisionalDocumentLoader.get());
+    FRAMELOADER_RELEASE_LOG_FORWARDABLE(FRAMELOADER_TRANSITIONTOCOMMITTED, (uint64_t)provisionalLoader);
     setProvisionalDocumentLoader(nullptr);
 
     // Nothing else can interrupt this commit - set the Provisional->Committed transition in stone

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -395,7 +395,7 @@ private:
     ResourceRequestCachePolicy defaultRequestCachingPolicy(const ResourceRequest&, FrameLoadType, bool isMainResource);
 
     void clearProvisionalLoad();
-    void transitionToCommitted(CachedPage*);
+    void transitionToCommitted(DocumentLoader*, CachedPage*);
     void frameLoadCompleted();
 
     SubstituteData defaultSubstituteDataForURL(const URL&);


### PR DESCRIPTION
#### 0803c0c0e2a6b07dfafe916e21f43bb9d685af41
<pre>
Re-entrant navigation commits wrong DocumentLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=302047">https://bugs.webkit.org/show_bug.cgi?id=302047</a>
<a href="https://rdar.apple.com/161084444">rdar://161084444</a>

Reviewed by NOBODY (OOPS!).

commitProvisionalLoad() captures which DocumentLoader to commit, but
transitionToCommitted() re-reads m_provisionalDocumentLoader instead of using
the captured value. When a child frame commits synchronously during the parent&apos;s
commit (e.g., &lt;embed&gt; with data: URL), the parser resumes and fires subsequent
handlers (e.g., &lt;svg onload&gt;) while parent commit is on the stack. If this
handler starts another navigation, BackForwardCache clears the original loader
and replaces it with the new one. transitionToCommitted() then reads the wrong
loader and commits it, orphaning the original document.

The fix passes the captured DocumentLoader as an explicit parameter to
transitionToCommitted(), ensuring the originally-intended loader is committed.
The re-entrancy check (provisionalLoader != m_provisionalDocumentLoader) now
aborts the commit when it detects the member variable changed.

The initial reported crash occurred in WebKitTestRunner when resetInternalsObject()
dereferenced the null frame pointer of the orphaned document during test cleanup. That
crash doesn&apos;t seem reproducible with run-webkit-tests because the harness terminates
before the bad commit completes.

The added layout test triggers the re-entrant scenario (style + embed + svg) and
navigates to a data: URL containing test completion logic. With the fix, the
first navigation is aborted when re-entrancy is detected, and the second
navigation proceeds cleanly, allowing testRunner.notifyDone() to execute.
Without the fix, the wrong loader is committed, the test document is orphaned,
and the test times out.

Test: loader/child-frame-navigation-during-commit.html

* LayoutTests/loader/child-frame-navigation-during-commit-expected.txt: Added.
* LayoutTests/loader/child-frame-navigation-during-commit.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::transitionToCommitted):
* Source/WebCore/loader/FrameLoader.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0803c0c0e2a6b07dfafe916e21f43bb9d685af41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85900 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c5785db-0b3b-47e1-8ab4-d081841c0eb2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6215 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102396 "Found 1 new test failure: loader/child-frame-navigation-during-commit.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69868 "Found 1 new test failure: loader/child-frame-navigation-during-commit.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/23a07eb5-db7a-4311-9ea9-32d043985e08) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136787 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4850 "Found 1 new test failure: loader/child-frame-navigation-during-commit.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83195 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b29332c9-982b-416e-b938-efcd5dc612ee) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4729 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2347 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/795 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113882 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38107 "Found 1 new test failure: loader/child-frame-navigation-during-commit.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144063 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6021 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38685 "Found 1 new test failure: loader/child-frame-navigation-during-commit.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110756 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6103 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5136 "Found 1 new test failure: loader/child-frame-navigation-during-commit.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110954 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4585 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116243 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59768 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6073 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34526 "Found 1 new test failure: loader/child-frame-navigation-during-commit.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6027 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->