### PR TITLE
[Site Isolation] Find in page does not work on iOS

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -410,6 +410,7 @@ UIProcess/DisplayLink.cpp
 UIProcess/DisplayLinkProcessProxyClient.cpp
 UIProcess/DrawingAreaProxy.cpp
 UIProcess/FindStringCallbackAggregator.cpp
+UIProcess/FindTextMatchesCallbackAggregator.cpp
 UIProcess/FrameLoadState.cpp
 UIProcess/FrameProcess.cpp
 UIProcess/GeolocationPermissionRequestManagerProxy.cpp

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -678,7 +678,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
     addTableRow(displayObject, "Device scale"_s, String::number(page->deviceScaleFactor()));
     addTableRow(displayObject, "Depth"_s, String::number(screenDepth(nullptr)));
     addTableRow(displayObject, "Bits per color component"_s, String::number(screenDepthPerComponent(nullptr)));
-    addTableRow(displayObject, "Font Scaling DPI"_s, String::number(fontDPI()));
+    addTableRow(displayObject, "Font Scaling DPI"_s, String::number(WebCore::fontDPI()));
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
     addTableRow(displayObject, "Screen DPI"_s, String::number(screenDPI(displayID.value_or(primaryScreenDisplayID()))));
 #endif

--- a/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
+++ b/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
@@ -30,6 +30,8 @@
 #include <wtf/FileSystem.h>
 #include <wtf/Language.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.cpp
+++ b/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.cpp
@@ -24,48 +24,31 @@
  */
 
 #include "config.h"
-#include "RemoteMediaSessionProxy.h"
+#include "FindTextMatchesCallbackAggregator.h"
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-
-#include "RemoteMediaSessionClientProxy.h"
-#include "RemoteMediaSessionManagerMessages.h"
-#include "RemoteMediaSessionManagerProxy.h"
-#include <WebCore/NotImplemented.h>
+#include "WebFoundTextRange.h"
 
 namespace WebKit {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionProxy);
-
-RemoteMediaSessionProxy::RemoteMediaSessionProxy(const RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager)
-    : PlatformMediaSession(*new RemoteMediaSessionClientProxy(state, manager))
-    , m_manager(manager)
-    , m_state(state)
-#if !RELEASE_LOG_DISABLED
-    , m_logger(manager.process()->logger())
-#endif
+Ref<FindTextMatchCallbackAggregator> FindTextMatchCallbackAggregator::create(CompletionHandler<void(Vector<WebFoundTextRange>&&)>&& completionHandler)
 {
-    setMediaSessionIdentifier(state.sessionIdentifier);
+    return adoptRef(*new FindTextMatchCallbackAggregator(WTFMove(completionHandler)));
 }
 
-RemoteMediaSessionProxy::~RemoteMediaSessionProxy()
+void FindTextMatchCallbackAggregator::foundMatches(Vector<WebFoundTextRange>&& range)
 {
+    // FIXME: matches will be returned in amy order from frames. Matches need to be sorted in the order they appear in the frame tree.
+    m_range.appendVector(range);
 }
 
-void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& state)
+FindTextMatchCallbackAggregator::~FindTextMatchCallbackAggregator()
 {
-    // FIXME: merge changes, notify as necessary
-    m_state = state;
+    m_completionHandler(WTFMove(m_range));
 }
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-void RemoteMediaSessionProxy::setShouldPlayToPlaybackTarget(bool shouldPlay)
+FindTextMatchCallbackAggregator::FindTextMatchCallbackAggregator(CompletionHandler<void(Vector<WebFoundTextRange>&&)>&& completionHandler)
+    : m_completionHandler(WTFMove(completionHandler))
 {
-    if (RefPtr manager = m_manager.get())
-        manager->send(Messages::RemoteMediaSessionManager::ClientSetShouldPlayToPlaybackTarget(sessionIdentifier(), shouldPlay));
 }
-#endif
 
 } // namespace WebKit
-
-#endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.h
+++ b/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.h
@@ -23,49 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "RemoteMediaSessionProxy.h"
+#pragma once
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-
-#include "RemoteMediaSessionClientProxy.h"
-#include "RemoteMediaSessionManagerMessages.h"
-#include "RemoteMediaSessionManagerProxy.h"
-#include <WebCore/NotImplemented.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/RefCounted.h>
 
 namespace WebKit {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionProxy);
+class WebPageProxy;
+struct WebFoundTextRange;
 
-RemoteMediaSessionProxy::RemoteMediaSessionProxy(const RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager)
-    : PlatformMediaSession(*new RemoteMediaSessionClientProxy(state, manager))
-    , m_manager(manager)
-    , m_state(state)
-#if !RELEASE_LOG_DISABLED
-    , m_logger(manager.process()->logger())
-#endif
-{
-    setMediaSessionIdentifier(state.sessionIdentifier);
-}
+enum class FindOptions : uint16_t;
 
-RemoteMediaSessionProxy::~RemoteMediaSessionProxy()
-{
-}
+class FindTextMatchCallbackAggregator : public RefCounted<FindTextMatchCallbackAggregator> {
+public:
+    static Ref<FindTextMatchCallbackAggregator> create(CompletionHandler<void(Vector<WebFoundTextRange>&&)>&&);
+    void foundMatches(Vector<WebFoundTextRange>&&);
+    ~FindTextMatchCallbackAggregator();
 
-void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& state)
-{
-    // FIXME: merge changes, notify as necessary
-    m_state = state;
-}
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-void RemoteMediaSessionProxy::setShouldPlayToPlaybackTarget(bool shouldPlay)
-{
-    if (RefPtr manager = m_manager.get())
-        manager->send(Messages::RemoteMediaSessionManager::ClientSetShouldPlayToPlaybackTarget(sessionIdentifier(), shouldPlay));
-}
-#endif
-
+private:
+    FindTextMatchCallbackAggregator(CompletionHandler<void(Vector<WebFoundTextRange>&&)>&&);
+    CompletionHandler<void(Vector<WebFoundTextRange>&&)> m_completionHandler;
+    Vector<WebFoundTextRange> m_range;
+};
 } // namespace WebKit
-
-#endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include "UIProcess/Media/RemoteMediaSessionManagerProxy.h"
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 
 #include "RemoteMediaSessionState.h"
 #include <WebCore/PlatformMediaSession.h>
 
 namespace WebKit {
+class RemoteMediaSessionManagerProxy;
 
 class RemoteMediaSessionProxy final
     : public WebCore::PlatformMediaSession {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2265,6 +2265,7 @@
 		D2E2FE6E29C8C30D00023E6B /* NetworkTaskCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E2FE6D29C8C30D00023E6B /* NetworkTaskCocoa.h */; };
 		D3B9484711FF4B6500032B39 /* WebPopupMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = D3B9484311FF4B6500032B39 /* WebPopupMenu.h */; };
 		D3B9484911FF4B6500032B39 /* WebSearchPopupMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = D3B9484511FF4B6500032B39 /* WebSearchPopupMenu.h */; };
+		D6C27CBC2EC275F600AA941F /* FindTextMatchesCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = D6C27CBA2EC2757B00AA941F /* FindTextMatchesCallbackAggregator.h */; };
 		D952EC7A289C6BFA006C240A /* WebPermissionControllerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = D952EC76289C4299006C240A /* WebPermissionControllerProxy.h */; };
 		D952EC7E289C9A4C006C240A /* WebPermissionControllerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = D952EC7B289C9A4C006C240A /* WebPermissionControllerProxyMessages.h */; };
 		DD284682291F7D210009A61D /* APIFeatureStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = DD284681291F7CEF0009A61D /* APIFeatureStatus.h */; };
@@ -8288,6 +8289,8 @@
 		D3B9484311FF4B6500032B39 /* WebPopupMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPopupMenu.h; sourceTree = "<group>"; };
 		D3B9484411FF4B6500032B39 /* WebSearchPopupMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSearchPopupMenu.cpp; sourceTree = "<group>"; };
 		D3B9484511FF4B6500032B39 /* WebSearchPopupMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSearchPopupMenu.h; sourceTree = "<group>"; };
+		D6C27CBA2EC2757B00AA941F /* FindTextMatchesCallbackAggregator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindTextMatchesCallbackAggregator.h; sourceTree = "<group>"; };
+		D6C27CBB2EC2759A00AA941F /* FindTextMatchesCallbackAggregator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FindTextMatchesCallbackAggregator.cpp; sourceTree = "<group>"; };
 		D93F6FB228C17970006C627C /* WebPermissionController.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebPermissionController.messages.in; sourceTree = "<group>"; };
 		D952EC76289C4299006C240A /* WebPermissionControllerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPermissionControllerProxy.h; sourceTree = "<group>"; };
 		D952EC77289C46B4006C240A /* WebPermissionControllerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPermissionControllerProxy.cpp; sourceTree = "<group>"; };
@@ -15238,6 +15241,8 @@
 				CDCDC99C248FE8DA00A69522 /* EndowmentStateTracker.mm */,
 				0250C24E2B5DCAFB00D05C0B /* FindStringCallbackAggregator.cpp */,
 				0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */,
+				D6C27CBB2EC2759A00AA941F /* FindTextMatchesCallbackAggregator.cpp */,
+				D6C27CBA2EC2757B00AA941F /* FindTextMatchesCallbackAggregator.h */,
 				1AE00D5E1831792100087DD7 /* FrameLoadState.cpp */,
 				1AE00D5F1831792100087DD7 /* FrameLoadState.h */,
 				FA6757052B815C8300C1566A /* FrameProcess.cpp */,
@@ -17749,6 +17754,7 @@
 				1A90C1F41264FD71003E44D4 /* FindController.h in Headers */,
 				DD4DB789280F9471001700D4 /* FindNodes.js in Headers */,
 				0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */,
+				D6C27CBC2EC275F600AA941F /* FindTextMatchesCallbackAggregator.h in Headers */,
 				C59C4A5918B81174007BDCB6 /* FocusedElementInformation.h in Headers */,
 				DD4DB78A280F9471001700D4 /* FormElementClear.js in Headers */,
 				DD4DB78B280F9471001700D4 /* FormSubmit.js in Headers */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -124,6 +124,7 @@ Tests/WebKitCocoa/ExitPiPOnSuspendVideoElement.mm @nonARC
 Tests/WebKitCocoa/FTP.mm @nonARC
 Tests/WebKitCocoa/FileSystemAccess.mm @nonARC
 Tests/WebKitCocoa/FindInPage.mm @nonARC
+Tests/WebKitCocoa/FindInPageUtilities.mm @nonARC
 Tests/WebKitCocoa/FindInPageAPI.mm @nonARC
 Tests/WebKitCocoa/FirstVisuallyNonEmptyMilestone.mm @nonARC
 Tests/WebKitCocoa/FixedLayoutSize.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -4065,6 +4065,8 @@
 		D2CC7CF32D9A8D6B00011B9E /* TestCocoaImageAndCocoaColor.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = TestCocoaImageAndCocoaColor.mm; path = cocoa/TestCocoaImageAndCocoaColor.mm; sourceTree = "<group>"; };
 		D2D9A6BD2D96B539004A2C92 /* icon-with-subresource.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 0; path = "icon-with-subresource.svg"; sourceTree = "<group>"; };
 		D3BE5E341E4CE85E00FD563A /* WKWebViewGetContents.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewGetContents.mm; sourceTree = "<group>"; };
+		D606F87F2EBC1C93002783D7 /* FindInPageUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindInPageUtilities.h; sourceTree = "<group>"; };
+		D606F8872EBC201D002783D7 /* FindInPageUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FindInPageUtilities.mm; sourceTree = "<group>"; };
 		D69D9E2F2E9041E800689F1D /* SiteIsolationUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SiteIsolationUtilities.h; sourceTree = "<group>"; };
 		D69D9E372E9041F400689F1D /* SiteIsolationUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SiteIsolationUtilities.mm; sourceTree = "<group>"; };
 		D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStyleChange.cpp; sourceTree = "<group>"; };
@@ -4859,6 +4861,8 @@
 				93468E6E2714B4F1009983E3 /* FileSystemAccess.mm */,
 				2D8104CB1BEC13E70020DA46 /* FindInPage.mm */,
 				51242CD42374E61E00EED9C1 /* FindInPageAPI.mm */,
+				D606F87F2EBC1C93002783D7 /* FindInPageUtilities.h */,
+				D606F8872EBC201D002783D7 /* FindInPageUtilities.mm */,
 				118153472208BADF00B2CCD2 /* FirstVisuallyNonEmptyMilestone.mm */,
 				2D1FE0AF1AD465C1006CD9E6 /* FixedLayoutSize.mm */,
 				2E92B8F8216490EA005B64F0 /* FontAttributes.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.h
@@ -23,49 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "RemoteMediaSessionProxy.h"
+#pragma once
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+#include <wtf/BlockPtr.h>
+#include <wtf/RetainPtr.h>
 
-#include "RemoteMediaSessionClientProxy.h"
-#include "RemoteMediaSessionManagerMessages.h"
-#include "RemoteMediaSessionManagerProxy.h"
-#include <WebCore/NotImplemented.h>
+#if HAVE(UIFINDINTERACTION)
 
-namespace WebKit {
+@interface TestSearchAggregator : NSObject <UITextSearchAggregator>
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionProxy);
+@property (readonly) NSUInteger count;
+@property (nonatomic, readonly) NSOrderedSet<UITextRange *> *allFoundRanges;
 
-RemoteMediaSessionProxy::RemoteMediaSessionProxy(const RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager)
-    : PlatformMediaSession(*new RemoteMediaSessionClientProxy(state, manager))
-    , m_manager(manager)
-    , m_state(state)
-#if !RELEASE_LOG_DISABLED
-    , m_logger(manager.process()->logger())
+- (instancetype)initWithCompletionHandler:(dispatch_block_t)completionHandler;
+
+@end
+
+void testPerformTextSearchWithQueryStringInWebView(WKWebView *, NSString *query, UITextSearchOptions *, NSUInteger expectedMatches);
+RetainPtr<NSOrderedSet<UITextRange *>> textRangesForQueryString(WKWebView *, NSString *query);
+
 #endif
-{
-    setMediaSessionIdentifier(state.sessionIdentifier);
-}
-
-RemoteMediaSessionProxy::~RemoteMediaSessionProxy()
-{
-}
-
-void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& state)
-{
-    // FIXME: merge changes, notify as necessary
-    m_state = state;
-}
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-void RemoteMediaSessionProxy::setShouldPlayToPlaybackTarget(bool shouldPlay)
-{
-    if (RefPtr manager = m_manager.get())
-        manager->send(Messages::RemoteMediaSessionManager::ClientSetShouldPlayToPlaybackTarget(sessionIdentifier(), shouldPlay));
-}
-#endif
-
-} // namespace WebKit
-
-#endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.mm
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FindInPageUtilities.h"
+
+#if HAVE(UIFINDINTERACTION)
+
+@implementation TestSearchAggregator {
+    RetainPtr<NSMutableOrderedSet<UITextRange *>> _foundRanges;
+    BlockPtr<void()> _completionHandler;
+}
+
+- (instancetype)initWithCompletionHandler:(dispatch_block_t)completionHandler
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _foundRanges = adoptNS([[NSMutableOrderedSet alloc] init]);
+    _completionHandler = makeBlockPtr(completionHandler);
+
+    return self;
+}
+
+- (void)foundRange:(UITextRange *)range forSearchString:(NSString *)string inDocument:(UITextSearchDocumentIdentifier)document
+{
+    if (!string.length)
+        return;
+
+    [_foundRanges addObject:range];
+}
+
+- (void)finishedSearching
+{
+    if (_completionHandler)
+        _completionHandler();
+}
+
+- (NSOrderedSet<UITextRange *> *)allFoundRanges
+{
+    return _foundRanges.get();
+}
+
+- (void)invalidateFoundRange:(UITextRange *)range inDocument:(UITextSearchDocumentIdentifier)document
+{
+    [_foundRanges removeObject:range];
+}
+
+- (void)invalidate
+{
+    [_foundRanges removeAllObjects];
+}
+
+- (NSUInteger)count
+{
+    return [_foundRanges count];
+}
+
+@end
+
+void testPerformTextSearchWithQueryStringInWebView(WKWebView *webView, NSString *query, UITextSearchOptions * searchOptions, NSUInteger expectedMatches)
+{
+    __block bool finishedSearching = false;
+    RetainPtr aggregator = adoptNS([[TestSearchAggregator alloc] initWithCompletionHandler:^{
+        finishedSearching = true;
+    }]);
+
+    [webView performTextSearchWithQueryString:query usingOptions:searchOptions resultAggregator:aggregator.get()];
+
+    TestWebKitAPI::Util::run(&finishedSearching);
+
+    EXPECT_EQ([aggregator count], expectedMatches);
+}
+
+RetainPtr<NSOrderedSet<UITextRange *>> textRangesForQueryString(WKWebView *webView, NSString *query)
+{
+    __block bool finishedSearching = false;
+    auto aggregator = adoptNS([[TestSearchAggregator alloc] initWithCompletionHandler:^{
+        finishedSearching = true;
+    }]);
+
+    auto options = adoptNS([[UITextSearchOptions alloc] init]);
+    [webView performTextSearchWithQueryString:query usingOptions:options.get() resultAggregator:aggregator.get()];
+
+    TestWebKitAPI::Util::run(&finishedSearching);
+
+    return adoptNS([[aggregator allFoundRanges] copy]);
+}
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "PlatformUtilities.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKUserContentControllerPrivate.h>
 #import <WebKit/_WKJSBuffer.h>


### PR DESCRIPTION
#### df98bde355e5cd7178fb9d539bea5d9175fd2762
<pre>
[Site Isolation] Find in page does not work on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=302051">https://bugs.webkit.org/show_bug.cgi?id=302051</a>
<a href="https://rdar.apple.com/164130275">rdar://164130275</a>

Reviewed by Aditya Keerthi and Sihui Liu.

Before this patch, the text matches would be requested only from
one web content process. Now, we use an aggregator, and collect
all the matches from every web content process. The aggregator
then calls the completion handler in it&apos;s destructor.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp:
* Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.cpp: Copied from Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp.
(WebKit::FindTextMatchCallbackAggregator::create):
(WebKit::FindTextMatchCallbackAggregator::foundMatches):
(WebKit::FindTextMatchCallbackAggregator::~FindTextMatchCallbackAggregator):
(WebKit::FindTextMatchCallbackAggregator::FindTextMatchCallbackAggregator):
* Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.h: Copied from Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::findTextRangesForStringMatches):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(-[TestSearchAggregator initWithCompletionHandler:]): Deleted.
(-[TestSearchAggregator foundRange:forSearchString:inDocument:]): Deleted.
(-[TestSearchAggregator finishedSearching]): Deleted.
(-[TestSearchAggregator allFoundRanges]): Deleted.
(-[TestSearchAggregator invalidateFoundRange:inDocument:]): Deleted.
(-[TestSearchAggregator invalidate]): Deleted.
(-[TestSearchAggregator count]): Deleted.
(testPerformTextSearchWithQueryStringInWebView): Deleted.
(textRangesForQueryString): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.h: Copied from Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.mm: Added.
(-[TestSearchAggregator initWithCompletionHandler:]):
(-[TestSearchAggregator foundRange:forSearchString:inDocument:]):
(-[TestSearchAggregator finishedSearching]):
(-[TestSearchAggregator allFoundRanges]):
(-[TestSearchAggregator invalidateFoundRange:inDocument:]):
(-[TestSearchAggregator invalidate]):
(-[TestSearchAggregator count]):
(testPerformTextSearchWithQueryStringInWebView):
(textRangesForQueryString):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, FindStringInFrameIOS)):
(TestWebKitAPI::(SiteIsolation, FindStringInNestedFrameIOS)):
(TestWebKitAPI::(SiteIsolation, FindStringAcrossMultipleFramesIOS)):

Canonical link: <a href="https://commits.webkit.org/303197@main">https://commits.webkit.org/303197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0da06318537a2d30ed6acbfa02ebaaccb920a47e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83265 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b2d3b40b-9475-48f9-bb09-811f49b3c630) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100392 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01f9c682-6b55-4631-9097-07ecdea35b27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81184 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d72d66df-a9e8-40ea-bc88-9e79bc09b2b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82187 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141641 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3564 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108761 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27643 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2706 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56752 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3625 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32430 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->