### PR TITLE
[WebGPU+Swift] Eliminate 'unsafe' caused by QuerySet.CounterSampleBuffer

### DIFF
--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -54,7 +54,10 @@ class Device;
 class QuerySet : public WGPUQuerySetImpl, public RefCounted<QuerySet> {
     WTF_MAKE_TZONE_ALLOCATED(QuerySet);
 public:
-    using CounterSampleBuffer = std::pair<id<MTLCounterSampleBuffer>, uint32_t>;
+    struct CounterSampleBuffer {
+        id<MTLCounterSampleBuffer> buffer { nil }; // Safety: ARC retains this pointer
+        uint32_t offset { 0 };
+    } SWIFT_ESCAPABLE;
 
     static Ref<QuerySet> create(id<MTLBuffer> visibilityBuffer, uint32_t count, WGPUQueryType type, Device& device)
     {


### PR DESCRIPTION
#### 26fdd36cde06b4614dea7d8dbc47f4c8581168d9
<pre>
[WebGPU+Swift] Eliminate &apos;unsafe&apos; caused by QuerySet.CounterSampleBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=302055">https://bugs.webkit.org/show_bug.cgi?id=302055</a>
<a href="https://rdar.apple.com/164135057">rdar://164135057</a>

Reviewed by Mike Wyrzykowski.

Swift treats std::pair&lt;id, int&gt; as unsafe because

(a) there&apos;s a pointer in there

(b) Swift has no way of knowing whether the pointer&apos;s lifetime is guaranteed or
not -- because Swift models C++ copy and move constructors and copy and move
assignment operators as opaque functions.

Switched from std::pair to a custom struct so I could declare it SWIFT_ESCAPABLE.
I also took the opporutnity to give the data members more descriptive names than
&apos;first&apos; and &apos;second&apos;.

Removed a Range(uncheckedBounds:) construction because it&apos;s unsafe and
we can use literal range syntax intead.

Changed some nil short-circuiting to use the ?? operator, for style.

Fixed up some stray &apos;;&apos;, for style.

Canonical link: <a href="https://commits.webkit.org/302666@main">https://commits.webkit.org/302666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e5b5dc31ce23d7f1778c27b60f2d394809c7190

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129843 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81325 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19329727-deaa-4880-a2b1-3641c2b6aee4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1994 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e21603fb-30db-46eb-abab-2c9d9757d5fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79598 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8bf385e-1f37-4433-9e85-6a90244b63cf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80506 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139715 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1898 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107300 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1532 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54699 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20253 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65340 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1785 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->