### PR TITLE
[AutoFill Debugging] Add an option to limit text extraction output to visible text

### DIFF
--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -49,6 +49,7 @@ namespace WebKit {
 enum class TextExtractionOptionFlag : uint8_t {
     IncludeURLs     = 1 << 0,
     IncludeRects    = 1 << 1,
+    OnlyIncludeText = 1 << 2,
 };
 
 using TextExtractionOptionFlags = OptionSet<TextExtractionOptionFlag>;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6643,6 +6643,7 @@ static HashMap<String, String> extractReplacementStrings(_WKTextExtractionConfig
         shouldFilter,
         includeURLs = configuration.includeURLs,
         includeRects = configuration.includeRects,
+        onlyIncludeText = configuration.onlyIncludeVisibleText,
         maxWordsPerParagraph = WTFMove(maxWordsPerParagraph),
         replacementStrings = extractReplacementStrings(configuration)
     ](auto&& item) mutable {
@@ -6712,7 +6713,8 @@ static HashMap<String, String> extractReplacementStrings(_WKTextExtractionConfig
             optionFlags.add(IncludeURLs);
         if (includeRects)
             optionFlags.add(IncludeRects);
-
+        if (onlyIncludeText)
+            optionFlags.add(OnlyIncludeText);
         WebKit::TextExtractionOptions options { WTFMove(filterCallback), [strongSelf _activeNativeMenuItemTitles], WTFMove(replacementStrings), optionFlags };
         WebKit::convertToText(WTFMove(*item), WTFMove(options), [completionHandler = WTFMove(completionHandler)](auto&& string) {
             completionHandler(string.createNSString().get());

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -35,6 +35,8 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
 
+@property (nonatomic, class, copy, readonly) _WKTextExtractionConfiguration *configurationForVisibleTextOnly NS_SWIFT_NAME(visibleTextOnly);
+
 /*!
  Element extraction is constrained to this rect (in the web view's coordinate space).
  Extracted elements must intersect with this rect, to be included.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "_WKTextExtractionInternal.h"
 
+#import "Logging.h"
 #import "WKWebViewInternal.h"
 #import "_WKJSHandleInternal.h"
 #import <WebKit/WKError.h>
@@ -39,16 +40,27 @@
 
 - (instancetype)init
 {
+    return [self _initForOnlyVisibleText:NO];
+}
+
++ (instancetype)configurationForVisibleTextOnly
+{
+    return adoptNS([[self alloc] _initForOnlyVisibleText:YES]).autorelease();
+}
+
+- (instancetype)_initForOnlyVisibleText:(BOOL)onlyVisibleText
+{
     if (!(self = [super init]))
         return nil;
 
     _shouldFilterText = YES;
-    _includeURLs = YES;
-    _includeRects = YES;
-    _includeNodeIdentifiers = YES;
-    _includeEventListeners = YES;
-    _includeAccessibilityAttributes = YES;
-    _includeTextInAutoFilledControls = YES;
+    _includeURLs = !onlyVisibleText;
+    _includeRects = !onlyVisibleText;
+    _includeNodeIdentifiers = !onlyVisibleText;
+    _includeEventListeners = !onlyVisibleText;
+    _includeAccessibilityAttributes = !onlyVisibleText;
+    _includeTextInAutoFilledControls = !onlyVisibleText;
+    _onlyIncludeVisibleText = onlyVisibleText;
     _targetRect = CGRectNull;
     _maxWordsPerParagraph = NSUIntegerMax;
     return self;
@@ -88,6 +100,57 @@
 {
     _replacementStrings = adoptNS([replacementStrings copy]);
 }
+
+#define ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value) do { \
+    if (_onlyIncludeVisibleText && value) { \
+        RELEASE_LOG_ERROR(TextExtraction, "%{public}s ignored for text-only %{public}@", __PRETTY_FUNCTION__, [self class]); \
+        return; \
+    } \
+} while (0)
+
+- (void)setIncludeURLs:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _includeURLs = value;
+}
+
+- (void)setIncludeRects:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _includeRects = value;
+}
+
+- (void)setIncludeNodeIdentifiers:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _includeNodeIdentifiers = value;
+}
+
+- (void)setIncludeEventListeners:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _includeEventListeners = value;
+}
+
+- (void)setIncludeAccessibilityAttributes:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _includeAccessibilityAttributes = value;
+}
+
+- (void)setIncludeTextInAutoFilledControls:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _includeTextInAutoFilledControls = value;
+}
+
+#undef ENSURE_VALID_TEXT_ONLY_CONFIGURATION
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -56,6 +56,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)forEachClientNodeAttribute:(void(^)(NSString *attribute, NSString *value, _WKJSHandle *))block;
 
+/*!
+ Only include visible text content, excluding all DOM attributes and element types.
+ Takes precedence over `includeURLs`, `includeRects`, etc.
+ Defaults to `NO`.
+ */
+@property (nonatomic) BOOL onlyIncludeVisibleText;
+
 @end
 
 @interface _WKTextExtractionInteraction ()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -290,4 +290,29 @@ TEST(TextExtractionTests, ReplacementStrings)
     EXPECT_TRUE([debugTextWithReplacements containsString:@"The quick brown cat jumped over the  mouse"]);
 }
 
+TEST(TextExtractionTests, VisibleTextOnly)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:[_WKTextExtractionConfiguration configurationForVisibleTextOnly]];
+
+    EXPECT_TRUE([debugText containsString:@"Test"]);
+    EXPECT_TRUE([debugText containsString:@"foo"]);
+    EXPECT_TRUE([debugText containsString:@"Subject “The quick brown fox jumped over the lazy dog”"]);
+    EXPECT_TRUE([debugText containsString:@"0"]);
+#if ENABLE(TEXT_EXTRACTION_FILTER)
+    EXPECT_FALSE([debugText containsString:@"Here’s to the crazy ones"]);
+    EXPECT_FALSE([debugText containsString:@"The round pegs in the square holes"]);
+    EXPECT_FALSE([debugText containsString:@"The ones who see things differently"]);
+    EXPECT_FALSE([debugText containsString:@"And they have no respect for the status quo"]);
+    EXPECT_FALSE([debugText containsString:@"They push the human race forward"]);
+    EXPECT_FALSE([debugText containsString:@"Because the people who are crazy"]);
+#endif // ENABLE(TEXT_EXTRACTION_FILTER)
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 9bce2e4947440a85fe148568a6e0f20184bd188d
<pre>
[AutoFill Debugging] Add an option to limit text extraction output to visible text
<a href="https://bugs.webkit.org/show_bug.cgi?id=302053">https://bugs.webkit.org/show_bug.cgi?id=302053</a>
<a href="https://rdar.apple.com/161663236">rdar://161663236</a>

Reviewed by Abrar Rahman Protyasha.

Add support for `+[_WKTextExtractionConfiguration configurationForVisibleTextOnly]`, which returns
a text extraction configuration that only extracts visible text from the DOM (applying default text
filtering heuristics, but ignoring all other DOM attributes and item types).

Test: TextExtractionTests.VisibleTextOnly

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::addResult):
(WebKit::TextExtractionAggregator::includeRects const):
(WebKit::TextExtractionAggregator::includeURLs const):
(WebKit::TextExtractionAggregator::onlyIncludeText const):
(WebKit::TextExtractionAggregator::addLineForNativeMenuItemsIfNeeded):
(WebKit::addPartsForText):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):

Teach `TextExtractionAggregator` (and related code) to honor the new flag by only emitting output
for text items (passing each piece of text through the normal filtering mechanisms, including OCR).

* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _debugTextWithConfiguration:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration init]):
(+[_WKTextExtractionConfiguration configurationForVisibleTextOnly]):
(-[_WKTextExtractionConfiguration _initForOnlyVisibleText:]):
(-[_WKTextExtractionConfiguration _logInvalidTextOnlyConfiguration:]):
(-[_WKTextExtractionConfiguration setIncludeURLs:]):
(-[_WKTextExtractionConfiguration setIncludeRects:]):
(-[_WKTextExtractionConfiguration setIncludeNodeIdentifiers:]):
(-[_WKTextExtractionConfiguration setIncludeEventListeners:]):
(-[_WKTextExtractionConfiguration setIncludeAccessibilityAttributes:]):
(-[_WKTextExtractionConfiguration setIncludeTextInAutoFilledControls:]):

Adjust some of these setters to log a warning message if a client attempts to set `include{…}` to
`YES`, on a configuration returned by `+configurationForVisibleTextOnly`. These flags ultimately
have no effect here, since the result of `+configurationForVisibleTextOnly` will ensure that we
only ever dump text content (not attributes, geometry, identifiers, or event listeners).

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, VisibleTextOnly)):

Add a new API test to exercise the new configuration.

Canonical link: <a href="https://commits.webkit.org/302652@main">https://commits.webkit.org/302652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/756f683663f9a63d606d36016a4a695f5361e95b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81228 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d213538d-0170-4726-bbad-6c379953f7fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98851 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66672 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f44d9dd3-7865-475a-bc9e-0fbe7a349cdf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132706 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79530 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/21d81b5a-516d-4c69-9a48-a1a9924cb529) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80421 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139631 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107357 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27304 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31056 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54571 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1736 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1808 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->