### PR TITLE
MediaSourcePrivate/SourceBufferPrivate should run on their own work queue.

### DIFF
--- a/LayoutTests/media/media-source/media-detachablemse-append-expected.txt
+++ b/LayoutTests/media/media-source/media-detachablemse-append-expected.txt
@@ -30,7 +30,7 @@ EXPECTED (video.duration > 0 == 'true') OK
 EVENT(loadedmetadata)
 EVENT(loadeddata)
 EXPECTED (video.buffered.length == '1') OK
-EXPECTED (video.readyState == '4') OK
+EXPECTED (video.readyState >= readyState == 'true') OK
 EXPECTED (video.videoTracks.length >= 1 == 'true') OK
 EXPECTED (video.audioTracks.length >= 1 == 'true') OK
 RUN(video.play())

--- a/LayoutTests/media/media-source/media-detachablemse-append.html
+++ b/LayoutTests/media/media-source/media-detachablemse-append.html
@@ -65,7 +65,7 @@
         testExpected('video.duration > 0', true);
         await Promise.all([waitFor(video, 'loadedmetadata'), waitFor(video, 'loadeddata')]);
         testExpected('video.buffered.length', 1);
-        testExpected('video.readyState', readyState);
+        testExpected('video.readyState >= readyState', true);
 
         // Tracks are re-created.
         testExpected('video.videoTracks.length >= 1', true);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -130,6 +130,7 @@ public:
 
     virtual MediaTime duration() const { return MediaTime::zeroTime(); }
 
+    // Methods need to be thread-safe should MSE be enabled in a worker.
     WEBCORE_EXPORT virtual MediaTime currentOrPendingSeekTime() const;
     virtual MediaTime currentTime() const { return MediaTime::zeroTime(); }
     virtual bool timeIsProgressing() const { return !paused(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -114,6 +114,7 @@ public:
     void characteristicsChanged();
 
     MediaTime currentTime() const override;
+    MediaTime currentOrPendingSeekTime() const final { return currentTime(); }
     bool timeIsProgressing() const final;
     MediaTime clampTimeToSensicalValue(const MediaTime&) const;
 
@@ -348,7 +349,7 @@ private:
     ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;
 #endif
     MediaPlayer::NetworkState m_networkState WTF_GUARDED_BY_CAPABILITY(mainThread);
-    MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
+    MediaPlayer::ReadyState m_readyState WTF_GUARDED_BY_CAPABILITY(mainThread) { MediaPlayer::ReadyState::HaveNothing };
     bool m_readyStateIsWaitingForAvailableFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     MediaTime m_duration WTF_GUARDED_BY_CAPABILITY(mainThread) { MediaTime::invalidTime() };
     MediaTime m_lastSeekTime WTF_GUARDED_BY_CAPABILITY(mainThread);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -205,7 +205,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const String&)
     assertIsMainThread();
     // This media engine only supports MediaSource URLs.
     m_networkState = MediaPlayer::NetworkState::FormatError;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->networkStateChanged();
 }
 
@@ -629,6 +629,7 @@ MediaPlayer::ReadyState MediaPlayerPrivateMediaSourceAVFObjC::readyState() const
 {
     if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
         return mediaSourcePrivate->mediaPlayerReadyState();
+    assertIsMainThread();
     return m_readyState;
 }
 
@@ -650,7 +651,6 @@ MediaTime MediaPlayerPrivateMediaSourceAVFObjC::minTimeSeekable() const
 
 const PlatformTimeRanges& MediaPlayerPrivateMediaSourceAVFObjC::buffered() const
 {
-    ASSERT_NOT_REACHED();
     return PlatformTimeRanges::emptyRanges();
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -66,8 +66,11 @@ MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const Cont
     if (MockMediaPlayerMediaSource::supportsType(parameters) == MediaPlayer::SupportsType::IsNotSupported)
         return AddStatus::NotSupported;
 
-    m_sourceBuffers.append(MockSourceBufferPrivate::create(*this));
-    outPrivate = m_sourceBuffers.last();
+    {
+        Locker locker { m_lock };
+        m_sourceBuffers.append(MockSourceBufferPrivate::create(*this));
+        outPrivate = m_sourceBuffers.last();
+    }
     outPrivate->setMediaSourceDuration(duration());
 
     return AddStatus::Ok;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -133,9 +133,10 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
     if (returnedStatus != AddStatus::Ok)
         return returnedStatus;
 
-    ensureOnDispatcher([protectedThis = Ref { *this }, this, sourceBuffer = returnedSourceBuffer]() mutable {
-        m_sourceBuffers.append(WTFMove(sourceBuffer));
-    });
+    {
+        Locker locker { m_lock };
+        m_sourceBuffers.append(returnedSourceBuffer);
+    };
     outPrivate = WTFMove(returnedSourceBuffer);
     return returnedStatus;
 }


### PR DESCRIPTION
#### 27f78b632f899bf8da735cb3fb14c8ae06d3ba30
<pre>
MediaSourcePrivate/SourceBufferPrivate should run on their own work queue.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302054">https://bugs.webkit.org/show_bug.cgi?id=302054</a>
<a href="https://rdar.apple.com/164133100">rdar://164133100</a>

Reviewed by Youenn Fablet.

Preliminary work had been earlier done to SourceBufferPrivate and MediaSourcePrivate
to use a dedicated queue. However this work was never completed and the queue
used was always the main thread.
We complete this work so that a different workqueue can be provided and
adopt it with the AVFoundation port of MSE.
This will allow to easily have SourceBuffer and MediaSource object runs
in a different thread (e.g a worker) than their private counterparts.
For now, the dedicated workqueue is only enabled when the MediaPlayerPrivate
is running in the web content process; in the GPU process we will continue
to use the main thread.

No observable changes, covered by existing tests.
* LayoutTests/media/media-source/media-detachablemse-append-expected.txt:
* LayoutTests/media/media-source/media-detachablemse-append.html: Test was missing an `await`
* LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort-expected.txt:
* LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html: Update event can be fired at anytime. Make the event silent.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete):
(WebCore::SourceBuffer::sourceBufferPrivateBufferedChanged):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::seekToTime):
(WebCore::MediaSourcePrivate::removeSourceBuffer):
(WebCore::MediaSourcePrivate::hasAudio const):
(WebCore::MediaSourcePrivate::hasVideo const):
(WebCore::MediaSourcePrivate::tracksTypeChanged):
(WebCore::MediaSourcePrivate::updateTracksType):
(WebCore::MediaSourcePrivate::durationChanged):
(WebCore::MediaSourcePrivate::trackBufferedChanged):
(WebCore::MediaSourcePrivate::updateBufferedRanges):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::setMediaSourceDuration):
(WebCore::SourceBufferPrivate::mediaSourceDuration const):
(WebCore::SourceBufferPrivate::setMode):
(WebCore::SourceBufferPrivate::resetTimestampOffsetInTrackBuffers):
(WebCore::SourceBufferPrivate::startChangingType):
(WebCore::SourceBufferPrivate::resetTrackBuffers):
(WebCore::SourceBufferPrivate::setTimestampOffset):
(WebCore::SourceBufferPrivate::setAppendWindowStart):
(WebCore::SourceBufferPrivate::setAppendWindowEnd):
(WebCore::SourceBufferPrivate::timestampOffset const):
(WebCore::SourceBufferPrivate::appendWindow const):
(WebCore::SourceBufferPrivate::updateHighestPresentationTimestamp):
(WebCore::SourceBufferPrivate::trackBuffersRanges const):
(WebCore::SourceBufferPrivate::hasAudio const):
(WebCore::SourceBufferPrivate::hasVideo const):
(WebCore::SourceBufferPrivate::hasReceivedFirstInitializationSegment const):
(WebCore::SourceBufferPrivate::reenqueSamples):
(WebCore::SourceBufferPrivate::computeSeekTime):
(WebCore::SourceBufferPrivate::seekToTime):
(WebCore::SourceBufferPrivate::clearTrackBuffers):
(WebCore::SourceBufferPrivate::bufferedSamplesForTrackId):
(WebCore::SourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID):
(WebCore::SourceBufferPrivate::updateMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivate::setMediaSourceEnded):
(WebCore::SourceBufferPrivate::trySignalAllSamplesInTrackEnqueued):
(WebCore::SourceBufferPrivate::provideMediaData):
(WebCore::SourceBufferPrivate::reenqueueMediaForTime):
(WebCore::SourceBufferPrivate::reenqueueMediaIfNeeded):
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):
(WebCore::SourceBufferPrivate::setMaximumBufferSize):
(WebCore::SourceBufferPrivate::computeEvictionData):
(WebCore::SourceBufferPrivate::hasTooManySamples const):
(WebCore::SourceBufferPrivate::asyncEvictCodedFrames):
(WebCore::SourceBufferPrivate::evictCodedFrames):
(WebCore::SourceBufferPrivate::evictCodedFramesInternal):
(WebCore::SourceBufferPrivate::isBufferFullFor const):
(WebCore::SourceBufferPrivate::canAppend const):
(WebCore::SourceBufferPrivate::evictionData const):
(WebCore::SourceBufferPrivate::contentSize const):
(WebCore::SourceBufferPrivate::addTrackBuffer):
(WebCore::SourceBufferPrivate::updateTrackIds):
(WebCore::SourceBufferPrivate::setAllTrackBuffersNeedRandomAccess):
(WebCore::SourceBufferPrivate::setGroupStartTimestamp):
(WebCore::SourceBufferPrivate::setGroupStartTimestampToEndTimestamp):
(WebCore::SourceBufferPrivate::setShouldGenerateTimestamps):
(WebCore::SourceBufferPrivate::protectedCurrentAppendProcessing const):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didUpdateFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::validateInitializationSegment):
(WebCore::SourceBufferPrivate::didReceiveSample):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::processPendingMediaSamples):
(WebCore::SourceBufferPrivate::processMediaSample):
(WebCore::SourceBufferPrivate::memoryPressure):
(WebCore::SourceBufferPrivate::protectedCurrentSourceBufferOperation const):
(WebCore::SourceBufferPrivate::minimumBufferedTime const):
(WebCore::SourceBufferPrivate::maximumBufferedTime const):
(WebCore::SourceBufferPrivate::evictFrames):
(WebCore::SourceBufferPrivate::setActive):
(WebCore::SourceBufferPrivate::iterateTrackBuffers):
(WebCore::SourceBufferPrivate::iterateTrackBuffers const):
(WebCore::SourceBufferPrivate::ensureWeakOnDispatcher):
(WebCore::SourceBufferPrivate::attach):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::WTF_GUARDED_BY_CAPABILITY):
(WebCore::SourceBufferPrivate::WTF_GUARDED_BY_LOCK):
(WebCore::SourceBufferPrivate::setMode): Deleted.
(WebCore::SourceBufferPrivate::setGroupStartTimestamp): Deleted.
(WebCore::SourceBufferPrivate::setGroupStartTimestampToEndTimestamp): Deleted.
(WebCore::SourceBufferPrivate::setShouldGenerateTimestamps): Deleted.
(WebCore::SourceBufferPrivate::startChangingType): Deleted.
(WebCore::SourceBufferPrivate::setTimestampOffset): Deleted.
(WebCore::SourceBufferPrivate::setAppendWindowStart): Deleted.
(WebCore::SourceBufferPrivate::setAppendWindowEnd): Deleted.
(WebCore::SourceBufferPrivate::setMediaSourceDuration): Deleted.
(WebCore::SourceBufferPrivate::evictionData const): Deleted.
(WebCore::SourceBufferPrivate::hasAudio const): Deleted.
(WebCore::SourceBufferPrivate::hasVideo const): Deleted.
(WebCore::SourceBufferPrivate::hasReceivedFirstInitializationSegment const): Deleted.
(WebCore::SourceBufferPrivate::timestampOffset const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::queueSingleton):
(WebCore::MediaSourcePrivateAVFObjC::MediaSourcePrivateAVFObjC):
(WebCore::MediaSourcePrivateAVFObjC::setPlayer):
(WebCore::MediaSourcePrivateAVFObjC::addSourceBuffer):
(WebCore::MediaSourcePrivateAVFObjC::removeSourceBuffer):
(WebCore::MediaSourcePrivateAVFObjC::notifyActiveSourceBuffersChanged):
(WebCore::MediaSourcePrivateAVFObjC::durationChanged):
(WebCore::MediaSourcePrivateAVFObjC::markEndOfStream):
(WebCore::MediaSourcePrivateAVFObjC::bufferedChanged):
(WebCore::MediaSourcePrivateAVFObjC::trackBufferedChanged): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::setTrackChangeCallbacks):
(WebCore::SourceBufferPrivateAVFObjC::precheckInitializationSegment):
(WebCore::SourceBufferPrivateAVFObjC::processInitializationSegment):
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::appendCompleted):
(WebCore::SourceBufferPrivateAVFObjC::clearTracks):
(WebCore::SourceBufferPrivateAVFObjC::videoTrackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::audioTrackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::removeTrackID):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeSelected): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::setActive):
(WebKit::SourceBufferPrivateRemote::setTimestampOffset):
(WebKit::SourceBufferPrivateRemote::setMaximumBufferSize):
(WebKit::SourceBufferPrivateRemote::isActive const): Deleted.
(WebKit::SourceBufferPrivateRemote::timestampOffset const): Deleted.
(WebKit::SourceBufferPrivateRemote::totalTrackBufferSizeInBytes const): Deleted.
(WebKit::SourceBufferPrivateRemote::isBufferFullFor const): Deleted.
(WebKit::SourceBufferPrivateRemote::canAppend const): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/303467@main">https://commits.webkit.org/303467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a879e83a3adf344b5e663da835135e157d48c24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84511 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68586 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6a043f87-40e1-4bc7-abdb-061b486e3a5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135463 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82104 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1300 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83270 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142688 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109685 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3558 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58074 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4736 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33327 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4570 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4693 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->