### PR TITLE
Web Inspector: support console screenshots in a Worker

### DIFF
--- a/LayoutTests/inspector/console/console-screenshot.html
+++ b/LayoutTests/inspector/console/console-screenshot.html
@@ -64,7 +64,7 @@ function test()
 {
     let suite = InspectorTest.createAsyncSuite("console.screenshot");
 
-    function addTest({name, expression, imageMessageAddedCallback, shouldCaptureViewport, shouldError}) {
+    function addTest({name, expression, shouldCaptureViewport, shouldError}) {
         suite.addTestCase({
             name,
             async test() {
@@ -132,13 +132,6 @@ function test()
     addTest({
         name: "console.screenshot.Node.DetachedScreenshotable.Canvas",
         expression: `testHTMLCanvasElement()`,
-        async imageMessageAddedCallback(message) {
-            InspectorTest.expectNotEqual(message.messageText, "data:", "The image should not be empty.");
-
-            let img = await WI.ImageUtilities.promisifyLoad(message.messageText);
-            InspectorTest.expectEqual(img.width, 2, "The image width should be 2px.");
-            InspectorTest.expectEqual(img.height, 2, "The image height should be 2px.");
-        },
     });
 
     addTest({

--- a/LayoutTests/inspector/worker/console-basic-subworker.html
+++ b/LayoutTests/inspector/worker/console-basic-subworker.html
@@ -8,7 +8,7 @@ let worker = new Worker("resources/subworker-manager.js");
 worker.postMessage({url: "worker-console.js", data: null});
 
 function triggerConsoleMethodInSubworker(method) {
-    worker.postMessage({url: "worker-console.js", data: method});
+    worker.postMessage({url: "worker-console.js", data: {method}});
 }
 
 async function test()

--- a/LayoutTests/inspector/worker/console-basic.html
+++ b/LayoutTests/inspector/worker/console-basic.html
@@ -5,8 +5,8 @@
 <script>
 let worker = new Worker("resources/worker-console.js");
 
-function triggerConsoleMethodInWorker(msg) {
-    worker.postMessage(msg);
+function triggerConsoleMethodInWorker(method) {
+    worker.postMessage({method});
 }
 
 function test()

--- a/LayoutTests/inspector/worker/console-screenshot-expected.txt
+++ b/LayoutTests/inspector/worker/console-screenshot-expected.txt
@@ -1,0 +1,61 @@
+Tests for the console.screenshot API in a Worker.
+
+
+== Running test suite: console.screenshot
+-- Running test case: console.screenshot.ImageData
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be 2px.
+PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.ImageBitmap
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be 2px.
+PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.OffscreenCanvas
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be 2px.
+PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.OffscreenCanvasRenderingContext2D
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be 2px.
+PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.String.Valid
+PASS: Error: Could not capture screenshot
+
+-- Running test case: console.screenshot.String.dataURL.Valid
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be 2px.
+PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.String.dataURL.InvalidMIME
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image should not load.
+
+-- Running test case: console.screenshot.String.dataURL.InvalidContent
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image should not load.
+
+-- Running test case: console.screenshot.String.dataURL.InvalidNoContent
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image should not load.
+
+-- Running test case: console.screenshot.String.dataURL.ValidNoContent
+PASS: Error: Could not capture screenshot
+
+-- Running test case: console.screenshot.NonScreenshotableTarget
+PASS: Error: Could not capture screenshot
+
+-- Running test case: console.screenshot.NoArguments
+PASS: Error: Could not capture screenshot
+

--- a/LayoutTests/inspector/worker/console-screenshot.html
+++ b/LayoutTests/inspector/worker/console-screenshot.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+
+let worker = new Worker("resources/worker-console.js");
+
+function test()
+{
+    let mainTarget = WI.mainTarget;
+    let workerTarget = Array.from(WI.targets).find((target) => target.type === WI.TargetType.Worker);
+    if (!workerTarget) {
+        InspectorTest.fail("Missing Worker Target");
+        InspectorTest.completeTest();
+        return;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("console.screenshot");
+
+    function addTest({name, type, args, shouldError}) {
+        suite.addTestCase({
+            name,
+            async test() {
+                let [event] = await Promise.all([
+                    WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                    InspectorTest.evaluateInPage(`worker.postMessage({method: "screenshot", type: "${type}", args: ${JSON.stringify(args)}});`),
+                ]);
+
+                let {message} = event.data;
+
+                if (message.level === WI.ConsoleMessage.MessageLevel.Error) {
+                    InspectorTest.expectThat(shouldError, "Error: " + message.messageText);
+                    return;
+                }
+
+                InspectorTest.expectEqual(message.type, WI.ConsoleMessage.MessageType.Image, "The added message should be an image.");
+                InspectorTest.expectNotEqual(message.messageText, "data:", "The image should not be empty.");
+
+                InspectorTest.assert(message.source === WI.ConsoleMessage.MessageSource.ConsoleAPI, "The added message should be from the console API.");
+                InspectorTest.assert(message.level === WI.ConsoleMessage.MessageLevel.Log, "The added message should be a log.");
+                InspectorTest.assert(message.timestamp, "The message should have a timestamp.");
+
+                try {
+                    let image = new Image;
+                    await new Promise((resolve, reject) => {
+                        image.addEventListener("load", resolve);
+                        image.addEventListener("error", reject);
+                        image.src = message.messageText;
+                    });
+
+                    InspectorTest.expectEqual(image.width, 2, "The image width should be 2px.");
+                    InspectorTest.expectEqual(image.height, 2, "The image height should be 2px.");
+                } catch {
+                    InspectorTest.expectThat(shouldError, "The image should not load.");
+                }
+            },
+        });
+    }
+
+    addTest({
+        name: "console.screenshot.ImageData",
+        type: "ImageData",
+        args: [],
+    });
+
+    addTest({
+        name: "console.screenshot.ImageBitmap",
+        type: "ImageBitmap",
+        args: [],
+    });
+
+    addTest({
+        name: "console.screenshot.OffscreenCanvas",
+        type: "OffscreenCanvas",
+        args: [],
+    });
+
+    addTest({
+        name: "console.screenshot.OffscreenCanvasRenderingContext2D",
+        type: "OffscreenCanvasRenderingContext2D",
+        args: [],
+    });
+
+    addTest({
+        name: "console.screenshot.String.Valid",
+        type: "primitive",
+        args: ["test"],
+        shouldError: true,
+    });
+
+    addTest({
+        name: "console.screenshot.String.dataURL.Valid",
+        type: "primitive",
+        args: ["data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAABNJREFUCB1j/M/AAEQMDEwgAgQAHxcCAmtAm/sAAAAASUVORK5CYII="], // 2x2 red square
+    });
+
+    addTest({
+        name: "console.screenshot.String.dataURL.InvalidMIME",
+        type: "primitive",
+        args: ["data:fake/mime"],
+        shouldError: true,
+    });
+
+    addTest({
+        name: "console.screenshot.String.dataURL.InvalidContent",
+        type: "primitive",
+        args: ["data:image/png;base64,<INVALID>"],
+        shouldError: true,
+    });
+
+    addTest({
+        name: "console.screenshot.String.dataURL.InvalidNoContent",
+        type: "primitive",
+        args: ["data:image/png;a1=b2;base64,"],
+        shouldError: true,
+    });
+
+    addTest({
+        name: "console.screenshot.String.dataURL.ValidNoContent",
+        type: "primitive",
+        args: ["data:"],
+        shouldError: true,
+    });
+
+    addTest({
+        name: "console.screenshot.NonScreenshotableTarget",
+        type: "primitive",
+        args: [42],
+        shouldError: true,
+    });
+
+    addTest({
+        name: "console.screenshot.NoArguments",
+        type: "primitive",
+        args: [],
+        shouldError: true,
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests for the console.screenshot API in a Worker.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/worker/resources/worker-console.js
+++ b/LayoutTests/inspector/worker/resources/worker-console.js
@@ -1,5 +1,5 @@
 onmessage = function(event) {
-    switch (event.data) {
+    switch (event.data.method) {
     case "log":
         console.log("log!", [self, self.location, 123, Symbol()]);
         break;
@@ -19,6 +19,40 @@ onmessage = function(event) {
         break;
     case "count":
         console.count();
+        break;
+    case "screenshot":
+        switch (event.data.type) {
+        case "ImageBitmap": {
+            // 2x2 red square
+            fetch("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAABNJREFUCB1j/M/AAEQMDEwgAgQAHxcCAmtAm/sAAAAASUVORK5CYII=")
+                .then((response) => response.blob())
+                .then((blob) => createImageBitmap(blob))
+                .then((imageBitmap) => {
+                    console.screenshot(imageBitmap);
+                });
+            break;
+        }
+        case "ImageData":
+            console.screenshot(new ImageData(2, 2))
+            break;
+        case "OffscreenCanvas": {
+            let canvas = new OffscreenCanvas(2, 2);
+            let context = canvas.getContext("2d");
+            context.fillStyle = "red";
+            context.fillRect(0, 0, 2, 2);
+            console.screenshot(canvas);
+            break;
+        }
+        case "OffscreenCanvasRenderingContext2D": {
+            let canvas = new OffscreenCanvas(2, 2);
+            let context = canvas.getContext("2d");
+            console.screenshot(context);
+            break;
+        }
+        case "primitive":
+            console.screenshot(...event.data.args);
+            break;
+        }
         break;
     }
 }


### PR DESCRIPTION
#### de9f264928a4dceb1b3c975d2c8a63fa15f4f422
<pre>
Web Inspector: support console screenshots in a Worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=243361">https://bugs.webkit.org/show_bug.cgi?id=243361</a>
&lt;<a href="https://rdar.apple.com/problem/98223234">rdar://problem/98223234</a>&gt;

Reviewed by Darin Adler.

This will be very useful for developers that are working with `Blob` inside a `Worker` and don&apos;t have an easy way of visualizing it (e.g. sending/transferring to the webpage for rendering via the DOM).

* Source/WebCore/workers/WorkerConsoleClient.cpp:
(WebCore::canvasRenderingContext): Added.
(WebCore::WorkerConsoleClient::screenshot):
Support `ImageData`, `ImageBitmap`, `OffscreenCanvas`, all the different types of `CanvasRenderingContext`, and valid base64 `data:` URL strings.

* LayoutTests/inspector/console/console-screenshot.html:
* LayoutTests/inspector/worker/console-basic.html:
* LayoutTests/inspector/worker/console-basic-subworker.html:
* LayoutTests/inspector/worker/console-screenshot.html: Added.
* LayoutTests/inspector/worker/console-screenshot-expected.txt: Added.
* LayoutTests/inspector/worker/resources/worker-console.js:
(onmessage):

* Source/WebCore/page/FrameConsoleClient.cpp:
(WebCore::FrameConsoleClient::screenshot):

Drive-by: add some comments to clarify what each argument means.
Canonical link: <a href="https://commits.webkit.org/302778@main">https://commits.webkit.org/302778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acdc5d3a5f2648f620ad21e28715eece123cf5a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81737 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133131 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79870 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34726 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140071 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2245 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2094 "19 flakes 1 failures") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27378 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2315 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65702 "Found 13 new failures in workers/WorkerConsoleClient.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->