### PR TITLE
Null pointer dereference in LegacyWebArchive::protectedMainResource()

### DIFF
--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -44,7 +44,6 @@ struct SimpleRange;
 class LegacyWebArchive final : public Archive {
 public:
     // Archive is created directly from data or members so ArchiveOptions is not needed.
-    WEBCORE_EXPORT static Ref<LegacyWebArchive> create();
     WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<FrameIdentifier>&& subframeIdentifiers, std::optional<FrameIdentifier> mainFrameIdentifier);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(FragmentedSharedBuffer&);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&);
@@ -86,6 +85,7 @@ private:
 
     enum MainResourceStatus { Subresource, MainResource };
 
+    static RefPtr<LegacyWebArchive> create(CFDictionaryRef);
     static RefPtr<LegacyWebArchive> createInternal(Node&, const ArchiveOptions&, NOESCAPE const Function<bool(LocalFrame&)>& frameFilter);
     static RefPtr<LegacyWebArchive> createInternal(const String& markupString, const ArchiveOptions&, LocalFrame&, Vector<Ref<Node>>&& nodes, NOESCAPE const Function<bool(LocalFrame&)>& frameFilter);
     static RefPtr<ArchiveResource> createResource(CFDictionaryRef);
@@ -94,8 +94,6 @@ private:
     static RetainPtr<CFDataRef> createPropertyListRepresentation(const ResourceResponse&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(Archive&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(ArchiveResource*, MainResourceStatus);
-
-    bool extract(CFDictionaryRef);
 
     std::optional<FrameIdentifier> m_frameIdentifier;
     Vector<FrameIdentifier> m_subframeIdentifiers;

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -77,7 +77,6 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
     self = [super init];
     if (!self)
         return nil;
-    coreArchive = LegacyWebArchive::create();
     return self;
 }
 


### PR DESCRIPTION
#### 581d4c4b644927f8412212387fd19c6acc595f58
<pre>
Null pointer dereference in LegacyWebArchive::protectedMainResource()
<a href="https://bugs.webkit.org/show_bug.cgi?id=302063">https://bugs.webkit.org/show_bug.cgi?id=302063</a>
<a href="https://rdar.apple.com/164088405">rdar://164088405</a>

Reviewed by Ryosuke Niwa and Anne van Kesteren.

Archive::mainResource() can return nullptr and LegacyWebArchive::protectedMainResource() currently defererences it
without null check, so we are seeing crashes. However, LegacyWebArchive should not be created with null main resource,
as it cannot be loaded anyways. So instead of adding null check in protectedMainResource(), this patch fixes the crash
by ensuring LegacyWebArchive is always created non-null main resource: LegacyWebArchive::create*() functions now returns
nullptr instead of default LegacyWebArchive object on error.

* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
(WebCore::LegacyWebArchive::createInternal):
(WebCore::LegacyWebArchive::extract): Deleted.
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebKitLegacy/mac/WebView/WebArchive.mm:
(-[WebArchivePrivate init]):

Canonical link: <a href="https://commits.webkit.org/302691@main">https://commits.webkit.org/302691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebd21370a6de66a7d1a1e02e1a875fae62aeb86b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40739 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137274 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81369 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e14433c-38d5-49e7-ab7f-97040b7f09da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98939 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbfe101b-dbee-42bc-8aee-cd37f79b0d93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79645 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e0a4944-300d-4d12-8703-5277a2dad7c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1496 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34450 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139756 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107444 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107328 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54739 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65379 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1824 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1859 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1933 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->