### PR TITLE
[Swift in WebKit] Format and lint Swift code in Source/WebCore

### DIFF
--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -1,27 +1,25 @@
-/*
-* Copyright (C) 2024 Apple Inc. All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions
-* are met:
-* 1. Redistributions of source code must retain the above copyright
-*    notice, this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-*    notice, this list of conditions and the following disclaimer in the
-*    documentation and/or other materials provided with the distribution.
-*
-* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
-* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-* THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
 
 #if swift(>=5.9)
 
@@ -29,9 +27,20 @@ import CryptoKit
 import Foundation
 import PALSwift
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public typealias CryptoOperationReturnValue = Cpp.CryptoOperationReturnValue
+
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public typealias ErrorCodes = Cpp.ErrorCodes
+
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public typealias VectorUInt8 = Cpp.VectorUInt8
+
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public typealias SpanConstUInt8 = Cpp.SpanConstUInt8
 
 private enum LocalErrors: Error {
@@ -42,68 +51,80 @@ private class Utils {
     static let zeroArray = [UInt8](repeating: 0, count: 0)
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public class AesGcm {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func encrypt(
-        key: SpanConstUInt8, iv: SpanConstUInt8, ad: SpanConstUInt8, message: SpanConstUInt8,
+        key: SpanConstUInt8,
+        iv: SpanConstUInt8,
+        ad: SpanConstUInt8,
+        message: SpanConstUInt8,
         desiredTagLengthInBytes: Int
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             if iv.size() == 0 {
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
                 return returnValue
             }
             let sealedBox: AES.GCM.SealedBox = try AES.GCM.seal(message, key: key, iv: iv, ad: ad)
             if desiredTagLengthInBytes > sealedBox.tag.count {
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
                 return returnValue
             }
             var result = sealedBox.ciphertext
             result.append(
                 sealedBox.tag[
-                    sealedBox.tag.startIndex..<(sealedBox.tag.startIndex + desiredTagLengthInBytes)]
+                    sealedBox.tag.startIndex..<(sealedBox.tag.startIndex + desiredTagLengthInBytes)
+                ]
             )
-             returnValue.errorCode = .Success
-             returnValue.result = result.copyToVectorUInt8()
+            returnValue.errorCode = .Success
+            returnValue.result = result.copyToVectorUInt8()
             return returnValue
         } catch {
-             returnValue.errorCode = .EncryptionFailed
+            returnValue.errorCode = .EncryptionFailed
         }
         return returnValue
     }
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public class AesKw {
-    public static func wrap(keyToWrap: SpanConstUInt8, using: SpanConstUInt8)
-        -> CryptoOperationReturnValue
-    {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func wrap(keyToWrap: SpanConstUInt8, using: SpanConstUInt8) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             let result = try AES.KeyWrap.wrap(keyToWrap, using: using)
-             returnValue.errorCode = .Success
-             returnValue.result = result
+            returnValue.errorCode = .Success
+            returnValue.result = result
         } catch {
-             returnValue.errorCode = .EncryptionFailed
+            returnValue.errorCode = .EncryptionFailed
         }
         return returnValue
     }
 
-    public static func unwrap(wrappedKey: SpanConstUInt8, using: SpanConstUInt8)
-        -> CryptoOperationReturnValue
-    {
+    public static func unwrap(wrappedKey: SpanConstUInt8, using: SpanConstUInt8) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             let result = try AES.KeyWrap.unwrap(
-                wrappedKey, using: using)
-             returnValue.errorCode = .Success
-             returnValue.result = result.copyToVectorUInt8()
+                wrappedKey,
+                using: using
+            )
+            returnValue.errorCode = .Success
+            returnValue.result = result.copyToVectorUInt8()
         } catch {
-             returnValue.errorCode = .EncryptionFailed
+            returnValue.errorCode = .EncryptionFailed
         }
         return returnValue
     }
-}  // AesKw
+} // AesKw
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public enum HashFunction {
     case sha1
     case sha256
@@ -111,66 +132,88 @@ public enum HashFunction {
     case sha512
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public class Digest {
     var ctx: any CryptoKit.HashFunction
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public required init<T: CryptoKit.HashFunction>(_: T.Type) {
         ctx = T()
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha1Init() -> Digest {
-        return Self(Insecure.SHA1.self)
+        Self(Insecure.SHA1.self)
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha256Init() -> Digest {
-        return Self(SHA256.self)
+        Self(SHA256.self)
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha384Init() -> Digest {
-        return Self(SHA384.self)
+        Self(SHA384.self)
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha512Init() -> Digest {
-        return Self(SHA512.self)
+        Self(SHA512.self)
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func update(_ data: SpanConstUInt8) {
         ctx.update(data: data)
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func finalize() -> VectorUInt8 {
         ctx.finalize().copyToVectorUInt8()
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha1(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, t: Insecure.SHA1.self)
+        digest(data, t: Insecure.SHA1.self)
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha256(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, t: SHA256.self)
+        digest(data, t: SHA256.self)
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha384(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, t: SHA384.self)
+        digest(data, t: SHA384.self)
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func sha512(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, t: SHA512.self)
+        digest(data, t: SHA512.self)
     }
-    fileprivate static func digest<T: CryptoKit.HashFunction>(_ data: SpanConstUInt8, _: T.Type)
-        -> T.Digest
-    {
+
+    fileprivate static func digest<T: CryptoKit.HashFunction>(_ data: SpanConstUInt8, _: T.Type) -> T.Digest {
         var hasher = T()
         hasher.update(data: data)
         return hasher.finalize()
     }
 
-    fileprivate static func digest<T: CryptoKit.HashFunction>(_ data: SpanConstUInt8, t: T.Type)
-        -> VectorUInt8
-    {
-        return Self.digest(data, t).copyToVectorUInt8()
+    fileprivate static func digest<T: CryptoKit.HashFunction>(_ data: SpanConstUInt8, t: T.Type) -> VectorUInt8 {
+        Self.digest(data, t).copyToVectorUInt8()
     }
 
-    fileprivate static func digest(_ data: SpanConstUInt8, hashFunction: HashFunction)
-        -> any CryptoKit.Digest
-    {
+    fileprivate static func digest(_ data: SpanConstUInt8, hashFunction: HashFunction) -> any CryptoKit.Digest {
         switch hashFunction {
         case .sha256:
             return digest(data, SHA256.self)
@@ -184,6 +227,8 @@ public class Digest {
     }
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public enum ECCurve {
     case p256
     case p384
@@ -201,23 +246,34 @@ enum ECPublicKey {
     case p384(P384.Signing.PublicKey)
     case p521(P521.Signing.PublicKey)
 }
+
 enum ECKeyInternal {
     case privateKey(ECPrivateKey)
     case publicKey(ECPublicKey)
 }
+
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public enum ECImportReturnCode {
     case defaultValue
     case success
     case importFailed
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public struct ECImportReturnValue {
     public var errorCode: ECImportReturnCode = .defaultValue
     public var key: ECKey? = nil
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public struct ECKey {
     let key: ECKeyInternal
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public init(curve: ECCurve) {
         switch curve {
         case .p256:
@@ -228,178 +284,198 @@ public struct ECKey {
             key = .privateKey(.p521(P521.Signing.PrivateKey(compactRepresentable: true)))
         }
     }
+
     private init(publicKey: ECPublicKey) {
         key = .publicKey(publicKey)
     }
+
     private init(privateKey: ECPrivateKey) {
         key = .privateKey(privateKey)
     }
+
     private init(internalKey: ECKeyInternal) {
         key = internalKey
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func toPub() -> ECKey {
         switch key {
         case .publicKey:
             return self
-        case let .privateKey(v):
+        case .privateKey(let v):
             switch v {
-            case let .p256(u):
+            case .p256(let u):
                 return ECKey(publicKey: .p256(u.publicKey))
-            case let .p384(u):
+            case .p384(let u):
                 return ECKey(publicKey: .p384(u.publicKey))
-            case let .p521(u):
+            case .p521(let u):
                 return ECKey(publicKey: .p521(u.publicKey))
             }
         }
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func importX963Pub(data: SpanConstUInt8, curve: ECCurve) -> ECImportReturnValue {
         var returnValue = ECImportReturnValue()
         do {
             switch curve {
             case .p256:
-                 returnValue.key = ECKey(internalKey: .publicKey(.p256(try P256.Signing.PublicKey(span: data))))
+                returnValue.key = ECKey(internalKey: .publicKey(.p256(try P256.Signing.PublicKey(span: data))))
             case .p384:
-                 returnValue.key = ECKey(internalKey: .publicKey(.p384(try P384.Signing.PublicKey(span: data))))
+                returnValue.key = ECKey(internalKey: .publicKey(.p384(try P384.Signing.PublicKey(span: data))))
             case .p521:
-                 returnValue.key = ECKey(internalKey: .publicKey(.p521(try P521.Signing.PublicKey(span: data))))
+                returnValue.key = ECKey(internalKey: .publicKey(.p521(try P521.Signing.PublicKey(span: data))))
             }
-             returnValue.errorCode = .success
+            returnValue.errorCode = .success
         } catch {
-             returnValue.errorCode = .importFailed
+            returnValue.errorCode = .importFailed
         }
         return returnValue
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func exportX963Pub() -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             switch try getInternalPublic() {
             case .p256(let k):
-                 returnValue.result = k.x963Representation.copyToVectorUInt8()
+                returnValue.result = k.x963Representation.copyToVectorUInt8()
             case .p384(let k):
-                 returnValue.result = k.x963Representation.copyToVectorUInt8()
+                returnValue.result = k.x963Representation.copyToVectorUInt8()
             case .p521(let k):
-                 returnValue.result = k.x963Representation.copyToVectorUInt8()
+                returnValue.result = k.x963Representation.copyToVectorUInt8()
             }
-             returnValue.errorCode = .Success
+            returnValue.errorCode = .Success
         } catch {
-             returnValue.errorCode = .FailedToExport
+            returnValue.errorCode = .FailedToExport
         }
         return returnValue
     }
-    public static func importCompressedPub(data: SpanConstUInt8, curve: ECCurve)
-        -> ECImportReturnValue
-    {
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func importCompressedPub(data: SpanConstUInt8, curve: ECCurve) -> ECImportReturnValue {
         var returnValue = ECImportReturnValue()
         do {
             switch curve {
             case .p256:
-                 returnValue.key = ECKey(publicKey: .p256(try P256.Signing.PublicKey(spanCompressed: data)))
+                returnValue.key = ECKey(publicKey: .p256(try P256.Signing.PublicKey(spanCompressed: data)))
             case .p384:
-                 returnValue.key = ECKey(publicKey: .p384(try P384.Signing.PublicKey(spanCompressed: data)))
+                returnValue.key = ECKey(publicKey: .p384(try P384.Signing.PublicKey(spanCompressed: data)))
             case .p521:
-                 returnValue.key = ECKey(publicKey: .p521(try P521.Signing.PublicKey(spanCompressed: data)))
+                returnValue.key = ECKey(publicKey: .p521(try P521.Signing.PublicKey(spanCompressed: data)))
             }
-             returnValue.errorCode = .success
+            returnValue.errorCode = .success
         } catch {
-             returnValue.errorCode = .importFailed
+            returnValue.errorCode = .importFailed
         }
         return returnValue
     }
-    public static func importX963Private(data: SpanConstUInt8, curve: ECCurve)
-        -> ECImportReturnValue
-    {
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func importX963Private(data: SpanConstUInt8, curve: ECCurve) -> ECImportReturnValue {
         var returnValue = ECImportReturnValue()
         do {
             switch curve {
             case .p256:
-                 returnValue.key = ECKey(privateKey: .p256(try P256.Signing.PrivateKey(span: data)))
+                returnValue.key = ECKey(privateKey: .p256(try P256.Signing.PrivateKey(span: data)))
             case .p384:
-                 returnValue.key = ECKey(privateKey: .p384(try P384.Signing.PrivateKey(span: data)))
+                returnValue.key = ECKey(privateKey: .p384(try P384.Signing.PrivateKey(span: data)))
             case .p521:
-                 returnValue.key = ECKey(privateKey: .p521(try P521.Signing.PrivateKey(span: data)))
+                returnValue.key = ECKey(privateKey: .p521(try P521.Signing.PrivateKey(span: data)))
             }
-             returnValue.errorCode = .success
+            returnValue.errorCode = .success
         } catch {
-             returnValue.errorCode = .importFailed
+            returnValue.errorCode = .importFailed
         }
         return returnValue
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func exportX963Private() -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             switch try getInternalPrivate() {
             case .p256(let k):
-                 returnValue.result = k.x963Representation.copyToVectorUInt8()
+                returnValue.result = k.x963Representation.copyToVectorUInt8()
             case .p384(let k):
-                 returnValue.result = k.x963Representation.copyToVectorUInt8()
+                returnValue.result = k.x963Representation.copyToVectorUInt8()
             case .p521(let k):
-                 returnValue.result = k.x963Representation.copyToVectorUInt8()
+                returnValue.result = k.x963Representation.copyToVectorUInt8()
             }
-             returnValue.errorCode = .Success
+            returnValue.errorCode = .Success
         } catch {
-             returnValue.errorCode = .FailedToExport
-        }
-        return returnValue
-    }
-    public func sign(message: SpanConstUInt8, hashFunction: HashFunction)
-        -> CryptoOperationReturnValue
-    {
-        var returnValue = CryptoOperationReturnValue()
-        do {
-            switch try getInternalPrivate() {
-            case .p256(let cryptoKey):
-                 returnValue.result =
-                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
-                    .rawRepresentation.copyToVectorUInt8()
-            case .p384(let cryptoKey):
-                 returnValue.result =
-                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
-                    .rawRepresentation.copyToVectorUInt8()
-            case .p521(let cryptoKey):
-                 returnValue.result =
-                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
-                    .rawRepresentation.copyToVectorUInt8()
-            }
-             returnValue.errorCode = .Success
-        } catch {
-             returnValue.errorCode = .FailedToSign
+            returnValue.errorCode = .FailedToExport
         }
         return returnValue
     }
 
-    public func verify(
-        message: SpanConstUInt8, signature: SpanConstUInt8, hashFunction: HashFunction
-    ) -> CryptoOperationReturnValue {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func sign(message: SpanConstUInt8, hashFunction: HashFunction) -> CryptoOperationReturnValue {
+        var returnValue = CryptoOperationReturnValue()
+        do {
+            switch try getInternalPrivate() {
+            case .p256(let cryptoKey):
+                returnValue.result =
+                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
+                    .rawRepresentation.copyToVectorUInt8()
+            case .p384(let cryptoKey):
+                returnValue.result =
+                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
+                    .rawRepresentation.copyToVectorUInt8()
+            case .p521(let cryptoKey):
+                returnValue.result =
+                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
+                    .rawRepresentation.copyToVectorUInt8()
+            }
+            returnValue.errorCode = .Success
+        } catch {
+            returnValue.errorCode = .FailedToSign
+        }
+        return returnValue
+    }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func verify(message: SpanConstUInt8, signature: SpanConstUInt8, hashFunction: HashFunction) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             let internalPublic = try getInternalPublic()
             switch internalPublic {
             case .p256(let cryptoKey):
-                 returnValue.errorCode =
+                returnValue.errorCode =
                     cryptoKey.isValidSignature(
                         try P256.Signing.ECDSASignature(span: signature),
-                        for: Digest.digest(message, hashFunction: hashFunction))
+                        for: Digest.digest(message, hashFunction: hashFunction)
+                    )
                     ? .Success : .FailedToVerify
             case .p384(let cryptoKey):
-                 returnValue.errorCode =
+                returnValue.errorCode =
                     cryptoKey.isValidSignature(
                         try P384.Signing.ECDSASignature(span: signature),
-                        for: Digest.digest(message, hashFunction: hashFunction))
+                        for: Digest.digest(message, hashFunction: hashFunction)
+                    )
                     ? .Success : .FailedToVerify
             case .p521(let cryptoKey):
-                 returnValue.errorCode =
+                returnValue.errorCode =
                     cryptoKey.isValidSignature(
                         try P521.Signing.ECDSASignature(span: signature),
-                        for: Digest.digest(message, hashFunction: hashFunction))
+                        for: Digest.digest(message, hashFunction: hashFunction)
+                    )
                     ? .Success : .FailedToVerify
             }
         } catch {
-             returnValue.errorCode = .FailedToVerify
+            returnValue.errorCode = .FailedToVerify
         }
         return returnValue
     }
+
     private func getInternalPrivate() throws -> ECPrivateKey {
         switch key {
         case .publicKey:
@@ -408,6 +484,7 @@ public struct ECKey {
             return privateKey
         }
     }
+
     private func getInternalPublic() throws -> ECPublicKey {
         switch key {
         case .privateKey:
@@ -417,6 +494,8 @@ public struct ECKey {
         }
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func deriveBits(publicKey: ECKey) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
@@ -425,57 +504,74 @@ public struct ECKey {
             switch internalPrivate {
             case .p256(let signing):
                 let scalar = try P256.KeyAgreement.PrivateKey(
-                    rawRepresentation: signing.rawRepresentation)
-                if case let .p256(publicKey) = internalPub {
+                    rawRepresentation: signing.rawRepresentation
+                )
+                if case .p256(let publicKey) = internalPub {
                     let derived = try scalar.sharedSecretFromKeyAgreement(
                         with: try P256.KeyAgreement.PublicKey(
-                            rawRepresentation: publicKey.rawRepresentation))
-                     returnValue.result = derived.copyToVectorUInt8()
+                            rawRepresentation: publicKey.rawRepresentation
+                        )
+                    )
+                    returnValue.result = derived.copyToVectorUInt8()
                     break
                 }
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
             case .p384(let signing):
                 let scalar = try P384.KeyAgreement.PrivateKey(
-                    rawRepresentation: signing.rawRepresentation)
-                if case let .p384(publicKey) = internalPub {
+                    rawRepresentation: signing.rawRepresentation
+                )
+                if case .p384(let publicKey) = internalPub {
                     let derived = try scalar.sharedSecretFromKeyAgreement(
                         with: try P384.KeyAgreement.PublicKey(
-                            rawRepresentation: publicKey.rawRepresentation))
-                     returnValue.result = derived.copyToVectorUInt8()
+                            rawRepresentation: publicKey.rawRepresentation
+                        )
+                    )
+                    returnValue.result = derived.copyToVectorUInt8()
                     break
                 }
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
             case .p521(let signing):
                 let scalar = try P521.KeyAgreement.PrivateKey(
-                    rawRepresentation: signing.rawRepresentation)
-                if case let .p521(publicKey) = internalPub {
+                    rawRepresentation: signing.rawRepresentation
+                )
+                if case .p521(let publicKey) = internalPub {
                     let derived = try scalar.sharedSecretFromKeyAgreement(
                         with: try P521.KeyAgreement.PublicKey(
-                            rawRepresentation: publicKey.rawRepresentation))
-                     returnValue.result = derived.copyToVectorUInt8()
+                            rawRepresentation: publicKey.rawRepresentation
+                        )
+                    )
+                    returnValue.result = derived.copyToVectorUInt8()
                     break
                 }
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
             }
-             returnValue.errorCode = .Success
+            returnValue.errorCode = .Success
         } catch {
-             returnValue.errorCode = .FailedToDerive
+            returnValue.errorCode = .FailedToDerive
         }
         return returnValue
     }
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public enum EdSigningAlgorithm {
     case ed25519
     case ed448
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public enum EdKeyAgreementAlgorithm {
     case x25519
     case x448
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public class EdKey {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func generatePrivateKey(algo: EdSigningAlgorithm) -> VectorUInt8 {
         switch algo {
         case .ed25519:
@@ -485,8 +581,9 @@ public class EdKey {
         }
     }
 
-    public static func generatePrivateKeyKeyAgreement(algo: EdKeyAgreementAlgorithm) -> VectorUInt8
-    {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func generatePrivateKeyKeyAgreement(algo: EdKeyAgreementAlgorithm) -> VectorUInt8 {
         switch algo {
         case .x25519:
             return Curve25519.KeyAgreement.PrivateKey().rawRepresentation.copyToVectorUInt8()
@@ -495,9 +592,9 @@ public class EdKey {
         }
     }
 
-    public static func privateToPublic(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8)
-        -> CryptoOperationReturnValue
-    {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func privateToPublic(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             if privateKey.size() != 32 {
@@ -505,23 +602,26 @@ public class EdKey {
             }
             switch algo {
             case .ed25519:
-                 returnValue.result = try Curve25519.Signing.PrivateKey(span: privateKey).publicKey
+                returnValue.result = try Curve25519.Signing.PrivateKey(span: privateKey).publicKey
                     .rawRepresentation.copyToVectorUInt8()
-                if  returnValue.result.size() != 32 {
+                if returnValue.result.size() != 32 {
                     throw LocalErrors.invalidArgument
                 }
-                 returnValue.errorCode = .Success
+                returnValue.errorCode = .Success
             case .ed448:
-                 returnValue.errorCode = .UnsupportedAlgorithm
+                returnValue.errorCode = .UnsupportedAlgorithm
             }
         } catch {
-             returnValue.errorCode = .FailedToImport
+            returnValue.errorCode = .FailedToImport
         }
         return returnValue
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func privateToPublicKeyAgreement(
-        algo: EdKeyAgreementAlgorithm, privateKey: SpanConstUInt8
+        algo: EdKeyAgreementAlgorithm,
+        privateKey: SpanConstUInt8
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
@@ -530,23 +630,24 @@ public class EdKey {
             }
             switch algo {
             case .x25519:
-                 returnValue.result = try Curve25519.KeyAgreement.PrivateKey(span: privateKey).publicKey
+                returnValue.result = try Curve25519.KeyAgreement.PrivateKey(span: privateKey).publicKey
                     .rawRepresentation.copyToVectorUInt8()
-                if  returnValue.result.size() != 32 {
+                if returnValue.result.size() != 32 {
                     throw LocalErrors.invalidArgument
                 }
-                 returnValue.errorCode = .Success
+                returnValue.errorCode = .Success
             case .x448:
-                 returnValue.errorCode = .UnsupportedAlgorithm
+                returnValue.errorCode = .UnsupportedAlgorithm
             }
         } catch {
-             returnValue.errorCode = .FailedToImport
+            returnValue.errorCode = .FailedToImport
         }
         return returnValue
     }
-    public static func validateKeyPair(
-        algo: EdSigningAlgorithm, privateKey: SpanConstUInt8, publicKey: SpanConstUInt8
-    ) -> Bool {
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func validateKeyPair(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8, publicKey: SpanConstUInt8) -> Bool {
         do {
             if privateKey.size() != 32 || publicKey.size() != 32 {
                 throw LocalErrors.invalidArgument
@@ -562,11 +663,14 @@ public class EdKey {
         } catch {
             return false
         }
-
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func validateKeyPairKeyAgreement(
-        algo: EdKeyAgreementAlgorithm, privateKey: SpanConstUInt8, publicKey: SpanConstUInt8
+        algo: EdKeyAgreementAlgorithm,
+        privateKey: SpanConstUInt8,
+        publicKey: SpanConstUInt8
     ) -> Bool {
         do {
             if privateKey.size() != 32 || publicKey.size() != 32 {
@@ -583,29 +687,33 @@ public class EdKey {
         } catch {
             return false
         }
-
     }
 
-    public static func sign(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8, data: SpanConstUInt8)
-        -> CryptoOperationReturnValue
-    {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func sign(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8, data: SpanConstUInt8) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             switch algo {
             case .ed25519:
                 let privateKeyImported = try Curve25519.Signing.PrivateKey(span: privateKey)
-                 returnValue.result = try privateKeyImported.signature(span: data)
-                 returnValue.errorCode = .Success
+                returnValue.result = try privateKeyImported.signature(span: data)
+                returnValue.errorCode = .Success
             case .ed448:
-                 returnValue.errorCode = .UnsupportedAlgorithm
+                returnValue.errorCode = .UnsupportedAlgorithm
             }
         } catch {
-             returnValue.errorCode = .FailedToSign
+            returnValue.errorCode = .FailedToSign
         }
         return returnValue
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func verify(
-        algo: EdSigningAlgorithm, publicKey: SpanConstUInt8, signature: SpanConstUInt8,
+        algo: EdSigningAlgorithm,
+        publicKey: SpanConstUInt8,
+        signature: SpanConstUInt8,
         data: SpanConstUInt8
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
@@ -613,43 +721,48 @@ public class EdKey {
             switch algo {
             case .ed25519:
                 let publicKeyImported = try Curve25519.Signing.PublicKey(span: publicKey)
-                 returnValue.errorCode =
+                returnValue.errorCode =
                     publicKeyImported.isValidSignature(signature: signature, data: data)
                     ? .Success : .FailedToVerify
             case .ed448:
-                 returnValue.errorCode = .UnsupportedAlgorithm
+                returnValue.errorCode = .UnsupportedAlgorithm
             }
         } catch {
-             returnValue.errorCode = .FailedToSign
+            returnValue.errorCode = .FailedToSign
         }
         return returnValue
     }
 
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func deriveBits(
-        algo: EdKeyAgreementAlgorithm, privateKey: SpanConstUInt8, publicKey: SpanConstUInt8
+        algo: EdKeyAgreementAlgorithm,
+        privateKey: SpanConstUInt8,
+        publicKey: SpanConstUInt8
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             switch algo {
             case .x25519:
                 let privateKeyImported = try Curve25519.KeyAgreement.PrivateKey(span: privateKey)
-                 returnValue.result = try privateKeyImported.sharedSecretFromKeyAgreement(pubSpan: publicKey)
-                 returnValue.errorCode = .Success
+                returnValue.result = try privateKeyImported.sharedSecretFromKeyAgreement(pubSpan: publicKey)
+                returnValue.errorCode = .Success
             case .x448:
-                 returnValue.errorCode = .UnsupportedAlgorithm
+                returnValue.errorCode = .UnsupportedAlgorithm
             }
         } catch {
-             returnValue.errorCode = .FailedToDerive
+            returnValue.errorCode = .FailedToDerive
         }
         return returnValue
-
     }
 }
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public class HMAC {
-    public static func sign(key: SpanConstUInt8, data: SpanConstUInt8, hashFunction: HashFunction)
-        -> VectorUInt8
-    {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func sign(key: SpanConstUInt8, data: SpanConstUInt8, hashFunction: HashFunction) -> VectorUInt8 {
         switch hashFunction {
         case .sha1:
             return CryptoKit.HMAC<Insecure.SHA1>.authenticationCode(data: data, key: key)
@@ -661,13 +774,18 @@ public class HMAC {
             return CryptoKit.HMAC<SHA512>.authenticationCode(data: data, key: key)
         }
     }
-    public static func verify(
-        mac: SpanConstUInt8, key: SpanConstUInt8, data: SpanConstUInt8, hashFunction: HashFunction
-    ) -> Bool {
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func verify(mac: SpanConstUInt8, key: SpanConstUInt8, data: SpanConstUInt8, hashFunction: HashFunction) -> Bool {
         switch hashFunction {
         case .sha1:
-            return CryptoKit.HMAC<Insecure.SHA1>.isValidAuthenticationCode(
-                mac: mac, data: data, key: key)
+            return CryptoKit.HMAC<Insecure.SHA1>
+                .isValidAuthenticationCode(
+                    mac: mac,
+                    data: data,
+                    key: key
+                )
         case .sha256:
             return CryptoKit.HMAC<SHA256>.isValidAuthenticationCode(mac: mac, data: data, key: key)
         case .sha384:
@@ -684,61 +802,84 @@ private let hkdfInputSizeLimitSHA256 = 255 * SHA256.byteCount * 8
 private let hkdfInputSizeLimitSHA384 = 255 * SHA384.byteCount * 8
 private let hkdfInputSizeLimitSHA512 = 255 * SHA512.byteCount * 8
 
+// FIXME: PALSwift should have no public symbols.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public class HKDF {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func deriveBits(
-        key: SpanConstUInt8, salt: SpanConstUInt8, info: SpanConstUInt8, outputBitCount: Int,
+        key: SpanConstUInt8,
+        salt: SpanConstUInt8,
+        info: SpanConstUInt8,
+        outputBitCount: Int,
         hashFunction: HashFunction
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         if outputBitCount <= 0 || outputBitCount % 8 != 0 {
-             returnValue.errorCode = .InvalidArgument
+            returnValue.errorCode = .InvalidArgument
             return returnValue
         } else {
-             returnValue.errorCode = .Success
+            returnValue.errorCode = .Success
         }
         switch hashFunction {
         case .sha1:
             if outputBitCount > hkdfInputSizeLimitSHA1 {
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
                 break
             }
-             returnValue.result =
-                CryptoKit.HKDF<Insecure.SHA1>.deriveKey(
-                    inputKeyMaterial: key, salt: salt, info: info,
-                    outputByteCount: outputBitCount / 8)
+            returnValue.result =
+                CryptoKit.HKDF<Insecure.SHA1>
+                .deriveKey(
+                    inputKeyMaterial: key,
+                    salt: salt,
+                    info: info,
+                    outputByteCount: outputBitCount / 8
+                )
 
         case .sha256:
             if outputBitCount > hkdfInputSizeLimitSHA256 {
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
                 break
             }
-             returnValue.result =
-                CryptoKit.HKDF<SHA256>.deriveKey(
-                    inputKeyMaterial: key, salt: salt, info: info,
-                    outputByteCount: outputBitCount / 8)
+            returnValue.result =
+                CryptoKit.HKDF<SHA256>
+                .deriveKey(
+                    inputKeyMaterial: key,
+                    salt: salt,
+                    info: info,
+                    outputByteCount: outputBitCount / 8
+                )
 
         case .sha384:
             if outputBitCount > hkdfInputSizeLimitSHA384 {
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
                 break
             }
-             returnValue.result =
-                CryptoKit.HKDF<SHA384>.deriveKey(
-                    inputKeyMaterial: key, salt: salt, info: info,
-                    outputByteCount: outputBitCount / 8)
+            returnValue.result =
+                CryptoKit.HKDF<SHA384>
+                .deriveKey(
+                    inputKeyMaterial: key,
+                    salt: salt,
+                    info: info,
+                    outputByteCount: outputBitCount / 8
+                )
 
         case .sha512:
             if outputBitCount > hkdfInputSizeLimitSHA512 {
-                 returnValue.errorCode = .InvalidArgument
+                returnValue.errorCode = .InvalidArgument
                 break
             }
-             returnValue.result =
-                CryptoKit.HKDF<SHA512>.deriveKey(
-                    inputKeyMaterial: key, salt: salt, info: info,
-                    outputByteCount: outputBitCount / 8)
-
+            returnValue.result =
+                CryptoKit.HKDF<SHA512>
+                .deriveKey(
+                    inputKeyMaterial: key,
+                    salt: salt,
+                    info: info,
+                    outputByteCount: outputBitCount / 8
+                )
         }
         return returnValue
     }
 }
+
 #endif

--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -1,27 +1,25 @@
-/*
-* Copyright (C) 2024 Apple Inc. All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions
-* are met:
-* 1. Redistributions of source code must retain the above copyright
-*    notice, this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-*    notice, this list of conditions and the following disclaimer in the
-*    documentation and/or other materials provided with the distribution.
-*
-* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
-* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-* THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
 
 #if swift(>=5.9)
 
@@ -38,47 +36,52 @@ enum UnsafeErrors: Error {
 extension CryptoKit.HashFunction {
     mutating func update(data: SpanConstUInt8) {
         if data.empty() {
-            self.update(data: Data.empty())
+            self.update(data: Data())
         } else {
             self.update(
                 bufferPointer: UnsafeRawBufferPointer(
-                    start: data.__dataUnsafe(), count: data.size()))
+                    start: data.__dataUnsafe(),
+                    count: data.size()
+                )
+            )
         }
     }
 }
 
 extension ContiguousBytes {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func copyToVectorUInt8() -> VectorUInt8 {
-        return self.withUnsafeBytes { buf in
+        self.withUnsafeBytes { buf in
             let result = VectorUInt8(buf.count)
             buf.copyBytes(
                 to: UnsafeMutableRawBufferPointer(
                     start: UnsafeMutableRawPointer(mutating: result.span().__dataUnsafe()),
-                    count: result.size()), count: result.size())
+                    count: result.size()
+                ),
+                count: result.size()
+            )
             return result
         }
     }
 }
 
 extension Data {
-    static let emptyData = Data()
     fileprivate static func temporaryDataFromSpan(spanNoCopy: SpanConstUInt8) -> Data {
-        if spanNoCopy.empty() {
-            return Data.empty()
-        } else {
+        guard spanNoCopy.empty() else {
             return Data(
                 bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
-                count: spanNoCopy.size(), deallocator: .none)
+                count: spanNoCopy.size(),
+                deallocator: .none
+            )
         }
-    }
 
-    // CryptoKit does not support a null pointer with zero length. We instead need to pass an empty Data. This class provides that.
-    public static func empty() -> Data {
-        return emptyData
+        // CryptoKit does not support a null pointer with zero length. We instead need to pass an empty Data. This class provides that.
+        return Data()
     }
 }
 
-private class _WorkAroundRadar116406681 {
+private class WorkAroundRadar116406681 {
     // rdar://116406681
     private func forceLinkageForVectorDestructor() {
         let _ = VectorUInt8()
@@ -86,41 +89,49 @@ private class _WorkAroundRadar116406681 {
 }
 
 extension AES.GCM {
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func seal(
-        _ message: SpanConstUInt8, key: SpanConstUInt8, iv: SpanConstUInt8, ad: SpanConstUInt8
+        _ message: SpanConstUInt8,
+        key: SpanConstUInt8,
+        iv: SpanConstUInt8,
+        ad: SpanConstUInt8
     ) throws -> AES.GCM.SealedBox {
-        if ad.size() > 0 {
-            return try AES.GCM.seal(
-                Data.temporaryDataFromSpan(spanNoCopy: message),
-                using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
-                nonce: AES.GCM.Nonce(data: Data.temporaryDataFromSpan(spanNoCopy: iv)),
-                authenticating: Data.temporaryDataFromSpan(spanNoCopy: ad))
-        } else {
+        guard ad.size() > 0 else {
             return try AES.GCM.seal(
                 Data.temporaryDataFromSpan(spanNoCopy: message),
                 using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
                 nonce: AES.GCM.Nonce(data: Data.temporaryDataFromSpan(spanNoCopy: iv))
             )
         }
+        return try AES.GCM.seal(
+            Data.temporaryDataFromSpan(spanNoCopy: message),
+            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
+            nonce: AES.GCM.Nonce(data: Data.temporaryDataFromSpan(spanNoCopy: iv)),
+            authenticating: Data.temporaryDataFromSpan(spanNoCopy: ad)
+        )
     }
 }
 
 extension AES.KeyWrap {
-    public static func unwrap(_ wrapped: SpanConstUInt8, using: SpanConstUInt8) throws
-        -> SymmetricKey
-    {
-        return try AES.KeyWrap.unwrap(
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func unwrap(_ wrapped: SpanConstUInt8, using: SpanConstUInt8) throws -> SymmetricKey {
+        try AES.KeyWrap.unwrap(
             Data.temporaryDataFromSpan(spanNoCopy: wrapped),
-            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: using)))
-
-    }
-    public static func wrap(_ keyToWrap: SpanConstUInt8, using: SpanConstUInt8) throws
-        -> VectorUInt8
-    {
-        return try AES.KeyWrap.wrap(
-            SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: keyToWrap)),
             using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: using))
-        ).copyToVectorUInt8()
+        )
+    }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public static func wrap(_ keyToWrap: SpanConstUInt8, using: SpanConstUInt8) throws -> VectorUInt8 {
+        try AES.KeyWrap
+            .wrap(
+                SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: keyToWrap)),
+                using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: using))
+            )
+            .copyToVectorUInt8()
     }
 }
 
@@ -132,6 +143,7 @@ extension P256.Signing.ECDSASignature {
         try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
+
 extension P384.Signing.ECDSASignature {
     init(span: SpanConstUInt8) throws {
         if span.empty() {
@@ -140,6 +152,7 @@ extension P384.Signing.ECDSASignature {
         try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
+
 extension P521.Signing.ECDSASignature {
     init(span: SpanConstUInt8) throws {
         if span.empty() {
@@ -156,12 +169,14 @@ extension P256.Signing.PublicKey {
         }
         try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
+
     init(spanCompressed: SpanConstUInt8) throws {
         if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try self.init(
-            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed))
+            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed)
+        )
     }
 }
 
@@ -172,12 +187,14 @@ extension P384.Signing.PublicKey {
         }
         try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
+
     init(spanCompressed: SpanConstUInt8) throws {
         if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try self.init(
-            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed))
+            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed)
+        )
     }
 }
 
@@ -188,12 +205,14 @@ extension P521.Signing.PublicKey {
         }
         try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
+
     init(spanCompressed: SpanConstUInt8) throws {
         if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try self.init(
-            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed))
+            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed)
+        )
     }
 }
 
@@ -231,9 +250,12 @@ extension Curve25519.Signing.PrivateKey {
         }
         try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func signature(span: SpanConstUInt8) throws -> VectorUInt8 {
         if span.empty() {
-            return try self.signature(for: Data.empty()).copyToVectorUInt8()
+            return try self.signature(for: Data()).copyToVectorUInt8()
         }
         return try self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span))
             .copyToVectorUInt8()
@@ -247,15 +269,19 @@ extension Curve25519.Signing.PublicKey {
         }
         try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func isValidSignature(signature: SpanConstUInt8, data: SpanConstUInt8) -> Bool {
         if signature.empty() || data.empty() {
             return false
         }
+
         return self.isValidSignature(
             Data.temporaryDataFromSpan(spanNoCopy: signature),
-            for: Data.temporaryDataFromSpan(spanNoCopy: data))
+            for: Data.temporaryDataFromSpan(spanNoCopy: data)
+        )
     }
-
 }
 
 extension Curve25519.KeyAgreement.PrivateKey {
@@ -265,12 +291,16 @@ extension Curve25519.KeyAgreement.PrivateKey {
         }
         try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
+
+    // FIXME: PALSwift should have no public symbols.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func sharedSecretFromKeyAgreement(pubSpan: SpanConstUInt8) throws -> VectorUInt8 {
         if pubSpan.empty() {
             throw UnsafeErrors.emptySpan
         }
         let pub = try Curve25519.KeyAgreement.PublicKey(
-            rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: pubSpan))
+            rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: pubSpan)
+        )
         return try self.sharedSecretFromKeyAgreement(with: pub).copyToVectorUInt8()
     }
 }
@@ -285,37 +315,39 @@ extension Curve25519.KeyAgreement.PublicKey {
 }
 
 extension CryptoKit.HMAC {
-    static func authenticationCode(
-        data: SpanConstUInt8,
-        key: SpanConstUInt8
-    ) -> VectorUInt8 {
-        return self.authenticationCode(
+    static func authenticationCode(data: SpanConstUInt8, key: SpanConstUInt8) -> VectorUInt8 {
+        self.authenticationCode(
             for: Data.temporaryDataFromSpan(spanNoCopy: data),
             using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key))
-        ).copyToVectorUInt8()
+        )
+        .copyToVectorUInt8()
     }
-    static func isValidAuthenticationCode(
-        mac: SpanConstUInt8, data: SpanConstUInt8, key: SpanConstUInt8
-    ) -> Bool {
-        return Self.isValidAuthenticationCode(
+
+    static func isValidAuthenticationCode(mac: SpanConstUInt8, data: SpanConstUInt8, key: SpanConstUInt8) -> Bool {
+        Self.isValidAuthenticationCode(
             Data.temporaryDataFromSpan(spanNoCopy: mac),
             authenticating: Data.temporaryDataFromSpan(spanNoCopy: data),
-            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)))
+            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key))
+        )
     }
 }
 
 extension CryptoKit.HKDF {
     static func deriveKey(
-        inputKeyMaterial: SpanConstUInt8, salt: SpanConstUInt8, info: SpanConstUInt8,
+        inputKeyMaterial: SpanConstUInt8,
+        salt: SpanConstUInt8,
+        info: SpanConstUInt8,
         outputByteCount: Int
     ) -> VectorUInt8 {
-        return Self.deriveKey(
+        Self.deriveKey(
             inputKeyMaterial: SymmetricKey(
-                data: Data.temporaryDataFromSpan(spanNoCopy: inputKeyMaterial)),
+                data: Data.temporaryDataFromSpan(spanNoCopy: inputKeyMaterial)
+            ),
             salt: Data.temporaryDataFromSpan(spanNoCopy: salt),
-            info: Data.temporaryDataFromSpan(spanNoCopy: info), outputByteCount: outputByteCount
-        ).copyToVectorUInt8()
-
+            info: Data.temporaryDataFromSpan(spanNoCopy: info),
+            outputByteCount: outputByteCount
+        )
+        .copyToVectorUInt8()
     }
 }
 


### PR DESCRIPTION
#### 096bf3c16e6dc918061d3f71db17fa4fcdb4a886
<pre>
[Swift in WebKit] Format and lint Swift code in Source/WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=302064">https://bugs.webkit.org/show_bug.cgi?id=302064</a>
<a href="https://rdar.apple.com/164143736">rdar://164143736</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(AesKw.wrap(_:using:)):
(AesKw.unwrap(_:using:)):
(Digest.sha1Init):
(Digest.sha256Init):
(Digest.sha384Init):
(Digest.sha512Init):
(Digest.sha1(_:)):
(Digest.sha256(_:)):
(Digest.sha384(_:)):
(Digest.sha512(_:)):
(Digest.digest(_:hashFunction:)):
(ECKey.toPub):
(ECKey.importX963Pub(_:curve:)):
(ECKey.exportX963Pub):
(ECKey.importCompressedPub(_:curve:)):
(ECKey.importX963Private(_:curve:)):
(ECKey.exportX963Private):
(ECKey.sign(_:hashFunction:)):
(ECKey.verify(_:signature:hashFunction:)):
(ECKey.deriveBits(_:)):
(EdKey.generatePrivateKeyKeyAgreement(_:)):
(EdKey.privateToPublic(_:privateKey:)):
(EdKey.validateKeyPair(_:privateKey:publicKey:)):
(EdKey.sign(_:privateKey:data:)):
(HMAC.sign(_:data:hashFunction:)):
(HMAC.verify(_:key:data:hashFunction:)):
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
(CryptoKit.update(_:)):
(ContiguousBytes.copyToVectorUInt8):
(Data.temporaryDataFromSpan(_:)):
(AES.unwrap(_:using:)):
(AES.wrap(_:using:)):
(Curve25519.signature(_:)):
(Curve25519.isValidSignature(_:data:)):
(Curve25519.sharedSecretFromKeyAgreement(_:)):
(CryptoKit.authenticationCode(_:key:)):
(CryptoKit.isValidAuthenticationCode(_:data:key:)):
(Data.empty): Deleted.
(_WorkAroundRadar116406681.forceLinkageForVectorDestructor): Deleted.

Canonical link: <a href="https://commits.webkit.org/302667@main">https://commits.webkit.org/302667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcd29d3a16b06d0ab11ec90ea9698e2ae3f25010

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81227 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b224f24-6754-45b8-8fb4-546a9895206e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98850 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66671 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c9200c8e-6e4d-451c-a153-376e845375ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79529 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ee46be0d-b1af-4791-8a6c-6c5d75bcca0c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34346 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80420 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139630 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107356 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107231 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27316 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54569 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1886 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65255 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1700 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->