### PR TITLE
[ iOS Release ] http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html is a flakey text failure

### DIFF
--- a/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html
+++ b/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -22,35 +22,33 @@ function iframeForMessage(message)
     return allFrames.find(frame => frame.contentWindow === message.source);
 }
 
-var failCount = 0;
-function iFrameLeaked()
-{
-    if (++failCount >= framesToCreate) {
-        testFailed("All iframe documents leaked.");
-        finishJSTest();
-    }
-}
+frameDocumentIDs = [];
+checkCount = 0;
 
 function iframeLoaded(iframe)
 {
     let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
-    let checkCount = 0;
-    iframe.addEventListener("load", () => {
-        let handle = setInterval(() => {
-            gc();
-            if (!internals.isDocumentAlive(frameDocumentID)) {
-                clearInterval(handle);
-                testPassed("The iframe document didn't leak.");
-                finishJSTest();
-            }
-            if (++checkCount > 5) {
-                clearInterval(handle);
-                iframeLeaked();
-            }
-        }, 10);
-    });
+    frameDocumentIDs.push(frameDocumentID);
 
     iframe.src = "about:blank";
+    if (frameDocumentIDs.length == framesToCreate) {
+        handle = setInterval(() => {
+            gc();
+            for (const documentID of frameDocumentIDs) {
+                if (!internals.isDocumentAlive(documentID)) {
+                    clearInterval(handle);
+                    testPassed("The iframe document didn't leak.");
+                    finishJSTest();
+                    return;
+                }
+            }
+            if (++checkCount > 10) {
+                clearInterval(handle);
+                testFailed("All iframe documents leaked.");
+                finishJSTest();
+            }
+        }, 10);
+    }
 }
 
 onload = () => {
@@ -63,6 +61,5 @@ onload = () => {
     allFrames.forEach(frame => frame.src = "https://127.0.0.1:8443/geolocation/resources/geolocation-get-position-callback.html");
 };
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8226,8 +8226,6 @@ webkit.org/b/297144 fast/forms/state-restore-to-non-edited-controls.html [ Pass 
 
 webkit.org/b/297240 http/tests/site-isolation/edge-sampling-commit-root-frame-load.html [ Failure ]
 
-webkit.org/b/295751 [ Release ] http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html [ Pass Failure ]
-
 webkit.org/b/297251 [ Release ] fast/mediastream/getUserMedia-echoCancellation.html [ Pass Failure ]
 
 # webkit.org/b/297405 2x imported/w3c/web-platform-tests/css/css-flexbox/ (layout-tests) tests are constant image failures 


### PR DESCRIPTION
#### 17a860829ed97a9d12ee29186cd520e0442beea1
<pre>
[ iOS Release ] http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html is a flakey text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=295751">https://bugs.webkit.org/show_bug.cgi?id=295751</a>
<a href="https://rdar.apple.com/155570673">rdar://155570673</a>

Reviewed by NOBODY (OOPS!).

The issue was that the test would call `setInterval()` once per iframe
but would only cancel the setInterval for one frame in case of success.
As a result, setInterval could fire for other iframes after calling
finishJSTest() and log further text.

Address the issue by using a single setInterval for all the frames.

* LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html:
* LayoutTests/platform/ios/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17a860829ed97a9d12ee29186cd520e0442beea1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81232 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0a0bcdb4-a316-4d46-bc79-6e5114cbe1b5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98855 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132710 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79535 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34353 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80425 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107360 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107235 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54577 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1891 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1705 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->