### PR TITLE
[ iOS Release ] http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html is a flakey text failure

### DIFF
--- a/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html
+++ b/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html
@@ -2,66 +2,12 @@
 <html>
 <head>
 <script src="../resources/js-test-pre.js"></script>
+<script src="../resources/document-leak-test.js"></script>
 </head>
 <body>
 <script>
 description("Tests that navigator.geolocation.getCurrentPosition() does not leak the document object.");
-jsTestIsAsync = true;
-
-var framesToCreate = 20;
-var allFrames = new Array(framesToCreate);
-
-for (let i = 0; i < framesToCreate; ++i) {
-    let iframe = document.createElement("iframe");
-    document.body.appendChild(iframe);
-    allFrames[i] = iframe;
-}
-
-function iframeForMessage(message)
-{
-    return allFrames.find(frame => frame.contentWindow === message.source);
-}
-
-var failCount = 0;
-function iFrameLeaked()
-{
-    if (++failCount >= framesToCreate) {
-        testFailed("All iframe documents leaked.");
-        finishJSTest();
-    }
-}
-
-function iframeLoaded(iframe)
-{
-    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
-    let checkCount = 0;
-    iframe.addEventListener("load", () => {
-        let handle = setInterval(() => {
-            gc();
-            if (!internals.isDocumentAlive(frameDocumentID)) {
-                clearInterval(handle);
-                testPassed("The iframe document didn't leak.");
-                finishJSTest();
-            }
-            if (++checkCount > 5) {
-                clearInterval(handle);
-                iframeLeaked();
-            }
-        }, 10);
-    });
-
-    iframe.src = "about:blank";
-}
-
-onload = () => {
-    if (!(window.internals && window.testRunner)) {
-        testFailed("Test requires internals and testRunner.");
-        finishJSTest();
-    }
-
-    window.addEventListener("message", message => iframeLoaded(iframeForMessage(message)));
-    allFrames.forEach(frame => frame.src = "https://127.0.0.1:8443/geolocation/resources/geolocation-get-position-callback.html");
-};
+onload = () => runDocumentLeakTest({ frameURL: "https://127.0.0.1:8443/geolocation/resources/geolocation-get-position-callback.html", framesToCreate: 20 });
 </script>
 <script src="../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/http/tests/resources/document-leak-test.js
+++ b/LayoutTests/http/tests/resources/document-leak-test.js
@@ -6,7 +6,8 @@ if (!(window.testRunner && window.internals)) {
 }
 
 var allFrames;
-var maxFailCount = 0;
+var frameDocumentIDs = [];
+var checkCount = 0;
 
 function createFrames(framesToCreate)
 {
@@ -14,7 +15,6 @@ function createFrames(framesToCreate)
         throw TypeError("framesToCreate must be a number.");
 
     allFrames = new Array(framesToCreate);
-    maxFailCount = framesToCreate;
 
     for (let i = 0; i < allFrames.length; ++i) {
         let frame = document.createElement("iframe");
@@ -28,38 +28,32 @@ function iframeForMessage(message)
     return allFrames.find(frame => frame.contentWindow === message.source);
 }
 
-var failCount = 0;
-function iframeLeaked()
-{
-    if (++failCount >= maxFailCount) {
-        testFailed("All iframe documents leaked.");
-        finishJSTest();
-    }
-}
-
 function iframeSentMessage(message)
 {
     let iframe = iframeForMessage(message);
     let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
-    let checkCount = 0;
-
-    iframe.addEventListener("load", () => {
-        let handle = setInterval(() => {
-            gc();
-            if (!internals.isDocumentAlive(frameDocumentID)) {
-                clearInterval(handle);
-                testPassed("The iframe document didn't leak.");
-                finishJSTest();
-            }
-
-            if (++checkCount > 5) {
-                clearInterval(handle);
-                iframeLeaked();
-            }
-        }, 10);
-    }, { once: true });
+    frameDocumentIDs.push(frameDocumentID);
 
     iframe.src = "about:blank";
+
+    if (frameDocumentIDs.length == allFrames.length) {
+        handle = setInterval(() => {
+            gc();
+            for (const documentID of frameDocumentIDs) {
+                if (!internals.isDocumentAlive(documentID)) {
+                    clearInterval(handle);
+                    testPassed("The iframe document didn't leak.");
+                    finishJSTest();
+                    return;
+                }
+                if (++checkCount > 10) {
+                    clearInterval(handle);
+                    testFailed("All iframe documents leaked.");
+                    finishJSTest();
+                }
+            }
+        }, 10);
+    }
 }
 
 function runDocumentLeakTest(options)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8105,8 +8105,6 @@ webkit.org/b/295999 media/media-garbage-collection.html [ Pass Failure Timeout ]
 
 webkit.org/b/296010 [ Debug ] fast/frames/frame-append-body-child-crash.html [ Pass Failure ]
 
-webkit.org/b/295992 [ Release ] http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html [ Pass Failure ]
-
 webkit.org/b/295989 [ Release ] http/tests/misc/embed-image-load-outlives-gc-without-crashing.html [ Pass Timeout ]
 
 webkit.org/b/296095 fast/forms/switch/click-animation-disabled.html [ Pass Timeout ]
@@ -8169,11 +8167,6 @@ webkit.org/b/296338 http/tests/site-isolation/fullscreen.html [ Pass Failure ]
 
 webkit.org/b/296389 [ Release ] http/tests/dom/noreferrer-window-not-targetable.html [ Pass Failure ]
 
-# webkit.org/b/296388 [ Release ] 3x http/tests/canvas/ (layout-tests) are flakey text failures
-[ Release ] http/tests/canvas/ctx.2d-canvas-style-color-no-document-leak.html [ Pass Failure ]
-[ Release ] http/tests/canvas/ctx.2d-canvas-style-gradient-no-document-leak.html [ Pass Failure ]
-[ Release ] http/tests/canvas/ctx.2d-canvas-style-pattern-no-document-leak.html [ Pass Failure ]
-
 webkit.org/b/296566 [ Release ] imported/w3c/web-platform-tests/screen-orientation/lock-basic.html [ Pass Failure ]
 
 # webkit.org/b/295803 2x http/tests/webcodecs/ (layout-tests) tests flakey text failures
@@ -8189,8 +8182,6 @@ webkit.org/b/296707 imported/w3c/web-platform-tests/screen-orientation/non-fully
 webkit.org/b/296709 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html [ ImageOnlyFailure ]
 
 webkit.org/b/296816 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-012.html [ Pass Failure ]
-
-webkit.org/b/296824 [ Release ] http/tests/webcodecs/audio-encoder-callbacks-do-not-leak.html [ Pass Failure ]
 
 webkit.org/b/296833 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-096.html [ Pass ImageOnlyFailure ]
 
@@ -8223,8 +8214,6 @@ fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-w
 webkit.org/b/297144 fast/forms/state-restore-to-non-edited-controls.html [ Pass Timeout ]
 
 webkit.org/b/297240 http/tests/site-isolation/edge-sampling-commit-root-frame-load.html [ Failure ]
-
-webkit.org/b/295751 [ Release ] http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html [ Pass Failure ]
 
 webkit.org/b/297251 [ Release ] fast/mediastream/getUserMedia-echoCancellation.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 83253d433aae47137c7e0cba6bae8b2b457abcf0
<pre>
[ iOS Release ] http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html is a flakey text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=295992">https://bugs.webkit.org/show_bug.cgi?id=295992</a>
<a href="https://rdar.apple.com/155890249">rdar://155890249</a>

Reviewed by Ryan Reno.

The issue was that the test would call `setInterval()` once per iframe
but would only cancel the setInterval for one frame in case of success.
As a result, setInterval could fire for other iframes after calling
finishJSTest() and log further text.

Address the issue by using a single setInterval for all the frames.

Address flakiness for the following tests that were flaky for the same reason:
- http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html
- http/tests/canvas/ctx.2d-canvas-style-color-no-document-leak.html
- http/tests/canvas/ctx.2d-canvas-style-gradient-no-document-leak.html
- http/tests/canvas/ctx.2d-canvas-style-pattern-no-document-leak.html
- http/tests/webcodecs/audio-encoder-callbacks-do-not-leak.html

* LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html:
* LayoutTests/http/tests/resources/document-leak-test.js:
(createFrames):
(iframeLeaked): Deleted.
(iframeSentMessage): Deleted.
(runDocumentLeakTest): Deleted.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/302683@main">https://commits.webkit.org/302683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e8eafea95d24690c8ebe4ba39c646187a7d8093

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137173 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81257 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98865 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66685 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d360768f-28e4-4af5-bab2-ba43c45f5b37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79545 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e374514-877e-4a7e-b48a-ea36083b0364) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80446 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139656 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1839 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1718 "1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107372 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27324 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54614 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1912 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1726 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1761 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->