### PR TITLE
os_script_config_storage is only required to be paged aligned.

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -35,6 +35,7 @@
 #include "Opcode.h"
 
 #if PLATFORM(COCOA)
+#include <wtf/ResourceUsage.h>
 #include <wtf/cocoa/Entitlements.h>
 #endif
 
@@ -55,7 +56,7 @@ namespace LLInt {
 #else
 #define LLINT_OPCODE_CONFIG_SECTION
 #endif
-alignas(OpcodeConfigAlignment) uint8_t LLINT_OPCODE_CONFIG_SECTION os_script_config_storage[OpcodeConfigSizeToProtect];
+alignas(CeilingOnPageSize) uint8_t LLINT_OPCODE_CONFIG_SECTION os_script_config_storage[OpcodeConfigSizeToProtect];
 #endif
 
 static_assert(sizeof(OpcodeConfig) <= OpcodeConfigSizeToProtect);
@@ -97,7 +98,7 @@ void initialize()
     // is a potential SDK vs OS mismatch. The check is intentionally designed to be cheap.
     auto osVersionSupports = [] (void* storageAddress) {
         auto addressValue = reinterpret_cast<uintptr_t>(storageAddress);
-        uintptr_t pageSizeMask = CeilingOnPageSize - 1;
+        uintptr_t pageSizeMask = vmPageSize() - 1;
 
         if (addressValue & pageSizeMask)
             return false; // os_script_config_storage should be page aligned.

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -67,11 +67,9 @@ struct OpcodeConfig {
     void* ipint_atomic_dispatch_base;
 };
 
-constexpr size_t OpcodeConfigAlignment = CeilingOnPageSize;
 constexpr size_t OpcodeConfigSizeToProtect = std::max(CeilingOnPageSize, 16 * KB);
 
 #if HAVE(OS_SCRIPT_CONFIG_SPI)
-static_assert(OS_SCRIPT_CONFIG_STORAGE_SIZE == OpcodeConfigAlignment);
 static_assert(OS_SCRIPT_CONFIG_STORAGE_SIZE == OpcodeConfigSizeToProtect);
 #else
 extern "C" WTF_EXPORT_PRIVATE uint8_t os_script_config_storage[];


### PR DESCRIPTION
#### 3d023cd1e358acd0ab194640ea997d61e2e8e074
<pre>
os_script_config_storage is only required to be paged aligned.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302066">https://bugs.webkit.org/show_bug.cgi?id=302066</a>
<a href="https://rdar.apple.com/164038455">rdar://164038455</a>

Reviewed by Yusuke Suzuki.

It does not need to be CeilingOnPageSize aligned.  This causes the RELEASE_ASSERT
on osVersionSupports() to fail on x86_64.  This patch fixes osVersionSupports() to
check for page alignment instead.

Also removed OpcodeConfigAlignment.  It is only needed if we need to provide our
own os_script_config_storage buffer (instead of one provided by the OS).  Just use
CeilingOnPageSize for the alignment in that case.  osVersionSupports() will not
be called since we are providing our own buffer.  Keeping OpcodeConfigAlignment
would wrongly infer that the OS provided os_script_config_storage will be
aligned on OpcodeConfigAlignment (i.e. CeilingOnPageSize), when it may not be.

No new tests needed.  The issue will be detected by simply launching the jsc
shell built for an x86_64 OS that provides os_script_config_storage.

* Source/JavaScriptCore/llint/LLIntData.cpp:
(JSC::LLInt::initialize):
* Source/JavaScriptCore/llint/LLIntData.h:

Canonical link: <a href="https://commits.webkit.org/302653@main">https://commits.webkit.org/302653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b027a935e566bbe9367fba30babef5566156d950

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81253 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/953393c3-4978-442b-bf94-073dd2abaf5d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98864 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66684 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f7081b5c-e71f-4761-b726-c453ba84c7c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132728 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1512 "Found 1 new test failure: fast/scrolling/ios/bounding-client-rect-on-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79544 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0f839b07-b406-4b9e-ae9b-49bcabdee645) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80443 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121773 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139653 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128233 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107369 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107245 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1487 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54611 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20249 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65278 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161247 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1723 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40203 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->