### PR TITLE
Only ignore generated JS* files in WebCore for safer C++ static analysis

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,4 +1,37 @@
 AutomationProtocolObjects.h
+JSWebExtensionAPIAction.mm
+JSWebExtensionAPIAlarms.mm
+JSWebExtensionAPICommands.mm
+JSWebExtensionAPICookies.mm
+JSWebExtensionAPIDOM.mm
+JSWebExtensionAPIDeclarativeNetRequest.mm
+JSWebExtensionAPIDevTools.mm
+JSWebExtensionAPIDevToolsExtensionPanel.mm
+JSWebExtensionAPIDevToolsInspectedWindow.mm
+JSWebExtensionAPIDevToolsNetwork.mm
+JSWebExtensionAPIDevToolsPanels.mm
+JSWebExtensionAPIEvent.mm
+JSWebExtensionAPIExtension.mm
+JSWebExtensionAPILocalization.mm
+JSWebExtensionAPIMenus.mm
+JSWebExtensionAPINamespace.mm
+JSWebExtensionAPINotifications.mm
+JSWebExtensionAPIPermissions.mm
+JSWebExtensionAPIPort.mm
+JSWebExtensionAPIRuntime.mm
+JSWebExtensionAPIScripting.mm
+JSWebExtensionAPIStorage.mm
+JSWebExtensionAPIStorageArea.mm
+JSWebExtensionAPITabs.mm
+JSWebExtensionAPITest.mm
+JSWebExtensionAPIWebNavigation.mm
+JSWebExtensionAPIWebNavigationEvent.mm
+JSWebExtensionAPIWebPageNamespace.mm
+JSWebExtensionAPIWebPageRuntime.mm
+JSWebExtensionAPIWebRequest.mm
+JSWebExtensionAPIWebRequestEvent.mm
+JSWebExtensionAPIWindows.mm
+JSWebExtensionAPIWindowsEvent.mm
 WebDriverBidiProtocolObjects.h
 [ iOS ] NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
 [ iOS ] Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm

--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -38,7 +38,7 @@ STATIC_ANALYZER_UNEXPECTED = 'StaticAnalyzerUnexpectedRegressions'
 UNEXPECTED_PASS = {'actual': 'PASS', 'expected': 'FAIL'}
 UNEXPECTED_FAILURE = {'actual': 'FAIL', 'expected': 'PASS'}
 EXPECTED_FAILURE = {'actual': 'FAIL', 'expected': 'FAIL'}
-DERIVED_SOURCES_RE = r'(^|.*\/)DerivedSources\/.*\/JS.*'
+DERIVED_SOURCES_RE = r'(^|.*\/)DerivedSources\/WebCore\/JS.*'
 EXPECTATION_LINE_RE = r'(\s*\[\s*(?P<platform>\w+)\s*\]\s*)?(?P<path>.+)'
 
 

--- a/Tools/Scripts/generate-dirty-files
+++ b/Tools/Scripts/generate-dirty-files
@@ -30,7 +30,7 @@ import re
 
 from webkitpy.safer_cpp.checkers import Checker
 
-DERIVED_SOURCES_RE = r'(^|.*\/)DerivedSources\/.*\/JS.*'
+DERIVED_SOURCES_RE = r'(^|.*\/)DerivedSources\/WebCore\/JS.*'
 
 
 def parser():
@@ -97,7 +97,7 @@ def find_project_results(args, project, file_list, results_data, issue_to_report
         bug_counts[bug_type] += 1
 
         if f'{project.lower()}/' not in file_name.lower():
-            # Ignore WebKitBuild/Debug files that are included in other projects
+            # Ignore WebKitBuild/Debug files that are included from other projects
             continue
         elif not re.match(DERIVED_SOURCES_RE, file_name):
             # Truncate path after project name to match the expectations file


### PR DESCRIPTION
#### 7d765a6d9e61d5124a387462dbcce707d5605011
<pre>
Only ignore generated JS* files in WebCore for safer C++ static analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=302070">https://bugs.webkit.org/show_bug.cgi?id=302070</a>

Reviewed by Anne van Kesteren.

Refine the regex to only ignore JS* derived sources in WebCore.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Tools/Scripts/compare-static-analysis-results:
* Tools/Scripts/generate-dirty-files:
(find_project_results):

Canonical link: <a href="https://commits.webkit.org/302700@main">https://commits.webkit.org/302700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6a209a1ba9a97246191434bc238e0c0508056a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ee604b0a-83d9-4c96-8b25-b9943ac79826) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98906 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66728 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/75dc79ac-88e2-4ec8-acbd-25bca18c7b82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79590 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61b5a15f-c764-4df0-bc8d-01a4eddb0d1e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34412 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80497 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139706 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107413 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107293 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54686 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20270 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65331 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1776 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1811 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->