### PR TITLE
[WPE][MSE][GStreamer] Fix QuotaExceededError for init segment when no text limit specified

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -370,11 +370,12 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
         }
     });
 
-    // If any track type size isn't specified, we consider that it has no limit and the values from the
-    // element have to be used. Otherwise, the track limits are accumulative. If everything is specified
-    // but there's no track (eg: because we're processing an init segment that we don't know yet which
-    // kind of track(s) is going to generate) we assume that the 3 kind of tracks might appear (audio,
-    // video, text) and use all the accumulated limits at once to make room for any possible outcome.
+    // If either audio or video track type size isn't specified, we consider that it has no limit
+    // and the values from the element have to be used. Otherwise, the track limits are accumulative.
+    // If at least video and audio are specified but there's no track (eg: because we're processing
+    // an init segment that we don't know yet which kind of track(s) is going to generate) we assume
+    // that the 3 kind of tracks might appear (audio, video, text) and use all the accumulated
+    // limits at once to make room for any possible outcome.
     do {
         bool hasVideo = false;
         bool hasAudio = false;
@@ -412,7 +413,7 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
         if (hasText || m_tracks.empty()) {
             if (maxBufferSizeText)
                 bufferSize += maxBufferSizeText;
-            else
+            else if (hasText)
                 break;
         }
         if (bufferSize)


### PR DESCRIPTION
#### f2932ed881fb562a956c573a3acfb84b821a9311
<pre>
[WPE][MSE][GStreamer] Fix QuotaExceededError for init segment when no text limit specified
<a href="https://bugs.webkit.org/show_bug.cgi?id=302072">https://bugs.webkit.org/show_bug.cgi?id=302072</a>

Reviewed by Philippe Normand and Alicia Boya Garcia.

Ignore missing &quot;Text&quot; limit in MSE_MAX_BUFFER_SIZE env when calculating max buffer size
for init segment.
With current impl, missing any of track type A/V/T from MSE_MAX_BUFFER_SIZE causes WebKit
to fallback to default value from HTMLMediaElement/settings that is ~15MB for WPE.
Providing higher video and audio limits in the env we can still end up in QuotaExceededError
because of that.

Assume video and audio limits are enough to calculate accumulative max buffer size
for any type of track.

Original author: Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1578">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1578</a>

* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::platformMaximumBufferSize const):

Canonical link: <a href="https://commits.webkit.org/302839@main">https://commits.webkit.org/302839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c77a9c73f4ee8c4c5998552deb43707bbd4da9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66693 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132740 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79555 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34380 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80455 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139665 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107382 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27429 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31082 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54629 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->