### PR TITLE
[threaded-animations] add testing support for remote layer tree animations

### DIFF
--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2001,6 +2001,18 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static remoteAnimationStackForElement(element)
+    {
+        if (!this.isWebKit2() || !element)
+            return Promise.resolve();
+
+        const layerID = window.internals?.layerIDForElement(element);
+        const script = `uiController.uiScriptComplete(uiController.animationStackForLayerWithID(${layerID}))`;
+        return new Promise(resolve => {
+            testRunner.runUIScript(script, result => resolve(JSON.parse(result)));
+        });
+    }
+
     static dragFromPointToPoint(fromX, fromY, toX, toY, duration)
     {
         if (!this.isWebKit2() || !this.isIOSFamily()) {

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt
@@ -1,4 +1,5 @@
 
 PASS A scroll-driven CSS animation can be accelerated.
 PASS A scroll-driven JS-originated animation can be accelerated.
+PASS A scroll-driven JS-originated animation yields a remote animation with a progress-based timeline.
 

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
@@ -17,9 +17,12 @@ body {
 }
 
 </style>
+
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
 <script>
 
 const make_target = t => {
@@ -53,6 +56,57 @@ promise_test(async t => {
     await animationAcceleration(animation);
     assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1);
 }, "A scroll-driven JS-originated animation can be accelerated.");
+
+promise_test(async t => {
+    const target = make_target(t);
+    const timeline = new ScrollTimeline({ source: document.documentElement });
+    const animation = target.animate({ translate: '100px' }, { timeline });
+
+    await animationAcceleration(animation);
+
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+
+    assert_equals(remoteAnimationStack.baseValues.translate, null);
+
+    const remoteAnimations = remoteAnimationStack.animations;
+    assert_equals(remoteAnimations.length, 1);
+
+    const remoteAnimation = remoteAnimations[0];
+    assert_equals(remoteAnimation.paused, false);
+    assert_equals(remoteAnimation.composite, "replace");
+    assert_equals(remoteAnimation.playbackRate, 1);
+    assert_equals(remoteAnimation.startTime, "0.00%");
+    assert_equals(remoteAnimation.holdTime, null);
+
+    const remoteTimeline = remoteAnimation.timeline;
+    assert_equals(remoteTimeline.currentTime, "0.00%");
+    assert_equals(remoteTimeline.duration, "100.00%");
+
+    const properties = remoteAnimation.properties;
+    assert_equals(properties.length, 1);
+    assert_equals(properties[0], "translate");
+
+    const timing = remoteAnimation.timing;
+    assert_equals(timing.direction, "normal");
+    assert_equals(timing.easing, "linear");
+    assert_equals(timing.fill, "auto");
+    assert_equals(timing.iterationStart, 0);
+    assert_equals(timing.iterations, 1);
+    assert_equals(timing.startDelay, "0.00%");
+    assert_equals(timing.endDelay, "0.00%");
+    assert_equals(timing.iterationDuration, "100.00%");
+    assert_equals(timing.activeDuration, "100.00%");
+    assert_equals(timing.endTime, "100.00%");
+
+    const keyframes = remoteAnimation.keyframes;
+    assert_equals(keyframes.length, 1);
+
+    const keyframe = keyframes[0];
+    assert_equals(keyframe.offset, 1);
+    assert_equals(keyframe.composite, null);
+    assert_equals(keyframe.easing, "linear");
+    assert_equals(keyframe.translate.x, 100);
+}, "A scroll-driven JS-originated animation yields a remote animation with a progress-based timeline.");
 
 </script>
 </body>

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -53,7 +53,7 @@ public:
 
     enum class Before : bool { No, Yes };
     double transformProgress(double progress, double duration, Before = Before::No) const;
-    String cssText() const;
+    WEBCORE_EXPORT String cssText() const;
 };
 
 class LinearTimingFunction final : public TimingFunction {

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -674,6 +674,7 @@ UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteAnimation.cpp
 UIProcess/RemoteLayerTree/RemoteAnimationStack.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+UIProcess/RemoteLayerTree/RemoteAnimationUtilities.cpp
 UIProcess/RemoteLayerTree/RemoteMonotonicTimeline.cpp
 UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.cpp
 UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm @nonARC

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -180,6 +180,10 @@ struct WKAppPrivacyReportTestingData {
 
 - (NSString *)_webContentProcessVariantForFrame:(nullable _WKFrameHandle *)frameHandle;
 
+#if defined(ENABLE_THREADED_ANIMATIONS) && ENABLE_THREADED_ANIMATIONS
+- (NSString *)_animationStackForLayerWithID:(unsigned long long)layerID;
+#endif
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKMediaSessionReadyState) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
@@ -30,6 +30,7 @@
 #include "RemoteAnimationTimeline.h"
 #include <WebCore/AcceleratedEffect.h>
 #include <WebCore/WebAnimationTime.h>
+#include <wtf/JSONValues.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -46,6 +47,8 @@ public:
     const Vector<WebCore::AcceleratedEffect::Keyframe>& keyframes() const { return m_effect->keyframes(); }
 
     void apply(WebCore::AcceleratedEffectValues&);
+
+    Ref<JSON::Object> toJSONForTesting() const;
 
 private:
     RemoteAnimation(const WebCore::AcceleratedEffect&, const RemoteAnimationTimeline&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -31,12 +31,16 @@
 #include <WebCore/AcceleratedEffectValues.h>
 #include <WebCore/PlatformCAFilters.h>
 #include <WebCore/PlatformLayer.h>
+#include <wtf/JSONValues.h>
 #include <wtf/OptionSet.h>
-#include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+
+#if PLATFORM(MAC)
+#include <wtf/RetainPtr.h>
 
 OBJC_CLASS CAPresentationModifierGroup;
 OBJC_CLASS CAPresentationModifier;
+#endif
 
 namespace WebKit {
 
@@ -49,6 +53,9 @@ public:
 
     bool isEmpty() const { return m_animations.isEmpty(); }
 
+    auto begin() const LIFETIME_BOUND { return m_animations.begin(); }
+    auto end() const LIFETIME_BOUND { return m_animations.end(); }
+
 #if PLATFORM(MAC)
     void initEffectsFromMainThread(PlatformLayer*);
     void applyEffectsFromScrollingThread() const;
@@ -57,6 +64,8 @@ public:
     void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque) const;
 
     void clear(PlatformLayer*);
+
+    Ref<JSON::Object> toJSONForTesting() const;
 
 private:
     explicit RemoteAnimationStack(RemoteAnimations&&, WebCore::AcceleratedEffectValues&&, WebCore::FloatRect);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
+#import "RemoteAnimationUtilities.h"
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -212,6 +213,22 @@ void RemoteAnimationStack::clear(PlatformLayer *layer)
     m_transformPresentationModifier = nil;
     m_presentationModifierGroup = nil;
 #endif
+}
+
+Ref<JSON::Object> RemoteAnimationStack::toJSONForTesting() const
+{
+    Ref convertedAnimations = JSON::Array::create();
+    OptionSet<WebCore::AcceleratedEffectProperty> animatedProperties;
+
+    for (auto& animation : m_animations) {
+        animatedProperties.add(animation->animatedProperties());
+        convertedAnimations->pushObject(animation->toJSONForTesting());
+    }
+
+    Ref object = JSON::Object::create();
+    object->setArray("animations"_s, WTFMove(convertedAnimations));
+    object->setObject("baseValues"_s, WebKit::toJSONForTesting(m_baseValues, animatedProperties));
+    return object;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
+#import "RemoteAnimationUtilities.h"
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -38,6 +39,15 @@ RemoteAnimationTimeline::RemoteAnimationTimeline(TimelineID identifier, std::opt
     : m_identifier(identifier)
     , m_duration(duration)
 {
+}
+
+Ref<JSON::Object> RemoteAnimationTimeline::toJSONForTesting() const
+{
+    Ref object = JSON::Object::create();
+    object->setValue("currentTime"_s, WebKit::toJSONForTesting(m_currentTime));
+    object->setValue("duration"_s, WebKit::toJSONForTesting(m_duration));
+    object->setString("identifier"_s, m_identifier.loggingString());
+    return object;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RemoteAnimationUtilities.h"
+
+#if ENABLE(THREADED_ANIMATIONS)
+
+#import <WebCore/AcceleratedEffectOffsetAnchor.h>
+#import <WebCore/AcceleratedEffectOffsetDistance.h>
+#import <WebCore/AcceleratedEffectOffsetPosition.h>
+#import <WebCore/AcceleratedEffectOffsetRotate.h>
+#import <WebCore/AcceleratedEffectOpacity.h>
+#import <WebCore/AcceleratedEffectValues.h>
+#import <WebCore/AnimationEffectTiming.h>
+#import <WebCore/CompositeOperation.h>
+#import <WebCore/Matrix3DTransformOperation.h>
+#import <WebCore/MatrixTransformOperation.h>
+#import <WebCore/PerspectiveTransformOperation.h>
+#import <WebCore/RotateTransformOperation.h>
+#import <WebCore/ScaleTransformOperation.h>
+#import <WebCore/SkewTransformOperation.h>
+#import <WebCore/TimingFunction.h>
+#import <WebCore/TransformOperation.h>
+#import <WebCore/TransformOperations.h>
+#import <WebCore/TransformationMatrix.h>
+#import <WebCore/TranslateTransformOperation.h>
+#import <WebCore/WebAnimationTypes.h>
+
+namespace WebKit {
+
+String toStringForTesting(WebCore::AcceleratedEffectProperty property)
+{
+    switch (property) {
+    case WebCore::AcceleratedEffectProperty::Invalid:
+        return "invalid"_s;
+    case WebCore::AcceleratedEffectProperty::Opacity:
+        return "opacity"_s;
+    case WebCore::AcceleratedEffectProperty::Transform:
+        return "transform"_s;
+    case WebCore::AcceleratedEffectProperty::Translate:
+        return "translate"_s;
+    case WebCore::AcceleratedEffectProperty::Rotate:
+        return "rotate"_s;
+    case WebCore::AcceleratedEffectProperty::Scale:
+        return "scale"_s;
+    case WebCore::AcceleratedEffectProperty::OffsetPath:
+        return "offsetPath"_s;
+    case WebCore::AcceleratedEffectProperty::OffsetDistance:
+        return "offsetDistance"_s;
+    case WebCore::AcceleratedEffectProperty::OffsetPosition:
+        return "offsetPosition"_s;
+    case WebCore::AcceleratedEffectProperty::OffsetAnchor:
+        return "offsetAnchor"_s;
+    case WebCore::AcceleratedEffectProperty::OffsetRotate:
+        return "offsetRotate"_s;
+    case WebCore::AcceleratedEffectProperty::Filter:
+        return "filter"_s;
+    case WebCore::AcceleratedEffectProperty::BackdropFilter:
+        return "backdropFilter"_s;
+    default:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+}
+
+Ref<JSON::Value> toJSONForTesting(std::optional<WebCore::WebAnimationTime> time)
+{
+    if (!time)
+        return JSON::Value::null();
+    TextStream ts;
+    if (auto seconds = time->time())
+        ts << *seconds << "s";
+    else if (auto percentage = time->percentage())
+        ts << *percentage << "%";
+    else
+        ASSERT_NOT_REACHED();
+    return JSON::Value::create(ts.release());
+}
+
+Ref<JSON::Value> toJSONForTesting(std::optional<WebCore::CompositeOperation> compositeOperation)
+{
+    if (!compositeOperation)
+        return JSON::Value::null();
+    switch (*compositeOperation) {
+    case WebCore::CompositeOperation::Replace:
+        return JSON::Value::create(makeString("replace"_s));
+    case WebCore::CompositeOperation::Add:
+        return JSON::Value::create(makeString("add"_s));
+    case WebCore::CompositeOperation::Accumulate:
+        return JSON::Value::create(makeString("accumulate"_s));
+    default:
+        ASSERT_NOT_REACHED();
+        return JSON::Value::null();
+    }
+}
+
+Ref<JSON::Value> toJSONForTesting(const RefPtr<WebCore::TimingFunction>& timingFunction)
+{
+    if (timingFunction)
+        return JSON::Value::create(timingFunction->cssText());
+    return JSON::Value::null();
+}
+
+Ref<JSON::Object> toJSONForTesting(const WebCore::AcceleratedEffectValues& values, const OptionSet<WebCore::AcceleratedEffectProperty>& properties)
+{
+    auto convertTransformOperation = [](const WebCore::TransformOperation& operation) {
+        TextStream ts;
+        if (RefPtr matrixOperation = dynamicDowncast<WebCore::MatrixTransformOperation>(operation)) {
+            auto matrix = matrixOperation->matrix();
+            ts << "matrix(" << matrix.a() << ", " << matrix.b() << ", " << matrix.c() << ", " << matrix.d() << ", " << matrix.e() << ", " << matrix.f() << ")";
+        } else if (RefPtr matrix3DOperation = dynamicDowncast<WebCore::Matrix3DTransformOperation>(operation)) {
+            auto matrix = matrix3DOperation->matrix();
+            ts << "matrix3d("
+            << matrix.m11() << ", " << matrix.m12() << ", " << matrix.m13() << ", " << matrix.m14() << ", "
+            << matrix.m21() << ", " << matrix.m22() << ", " << matrix.m23() << ", " << matrix.m24() << ", "
+            << matrix.m31() << ", " << matrix.m32() << ", " << matrix.m33() << ", " << matrix.m34() << ", "
+            << matrix.m41() << ", " << matrix.m42() << ", " << matrix.m43() << ", " << matrix.m44() << ")";
+        } else if (RefPtr perspective = dynamicDowncast<WebCore::PerspectiveTransformOperation>(operation)) {
+            ts << "perspective(";
+            if (auto perspectiveValue = perspective->perspective())
+                ts << *perspectiveValue;
+            ts << ")";
+        } else if (RefPtr rotate = dynamicDowncast<WebCore::RotateTransformOperation>(operation))
+            ts << "rotate(" << rotate->angle() << "deg," << rotate->x() << "," << rotate->y() << "," << rotate->z() << ")";
+        else if (RefPtr scale = dynamicDowncast<WebCore::ScaleTransformOperation>(operation))
+            ts << "scale(" << scale->x() << "," << scale->y() << "," << scale->z() << ")";
+        else if (RefPtr skew = dynamicDowncast<WebCore::SkewTransformOperation>(operation))
+            ts << "skew(" << skew->angleX() << "," << skew->angleY() << ")";
+        else if (RefPtr translate = dynamicDowncast<WebCore::TranslateTransformOperation>(operation))
+            ts << "translate(" << translate->x() << "," << translate->y() << "," << translate->z() << ")";
+        else
+            ASSERT_NOT_REACHED();
+        return ts.release();
+    };
+
+    auto convertFloatPoint = [](const WebCore::FloatPoint& point) {
+        Ref object = JSON::Object::create();
+        object->setDouble("x"_s, point.x());
+        object->setDouble("y"_s, point.y());
+        return object;
+    };
+
+    Ref convertedValues = JSON::Object::create();
+    for (auto property : properties) {
+        auto propertyName = toStringForTesting(property);
+        switch (property) {
+        case WebCore::AcceleratedEffectProperty::Opacity:
+            convertedValues->setDouble(propertyName, values.opacity.value);
+            break;
+        case WebCore::AcceleratedEffectProperty::Rotate: {
+            if (RefPtr rotate = dynamicDowncast<WebCore::RotateTransformOperation>(values.rotate)) {
+                Ref object = JSON::Object::create();
+                object->setDouble("x"_s, rotate->x());
+                object->setDouble("y"_s, rotate->y());
+                object->setDouble("z"_s, rotate->z());
+                object->setDouble("angle"_s, rotate->angle());
+                convertedValues->setObject(propertyName, WTFMove(object));
+            } else
+                convertedValues->setValue(propertyName, JSON::Value::null());
+            break;
+        }
+        case WebCore::AcceleratedEffectProperty::Scale: {
+            if (RefPtr scale = downcast<WebCore::ScaleTransformOperation>(values.scale)) {
+                Ref object = JSON::Object::create();
+                object->setDouble("x"_s, scale->x());
+                object->setDouble("y"_s, scale->y());
+                object->setDouble("z"_s, scale->z());
+                convertedValues->setObject(propertyName, WTFMove(object));
+            } else
+                convertedValues->setValue(propertyName, JSON::Value::null());
+            break;
+        }
+        case WebCore::AcceleratedEffectProperty::Transform: {
+            if (values.transform.isEmpty())
+                convertedValues->setValue(propertyName, JSON::Value::null());
+            else {
+                Ref convertedTransform = JSON::Array::create();
+                for (auto& operation : values.transform)
+                    convertedTransform->pushString(convertTransformOperation(operation.get()));
+                convertedValues->setArray(propertyName, WTFMove(convertedTransform));
+            }
+            break;
+        }
+        case WebCore::AcceleratedEffectProperty::Translate: {
+            if (RefPtr translate = downcast<WebCore::TranslateTransformOperation>(values.translate)) {
+                Ref object = JSON::Object::create();
+                object->setDouble("x"_s, translate->x());
+                object->setDouble("y"_s, translate->y());
+                object->setDouble("z"_s, translate->z());
+                convertedValues->setObject(propertyName, WTFMove(object));
+            } else
+                convertedValues->setValue(propertyName, JSON::Value::null());
+            break;
+        }
+        case WebCore::AcceleratedEffectProperty::OffsetDistance:
+            convertedValues->setDouble(propertyName, values.offsetDistance.value);
+            break;
+        case WebCore::AcceleratedEffectProperty::OffsetPosition:
+            WTF::switchOn(values.offsetPosition.value,
+                [&](const WebCore::AcceleratedEffectOffsetPosition::Normal&) { convertedValues->setString(propertyName, "normal"_s); },
+                [&](const WebCore::AcceleratedEffectOffsetPosition::Auto&) { convertedValues->setString(propertyName, "auto"_s); },
+                [&](const WebCore::FloatPoint& point) { convertedValues->setObject(propertyName, convertFloatPoint(point)); }
+            );
+            break;
+        case WebCore::AcceleratedEffectProperty::OffsetAnchor:
+            if (auto anchor = values.offsetAnchor.value)
+                convertedValues->setObject(propertyName, convertFloatPoint(*anchor));
+            else
+                convertedValues->setValue(propertyName, JSON::Value::null());
+            break;
+        case WebCore::AcceleratedEffectProperty::OffsetRotate:
+            if (values.offsetRotate.hasAuto)
+                convertedValues->setString(propertyName, "auto"_s);
+            else
+                convertedValues->setDouble(propertyName, values.offsetRotate.angle);
+            break;
+        case WebCore::AcceleratedEffectProperty::OffsetPath:
+        case WebCore::AcceleratedEffectProperty::Filter:
+        case WebCore::AcceleratedEffectProperty::BackdropFilter:
+            // Not implemented.
+            break;
+        default:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+    return convertedValues;
+}
+
+Ref<JSON::Object> toJSONForTesting(const WebCore::AnimationEffectTiming& timing)
+{
+    auto convertDirection = [](WebCore::PlaybackDirection direction) {
+        switch (direction) {
+        case WebCore::PlaybackDirection::Normal:
+            return "normal"_s;
+        case WebCore::PlaybackDirection::Reverse:
+            return "reverse"_s;
+        case WebCore::PlaybackDirection::Alternate:
+            return "alternate"_s;
+        case WebCore::PlaybackDirection::AlternateReverse:
+            return "alternate-reverse"_s;
+        default:
+            ASSERT_NOT_REACHED();
+            return ""_s;
+        }
+    };
+
+    auto convertFill = [](WebCore::FillMode fillMode) {
+        switch (fillMode) {
+        case WebCore::FillMode::None:
+            return "none"_s;
+        case WebCore::FillMode::Forwards:
+            return "forwards"_s;
+        case WebCore::FillMode::Backwards:
+            return "backwards"_s;
+        case WebCore::FillMode::Both:
+            return "both"_s;
+        case WebCore::FillMode::Auto:
+            return "auto"_s;
+        default:
+            ASSERT_NOT_REACHED();
+            return ""_s;
+        }
+    };
+
+    Ref object = JSON::Object::create();
+    object->setString("direction"_s, convertDirection(timing.direction));
+    object->setValue("easing"_s, toJSONForTesting(timing.timingFunction));
+    object->setString("fill"_s, convertFill(timing.fill));
+    object->setDouble("iterationStart"_s, timing.iterationStart);
+    object->setDouble("iterations"_s, timing.iterations);
+    object->setValue("startDelay"_s, WebKit::toJSONForTesting(timing.startDelay));
+    object->setValue("endDelay"_s, WebKit::toJSONForTesting(timing.endDelay));
+    object->setValue("iterationDuration"_s, WebKit::toJSONForTesting(timing.iterationDuration));
+    object->setValue("activeDuration"_s, WebKit::toJSONForTesting(timing.activeDuration));
+    object->setValue("endTime"_s, WebKit::toJSONForTesting(timing.endTime));
+    return object;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.h
@@ -27,38 +27,26 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-#include <WebCore/ProcessQualified.h>
-#include <WebCore/TimelineIdentifier.h>
-#include <WebCore/WebAnimationTime.h>
 #include <wtf/JSONValues.h>
-#include <wtf/RefCounted.h>
-#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+enum class AcceleratedEffectProperty : uint16_t;
+enum class CompositeOperation : uint8_t;
+struct AcceleratedEffectValues;
+struct AnimationEffectTiming;
+class TimingFunction;
+class WebAnimationTime;
+}
 
 namespace WebKit {
 
-using TimelineID = WebCore::ProcessQualified<WebCore::TimelineIdentifier>;
+String toStringForTesting(WebCore::AcceleratedEffectProperty);
+Ref<JSON::Value> toJSONForTesting(std::optional<WebCore::WebAnimationTime>);
+Ref<JSON::Value> toJSONForTesting(std::optional<WebCore::CompositeOperation>);
+Ref<JSON::Value> toJSONForTesting(const RefPtr<WebCore::TimingFunction>&);
+Ref<JSON::Object> toJSONForTesting(const WebCore::AcceleratedEffectValues&, const OptionSet<WebCore::AcceleratedEffectProperty>&);
+Ref<JSON::Object> toJSONForTesting(const WebCore::AnimationEffectTiming&);
 
-class RemoteAnimationTimeline : public RefCounted<RemoteAnimationTimeline> {
-    WTF_MAKE_TZONE_ALLOCATED(RemoteAnimationTimeline);
-public:
-    virtual ~RemoteAnimationTimeline() = default;
-
-    const WebCore::WebAnimationTime& currentTime() const { return m_currentTime; }
-    const std::optional<WebCore::WebAnimationTime>& duration() const { return m_duration; }
-    const TimelineID& identifier() const { return m_identifier; }
-
-    Ref<JSON::Object> toJSONForTesting() const;
-
-protected:
-    RemoteAnimationTimeline(TimelineID, std::optional<WebCore::WebAnimationTime> duration);
-
-    WebCore::WebAnimationTime m_currentTime;
-
-private:
-    TimelineID m_identifier;
-    std::optional<WebCore::WebAnimationTime> m_duration;
-};
-
-} // namespace WebKit
+}
 
 #endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -47,6 +47,7 @@ struct MainFrameData;
 struct RemoteLayerTreeCommitBundle;
 
 #if ENABLE(THREADED_ANIMATIONS)
+class RemoteAnimationStack;
 class RemoteAnimationTimeline;
 #endif
 
@@ -86,6 +87,7 @@ public:
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
+    RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 #endif
 
     // For testing.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -887,6 +887,12 @@ RefPtr<const RemoteAnimationTimeline> RemoteLayerTreeDrawingAreaProxy::timeline(
         return page->checkedScrollingCoordinatorProxy()->timeline(timelineID);
     return nullptr;
 }
+
+RefPtr<const RemoteAnimationStack> RemoteLayerTreeDrawingAreaProxy::animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier layerID) const
+{
+    return m_remoteLayerTreeHost->animationStackForNodeWithIDForTesting(layerID);
+}
+
 #endif // ENABLE(THREADED_ANIMATIONS)
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -52,6 +52,7 @@ class WebPageProxy;
 struct MainFrameData;
 
 #if ENABLE(THREADED_ANIMATIONS)
+class RemoteAnimationStack;
 class RemoteAnimationTimeline;
 #endif
 
@@ -89,6 +90,7 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
+    RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 #endif
 
     void detachFromDrawingArea();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -531,6 +531,13 @@ RefPtr<const RemoteAnimationTimeline> RemoteLayerTreeHost::timeline(const Timeli
 {
     return protectedDrawingArea()->timeline(timelineID);
 }
+
+RefPtr<const RemoteAnimationStack> RemoteLayerTreeHost::animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier layerID) const
+{
+    if (RefPtr node = nodeForID(layerID))
+        return node->animationStack();
+    return nullptr;
+}
 #endif
 
 void RemoteLayerTreeHost::remotePageProcessDidTerminate(WebCore::ProcessIdentifier processIdentifier)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -316,7 +316,7 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
     if (effects.isEmpty())
         return;
 
-    Ref animationStack = RemoteAnimationStack::create(effects.map([&](const Ref<AcceleratedEffect>& effect) {
+    Ref animationStack = RemoteAnimationStack::create(effects.map([&](const Ref<WebCore::AcceleratedEffect>& effect) {
         TimelineID timelineID { effect->timelineIdentifier(), m_layerID.processIdentifier() };
         RefPtr timeline = host.timeline(timelineID);
         ASSERT(timeline);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -40,10 +40,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
-#if ENABLE(THREADED_ANIMATIONS)
-#include "RemoteAnimationTimeline.h"
-#endif
-
 OBJC_CLASS UIScrollView;
 
 namespace WebCore {
@@ -60,6 +56,11 @@ class RemoteScrollingCoordinatorTransaction;
 class RemoteScrollingTree;
 class WebPageProxy;
 class WebWheelEvent;
+
+#if ENABLE(THREADED_ANIMATIONS)
+class RemoteAnimationStack;
+class RemoteAnimationTimeline;
+#endif
 
 class RemoteScrollingCoordinatorProxy : public CanMakeWeakPtr<RemoteScrollingCoordinatorProxy>, public CanMakeCheckedPtr<RemoteScrollingCoordinatorProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxy);
@@ -147,6 +148,7 @@ public:
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
     virtual void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) { }
     virtual RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const { return nullptr; }
+    virtual RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const { return nullptr; }
 #endif
 
     String scrollingTreeAsText() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -114,6 +114,7 @@ public:
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&);
     void updateAnimations();
+    RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -694,6 +694,16 @@ void RemoteLayerTreeEventDispatcher::updateAnimations()
             m_animationStacks.set(layerID, WTFMove(animationStack));
     }
 }
+
+RefPtr<const RemoteAnimationStack> RemoteLayerTreeEventDispatcher::animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier layerID) const
+{
+    assertIsHeld(m_animationLock);
+
+    auto it = m_animationStacks.find(layerID);
+    if (it != m_animationStacks.end())
+        return it->value.ptr();
+    return nullptr;
+}
 #endif
 
 void RemoteLayerTreeEventDispatcher::windowScreenWillChange()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -79,6 +79,7 @@ private:
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const override;
+    RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const override;
 #else
     void willCommitLayerAndScrollingTrees() override;
     void didCommitLayerAndScrollingTrees() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -328,6 +328,14 @@ RefPtr<const RemoteAnimationTimeline> RemoteScrollingCoordinatorProxyMac::timeli
 {
     return m_eventDispatcher->timeline(timelineID);
 }
+
+RefPtr<const RemoteAnimationStack> RemoteScrollingCoordinatorProxyMac::animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier layerID) const
+{
+    m_eventDispatcher->lockForAnimationChanges();
+    RefPtr animationStack = m_eventDispatcher->animationStackForNodeWithIDForTesting(layerID);
+    m_eventDispatcher->unlockForAnimationChanges();
+    return animationStack;
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1553,6 +1553,7 @@
 		6D4DF20C2D824242001F964C /* ScreenTimeWebsiteDataSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D77DBC22D80D3D6008ED0DD /* ScreenTimeWebsiteDataSupport.h */; };
 		6D9A666E2A27FAE300BD68A0 /* WebTouchEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4001002527D73C00E91DA7 /* WebTouchEvent.h */; };
 		6EE849C81368D9390038D481 /* WKInspectorPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EE849C61368D92D0038D481 /* WKInspectorPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7114EA442EBCB3FD00190912 /* RemoteAnimationUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 7114EA422EBCB35600190912 /* RemoteAnimationUtilities.h */; };
 		711725A9228D564300018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 711725A8228D563A00018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h */; };
 		7121A3CF2B73728B00C8F7A4 /* CAFrameRateRangeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 7121A3CE2B73727B00C8F7A4 /* CAFrameRateRangeUtilities.h */; };
 		7134A3DA2603B92500624BD3 /* WKModelInteractionGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7134A3D92603B80E00624BD3 /* WKModelInteractionGestureRecognizer.h */; };
@@ -6682,6 +6683,8 @@
 		6D77DBC32D80D3EC008ED0DD /* ScreenTimeWebsiteDataSupport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScreenTimeWebsiteDataSupport.mm; sourceTree = "<group>"; };
 		6D8A91A511F0EFD100DD01FE /* com.apple.WebProcess.sb.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = com.apple.WebProcess.sb.in; path = WebProcess/com.apple.WebProcess.sb.in; sourceTree = "<group>"; };
 		6EE849C61368D92D0038D481 /* WKInspectorPrivateMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKInspectorPrivateMac.h; path = mac/WKInspectorPrivateMac.h; sourceTree = "<group>"; };
+		7114EA422EBCB35600190912 /* RemoteAnimationUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAnimationUtilities.h; sourceTree = "<group>"; };
+		7114EA432EBCB35600190912 /* RemoteAnimationUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAnimationUtilities.cpp; sourceTree = "<group>"; };
 		711725A8228D563A00018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteLegacyOverflowScrollingTouchPolicy.h; sourceTree = "<group>"; };
 		7121A3CE2B73727B00C8F7A4 /* CAFrameRateRangeUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CAFrameRateRangeUtilities.h; sourceTree = "<group>"; };
 		7134A3D82603B80E00624BD3 /* WKModelInteractionGestureRecognizer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKModelInteractionGestureRecognizer.mm; sourceTree = "<group>"; };
@@ -11438,6 +11441,8 @@
 				71371D1F2B1F89C10092C32D /* RemoteAnimationStack.mm */,
 				71C9EC9E2CF9F93600B8AF06 /* RemoteAnimationTimeline.cpp */,
 				71C9EC9D2CF9F93600B8AF06 /* RemoteAnimationTimeline.h */,
+				7114EA432EBCB35600190912 /* RemoteAnimationUtilities.cpp */,
+				7114EA422EBCB35600190912 /* RemoteAnimationUtilities.h */,
 				1AB16AE01648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.h */,
 				0FF24A2F1879E4FE003ABF0C /* RemoteLayerTreeDrawingAreaProxy.messages.in */,
 				1AB16ADF1648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.mm */,
@@ -18028,6 +18033,7 @@
 				71F62F752D076DEE00B591D2 /* RemoteAnimation.h in Headers */,
 				71E29A342B20610C0010F3C9 /* RemoteAnimationStack.h in Headers */,
 				71C9EC9F2CF9FB6400B8AF06 /* RemoteAnimationTimeline.h in Headers */,
+				7114EA442EBCB3FD00190912 /* RemoteAnimationUtilities.h in Headers */,
 				9B1229D223FF2BCC008CA751 /* RemoteAudioDestinationIdentifier.h in Headers */,
 				9B1229CD23FF25F2008CA751 /* RemoteAudioDestinationManager.h in Headers */,
 				9B5BEC2A240101580070C6EF /* RemoteAudioDestinationProxy.h in Headers */,

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -459,4 +459,8 @@ interface UIScriptController {
 
     readonly attribute boolean didCallEnsurePositionInformationIsUpToDateSinceLastCheck;
     undefined clearEnsurePositionInformationIsUpToDateTracking();
+
+#if defined(ENABLE_THREADED_ANIMATIONS) && ENABLE_THREADED_ANIMATIONS
+    DOMString animationStackForLayerWithID(unsigned long long layerID);
+#endif
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -468,6 +468,11 @@ public:
     virtual bool didCallEnsurePositionInformationIsUpToDateSinceLastCheck() const { notImplemented(); return false; }
     virtual void clearEnsurePositionInformationIsUpToDateTracking() { notImplemented(); }
 
+#if ENABLE(THREADED_ANIMATIONS)
+    // Animations
+    virtual JSRetainPtr<JSStringRef> animationStackForLayerWithID(uint64_t) const { notImplemented(); return nullptr; }
+#endif
+
 protected:
     explicit UIScriptController(UIScriptContext&);
     

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -103,6 +103,10 @@ private:
     void cancelFixedColorExtensionFadeAnimations() const final;
 
     void setObscuredInsets(double top, double right, double bottom, double left) final;
+
+#if ENABLE(THREADED_ANIMATIONS)
+    JSRetainPtr<JSStringRef> animationStackForLayerWithID(uint64_t layerID) const final;
+#endif
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -551,4 +551,11 @@ void UIScriptControllerCocoa::setObscuredInsets(double top, double right, double
     [webView() setObscuredContentInsets:insets];
 }
 
+#if ENABLE(THREADED_ANIMATIONS)
+JSRetainPtr<JSStringRef> UIScriptControllerCocoa::animationStackForLayerWithID(uint64_t layerID) const
+{
+    return adopt(JSStringCreateWithCFString((CFStringRef) [webView() _animationStackForLayerWithID:layerID]));
+}
+#endif
+
 } // namespace WTR


### PR DESCRIPTION
#### 8740ea8994be7fb3f7b14502e4ba9b61ef9479f6
<pre>
[threaded-animations] add testing support for remote layer tree animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=302077">https://bugs.webkit.org/show_bug.cgi?id=302077</a>
<a href="https://rdar.apple.com/164164711">rdar://164164711</a>

Reviewed by Simon Fraser.

In order to be able to test the state of animations associated with remote layer
tree nodes, we add a new `UIScriptController.animationStackForLayerWithID()` function
which we wrap as `UIHelper.remoteAnimationStackForElement()` in JavaScript.

To that end we add a suite of methods to convert objects related to remote layer
tree animations to JSON representations encoded as a string for transport.

Note that we haven&apos;t yet added support for producing JSON representations for filters
and offset paths. Those will be implemented as necessary as further tests are developed.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.remoteAnimationStackForElement):
* LayoutTests/webanimations/threaded-animations/scroll-driven-animations-expected.txt:
* LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html:
* Source/WebCore/platform/animation/TimingFunction.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _animationStackForLayerWithID:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp:
(WebKit::RemoteAnimation::toJSONForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::toJSONForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp:
(WebKit::RemoteAnimationTimeline::RemoteAnimationTimeline):
(WebKit::RemoteAnimationTimeline::toJSONForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.cpp: Added.
(WebKit::toStringForTesting):
(WebKit::toJSONForTesting):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.h: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationStackForNodeWithIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::animationStackForNodeWithIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::animationStackForNodeWithIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::animationStackForNodeWithIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::animationStackForNodeWithIDForTesting const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::animationStackForLayerWithID const):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::animationStackForLayerWithID const):

Canonical link: <a href="https://commits.webkit.org/302673@main">https://commits.webkit.org/302673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93513a2d0380f4f26f570012f4fa97a85a2bf2c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81335 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2f0e3d6f-f813-4907-a5a8-5a7985bfe6ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/84a80255-0874-4606-9095-a16e1e64950e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132799 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79606 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b4d4dfe8-0246-4dbc-a4ad-2fa090097f46) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34431 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80515 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139724 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1907 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107306 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1543 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31129 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54709 "Hash 93513a2d for PR 53521 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20256 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65349 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->