### PR TITLE
[JSC] Make B3::IsLegalOffset actually enforce signed 32-bit types

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerInt64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.cpp
@@ -513,9 +513,9 @@ private:
                     highArgs.append(childParts.second);
 
                     if (rep.isStack())
-                        rep = B3::ValueRep::stack(checkedSum<intptr_t>(rep.offsetFromFP(), static_cast<intptr_t>(bytesForWidth(Width32))));
+                        rep = B3::ValueRep::stack(checkedSum<intptr_t>(rep.offsetFromFP(), static_cast<intptr_t>(bytesForWidth(Width32))).value());
                     else if (rep.isStackArgument())
-                        rep = B3::ValueRep::stackArgument(checkedSum<intptr_t>(rep.offsetFromSP(), static_cast<intptr_t>(bytesForWidth(Width32))));
+                        rep = B3::ValueRep::stackArgument(checkedSum<intptr_t>(rep.offsetFromSP(), static_cast<intptr_t>(bytesForWidth(Width32))).value());
 
                     highReps.append(rep);
                 } else
@@ -580,9 +580,9 @@ private:
                     || rep.kind() == ValueRep::SomeLateRegister
                     || rep.isAny());
                 if (rep.isStack())
-                    rep = B3::ValueRep::stack(checkedSum<intptr_t>(rep.offsetFromFP(), static_cast<intptr_t>(bytesForWidth(Width32))));
+                    rep = B3::ValueRep::stack(checkedSum<intptr_t>(rep.offsetFromFP(), static_cast<intptr_t>(bytesForWidth(Width32))).value());
                 else if (rep.isStackArgument())
-                    rep = B3::ValueRep::stackArgument(checkedSum<intptr_t>(rep.offsetFromSP(), static_cast<intptr_t>(bytesForWidth(Width32))));
+                    rep = B3::ValueRep::stackArgument(checkedSum<intptr_t>(rep.offsetFromSP(), static_cast<intptr_t>(bytesForWidth(Width32))).value());
                 patchpoint->resultConstraints.append(rep);
                 setMapping(m_value, valueLo(patchpoint, m_index + 1), valueHi(patchpoint, m_index + 1));
                 valueReplaced();

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -62,7 +62,7 @@ class Procedure;
 // isLegalOffset runtime method used to determine value legality at runtime. This is exposed to users
 // of B3 to force them to reason about the target's offset.
 template<typename Int>
-concept IsLegalOffset = std::integral<Int>;
+concept IsLegalOffset = std::signed_integral<Int> && sizeof(Int) <= sizeof(int32_t);
 
 class JS_EXPORT_PRIVATE Value {
     WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(Value);

--- a/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
+++ b/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
@@ -241,14 +241,14 @@ static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& 
             int64_t targetOffsetFromFP = targetOffset - code.frameSize();
 
             if (isValidOffset(instOffsetFromFP) && targetOffsetFromFP == (instOffsetFromFP + bytesForWidth(instWidth))) {
-                Inst newInst(pairOpcode, target.origin, inst.args[0], target.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), instOffsetFromFP));
+                Inst newInst(pairOpcode, target.origin, inst.args[0], target.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), static_cast<int32_t>(instOffsetFromFP)));
                 logFound(newInst);
                 target = newInst;
                 return true;
             }
 
             if (isValidOffset(targetOffsetFromFP) && (targetOffsetFromFP + bytesForWidth(instWidth)) == instOffsetFromFP) {
-                Inst newInst(pairOpcode, target.origin, target.args[0], inst.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), targetOffsetFromFP));
+                Inst newInst(pairOpcode, target.origin, target.args[0], inst.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), static_cast<int32_t>(targetOffsetFromFP)));
                 logFound(newInst);
                 target = newInst;
                 return true;

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -180,10 +180,10 @@ void testShuffleSimpleSwap()
     int32_t things[4];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -215,11 +215,11 @@ void testShuffleSimpleShift()
     int32_t things[5];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -261,14 +261,14 @@ void testShuffleLongShift()
     int32_t things[8];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, 6 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, 7 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, static_cast<int32_t>(6 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, static_cast<int32_t>(7 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -313,14 +313,14 @@ void testShuffleLongShiftBackwards()
     int32_t things[8];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, 6 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, 7 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, static_cast<int32_t>(6 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, static_cast<int32_t>(7 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -357,10 +357,10 @@ void testShuffleSimpleRotate()
     int32_t things[4];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -393,10 +393,10 @@ void testShuffleSimpleBroadcast()
     int32_t things[4];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -432,14 +432,14 @@ void testShuffleBroadcastAllRegs()
 
     StackSlot* slot = code.addStackSlot(sizeof(int32_t) * regs.size(), StackSlotKind::Locked);
     for (unsigned i = 0; i < regs.size(); ++i)
-        root->append(Move32, nullptr, Tmp(regs[i]), Arg::stack(slot, i * sizeof(int32_t)));
+        root->append(Move32, nullptr, Tmp(regs[i]), Arg::stack(slot, static_cast<int32_t>(i * sizeof(int32_t))));
 
     Vector<int32_t> things(regs.size(), 666);
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), base);
     for (unsigned i = 0; i < regs.size(); ++i) {
-        root->append(Move32, nullptr, Arg::stack(slot, i * sizeof(int32_t)), Tmp(GPRInfo::regT0));
-        root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, i * sizeof(int32_t)));
+        root->append(Move32, nullptr, Arg::stack(slot, static_cast<int32_t>(i * sizeof(int32_t))), Tmp(GPRInfo::regT0));
+        root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(i * sizeof(int32_t))));
     }
     
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
@@ -478,14 +478,14 @@ void testShuffleTreeShift()
     int32_t things[8];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, 6 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, 7 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, static_cast<int32_t>(6 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, static_cast<int32_t>(7 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -530,14 +530,14 @@ void testShuffleTreeShiftBackward()
     int32_t things[8];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, 6 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, 7 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, static_cast<int32_t>(6 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, static_cast<int32_t>(7 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -585,14 +585,14 @@ void testShuffleTreeShiftOtherBackward()
     int32_t things[8];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, 6 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, 7 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, static_cast<int32_t>(6 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, static_cast<int32_t>(7 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -632,12 +632,12 @@ void testShuffleMultipleShifts()
     int32_t things[6];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -677,12 +677,12 @@ void testShuffleRotateWithFringe()
     int32_t things[6];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -722,12 +722,12 @@ void testShuffleRotateWithFringeInWeirdOrder()
     int32_t things[6];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -767,12 +767,12 @@ void testShuffleRotateWithLongFringe()
     int32_t things[6];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -812,12 +812,12 @@ void testShuffleMultipleRotates()
     int32_t things[6];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -856,12 +856,12 @@ void testShuffleShiftAndRotate()
     int32_t things[6];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -907,14 +907,14 @@ void testRotateFringeClobber()
         Tmp(GPRInfo::regT2), Tmp(GPRInfo::regT6), Arg::widthArg(Width32),
         Tmp(GPRInfo::regT3), Tmp(GPRInfo::regT7), Arg::widthArg(Width32));
 
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, 5 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, 6 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, 7 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT5), Arg::addr(base, static_cast<int32_t>(5 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT6), Arg::addr(base, static_cast<int32_t>(6 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT7), Arg::addr(base, static_cast<int32_t>(7 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -965,14 +965,14 @@ void testShuffleShiftAllRegs()
 
     StackSlot* slot = code.addStackSlot(sizeof(int32_t) * regs.size(), StackSlotKind::Locked);
     for (unsigned i = 0; i < regs.size(); ++i)
-        root->append(Move32, nullptr, Tmp(regs[i]), Arg::stack(slot, i * sizeof(int32_t)));
+        root->append(Move32, nullptr, Tmp(regs[i]), Arg::stack(slot, static_cast<int32_t>(i * sizeof(int32_t))));
 
     Vector<int32_t> things(regs.size(), 666);
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), base);
     for (unsigned i = 0; i < regs.size(); ++i) {
-        root->append(Move32, nullptr, Arg::stack(slot, i * sizeof(int32_t)), Tmp(GPRInfo::regT0));
-        root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, i * sizeof(int32_t)));
+        root->append(Move32, nullptr, Arg::stack(slot, static_cast<int32_t>(i * sizeof(int32_t))), Tmp(GPRInfo::regT0));
+        root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(i * sizeof(int32_t))));
     }
     
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
@@ -1002,14 +1002,14 @@ void testShuffleRotateAllRegs()
 
     StackSlot* slot = code.addStackSlot(sizeof(int32_t) * regs.size(), StackSlotKind::Locked);
     for (unsigned i = 0; i < regs.size(); ++i)
-        root->append(Move32, nullptr, Tmp(regs[i]), Arg::stack(slot, i * sizeof(int32_t)));
+        root->append(Move32, nullptr, Tmp(regs[i]), Arg::stack(slot, static_cast<int32_t>(i * sizeof(int32_t))));
 
     Vector<int32_t> things(regs.size(), 666);
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), base);
     for (unsigned i = 0; i < regs.size(); ++i) {
-        root->append(Move32, nullptr, Arg::stack(slot, i * sizeof(int32_t)), Tmp(GPRInfo::regT0));
-        root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, i * sizeof(int32_t)));
+        root->append(Move32, nullptr, Arg::stack(slot, static_cast<int32_t>(i * sizeof(int32_t))), Tmp(GPRInfo::regT0));
+        root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(i * sizeof(int32_t))));
     }
     
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
@@ -1042,10 +1042,10 @@ void testShuffleSimpleSwap64()
     int64_t things[4];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int64_t)));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int64_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1078,11 +1078,11 @@ void testShuffleSimpleShift64()
     int64_t things[5];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int64_t)));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int64_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1115,10 +1115,10 @@ void testShuffleSwapMixedWidth()
     int64_t things[4];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int64_t)));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int64_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1151,11 +1151,11 @@ void testShuffleShiftMixedWidth()
     int64_t things[5];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, 3 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, 4 * sizeof(int64_t)));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT4), Arg::addr(base, static_cast<int32_t>(4 * sizeof(int64_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1188,14 +1188,14 @@ void testShuffleShiftMemory()
     root->append(
         Shuffle, nullptr,
         Tmp(GPRInfo::regT0), Tmp(GPRInfo::regT1), Arg::widthArg(Width32),
-        Arg::addr(Tmp(GPRInfo::regT2), 0 * sizeof(int32_t)),
-        Arg::addr(Tmp(GPRInfo::regT2), 1 * sizeof(int32_t)), Arg::widthArg(Width32));
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(0 * sizeof(int32_t))),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(1 * sizeof(int32_t))), Arg::widthArg(Width32));
 
     int32_t things[2];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1228,21 +1228,21 @@ void testShuffleShiftMemoryLong()
         
         Tmp(GPRInfo::regT0), Tmp(GPRInfo::regT1), Arg::widthArg(Width32),
         
-        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT3), 0 * sizeof(int32_t)),
+        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT3), static_cast<int32_t>(0 * sizeof(int32_t))),
         Arg::widthArg(Width32),
         
-        Arg::addr(Tmp(GPRInfo::regT3), 0 * sizeof(int32_t)),
-        Arg::addr(Tmp(GPRInfo::regT3), 1 * sizeof(int32_t)), Arg::widthArg(Width32),
+        Arg::addr(Tmp(GPRInfo::regT3), static_cast<int32_t>(0 * sizeof(int32_t))),
+        Arg::addr(Tmp(GPRInfo::regT3), static_cast<int32_t>(1 * sizeof(int32_t))), Arg::widthArg(Width32),
 
-        Arg::addr(Tmp(GPRInfo::regT3), 1 * sizeof(int32_t)), Tmp(GPRInfo::regT2),
+        Arg::addr(Tmp(GPRInfo::regT3), static_cast<int32_t>(1 * sizeof(int32_t))), Tmp(GPRInfo::regT2),
         Arg::widthArg(Width32));
 
     int32_t things[3];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, 2 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1276,13 +1276,13 @@ void testShuffleShiftMemoryAllRegs()
     Inst& shuffle = root->append(
         Shuffle, nullptr,
         
-        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int32_t)),
+        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int32_t))),
         Arg::widthArg(Width32),
         
-        Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int32_t)),
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int32_t)), Arg::widthArg(Width32),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int32_t))),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int32_t))), Arg::widthArg(Width32),
 
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int32_t)), Tmp(regs[1]),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int32_t))), Tmp(regs[1]),
         Arg::widthArg(Width32));
 
     for (unsigned i = 2; i < regs.size(); ++i)
@@ -1292,7 +1292,7 @@ void testShuffleShiftMemoryAllRegs()
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
     for (unsigned i = 0; i < regs.size(); ++i) {
         root->append(
-            Move32, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), i * sizeof(int32_t)));
+            Move32, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(i * sizeof(int32_t))));
     }
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
@@ -1328,13 +1328,13 @@ void testShuffleShiftMemoryAllRegs64()
     Inst& shuffle = root->append(
         Shuffle, nullptr,
         
-        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
+        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
         Arg::widthArg(Width64),
         
-        Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Arg::widthArg(Width64),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
 
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Tmp(regs[1]),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
         Arg::widthArg(Width64));
 
     for (unsigned i = 2; i < regs.size(); ++i)
@@ -1344,7 +1344,7 @@ void testShuffleShiftMemoryAllRegs64()
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
     for (unsigned i = 0; i < regs.size(); ++i) {
         root->append(
-            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), i * sizeof(int64_t)));
+            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(i * sizeof(int64_t))));
     }
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
@@ -1389,13 +1389,13 @@ void testShuffleShiftMemoryAllRegsMixedWidth()
     Inst& shuffle = root->append(
         Shuffle, nullptr,
         
-        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
+        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
         Arg::widthArg(Width32),
         
-        Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Arg::widthArg(Width64),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
 
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Tmp(regs[1]),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
         Arg::widthArg(Width32));
 
     for (unsigned i = 2; i < regs.size(); ++i) {
@@ -1408,7 +1408,7 @@ void testShuffleShiftMemoryAllRegsMixedWidth()
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
     for (unsigned i = 0; i < regs.size(); ++i) {
         root->append(
-            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), i * sizeof(int64_t)));
+            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(i * sizeof(int64_t))));
     }
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
@@ -1445,20 +1445,20 @@ void testShuffleRotateMemory()
         
         Tmp(GPRInfo::regT0), Tmp(GPRInfo::regT1), Arg::widthArg(Width32),
 
-        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT2), 0 * sizeof(int32_t)),
+        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(0 * sizeof(int32_t))),
         Arg::widthArg(Width32),
         
-        Arg::addr(Tmp(GPRInfo::regT2), 0 * sizeof(int32_t)),
-        Arg::addr(Tmp(GPRInfo::regT2), 1 * sizeof(int32_t)), Arg::widthArg(Width32),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(0 * sizeof(int32_t))),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(1 * sizeof(int32_t))), Arg::widthArg(Width32),
 
-        Arg::addr(Tmp(GPRInfo::regT2), 1 * sizeof(int32_t)), Tmp(GPRInfo::regT0),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(1 * sizeof(int32_t))), Tmp(GPRInfo::regT0),
         Arg::widthArg(Width32));
 
     int32_t things[2];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int32_t)));
-    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int32_t)));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int32_t))));
+    root->append(Move32, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1492,20 +1492,20 @@ void testShuffleRotateMemory64()
         
         Tmp(GPRInfo::regT0), Tmp(GPRInfo::regT1), Arg::widthArg(Width64),
 
-        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT2), 0 * sizeof(int64_t)),
+        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(0 * sizeof(int64_t))),
         Arg::widthArg(Width64),
         
-        Arg::addr(Tmp(GPRInfo::regT2), 0 * sizeof(int64_t)),
-        Arg::addr(Tmp(GPRInfo::regT2), 1 * sizeof(int64_t)), Arg::widthArg(Width64),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(0 * sizeof(int64_t))),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
 
-        Arg::addr(Tmp(GPRInfo::regT2), 1 * sizeof(int64_t)), Tmp(GPRInfo::regT0),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(GPRInfo::regT0),
         Arg::widthArg(Width64));
 
     int64_t things[2];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int64_t)));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int64_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1537,20 +1537,20 @@ void testShuffleRotateMemoryMixedWidth()
         
         Tmp(GPRInfo::regT0), Tmp(GPRInfo::regT1), Arg::widthArg(Width32),
 
-        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT2), 0 * sizeof(int64_t)),
+        Tmp(GPRInfo::regT1), Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(0 * sizeof(int64_t))),
         Arg::widthArg(Width64),
         
-        Arg::addr(Tmp(GPRInfo::regT2), 0 * sizeof(int64_t)),
-        Arg::addr(Tmp(GPRInfo::regT2), 1 * sizeof(int64_t)), Arg::widthArg(Width32),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(0 * sizeof(int64_t))),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width32),
 
-        Arg::addr(Tmp(GPRInfo::regT2), 1 * sizeof(int64_t)), Tmp(GPRInfo::regT0),
+        Arg::addr(Tmp(GPRInfo::regT2), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(GPRInfo::regT0),
         Arg::widthArg(Width64));
 
     int64_t things[2];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, 0 * sizeof(int64_t)));
-    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, 1 * sizeof(int64_t)));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(int64_t))));
+    root->append(Move, nullptr, Tmp(GPRInfo::regT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(int64_t))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1583,13 +1583,13 @@ void testShuffleRotateMemoryAllRegs64()
     Inst& shuffle = root->append(
         Shuffle, nullptr,
         
-        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
+        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
         Arg::widthArg(Width64),
         
-        Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Arg::widthArg(Width64),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
 
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Tmp(regs[1]),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
         Arg::widthArg(Width64),
 
         regs.last(), regs[0], Arg::widthArg(Width64));
@@ -1601,7 +1601,7 @@ void testShuffleRotateMemoryAllRegs64()
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
     for (unsigned i = 0; i < regs.size(); ++i) {
         root->append(
-            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), i * sizeof(int64_t)));
+            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(i * sizeof(int64_t))));
     }
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
@@ -1635,13 +1635,13 @@ void testShuffleRotateMemoryAllRegsMixedWidth()
     Inst& shuffle = root->append(
         Shuffle, nullptr,
         
-        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
+        Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
         Arg::widthArg(Width32),
         
-        Arg::addr(Tmp(GPRInfo::regT0), 0 * sizeof(int64_t)),
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Arg::widthArg(Width64),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
 
-        Arg::addr(Tmp(GPRInfo::regT0), 1 * sizeof(int64_t)), Tmp(regs[1]),
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
         Arg::widthArg(Width32),
 
         regs.last(), regs[0], Arg::widthArg(Width32));
@@ -1653,7 +1653,7 @@ void testShuffleRotateMemoryAllRegsMixedWidth()
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
     for (unsigned i = 0; i < regs.size(); ++i) {
         root->append(
-            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), i * sizeof(int64_t)));
+            Move, nullptr, Tmp(regs[i]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(i * sizeof(int64_t))));
     }
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
@@ -1688,10 +1688,10 @@ void testShuffleSwapDouble()
     double things[4];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT0), Arg::addr(base, 0 * sizeof(double)));
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT1), Arg::addr(base, 1 * sizeof(double)));
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT2), Arg::addr(base, 2 * sizeof(double)));
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT3), Arg::addr(base, 3 * sizeof(double)));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(double))));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(double))));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(double))));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(double))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1722,10 +1722,10 @@ void testShuffleShiftDouble()
     double things[4];
     Tmp base = code.newTmp(GP);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT0), Arg::addr(base, 0 * sizeof(double)));
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT1), Arg::addr(base, 1 * sizeof(double)));
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT2), Arg::addr(base, 2 * sizeof(double)));
-    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT3), Arg::addr(base, 3 * sizeof(double)));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT0), Arg::addr(base, static_cast<int32_t>(0 * sizeof(double))));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT1), Arg::addr(base, static_cast<int32_t>(1 * sizeof(double))));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT2), Arg::addr(base, static_cast<int32_t>(2 * sizeof(double))));
+    root->append(MoveDouble, nullptr, Tmp(FPRInfo::fpRegT3), Arg::addr(base, static_cast<int32_t>(3 * sizeof(double))));
     root->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -1964,7 +1964,7 @@ void testInvalidateCachedTempRegisters()
     root->append(Patch, patchpoint1, Arg::special(patchpointSpecial));
 
     // Load things[1] -> x17, trashing dataMemoryRegister.
-    root->append(Move32, nullptr, Arg::addr(base, 1 * sizeof(int32_t)), Tmp(ARM64Registers::x17));
+    root->append(Move32, nullptr, Arg::addr(base, static_cast<int32_t>(1 * sizeof(int32_t))), Tmp(ARM64Registers::x17));
     root->append(Add32, nullptr, Tmp(tmp), Tmp(ARM64Registers::x17), Tmp(GPRInfo::returnValueGPR));
 
     // In Patchpoint, Load things[2] -> tmp. This should not reuse the prior contents of x17.
@@ -2010,7 +2010,7 @@ void testInvalidateCachedTempRegisters()
 
     root->append(Move, nullptr, Arg::bigImm(0xdead), Tmp(tmp));
     root->append(Xor32, nullptr, Tmp(tmp), Tmp(GPRInfo::returnValueGPR));
-    root->append(Move32, nullptr, Arg::addr(base, 3 * sizeof(int32_t)), Tmp(tmp));
+    root->append(Move32, nullptr, Arg::addr(base, static_cast<int32_t>(3 * sizeof(int32_t))), Tmp(tmp));
     root->append(Add32, nullptr, Tmp(tmp), Tmp(GPRInfo::returnValueGPR), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
@@ -2134,7 +2134,7 @@ void testLea64()
     BasicBlock* root = code.addBlock();
 
     int64_t a = 0x11223344;
-    int64_t b = 1 << 13;
+    int32_t b = 1 << 13;
 
     root->append(Lea64, nullptr, Arg::addr(Tmp(GPRInfo::argumentGPR0), b), Tmp(GPRInfo::returnValueGPR));
     root->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));

--- a/Source/JavaScriptCore/b3/testb3_5.cpp
+++ b/Source/JavaScriptCore/b3/testb3_5.cpp
@@ -146,7 +146,7 @@ void testPatchpointWithStackArgumentResult()
         [&] (CCallHelpers& jit, const StackmapGenerationParams& params) {
             AllowMacroScratchRegisterUsage allowScratch(jit);
             CHECK_EQ(params.size(), 3u);
-            CHECK_EQ(params[0], ValueRep::stack(-static_cast<intptr_t>(proc.frameSize())));
+            CHECK_EQ(params[0], ValueRep::stack(-static_cast<int32_t>(proc.frameSize())));
             CHECK(params[1].isGPR());
             CHECK(params[2].isGPR());
             jit.add32(params[1].gpr(), params[2].gpr(), jit.scratchRegister());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -2197,7 +2197,7 @@ void testVectorXorOrAllOnesToVectorAndXor()
     Value* address = arguments[0];
     Value* constant = root->appendNew<Const128Value>(proc, Origin(), vectorAllOnes());
     Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
-    Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, sizeof(v128_t));
+    Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
     Value* result0 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input0, constant);
     Value* result1 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input1, constant);
     Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, result0, result1);
@@ -2226,7 +2226,7 @@ void testVectorXorAndAllOnesToVectorOrXor()
     Value* address = arguments[0];
     Value* constant = root->appendNew<Const128Value>(proc, Origin(), vectorAllOnes());
     Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
-    Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, sizeof(v128_t));
+    Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
     Value* result0 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input0, constant);
     Value* result1 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input1, constant);
     Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, result0, result1);
@@ -2681,7 +2681,7 @@ void testVectorMulHigh()
 
         Value* address = arguments[0];
         Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
-        Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, sizeof(v128_t));
+        Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
         Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorMulHigh, B3::V128, lane, signMode, input0, input1);
         root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
         root->appendNewControlValue(proc, Return, Origin());
@@ -2736,7 +2736,7 @@ void testVectorMulLow()
 
         Value* address = arguments[0];
         Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
-        Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, sizeof(v128_t));
+        Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
         Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorMulLow, B3::V128, lane, signMode, input0, input1);
         root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
         root->appendNewControlValue(proc, Return, Origin());

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12646,7 +12646,7 @@ IGNORE_CLANG_WARNINGS_END
         arguments.append(ConstrainedValue(jsCallee, ValueRep::reg(BaselineJITRegisters::Call::calleeGPR)));
 
         auto addArgument = [&] (LValue value, VirtualRegister reg, int offset) {
-            intptr_t offsetFromSP =
+            Value::OffsetType offsetFromSP =
                 (reg.offset() - CallerFrameAndPC::sizeInRegisters) * sizeof(EncodedJSValue) + offset;
             arguments.append(ConstrainedValue(value, ValueRep::stackArgument(offsetFromSP)));
         };
@@ -12728,7 +12728,7 @@ IGNORE_CLANG_WARNINGS_END
         arguments.append(ConstrainedValue(jsCallee, ValueRep::SomeRegister));
         if (!isTail) {
             auto addArgument = [&] (LValue value, VirtualRegister reg, int offset) {
-                intptr_t offsetFromSP =
+                Value::OffsetType offsetFromSP =
                     (reg.offset() - CallerFrameAndPC::sizeInRegisters) * sizeof(EncodedJSValue) + offset;
                 arguments.append(ConstrainedValue(value, ValueRep::stackArgument(offsetFromSP)));
             };
@@ -13655,7 +13655,7 @@ IGNORE_CLANG_WARNINGS_END
         arguments.append(ConstrainedValue(thisValue, ValueRep::reg(GPRInfo::regT3)));
 
         auto addArgument = [&] (LValue value, VirtualRegister reg, int offset) {
-            intptr_t offsetFromSP =
+            Value::OffsetType offsetFromSP =
                 (reg.offset() - CallerFrameAndPC::sizeInRegisters) * sizeof(EncodedJSValue) + offset;
             arguments.append(ConstrainedValue(value, ValueRep::stackArgument(offsetFromSP)));
         };
@@ -13752,7 +13752,7 @@ IGNORE_CLANG_WARNINGS_END
             switch (type.kind) {
             case Wasm::TypeKind::I32:
                 if (isStack)
-                    arguments.append(ConstrainedValue(lowInt32(m_graph.varArgChild(node, 2 + i)), ValueRep::stackArgument(wasmCallInfo.params[i].location.offsetFromSP())));
+                    arguments.append(ConstrainedValue(lowInt32(m_graph.varArgChild(node, 2 + i)), ValueRep::stackArgument(safeCast<int32_t>(wasmCallInfo.params[i].location.offsetFromSP()))));
                 else
                     arguments.append(ConstrainedValue(m_out.zeroExtPtr(lowInt32(m_graph.varArgChild(node, 2 + i))), ValueRep::reg(wasmCallInfo.params[i].location.jsr().payloadGPR())));
                 break;
@@ -13770,7 +13770,7 @@ IGNORE_CLANG_WARNINGS_END
                         jit.toBigInt64(params[1].gpr(), params[0].gpr(), params.gpScratch(0), params.gpScratch(1));
                     });
                 if (isStack)
-                    arguments.append(ConstrainedValue(patchpoint, ValueRep::stackArgument(wasmCallInfo.params[i].location.offsetFromSP())));
+                    arguments.append(ConstrainedValue(patchpoint, ValueRep::stackArgument(safeCast<Value::OffsetType>(wasmCallInfo.params[i].location.offsetFromSP()))));
                 else
                     arguments.append(ConstrainedValue(patchpoint, ValueRep::reg(wasmCallInfo.params[i].location.jsr().payloadGPR())));
                 break;
@@ -13781,19 +13781,19 @@ IGNORE_CLANG_WARNINGS_END
             case Wasm::TypeKind::Externref:
                 ASSERT(Wasm::isExternref(type) && type.isNullable());
                 if (isStack)
-                    arguments.append(ConstrainedValue(lowJSValue(m_graph.varArgChild(node, 2 + i)), ValueRep::stackArgument(wasmCallInfo.params[i].location.offsetFromSP())));
+                    arguments.append(ConstrainedValue(lowJSValue(m_graph.varArgChild(node, 2 + i)), ValueRep::stackArgument(safeCast<Value::OffsetType>(wasmCallInfo.params[i].location.offsetFromSP()))));
                 else
                     arguments.append(ConstrainedValue(lowJSValue(m_graph.varArgChild(node, 2 + i)), ValueRep::reg(wasmCallInfo.params[i].location.jsr().payloadGPR())));
                 break;
             case Wasm::TypeKind::F32:
                 if (isStack)
-                    arguments.append(ConstrainedValue(m_out.doubleToFloat(lowDouble(m_graph.varArgChild(node, 2 + i))), ValueRep::stackArgument(wasmCallInfo.params[i].location.offsetFromSP())));
+                    arguments.append(ConstrainedValue(m_out.doubleToFloat(lowDouble(m_graph.varArgChild(node, 2 + i))), ValueRep::stackArgument(safeCast<Value::OffsetType>(wasmCallInfo.params[i].location.offsetFromSP()))));
                 else
                     arguments.append(ConstrainedValue(m_out.doubleToFloat(lowDouble(m_graph.varArgChild(node, 2 + i))), ValueRep::reg(wasmCallInfo.params[i].location.fpr())));
                 break;
             case Wasm::TypeKind::F64:
                 if (isStack)
-                    arguments.append(ConstrainedValue(lowDouble(m_graph.varArgChild(node, 2 + i)), ValueRep::stackArgument(wasmCallInfo.params[i].location.offsetFromSP())));
+                    arguments.append(ConstrainedValue(lowDouble(m_graph.varArgChild(node, 2 + i)), ValueRep::stackArgument(safeCast<Value::OffsetType>(wasmCallInfo.params[i].location.offsetFromSP()))));
                 else
                     arguments.append(ConstrainedValue(lowDouble(m_graph.varArgChild(node, 2 + i)), ValueRep::reg(wasmCallInfo.params[i].location.fpr())));
                 break;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1091,7 +1091,7 @@ void BBQJIT::emitMutatorFence()
 
 Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 {
-    if (static_cast<uint64_t>(uoffset) > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, uoffset, Width::Width128)) {
+    if (static_cast<uint64_t>(uoffset) > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(uoffset), Width::Width128)) {
         m_jit.addPtr(TrustedImmPtr(static_cast<int64_t>(uoffset)), pointerLocation.asGPR());
         return Address(pointerLocation.asGPR());
     }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
@@ -52,7 +52,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint32
     if (pointer.isConst()) {
         uint64_t constantPointer = static_cast<uint64_t>(static_cast<uint32_t>(pointer.asI32()));
         uint64_t finalOffset = constantPointer + uoffset;
-        if (!(finalOffset > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, finalOffset, Width::Width128))) {
+        if (!(finalOffset > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(finalOffset), Width::Width128))) {
             switch (m_mode) {
             case MemoryMode::BoundsChecking: {
                 m_jit.move(TrustedImmPtr(constantPointer + boundary), wasmScratchGPR);
@@ -113,7 +113,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint32
     m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
     m_jit.addPtr(wasmBaseMemoryPointer, wasmScratchGPR);
 
-    if (static_cast<uint64_t>(uoffset) > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, uoffset, Width::Width128)) {
+    if (static_cast<uint64_t>(uoffset) > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(uoffset), Width::Width128)) {
         m_jit.addPtr(TrustedImmPtr(static_cast<int64_t>(uoffset)), wasmScratchGPR);
         return functor(Address(wasmScratchGPR));
     }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -52,7 +52,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint32
     if (pointer.isConst()) {
         uint64_t constantPointer = static_cast<uint64_t>(static_cast<uint32_t>(pointer.asI32()));
         uint64_t finalOffset = constantPointer + uoffset;
-        if (!(finalOffset > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, finalOffset, Width::Width128))) {
+        if (!(finalOffset > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(finalOffset), Width::Width128))) {
             switch (m_mode) {
             case MemoryMode::BoundsChecking: {
                 m_jit.move(TrustedImmPtr(constantPointer + boundary), wasmScratchGPR);
@@ -115,7 +115,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint32
     }
     }
 
-    if (!(static_cast<uint64_t>(uoffset) > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, uoffset, Width::Width128)))
+    if (!(static_cast<uint64_t>(uoffset) > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(uoffset), Width::Width128)))
         return functor(CCallHelpers::BaseIndex(wasmBaseMemoryPointer, pointerLocation.asGPR(), CCallHelpers::TimesOne, static_cast<int32_t>(uoffset)));
 
     m_jit.addPtr(wasmBaseMemoryPointer, pointerLocation.asGPR(), wasmScratchGPR);


### PR DESCRIPTION
#### 9d9bfb82f4fd2162d6a366d293a64db50f5360bc
<pre>
[JSC] Make B3::IsLegalOffset actually enforce signed 32-bit types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302089">https://bugs.webkit.org/show_bug.cgi?id=302089</a>
<a href="https://rdar.apple.com/164175031">rdar://164175031</a>

Reviewed by Yusuke Suzuki.

Apparently IsLegalOffset never actually enforced the constraint it
intended to since being introduced in 2017 in 187822@main. This
became apparent with the recent transition to using modern C++ concept.

Fix the concept to match the intended constraint, and cleanup some code
to satisfy the constraint. To do that, move the
B3 IsLegalOffset / OffsetType frontier to include stack ValueReps
as this seemed like a less disruptive change and cleaner boundary.

Tests: Source/JavaScriptCore/b3/air/testair.cpp
       Source/JavaScriptCore/b3/testb3_5.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

Canonical link: <a href="https://commits.webkit.org/302727@main">https://commits.webkit.org/302727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f428df615247168ac3a50ce2309e3a6610e0ba05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81360 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00f7323a-cdcc-48ea-b0b8-b5aeed4c9548) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98934 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66746 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79621 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ade62ad3-f089-4d26-9a97-500a9950b709) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34449 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80537 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121866 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139748 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128326 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107439 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107323 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54731 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65371 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161340 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1816 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40216 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1925 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->