### PR TITLE
[blocks-in-inline] Wrap floats and out-of-flow boxes in anonymous block only within in-flow block range

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float-expected.html
@@ -1,0 +1,19 @@
+<style>
+.case { border: 2px solid blue; margin: 20px; }
+.topMargin { height: 20px; margin-top: 20px; border: 2px solid green; }
+.bottomMargin { height: 20px; margin-bottom: 20px; border: 2px solid green; }
+.float { float:left; background: teal; }
+</style>
+<div class=case>
+    <span>span start
+        <div class=bottomMargin>div 1</div>
+        <div class=float>float</div>
+        <div class=topMargin>div 2</div>
+    span end</span>
+</div>
+<div class=case>
+    <span>span start
+        <div class=float>float 1</div>
+        <div class=float>float 2</div>
+    span end</span>
+</div>

--- a/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float.html
@@ -1,0 +1,20 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<style>
+.case { border: 2px solid blue; margin: 20px; }
+.topMargin { height: 20px; margin-top: 20px; border: 2px solid green; }
+.bottomMargin { height: 20px; margin-bottom: 20px; border: 2px solid green; }
+.float { float:left; background: teal; }
+</style>
+<div class=case>
+    <span>span start
+        <div class=bottomMargin>div 1</div>
+        <div class=float>float</div>
+        <div class=topMargin>div 2</div>
+    span end</span>
+</div>
+<div class=case>
+    <span>span start
+        <div class=float>float 1</div>
+        <div class=float>float 2</div>
+    span end</span>
+</div>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -479,7 +479,8 @@ void RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock(RenderInline& p
             lastInRun = nullptr;
             continue;
         }
-        if (auto* blockChild = dynamicDowncast<RenderBlock>(*child)) {
+        if (auto* blockChild = dynamicDowncast<RenderBlock>(*child); blockChild && blockChild->isInFlow()) {
+            // Floats and out-of-flow boxes are wrapped if they are in the middle of a block run.
             if (!firstInRun)
                 firstInRun = blockChild;
             lastInRun = blockChild;


### PR DESCRIPTION
#### 38ace2fb6519f7815a18606e8f270c30773f8617
<pre>
[blocks-in-inline] Wrap floats and out-of-flow boxes in anonymous block only within in-flow block range
<a href="https://bugs.webkit.org/show_bug.cgi?id=302095">https://bugs.webkit.org/show_bug.cgi?id=302095</a>
<a href="https://rdar.apple.com/164180121">rdar://164180121</a>

Reviewed by Alan Baradlay.

They don&apos;t need wrapping if they are by themselves. This affects margin collapsing.

Test: fast/inline/blocks-in-inline-margin-collapse-float.html
* LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock):

Canonical link: <a href="https://commits.webkit.org/302671@main">https://commits.webkit.org/302671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80f1757e756bc52f68f488bdfe0af8aa5c92a0d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81323 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29cd030e-009e-421f-8dba-f19725300ea5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98912 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a6b780f-23f6-4c39-a31f-8cd65fe3aa40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79596 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f0f9b1d-6ac7-4796-990b-6d24f2cf1f71) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139713 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1896 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107418 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107298 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54697 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1969 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65338 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->