### PR TITLE
Remove pixel-snapping logic in LineWidth

### DIFF
--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -72,8 +72,21 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
     if (primitiveValue->isValueID())
         return handleKeywordValue(state, primitiveValue->valueID());
 
-    if (evaluationTimeZoomEnabled(state))
-        return toStyleFromCSSValue<LineWidth::Length>(state, value);
+    if (evaluationTimeZoomEnabled(state)) {
+        auto result = primitiveValue->resolveAsLength<float>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, LineWidth::Length::range.zoomOptions));
+
+        float deviceScaleFactor = state.document().deviceScaleFactor();
+        float resultInDevicePixels = result * deviceScaleFactor;
+        float snappedResult;
+
+        // https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width
+        if (resultInDevicePixels > 0.0f && resultInDevicePixels < 1.0f)
+            snappedResult = 1.0f / deviceScaleFactor;
+        else
+            snappedResult = floorf(resultInDevicePixels) / deviceScaleFactor;
+
+        return LineWidth::Length { CSS::clampToRange<LineWidth::Length::range, LineWidth::Length::ResolvedValueType>(snappedResult) };
+    }
 
     // Any original result that was >= 1 should not be allowed to fall below 1. This keeps border lines from vanishing.
 
@@ -99,8 +112,6 @@ void Serialize<LineWidth>::operator()(StringBuilder& builder, const CSS::Seriali
 
     if (auto minimumLineWidth = 1.0f / deviceScaleFactor; result > 0.0f && result < minimumLineWidth)
         result = minimumLineWidth;
-
-    result = floorToDevicePixel(result, deviceScaleFactor);
 
     CSS::serializationForCSS(builder, context, CSS::LengthRaw<> { CSS::LengthUnit::Px, result });
 }

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -77,7 +77,7 @@ template<typename Result> struct Evaluation<LineWidth, Result> {
         if (auto minimumLineWidth = 1.0f / zoom.deviceScaleFactor; result > 0.0f && result < minimumLineWidth)
             return Result(minimumLineWidth);
 
-        return Result(floorToDevicePixel(result, zoom.deviceScaleFactor));
+        return Result(result);
     }
 };
 


### PR DESCRIPTION
#### f4eda01482b8
<pre>
Remove pixel-snapping logic in LineWidth
<a href="https://bugs.webkit.org/show_bug.cgi?id=300658">https://bugs.webkit.org/show_bug.cgi?id=300658</a>
<a href="https://rdar.apple.com/problem/162557957">rdar://problem/162557957</a>

Reviewed by NOBODY (OOPS!).

After moving zoom application to evaluation time, we remove the
pixel-snapping logic from LineWidth since fractional pixels are now supported.

* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
(WebCore::Layout::FormattingGeometry::computedHeightValue const):
* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::recalcColumn):
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):
(WebCore::AutoTableLayout::layout):
* Source/WebCore/rendering/FixedTableLayout.cpp:
(WebCore::FixedTableLayout::calcWidthArray):
(WebCore::FixedTableLayout::layout):
* Source/WebCore/rendering/RenderTableCellInlines.h:
(WebCore::RenderTableCell::styleOrColLogicalWidth const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle const):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::TextAutoSizingValue::adjustTextNodeSizes):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::isIdempotentTextAutosizingCandidate const):
(WebCore::RenderStyle::setDeviceScaleFactor): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::usedZoomForLength const):
(WebCore::RenderStyle::deviceScaleFactor const): Deleted.
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustmentForTextAutosizing):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyLineHeight&gt;::computedValue const):
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/calc/StyleCalculationTree+Evaluation.cpp:
(WebCore::Style::Calculation::evaluate):
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
(WebCore::Style::Serialize&lt;LineWidth&gt;::operator):
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
(WebCore::Style::CSSValueConversion&lt;LineHeight&gt;::operator):
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::computeNonCalcLengthDouble):
* Source/WebCore/style/values/primitives/StyleZoomPrimitives.h:
(WebCore::Style::ZoomFactor::ZoomFactor):
(): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4eda01482b89ca442904c4a7a437242075e2b4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82860 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ef4283d-b353-46a3-96c1-504bf525eebb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133008 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3459 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3306 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99920 "Found 5 new test failures: fast/backgrounds/background-position-parsing.html fast/backgrounds/size/contain-and-cover-zoomed.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/repaint-during-scroll-with-zoom.html media/video-zoom.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67684 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09816461-d5f6-4366-8b79-8c7128d982be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134084 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3459 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/117395 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80614 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6ec95903-6047-4815-bd77-d1334a99d4b5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3459 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/88 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81826 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3459 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35518 "Found 11 new test failures: fast/backgrounds/background-position-parsing.html fast/backgrounds/size/contain-and-cover-zoomed.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/repaint-during-scroll-with-zoom.html inspector/animation/lifecycle-css-transition.html svg/zoom/page/zoom-background-image-tiled.html svg/zoom/page/zoom-background-images.html svg/zoom/page/zoom-img-preserveAspectRatio-support-1.html svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm svg/zoom/page/zoom-svg-float-border-padding.xml ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141076 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3208 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36032 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 6 flakes 14 failures; Uploaded test results; 10 flakes 12 failures; Compiled WebKit (cancelled)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108439 "Found 4 new test failures: fast/backgrounds/size/contain-and-cover-zoomed.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/repaint-during-scroll-with-zoom.html media/video-zoom.html (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3260 "Hash f4eda014 for PR 53538 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2880 "Found 10 new test failures: fast/backgrounds/background-position-parsing.html fast/backgrounds/size/contain-and-cover-zoomed.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/repaint-during-scroll-with-zoom.html svg/zoom/page/zoom-background-image-tiled.html svg/zoom/page/zoom-background-images.html svg/zoom/page/zoom-img-preserveAspectRatio-support-1.html svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm svg/zoom/page/zoom-svg-float-border-padding.xml svg/zoom/page/zoom-svg-through-object-with-auto-size.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108378 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113726 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56267 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3275 "Hash f4eda014 for PR 53538 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32154 "Found 10 new test failures: fast/backgrounds/background-position-parsing.html fast/backgrounds/size/contain-and-cover-zoomed.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/repaint-during-scroll-with-zoom.html svg/zoom/page/zoom-background-image-tiled.html svg/zoom/page/zoom-background-images.html svg/zoom/page/zoom-img-preserveAspectRatio-support-1.html svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm svg/zoom/page/zoom-svg-float-border-padding.xml svg/zoom/page/zoom-svg-through-object-with-auto-size.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3097 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3297 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->