### PR TITLE
Unreviewed, reverting 302657@main (f06680f6e584)

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -365,10 +365,7 @@ void RemoteAudioVideoRendererProxyManager::seekTo(RemoteAudioVideoRendererIdenti
         completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
         return;
     }
-    renderer->seekTo(time)->whenSettled(RunLoop::mainSingleton(), [protectedThis = Ref { *this }, identifier, completionHandler = WTFMove(completionHandler)](auto&& result) mutable {
-        protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
-        completionHandler(WTFMove(result));
-    });
+    renderer->seekTo(time)->whenSettled(RunLoop::currentSingleton(), WTFMove(completionHandler));
 }
 
 void RemoteAudioVideoRendererProxyManager::setVolume(RemoteAudioVideoRendererIdentifier identifier, float volume)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -117,10 +117,8 @@ AudioVideoRendererRemote::~AudioVideoRendererRemote()
 #endif
 
     if (RefPtr gpuProcessConnection = m_gpuProcessConnection.get(); gpuProcessConnection && !m_shutdown) {
-        ensureOnDispatcher([gpuProcessConnection, identifier = m_identifier] {
-            gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Shutdown(identifier), 0);
-            gpuProcessConnection->connection().removeWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), identifier.toUInt64());
-        });
+        gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Shutdown(m_identifier), 0);
+        gpuProcessConnection->connection().removeWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), m_identifier.toUInt64());
     }
 
     for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
@@ -129,143 +127,161 @@ AudioVideoRendererRemote::~AudioVideoRendererRemote()
 
 void AudioVideoRendererRemote::setVolume(float volume)
 {
-    ensureOnDispatcherWithConnection([volume](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetVolume(renderer.m_identifier, volume), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetVolume(m_identifier, volume), 0);
 }
 
 void AudioVideoRendererRemote::setMuted(bool muted)
 {
-    ensureOnDispatcherWithConnection([muted](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetMuted(renderer.m_identifier, muted), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetMuted(m_identifier, muted), 0);
 }
 
 void AudioVideoRendererRemote::setPreservesPitchAndCorrectionAlgorithm(bool preservesPitch, std::optional<PitchCorrectionAlgorithm> algorithm)
 {
-    ensureOnDispatcherWithConnection([preservesPitch, algorithm = WTFMove(algorithm)](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetPreservesPitchAndCorrectionAlgorithm(renderer.m_identifier, preservesPitch, algorithm), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetPreservesPitchAndCorrectionAlgorithm(m_identifier, preservesPitch, algorithm), 0);
 }
 
 #if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
 void AudioVideoRendererRemote::setOutputDeviceId(const String& deviceId)
 {
-    ensureOnDispatcherWithConnection([deviceId = deviceId.isolatedCopy()](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetOutputDeviceId(renderer.m_identifier, deviceId), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetOutputDeviceId(m_identifier, deviceId), 0);
 }
 #endif
 
 void AudioVideoRendererRemote::setIsVisible(bool visible)
 {
-    ensureOnDispatcherWithConnection([visible](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetIsVisible(renderer.m_identifier, visible), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetIsVisible(m_identifier, visible), 0);
 }
 
 void AudioVideoRendererRemote::setPresentationSize(const IntSize& size)
 {
-    ensureOnDispatcherWithConnection([size](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetPresentationSize(renderer.m_identifier, size), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetPresentationSize(m_identifier, size), 0);
 }
 
 void AudioVideoRendererRemote::setShouldMaintainAspectRatio(bool maintain)
 {
-    ensureOnDispatcherWithConnection([maintain](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetShouldMaintainAspectRatio(renderer.m_identifier, maintain), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetShouldMaintainAspectRatio(m_identifier, maintain), 0);
 }
 
 void AudioVideoRendererRemote::renderingCanBeAcceleratedChanged(bool acceleratedRendering)
 {
-    ensureOnDispatcherWithConnection([acceleratedRendering](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::RenderingCanBeAcceleratedChanged(renderer.m_identifier, acceleratedRendering), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::RenderingCanBeAcceleratedChanged(m_identifier, acceleratedRendering), 0);
 }
 
 void AudioVideoRendererRemote::contentBoxRectChanged(const LayoutRect& rect)
 {
-    ensureOnDispatcherWithConnection([rect](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::ContentBoxRectChanged(renderer.m_identifier, rect), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::ContentBoxRectChanged(m_identifier, rect), 0);
 }
 
 void AudioVideoRendererRemote::notifyFirstFrameAvailable(Function<void()>&& callback)
 {
-    ensureOnDispatcherWithConnection([callback = WTFMove(callback)](auto& renderer, auto&) mutable {
-        assertIsCurrent(queueSingleton());
-        renderer.m_firstFrameAvailableCallback = WTFMove(callback);
-    });
+    m_firstFrameAvailableCallback = WTFMove(callback);
 }
 
 void AudioVideoRendererRemote::notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&& callback)
 {
-    ensureOnDispatcherWithConnection([callback = WTFMove(callback)](auto& renderer, auto& connection) mutable {
-        assertIsCurrent(queueSingleton());
-        renderer.m_hasAvailableVideoFrameCallback = WTFMove(callback);
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::NotifyWhenHasAvailableVideoFrame(renderer.m_identifier, !!renderer.m_hasAvailableVideoFrameCallback), 0);
-    });
+    m_hasAvailableVideoFrameCallback = WTFMove(callback);
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::NotifyWhenHasAvailableVideoFrame(m_identifier, !!m_hasAvailableVideoFrameCallback), 0);
 }
 
 void AudioVideoRendererRemote::notifyWhenRequiresFlushToResume(Function<void()>&& callback)
 {
-    ensureOnDispatcherWithConnection([callback = WTFMove(callback)](auto& renderer, auto&) mutable {
-        assertIsCurrent(queueSingleton());
-        renderer.m_notifyWhenRequiresFlushToResumeCallback = WTFMove(callback);
-    });
+    m_notifyWhenRequiresFlushToResumeCallback = WTFMove(callback);
 }
 
 void AudioVideoRendererRemote::notifyRenderingModeChanged(Function<void()>&& callback)
 {
-    ensureOnDispatcherWithConnection([callback = WTFMove(callback)](auto& renderer, auto&) mutable {
-        assertIsCurrent(queueSingleton());
-        renderer.m_renderingModeChangedCallback = WTFMove(callback);
-    });
+    m_renderingModeChangedCallback = WTFMove(callback);
 }
 
 void AudioVideoRendererRemote::expectMinimumUpcomingPresentationTime(const MediaTime& minimum)
 {
-    ensureOnDispatcherWithConnection([minimum](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::ExpectMinimumUpcomingPresentationTime(renderer.m_identifier, minimum), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::ExpectMinimumUpcomingPresentationTime(m_identifier, minimum), 0);
 }
 
 void AudioVideoRendererRemote::notifySizeChanged(Function<void(const MediaTime&, FloatSize)>&& callback)
 {
-    ensureOnDispatcherWithConnection([callback = WTFMove(callback)](auto& renderer, auto&) mutable {
-        assertIsCurrent(queueSingleton());
-        renderer.m_sizeChangedCallback = WTFMove(callback);
-    });
+    m_sizeChangedCallback = WTFMove(callback);
 }
 
 void AudioVideoRendererRemote::setShouldDisableHDR(bool disable)
 {
-    ensureOnDispatcherWithConnection([disable](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetShouldDisableHDR(renderer.m_identifier, disable), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetShouldDisableHDR(m_identifier, disable), 0);
 }
 
 void AudioVideoRendererRemote::setPlatformDynamicRangeLimit(const PlatformDynamicRangeLimit& limit)
 {
-    ensureOnDispatcherWithConnection([limit](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetPlatformDynamicRangeLimit(renderer.m_identifier, limit), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetPlatformDynamicRangeLimit(m_identifier, limit), 0);
 }
 
 void AudioVideoRendererRemote::setResourceOwner(const ProcessIdentity& processIdentity)
 {
-    ensureOnDispatcherWithConnection([processIdentity = ProcessIdentity { processIdentity }](auto& renderer, auto& connection) mutable {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetResourceOwner(renderer.m_identifier, WTFMove(processIdentity)), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetResourceOwner(m_identifier, ProcessIdentity { processIdentity }), 0);
 }
 
 void AudioVideoRendererRemote::flushAndRemoveImage()
 {
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::FlushAndRemoveImage(renderer.m_identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::FlushAndRemoveImage(m_identifier), 0);
 }
 
 RefPtr<VideoFrame> AudioVideoRendererRemote::currentVideoFrame() const
@@ -274,18 +290,14 @@ RefPtr<VideoFrame> AudioVideoRendererRemote::currentVideoFrame() const
     if (!isGPURunning() || !gpuProcessConnection)
         return nullptr;
 
-    RefPtr<VideoFrame> videoFrame;
-    callOnMainRunLoopAndWait([&] {
-        auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteAudioVideoRendererProxyManager::CurrentVideoFrame(m_identifier), 0);
-        if (!sendResult.succeeded())
-            return;
+    auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteAudioVideoRendererProxyManager::CurrentVideoFrame(m_identifier), 0);
+    if (!sendResult.succeeded())
+        return nullptr;
 
-        auto [result] = sendResult.takeReply();
-        if (!result)
-            return;
-        videoFrame = RemoteVideoFrameProxy::create(gpuProcessConnection->connection(), gpuProcessConnection->protectedVideoFrameObjectHeapProxy(), WTFMove(*result));
-    });
-    return videoFrame;
+    auto [result] = sendResult.takeReply();
+    if (result)
+        return RemoteVideoFrameProxy::create(gpuProcessConnection->connection(), gpuProcessConnection->protectedVideoFrameObjectHeapProxy(), WTFMove(*result));
+    return nullptr;
 }
 
 void AudioVideoRendererRemote::paintCurrentVideoFrameInContext(GraphicsContext& context, const FloatRect& rect)
@@ -315,14 +327,12 @@ RefPtr<NativeImage> AudioVideoRendererRemote::currentNativeImage() const
 
 std::optional<VideoPlaybackQualityMetrics> AudioVideoRendererRemote::videoPlaybackQualityMetrics()
 {
-    Locker locker { m_lock };
     return m_state.videoPlaybackQualityMetrics;
 }
 
 PlatformLayer* AudioVideoRendererRemote::platformVideoLayer() const
 {
 #if PLATFORM(COCOA)
-    Locker locker { m_lock };
     if (!m_videoLayer && m_layerHostingContext.contextID) {
         auto expandedVideoLayerSize = expandedIntSize(videoLayerSize());
         m_videoLayer = createVideoLayerRemote(const_cast<AudioVideoRendererRemote&>(*this), m_layerHostingContext.contextID, WebCore::MediaPlayer::VideoGravity::ResizeAspect, expandedVideoLayerSize);
@@ -338,311 +348,288 @@ PlatformLayer* AudioVideoRendererRemote::platformVideoLayer() const
 void AudioVideoRendererRemote::setVideoFullscreenLayer(PlatformLayer* videoFullscreenLayer, WTF::Function<void()>&& completionHandler)
 {
 #if PLATFORM(COCOA)
-    Locker locker { m_lock };
     m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), nullptr);
 #endif
 }
 
 void AudioVideoRendererRemote::setVideoFullscreenFrame(const FloatRect& frame)
 {
-    ensureOnDispatcherWithConnection([frame](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetVideoFullscreenFrame(renderer.m_identifier, frame), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::FlushAndRemoveImage(m_identifier), 0);
+
 }
 
 void AudioVideoRendererRemote::isInFullscreenOrPictureInPictureChanged(bool inFullscreen)
 {
-    ensureOnDispatcherWithConnection([inFullscreen](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::IsInFullscreenOrPictureInPictureChanged(renderer.m_identifier, inFullscreen), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::IsInFullscreenOrPictureInPictureChanged(m_identifier, inFullscreen), 0);
 }
 #endif
 
 void AudioVideoRendererRemote::play(std::optional<MonotonicTime> hostTime)
 {
-    {
-        Locker locker { m_lock };
-        m_state.paused = false;
-    }
-    ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Play(renderer.m_identifier, hostTime), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    m_state.paused = false;
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Play(m_identifier, hostTime), 0);
 }
 
 void AudioVideoRendererRemote::pause(std::optional<MonotonicTime> hostTime)
 {
-    {
-        Locker locker { m_lock };
-        m_state.paused = true;
-    }
-    ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Pause(renderer.m_identifier, hostTime), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    m_state.paused = true;
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Pause(m_identifier, hostTime), 0);
 }
 
 bool AudioVideoRendererRemote::paused() const
 {
-    Locker locker { m_lock };
     return m_state.paused;
 }
 
 void AudioVideoRendererRemote::setRate(double rate)
 {
-    ensureOnDispatcherWithConnection([rate](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetRate(renderer.m_identifier, rate), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetRate(m_identifier, rate), 0);
 }
 
 double AudioVideoRendererRemote::effectiveRate() const
 {
-    Locker locker { m_lock };
     return m_state.effectiveRate;
 }
 
 void AudioVideoRendererRemote::stall()
 {
-    {
-        Locker locker { m_lock };
-        m_state.effectiveRate = 0;
-    }
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Stall(renderer.m_identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    m_state.effectiveRate = 0;
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Stall(m_identifier), 0);
 }
 
 void AudioVideoRendererRemote::prepareToSeek()
 {
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::PrepareToSeek(renderer.m_identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::PrepareToSeek(m_identifier), 0);
 }
 
 Ref<MediaTimePromise> AudioVideoRendererRemote::seekTo(const MediaTime& time)
 {
-    {
-        Locker locker { m_lock };
-        m_state.currentTime = time;
-    }
-    m_seeking = true;
-    m_lastSeekTime = time;
-    return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {
+    return invokeAsync(RunLoop::mainSingleton(), [protectedThis = Ref { *this }, this, time] {
         RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
         if (!isGPURunning() || !gpuProcessConnection)
             return MediaTimePromise::createAndReject(PlatformMediaError::Cancelled);
 
-        return gpuProcessConnection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::SeekTo(m_identifier, time), 0)->whenSettled(queueSingleton(), [protectedThis](auto&& result) {
-            if (result)
-                protectedThis->m_seeking = false;
-            return MediaTimePromise::createAndSettle(WTFMove(result));
-        });
+        m_state.currentTime = time;
+        return gpuProcessConnection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::SeekTo(m_identifier, time), 0);
     });
 }
 
 bool AudioVideoRendererRemote::seeking() const
 {
-    Locker locker { m_lock };
     return m_state.seeking;
 }
 
 void AudioVideoRendererRemote::setPreferences(VideoRendererPreferences preferences)
 {
-    ensureOnDispatcherWithConnection([preferences](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetPreferences(renderer.m_identifier, preferences), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetPreferences(m_identifier, preferences), 0);
 }
 
 void AudioVideoRendererRemote::setHasProtectedVideoContent(bool isProtected)
 {
-    ensureOnDispatcherWithConnection([isProtected](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetHasProtectedVideoContent(renderer.m_identifier, isProtected), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetHasProtectedVideoContent(m_identifier, isProtected), 0);
 }
 
 AudioVideoRendererRemote::TrackIdentifier AudioVideoRendererRemote::addTrack(TrackType type)
 {
     // the sendSync() call requires us to run on the connection's dispatcher, which is the main thread.
-    Expected<WebCore::SamplesRendererTrackIdentifier, WebCore::PlatformMediaError> result = makeUnexpected(PlatformMediaError::IPCError);
-    callOnMainRunLoopAndWait([&] {
-        // FIXME: Uses a new Connection for remote playback, and not the main GPUProcessConnection's one.
-        auto sendResult = m_gpuProcessConnection.get()->connection().sendSync(Messages::RemoteAudioVideoRendererProxyManager::AddTrack(m_identifier, type), 0);
-        if (!sendResult.succeeded()) {
-            ASSERT_NOT_REACHED();
-            return;
-        }
-        result = std::get<0>(sendResult.takeReply());
-        ASSERT(!!result);
-    });
+    assertIsMainThread();
+    // FIXME: Uses a new Connection for remote playback, and not the main GPUProcessConnection's one.
+    // FIXME: m_mimeTypeCache is a main-thread only object.
+    auto sendResult = m_gpuProcessConnection.get()->connection().sendSync(Messages::RemoteAudioVideoRendererProxyManager::AddTrack(m_identifier, type), 0);
+    auto result = std::get<0>(sendResult.takeReplyOr(makeUnexpected(PlatformMediaError::IPCError)));
+    ASSERT(!!result);
     return *result;
 }
 
 void AudioVideoRendererRemote::removeTrack(TrackIdentifier trackIdentifier)
 {
-    ensureOnDispatcherWithConnection([trackIdentifier](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::RemoveTrack(renderer.m_identifier, trackIdentifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::RemoveTrack(m_identifier, trackIdentifier), 0);
 }
 
 void AudioVideoRendererRemote::enqueueSample(TrackIdentifier trackIdentifier, Ref<MediaSample>&& sample, std::optional<MediaTime> expectedMinimum)
 {
-    {
-        Locker locker { m_lock };
-        readyForMoreData(trackIdentifier).sampleEnqueued();
-    }
-    ensureOnDispatcherWithConnection([trackIdentifier, sample = WTFMove(sample), expectedMinimum](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::EnqueueSample(renderer.m_identifier, trackIdentifier, MediaSamplesBlock::fromMediaSample(sample), expectedMinimum), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::EnqueueSample(m_identifier, trackIdentifier, MediaSamplesBlock::fromMediaSample(sample), expectedMinimum), 0);
+    if (auto it = m_requestMediaDataWhenReadyData.find(trackIdentifier); it != m_requestMediaDataWhenReadyData.end())
+        it->value.pendingSamples++;
 }
 
 bool AudioVideoRendererRemote::isReadyForMoreSamples(TrackIdentifier trackIdentifier)
 {
-    Locker locker { m_lock };
-    return readyForMoreData(trackIdentifier).isReadyForMoreData();
+    auto it = m_requestMediaDataWhenReadyData.find(trackIdentifier);
+    return it != m_requestMediaDataWhenReadyData.end() && it->value.readyForMoreData();
 }
 
 void AudioVideoRendererRemote::requestMediaDataWhenReady(TrackIdentifier trackIdentifier, Function<void(TrackIdentifier)>&& callback)
 {
-    ensureOnDispatcherWithConnection([trackIdentifier, callback = WTFMove(callback)](auto& renderer, auto& connection) mutable {
-        assertIsCurrent(queueSingleton());
-        auto addResult = renderer.m_requestMediaDataWhenReadyDataCallbacks.add(trackIdentifier, nullptr);
-        addResult.iterator->value = WTFMove(callback);
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::RequestMediaDataWhenReady(renderer.m_identifier, trackIdentifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+    if (auto it = m_requestMediaDataWhenReadyData.find(trackIdentifier); it != m_requestMediaDataWhenReadyData.end())
+        it->value.callback = WTFMove(callback);
+    else {
+        RequestMediaDataWhenReadyData data { .callback = WTFMove(callback) };
+        m_requestMediaDataWhenReadyData.set(trackIdentifier, WTFMove(data));
+    }
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::RequestMediaDataWhenReady(m_identifier, trackIdentifier), 0);
 }
 
 void AudioVideoRendererRemote::stopRequestingMediaData(TrackIdentifier trackIdentifier)
 {
-    ensureOnDispatcherWithConnection([trackIdentifier](auto& renderer, auto& connection) {
-        assertIsCurrent(queueSingleton());
-        if (auto it = renderer.m_requestMediaDataWhenReadyDataCallbacks.find(trackIdentifier); it != renderer.m_requestMediaDataWhenReadyDataCallbacks.end())
-            it->value = nullptr;
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::StopRequestingMediaData(renderer.m_identifier, trackIdentifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+    if (auto it = m_requestMediaDataWhenReadyData.find(trackIdentifier); it != m_requestMediaDataWhenReadyData.end())
+        it->value.callback = nullptr;
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::StopRequestingMediaData(m_identifier, trackIdentifier), 0);
 }
 
 void AudioVideoRendererRemote::notifyTrackNeedsReenqueuing(TrackIdentifier trackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>&& callback)
 {
-    ensureOnDispatcher([protectedThis = Ref { *this }, trackIdentifier, callback = WTFMove(callback)]() mutable {
-        assertIsCurrent(queueSingleton());
-        if (callback)
-            protectedThis->m_trackNeedsReenqueuingCallbacks.set(trackIdentifier, WTFMove(callback));
-        else
-            protectedThis->m_trackNeedsReenqueuingCallbacks.remove(trackIdentifier);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+    if (callback)
+        m_trackNeedsReenqueuingCallbacks.set(trackIdentifier, WTFMove(callback));
+    else
+        m_trackNeedsReenqueuingCallbacks.remove(trackIdentifier);
 }
 
 bool AudioVideoRendererRemote::timeIsProgressing() const
 {
-    Locker locker { m_lock };
     return m_state.timeIsProgressing;
 }
 
 void AudioVideoRendererRemote::notifyEffectiveRateChanged(Function<void(double)>&& callback)
 {
-    ensureOnDispatcher([protectedThis = Ref { *this }, callback = WTFMove(callback)]() mutable {
-        assertIsCurrent(queueSingleton());
-        protectedThis->m_effectiveRateChangedCallback = WTFMove(callback);
-    });
+    m_effectiveRateChangedCallback = WTFMove(callback);
 }
 
 MediaTime AudioVideoRendererRemote::currentTime() const
 {
-    if (m_seeking)
-        return m_lastSeekTime;
-    Locker locker { m_lock };
     return m_state.currentTime;
 }
 
 void AudioVideoRendererRemote::notifyTimeReachedAndStall(const MediaTime& time, Function<void(const MediaTime&)>&& callback)
 {
-    ensureOnDispatcherWithConnection([time, callback = WTFMove(callback)](auto& renderer, auto& connection) mutable {
-        assertIsCurrent(queueSingleton());
-        renderer.m_timeReachedAndStallCallback = WTFMove(callback);
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::NotifyTimeReachedAndStall(renderer.m_identifier, time), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    m_timeReachedAndStallCallback = WTFMove(callback);
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::NotifyTimeReachedAndStall(m_identifier, time), 0);
 }
 
 void AudioVideoRendererRemote::cancelTimeReachedAction()
 {
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        assertIsCurrent(queueSingleton());
-        renderer.m_timeReachedAndStallCallback = { };
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::CancelTimeReachedAction(renderer.m_identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+    m_timeReachedAndStallCallback = { };
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::CancelTimeReachedAction(m_identifier), 0);
 }
 
 void AudioVideoRendererRemote::performTaskAtTime(const MediaTime& time, Function<void(const MediaTime&)>&& callback)
 {
-    ensureOnDispatcherWithConnection([time, callback = WTFMove(callback)](auto& renderer, auto& connection) mutable {
-        assertIsCurrent(queueSingleton());
-        renderer.m_performTaskAtTimeCallback = WTFMove(callback);
-        renderer.m_performTaskAtTime = time;
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::PerformTaskAtTime(renderer.m_identifier, time), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+    m_performTaskAtTimeCallback = WTFMove(callback);
+    m_performTaskAtTime = time;
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::PerformTaskAtTime(m_identifier, time), 0);
 }
 
 void AudioVideoRendererRemote::flush()
 {
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Flush(renderer.m_identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Flush(m_identifier), 0);
 }
 
 void AudioVideoRendererRemote::flushTrack(TrackIdentifier identifier)
 {
-    ensureOnDispatcherWithConnection([identifier](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::FlushTrack(renderer.m_identifier, identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::FlushTrack(m_identifier, identifier), 0);
 }
 
 void AudioVideoRendererRemote::applicationWillResignActive()
 {
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::ApplicationWillResignActive(renderer.m_identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::ApplicationWillResignActive(m_identifier), 0);
 }
 
 void AudioVideoRendererRemote::notifyWhenErrorOccurs(Function<void(PlatformMediaError)>&& callback)
 {
-    ensureOnDispatcher([protectedThis = Ref { *this }, callback = WTFMove(callback)]() mutable {
-        assertIsCurrent(queueSingleton());
-        protectedThis->m_errorCallback = WTFMove(callback);
-    });
+    m_errorCallback = WTFMove(callback);
 }
 
 void AudioVideoRendererRemote::setSpatialTrackingInfo(bool prefersSpatialAudioExperience , SoundStageSize stage, const String& sceneIdentifier, const String& defaultLabel, const String& label)
 {
-    ensureOnDispatcherWithConnection([prefersSpatialAudioExperience, stage, sceneIdentifier = sceneIdentifier.isolatedCopy(), defaultLabel = defaultLabel.isolatedCopy(), label = label.isolatedCopy()](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetSpatialTrackingInfo(renderer.m_identifier, prefersSpatialAudioExperience, stage, sceneIdentifier, defaultLabel, label), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetSpatialTrackingInfo(m_identifier, prefersSpatialAudioExperience, stage, sceneIdentifier, defaultLabel, label), 0);
 }
 
-void AudioVideoRendererRemote::ensureOnDispatcherSync(NOESCAPE Function<void()>&& function)
+void AudioVideoRendererRemote::ensureOnDispatcherSync(Function<void()>&& function)
 {
-    if (queueSingleton().isCurrent())
-        function();
-    else
-        queueSingleton().dispatchSync(WTFMove(function));
+    callOnMainRunLoopAndWait(WTFMove(function));
 }
 
 void AudioVideoRendererRemote::ensureOnDispatcher(Function<void()>&& function)
 {
-    if (queueSingleton().isCurrent())
-        function();
-    else
-        queueSingleton().dispatch(WTFMove(function));
-}
-
-void AudioVideoRendererRemote::ensureOnDispatcherWithConnection(Function<void(AudioVideoRendererRemote&, IPC::Connection&)>&& function)
-{
-    ensureOnDispatcher([weakThis = ThreadSafeWeakPtr { *this }, function = WTFMove(function)]() mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-        RefPtr gpuProcessConnection = protectedThis->m_gpuProcessConnection.get();
-        if (!protectedThis->isGPURunning() || !gpuProcessConnection)
-            return;
-        function(*protectedThis, gpuProcessConnection->connection());
-    });
+    ensureOnMainThread(WTFMove(function));
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -654,183 +641,129 @@ WTFLogChannel& AudioVideoRendererRemote::logChannel() const
 
 void AudioVideoRendererRemote::updateCacheState(const RemoteAudioVideoRendererState& state)
 {
-    Locker locker { m_lock };
     m_state = state;
-}
-
-AudioVideoRendererRemote::ReadyForMoreData& AudioVideoRendererRemote::readyForMoreData(TrackIdentifier trackIdentifier)
-{
-    assertIsHeld(m_lock);
-    auto addResult = m_readyForMoreData.add(trackIdentifier,  ReadyForMoreData { });
-    return addResult.iterator->value;
 }
 
 void AudioVideoRendererRemote::requestHostingContext(LayerHostingContextCallback&& completionHandler)
 {
-    ensureOnDispatcher([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis) {
-            completionHandler({ });
-            return;
-        }
-        assertIsCurrent(queueSingleton());
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection) {
+        completionHandler({ });
+        return;
+    }
 
-        // FIXME: should it be called on the main thread???
-        RefPtr gpuProcessConnection = protectedThis->m_gpuProcessConnection.get();
-        if (!protectedThis->isGPURunning() || !gpuProcessConnection) {
-            completionHandler({ });
-            return;
-        }
+    if (m_layerHostingContext.contextID) {
+        completionHandler(m_layerHostingContext);
+        return;
+    }
 
-        auto layerHostingContext = [&] {
-            Locker locker { protectedThis->m_lock };
-            return protectedThis->m_layerHostingContext;
-        }();
-        if (layerHostingContext.contextID) {
-            completionHandler(layerHostingContext);
-            return;
-        }
-
-        protectedThis->m_layerHostingContextRequests.append(WTFMove(completionHandler));
-        gpuProcessConnection->connection().sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::RequestHostingContext(protectedThis->m_identifier), queueSingleton(), [weakThis] (WebCore::HostingContext context) {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->setLayerHostingContext(WTFMove(context));
-        }, 0);
-    });
+    m_layerHostingContextRequests.append(WTFMove(completionHandler));
+    gpuProcessConnection->connection().sendWithAsyncReply(Messages::RemoteAudioVideoRendererProxyManager::RequestHostingContext(m_identifier), [weakThis = ThreadSafeWeakPtr { *this }] (WebCore::HostingContext context) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setLayerHostingContext(WTFMove(context));
+    }, m_identifier);
 }
 
 WebCore::HostingContext AudioVideoRendererRemote::hostingContext() const
 {
-    Locker locker { m_lock };
     return m_layerHostingContext;
 }
 
 void AudioVideoRendererRemote::setLayerHostingContext(WebCore::HostingContext&& hostingContext)
 {
-    assertIsCurrent(queueSingleton());
+    if (m_layerHostingContext.contextID == hostingContext.contextID)
+        return;
 
-    Vector<LayerHostingContextCallback> layerHostingContextRequests;
-    HostingContext layerHostingContext { hostingContext };
-    {
-        Locker locker { m_lock };
-        if (m_layerHostingContext.contextID == hostingContext.contextID)
-            return;
-
-        m_layerHostingContext = WTFMove(hostingContext);
+    m_layerHostingContext = WTFMove(hostingContext);
 #if PLATFORM(COCOA)
-        m_videoLayer = nullptr;
+    m_videoLayer = nullptr;
 #endif
-    }
-    callOnMainRunLoop([layerHostingContext = WTFMove(layerHostingContext), layerHostingContextRequests = std::exchange(m_layerHostingContextRequests, { })]() mutable {
-        for (auto& request : layerHostingContextRequests)
-            request(layerHostingContext);
-    });
+
+    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
+        request(m_layerHostingContext);
 }
 
 bool AudioVideoRendererRemote::inVideoFullscreenOrPictureInPicture() const
 {
 #if PLATFORM(COCOA) && ENABLE(VIDEO_PRESENTATION_MODE)
-    Locker locker { m_lock };
     return !!m_videoLayerManager->videoFullscreenLayer();
 #else
     return false;
 #endif
 }
 
-WebCore::FloatSize AudioVideoRendererRemote::naturalSize() const
-{
-    Locker locker { m_lock };
-    return m_naturalSize;
-}
-
 #if ENABLE(ENCRYPTED_MEDIA)
 void AudioVideoRendererRemote::setCDMInstance(CDMInstance* instance)
 {
-    std::optional<RemoteCDMInstanceIdentifier> identifier;
-    if (RefPtr remoteInstance = dynamicDowncast<RemoteCDMInstance>(instance))
-        identifier = remoteInstance->identifier();
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
 
-    ensureOnDispatcherWithConnection([identifier = WTFMove(identifier)](auto& renderer, auto& connection) mutable {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetCDMInstance(renderer.m_identifier, WTFMove(identifier)), 0);
-    });
+    if (RefPtr remoteInstance = dynamicDowncast<RemoteCDMInstance>(instance))
+        gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetCDMInstance(m_identifier, remoteInstance->identifier()), 0);
+    else
+        gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetCDMInstance(m_identifier, std::nullopt), 0);
 }
 
 Ref<MediaPromise> AudioVideoRendererRemote::setInitData(Ref<SharedBuffer> initData)
 {
-    return invokeAsync(queueSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, initData = WTFMove(initData)]() mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
-        RefPtr gpuProcessConnection = protectedThis->m_gpuProcessConnection.get();
-        if (!protectedThis->isGPURunning() || !gpuProcessConnection)
-            return MediaPromise::createAndReject(PlatformMediaError::IPCError);
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return gpuProcessConnection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::SetInitData(protectedThis->m_identifier, WTFMove(initData)), 0);
-    });
+    return gpuProcessConnection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::SetInitData(m_identifier, WTFMove(initData)), 0);
 }
 
 void AudioVideoRendererRemote::attemptToDecrypt()
 {
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::AttemptToDecrypt(renderer.m_identifier), 0);
-    });
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::AttemptToDecrypt(m_identifier), 0);
 }
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 void AudioVideoRendererRemote::setCDMSession(LegacyCDMSession* session)
 {
-    std::optional<RemoteLegacyCDMSessionIdentifier> identifier;
-    if (RefPtr remoteSession = dynamicDowncast<RemoteLegacyCDMSession>(session))
-        identifier = remoteSession->identifier();
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
 
-    ensureOnDispatcherWithConnection([identifier = WTFMove(identifier)](auto& renderer, auto& connection) mutable {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetLegacyCDMSession(renderer.m_identifier, WTFMove(identifier)), 0);
-    });
+    if (RefPtr remoteSession = dynamicDowncast<RemoteLegacyCDMSession>(session))
+        gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetLegacyCDMSession(m_identifier, remoteSession->identifier()), 0);
+    else
+        gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetLegacyCDMSession(m_identifier, std::nullopt), 0);
 }
 #endif
 
 
 #if PLATFORM(COCOA)
-
-WebCore::FloatSize AudioVideoRendererRemote::videoLayerSize() const
-{
-    Locker locker { m_lock };
-    return m_videoLayerSize;
-}
-
 void AudioVideoRendererRemote::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
-    {
-        Locker locker { m_lock };
-        m_videoLayerSize = size;
-    }
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
 
-    ensureOnDispatcherWithConnection([size, sendRightAnnotated = WTFMove(sendRightAnnotated)](auto& renderer, auto& connection) mutable {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetVideoLayerSizeFenced(renderer.m_identifier, size, WTFMove(sendRightAnnotated)), 0);
-    });
+    m_videoLayerSize = size;
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetVideoLayerSizeFenced(m_identifier, size, WTFMove(sendRightAnnotated)), 0);
 }
 #endif
 
 void AudioVideoRendererRemote::notifyVideoLayerSizeChanged(Function<void(const MediaTime&, FloatSize)>&& callback)
 {
-    ensureOnDispatcher([protectedThis = Ref { *this }, callback = WTFMove(callback)]() mutable {
-        assertIsCurrent(queueSingleton());
-        protectedThis->m_videoLayerSizeChangedCallback = WTFMove(callback);
-    });
+    m_videoLayerSizeChangedCallback = WTFMove(callback);
 }
 
 void AudioVideoRendererRemote::gpuProcessConnectionDidClose(GPUProcessConnection& connection)
 {
     ASSERT(m_gpuProcessConnection.get() == &connection);
     m_shutdown = true;
-    ensureOnDispatcher([connection = Ref { connection }, identifier = m_identifier, protectedThis = Ref { *this }] {
-        connection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Shutdown(identifier), 0);
-        connection->connection().removeWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), identifier.toUInt64());
-        assertIsCurrent(queueSingleton());
-        if (protectedThis->m_errorCallback)
-            protectedThis->m_errorCallback(PlatformMediaError::IPCError);
-    });
+    connection.connection().send(Messages::RemoteAudioVideoRendererProxyManager::Shutdown(m_identifier), 0);
+    connection.connection().removeWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), m_identifier.toUInt64());
+    if (m_errorCallback)
+        m_errorCallback(PlatformMediaError::IPCError);
 }
 
 AudioVideoRendererRemote::MessageReceiver::MessageReceiver(AudioVideoRendererRemote& parent)
@@ -841,148 +774,153 @@ AudioVideoRendererRemote::MessageReceiver::MessageReceiver(AudioVideoRendererRem
 void AudioVideoRendererRemote::MessageReceiver::firstFrameAvailable(RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_firstFrameAvailableCallback)
-            parent->m_firstFrameAvailableCallback();
+        parent->ensureOnDispatcher([parent, state] {
+            parent->updateCacheState(state);
+            if (parent->m_firstFrameAvailableCallback)
+                parent->m_firstFrameAvailableCallback();
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::hasAvailableVideoFrame(MediaTime time, double clockTime, RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_hasAvailableVideoFrameCallback)
-            parent->m_hasAvailableVideoFrameCallback(time, clockTime);
+        parent->ensureOnDispatcher([parent, time, clockTime, state] {
+            parent->updateCacheState(state);
+            if (parent->m_hasAvailableVideoFrameCallback)
+                parent->m_hasAvailableVideoFrameCallback(time, clockTime);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::requiresFlushToResume(RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_notifyWhenRequiresFlushToResumeCallback)
-            parent->m_notifyWhenRequiresFlushToResumeCallback();
+        parent->ensureOnDispatcher([parent, state] {
+            parent->updateCacheState(state);
+            if (parent->m_notifyWhenRequiresFlushToResumeCallback)
+                parent->m_notifyWhenRequiresFlushToResumeCallback();
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::renderingModeChanged(RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_renderingModeChangedCallback)
-            parent->m_renderingModeChangedCallback();
+        parent->ensureOnDispatcher([parent, state] {
+            parent->updateCacheState(state);
+            if (parent->m_renderingModeChangedCallback)
+                parent->m_renderingModeChangedCallback();
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::sizeChanged(MediaTime time, WebCore::FloatSize size, RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        {
-            Locker locker { parent->m_lock };
+        parent->ensureOnDispatcher([parent, time, size, state] {
+            parent->updateCacheState(state);
             parent->m_naturalSize = size;
-        }
-        if (parent->m_sizeChangedCallback)
-            parent->m_sizeChangedCallback(time, size);
+            if (parent->m_sizeChangedCallback)
+                parent->m_sizeChangedCallback(time, size);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::trackNeedsReenqueuing(TrackIdentifier trackIdentifier, MediaTime time, RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        auto iterator = parent->m_trackNeedsReenqueuingCallbacks.find(trackIdentifier);
-        if (iterator == parent->m_trackNeedsReenqueuingCallbacks.end() || !iterator->value)
-            return;
-        iterator->value(trackIdentifier, time);
+        parent->ensureOnDispatcher([parent, trackIdentifier, time, state] {
+            parent->updateCacheState(state);
+            auto iterator = parent->m_trackNeedsReenqueuingCallbacks.find(trackIdentifier);
+            if (iterator == parent->m_trackNeedsReenqueuingCallbacks.end() || !iterator->value)
+                return;
+            iterator->value(trackIdentifier, time);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::effectiveRateChanged(RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_effectiveRateChangedCallback)
-            parent->m_effectiveRateChangedCallback(state.effectiveRate);
+        parent->ensureOnDispatcher([parent, state] {
+            parent->updateCacheState(state);
+            if (parent->m_effectiveRateChangedCallback)
+                parent->m_effectiveRateChangedCallback(parent->m_state.effectiveRate);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::stallTimeReached(MediaTime time, RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_timeReachedAndStallCallback)
-            parent->m_timeReachedAndStallCallback(time);
+        parent->ensureOnDispatcher([parent, time, state] {
+            parent->updateCacheState(state);
+            if (parent->m_timeReachedAndStallCallback)
+                parent->m_timeReachedAndStallCallback(time);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::taskTimeReached(MediaTime time, RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_performTaskAtTimeCallback && time == parent->m_performTaskAtTime)
-            parent->m_performTaskAtTimeCallback(time);
+        parent->ensureOnDispatcher([parent, time, state] {
+            parent->updateCacheState(state);
+            if (parent->m_performTaskAtTimeCallback && time == parent->m_performTaskAtTime)
+                parent->m_performTaskAtTimeCallback(time);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::errorOccurred(WebCore::PlatformMediaError error)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        if (parent->m_errorCallback)
-            parent->m_errorCallback(error);
+        parent->ensureOnDispatcher([parent, error] {
+            if (parent->m_errorCallback)
+                parent->m_errorCallback(error);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::requestMediaDataWhenReady(TrackIdentifier trackIdentifier)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        {
-            Locker locker { parent->m_lock };
-            parent->readyForMoreData(trackIdentifier).reset();
-        }
-        auto iterator = parent->m_requestMediaDataWhenReadyDataCallbacks.find(trackIdentifier);
-        if (iterator == parent->m_requestMediaDataWhenReadyDataCallbacks.end() || !iterator->value)
-            return;
-        iterator->value(trackIdentifier);
+        parent->ensureOnDispatcher([parent, trackIdentifier] {
+            auto iterator = parent->m_requestMediaDataWhenReadyData.find(trackIdentifier);
+            if (iterator == parent->m_requestMediaDataWhenReadyData.end() || !iterator->value.callback)
+                return;
+            iterator->value.pendingSamples = 0;
+            iterator->value.callback(trackIdentifier);
+        });
     }
 }
 
 void AudioVideoRendererRemote::MessageReceiver::stateUpdate(RemoteAudioVideoRendererState state)
 {
-    if (RefPtr parent = m_parent.get())
-        parent->updateCacheState(state);
+    if (RefPtr parent = m_parent.get()) {
+        parent->ensureOnDispatcher([parent, state] {
+            parent->updateCacheState(state);
+        });
+    }
 }
 
 #if PLATFORM(COCOA)
-void AudioVideoRendererRemote::MessageReceiver::layerHostingContextChanged(RemoteAudioVideoRendererState state, WebCore::HostingContext&& hostingContext, const WebCore::FloatSize& videoLayerSize)
+void AudioVideoRendererRemote::MessageReceiver::layerHostingContextChanged(RemoteAudioVideoRendererState state, WebCore::HostingContext&& inlineLayerHostingContext, const WebCore::FloatSize& videoLayerSize)
 {
     if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        if (!hostingContext.contextID) {
-            Locker locker { parent->m_lock };
-            parent->m_videoLayer = nullptr;
-            parent->m_videoLayerManager->didDestroyVideoLayer();
-            return;
-        }
-        {
-            Locker locker { parent->m_lock };
+        parent->ensureOnDispatcher([parent, state, hostingContext = WTFMove(inlineLayerHostingContext), videoLayerSize]() mutable {
+            if (!hostingContext.contextID) {
+                parent->m_videoLayer = nullptr;
+                parent->m_videoLayerManager->didDestroyVideoLayer();
+                return;
+            }
             parent->m_videoLayerSize = videoLayerSize;
-        }
-        parent->updateCacheState(state);
-        parent->setLayerHostingContext(WTFMove(hostingContext));
-        if (parent->m_videoLayerSizeChangedCallback)
-            parent->m_videoLayerSizeChangedCallback(state.currentTime, videoLayerSize);
+            parent->updateCacheState(state);
+            parent->setLayerHostingContext(WTFMove(hostingContext));
+            if (parent->m_videoLayerSizeChangedCallback)
+                parent->m_videoLayerSizeChangedCallback(state.currentTime, videoLayerSize);
+        });
     }
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -184,13 +184,13 @@ private:
     WebCore::HostingContext hostingContext() const final;
     void setLayerHostingContext(WebCore::HostingContext&&);
 #if PLATFORM(COCOA)
-    WebCore::FloatSize videoLayerSize() const;
+    WebCore::FloatSize videoLayerSize() const { return m_videoLayerSize; };
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;
 #endif
     void notifyVideoLayerSizeChanged(Function<void(const MediaTime&, WebCore::FloatSize)>&& callback) final;
     // VideoLayerRemoteParent
     bool inVideoFullscreenOrPictureInPicture() const final;
-    WebCore::FloatSize naturalSize() const final;
+    WebCore::FloatSize naturalSize() const final { return m_naturalSize; }
 
 #if ENABLE(ENCRYPTED_MEDIA)
     void setCDMInstance(WebCore::CDMInstance*) final;
@@ -210,61 +210,50 @@ private:
     WTFLogChannel& logChannel() const final;
 #endif
 
-    void setState(RemoteAudioVideoRendererState);
-
     void ensureOnDispatcher(Function<void()>&&);
-    void ensureOnDispatcherSync(NOESCAPE Function<void()>&&);
-    void ensureOnDispatcherWithConnection(Function<void(AudioVideoRendererRemote&, IPC::Connection&)>&&);
+    void ensureOnDispatcherSync(Function<void()>&&);
     static WorkQueue& queueSingleton();
     bool isGPURunning() const { return !m_shutdown; }
 
     void updateCacheState(const RemoteAudioVideoRendererState&);
-    class ReadyForMoreData {
-    public:
-        static constexpr size_t kMaxPendingSample = 10;
-        bool isReadyForMoreData() const { return m_pendingSamples < kMaxPendingSample; }
-        void reset() { m_pendingSamples = 0; }
-        void sampleEnqueued() { m_pendingSamples++; }
-    private:
-        size_t m_pendingSamples { 0 };
-    };
-    ReadyForMoreData& readyForMoreData(TrackIdentifier);
 
     const ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     const Ref<MessageReceiver> m_receiver;
     const RemoteAudioVideoRendererIdentifier m_identifier;
 
-    std::atomic<bool> m_shutdown { false };
+    bool m_shutdown { false };
 
-    mutable Lock m_lock;
-    RemoteAudioVideoRendererState m_state WTF_GUARDED_BY_LOCK(m_lock);
+    RemoteAudioVideoRendererState m_state;
 
-    Function<void(WebCore::PlatformMediaError)> m_errorCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void()> m_firstFrameAvailableCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(const MediaTime&, double)> m_hasAvailableVideoFrameCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void()> m_notifyWhenRequiresFlushToResumeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void()> m_renderingModeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(const MediaTime&, WebCore::FloatSize)> m_sizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(const MediaTime&)> m_currentTimeDidChangeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(double)> m_effectiveRateChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(const MediaTime&)> m_timeReachedAndStallCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(const MediaTime&)> m_performTaskAtTimeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    MediaTime m_performTaskAtTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(const MediaTime&, WebCore::FloatSize)> m_videoLayerSizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(WebCore::PlatformMediaError)> m_errorCallback;
+    Function<void()> m_firstFrameAvailableCallback;
+    Function<void(const MediaTime&, double)> m_hasAvailableVideoFrameCallback;
+    Function<void()> m_notifyWhenRequiresFlushToResumeCallback;
+    Function<void()> m_renderingModeChangedCallback;
+    Function<void(const MediaTime&, WebCore::FloatSize)> m_sizeChangedCallback;
+    Function<void(const MediaTime&)> m_currentTimeDidChangeCallback;
+    Function<void(double)> m_effectiveRateChangedCallback;
+    Function<void(const MediaTime&)> m_timeReachedAndStallCallback;
+    Function<void(const MediaTime&)> m_performTaskAtTimeCallback;
+    MediaTime m_performTaskAtTime;
+    Function<void(const MediaTime&, WebCore::FloatSize)> m_videoLayerSizeChangedCallback;
 
-    HashMap<TrackIdentifier, ReadyForMoreData> m_readyForMoreData WTF_GUARDED_BY_LOCK(m_lock);
-    HashMap<TrackIdentifier, Function<void(TrackIdentifier)>> m_requestMediaDataWhenReadyDataCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    HashMap<TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>> m_trackNeedsReenqueuingCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    static constexpr size_t kMaxPendingSample = 10;
+    struct RequestMediaDataWhenReadyData {
+        bool readyForMoreData() const { return pendingSamples < kMaxPendingSample; }
+        size_t pendingSamples { kMaxPendingSample };
+        Function<void(TrackIdentifier)> callback;
+    };
+    HashMap<TrackIdentifier, RequestMediaDataWhenReadyData> m_requestMediaDataWhenReadyData;
+    HashMap<TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>> m_trackNeedsReenqueuingCallbacks;
 
-    Vector<LayerHostingContextCallback> m_layerHostingContextRequests WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    WebCore::HostingContext m_layerHostingContext WTF_GUARDED_BY_LOCK(m_lock);
-    WebCore::FloatSize m_naturalSize WTF_GUARDED_BY_LOCK(m_lock);
-    std::atomic<bool> m_seeking { false };
-    MediaTime m_lastSeekTime; // Always call on the renderer's client thread.
+    Vector<LayerHostingContextCallback> m_layerHostingContextRequests;
+    WebCore::HostingContext m_layerHostingContext;
+    WebCore::FloatSize m_naturalSize;
 #if PLATFORM(COCOA)
-    const UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager WTF_GUARDED_BY_LOCK(m_lock);
-    mutable PlatformLayerContainer m_videoLayer WTF_GUARDED_BY_LOCK(m_lock);
-    WebCore::FloatSize m_videoLayerSize WTF_GUARDED_BY_LOCK(m_lock);
+    const UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager;
+    mutable PlatformLayerContainer m_videoLayer;
+    WebCore::FloatSize m_videoLayerSize;
 #endif
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;


### PR DESCRIPTION
#### 4e119015e11e0c9e505a7b06aef9ee7a19938a2e
<pre>
Unreviewed, reverting 302657@main (f06680f6e584)
<a href="https://rdar.apple.com/164185735">rdar://164185735</a>

Revert 302657@main broke internal builds

Reverted change:

    AudioVideoRendererRemote should use its own work queue
    <a href="https://bugs.webkit.org/show_bug.cgi?id=301964">https://bugs.webkit.org/show_bug.cgi?id=301964</a>
    <a href="https://rdar.apple.com/164040921">rdar://164040921</a>
    302657@main (f06680f6e584)

Canonical link: <a href="https://commits.webkit.org/302665@main">https://commits.webkit.org/302665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07ffc5e548de8fc41ee21391064ab75fb2cfe727

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129864 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/2125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40721 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131735 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/2078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/2015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/137256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132811 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/2078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/2078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/34438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/80527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/2078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139737 "Failed to checkout and rebase branch from PR 53539") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/2015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/139737 "Failed to checkout and rebase branch from PR 53539") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/1964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/112654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/139737 "Failed to checkout and rebase branch from PR 53539") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20252 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/1992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/65361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/1915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->