### PR TITLE
[macOS] Simple WKWebView app with a toolbar fails to get a toolbar background

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1637,7 +1637,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    _impl->setCanInstallScrollPocket();
+    _impl->setClientImplicitlyRequestedTopScrollPocket();
 #endif
 
     _impl->setObscuredContentInsets(coreBoxExtentsFromEdgeInsets(insets));
@@ -1665,7 +1665,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_setOverflowHeightForTopScrollEdgeEffect:(CGFloat)height
 {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    _impl->setCanInstallScrollPocket();
+    _impl->setClientImplicitlyRequestedTopScrollPocket();
 #endif
 
     if (_page->overflowHeightForTopScrollEdgeEffect() == height)
@@ -1689,7 +1689,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_setOverrideTopScrollEdgeEffectColor:(NSColor *)color
 {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    _impl->setCanInstallScrollPocket();
+    _impl->setClientImplicitlyRequestedTopScrollPocket();
 #endif
 
     if (_overrideTopScrollEdgeEffectColor == color || [_overrideTopScrollEdgeEffectColor isEqual:color])
@@ -1729,7 +1729,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_setUsesAutomaticContentInsetBackgroundFill:(BOOL)value
 {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    _impl->setCanInstallScrollPocket();
+    _impl->setClientImplicitlyRequestedTopScrollPocket();
 #endif
 
     if (_usesAutomaticContentInsetBackgroundFill == value)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -812,7 +812,7 @@ public:
     void updateTopScrollPocketCaptureColor();
     void updateTopScrollPocketStyle();
     void updatePrefersSolidColorHardPocket();
-    void setCanInstallScrollPocket();
+    void setClientImplicitlyRequestedTopScrollPocket();
 #endif
 
 private:
@@ -1098,7 +1098,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     RetainPtr<NSScrollPocket> m_topScrollPocket;
     RetainPtr<NSHashTable<NSView *>> m_viewsAboveScrollPocket;
-    bool m_canInstallScrollPocket { false };
+    bool m_clientImplicitlyRequestedTopScrollPocket { false };
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7163,12 +7163,12 @@ void WebViewImpl::fulfillDeferredImageAnalysisOverlayViewHierarchyTask()
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
-void WebViewImpl::setCanInstallScrollPocket()
+void WebViewImpl::setClientImplicitlyRequestedTopScrollPocket()
 {
-    if (m_canInstallScrollPocket)
+    if (m_clientImplicitlyRequestedTopScrollPocket)
         return;
 
-    m_canInstallScrollPocket = true;
+    m_clientImplicitlyRequestedTopScrollPocket = true;
     updateScrollPocket();
 }
 
@@ -7202,15 +7202,13 @@ void WebViewImpl::updateScrollPocket()
         return;
 
     Ref page = m_page.get();
-    if (!m_canInstallScrollPocket)
-        return;
-
     RetainPtr view = m_view.get();
     CGFloat topContentInset = obscuredContentInsets().top();
     CGFloat additionalHeight = page->overflowHeightForTopScrollEdgeEffect();
     bool needsTopView = page->preferences().contentInsetBackgroundFillEnabled()
         && view
         && !view->_reasonsToHideTopScrollPocket
+        && (m_clientImplicitlyRequestedTopScrollPocket || automaticallyAdjustsContentInsets())
         && (topContentInset > 0 || additionalHeight > 0);
 
     RetainPtr topScrollPocketSelector = NSStringFromSelector(@selector(_topScrollPocket));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
@@ -320,6 +320,7 @@ TEST(ObscuredContentInsets, TopScrollPocketKVO)
 TEST(ObscuredContentInsets, NonObscuredTopContentInset)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+    [webView _setAutomaticallyAdjustsContentInsets:NO];
     EXPECT_NULL([webView _topScrollPocket]);
 
     [webView _setTopContentInset:50];
@@ -329,6 +330,21 @@ TEST(ObscuredContentInsets, NonObscuredTopContentInset)
 
     [webView _setOverrideTopScrollEdgeEffectColor:NSColor.redColor];
     [webView waitForNextPresentationUpdate];
+    EXPECT_NOT_NULL([webView _topScrollPocket]);
+}
+
+TEST(ObscuredContentInsets, ScrollPocketWithAutomaticTopContentInset)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+    RetainPtr window = [webView window];
+
+    [window setStyleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView];
+    [window setTitlebarAppearsTransparent:NO];
+    [window setToolbarStyle:NSWindowToolbarStyleExpanded];
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+    [webView evaluateJavaScript:@"scrollBy(0, 1000)" completionHandler:nil];
+    [webView waitForNextPresentationUpdate];
+
     EXPECT_NOT_NULL([webView _topScrollPocket]);
 }
 


### PR DESCRIPTION
#### 93fffd881e9d01735558b16dfd64d1c4d3c6959e
<pre>
[macOS] Simple WKWebView app with a toolbar fails to get a toolbar background
<a href="https://bugs.webkit.org/show_bug.cgi?id=302098">https://bugs.webkit.org/show_bug.cgi?id=302098</a>
<a href="https://rdar.apple.com/161370795">rdar://161370795</a>

Reviewed by Abrar Rahman Protyasha.

Currently, an app that uses none of the following SPI or API methods:

• `-setObscuredContentInsets:` / `-_setObscuredContentInsets:immediate:`
• `-_setOverflowHeightForTopScrollEdgeEffect:`
• `-_setOverrideTopScrollEdgeEffectColor:`
• `-_setUsesAutomaticContentInsetBackgroundFill:`

...will not get an automatic hard scroll pocket in the top content inset area. This was done to
prevent clients that only specify a top content inset without obscuring content (e.g. the Music
app&apos;s iTunes pane) from unexpectedly getting a hard pocket (see  <a href="https://webkit.org/b/298134).">https://webkit.org/b/298134).</a>

However, this also means that a WebKit client that uses neither `-_setTopContentInset:` nor
`-_setAutomaticallyAdjustsContentInsets:` but still expects a top inset due to the automatic
content inset adjustment won&apos;t get a top scroll pocket, when it actually needs it.

To mitigate this, we adjust this policy so that we only avoid adding the scroll pocket in the case
where we are not automatically computing content insets; in both cases where:

- The client gets its top content inset automatically, from the window&apos;s title bar.
- The client has used one of the above APIs, which implies the need for a top scroll pocket.

Test: ObscuredContentInsets.ScrollPocketWithAutomaticTopContentInset

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setObscuredContentInsets:immediate:]):
(-[WKWebView _setOverflowHeightForTopScrollEdgeEffect:]):
(-[WKWebView _setOverrideTopScrollEdgeEffectColor:]):
(-[WKWebView _setUsesAutomaticContentInsetBackgroundFill:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setClientImplicitlyRequestedTopScrollPocket):
(WebKit::WebViewImpl::updateScrollPocket):

Rename `m_canInstallScrollPocket` to `m_clientImplicitlyRequestedTopScrollPocket`, to better reflect
its new purpose.

(WebKit::WebViewImpl::setCanInstallScrollPocket): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, NonObscuredTopContentInset)):

Adjust this test to disable automatic top content inset compuation, to ensure that the top scroll
pocket is created.

(TestWebKitAPI::TEST(ObscuredContentInsets, ScrollPocketWithAutomaticTopContentInset)):

Canonical link: <a href="https://commits.webkit.org/302682@main">https://commits.webkit.org/302682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a742fdb4f553875dbb8793a3ea8049486a6e937

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81354 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b1a4ebc-c909-41ca-9af7-06b24faaf83d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2020 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98930 "Failure limit exceed. At least found 1 new test failure: fast/dom/zoom-scroll-page-test.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132816 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79617 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c3578a04-2134-4a07-b645-5095e8a66873) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80532 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139743 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1924 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107433 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107317 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27323 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1549 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31139 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54726 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65366 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1811 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->