### PR TITLE
AudioVideoRendererRemote should use its own work queue

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -119,62 +119,6 @@ MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(Media
     m_defaultSpatialTrackingLabel = player->defaultSpatialTrackingLabel();
     m_spatialTrackingLabel = player->spatialTrackingLabel();
 #endif
-
-    m_renderer->notifyWhenErrorOccurs([weakThis = WeakPtr { *this }](PlatformMediaError) {
-        if (RefPtr protectedThis = weakThis.get()) {
-            protectedThis->setNetworkState(MediaPlayer::NetworkState::DecodeError);
-            protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
-        }
-    });
-
-    ASSERT(player);
-    if (RefPtr protectedPlayer = player) {
-        m_renderer->setVolume(protectedPlayer->volume());
-        m_renderer->setMuted(protectedPlayer->muted());
-        m_renderer->setPreservesPitchAndCorrectionAlgorithm(protectedPlayer->preservesPitch(), protectedPlayer->pitchCorrectionAlgorithm());
-#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
-        m_renderer->setOutputDeviceId(protectedPlayer->audioOutputDeviceIdOverride());
-#endif
-    }
-
-    m_renderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && !protectedThis->seeking())
-            protectedThis->setHasAvailableVideoFrame(true);
-    });
-
-    m_renderer->notifyWhenRequiresFlushToResume([weakThis = WeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setLayerRequiresFlush();
-    });
-
-    m_renderer->notifyRenderingModeChanged([weakThis = WeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get()) {
-            if (RefPtr player = protectedThis->m_player.get())
-                player->renderingModeChanged();
-        }
-    });
-
-    m_renderer->notifySizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setNaturalSize(size);
-    });
-
-    m_renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }](double) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->effectiveRateChanged();
-    });
-
-    m_renderer->notifyVideoLayerSizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
-        if (RefPtr protectedThis = weakThis.get()) {
-            if (RefPtr player = protectedThis->m_player.get())
-                player->videoLayerSizeDidChange(size);
-        }
-    });
-
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-    if (RetainPtr videoTarget = player->videoTarget())
-        m_renderer->setVideoTarget(videoTarget.get());
-#endif
 }
 
 MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC()
@@ -271,19 +215,84 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const LoadOptions& o
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    if (RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateAVFObjC>(client.mediaSourcePrivate())) {
-        mediaSourcePrivate->setPlayer(this);
-        m_mediaSourcePrivate = WTFMove(mediaSourcePrivate);
-        client.reOpen();
-    } else
-        m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
+    m_renderer->notifyWhenErrorOccurs([weakThis = WeakPtr { *this }](PlatformMediaError) {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                protectedThis->setNetworkState(MediaPlayer::NetworkState::DecodeError);
+                protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
+            }
+        });
+    });
+
+    m_renderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }] {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && !protectedThis->seeking())
+                protectedThis->setHasAvailableVideoFrame(true);
+        });
+    });
+
+    m_renderer->notifyWhenRequiresFlushToResume([weakThis = WeakPtr { *this }] {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->setLayerRequiresFlush();
+        });
+    });
+
+    m_renderer->notifyRenderingModeChanged([weakThis = WeakPtr { *this }] {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->m_player.get())
+                    player->renderingModeChanged();
+            }
+        });
+    });
+
+    m_renderer->notifySizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
+        ensureOnMainThread([weakThis, size] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->setNaturalSize(size);
+        });
+    });
+
+    m_renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }](double) {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->effectiveRateChanged();
+        });
+    });
+
+    m_renderer->notifyVideoLayerSizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
+        ensureOnMainThread([weakThis, size] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->m_player.get())
+                    player->videoLayerSizeDidChange(size);
+            }
+        });
+    });
 
     m_loadOptions = options;
     m_renderer->setPreferences(options.videoRendererPreferences);
     if (RefPtr player = m_player.get()) {
         m_renderer->setPresentationSize(player->presentationSize());
         m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
+        m_renderer->setVolume(player->volume());
+        m_renderer->setMuted(player->muted());
+        m_renderer->setPreservesPitchAndCorrectionAlgorithm(player->preservesPitch(), player->pitchCorrectionAlgorithm());
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+        m_renderer->setOutputDeviceId(player->audioOutputDeviceIdOverride());
+#endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+        if (RetainPtr videoTarget = player->videoTarget())
+            m_renderer->setVideoTarget(videoTarget.get());
+#endif
     }
+
+    if (RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateAVFObjC>(client.mediaSourcePrivate())) {
+        mediaSourcePrivate->setPlayer(this);
+        m_mediaSourcePrivate = WTFMove(mediaSourcePrivate);
+        client.reOpen();
+    } else
+        m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setResourceOwner(const ProcessIdentity& resourceOwner)
@@ -425,7 +434,10 @@ MediaTime MediaPlayerPrivateMediaSourceAVFObjC::clampTimeToSensicalValue(const M
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&& callback)
 {
+    assertIsMainThread();
     m_renderer->setTimeObserver(10_ms, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](const MediaTime& currentTime) mutable {
+        // This method is only used with the RemoteMediaPlayerProxy and RemoteAudioVideoRendererProxyManager where m_renderer is an AudioVideoRendererAVFObjC that runs on the main thread only (for now).
+        assertIsMainThread();
         if (RefPtr protectedThis = weakThis.get())
             callback(protectedThis->clampTimeToSensicalValue(currentTime));
     });
@@ -638,20 +650,22 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
             auto logSiteIdentifier = LOGIDENTIFIER;
             UNUSED_PARAM(logSiteIdentifier);
             m_renderer->notifyTimeReachedAndStall(gapStart, [weakThis = WeakPtr { *this }, logSiteIdentifier](const MediaTime& stallTime) {
-                RefPtr protectedThis = weakThis.get();
-                if (!protectedThis)
-                    return;
-                if (protectedThis->protectedMediaSourcePrivate()->hasFutureTime(stallTime) && protectedThis->shouldBePlaying()) {
-                    ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "Data now available at ", stallTime, " resuming");
-                    protectedThis->m_renderer->play(); // New data was added, resume. Can't happen in practice, action would have been cancelled once buffered changed.
-                    return;
-                }
-                MediaTime now = protectedThis->currentTime();
-                ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
+                ensureOnMainThread([weakThis, logSiteIdentifier, stallTime] {
+                    RefPtr protectedThis = weakThis.get();
+                    if (!protectedThis)
+                        return;
+                    if (protectedThis->protectedMediaSourcePrivate()->hasFutureTime(stallTime) && protectedThis->shouldBePlaying()) {
+                        ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "Data now available at ", stallTime, " resuming");
+                        protectedThis->m_renderer->play(); // New data was added, resume. Can't happen in practice, action would have been cancelled once buffered changed.
+                        return;
+                    }
+                    MediaTime now = protectedThis->currentTime();
+                    ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
 
-                if (stallTime == protectedThis->duration())
-                    protectedThis->pause();
-                protectedThis->timeChanged();
+                    if (stallTime == protectedThis->duration())
+                        protectedThis->pause();
+                    protectedThis->timeChanged();
+                });
             });
             return;
         }
@@ -1115,7 +1129,11 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::isCurrentPlaybackTargetWireless() con
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtTime(WTF::Function<void(const MediaTime&)>&& task, const MediaTime& time)
 {
-    m_renderer->performTaskAtTime(time, WTFMove(task));
+    m_renderer->performTaskAtTime(time, [task = WTFMove(task)](const MediaTime& time) mutable {
+        ensureOnMainThread([time, task = WTFMove(task)] {
+            task(time);
+        });
+    });
     return true;
 }
 
@@ -1137,8 +1155,10 @@ void MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering()
 
     m_isGatheringVideoFrameMetadata = true;
     m_renderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->checkNewVideoFrameMetadata(presentationTime, displayTime);
+        ensureOnMainThread([weakThis, presentationTime, displayTime] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->checkNewVideoFrameMetadata(presentationTime, displayTime);
+        });
     });
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -116,67 +116,6 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
             didProvideMediaDataForTrackId(WTFMove(sample), trackId, mediaType);
     });
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-    m_renderer->setVideoTarget(player->videoTarget());
-#endif
-
-    m_renderer->notifyWhenErrorOccurs([weakThis = WeakPtr { *this }](PlatformMediaError error) {
-        if (RefPtr protectedThis = weakThis.get()) {
-            protectedThis->m_errored = true;
-            if (RefPtr player = protectedThis->m_player.get(); player && error == PlatformMediaError::IPCError) {
-                player->reloadAndResumePlaybackIfNeeded();
-                return;
-            }
-            protectedThis->setNetworkState(MediaPlayer::NetworkState::DecodeError);
-            protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
-        }
-    });
-
-    if (RefPtr protectedPlayer = player) {
-        m_renderer->setVolume(protectedPlayer->volume());
-        m_renderer->setVolume(protectedPlayer->muted());
-        m_renderer->setPreservesPitchAndCorrectionAlgorithm(protectedPlayer->preservesPitch(), protectedPlayer->pitchCorrectionAlgorithm());
-#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
-        m_renderer->setOutputDeviceId(protectedPlayer->audioOutputDeviceIdOverride());
-#endif
-    }
-
-    m_renderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setHasAvailableVideoFrame(true);
-    });
-
-    m_renderer->notifyWhenRequiresFlushToResume([weakThis = WeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setLayerRequiresFlush();
-    });
-
-    m_renderer->notifyRenderingModeChanged([weakThis = WeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get()) {
-            if (RefPtr player = protectedThis->m_player.get())
-                player->renderingModeChanged();
-        }
-    });
-
-    m_renderer->notifySizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setNaturalSize(size);
-    });
-
-    m_renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }](double) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->effectiveRateChanged();
-    });
-
-    m_renderer->setPreferences(VideoRendererPreference::PrefersDecompressionSession);
-
-    m_renderer->notifyVideoLayerSizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
-        if (RefPtr protectedThis = weakThis.get()) {
-            if (RefPtr player = protectedThis->m_player.get())
-                player->videoLayerSizeDidChange(size);
-        }
-    });
-
 #if HAVE(SPATIAL_TRACKING_LABEL)
     m_defaultSpatialTrackingLabel = player->defaultSpatialTrackingLabel();
     m_spatialTrackingLabel = player->spatialTrackingLabel();
@@ -268,7 +207,78 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
 
     m_renderer->setPreferences(options.videoRendererPreferences | VideoRendererPreference::PrefersDecompressionSession);
 
+    m_renderer->notifyWhenErrorOccurs([weakThis = WeakPtr { *this }](PlatformMediaError error) {
+        ensureOnMainThread([weakThis, error] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                protectedThis->m_errored = true;
+                if (RefPtr player = protectedThis->m_player.get(); player && error == PlatformMediaError::IPCError) {
+                    player->reloadAndResumePlaybackIfNeeded();
+                    return;
+                }
+                protectedThis->setNetworkState(MediaPlayer::NetworkState::DecodeError);
+                protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
+            }
+        });
+    });
+
+    m_renderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }] {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->setHasAvailableVideoFrame(true);
+        });
+    });
+
+    m_renderer->notifyWhenRequiresFlushToResume([weakThis = WeakPtr { *this }] {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->setLayerRequiresFlush();
+        });
+    });
+
+    m_renderer->notifyRenderingModeChanged([weakThis = WeakPtr { *this }] {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->m_player.get())
+                    player->renderingModeChanged();
+            }
+        });
+    });
+
+    m_renderer->notifySizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
+        ensureOnMainThread([weakThis, size] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->setNaturalSize(size);
+        });
+    });
+
+    m_renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }](double) {
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->effectiveRateChanged();
+        });
+    });
+
+    m_renderer->setPreferences(VideoRendererPreference::PrefersDecompressionSession);
+
+    m_renderer->notifyVideoLayerSizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
+        ensureOnMainThread([weakThis, size] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->m_player.get())
+                    player->videoLayerSizeDidChange(size);
+            }
+        });
+    });
+
     if (RefPtr player = m_player.get()) {
+        m_renderer->setVolume(player->volume());
+        m_renderer->setMuted(player->muted());
+        m_renderer->setPreservesPitchAndCorrectionAlgorithm(player->preservesPitch(), player->pitchCorrectionAlgorithm());
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+        m_renderer->setOutputDeviceId(player->audioOutputDeviceIdOverride());
+#endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+        m_renderer->setVideoTarget(player->videoTarget());
+#endif
         m_renderer->setPresentationSize(player->presentationSize());
         m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
     }
@@ -793,11 +803,13 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
         return;
 
     m_renderer->notifyTimeReachedAndStall(duration, [weakThis = ThreadSafeWeakPtr { *this }](const MediaTime&) {
-        if (RefPtr protectedThis = weakThis.get()) {
-            protectedThis->m_renderer->pause();
-            if (RefPtr player = protectedThis->m_player.get())
-                player->timeChanged();
-        }
+        ensureOnMainThread([weakThis] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                protectedThis->m_renderer->pause();
+                if (RefPtr player = protectedThis->m_player.get())
+                    player->timeChanged();
+            }
+        });
     });
 
     m_duration = WTFMove(duration);
@@ -994,8 +1006,10 @@ void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId
     if (!trackIdentifier)
         return; // track hasn't been enabled yet.
     m_renderer->requestMediaDataWhenReady(*trackIdentifier, [weakThis = ThreadSafeWeakPtr { *this }, trackId](AudioVideoRenderer::TrackIdentifier) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->didBecomeReadyForMoreSamples(trackId);
+        ensureOnMainThread([weakThis, trackId] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->didBecomeReadyForMoreSamples(trackId);
+        });
     });
 }
 
@@ -1134,8 +1148,10 @@ void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, boo
             characteristicsChanged();
         }
         m_renderer->notifyTrackNeedsReenqueuing(trackIdentifier, [weakThis = WeakPtr { *this }, trackId](TrackIdentifier, const MediaTime&) {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->reenqueSamples(trackId, NeedsFlush::No);
+            ensureOnMainThread([weakThis, trackId] {
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->reenqueSamples(trackId, NeedsFlush::No);
+            });
         });
         return;
     }
@@ -1321,8 +1337,10 @@ void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = true;
     m_renderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->checkNewVideoFrameMetadata(presentationTime, displayTime);
+        ensureOnMainThread([weakThis, presentationTime, displayTime] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->checkNewVideoFrameMetadata(presentationTime, displayTime);
+        });
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -184,13 +184,13 @@ private:
     WebCore::HostingContext hostingContext() const final;
     void setLayerHostingContext(WebCore::HostingContext&&);
 #if PLATFORM(COCOA)
-    WebCore::FloatSize videoLayerSize() const { return m_videoLayerSize; };
+    WebCore::FloatSize videoLayerSize() const;
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;
 #endif
     void notifyVideoLayerSizeChanged(Function<void(const MediaTime&, WebCore::FloatSize)>&& callback) final;
     // VideoLayerRemoteParent
     bool inVideoFullscreenOrPictureInPicture() const final;
-    WebCore::FloatSize naturalSize() const final { return m_naturalSize; }
+    WebCore::FloatSize naturalSize() const final;
 
 #if ENABLE(ENCRYPTED_MEDIA)
     void setCDMInstance(WebCore::CDMInstance*) final;
@@ -210,50 +210,61 @@ private:
     WTFLogChannel& logChannel() const final;
 #endif
 
+    void setState(RemoteAudioVideoRendererState);
+
     void ensureOnDispatcher(Function<void()>&&);
-    void ensureOnDispatcherSync(Function<void()>&&);
+    void ensureOnDispatcherSync(NOESCAPE Function<void()>&&);
+    void ensureOnDispatcherWithConnection(Function<void(AudioVideoRendererRemote&, IPC::Connection&)>&&);
     static WorkQueue& queueSingleton();
     bool isGPURunning() const { return !m_shutdown; }
 
     void updateCacheState(const RemoteAudioVideoRendererState&);
+    class ReadyForMoreData {
+    public:
+        static constexpr size_t kMaxPendingSample = 20;
+        bool isReadyForMoreData() const { return m_pendingSamples < kMaxPendingSample; }
+        void reset() { m_pendingSamples = 0; }
+        void sampleEnqueued() { m_pendingSamples++; }
+    private:
+        size_t m_pendingSamples { 0 };
+    };
+    ReadyForMoreData& readyForMoreData(TrackIdentifier);
 
     const ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     const Ref<MessageReceiver> m_receiver;
     const RemoteAudioVideoRendererIdentifier m_identifier;
 
-    bool m_shutdown { false };
+    std::atomic<bool> m_shutdown { false };
 
-    RemoteAudioVideoRendererState m_state;
+    mutable Lock m_lock;
+    RemoteAudioVideoRendererState m_state WTF_GUARDED_BY_LOCK(m_lock);
 
-    Function<void(WebCore::PlatformMediaError)> m_errorCallback;
-    Function<void()> m_firstFrameAvailableCallback;
-    Function<void(const MediaTime&, double)> m_hasAvailableVideoFrameCallback;
-    Function<void()> m_notifyWhenRequiresFlushToResumeCallback;
-    Function<void()> m_renderingModeChangedCallback;
-    Function<void(const MediaTime&, WebCore::FloatSize)> m_sizeChangedCallback;
-    Function<void(const MediaTime&)> m_currentTimeDidChangeCallback;
-    Function<void(double)> m_effectiveRateChangedCallback;
-    Function<void(const MediaTime&)> m_timeReachedAndStallCallback;
-    Function<void(const MediaTime&)> m_performTaskAtTimeCallback;
-    MediaTime m_performTaskAtTime;
-    Function<void(const MediaTime&, WebCore::FloatSize)> m_videoLayerSizeChangedCallback;
+    Function<void(WebCore::PlatformMediaError)> m_errorCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void()> m_firstFrameAvailableCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(const MediaTime&, double)> m_hasAvailableVideoFrameCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void()> m_notifyWhenRequiresFlushToResumeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void()> m_renderingModeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(const MediaTime&, WebCore::FloatSize)> m_sizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(const MediaTime&)> m_currentTimeDidChangeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(double)> m_effectiveRateChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(const MediaTime&)> m_timeReachedAndStallCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(const MediaTime&)> m_performTaskAtTimeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    MediaTime m_performTaskAtTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Function<void(const MediaTime&, WebCore::FloatSize)> m_videoLayerSizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
 
-    static constexpr size_t kMaxPendingSample = 10;
-    struct RequestMediaDataWhenReadyData {
-        bool readyForMoreData() const { return pendingSamples < kMaxPendingSample; }
-        size_t pendingSamples { kMaxPendingSample };
-        Function<void(TrackIdentifier)> callback;
-    };
-    HashMap<TrackIdentifier, RequestMediaDataWhenReadyData> m_requestMediaDataWhenReadyData;
-    HashMap<TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>> m_trackNeedsReenqueuingCallbacks;
+    HashMap<TrackIdentifier, ReadyForMoreData> m_readyForMoreData WTF_GUARDED_BY_LOCK(m_lock);
+    HashMap<TrackIdentifier, Function<void(TrackIdentifier)>> m_requestMediaDataWhenReadyDataCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    HashMap<TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>> m_trackNeedsReenqueuingCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
 
-    Vector<LayerHostingContextCallback> m_layerHostingContextRequests;
-    WebCore::HostingContext m_layerHostingContext;
-    WebCore::FloatSize m_naturalSize;
+    Vector<LayerHostingContextCallback> m_layerHostingContextRequests WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    WebCore::HostingContext m_layerHostingContext WTF_GUARDED_BY_LOCK(m_lock);
+    WebCore::FloatSize m_naturalSize WTF_GUARDED_BY_LOCK(m_lock);
+    std::atomic<bool> m_seeking { false };
+    MediaTime m_lastSeekTime; // Always call on the renderer's client thread.
 #if PLATFORM(COCOA)
-    const UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager;
-    mutable PlatformLayerContainer m_videoLayer;
-    WebCore::FloatSize m_videoLayerSize;
+    const UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager WTF_GUARDED_BY_LOCK(m_lock);
+    mutable PlatformLayerContainer m_videoLayer WTF_GUARDED_BY_LOCK(m_lock);
+    WebCore::FloatSize m_videoLayerSize WTF_GUARDED_BY_LOCK(m_lock);
 #endif
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;


### PR DESCRIPTION
#### 2e95a76cf633a08aff0df1a41f05cbdaa186f6f0
<pre>
AudioVideoRendererRemote should use its own work queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=301964">https://bugs.webkit.org/show_bug.cgi?id=301964</a>
<a href="https://rdar.apple.com/164040921">rdar://164040921</a>

Reviewed by Youenn Fablet.

We make the AudioVideoRendererRemote thread-safe and run on a dedicated queue.
This will allow the SourceBufferPrivate to run on a thread different than
the main thread (as required when doing MSE in a worker).
As a future improvements, we could make the MediaPlayerPrivateWebM run on
a different thread than the main thread to allow for smoother startup time.

All renderer&apos;s callback are now called on the renderer&apos;s workqueue, as such
all AudioVideoRenderer&apos;s users must be modified to ensure that the callback
is then dispatched on the right thread.

No change in observable behaviour. Covered by existing tests.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load): Move initialisation of AudioVideoRenderer from constructor to load() to avoid constructing a WeakPtr while in the constructor.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::load): Set the renderer&apos;s callback outside the constructor to avoid constructing a WeakPtr in the constructor which causes a crash.
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeEnabled):
(WebCore::MediaPlayerPrivateWebM::startVideoFrameMetadataGathering):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::seekTo): Ensure that we send a state update once seek completes
so that the currentTime reported in the web content process is always up to date.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::~AudioVideoRendererRemote):
(WebKit::AudioVideoRendererRemote::setVolume):
(WebKit::AudioVideoRendererRemote::setMuted):
(WebKit::AudioVideoRendererRemote::setPreservesPitchAndCorrectionAlgorithm):
(WebKit::AudioVideoRendererRemote::setOutputDeviceId):
(WebKit::AudioVideoRendererRemote::setIsVisible):
(WebKit::AudioVideoRendererRemote::setPresentationSize):
(WebKit::AudioVideoRendererRemote::setShouldMaintainAspectRatio):
(WebKit::AudioVideoRendererRemote::renderingCanBeAcceleratedChanged):
(WebKit::AudioVideoRendererRemote::contentBoxRectChanged):
(WebKit::AudioVideoRendererRemote::notifyFirstFrameAvailable):
(WebKit::AudioVideoRendererRemote::notifyWhenHasAvailableVideoFrame):
(WebKit::AudioVideoRendererRemote::notifyWhenRequiresFlushToResume):
(WebKit::AudioVideoRendererRemote::notifyRenderingModeChanged):
(WebKit::AudioVideoRendererRemote::expectMinimumUpcomingPresentationTime):
(WebKit::AudioVideoRendererRemote::notifySizeChanged):
(WebKit::AudioVideoRendererRemote::setShouldDisableHDR):
(WebKit::AudioVideoRendererRemote::setPlatformDynamicRangeLimit):
(WebKit::AudioVideoRendererRemote::setResourceOwner):
(WebKit::AudioVideoRendererRemote::flushAndRemoveImage):
(WebKit::AudioVideoRendererRemote::currentVideoFrame const):
(WebKit::AudioVideoRendererRemote::videoPlaybackQualityMetrics):
(WebKit::AudioVideoRendererRemote::platformVideoLayer const):
(WebKit::AudioVideoRendererRemote::setVideoFullscreenLayer):
(WebKit::AudioVideoRendererRemote::setVideoFullscreenFrame):
(WebKit::AudioVideoRendererRemote::isInFullscreenOrPictureInPictureChanged):
(WebKit::AudioVideoRendererRemote::play):
(WebKit::AudioVideoRendererRemote::pause):
(WebKit::AudioVideoRendererRemote::paused const):
(WebKit::AudioVideoRendererRemote::setRate):
(WebKit::AudioVideoRendererRemote::effectiveRate const):
(WebKit::AudioVideoRendererRemote::stall):
(WebKit::AudioVideoRendererRemote::prepareToSeek):
(WebKit::AudioVideoRendererRemote::seekTo):
(WebKit::AudioVideoRendererRemote::seeking const):
(WebKit::AudioVideoRendererRemote::setPreferences):
(WebKit::AudioVideoRendererRemote::setHasProtectedVideoContent):
(WebKit::AudioVideoRendererRemote::addTrack):
(WebKit::AudioVideoRendererRemote::removeTrack):
(WebKit::AudioVideoRendererRemote::enqueueSample):
(WebKit::AudioVideoRendererRemote::isReadyForMoreSamples):
(WebKit::AudioVideoRendererRemote::requestMediaDataWhenReady):
(WebKit::AudioVideoRendererRemote::stopRequestingMediaData):
(WebKit::AudioVideoRendererRemote::notifyTrackNeedsReenqueuing):
(WebKit::AudioVideoRendererRemote::timeIsProgressing const):
(WebKit::AudioVideoRendererRemote::notifyEffectiveRateChanged):
(WebKit::AudioVideoRendererRemote::currentTime const):
(WebKit::AudioVideoRendererRemote::notifyTimeReachedAndStall):
(WebKit::AudioVideoRendererRemote::cancelTimeReachedAction):
(WebKit::AudioVideoRendererRemote::performTaskAtTime):
(WebKit::AudioVideoRendererRemote::flush):
(WebKit::AudioVideoRendererRemote::flushTrack):
(WebKit::AudioVideoRendererRemote::applicationWillResignActive):
(WebKit::AudioVideoRendererRemote::notifyWhenErrorOccurs):
(WebKit::AudioVideoRendererRemote::setSpatialTrackingInfo):
(WebKit::AudioVideoRendererRemote::ensureOnDispatcherSync):
(WebKit::AudioVideoRendererRemote::ensureOnDispatcher):
(WebKit::AudioVideoRendererRemote::ensureOnDispatcherWithConnection): Add utility method to simplify the dispatch the task on the right workqueue.
(WebKit::AudioVideoRendererRemote::updateCacheState):
(WebKit::AudioVideoRendererRemote::readyForMoreData):
(WebKit::AudioVideoRendererRemote::requestHostingContext):
(WebKit::AudioVideoRendererRemote::hostingContext const):
(WebKit::AudioVideoRendererRemote::setLayerHostingContext):
(WebKit::AudioVideoRendererRemote::inVideoFullscreenOrPictureInPicture const):
(WebKit::AudioVideoRendererRemote::naturalSize const):
(WebKit::AudioVideoRendererRemote::setCDMInstance):
(WebKit::AudioVideoRendererRemote::setInitData):
(WebKit::AudioVideoRendererRemote::attemptToDecrypt):
(WebKit::AudioVideoRendererRemote::setCDMSession):
(WebKit::AudioVideoRendererRemote::videoLayerSize const):
(WebKit::AudioVideoRendererRemote::setVideoLayerSizeFenced):
(WebKit::AudioVideoRendererRemote::notifyVideoLayerSizeChanged):
(WebKit::AudioVideoRendererRemote::gpuProcessConnectionDidClose):
(WebKit::AudioVideoRendererRemote::MessageReceiver::firstFrameAvailable):
(WebKit::AudioVideoRendererRemote::MessageReceiver::hasAvailableVideoFrame):
(WebKit::AudioVideoRendererRemote::MessageReceiver::requiresFlushToResume):
(WebKit::AudioVideoRendererRemote::MessageReceiver::renderingModeChanged):
(WebKit::AudioVideoRendererRemote::MessageReceiver::sizeChanged):
(WebKit::AudioVideoRendererRemote::MessageReceiver::trackNeedsReenqueuing):
(WebKit::AudioVideoRendererRemote::MessageReceiver::effectiveRateChanged):
(WebKit::AudioVideoRendererRemote::MessageReceiver::stallTimeReached):
(WebKit::AudioVideoRendererRemote::MessageReceiver::taskTimeReached):
(WebKit::AudioVideoRendererRemote::MessageReceiver::errorOccurred):
(WebKit::AudioVideoRendererRemote::MessageReceiver::requestMediaDataWhenReady):
(WebKit::AudioVideoRendererRemote::MessageReceiver::stateUpdate):
(WebKit::AudioVideoRendererRemote::MessageReceiver::layerHostingContextChanged):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/302690@main">https://commits.webkit.org/302690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78aa5d4749836d72bb540e71582231f461923572

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137295 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e73de14f-8a8b-47e3-9344-fd2f67d29e42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98951 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8ec194f-ebf5-4501-9575-b6474624ca3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132849 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79642 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b35680c-7bfa-480c-9571-8077660cc7bd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80565 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139776 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107457 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107343 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1563 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54759 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65399 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1844 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1953 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->