### PR TITLE
Prevent overflow in LayoutUnit operator++

### DIFF
--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -126,7 +126,7 @@ public:
 
     LayoutUnit& operator++()
     {
-        m_value += kFixedPointDenominator;
+        m_value = saturatedSum<int>(m_value, kFixedPointDenominator);
         return *this;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
@@ -321,4 +321,13 @@ TEST(WebCoreLayoutUnit, FromFloatRound)
     ASSERT_EQ(LayoutUnit::min(), LayoutUnit::fromFloatRound(-Limits::infinity()));
 }
 
+TEST(WebCoreLayoutUnit, LayoutUnitPlusPlus)
+{
+    ASSERT_EQ(LayoutUnit(-1), ++LayoutUnit(-2));
+    ASSERT_EQ(LayoutUnit(0), ++LayoutUnit(-1));
+    ASSERT_EQ(LayoutUnit(1), ++LayoutUnit(0));
+    ASSERT_EQ(LayoutUnit(2), ++LayoutUnit(1));
+    ASSERT_EQ(LayoutUnit::max(), ++LayoutUnit(LayoutUnit::max()));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4d7b119b4c65ee2318d97fc8834edbb2a26c28f4
<pre>
Prevent overflow in LayoutUnit operator++
<a href="https://bugs.webkit.org/show_bug.cgi?id=266939">https://bugs.webkit.org/show_bug.cgi?id=266939</a>
<a href="https://rdar.apple.com/120572251">rdar://120572251</a>

Reviewed by Alan Baradlay.

Prevent overflows in the Layout Unit ++ operator.

Influenced by &lt;<a href="https://source.chromium.org/chromium/chromium/src/+/43a5cd79fe73e334515f0ef0a55dbf670f133923">https://source.chromium.org/chromium/chromium/src/+/43a5cd79fe73e334515f0ef0a55dbf670f133923</a>&gt;

Test: Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp

* Source/WebCore/platform/LayoutUnit.h:
(WebCore::LayoutUnit::operator++):
* Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp:
(TestWebKitAPI::TEST(WebCoreLayoutUnit, LayoutUnitPlusPlus)):

Canonical link: <a href="https://commits.webkit.org/302719@main">https://commits.webkit.org/302719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56e20fd694588dee1d58f8cedbb2d70d22d6c96c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81427 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d75cedf9-d2cb-4e29-b9d3-79ee7e8be069) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66785 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ab848d0-bf1d-4da4-aab3-dffbf219ea7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79659 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff7601e8-bcdb-4b1f-87ae-9c61940ab0e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80588 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139799 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107472 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107360 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27341 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54782 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65422 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->