### PR TITLE
[threaded-animations] add support for scroll timelines

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
@@ -22,6 +22,7 @@ body {
 <script src="../../resources/testharnessreport.js"></script>
 <script src="../../resources/ui-helper.js"></script>
 <script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="threaded-animations-utils.js"></script>
 
 <script>
 
@@ -29,15 +30,6 @@ const make_target = t => {
     const target = createDiv(t);
     target.className = "target";
     return target;
-};
-
-const animationAcceleration = async animation => {
-    // An animation must be ready to be considered for acceleration.
-    await animation.ready;
-    // We only need to wait for the next JS run loop here
-    // because composition will happen during the animation frame,
-    // but after the requestAnimationFrame callbacks have been serviced.
-    await new Promise(setTimeout);
 };
 
 promise_test(async t => {

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The timeline current time updates as its source is scrolled with a nested scroller
+

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<body>
+<style>
+
+#scroller {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    overflow-y: scroll;
+    background-color: black;
+}
+
+#content {
+    height: 200px;
+    background-color: blue;
+}
+
+#target {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    background-color: green;
+}
+
+</style>
+
+<div id="scroller">
+    <div id="content"></div>
+    <div id="target"></div>
+</div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const scrollAndCheckTimeline = async (scroller, progress) => {
+    const maxScrollTop = scroller.scrollHeight - scroller.offsetHeight;
+    const scrollTop = progress * maxScrollTop;
+    scroller.scrollTop = scrollTop;
+
+    const expectedTimelineTime = `${(progress * 100).toFixed(2)}%`;
+
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+    assert_equals(remoteAnimationStack.animations.length, 1);
+    const timelineTime = remoteAnimationStack.animations[0].timeline.currentTime;
+    assert_equals(timelineTime, expectedTimelineTime, `After scrolling to ${scrollTop}, the timeline time is ${expectedTimelineTime}`);
+};
+
+promise_test(async t => { 
+    const timeline = new ScrollTimeline({ source : scroller });
+    const animation = target.animate({ opacity: 1 }, { timeline });
+
+    await animationAcceleration(animation);
+
+    await scrollAndCheckTimeline(scroller, 0);
+    await scrollAndCheckTimeline(scroller, 0.5);
+    await scrollAndCheckTimeline(scroller, 0.25);
+    await scrollAndCheckTimeline(scroller, 0.75);
+}, "The timeline current time updates as its source is scrolled with a nested scroller");
+
+</script>
+</body>

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The timeline current time updates as its source is scrolled with a root scroller
+

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+#target {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+
+    background-color: green;
+    opacity: 0;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const scrollAndCheckTimeline = async (scroller, progress) => {
+    const maxScrollTop = scroller.scrollHeight - window.innerHeight;
+    const scrollTop = progress * maxScrollTop;
+
+    window.scrollTo(0, scrollTop);
+    await UIHelper.renderingUpdate();
+
+    const expectedTimelineTime = `${(progress * 100).toFixed(2)}%`;
+
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+    assert_equals(remoteAnimationStack.animations.length, 1);
+    const timelineTime = remoteAnimationStack.animations[0].timeline.currentTime;
+    assert_equals(timelineTime, expectedTimelineTime, `After scrolling to ${scrollTop}, the timeline time is ${expectedTimelineTime}`);
+};
+
+promise_test(async t => { 
+    const scroller = document.documentElement;
+    const timeline = new ScrollTimeline({ source : scroller });
+    const animation = target.animate({ opacity: 1 }, { timeline });
+
+    await animationAcceleration(animation);
+
+    await scrollAndCheckTimeline(scroller, 0);
+    await scrollAndCheckTimeline(scroller, 0.5);
+    await scrollAndCheckTimeline(scroller, 0.25);
+    await scrollAndCheckTimeline(scroller, 0.75);
+}, "The timeline current time updates as its source is scrolled with a root scroller");
+
+</script>
+</body>

--- a/LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js
@@ -1,0 +1,15 @@
+
+const animationAcceleration = async animation => {
+    // If the animation is already ready, it should already
+    // have been considered for acceleration.
+    if (!animation.pending)
+        return;
+
+    // An animation must be ready to be considered for acceleration.
+    await animation.ready;
+
+    // We only need to wait for the next JS run loop here
+    // because composition will happen during the animation frame,
+    // but after the requestAnimationFrame callbacks have been serviced.
+    await new Promise(setTimeout);
+};

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
@@ -28,7 +28,7 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-#import <WebCore/AcceleratedTimeline.h>
+#import <WebCore/ScrollingTreeScrollingNode.h>
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -122,6 +122,27 @@ RemoteProgressBasedTimeline* RemoteProgressBasedTimelineRegistry::get(const Time
     }
 
     return nullptr;
+}
+
+bool RemoteProgressBasedTimelineRegistry::hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode& node) const
+{
+    auto scrollingNodeID = node.scrollingNodeID();
+    auto it = m_timelines.find(scrollingNodeID.processIdentifier());
+    return it != m_timelines.end() && it->value.contains(scrollingNodeID);
+}
+
+void RemoteProgressBasedTimelineRegistry::updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode& node)
+{
+    auto processIterator = m_timelines.find(node.scrollingNodeID().processIdentifier());
+    if (processIterator == m_timelines.end())
+        return;
+
+    auto& processTimelines = processIterator->value;
+    auto sourceIterator = processTimelines.find(node.scrollingNodeID());
+    if (sourceIterator != processTimelines.end()) {
+        for (auto& timeline : sourceIterator->value)
+            timeline->updateCurrentTime(node);
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
@@ -41,6 +41,8 @@ public:
     bool isEmpty() const { return m_timelines.isEmpty(); }
     void update(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&);
     RemoteProgressBasedTimeline* get(const TimelineID&) const;
+    void updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
+    bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;
 
 private:
     UncheckedKeyHashMap<WebCore::ProcessIdentifier, UncheckedKeyHashMap<WebCore::ScrollingNodeID, HashSet<Ref<RemoteProgressBasedTimeline>>>> m_timelines;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -148,6 +148,7 @@ public:
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
     virtual void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) { }
     virtual RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const { return nullptr; }
+    virtual void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) { }
     virtual RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const { return nullptr; }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/ScrollingTreePluginHostingNode.h>
 #include <WebCore/ScrollingTreePluginScrollingNode.h>
 #include <WebCore/ScrollingTreePositionedNodeCocoa.h>
+#include <WebCore/ScrollingTreeScrollingNode.h>
 #include <WebCore/ScrollingTreeStickyNodeCocoa.h>
 
 namespace WebKit {
@@ -313,6 +314,17 @@ RefPtr<const RemoteAnimationTimeline> RemoteScrollingTree::timeline(const Timeli
     if (m_progressBasedTimelineRegistry)
         return m_progressBasedTimelineRegistry->get(timelineID);
     return nullptr;
+}
+
+bool RemoteScrollingTree::hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode& node) const
+{
+    return m_progressBasedTimelineRegistry && m_progressBasedTimelineRegistry->hasTimelineForNode(node);
+}
+
+void RemoteScrollingTree::updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode& node)
+{
+    if (m_progressBasedTimelineRegistry)
+        m_progressBasedTimelineRegistry->updateTimelinesForNode(node);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -40,6 +40,9 @@
 
 namespace WebCore {
 class PlatformMouseEvent;
+#if ENABLE(THREADED_ANIMATIONS)
+class ScrollingTreeScrollingNode;
+#endif
 };
 
 namespace WebKit {
@@ -92,6 +95,7 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
+    bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;
 #endif
 
 protected:
@@ -109,6 +113,8 @@ protected:
     bool m_hasNodesWithSynchronousScrollingReasons WTF_GUARDED_BY_LOCK(m_treeLock) { false };
 
 #if ENABLE(THREADED_ANIMATIONS)
+    void updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
+
 private:
     std::unique_ptr<RemoteProgressBasedTimelineRegistry> m_progressBasedTimelineRegistry;
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -77,6 +77,7 @@ public:
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const override;
+    void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) override;
     void updateAnimations();
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -447,7 +447,14 @@ RemoteLayerTreeDrawingAreaProxyIOS& RemoteScrollingCoordinatorProxyIOS::drawingA
 void RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode(RemoteLayerTreeNode& node)
 {
     m_animatedNodeLayerIDs.add(node.layerID());
-    drawingAreaIOS().scheduleDisplayRefreshCallbacksForAnimation();
+    if (m_monotonicTimelineRegistry && !m_monotonicTimelineRegistry->isEmpty())
+        drawingAreaIOS().scheduleDisplayRefreshCallbacksForAnimation();
+}
+
+void RemoteScrollingCoordinatorProxyIOS::progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode& node)
+{
+    if (scrollingTree().hasTimelineForNode(node))
+        drawingAreaIOS().scheduleDisplayRefreshCallbacksForAnimation();
 }
 
 void RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -57,6 +57,12 @@ void RemoteScrollingTreeIOS::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNo
 {
     ASSERT(isMainRunLoop());
 
+#if ENABLE(THREADED_ANIMATIONS)
+    updateProgressBasedTimelinesForNode(node);
+    if (CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get())
+        scrollingCoordinatorProxy->progressBasedTimelinesWereUpdatedForNode(node);
+#endif
+
     // Scroll updates for the main frame on iOS are sent via WebPageProxy::updateVisibleContentRects()
     if (node.isRootNode()) {
         ScrollingTree::scrollingTreeNodeDidScroll(node, scrollingLayerPositionAction);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -393,7 +393,7 @@ void RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread()
 #if ENABLE(THREADED_ANIMATIONS)
         {
             Locker lock { m_animationLock };
-            if (!m_animationStacks.isEmpty())
+            if (m_monotonicTimelineRegistry && !m_monotonicTimelineRegistry->isEmpty())
                 return true;
         }
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -226,6 +226,10 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNo
 {
     ScrollingTree::scrollingTreeNodeDidScroll(node, action);
 
+#if ENABLE(THREADED_ANIMATIONS)
+    updateProgressBasedTimelinesForNode(node);
+#endif
+
     std::optional<FloatPoint> layoutViewportOrigin;
     if (auto* scrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNode>(node))
         layoutViewportOrigin = scrollingNode->layoutViewport().location();


### PR DESCRIPTION
#### 3fc022cc4bb9ec5be2fd8a22bfe2798678c59160
<pre>
[threaded-animations] add support for scroll timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=299804">https://bugs.webkit.org/show_bug.cgi?id=299804</a>
<a href="https://rdar.apple.com/161579685">rdar://161579685</a>

Reviewed by Matt Woodrow.

After foundational work done throughout 301942@main, 302029@main, 302282@main,
302580@main and 302634@main, we all the necessary data to represent scroll-driven
animations and their associated progress-based timelines in the remote layer tree.

The final piece of the puzzle is to now update progress-based timelines when
a scrolling tree node is scrolled, starting under the platform-specific
implementations of `RemoteScrollingTree::scrollingTreeNodeDidScroll()`.

Once progress-based timelines are updated, we make sure to schedule a rendering
update for the relevant animations.

To make sure this works, we add two new basic tests that scroll a root and a
nested scroller and check the timeline time in the remote layer tree is updated.

Note that this patch fails to make keyboard-originated scrolls work, this will
be addressed in a subsequent patch.

Tests: webanimations/threaded-animations/scroll-timeline-nested-scroller.html
       webanimations/threaded-animations/scroll-timeline-root-scroller.html

* LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html:
* LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html: Added.
* LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html: Added.
* LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js: Added.
(const.animationAcceleration.async animation):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp:
(WebKit::RemoteProgressBasedTimelineRegistry::hasTimelineForNode const):
(WebKit::RemoteProgressBasedTimelineRegistry::updateTimelinesForNode):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::progressBasedTimelinesWereUpdatedForNode):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::hasTimelineForNode const):
(WebKit::RemoteScrollingTree::updateProgressBasedTimelinesForNode):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::progressBasedTimelinesWereUpdatedForNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp:
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeDidScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidScroll):

Canonical link: <a href="https://commits.webkit.org/302702@main">https://commits.webkit.org/302702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cb8cee9ed0dda2e29bee1de5008ca52519f3760

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81379 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c29f4d3-27a4-493e-ada6-d99765f4ea95) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98945 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66755 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c56ebea2-275c-4d9e-ae9e-8e0ec9ce603c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/47b7e8cc-c801-4021-bbf8-303d6e022d6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34464 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80553 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139764 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107333 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31157 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54747 "Hash 8cb8cee9 for PR 53551 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20272 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65387 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1832 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1867 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->