### PR TITLE
[Safe CPP] Address Warnings in rendering/line

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -71,6 +71,7 @@ page/EventHandler.h
 page/Page.h
 page/PageOverlayController.cpp
 page/WheelEventTestMonitor.h
+[ iOS ] page/ios/ContentChangeObserver.h
 [ Mac ] page/mac/ImageOverlayControllerMac.mm
 [ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/ScrollingCoordinator.h
@@ -79,11 +80,15 @@ page/scrolling/ScrollingStateNode.h
 platform/PODRedBlackTree.h
 platform/Scrollbar.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
+[ iOS ] platform/ios/DeviceMotionClientIOS.h
+[ iOS ] platform/ios/LegacyTileCache.h
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
+[ iOS ] platform/text/TextBoundaries.cpp
 rendering/BreakablePositions.h
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
@@ -91,7 +96,6 @@ rendering/RenderTableCellInlines.h
 rendering/RenderText.cpp
 rendering/RenderTextLineBoxes.h
 rendering/TableLayout.h
-rendering/line/LineWidth.h
 rendering/style/StyleCachedImage.cpp
 rendering/svg/SVGRenderingContext.h
 style/StyleExtractorState.h
@@ -100,8 +104,3 @@ style/values/will-change/StyleWillChange.cpp
 testing/Internals.cpp
 xml/XSLStyleSheetLibxslt.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp
-[ iOS ] page/ios/ContentChangeObserver.h
-[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
-[ iOS ] platform/ios/DeviceMotionClientIOS.h
-[ iOS ] platform/ios/LegacyTileCache.h
-[ iOS ] platform/text/TextBoundaries.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -70,10 +70,6 @@ rendering/TextBoxPainter.h
 rendering/TextDecorationPainter.h
 [ iOS ] rendering/ios/RenderThemeIOS.mm
 rendering/line/BreakingContext.h
-rendering/line/LineBreaker.h
-rendering/line/LineWidth.h
-rendering/line/TrailingObjects.h
-rendering/line/WordTrailingSpace.h
 rendering/mathml/RenderMathMLScripts.h
 rendering/shapes/ShapeOutsideInfo.h
 rendering/svg/SVGRenderingContext.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -571,7 +571,6 @@ rendering/TextDecorationPainter.cpp
 [ iOS ] rendering/ios/RenderThemeIOS.mm
 rendering/line/BreakingContext.h
 rendering/line/LineInlineHeaders.h
-rendering/line/LineWidth.cpp
 rendering/line/TrailingObjects.cpp
 rendering/line/WordTrailingSpace.h
 rendering/mathml/MathOperator.cpp

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -46,7 +46,7 @@ void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& 
 
 LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo)
 {
-    ASSERT(resolver.position().root() == &m_block);
+    ASSERT(resolver.position().root() == m_block.ptr());
 
     bool appliedStartWidth = resolver.position().offset();
 

--- a/Source/WebCore/rendering/line/LineBreaker.h
+++ b/Source/WebCore/rendering/line/LineBreaker.h
@@ -27,6 +27,7 @@
 #include "FontCascade.h"
 #include "LegacyInlineIterator.h"
 #include "LineInfo.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -35,10 +36,10 @@ class RenderText;
 class TextLayout;
 
 struct RenderTextInfo {
-    RenderText* text { nullptr };
+    CheckedPtr<RenderText> text;
     std::unique_ptr<TextLayout, TextLayoutDeleter> layout;
     CachedLineBreakIteratorFactory lineBreakIteratorFactory;
-    const FontCascade* font { nullptr };
+    CheckedPtr<const FontCascade> font;
 };
 
 class LineBreaker {
@@ -56,7 +57,7 @@ private:
     void skipTrailingWhitespace(LegacyInlineIterator&, const LineInfo&);
     void skipLeadingWhitespace(InlineBidiResolver&, LineInfo&);
 
-    RenderBlockFlow& m_block;
+    CheckedRef<RenderBlockFlow> m_block;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/line/LineWidth.cpp
+++ b/Source/WebCore/rendering/line/LineWidth.cpp
@@ -68,10 +68,10 @@ bool LineWidth::fitsOnLineExcludingTrailingCollapsedWhitespace() const
 
 void LineWidth::updateAvailableWidth()
 {
-    LayoutUnit height = m_block.logicalHeight();
-    auto lineHeight = std::max(0_lu, m_block.lineHeight());
-    m_left = m_block.logicalLeftOffsetForLine(height, lineHeight);
-    m_right = m_block.logicalRightOffsetForLine(height, lineHeight);
+    LayoutUnit height = m_block->logicalHeight();
+    auto lineHeight = std::max(0_lu, m_block->lineHeight());
+    m_left = m_block->logicalLeftOffsetForLine(height, lineHeight);
+    m_right = m_block->logicalRightOffsetForLine(height, lineHeight);
 
     computeAvailableWidthFromLeftAndRight();
 }
@@ -92,7 +92,7 @@ void LineWidth::updateLineDimension(LayoutUnit newLineTop, LayoutUnit newLineWid
     if (newLineWidth <= m_availableWidth)
         return;
 
-    m_block.setLogicalHeight(newLineTop);
+    m_block->setLogicalHeight(newLineTop);
     m_availableWidth = newLineWidth;
     m_left = newLineLeft;
     m_right = newLineRight;

--- a/Source/WebCore/rendering/line/LineWidth.h
+++ b/Source/WebCore/rendering/line/LineWidth.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <WebCore/LayoutUnit.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -76,7 +77,7 @@ private:
     bool fitsOnLineExcludingTrailingCollapsedWhitespace() const;
     void updateLineDimension(LayoutUnit newLineTop, LayoutUnit newLineWidth, float newLineLeft, float newLineRight);
 
-    RenderBlockFlow& m_block;
+    const CheckedRef<RenderBlockFlow> m_block;
     float m_uncommittedWidth { 0 };
     float m_committedWidth { 0 };
     float m_trailingWhitespaceWidth { 0 };

--- a/Source/WebCore/rendering/line/TrailingObjects.cpp
+++ b/Source/WebCore/rendering/line/TrailingObjects.cpp
@@ -64,7 +64,7 @@ void TrailingObjects::updateWhitespaceCollapsingTransitionsForTrailingBoxes(Line
         // Add a new end transition that stops right at the very end.
         unsigned length = m_whitespace->text().length();
         unsigned pos = length >= 2 ? length - 2 : UINT_MAX;
-        LegacyInlineIterator endMid(0, m_whitespace, pos);
+        LegacyInlineIterator endMid(0, m_whitespace.get(), pos);
         lineWhitespaceCollapsingState.startIgnoringSpaces(endMid);
         for (size_t i = 0; i < m_boxes.size(); ++i)
             lineWhitespaceCollapsingState.ensureLineBoxInsideIgnoredSpaces(m_boxes[i]);

--- a/Source/WebCore/rendering/line/TrailingObjects.h
+++ b/Source/WebCore/rendering/line/TrailingObjects.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ public:
     void setTrailingWhitespace(RenderText& whitespace) { m_whitespace = &whitespace; }
     void clear()
     {
-        m_whitespace = { };
+        m_whitespace = nullptr;
         m_boxes.shrink(0); // Use shrink(0) instead of clear() to retain our capacity.
     }
 
@@ -60,7 +61,7 @@ public:
     void updateWhitespaceCollapsingTransitionsForTrailingBoxes(LineWhitespaceCollapsingState&, const LegacyInlineIterator& lBreak, CollapseFirstSpace);
 
 private:
-    RenderText* m_whitespace { nullptr };
+    CheckedPtr<RenderText> m_whitespace;
     Vector<std::reference_wrapper<RenderBoxModelObject>, 4> m_boxes;
 };
 

--- a/Source/WebCore/rendering/line/WordTrailingSpace.h
+++ b/Source/WebCore/rendering/line/WordTrailingSpace.h
@@ -28,6 +28,7 @@
 #include "RenderBlock.h"
 #include "RenderStyle.h"
 #include <optional>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ struct WordTrailingSpace {
     WordTrailingSpace(const RenderStyle& style, bool measuringWithTrailingWhitespaceEnabled = true)
         : m_style(style)
     {
-        if (!measuringWithTrailingWhitespaceEnabled || !m_style.fontCascade().enableKerning())
+        if (!measuringWithTrailingWhitespaceEnabled || !m_style->fontCascade().enableKerning())
             m_state = WordTrailingSpaceState::Initialized;
     }
 
@@ -45,7 +46,7 @@ struct WordTrailingSpace {
         if (m_state == WordTrailingSpaceState::Initialized)
             return m_width;
 
-        auto& font = m_style.fontCascade();
+        auto& font = m_style->fontCascade();
         m_width = font.width(RenderBlock::constructTextRun(span(space), m_style), &fallbackFonts) + font.wordSpacing();
         m_state = WordTrailingSpaceState::Initialized;
         return m_width;
@@ -53,7 +54,7 @@ struct WordTrailingSpace {
 
 private:
     enum class WordTrailingSpaceState { Uninitialized, Initialized };
-    const RenderStyle& m_style;
+    const CheckedRef<const RenderStyle> m_style;
     WordTrailingSpaceState m_state { WordTrailingSpaceState::Uninitialized };
     std::optional<float> m_width;
 };


### PR DESCRIPTION
#### b8d2efdb55675aefd42c9cf6b22b6ab1126c31a1
<pre>
[Safe CPP] Address Warnings in rendering/line
<a href="https://bugs.webkit.org/show_bug.cgi?id=302112">https://bugs.webkit.org/show_bug.cgi?id=302112</a>
<a href="https://rdar.apple.com/problem/164194446">rdar://problem/164194446</a>

Reviewed by Chris Dumez.

Fix Safe CPP warnings rendering/line/

rendering/line/LineBreaker.h
rendering/line/LineWidth.h
rendering/line/TrailingObjects.h
rendering/line/WordTrailingSpace.h

*  Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
* Source/WebCore/rendering/line/LineBreaker.h
* Source/WebCore/rendering/line/LineWidth.cpp
* Source/WebCore/rendering/line/LineWidth.h
* Source/WebCore/rendering/line/TrailingObjects.cpp
* Source/WebCore/rendering/line/TrailingObjects.h
* Source/WebCore/rendering/line/WordTrailingSpace.h

Canonical link: <a href="https://commits.webkit.org/302726@main">https://commits.webkit.org/302726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/596fd43de5ca20fa4a7530e79ea836b3a8f0cc79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81497 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d1d92a6-a9e4-4067-9917-3db0b786e41c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99018 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/407297ce-6ad5-482f-8fb6-0899d742f8f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79716 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2dfa8334-b4b7-4973-92f5-6169639db031) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34551 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80657 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1891 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107524 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107415 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27347 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31233 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65490 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->