### PR TITLE
[JSC] Mark inlined JSValue methods with `inline` keyword (and fix a bunch of things that break when that happens)

### DIFF
--- a/Source/JavaScriptCore/API/JSValueRef.cpp
+++ b/Source/JavaScriptCore/API/JSValueRef.cpp
@@ -30,6 +30,7 @@
 #include "APIUtils.h"
 #include "DateInstance.h"
 #include "JSAPIWrapperObject.h"
+#include "JSBigIntInlines.h"
 #include "JSCInlines.h"
 #include "JSCallbackObject.h"
 #include "JSONObject.h"

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1148,6 +1148,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSArrayIterator.h
     runtime/JSArrayBuffer.h
     runtime/JSBigInt.h
+    runtime/JSBigIntInlines.h
     runtime/JSBoundFunction.h
     runtime/JSCBytecodeCacheVersion.h
     runtime/JSCConfig.h
@@ -1159,6 +1160,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSCellInlines.h
     runtime/JSCInlines.h
     runtime/JSCJSValue.h
+    runtime/JSCJSValueCellInlines.h
     runtime/JSCJSValueInlines.h
     runtime/JSCPtrTag.h
     runtime/JSCustomGetterFunction.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1888,6 +1888,8 @@
 		CD1F9B3C270C0C1A00617EB6 /* TypedArrayAdaptersForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B3B270C0C1A00617EB6 /* TypedArrayAdaptersForwardDeclarations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD1F9B49270CFDCC00617EB6 /* HandleForward.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B48270CFDCC00617EB6 /* HandleForward.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD1F9B4B270CFE0F00617EB6 /* StrongForward.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B4A270CFE0F00617EB6 /* StrongForward.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CDBF70752EBC872F00F6D00B /* JSBigIntInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBF70742EBC872F00F6D00B /* JSBigIntInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CDBF70772EBCFE6D00F6D00B /* JSCJSValueCellInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBF70762EBCFE6D00F6D00B /* JSCJSValueCellInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CE20BD05237D3E230046E520 /* FileBasedFuzzerAgentBase.h in Headers */ = {isa = PBXBuildFile; fileRef = CE20BD03237D3AD40046E520 /* FileBasedFuzzerAgentBase.h */; };
 		CE20BD07237D3E480046E520 /* PredictionFileCreatingFuzzerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = CE20BD01237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.h */; };
 		CEAE7D7B889B477BA93ABA6C /* ScriptFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 8852151A9C3842389B3215B7 /* ScriptFetcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5653,6 +5655,8 @@
 		CD1F9B3B270C0C1A00617EB6 /* TypedArrayAdaptersForwardDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TypedArrayAdaptersForwardDeclarations.h; sourceTree = "<group>"; };
 		CD1F9B48270CFDCC00617EB6 /* HandleForward.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HandleForward.h; sourceTree = "<group>"; };
 		CD1F9B4A270CFE0F00617EB6 /* StrongForward.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StrongForward.h; sourceTree = "<group>"; };
+		CDBF70742EBC872F00F6D00B /* JSBigIntInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSBigIntInlines.h; sourceTree = "<group>"; };
+		CDBF70762EBCFE6D00F6D00B /* JSCJSValueCellInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSCJSValueCellInlines.h; sourceTree = "<group>"; };
 		CE20BD01237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PredictionFileCreatingFuzzerAgent.h; sourceTree = "<group>"; };
 		CE20BD02237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PredictionFileCreatingFuzzerAgent.cpp; sourceTree = "<group>"; };
 		CE20BD03237D3AD40046E520 /* FileBasedFuzzerAgentBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileBasedFuzzerAgentBase.h; sourceTree = "<group>"; };
@@ -8666,6 +8670,7 @@
 				276B38B42A71D25A00252F4E /* JSAsyncGeneratorFunctionInlines.h */,
 				868921C31F9C2947001159F6 /* JSBigInt.cpp */,
 				868921C11F9C0CB7001159F6 /* JSBigInt.h */,
+				CDBF70742EBC872F00F6D00B /* JSBigIntInlines.h */,
 				86FA9E8F142BBB2D001773B7 /* JSBoundFunction.cpp */,
 				86FA9E90142BBB2E001773B7 /* JSBoundFunction.h */,
 				276B39022A71D2B300252F4E /* JSBoundFunctionInlines.h */,
@@ -8686,6 +8691,7 @@
 				0F1DD84918A945BE0026F3FA /* JSCInlines.h */,
 				F692A8870255597D01FF60F7 /* JSCJSValue.cpp */,
 				14ABB36E099C076400E2A24F /* JSCJSValue.h */,
+				CDBF70762EBCFE6D00F6D00B /* JSCJSValueCellInlines.h */,
 				865A30F0135007E100CDB49E /* JSCJSValueInlines.h */,
 				FE1E2C3C2240C1EF00F6B729 /* JSCPtrTag.cpp */,
 				FE7497E5209001B00003565B /* JSCPtrTag.h */,
@@ -11610,6 +11616,7 @@
 				79872C48221BBAF3008C6969 /* JSBaseInternal.h in Headers */,
 				140D17D70E8AD4A9000CD17D /* JSBasePrivate.h in Headers */,
 				868921C21F9C0CB7001159F6 /* JSBigInt.h in Headers */,
+				CDBF70752EBC872F00F6D00B /* JSBigIntInlines.h in Headers */,
 				86FA9E92142BBB2E001773B7 /* JSBoundFunction.h in Headers */,
 				276B391A2A71D2B600252F4E /* JSBoundFunctionInlines.h in Headers */,
 				BC18C4190E16F5CD00B34460 /* JSCallbackConstructor.h in Headers */,
@@ -11628,6 +11635,7 @@
 				0F9749711687ADE400A4FF6A /* JSCellInlines.h in Headers */,
 				0F1DD84A18A945BE0026F3FA /* JSCInlines.h in Headers */,
 				BC18C42B0E16F5CD00B34460 /* JSCJSValue.h in Headers */,
+				CDBF70772EBCFE6D00F6D00B /* JSCJSValueCellInlines.h in Headers */,
 				865A30F1135007E100CDB49E /* JSCJSValueInlines.h in Headers */,
 				BC18C41D0E16F5CD00B34460 /* JSClassRef.h in Headers */,
 				86E3C613167BABD7006D760A /* JSContext.h in Headers */,

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -55,7 +55,7 @@
 #include "JSArrayIterator.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncGenerator.h"
-#include "JSBigInt.h"
+#include "JSBigIntInlines.h"
 #include "JSBoundFunction.h"
 #include "JSGenericTypedArrayViewConstructorInlines.h"
 #include "JSGenericTypedArrayViewInlines.h"

--- a/Source/JavaScriptCore/runtime/BrandedStructure.h
+++ b/Source/JavaScriptCore/runtime/BrandedStructure.h
@@ -29,7 +29,7 @@
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/Symbol.h>
 #include <JavaScriptCore/Watchpoint.h>
-#include <JavaScriptCore/WriteBarrierInlines.h>
+#include <JavaScriptCore/WriteBarrier.h>
 
 namespace WTF {
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -29,6 +29,7 @@
 #include "IntlNumberFormat.h"
 #include "IntlPluralRules.h"
 #include "IntlObjectInlines.h"
+#include "JSBigIntInlines.h"
 #include "JSGlobalObject.h"
 #include "JSGlobalObjectFunctions.h"
 

--- a/Source/JavaScriptCore/runtime/JSBigIntInlines.h
+++ b/Source/JavaScriptCore/runtime/JSBigIntInlines.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/JSBigInt.h>
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace JSC {
+
+inline JSValue JSBigInt::toNumber(JSValue bigInt)
+{
+    ASSERT(bigInt.isBigInt());
+#if USE(BIGINT32)
+    if (bigInt.isBigInt32())
+        return jsNumber(bigInt.bigInt32AsInt32());
+#endif
+    return toNumberHeap(jsCast<JSBigInt*>(bigInt));
+}
+
+uint64_t JSBigInt::toBigUInt64(JSValue bigInt)
+{
+    ASSERT(bigInt.isBigInt());
+#if USE(BIGINT32)
+    if (bigInt.isBigInt32())
+        return static_cast<uint64_t>(static_cast<int64_t>(bigInt.bigInt32AsInt32()));
+#endif
+    return toBigUInt64Heap(bigInt.asHeapBigInt());
+}
+
+inline int64_t JSBigInt::toBigInt64(JSValue bigInt)
+{
+    ASSERT(bigInt.isBigInt());
+#if USE(BIGINT32)
+    if (bigInt.isBigInt32())
+        return static_cast<int64_t>(bigInt.bigInt32AsInt32());
+#endif
+    return static_cast<int64_t>(toBigUInt64Heap(bigInt.asHeapBigInt()));
+}
+
+ALWAYS_INLINE std::optional<double> JSBigInt::tryExtractDouble(JSValue value)
+{
+    if (value.isNumber())
+        return value.asNumber();
+
+    if (!value.isBigInt())
+        return std::nullopt;
+
+#if USE(BIGINT32)
+    if (value.isBigInt32())
+        return value.bigInt32AsInt32();
+#endif
+
+    ASSERT(value.isHeapBigInt());
+    JSBigInt* bigInt = value.asHeapBigInt();
+    if (!bigInt->length())
+        return 0;
+
+    uint64_t integer = 0;
+    if constexpr (sizeof(Digit) == 8) {
+        if (bigInt->length() != 1)
+            return std::nullopt;
+        integer = bigInt->digit(0);
+    } else {
+        ASSERT(sizeof(Digit) == 4);
+        if (bigInt->length() > 2)
+            return std::nullopt;
+        integer = bigInt->digit(0);
+        if (bigInt->length() == 2)
+            integer |= (static_cast<uint64_t>(bigInt->digit(1)) << 32);
+    }
+
+    if (integer <= maxSafeIntegerAsUInt64())
+        return (bigInt->sign()) ? -static_cast<double>(integer) : static_cast<double>(integer);
+
+    return std::nullopt;
+}
+
+}

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -27,7 +27,7 @@
 #include "BooleanConstructor.h"
 #include "CustomGetterSetter.h"
 #include "GetterSetter.h"
-#include "JSBigInt.h"
+#include "JSBigIntInlines.h"
 #include "JSCInlines.h"
 #include "NumberObject.h"
 #include "NumberPrototype.h"
@@ -444,6 +444,21 @@ WTF::String JSValue::toWTFStringForConsole(JSGlobalObject* globalObject) const
     if (jsDynamicCast<JSBigInt*>(*this))
         return tryMakeString(result.data, 'n');
     return result;
+}
+
+bool JSValue::isGetterSetterSlow() const
+{
+    return isGetterSetter();
+}
+
+bool JSValue::isCustomGetterSetterSlow() const
+{
+    return isCustomGetterSetter();
+}
+
+bool JSValue::isStringSlow() const
+{
+    return isString();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -129,8 +129,8 @@ enum WhichValueWord {
     PayloadWord
 };
 
-int64_t tryConvertToInt52(double);
-bool isInt52(double);
+inline int64_t tryConvertToInt52(double);
+inline bool isInt52(double);
 
 enum class SourceCodeRepresentation : uint8_t {
     Other,
@@ -219,7 +219,7 @@ public:
 
     // Numbers
     JSValue(EncodeAsDoubleTag, double);
-    explicit JSValue(double);
+    inline explicit JSValue(double); // Defined in JSCJSValueInlines.h
     explicit JSValue(char);
     explicit JSValue(unsigned char);
     explicit JSValue(short);
@@ -242,8 +242,8 @@ public:
 
     int32_t asInt32() const;
     uint32_t asUInt32() const;
-    std::optional<uint32_t> tryGetAsUint32Index();
-    std::optional<int32_t> tryGetAsInt32();
+    inline std::optional<uint32_t> tryGetAsUint32Index(); // Defined in JSCJSValueInlines.h
+    inline std::optional<int32_t> tryGetAsInt32(); // Defined in JSCJSValueInlines.h
     int64_t asAnyInt() const;
     uint32_t asUInt32AsAnyInt() const;
     int32_t asInt32AsAnyInt() const;
@@ -258,10 +258,10 @@ public:
 
     // Querying the type.
     bool isEmpty() const;
-    bool isCallable() const;
-    template<Concurrency> TriState isCallableWithConcurrency() const;
-    bool isConstructor() const;
-    template<Concurrency> TriState isConstructorWithConcurrency() const;
+    inline bool isCallable() const; // Defined in JSCJSValueCellInlines.h
+    template<Concurrency> inline TriState isCallableWithConcurrency() const; // Defined in JSCJSValueCellInlines.h
+    inline bool isConstructor() const; // Defined in JSCJSValueCellInlines.h
+    template<Concurrency> inline TriState isConstructorWithConcurrency() const; // Defined in JSCJSValueCellInlines.h
     bool isUndefined() const;
     bool isNull() const;
     bool isUndefinedOrNull() const;
@@ -270,33 +270,38 @@ public:
     bool isUInt32AsAnyInt() const;
     bool isInt32AsAnyInt() const;
     bool isNumber() const;
-    bool isString() const;
-    bool isBigInt() const;
-    bool isHeapBigInt() const;
+    inline bool isString() const; // Defined in JSCJSValueCellInlines.h
+    inline bool isBigInt() const; // Defined in JSCJSValueCellInlines.h
+    inline bool isHeapBigInt() const; // Defined in JSCJSValueCellInlines.h
     bool isBigInt32() const;
-    bool isZeroBigInt() const;
-    bool isNegativeBigInt() const;
-    bool isSymbol() const;
-    bool isPrimitive() const;
-    bool isGetterSetter() const;
-    bool isCustomGetterSetter() const;
-    bool isObject() const;
+    inline bool isZeroBigInt() const; // Defined in JSCJSValueInlines.h
+    inline bool isNegativeBigInt() const; // Defined in JSCJSValueInlines.h
+    inline bool isSymbol() const; // Defined in JSCJSValueCellInlines.h
+    inline bool isPrimitive() const; // Defined in JSCJSValueCellInlines.h
+    inline bool isGetterSetter() const; // Defined in JSCJSValueCellInlines.h
+    inline bool isCustomGetterSetter() const; // Defined in JSCJSValueCellInlines.h
+    inline bool isObject() const; // Defined in JSCJSValueCellInlines.h
     bool inherits(const ClassInfo*) const;
     template<typename Target> bool inherits() const;
     const ClassInfo* classInfoOrNull() const;
 
+    // Non-inline versions of above for use in header ASSERT macros:
+    JS_EXPORT_PRIVATE bool isGetterSetterSlow() const;
+    JS_EXPORT_PRIVATE bool isCustomGetterSetterSlow() const;
+    JS_EXPORT_PRIVATE bool isStringSlow() const;
+
     // Extracting the value.
-    bool getString(JSGlobalObject*, WTF::String&) const;
-    WTF::String getString(JSGlobalObject*) const; // null string if not a string
-    JSObject* getObject() const; // 0 if not an object
+    inline bool getString(JSGlobalObject*, WTF::String&) const; // Defined in JSCJSValueCellInlines.h
+    inline WTF::String getString(JSGlobalObject*) const; // null string if not a string. Defined in JSCJSValueCellInlines.h
+    inline JSObject* getObject() const; // 0 if not an object. Defined in JSCJSValueCellInlines.h
 
     // Extracting integer values.
     bool getUInt32(uint32_t&) const;
         
     // Basic conversions.
-    JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType = NoPreference) const;
-    bool toBoolean(JSGlobalObject*) const;
-    TriState pureToBoolean() const;
+    inline JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType = NoPreference) const; // Defined in JSCJSValueCellInlines.h
+    inline bool toBoolean(JSGlobalObject*) const; // Defined in JSCJSValueCellInlines.h
+    inline TriState pureToBoolean() const; // Defined in JSCJSValueInlines.h
 
     // toNumber conversion is expected to be side effect free if an exception has
     // been set in the CallFrame already.
@@ -309,21 +314,21 @@ public:
     // toNumber conversion if it can be done without side effects.
     std::optional<double> toNumberFromPrimitive() const;
 
-    JSString* toString(JSGlobalObject*) const; // On exception, this returns the empty string.
-    JSString* toStringOrNull(JSGlobalObject*) const; // On exception, this returns null, to make exception checks faster.
+    inline JSString* toString(JSGlobalObject*) const; // On exception, this returns the empty string. Defined in JSCJSValueInlines.h
+    inline JSString* toStringOrNull(JSGlobalObject*) const; // On exception, this returns null, to make exception checks faster. Defined in JSCJSValueInlines.h
     Identifier toPropertyKey(JSGlobalObject*) const;
     JSValue toPropertyKeyValue(JSGlobalObject*) const;
-    WTF::String toWTFString(JSGlobalObject*) const;
+    inline WTF::String toWTFString(JSGlobalObject*) const; // Defined in JSCJSValueInlines.h
     JS_EXPORT_PRIVATE WTF::String toWTFStringForConsole(JSGlobalObject*) const;
-    JSObject* toObject(JSGlobalObject*) const;
+    inline JSObject* toObject(JSGlobalObject*) const; // Defined in JSCJSValueCellInlines.h
 
     // Integer conversions.
     JS_EXPORT_PRIVATE double toIntegerPreserveNaN(JSGlobalObject*) const;
     double toIntegerWithTruncation(JSGlobalObject*) const;
     double toIntegerOrInfinity(JSGlobalObject*) const;
-    int32_t toInt32(JSGlobalObject*) const;
-    uint32_t toUInt32(JSGlobalObject*) const;
-    uint64_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const;
+    inline int32_t toInt32(JSGlobalObject*) const; // Defined in JSCJSValueInlines.h
+    inline uint32_t toUInt32(JSGlobalObject*) const; // Defined in JSCJSValueInlines.h
+    inline uint64_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const; // Defined in JSCJSValueInlines.h
     uint64_t toLength(JSGlobalObject*) const;
 
     JS_EXPORT_PRIVATE JSValue toBigInt(JSGlobalObject*) const;
@@ -352,21 +357,21 @@ public:
 
     bool getOwnPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&) const;
 
-    bool put(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    inline bool put(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&); // Defined in JSCJSValueInlines.h
     bool putInline(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE bool putToPrimitive(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE bool putToPrimitiveByIndex(JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
-    bool putByIndex(JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
+    inline bool putByIndex(JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow); // Defined in JSCJSValueInlines.h
 
     JSValue getPrototype(JSGlobalObject*) const;
     JSValue toThis(JSGlobalObject*, ECMAMode) const;
 
-    static bool equal(JSGlobalObject*, JSValue v1, JSValue v2);
+    inline static bool equal(JSGlobalObject*, JSValue v1, JSValue v2); // Defined in JSCJSValueInlines.h
     static bool equalSlowCase(JSGlobalObject*, JSValue v1, JSValue v2);
-    static bool equalSlowCaseInline(JSGlobalObject*, JSValue v1, JSValue v2);
-    static bool strictEqual(JSGlobalObject*, JSValue v1, JSValue v2);
-    static bool strictEqualForCells(JSGlobalObject*, JSCell* v1, JSCell* v2);
-    static TriState pureStrictEqual(JSValue v1, JSValue v2);
+    inline static bool equalSlowCaseInline(JSGlobalObject*, JSValue v1, JSValue v2); // Defined in JSCJSValueInlines.h
+    inline static bool strictEqual(JSGlobalObject*, JSValue v1, JSValue v2); // Defined in JSCJSValueInlines.h
+    inline static bool strictEqualForCells(JSGlobalObject*, JSCell* v1, JSCell* v2); // Defined in JSCJSValueInlines.h
+    inline static TriState pureStrictEqual(JSValue v1, JSValue v2); // Defined in JSCJSValueInlines.h
 
     bool isCell() const;
     JSCell* asCell() const;
@@ -379,7 +384,7 @@ public:
     void dumpForBacktrace(PrintStream&) const;
 
     JS_EXPORT_PRIVATE JSObject* synthesizePrototype(JSGlobalObject*) const;
-    bool requireObjectCoercible(JSGlobalObject*) const;
+    inline bool requireObjectCoercible(JSGlobalObject*) const;
 
     // Constants used for Int52. Int52 isn't part of JSValue right now, but JSValues may be
     // converted to Int52s and back again.
@@ -663,23 +668,500 @@ ALWAYS_INLINE JSValue wasmUnboxedFloat(float f)
 }
 #endif
 
+inline JSValue jsNaN()
+{
+    return JSValue(JSValue::EncodeAsDouble, PNaN);
+}
+
+inline JSValue::JSValue(char i)
+{
+    *this = JSValue(static_cast<int32_t>(i));
+}
+
+inline JSValue::JSValue(unsigned char i)
+{
+    *this = JSValue(static_cast<int32_t>(i));
+}
+
+inline JSValue::JSValue(short i)
+{
+    *this = JSValue(static_cast<int32_t>(i));
+}
+
+inline JSValue::JSValue(unsigned short i)
+{
+    *this = JSValue(static_cast<int32_t>(i));
+}
+
+inline JSValue::JSValue(unsigned i)
+{
+    if (static_cast<int32_t>(i) < 0) {
+        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
+        return;
+    }
+    *this = JSValue(static_cast<int32_t>(i));
+}
+
+inline JSValue::JSValue(long i)
+{
+    if (static_cast<int32_t>(i) != i) {
+        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
+        return;
+    }
+    *this = JSValue(static_cast<int32_t>(i));
+}
+
+inline JSValue::JSValue(unsigned long i)
+{
+    if (static_cast<uint32_t>(i) != i) {
+        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
+        return;
+    }
+    *this = JSValue(static_cast<uint32_t>(i));
+}
+
+inline JSValue::JSValue(long long i)
+{
+    if (static_cast<int32_t>(i) != i) {
+        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
+        return;
+    }
+    *this = JSValue(static_cast<int32_t>(i));
+}
+
+inline JSValue::JSValue(unsigned long long i)
+{
+    if (static_cast<uint32_t>(i) != i) {
+        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
+        return;
+    }
+    *this = JSValue(static_cast<uint32_t>(i));
+}
+
+inline EncodedJSValue JSValue::encode(JSValue value)
+{
+    return value.u.asInt64;
+}
+
+inline JSValue JSValue::decode(EncodedJSValue encodedJSValue)
+{
+    JSValue v;
+    v.u.asInt64 = encodedJSValue;
+    return v;
+}
+
+#if USE(JSVALUE32_64)
+inline JSValue::JSValue()
+{
+    u.asBits.tag = EmptyValueTag;
+    u.asBits.payload = 0;
+}
+
+inline JSValue::JSValue(JSNullTag)
+{
+    u.asBits.tag = NullTag;
+    u.asBits.payload = 0;
+}
+
+inline JSValue::JSValue(JSUndefinedTag)
+{
+    u.asBits.tag = UndefinedTag;
+    u.asBits.payload = 0;
+}
+
+inline JSValue::JSValue(JSTrueTag)
+{
+    u.asBits.tag = BooleanTag;
+    u.asBits.payload = 1;
+}
+
+inline JSValue::JSValue(JSFalseTag)
+{
+    u.asBits.tag = BooleanTag;
+    u.asBits.payload = 0;
+}
+
+inline JSValue::JSValue(HashTableDeletedValueTag)
+{
+    u.asBits.tag = DeletedValueTag;
+    u.asBits.payload = 0;
+}
+
+inline JSValue::JSValue(JSCell* ptr)
+{
+    if (ptr)
+        u.asBits.tag = CellTag;
+    else
+        u.asBits.tag = EmptyValueTag;
+    u.asBits.payload = reinterpret_cast<int32_t>(ptr);
+}
+
+inline JSValue::JSValue(const JSCell* ptr)
+{
+    if (ptr)
+        u.asBits.tag = CellTag;
+    else
+        u.asBits.tag = EmptyValueTag;
+    u.asBits.payload = reinterpret_cast<int32_t>(const_cast<JSCell*>(ptr));
+}
+
+inline JSValue::operator bool() const
+{
+    ASSERT(tag() != DeletedValueTag);
+    return tag() != EmptyValueTag;
+}
+
+inline bool JSValue::operator==(const JSValue& other) const
+{
+    return u.asInt64 == other.u.asInt64;
+}
+
+inline bool JSValue::isEmpty() const
+{
+    return tag() == EmptyValueTag;
+}
+
+inline bool JSValue::isUndefined() const
+{
+    return tag() == UndefinedTag;
+}
+
+inline bool JSValue::isNull() const
+{
+    return tag() == NullTag;
+}
+
+inline bool JSValue::isUndefinedOrNull() const
+{
+    return isUndefined() || isNull();
+}
+
+inline bool JSValue::isCell() const
+{
+    return tag() == CellTag;
+}
+
+inline bool JSValue::isInt32() const
+{
+    return tag() == Int32Tag;
+}
+
+inline bool JSValue::isDouble() const
+{
+    return tag() < LowestTag;
+}
+
+inline bool JSValue::isTrue() const
+{
+    return tag() == BooleanTag && payload();
+}
+
+inline bool JSValue::isFalse() const
+{
+    return tag() == BooleanTag && !payload();
+}
+
+inline uint32_t JSValue::tag() const
+{
+    return u.asBits.tag;
+}
+
+inline int32_t JSValue::payload() const
+{
+    return u.asBits.payload;
+}
+
+inline int32_t JSValue::asInt32() const
+{
+    ASSERT(isInt32());
+    return u.asBits.payload;
+}
+
+inline double JSValue::asDouble() const
+{
+    ASSERT(isDouble());
+    return u.asDouble;
+}
+
+ALWAYS_INLINE JSCell* JSValue::asCell() const
+{
+    ASSERT(isCell());
+    return reinterpret_cast<JSCell*>(u.asBits.payload);
+}
+
+ALWAYS_INLINE JSValue::JSValue(EncodeAsDoubleTag, double d)
+{
+    ASSERT(!isImpureNaN(d));
+    u.asDouble = d;
+}
+
+inline JSValue::JSValue(int i)
+{
+    u.asBits.tag = Int32Tag;
+    u.asBits.payload = i;
+}
+
+inline JSValue::JSValue(int32_t tag, int32_t payload)
+{
+    u.asBits.tag = tag;
+    u.asBits.payload = payload;
+}
+
+inline bool JSValue::isNumber() const
+{
+    return isInt32() || isDouble();
+}
+
+inline bool JSValue::isBoolean() const
+{
+    return tag() == BooleanTag;
+}
+
+inline bool JSValue::asBoolean() const
+{
+    ASSERT(isBoolean());
+    return payload();
+}
+
+#else // !USE(JSVALUE32_64) i.e. USE(JSVALUE64)
+
+// 0x0 can never occur naturally because it has a tag of 00, indicating a pointer value, but a payload of 0x0, which is in the (invalid) zero page.
+inline JSValue::JSValue()
+{
+    u.asInt64 = ValueEmpty;
+}
+
+// 0x4 can never occur naturally because it has a tag of 00, indicating a pointer value, but a payload of 0x4, which is in the (invalid) zero page.
+inline JSValue::JSValue(HashTableDeletedValueTag)
+{
+    u.asInt64 = ValueDeleted;
+}
+
+inline JSValue::JSValue(JSCell* ptr)
+{
+    u.asInt64 = reinterpret_cast<uintptr_t>(ptr);
+}
+
+inline JSValue::JSValue(const JSCell* ptr)
+{
+    u.asInt64 = reinterpret_cast<uintptr_t>(const_cast<JSCell*>(ptr));
+}
+
+inline JSValue::operator bool() const
+{
+    return u.asInt64;
+}
+
+inline bool JSValue::operator==(const JSValue& other) const
+{
+    return u.asInt64 == other.u.asInt64;
+}
+
+inline bool JSValue::isEmpty() const
+{
+    return u.asInt64 == ValueEmpty;
+}
+
+inline bool JSValue::isUndefined() const
+{
+    return asValue() == JSValue(JSUndefined);
+}
+
+inline bool JSValue::isNull() const
+{
+    return asValue() == JSValue(JSNull);
+}
+
+inline bool JSValue::isTrue() const
+{
+    return asValue() == JSValue(JSTrue);
+}
+
+inline bool JSValue::isFalse() const
+{
+    return asValue() == JSValue(JSFalse);
+}
+
+inline bool JSValue::asBoolean() const
+{
+    ASSERT(isBoolean());
+    return asValue() == JSValue(JSTrue);
+}
+
+inline int32_t JSValue::asInt32() const
+{
+    ASSERT(isInt32());
+    return static_cast<int32_t>(u.asInt64);
+}
+
+inline bool JSValue::isDouble() const
+{
+    return isNumber() && !isInt32();
+}
+
+inline JSValue::JSValue(JSNullTag)
+{
+    u.asInt64 = ValueNull;
+}
+
+inline JSValue::JSValue(JSUndefinedTag)
+{
+    u.asInt64 = ValueUndefined;
+}
+
+inline JSValue::JSValue(JSTrueTag)
+{
+    u.asInt64 = ValueTrue;
+}
+
+inline JSValue::JSValue(JSFalseTag)
+{
+    u.asInt64 = ValueFalse;
+}
+
+inline bool JSValue::isUndefinedOrNull() const
+{
+    // Undefined and null share the same value, bar the 'undefined' bit in the extended tag.
+    return (u.asInt64 & ~UndefinedTag) == ValueNull;
+}
+
+inline bool JSValue::isBoolean() const
+{
+    return (u.asInt64 & ~1) == ValueFalse;
+}
+
+inline bool JSValue::isCell() const
+{
+    return !(u.asInt64 & NotCellMask);
+}
+
+inline bool JSValue::isInt32() const
+{
+    return (u.asInt64 & NumberTag) == NumberTag;
+}
+
+inline int64_t reinterpretDoubleToInt64(double value)
+{
+    return std::bit_cast<int64_t>(value);
+}
+inline double reinterpretInt64ToDouble(int64_t value)
+{
+    return std::bit_cast<double>(value);
+}
+
+ALWAYS_INLINE JSValue::JSValue(EncodeAsDoubleTag, double d)
+{
+    ASSERT(!isImpureNaN(d));
+    u.asInt64 = reinterpretDoubleToInt64(d) + JSValue::DoubleEncodeOffset;
+}
+
+inline JSValue::JSValue(int i)
+{
+    u.asInt64 = JSValue::NumberTag | static_cast<uint32_t>(i);
+}
+
+inline double JSValue::asDouble() const
+{
+    ASSERT(isDouble());
+    return reinterpretInt64ToDouble(u.asInt64 - JSValue::DoubleEncodeOffset);
+}
+
+inline bool JSValue::isNumber() const
+{
+    return u.asInt64 & JSValue::NumberTag;
+}
+
+ALWAYS_INLINE JSCell* JSValue::asCell() const
+{
+    ASSERT(isCell());
+    return u.ptr;
+}
+
+#endif // USE(JSVALUE64)
+
+#if USE(BIGINT32)
+inline JSValue::JSValue(EncodeAsBigInt32Tag, int32_t value)
+{
+    uint64_t shiftedValue = static_cast<uint64_t>(static_cast<uint32_t>(value)) << 16;
+    ASSERT(!(shiftedValue & NumberTag));
+    u.asInt64 = shiftedValue | BigInt32Tag;
+}
+#endif // USE(BIGINT32)
+
+#if ENABLE(WEBASSEMBLY) && USE(JSVALUE32_64)
+inline JSValue::JSValue(EncodeAsUnboxedFloatTag, float value)
+{
+    u.asBits.payload = std::bit_cast<int32_t>(value);
+}
+#endif
+
+inline bool JSValue::isBigInt32() const
+{
+#if USE(BIGINT32)
+    return (u.asInt64 & BigInt32Mask) == BigInt32Tag;
+#else
+    return false;
+#endif
+}
+
+ALWAYS_INLINE double JSValue::toNumber(JSGlobalObject* globalObject) const
+{
+    if (isInt32())
+        return asInt32();
+    if (isDouble())
+        return asDouble();
+    return toNumberSlowCase(globalObject);
+}
+
+// https://tc39.es/proposal-temporal/#sec-tointegerwithtruncation
+inline double JSValue::toIntegerWithTruncation(JSGlobalObject* globalObject) const
+{
+    if (isInt32())
+        return asInt32();
+    return trunc(toNumber(globalObject) + 0.0);
+}
+
+// https://tc39.es/ecma262/#sec-tointegerorinfinity
+inline double JSValue::toIntegerOrInfinity(JSGlobalObject* globalObject) const
+{
+    if (isInt32())
+        return asInt32();
+    double d = toNumber(globalObject);
+    return isnan(d) ? 0.0 : trunc(d) + 0.0;
+}
+
+inline bool JSValue::isUInt32() const
+{
+    return isInt32() && asInt32() >= 0;
+}
+
+inline uint32_t JSValue::asUInt32() const
+{
+    ASSERT(isUInt32());
+    return asInt32();
+}
+
+inline double JSValue::asNumber() const
+{
+    ASSERT(isNumber());
+    return isInt32() ? asInt32() : asDouble();
+}
+
 ALWAYS_INLINE JSValue jsDoubleNumber(double d)
 {
     ASSERT(JSValue(JSValue::EncodeAsDouble, d).isNumber());
     return JSValue(JSValue::EncodeAsDouble, d);
 }
 
-ALWAYS_INLINE JSValue jsNumber(double d)
+inline int32_t JSValue::asInt32ForArithmetic() const
 {
-    ASSERT(JSValue(d).isNumber());
-    ASSERT(!isImpureNaN(d));
-    return JSValue(d);
+    if (isBoolean())
+        return asBoolean();
+    return asInt32();
 }
 
-ALWAYS_INLINE JSValue jsNumber(const MediaTime& t)
-{
-    return jsNumber(t.toDouble());
-}
+inline JSValue jsNumber(double); // Defined in JSCJSValueInlines.h
+inline JSValue jsNumber(const MediaTime&); // Defined in JSCJSValueInlines.h
 
 ALWAYS_INLINE JSValue jsNumber(char i)
 {
@@ -743,10 +1225,89 @@ ALWAYS_INLINE EncodedJSValue encodedJSValue()
 
 inline bool operator==(const JSValue a, const JSCell* b) { return a == JSValue(b); }
 
-bool isThisValueAltered(const PutPropertySlot&, JSObject* baseObject);
+inline int64_t tryConvertToInt52(double number)
+{
+    if (number != number)
+        return JSValue::notInt52;
+#if OS(WINDOWS) && CPU(X86)
+    // The VS Compiler for 32-bit builds generates a floating point error when attempting to cast
+    // from an infinity to a 64-bit integer. We leave this routine with the floating point error
+    // left in a register, causing undefined behavior in later floating point operations.
+    //
+    // To avoid this issue, we check for infinity here, and return false in that case.
+    if (std::isinf(number))
+        return JSValue::notInt52;
+#endif
+    int64_t asInt64 = static_cast<int64_t>(number);
+    if (asInt64 != number)
+        return JSValue::notInt52;
+    if (!asInt64 && std::signbit(number))
+        return JSValue::notInt52;
+    if (asInt64 >= (static_cast<int64_t>(1) << (JSValue::numberOfInt52Bits - 1)))
+        return JSValue::notInt52;
+    if (asInt64 < -(static_cast<int64_t>(1) << (JSValue::numberOfInt52Bits - 1)))
+        return JSValue::notInt52;
+    return asInt64;
+}
+
+inline bool isInt52(double number)
+{
+    return tryConvertToInt52(number) != JSValue::notInt52;
+}
+
+inline bool JSValue::isAnyInt() const
+{
+    if (isInt32())
+        return true;
+    if (!isNumber())
+        return false;
+    return isInt52(asDouble());
+}
+
+inline int64_t JSValue::asAnyInt() const
+{
+    ASSERT(isAnyInt());
+    if (isInt32())
+        return asInt32();
+    return static_cast<int64_t>(asDouble());
+}
+
+inline bool JSValue::isInt32AsAnyInt() const
+{
+    if (!isAnyInt())
+        return false;
+    int64_t value = asAnyInt();
+    return value >= INT32_MIN && value <= INT32_MAX;
+}
+
+inline int32_t JSValue::asInt32AsAnyInt() const
+{
+    ASSERT(isInt32AsAnyInt());
+    if (isInt32())
+        return asInt32();
+    return static_cast<int32_t>(asDouble());
+}
+
+inline bool JSValue::isUInt32AsAnyInt() const
+{
+    if (!isAnyInt())
+        return false;
+    int64_t value = asAnyInt();
+    return value >= 0 && value <= UINT32_MAX;
+}
+
+inline uint32_t JSValue::asUInt32AsAnyInt() const
+{
+    ASSERT(isUInt32AsAnyInt());
+    if (isUInt32())
+        return asUInt32();
+    return static_cast<uint32_t>(asDouble());
+}
+
+inline bool isThisValueAltered(const PutPropertySlot&, JSObject* baseObject);
 
 // See section 7.2.9: https://tc39.github.io/ecma262/#sec-samevalue
-bool sameValue(JSGlobalObject*, JSValue a, JSValue b);
+inline bool sameValue(JSGlobalObject*, JSValue, JSValue);
 
 ALWAYS_INLINE void ensureStillAliveHere(JSValue value)
 {
@@ -840,5 +1401,13 @@ inline void clearEncodedJSValueConcurrent(EncodedJSValue& dest)
 #else
 #  error "Unsupported configuration"
 #endif
+
+#if USE(BIGINT32)
+inline int32_t JSValue::bigInt32AsInt32() const
+{
+    ASSERT(isBigInt32());
+    return static_cast<int32_t>(u.asInt64 >> 16);
+}
+#endif // USE(BIGINT32)
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCJSValueCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueCellInlines.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// This header serves two purposes:
+// 1. It allows clients to access these inlined methods without causing
+//    circular references in headers caused by JSCJSValueInlines.h
+// 2. It enables build speed reductions when clients which only need to
+//    definitions for a subset of JSValue's inlined methods include this
+//    file rather than all of JSCJSValueInlines.h
+
+#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSCell.h>
+
+namespace JSC {
+
+inline bool JSValue::isString() const
+{
+    return isCell() && asCell()->isString();
+}
+
+inline bool JSValue::isBigInt() const
+{
+    return isBigInt32() || isHeapBigInt();
+}
+
+inline bool JSValue::isHeapBigInt() const
+{
+    return isCell() && asCell()->isHeapBigInt();
+}
+
+inline bool JSValue::isSymbol() const
+{
+    return isCell() && asCell()->isSymbol();
+}
+
+inline bool JSValue::isPrimitive() const
+{
+    return !isCell() || asCell()->isString() || asCell()->isSymbol() || asCell()->isHeapBigInt();
+}
+
+inline bool JSValue::isGetterSetter() const
+{
+    return isCell() && asCell()->isGetterSetter();
+}
+
+inline bool JSValue::isCustomGetterSetter() const
+{
+    return isCell() && asCell()->isCustomGetterSetter();
+}
+
+inline bool JSValue::isObject() const
+{
+    return isCell() && asCell()->isObject();
+}
+
+inline bool JSValue::getString(JSGlobalObject* globalObject, String& s) const
+{
+    return isCell() && asCell()->getString(globalObject, s);
+}
+
+inline String JSValue::getString(JSGlobalObject* globalObject) const
+{
+    return isCell() ? asCell()->getString(globalObject) : String();
+}
+
+inline JSObject* JSValue::getObject() const
+{
+    return isCell() ? asCell()->getObject() : nullptr;
+}
+
+inline JSValue JSValue::toPrimitive(JSGlobalObject* globalObject, PreferredPrimitiveType preferredType) const
+{
+    return isCell() ? asCell()->toPrimitive(globalObject, preferredType) : asValue();
+}
+
+inline bool JSValue::toBoolean(JSGlobalObject* globalObject) const
+{
+    if (isInt32())
+        return asInt32();
+    if (isDouble())
+        return asDouble() > 0.0 || asDouble() < 0.0; // false for NaN
+    if (isCell())
+        return asCell()->toBoolean(globalObject);
+#if USE(BIGINT32)
+    if (isBigInt32())
+        return !!bigInt32AsInt32();
+#endif
+    return isTrue(); // false, null, and undefined all convert to false.
+}
+
+inline JSObject* JSValue::toObject(JSGlobalObject* globalObject) const
+{
+    return isCell() ? asCell()->toObject(globalObject) : toObjectSlowCase(globalObject);
+}
+
+inline bool JSValue::isCallable() const
+{
+    return isCell() && asCell()->isCallable();
+}
+
+template<Concurrency concurrency>
+inline TriState JSValue::isCallableWithConcurrency() const
+{
+    if (!isCell())
+        return TriState::False;
+    return asCell()->isCallableWithConcurrency<concurrency>();
+}
+
+inline bool JSValue::isConstructor() const
+{
+    return isCell() && asCell()->isConstructor();
+}
+
+template<Concurrency concurrency>
+inline TriState JSValue::isConstructorWithConcurrency() const
+{
+    if (!isCell())
+        return TriState::False;
+    return asCell()->isConstructorWithConcurrency<concurrency>();
+}
+
+// this method is here to be after the inline declaration of JSCell::inherits
+inline bool JSValue::inherits(const ClassInfo* classInfo) const
+{
+    return isCell() && asCell()->inherits(classInfo);
+}
+
+template<typename Target>
+inline bool JSValue::inherits() const
+{
+    return isCell() && asCell()->inherits<Target>();
+}
+
+inline const ClassInfo* JSValue::classInfoOrNull() const
+{
+    return isCell() ? asCell()->classInfo() : nullptr;
+}
+
+inline Structure* JSValue::structureOrNull() const
+{
+    if (isCell())
+        return asCell()->structure();
+    return nullptr;
+}
+
+}

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -36,6 +36,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/JSBigInt.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSCJSValueCellInlines.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSFunction.h>
 #include <JavaScriptCore/JSGlobalProxy.h>
@@ -48,6 +49,27 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
+
+inline JSValue jsNumber(double d)
+{
+    ASSERT(JSValue(d).isNumber());
+    ASSERT(!isImpureNaN(d));
+    return JSValue(d);
+}
+
+inline JSValue jsNumber(const MediaTime& t)
+{
+    return jsNumber(t.toDouble());
+}
+
+inline JSValue::JSValue(double d)
+{
+    if (canBeStrictInt32(d)) {
+        *this = JSValue(static_cast<int32_t>(d));
+        return;
+    }
+    *this = JSValue(EncodeAsDouble, d);
+}
 
 ALWAYS_INLINE int32_t JSValue::toInt32(JSGlobalObject* globalObject) const
 {
@@ -95,40 +117,6 @@ inline uint64_t JSValue::toIndex(JSGlobalObject* globalObject, ASCIILiteral erro
     RELEASE_AND_RETURN(scope, d);
 }
 
-// https://tc39.es/proposal-temporal/#sec-tointegerwithtruncation
-inline double JSValue::toIntegerWithTruncation(JSGlobalObject* globalObject) const
-{
-    if (isInt32())
-        return asInt32();
-    return trunc(toNumber(globalObject) + 0.0);
-}
-
-// https://tc39.es/ecma262/#sec-tointegerorinfinity
-inline double JSValue::toIntegerOrInfinity(JSGlobalObject* globalObject) const
-{
-    if (isInt32())
-        return asInt32();
-    double d = toNumber(globalObject);
-    return isnan(d) ? 0.0 : trunc(d) + 0.0;
-}
-
-inline bool JSValue::isUInt32() const
-{
-    return isInt32() && asInt32() >= 0;
-}
-
-inline uint32_t JSValue::asUInt32() const
-{
-    ASSERT(isUInt32());
-    return asInt32();
-}
-
-inline double JSValue::asNumber() const
-{
-    ASSERT(isNumber());
-    return isInt32() ? asInt32() : asDouble();
-}
-
 inline std::optional<uint32_t> JSValue::tryGetAsUint32Index()
 {
     if (isUInt32()) {
@@ -157,564 +145,28 @@ inline std::optional<int32_t> JSValue::tryGetAsInt32()
     return std::nullopt;
 }
 
-inline JSValue jsNaN()
-{
-    return JSValue(JSValue::EncodeAsDouble, PNaN);
-}
-
-inline JSValue::JSValue(char i)
-{
-    *this = JSValue(static_cast<int32_t>(i));
-}
-
-inline JSValue::JSValue(unsigned char i)
-{
-    *this = JSValue(static_cast<int32_t>(i));
-}
-
-inline JSValue::JSValue(short i)
-{
-    *this = JSValue(static_cast<int32_t>(i));
-}
-
-inline JSValue::JSValue(unsigned short i)
-{
-    *this = JSValue(static_cast<int32_t>(i));
-}
-
-inline JSValue::JSValue(unsigned i)
-{
-    if (static_cast<int32_t>(i) < 0) {
-        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
-        return;
-    }
-    *this = JSValue(static_cast<int32_t>(i));
-}
-
-inline JSValue::JSValue(long i)
-{
-    if (static_cast<int32_t>(i) != i) {
-        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
-        return;
-    }
-    *this = JSValue(static_cast<int32_t>(i));
-}
-
-inline JSValue::JSValue(unsigned long i)
-{
-    if (static_cast<uint32_t>(i) != i) {
-        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
-        return;
-    }
-    *this = JSValue(static_cast<uint32_t>(i));
-}
-
-inline JSValue::JSValue(long long i)
-{
-    if (static_cast<int32_t>(i) != i) {
-        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
-        return;
-    }
-    *this = JSValue(static_cast<int32_t>(i));
-}
-
-inline JSValue::JSValue(unsigned long long i)
-{
-    if (static_cast<uint32_t>(i) != i) {
-        *this = JSValue(EncodeAsDouble, static_cast<double>(i));
-        return;
-    }
-    *this = JSValue(static_cast<uint32_t>(i));
-}
-
-inline JSValue::JSValue(double d)
-{
-    if (canBeStrictInt32(d)) {
-        *this = JSValue(static_cast<int32_t>(d));
-        return;
-    }
-    *this = JSValue(EncodeAsDouble, d);
-}
-
-inline EncodedJSValue JSValue::encode(JSValue value)
-{
-    return value.u.asInt64;
-}
-
-inline JSValue JSValue::decode(EncodedJSValue encodedJSValue)
-{
-    JSValue v;
-    v.u.asInt64 = encodedJSValue;
-    return v;
-}
-
 #if USE(JSVALUE32_64)
-inline JSValue::JSValue()
-{
-    u.asBits.tag = EmptyValueTag;
-    u.asBits.payload = 0;
-}
-
-inline JSValue::JSValue(JSNullTag)
-{
-    u.asBits.tag = NullTag;
-    u.asBits.payload = 0;
-}
-    
-inline JSValue::JSValue(JSUndefinedTag)
-{
-    u.asBits.tag = UndefinedTag;
-    u.asBits.payload = 0;
-}
-    
-inline JSValue::JSValue(JSTrueTag)
-{
-    u.asBits.tag = BooleanTag;
-    u.asBits.payload = 1;
-}
-    
-inline JSValue::JSValue(JSFalseTag)
-{
-    u.asBits.tag = BooleanTag;
-    u.asBits.payload = 0;
-}
-
-inline JSValue::JSValue(HashTableDeletedValueTag)
-{
-    u.asBits.tag = DeletedValueTag;
-    u.asBits.payload = 0;
-}
-
-inline JSValue::JSValue(JSCell* ptr)
-{
-    if (ptr)
-        u.asBits.tag = CellTag;
-    else
-        u.asBits.tag = EmptyValueTag;
-    u.asBits.payload = reinterpret_cast<int32_t>(ptr);
-}
-
-inline JSValue::JSValue(const JSCell* ptr)
-{
-    if (ptr)
-        u.asBits.tag = CellTag;
-    else
-        u.asBits.tag = EmptyValueTag;
-    u.asBits.payload = reinterpret_cast<int32_t>(const_cast<JSCell*>(ptr));
-}
-
-inline JSValue::operator bool() const
-{
-    ASSERT(tag() != DeletedValueTag);
-    return tag() != EmptyValueTag;
-}
-
-inline bool JSValue::operator==(const JSValue& other) const
-{
-    return u.asInt64 == other.u.asInt64;
-}
-
-inline bool JSValue::isEmpty() const
-{
-    return tag() == EmptyValueTag;
-}
-
-inline bool JSValue::isUndefined() const
-{
-    return tag() == UndefinedTag;
-}
-
-inline bool JSValue::isNull() const
-{
-    return tag() == NullTag;
-}
-
-inline bool JSValue::isUndefinedOrNull() const
-{
-    return isUndefined() || isNull();
-}
-
-inline bool JSValue::isCell() const
-{
-    return tag() == CellTag;
-}
-
-inline bool JSValue::isInt32() const
-{
-    return tag() == Int32Tag;
-}
-
-inline bool JSValue::isDouble() const
-{
-    return tag() < LowestTag;
-}
-
-inline bool JSValue::isTrue() const
-{
-    return tag() == BooleanTag && payload();
-}
-
-inline bool JSValue::isFalse() const
-{
-    return tag() == BooleanTag && !payload();
-}
-
-inline uint32_t JSValue::tag() const
-{
-    return u.asBits.tag;
-}
-    
-inline int32_t JSValue::payload() const
-{
-    return u.asBits.payload;
-}
-    
-inline int32_t JSValue::asInt32() const
-{
-    ASSERT(isInt32());
-    return u.asBits.payload;
-}
-    
-inline double JSValue::asDouble() const
-{
-    ASSERT(isDouble());
-    return u.asDouble;
-}
-    
-ALWAYS_INLINE JSCell* JSValue::asCell() const
-{
-    ASSERT(isCell());
-    return reinterpret_cast<JSCell*>(u.asBits.payload);
-}
-
 ALWAYS_INLINE JSBigInt* JSValue::asHeapBigInt() const
 {
     ASSERT(isHeapBigInt());
     return reinterpret_cast<JSBigInt*>(u.asBits.payload);
 }
-
-ALWAYS_INLINE JSValue::JSValue(EncodeAsDoubleTag, double d)
-{
-    ASSERT(!isImpureNaN(d));
-    u.asDouble = d;
-}
-
-inline JSValue::JSValue(int i)
-{
-    u.asBits.tag = Int32Tag;
-    u.asBits.payload = i;
-}
-
-inline JSValue::JSValue(int32_t tag, int32_t payload)
-{
-    u.asBits.tag = tag;
-    u.asBits.payload = payload;
-}
-
-inline bool JSValue::isNumber() const
-{
-    return isInt32() || isDouble();
-}
-
-inline bool JSValue::isBoolean() const
-{
-    return tag() == BooleanTag;
-}
-
-inline bool JSValue::asBoolean() const
-{
-    ASSERT(isBoolean());
-    return payload();
-}
-
 #else // !USE(JSVALUE32_64) i.e. USE(JSVALUE64)
-
-// 0x0 can never occur naturally because it has a tag of 00, indicating a pointer value, but a payload of 0x0, which is in the (invalid) zero page.
-inline JSValue::JSValue()
-{
-    u.asInt64 = ValueEmpty;
-}
-
-// 0x4 can never occur naturally because it has a tag of 00, indicating a pointer value, but a payload of 0x4, which is in the (invalid) zero page.
-inline JSValue::JSValue(HashTableDeletedValueTag)
-{
-    u.asInt64 = ValueDeleted;
-}
-
-inline JSValue::JSValue(JSCell* ptr)
-{
-    u.asInt64 = reinterpret_cast<uintptr_t>(ptr);
-}
-
-inline JSValue::JSValue(const JSCell* ptr)
-{
-    u.asInt64 = reinterpret_cast<uintptr_t>(const_cast<JSCell*>(ptr));
-}
-
-inline JSValue::operator bool() const
-{
-    return u.asInt64;
-}
-
-inline bool JSValue::operator==(const JSValue& other) const
-{
-    return u.asInt64 == other.u.asInt64;
-}
-
-inline bool JSValue::isEmpty() const
-{
-    return u.asInt64 == ValueEmpty;
-}
-
-inline bool JSValue::isUndefined() const
-{
-    return asValue() == JSValue(JSUndefined);
-}
-
-inline bool JSValue::isNull() const
-{
-    return asValue() == JSValue(JSNull);
-}
-
-inline bool JSValue::isTrue() const
-{
-    return asValue() == JSValue(JSTrue);
-}
-
-inline bool JSValue::isFalse() const
-{
-    return asValue() == JSValue(JSFalse);
-}
-
-inline bool JSValue::asBoolean() const
-{
-    ASSERT(isBoolean());
-    return asValue() == JSValue(JSTrue);
-}
-
-inline int32_t JSValue::asInt32() const
-{
-    ASSERT(isInt32());
-    return static_cast<int32_t>(u.asInt64);
-}
-
-inline bool JSValue::isDouble() const
-{
-    return isNumber() && !isInt32();
-}
-
-inline JSValue::JSValue(JSNullTag)
-{
-    u.asInt64 = ValueNull;
-}
-    
-inline JSValue::JSValue(JSUndefinedTag)
-{
-    u.asInt64 = ValueUndefined;
-}
-
-inline JSValue::JSValue(JSTrueTag)
-{
-    u.asInt64 = ValueTrue;
-}
-
-inline JSValue::JSValue(JSFalseTag)
-{
-    u.asInt64 = ValueFalse;
-}
-
-inline bool JSValue::isUndefinedOrNull() const
-{
-    // Undefined and null share the same value, bar the 'undefined' bit in the extended tag.
-    return (u.asInt64 & ~UndefinedTag) == ValueNull;
-}
-
-inline bool JSValue::isBoolean() const
-{
-    return (u.asInt64 & ~1) == ValueFalse;
-}
-
-inline bool JSValue::isCell() const
-{
-    return !(u.asInt64 & NotCellMask);
-}
-
-inline bool JSValue::isInt32() const
-{
-    return (u.asInt64 & NumberTag) == NumberTag;
-}
-
-inline int64_t reinterpretDoubleToInt64(double value)
-{
-    return std::bit_cast<int64_t>(value);
-}
-inline double reinterpretInt64ToDouble(int64_t value)
-{
-    return std::bit_cast<double>(value);
-}
-
-ALWAYS_INLINE JSValue::JSValue(EncodeAsDoubleTag, double d)
-{
-    ASSERT(!isImpureNaN(d));
-    u.asInt64 = reinterpretDoubleToInt64(d) + JSValue::DoubleEncodeOffset;
-}
-
-inline JSValue::JSValue(int i)
-{
-    u.asInt64 = JSValue::NumberTag | static_cast<uint32_t>(i);
-}
-
-inline double JSValue::asDouble() const
-{
-    ASSERT(isDouble());
-    return reinterpretInt64ToDouble(u.asInt64 - JSValue::DoubleEncodeOffset);
-}
-
-inline bool JSValue::isNumber() const
-{
-    return u.asInt64 & JSValue::NumberTag;
-}
-
-ALWAYS_INLINE JSCell* JSValue::asCell() const
-{
-    ASSERT(isCell());
-    return u.ptr;
-}
-
 ALWAYS_INLINE JSBigInt* JSValue::asHeapBigInt() const
 {
     ASSERT(isHeapBigInt());
     return static_cast<JSBigInt*>(u.ptr);
 }
-
 #endif // USE(JSVALUE64)
 
-#if USE(BIGINT32)
-inline JSValue::JSValue(EncodeAsBigInt32Tag, int32_t value)
+// ECMA 11.9.3
+inline bool JSValue::equal(JSGlobalObject* globalObject, JSValue v1, JSValue v2)
 {
-    uint64_t shiftedValue = static_cast<uint64_t>(static_cast<uint32_t>(value)) << 16;
-    ASSERT(!(shiftedValue & NumberTag));
-    u.asInt64 = shiftedValue | BigInt32Tag;
-}
-#endif // USE(BIGINT32)
+    if (v1.isInt32() && v2.isInt32())
+        return v1 == v2;
 
-#if ENABLE(WEBASSEMBLY) && USE(JSVALUE32_64)
-inline JSValue::JSValue(EncodeAsUnboxedFloatTag, float value)
-{
-    u.asBits.payload = std::bit_cast<int32_t>(value);
+    return equalSlowCase(globalObject, v1, v2);
 }
-#endif
-
-inline int64_t tryConvertToInt52(double number)
-{
-    if (number != number)
-        return JSValue::notInt52;
-#if OS(WINDOWS) && CPU(X86)
-    // The VS Compiler for 32-bit builds generates a floating point error when attempting to cast
-    // from an infinity to a 64-bit integer. We leave this routine with the floating point error
-    // left in a register, causing undefined behavior in later floating point operations.
-    //
-    // To avoid this issue, we check for infinity here, and return false in that case.
-    if (std::isinf(number))
-        return JSValue::notInt52;
-#endif
-    int64_t asInt64 = static_cast<int64_t>(number);
-    if (asInt64 != number)
-        return JSValue::notInt52;
-    if (!asInt64 && std::signbit(number))
-        return JSValue::notInt52;
-    if (asInt64 >= (static_cast<int64_t>(1) << (JSValue::numberOfInt52Bits - 1)))
-        return JSValue::notInt52;
-    if (asInt64 < -(static_cast<int64_t>(1) << (JSValue::numberOfInt52Bits - 1)))
-        return JSValue::notInt52;
-    return asInt64;
-}
-
-inline bool isInt52(double number)
-{
-    return tryConvertToInt52(number) != JSValue::notInt52;
-}
-
-inline bool JSValue::isAnyInt() const
-{
-    if (isInt32())
-        return true;
-    if (!isNumber())
-        return false;
-    return isInt52(asDouble());
-}
-
-inline int64_t JSValue::asAnyInt() const
-{
-    ASSERT(isAnyInt());
-    if (isInt32())
-        return asInt32();
-    return static_cast<int64_t>(asDouble());
-}
-
-inline bool JSValue::isInt32AsAnyInt() const
-{
-    if (!isAnyInt())
-        return false;
-    int64_t value = asAnyInt();
-    return value >= INT32_MIN && value <= INT32_MAX;
-}
-
-inline int32_t JSValue::asInt32AsAnyInt() const
-{
-    ASSERT(isInt32AsAnyInt());
-    if (isInt32())
-        return asInt32();
-    return static_cast<int32_t>(asDouble());
-}
-
-inline bool JSValue::isUInt32AsAnyInt() const
-{
-    if (!isAnyInt())
-        return false;
-    int64_t value = asAnyInt();
-    return value >= 0 && value <= UINT32_MAX;
-}
-
-inline uint32_t JSValue::asUInt32AsAnyInt() const
-{
-    ASSERT(isUInt32AsAnyInt());
-    if (isUInt32())
-        return asUInt32();
-    return static_cast<uint32_t>(asDouble());
-}
-
-inline bool JSValue::isString() const
-{
-    return isCell() && asCell()->isString();
-}
-
-inline bool JSValue::isBigInt() const
-{
-    return isBigInt32() || isHeapBigInt();
-}
-
-inline bool JSValue::isHeapBigInt() const
-{
-    return isCell() && asCell()->isHeapBigInt();
-}
-
-inline bool JSValue::isBigInt32() const
-{
-#if USE(BIGINT32)
-    return (u.asInt64 & BigInt32Mask) == BigInt32Tag;
-#else
-    return false;
-#endif
-}
-
-#if USE(BIGINT32)
-inline int32_t JSValue::bigInt32AsInt32() const
-{
-    ASSERT(isBigInt32());
-    return static_cast<int32_t>(u.asInt64 >> 16);
-}
-#endif // USE(BIGINT32)
 
 inline bool JSValue::isZeroBigInt() const
 {
@@ -738,49 +190,9 @@ inline bool JSValue::isNegativeBigInt() const
     return asHeapBigInt()->sign();
 }
 
-inline bool JSValue::isSymbol() const
-{
-    return isCell() && asCell()->isSymbol();
-}
-
-inline bool JSValue::isPrimitive() const
-{
-    return !isCell() || asCell()->isString() || asCell()->isSymbol() || asCell()->isHeapBigInt();
-}
-
-inline bool JSValue::isGetterSetter() const
-{
-    return isCell() && asCell()->isGetterSetter();
-}
-
-inline bool JSValue::isCustomGetterSetter() const
-{
-    return isCell() && asCell()->isCustomGetterSetter();
-}
-
-inline bool JSValue::isObject() const
-{
-    return isCell() && asCell()->isObject();
-}
-
-inline bool JSValue::getString(JSGlobalObject* globalObject, String& s) const
-{
-    return isCell() && asCell()->getString(globalObject, s);
-}
-
-inline String JSValue::getString(JSGlobalObject* globalObject) const
-{
-    return isCell() ? asCell()->getString(globalObject) : String();
-}
-
 template <typename Base> String HandleConverter<Base, Unknown>::getString(JSGlobalObject* globalObject) const
 {
     return jsValue().getString(globalObject);
-}
-
-inline JSObject* JSValue::getObject() const
-{
-    return isCell() ? asCell()->getObject() : nullptr;
 }
 
 ALWAYS_INLINE bool JSValue::getUInt32(uint32_t& v) const
@@ -832,11 +244,6 @@ ALWAYS_INLINE JSValue JSValue::toPropertyKeyValue(JSGlobalObject* globalObject) 
     RELEASE_AND_RETURN(scope, primitive.toString(globalObject));
 }
 
-inline JSValue JSValue::toPrimitive(JSGlobalObject* globalObject, PreferredPrimitiveType preferredType) const
-{
-    return isCell() ? asCell()->toPrimitive(globalObject, preferredType) : asValue();
-}
-
 inline PreferredPrimitiveType toPreferredPrimitiveType(JSGlobalObject* globalObject, JSValue value)
 {
     VM& vm = getVM(globalObject);
@@ -859,15 +266,6 @@ inline PreferredPrimitiveType toPreferredPrimitiveType(JSGlobalObject* globalObj
 
     throwTypeError(globalObject, scope, "Expected primitive hint to match one of 'default', 'number', 'string'."_s);
     return NoPreference;
-}
-
-ALWAYS_INLINE double JSValue::toNumber(JSGlobalObject* globalObject) const
-{
-    if (isInt32())
-        return asInt32();
-    if (isDouble())
-        return asDouble();
-    return toNumberSlowCase(globalObject);
 }
 
 ALWAYS_INLINE JSValue JSValue::toNumeric(JSGlobalObject* globalObject) const
@@ -925,20 +323,6 @@ ALWAYS_INLINE JSValue JSValue::toBigIntOrInt32(JSGlobalObject* globalObject) con
     return jsNumber(value);
 }
 
-inline bool JSValue::toBoolean(JSGlobalObject* globalObject) const
-{
-    if (isInt32())
-        return asInt32();
-    if (isDouble())
-        return asDouble() > 0.0 || asDouble() < 0.0; // false for NaN
-    if (isCell())
-        return asCell()->toBoolean(globalObject);
-#if USE(BIGINT32)
-    if (isBigInt32())
-        return !!bigInt32AsInt32();
-#endif
-    return isTrue(); // false, null, and undefined all convert to false.
-}
 
 inline JSString* JSValue::toString(JSGlobalObject* globalObject) const
 {
@@ -963,53 +347,6 @@ inline String JSValue::toWTFString(JSGlobalObject* globalObject) const
     return toWTFStringSlowCase(globalObject);
 }
 
-inline JSObject* JSValue::toObject(JSGlobalObject* globalObject) const
-{
-    return isCell() ? asCell()->toObject(globalObject) : toObjectSlowCase(globalObject);
-}
-
-inline bool JSValue::isCallable() const
-{
-    return isCell() && asCell()->isCallable();
-}
-
-template<Concurrency concurrency>
-inline TriState JSValue::isCallableWithConcurrency() const
-{
-    if (!isCell())
-        return TriState::False;
-    return asCell()->isCallableWithConcurrency<concurrency>();
-}
-
-inline bool JSValue::isConstructor() const
-{
-    return isCell() && asCell()->isConstructor();
-}
-
-template<Concurrency concurrency>
-inline TriState JSValue::isConstructorWithConcurrency() const
-{
-    if (!isCell())
-        return TriState::False;
-    return asCell()->isConstructorWithConcurrency<concurrency>();
-}
-
-// this method is here to be after the inline declaration of JSCell::inherits
-inline bool JSValue::inherits(const ClassInfo* classInfo) const
-{
-    return isCell() && asCell()->inherits(classInfo);
-}
-
-template<typename Target>
-inline bool JSValue::inherits() const
-{
-    return isCell() && asCell()->inherits<Target>();
-}
-
-inline const ClassInfo* JSValue::classInfoOrNull() const
-{
-    return isCell() ? asCell()->classInfo() : nullptr;
-}
 
 inline JSValue JSValue::toThis(JSGlobalObject* globalObject, ECMAMode ecmaMode) const
 {
@@ -1182,22 +519,6 @@ ALWAYS_INLINE JSValue JSValue::getPrototype(JSGlobalObject* globalObject) const
     return synthesizePrototype(globalObject);
 }
 
-inline Structure* JSValue::structureOrNull() const
-{
-    if (isCell())
-        return asCell()->structure();
-    return nullptr;
-}
-
-// ECMA 11.9.3
-inline bool JSValue::equal(JSGlobalObject* globalObject, JSValue v1, JSValue v2)
-{
-    if (v1.isInt32() && v2.isInt32())
-        return v1 == v2;
-
-    return equalSlowCase(globalObject, v1, v2);
-}
-
 ALWAYS_INLINE bool JSValue::equalSlowCaseInline(JSGlobalObject* globalObject, JSValue v1, JSValue v2)
 {
     VM& vm = getVM(globalObject);
@@ -1355,13 +676,6 @@ inline bool JSValue::strictEqual(JSGlobalObject* globalObject, JSValue v1, JSVal
         return strictEqualForCells(globalObject, v1.asCell(), v2.asCell());
 
     return v1 == v2;
-}
-
-inline int32_t JSValue::asInt32ForArithmetic() const
-{
-    if (isBoolean())
-        return asBoolean();
-    return asInt32();
 }
 
 inline TriState JSValue::pureStrictEqual(JSValue v1, JSValue v2)

--- a/Source/JavaScriptCore/runtime/JSCellButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSCellButterfly.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/Butterfly.h>
 #include <JavaScriptCore/IndexingHeader.h>
+#include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSCell.h>
 #include <JavaScriptCore/ResourceExhaustion.h>

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/ThrowScope.h>
-#include <JavaScriptCore/ToNativeFromValue.h>
 #include <wtf/CheckedArithmetic.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/JSArrayBufferViewInlines.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSGenericTypedArrayView.h>
+#include <JavaScriptCore/ToNativeFromValue.h>
 #include <JavaScriptCore/TypeError.h>
 #include <JavaScriptCore/TypedArrays.h>
 #include <wtf/CheckedArithmetic.h>

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -51,12 +51,7 @@ namespace DOMJIT {
 class Signature;
 }
 
-inline JSCell* getJSFunction(JSValue value)
-{
-    if (value.isCell() && (value.asCell()->type() == JSFunctionType))
-        return value.asCell();
-    return nullptr;
-}
+inline JSCell* getJSFunction(JSValue); // Defined in JSObjectInlines.h
 
 class ArrayProfile;
 class Exception;
@@ -249,7 +244,7 @@ public:
     // otherwise, it creates a property with the provided attributes. Semantically, this is performing defineOwnProperty.
     bool putDirectIndex(JSGlobalObject* globalObject, unsigned propertyName, JSValue value, unsigned attributes, PutDirectIndexMode mode)
     {
-        ASSERT(!value.isCustomGetterSetter());
+        ASSERT(!value.isCustomGetterSetterSlow());
         auto canSetIndexQuicklyForPutDirect = [&] () -> bool {
             switch (indexingMode()) {
             case ALL_BLANK_INDEXING_TYPES:
@@ -1447,23 +1442,23 @@ ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, Prope
 
 inline bool JSObject::putDirect(VM& vm, PropertyName propertyName, JSValue value, unsigned attributes)
 {
-    ASSERT(!value.isGetterSetter() && !(attributes & PropertyAttribute::Accessor));
-    ASSERT(!value.isCustomGetterSetter() && !(attributes & PropertyAttribute::CustomAccessorOrValue));
+    ASSERT(!value.isGetterSetterSlow() && !(attributes & PropertyAttribute::Accessor));
+    ASSERT(!value.isCustomGetterSetterSlow() && !(attributes & PropertyAttribute::CustomAccessorOrValue));
     PutPropertySlot slot(this);
     return putDirectInternal<PutModeDefineOwnProperty>(vm, propertyName, value, attributes, slot).isNull();
 }
 
 inline bool JSObject::putDirect(VM& vm, PropertyName propertyName, JSValue value, unsigned attributes, PutPropertySlot& slot)
 {
-    ASSERT(!value.isGetterSetter());
-    ASSERT(!value.isCustomGetterSetter());
+    ASSERT(!value.isGetterSetterSlow());
+    ASSERT(!value.isCustomGetterSetterSlow());
     return putDirectInternal<PutModeDefineOwnProperty>(vm, propertyName, value, attributes, slot).isNull();
 }
 
 inline bool JSObject::putDirect(VM& vm, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    ASSERT(!value.isGetterSetter());
-    ASSERT(!value.isCustomGetterSetter());
+    ASSERT(!value.isGetterSetterSlow());
+    ASSERT(!value.isCustomGetterSetterSlow());
     return putDirectInternal<PutModeDefineOwnProperty>(vm, propertyName, value, 0, slot).isNull();
 }
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -45,6 +45,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+inline JSCell* getJSFunction(JSValue value)
+{
+    if (value.isCell() && (value.asCell()->type() == JSFunctionType))
+        return value.asCell();
+    return nullptr;
+}
+
 inline Structure* JSObject::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -792,7 +792,7 @@ inline StringImpl* JSString::tryGetValueImpl() const
 
 inline JSString* asString(JSValue value)
 {
-    ASSERT(value.isString());
+    ASSERT(value.isStringSlow());
     return jsCast<JSString*>(value.asCell());
 }
 

--- a/Source/JavaScriptCore/runtime/NumberConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/NumberConstructor.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "NumberConstructor.h"
 
+#include "JSBigIntInlines.h"
 #include "JSCInlines.h"
 #include "NumberObject.h"
 #include "NumberPrototype.h"

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.h
@@ -80,13 +80,6 @@ inline JSFinalObject* constructEmptyObject(JSGlobalObject* globalObject)
     return JSFinalObject::createDefaultEmptyObject(globalObject);
 }
 
-inline JSObject* constructObject(JSGlobalObject* globalObject, JSValue arg)
-{
-    if (arg.isUndefinedOrNull())
-        return constructEmptyObject(globalObject, globalObject->objectPrototype());
-    return arg.toObject(globalObject);
-}
-
 JS_EXPORT_PRIVATE JSObject* constructObjectFromPropertyDescriptorSlow(JSGlobalObject*, const PropertyDescriptor&);
 
 static constexpr PropertyOffset dataPropertyDescriptorValuePropertyOffset = 0;

--- a/Source/JavaScriptCore/runtime/PropertyDescriptor.h
+++ b/Source/JavaScriptCore/runtime/PropertyDescriptor.h
@@ -46,8 +46,8 @@ public:
         , m_seenAttributes(EnumerablePresent | ConfigurablePresent | WritablePresent)
     {
         ASSERT(m_value);
-        ASSERT(!m_value.isGetterSetter());
-        ASSERT(!m_value.isCustomGetterSetter());
+        ASSERT(!m_value.isGetterSetterSlow());
+        ASSERT(!m_value.isCustomGetterSetterSlow());
     }
     JS_EXPORT_PRIVATE bool writable() const;
     JS_EXPORT_PRIVATE bool enumerable() const;

--- a/Source/JavaScriptCore/runtime/ToNativeFromValue.h
+++ b/Source/JavaScriptCore/runtime/ToNativeFromValue.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSBigIntInlines.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/TypedArrayAdaptors.h>
 

--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -179,11 +179,11 @@ public:
     void setStartingValue(JSValue value) { m_value = JSValue::encode(value); }
     bool isNumber() const { return get().isNumber(); }
     bool isInt32() const { return get().isInt32(); }
-    bool isObject() const { return get().isObject(); }
-    bool isNull() const { return get().isNull(); }
-    bool isGetterSetter() const { return get().isGetterSetter(); }
-    bool isCustomGetterSetter() const { return get().isCustomGetterSetter(); }
-    
+    inline bool isObject() const; // Defined in WriteBarrierInlines.h
+    inline bool isNull() const; // Defined in WriteBarrierInlines.h
+    inline bool isGetterSetter() const; // Defined in WriteBarrierInlines.h
+    inline bool isCustomGetterSetter() const; // Defined in WriteBarrierInlines.h
+
     JSValue* slot() const
     { 
         return std::bit_cast<JSValue*>(&m_value);

--- a/Source/JavaScriptCore/runtime/WriteBarrierInlines.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrierInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/WriteBarrier.h>
 
@@ -85,5 +86,26 @@ inline void WriteBarrierStructureID::setEarlyValue(VM& vm, const JSCell* owner, 
     m_structureID = StructureID::encode(value);
     vm.writeBarrier(owner, reinterpret_cast<JSCell*>(value));
 }
+
+inline bool WriteBarrierBase<Unknown, RawValueTraits<Unknown>>::isObject() const
+{
+    return get().isObject();
+}
+
+inline bool WriteBarrierBase<Unknown, RawValueTraits<Unknown>>::isNull() const
+{
+    return get().isNull();
+}
+
+inline bool WriteBarrierBase<Unknown, RawValueTraits<Unknown>>::isGetterSetter() const
+{
+    return get().isGetterSetter();
+}
+
+inline bool WriteBarrierBase<Unknown, RawValueTraits<Unknown>>::isCustomGetterSetter() const
+{
+    return get().isCustomGetterSetter();
+}
+
 
 } // namespace JSC 

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -76,4 +76,9 @@ DOMWrapperWorld& mainThreadNormalWorldSingleton()
     return cachedNormalWorld;
 }
 
+bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
+{
+    return !value.isObject() || &worldForDOMObject(*value.getObject()) == &currentWorld(lexicalGlobalObject);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -125,7 +125,7 @@ DOMWrapperWorld& worldForDOMObject(JSC::JSObject&);
 Ref<DOMWrapperWorld> protectedWorldForDOMObject(JSC::JSObject&);
 
 // Helper function for code paths that must not share objects across isolated DOM worlds.
-bool isWorldCompatible(JSC::JSGlobalObject&, JSC::JSValue);
+WEBCORE_EXPORT bool isWorldCompatible(JSC::JSGlobalObject&, JSC::JSValue);
 
 inline DOMWrapperWorld& currentWorld(JSC::JSGlobalObject& lexicalGlobalObject)
 {
@@ -140,11 +140,6 @@ inline DOMWrapperWorld& worldForDOMObject(JSC::JSObject& object)
 inline Ref<DOMWrapperWorld> protectedWorldForDOMObject(JSC::JSObject& object)
 {
     return worldForDOMObject(object);
-}
-
-inline bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
-{
-    return !value.isObject() || &worldForDOMObject(*value.getObject()) == &currentWorld(lexicalGlobalObject);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSRTCRtpSFrameTransformCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRTCRtpSFrameTransformCustom.cpp
@@ -30,7 +30,7 @@
 
 #include "JSCryptoKey.h"
 #include "JSDOMPromiseDeferred.h"
-#include <JavaScriptCore/JSBigInt.h>
+#include <JavaScriptCore/JSBigIntInlines.h>
 
 namespace WebCore {
 using namespace JSC;


### PR DESCRIPTION
#### d7deeb4d678e012b7665d53198f3d80952fffdd6
<pre>
[JSC] Mark inlined JSValue methods with `inline` keyword (and fix a bunch of things that break when that happens)
<a href="https://rdar.apple.com/164200123">rdar://164200123</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302121">https://bugs.webkit.org/show_bug.cgi?id=302121</a>

Reviewed by Keith Miller.

Clients of JSC can face &quot;missing symbol&quot; linker errors for inlined methods when the
correct *Inlines.h headers are not included, and that task is made much, much more difficult when
the inlined methods aren&apos;t marked as &quot;inline&quot;. Adding the &quot;inline&quot; keyword causes the compiler to
throw an error when that symbol is referenced, making it much easier to notice a missing *Inlines.h
header at compile time.

Also, adding the &quot;inline&quot; keyword to inlined JSValue methods causes a _ton_ of compiler errors.

It&apos;s not entirely clear how this ever worked; those inlined methods must have successfully been linked
against accidentally (which ironically defeats the purpose of inlining) by the linker so long as some
other cpp file in the same unified compilation file included the right Inlines.h header.

Another problem within JSC is that there are circular dependencies between headers; inlined methods
depend upon a type which is defined by a header that first includes the *Inlines.h header, causing
complicated compile errors in unrelated code.

To resolve all of these issues, all the externally defined inline functions in JSCJSValue.h are now
correctly attributed with &quot;inline&quot;, have comments declaring the header file containing the definition
of that inlined method, and in some cases the Inlines.h headers have been broken up into smaller
headers with fewer include requirements.

Canonical link: <a href="https://commits.webkit.org/302733@main">https://commits.webkit.org/302733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/871830dca0d2da766e9cfc1927d7d535ee09d184

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81530 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d4cc8470-b720-4a49-972e-4786605569c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99041 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/678a0c5f-0651-4486-94de-8667c9ed5fc9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79741 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c2de110-c238-437e-b68a-3d8f04db3afc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34579 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80686 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122012 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139894 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128472 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1922 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1653 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54906 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65517 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161486 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1964 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40250 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->