### PR TITLE
REGRESSION(301719@main)[iOS]: fast/scrolling/ios/bounding-client-rect-on-fixed.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed-expected.txt
@@ -3,7 +3,7 @@ Verifies that getBoundingClientRect() on a fixedpos always returns the layout va
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS unexpectedValue is undefined
+PASS largestDelta is 0
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed.html
+++ b/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed.html
@@ -24,20 +24,15 @@ body {
 <script>
 jsTestIsAsync = true;
 
-let unexpectedValue = undefined;
+let largestDelta = 0;
 
 async function runTest()
 {
     description("Verifies that getBoundingClientRect() on a fixedpos always returns the layout value.");
 
     window.addEventListener('scroll', () => {
-        if (unexpectedValue !== undefined)
-            return;
-
         const targetTop = document.getElementById('target').getBoundingClientRect().top;
-        
-        if (targetTop != 100)
-            unexpectedValue = targetTop;
+        largestDelta = Math.max(largestDelta, Math.abs(targetTop - 100));
     }, false);
 
     if (!window.testRunner)
@@ -45,7 +40,7 @@ async function runTest()
 
     await UIHelper.dragFromPointToPoint(150, 300, 150, 50, 0.1);
     await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
-    shouldBe("unexpectedValue", "undefined");
+    shouldBe("largestDelta", "0");
 
    finishJSTest();
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5127,12 +5127,12 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
     auto scrollPosition = roundedIntPoint(unobscuredContentRect.location());
 
     // Computation of layoutViewportRect is done in LayoutUnits which loses some precision, so test with an epsilon.
-    // FIXME: The loss of precision when converting floating point values to LayoutUnit does not, by itself, explain
+    // FIXME (302123): The loss of precision when converting floating point values to LayoutUnit does not, by itself, explain
     // the differences between the `layoutViewportRect` and `unobscuredContentRect`'s locations. While scrolling on iOS,
     // the absolute differences can sometimes exceed 3px, which is well over this fractional error threshold.
     // For now, we maintain behavior shipped in iOS 26 by snapping to the unobscured content rect location as long as
-    // the difference is fairly small (~5 px).
-    static constexpr auto maxEpsilon = 5.0;
+    // the difference is fairly small (~45 px).
+    static constexpr auto maxEpsilon = 45.0;
     static constexpr auto epsilonRatio = 1.0 / (2 * kFixedPointDenominator);
     auto unobscuredContentRectLocation = unobscuredContentRect.location();
     auto epsilonX = std::min(maxEpsilon, epsilonRatio * std::abs(unobscuredContentRectLocation.x()));


### PR DESCRIPTION
#### aa79eb44da12c2e15d013674f2371cbbbc9c0b44
<pre>
REGRESSION(301719@main)[iOS]: fast/scrolling/ios/bounding-client-rect-on-fixed.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=302104">https://bugs.webkit.org/show_bug.cgi?id=302104</a>
<a href="https://rdar.apple.com/164189184">rdar://164189184</a>

Reviewed by Abrar Rahman Protyasha.

In iOS 26, the changes in 295783@main fixed a long-standing bug related to `getBoundingClientRect`
in viewport-constrained elements. However, in doing so, it caused another bug because the &quot;layout
viewport origin is close enough to the unobscured rect&quot; heuristic unintentionally checked against a
minimum delta of ≤3.125% of the scroll offset). This was subsequently fixed in 301719@main, which
attempted to keep the layout test added in 295783@main passing.

However, this subsequent change, 301719@main, ended up making the test flaky. To mitigate this, we
raise the clamped maximum delta from 5 to 45, which (approximately) matches the value of the delta
in `fast/scrolling/ios/bounding-client-rect-on-fixed.html`.

Note that this approach of clamping the layout viewport origin to the unobscured content rect if
it&apos;s close enough (for some arbitrarily determined threshold) is still a hack — I filed a followup
bug, <a href="https://bugs.webkit.org/show_bug.cgi?id=302123">https://bugs.webkit.org/show_bug.cgi?id=302123</a>, to track finding and fixing the real source of
the discrepancy.

* LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed-expected.txt:
* LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed.html:

Also adjust this test to report the _maximum_ delta, rather than the first incorrect scroll
position; this allows us to (more easily) determine the extent of the error, in the event this test
still ends up being flaky in automation.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/302711@main">https://commits.webkit.org/302711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91f39daa5433d46063c084527de2c67425b21aac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81414 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1c6f776-2d74-4246-8503-64f5ddb5d132) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98962 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66772 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b6b25de-3f00-4330-9ed9-4bca8e1a692e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb3d4173-0f70-4172-9751-cdf4a31ec013) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34483 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80585 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139796 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107471 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107359 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27338 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54779 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65419 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->