### PR TITLE
Web Inspector: Make frame targets compatible with WebKitLegacy

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1882,10 +1882,6 @@ inspector/heap/getRemoteObject.html [ Skip ]
 inspector/unit-tests/heap-snapshot.html [ Skip ]
 inspector/unit-tests/heap-snapshot-collection-event.html [ Skip ]
 
-# Frame Targets are not supported in WK1.
-# FIXME: <https://webkit.org/b/299207> Add or rewrite tests to account for lack of frame targets in WK1.
-inspector/unit-tests/target-manager.html [ Skip ]
-
 # WK1 Inspector cannot leverage InspectorAdditions runtime enabled features
 inspector/canvas/recording-html-2d.html
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
@@ -60,6 +60,9 @@ public:
         Automation,
         ITML,
         JavaScript,
+        // This gets surfaced also as a "web-page"-typed target in the frontend. The "Legacy" prefix is only there
+        // to support static typing, the SPECIALIZE_TYPE_TRAITS_CONTROLLABLE_TARGET in LegacyWebPageDebuggable.
+        LegacyWebPage,
         Page,
         ServiceWorker,
         // This is specifically for the JSC Wasm Debugger server, which is a standalone

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -514,6 +514,7 @@ RetainPtr<NSDictionary> RemoteInspector::listingForInspectionTarget(const Remote
         [listing setObject:WIRTypeServiceWorker forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::WebPage:
+    case RemoteInspectionTarget::Type::LegacyWebPage:
         [listing setObject:target.url().createNSString().get() forKey:WIRURLKey];
         [listing setObject:target.name().createNSString().get() forKey:WIRTitleKey];
         [listing setObject:target.nameOverride().createNSString().get() forKey:WIROverrideNameKey];

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -129,7 +129,7 @@ TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspection
     targetListing->setString("url"_s, target.url());
     targetListing->setInteger("targetID"_s, target.targetIdentifier());
     targetListing->setBoolean("hasLocalDebugger"_s, target.hasLocalDebugger());
-    if (target.type() == RemoteInspectionTarget::Type::WebPage)
+    if (target.type() == RemoteInspectionTarget::Type::WebPage || target.type() == RemoteInspectionTarget::Type::LegacyWebPage)
         targetListing->setString("type"_s, "web-page"_s);
     else if (target.type() == RemoteInspectionTarget::Type::Page)
         targetListing->setString("type"_s, "page"_s);

--- a/Source/WebCore/inspector/InspectorBackendClient.h
+++ b/Source/WebCore/inspector/InspectorBackendClient.h
@@ -78,10 +78,6 @@ public:
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     virtual bool setEmulatedConditions(std::optional<int64_t>&& /* bytesPerSecondLimit */) { return false; }
 #endif
-
-#if ENABLE(REMOTE_INSPECTOR)
-    virtual bool allowRemoteInspectionToPageDirectly() const { return false; }
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -99,7 +99,7 @@ public:
     virtual void attachWindow(DockSide) = 0;
     virtual void detachWindow() = 0;
 
-    WEBCORE_EXPORT void sendMessageToBackend(const String& message) final;
+    WEBCORE_EXPORT void sendMessageToBackend(const String& message) override;
 
     WEBCORE_EXPORT bool isUnderTest() final;
     bool isRemote() const final { return false; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -512,11 +512,6 @@ Page::Page(PageConfiguration&& pageConfiguration)
 
     protectedStorageNamespaceProvider()->setSessionStorageQuota(m_settings->sessionStorageQuota());
 
-#if ENABLE(REMOTE_INSPECTOR)
-    if (m_inspectorController->inspectorBackendClient() && m_inspectorController->inspectorBackendClient()->allowRemoteInspectionToPageDirectly())
-        m_inspectorDebuggable->init();
-#endif
-
 #if PLATFORM(COCOA)
     platformInitialize();
 #endif

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LegacyWebPageDebuggable.h"
+
+#include <WebCore/Document.h>
+#include <WebCore/Page.h>
+#include <WebCore/PageInspectorController.h>
+#include <wtf/TZoneMallocInlines.h>
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyWebPageDebuggable);
+
+LegacyWebPageDebuggable::LegacyWebPageDebuggable(LegacyWebPageInspectorController& inspectorController, WebCore::Page& page)
+    : m_inspectorController(&inspectorController)
+    , m_page(&page)
+{
+}
+
+Ref<LegacyWebPageDebuggable> LegacyWebPageDebuggable::create(LegacyWebPageInspectorController& controller, WebCore::Page& page)
+{
+    return adoptRef(*new LegacyWebPageDebuggable(controller, page));
+}
+
+String LegacyWebPageDebuggable::name() const
+{
+    String result;
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &result] {
+        if (RefPtr page = m_page.get()) {
+            if (RefPtr document = page->localTopDocument())
+                result = document->title().isolatedCopy();
+        }
+    });
+    return result;
+}
+
+String LegacyWebPageDebuggable::url() const
+{
+    String result;
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &result] {
+        RefPtr page = m_page.get();
+        if (!page)
+            return;
+
+        result = page->mainFrameURL().string().isolatedCopy();
+        if (result.isEmpty())
+            result = "about:blank"_s;
+    });
+    return result;
+}
+
+bool LegacyWebPageDebuggable::hasLocalDebugger() const
+{
+    bool result;
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &result] {
+        RefPtr controller = m_inspectorController.get();
+        result = controller && controller->hasLocalFrontend();
+    });
+    return result;
+}
+
+void LegacyWebPageDebuggable::connect(Inspector::FrontendChannel& frontendChannel, bool isAutomaticConnection, bool immediatelyPause)
+{
+    UNUSED_PARAM(isAutomaticConnection);
+    UNUSED_PARAM(immediatelyPause);
+
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &frontendChannel] {
+        if (RefPtr controller = m_inspectorController.get())
+            controller->connectFrontend(frontendChannel);
+    });
+}
+
+void LegacyWebPageDebuggable::disconnect(Inspector::FrontendChannel& frontendChannel)
+{
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &frontendChannel] {
+        if (RefPtr controller = m_inspectorController.get())
+            controller->disconnectFrontend(frontendChannel);
+    });
+}
+
+void LegacyWebPageDebuggable::dispatchMessageFromRemote(String&& message)
+{
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, message = WTFMove(message).isolatedCopy()] mutable {
+        if (RefPtr controller = m_inspectorController.get())
+            controller->dispatchMessageFromFrontend(WTFMove(message));
+    });
+}
+
+void LegacyWebPageDebuggable::setIndicating(bool indicating)
+{
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, indicating] {
+        if (RefPtr page = m_page.get())
+            page->protectedInspectorController()->setIndicating(indicating);
+    });
+}
+
+void LegacyWebPageDebuggable::setNameOverride(const String& name)
+{
+    m_nameOverride = name;
+    update();
+}
+
+void LegacyWebPageDebuggable::detachFromPage()
+{
+    m_page = nullptr;
+}

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.h
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,29 +23,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// FIXME <https://webkit.org/b/302429>: Remove this deprecated Page debuggable type as WebKitLegacy now also has
-// multi-target support, with the LegacyWebPageDebuggable that works with WI.MultiplexingBackendTarget in the frontend.
-
 #pragma once
 
-#if ENABLE(REMOTE_INSPECTOR)
+#include "LegacyWebPageInspectorController.h"
 
+#include <JavaScriptCore/RemoteControllableTarget.h>
 #include <JavaScriptCore/RemoteInspectionTarget.h>
+#include <WebCore/Page.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
 
-namespace WebCore {
-
-class Page;
-
-class PageDebuggable final : public Inspector::RemoteInspectionTarget {
-    WTF_MAKE_TZONE_ALLOCATED(PageDebuggable);
-    WTF_MAKE_NONCOPYABLE(PageDebuggable);
+class LegacyWebPageDebuggable final : public Inspector::RemoteInspectionTarget {
+    WTF_MAKE_TZONE_ALLOCATED(LegacyWebPageDebuggable);
+    WTF_MAKE_NONCOPYABLE(LegacyWebPageDebuggable);
 public:
-    static Ref<PageDebuggable> create(Page&);
+    static Ref<LegacyWebPageDebuggable> create(LegacyWebPageInspectorController&, WebCore::Page&);
+    ~LegacyWebPageDebuggable() = default;
 
-    Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::Page; }
+    Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::LegacyWebPage; }
 
     String name() const final;
     String url() const final;
@@ -56,20 +53,17 @@ public:
     void dispatchMessageFromRemote(String&& message) final;
     void setIndicating(bool) final;
 
-    const String& nameOverride() const { return m_nameOverride; }
+    const String& nameOverride() const final { return m_nameOverride; }
     void setNameOverride(const String&);
 
     void detachFromPage();
 
 private:
-    explicit PageDebuggable(Page&);
+    LegacyWebPageDebuggable(LegacyWebPageInspectorController&, WebCore::Page&);
 
-    WeakPtr<Page> m_page;
+    WeakPtr<LegacyWebPageInspectorController> m_inspectorController;
+    WeakPtr<WebCore::Page> m_page;
     String m_nameOverride;
 };
 
-} // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_CONTROLLABLE_TARGET(WebCore::PageDebuggable, Page);
-
-#endif // ENABLE(REMOTE_INSPECTOR)
+SPECIALIZE_TYPE_TRAITS_CONTROLLABLE_TARGET(LegacyWebPageDebuggable, LegacyWebPage);

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
@@ -1,0 +1,321 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LegacyWebPageInspectorController.h"
+
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <JavaScriptCore/InspectorTarget.h>
+#include <JavaScriptCore/InspectorTargetAgent.h>
+#include <WebCore/Frame.h>
+#include <WebCore/FrameInspectorController.h>
+#include <WebCore/LocalFrame.h>
+#include <WebCore/Page.h>
+#include <WebCore/PageInspectorController.h>
+#include <wtf/Compiler.h>
+#include <wtf/MainThread.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/WeakRef.h>
+#include <wtf/text/StringConcatenate.h>
+#include <wtf/text/WTFString.h>
+
+namespace {
+
+class FrontendChannel final : public Inspector::FrontendChannel {
+    WTF_MAKE_TZONE_ALLOCATED(FrontendChannel);
+    WTF_MAKE_NONCOPYABLE(FrontendChannel);
+public:
+    using MessageHandler = Function<void(const String& targetID, const String& message)>;
+
+    FrontendChannel(String&& targetID, Inspector::FrontendChannel::ConnectionType connectionType, MessageHandler& handler)
+        : m_targetID(WTFMove(targetID))
+        , m_connectionType(connectionType)
+        , m_handler(handler)
+    {
+    }
+
+    ~FrontendChannel() = default;
+
+    ConnectionType connectionType() const override { return m_connectionType; }
+
+    void sendMessageToFrontend(const String& message) override
+    {
+        m_handler(m_targetID, message);
+    }
+
+private:
+    String m_targetID;
+    Inspector::FrontendChannel::ConnectionType m_connectionType;
+    MessageHandler& m_handler;
+};
+
+class PageTarget final : public Inspector::InspectorTarget {
+    WTF_MAKE_TZONE_ALLOCATED(PageTarget);
+    WTF_MAKE_NONCOPYABLE(PageTarget);
+public:
+    static String identifier(const WebCore::Page& page)
+    {
+        return makeString("page-"_s, page.identifier()->toUInt64());
+    }
+
+    PageTarget(WebCore::Page& page, FrontendChannel::MessageHandler&& handler)
+        : m_page(page)
+        , m_handler(WTFMove(handler))
+    {
+    }
+
+    Inspector::InspectorTargetType type() const final
+    {
+        return Inspector::InspectorTargetType::Page;
+    }
+
+    String identifier() const final
+    {
+        return identifier(Ref { m_page.get() });
+    }
+
+    void connect(Inspector::FrontendChannel::ConnectionType connectionType) override
+    {
+        if (m_channel)
+            return;
+
+        m_channel = makeUnique<FrontendChannel>(identifier(), connectionType, m_handler);
+        Ref { m_page.get() }->protectedInspectorController()->connectFrontend(*m_channel);
+    }
+
+    void disconnect() override
+    {
+        if (!m_channel)
+            return;
+
+        Ref { m_page.get() }->protectedInspectorController()->disconnectFrontend(*m_channel);
+        m_channel = nullptr;
+    }
+
+    void sendMessageToTargetBackend(const String& message) override
+    {
+        Ref { m_page.get() }->protectedInspectorController()->dispatchMessageFromFrontend(message);
+    }
+
+private:
+    WeakRef<WebCore::Page> m_page;
+    std::unique_ptr<FrontendChannel> m_channel;
+    FrontendChannel::MessageHandler m_handler;
+};
+
+class FrameTarget final : public Inspector::InspectorTarget {
+    WTF_MAKE_TZONE_ALLOCATED(FrameTarget);
+    WTF_MAKE_NONCOPYABLE(FrameTarget);
+public:
+    static String identifier(const WebCore::LocalFrame& frame)
+    {
+        return makeString("frame-"_s, frame.frameID().toUInt64());
+    }
+
+    FrameTarget(WebCore::LocalFrame& frame, FrontendChannel::MessageHandler&& handler)
+        : m_frame(frame)
+        , m_handler(WTFMove(handler))
+    {
+    }
+
+    Inspector::InspectorTargetType type() const final
+    {
+        return Inspector::InspectorTargetType::Frame;
+    }
+
+    String identifier() const final
+    {
+        return identifier(Ref { m_frame.get() });
+    }
+
+    void connect(Inspector::FrontendChannel::ConnectionType connectionType) override
+    {
+        if (m_channel)
+            return;
+
+        m_channel = makeUnique<FrontendChannel>(identifier(), connectionType, m_handler);
+        Ref { m_frame.get() }->protectedInspectorController()->connectFrontend(*m_channel);
+    }
+
+    void disconnect() override
+    {
+        if (!m_channel)
+            return;
+
+        Ref { m_frame.get() }->protectedInspectorController()->disconnectFrontend(*m_channel);
+        m_channel = nullptr;
+    }
+
+    void sendMessageToTargetBackend(const String& message) override
+    {
+        Ref { m_frame.get() }->protectedInspectorController()->dispatchMessageFromFrontend(message);
+    }
+
+private:
+    WeakRef<WebCore::LocalFrame> m_frame;
+    std::unique_ptr<FrontendChannel> m_channel;
+    FrontendChannel::MessageHandler m_handler;
+};
+
+class EmptyBrowserAgent final : public Inspector::InspectorAgentBase, public Inspector::BrowserBackendDispatcherHandler {
+    WTF_MAKE_NONCOPYABLE(EmptyBrowserAgent);
+    WTF_MAKE_TZONE_ALLOCATED(EmptyBrowserAgent);
+public:
+    explicit EmptyBrowserAgent(Inspector::BackendDispatcher& backendDispatcher)
+        : Inspector::InspectorAgentBase("Browser"_s)
+        , m_backendDispatcher(Inspector::BrowserBackendDispatcher::create(backendDispatcher, this))
+    {
+    }
+
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend() final { }
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason) final { }
+
+    // BrowserBackendDispatcherHandler
+    Inspector::Protocol::ErrorStringOr<void> enable() final { return { }; }
+    Inspector::Protocol::ErrorStringOr<void> disable() final { return { }; }
+
+private:
+    const Ref<Inspector::BrowserBackendDispatcher> m_backendDispatcher;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrontendChannel);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageTarget);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameTarget);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyBrowserAgent);
+
+} // namespace
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyWebPageInspectorController);
+
+Ref<LegacyWebPageInspectorController> LegacyWebPageInspectorController::create(WebCore::Page& page)
+{
+    return adoptRef(*new LegacyWebPageInspectorController(page));
+}
+
+LegacyWebPageInspectorController::LegacyWebPageInspectorController(WebCore::Page& page)
+    : m_frontendRouter(Inspector::FrontendRouter::create())
+    , m_backendDispatcher(Inspector::BackendDispatcher::create(m_frontendRouter.copyRef()))
+{
+    UniqueRef targetAgent = makeUniqueRef<Inspector::InspectorTargetAgent>(m_frontendRouter, m_backendDispatcher);
+    m_targetAgent = targetAgent.ptr();
+    m_agents.append(WTFMove(targetAgent));
+
+    m_agents.append(makeUniqueRef<EmptyBrowserAgent>(m_backendDispatcher));
+
+    // In WK1, the Page object persists for the entire lifetime of the WebView and is never recreated during navigation.
+    // (Unlike WK2, there is no Process Swap On Navigation (PSON) that would require recreating the PageTarget.)
+    addTarget(makeUnique<PageTarget>(page, [weakThis = WeakPtr { *this }](const String& targetID, const String& message) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->sendMessageToInspectorFrontend(targetID, message);
+    }));
+}
+
+void LegacyWebPageInspectorController::frameCreated(WebCore::LocalFrame& frame)
+{
+    addTarget(makeUnique<FrameTarget>(frame, [weakThis = WeakPtr { *this }](const String& targetID, const String& message) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->sendMessageToInspectorFrontend(targetID, message);
+    }));
+}
+
+void LegacyWebPageInspectorController::willDestroyFrame(const WebCore::LocalFrame& frame)
+{
+    removeTarget(FrameTarget::identifier(frame));
+}
+
+void LegacyWebPageInspectorController::willDestroyPage(const WebCore::Page& page)
+{
+    removeTarget(PageTarget::identifier(page));
+
+    disconnectAllFrontends();
+    m_agents.discardValues();
+}
+
+void LegacyWebPageInspectorController::addTarget(std::unique_ptr<Inspector::InspectorTarget>&& target)
+{
+    checkedTargetAgent()->targetCreated(*target);
+    m_targets.set(target->identifier(), WTFMove(target));
+}
+
+void LegacyWebPageInspectorController::removeTarget(const String& targetID)
+{
+    auto it = m_targets.find(targetID);
+    if (it == m_targets.end())
+        return;
+
+    checkedTargetAgent()->targetDestroyed(*it->value);
+    m_targets.remove(it);
+}
+
+void LegacyWebPageInspectorController::connectFrontend(Inspector::FrontendChannel& frontendChannel)
+{
+    bool connectingFirstFrontend = !m_frontendRouter->hasFrontends();
+    m_frontendRouter->connectFrontend(frontendChannel);
+    if (connectingFirstFrontend)
+        m_agents.didCreateFrontendAndBackend();
+}
+
+void LegacyWebPageInspectorController::disconnectFrontend(Inspector::FrontendChannel& frontendChannel)
+{
+    m_frontendRouter->disconnectFrontend(frontendChannel);
+    bool disconnectingLastFrontend = !m_frontendRouter->hasFrontends();
+    if (disconnectingLastFrontend)
+        m_agents.willDestroyFrontendAndBackend(Inspector::DisconnectReason::InspectorDestroyed);
+}
+
+bool LegacyWebPageInspectorController::hasLocalFrontend() const
+{
+    return m_frontendRouter->hasLocalFrontend();
+}
+
+void LegacyWebPageInspectorController::disconnectAllFrontends()
+{
+    if (!m_frontendRouter->hasFrontends())
+        return;
+
+    m_agents.willDestroyFrontendAndBackend(Inspector::DisconnectReason::InspectedTargetDestroyed);
+    m_frontendRouter->disconnectAllFrontends();
+}
+
+void LegacyWebPageInspectorController::dispatchMessageFromFrontend(const String& message)
+{
+    callOnMainThread([backendDispatcher = Ref { m_backendDispatcher }, message = message.isolatedCopy()] {
+        backendDispatcher->dispatch(message);
+    });
+}
+
+void LegacyWebPageInspectorController::sendMessageToInspectorFrontend(const String& targetID, const String& message)
+{
+    checkedTargetAgent()->sendMessageFromTargetToFrontend(targetID, message);
+}

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.h
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/InspectorAgentRegistry.h>
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <JavaScriptCore/InspectorTarget.h>
+#include <JavaScriptCore/InspectorTargetAgent.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+class LocalFrame;
+class Page;
+}
+
+class LegacyWebPageInspectorController : public RefCountedAndCanMakeWeakPtr<LegacyWebPageInspectorController> {
+    WTF_MAKE_TZONE_ALLOCATED(LegacyWebPageInspectorController);
+    WTF_MAKE_NONCOPYABLE(LegacyWebPageInspectorController);
+public:
+    static Ref<LegacyWebPageInspectorController> create(WebCore::Page&);
+
+    void frameCreated(WebCore::LocalFrame&);
+    void willDestroyFrame(const WebCore::LocalFrame&);
+    void willDestroyPage(const WebCore::Page&);
+
+    void connectFrontend(Inspector::FrontendChannel&);
+    void disconnectFrontend(Inspector::FrontendChannel&);
+    void disconnectAllFrontends();
+    bool hasLocalFrontend() const;
+
+    void dispatchMessageFromFrontend(const String& message);
+    void sendMessageToInspectorFrontend(const String& targetID, const String& message);
+
+private:
+    explicit LegacyWebPageInspectorController(WebCore::Page&);
+
+    CheckedPtr<Inspector::InspectorTargetAgent> checkedTargetAgent() { return m_targetAgent; }
+
+    void addTarget(std::unique_ptr<Inspector::InspectorTarget>&&);
+    void removeTarget(const String& targetID);
+
+    const Ref<Inspector::FrontendRouter> m_frontendRouter;
+    const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
+    Inspector::AgentRegistry m_agents;
+    CheckedPtr<Inspector::InspectorTargetAgent> m_targetAgent;
+    HashMap<String, std::unique_ptr<Inspector::InspectorTarget>> m_targets;
+};

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -649,6 +649,10 @@
 		E15663190FB61C1F00C199CA /* WebDownload.mm in Sources */ = {isa = PBXBuildFile; fileRef = E15663180FB61C1F00C199CA /* WebDownload.mm */; };
 		E4AEF97C1C0DF4BC00B01727 /* WebResourceLoadScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = E4AEF97A1C0DF4BC00B01727 /* WebResourceLoadScheduler.h */; };
 		ED5B9524111B725A00472298 /* WebLocalizableStrings.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED5B9523111B725A00472298 /* WebLocalizableStrings.mm */; };
+		F36D2BC52EBE994B0001B4A8 /* LegacyWebPageDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = F36D2BC12EBE994B0001B4A8 /* LegacyWebPageDebuggable.h */; };
+		F36D2BC62EBE994B0001B4A8 /* LegacyWebPageInspectorController.h in Headers */ = {isa = PBXBuildFile; fileRef = F36D2BC32EBE994B0001B4A8 /* LegacyWebPageInspectorController.h */; };
+		F36D2BC72EBE994B0001B4A8 /* LegacyWebPageInspectorController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F36D2BC42EBE994B0001B4A8 /* LegacyWebPageInspectorController.cpp */; };
+		F36D2BC82EBE994B0001B4A8 /* LegacyWebPageDebuggable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F36D2BC22EBE994B0001B4A8 /* LegacyWebPageDebuggable.cpp */; };
 		F439B1A1284D8C39003DE041 /* WebHTMLViewForTestingMac.h in Headers */ = {isa = PBXBuildFile; fileRef = F439B1A0284D8C39003DE041 /* WebHTMLViewForTestingMac.h */; };
 		F4C98E5D1DD6476F0012FDEC /* DOMHTMLElementPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F4C98E5C1DD6476F0012FDEC /* DOMHTMLElementPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F4F665C21DD67672007714B4 /* WebAutocapitalizeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F665C11DD67672007714B4 /* WebAutocapitalizeTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1484,6 +1488,10 @@
 		EDD1A5C605C83987008E3150 /* WebNSPrintOperationExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = WebNSPrintOperationExtras.h; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
 		EDD1A5C705C83987008E3150 /* WebNSPrintOperationExtras.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = WebNSPrintOperationExtras.m; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
 		EDE850CD06ECC79E005FAB05 /* WebPreferenceKeysPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = WebPreferenceKeysPrivate.h; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
+		F36D2BC12EBE994B0001B4A8 /* LegacyWebPageDebuggable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LegacyWebPageDebuggable.h; path = WebCoreSupport/LegacyWebPageDebuggable.h; sourceTree = SOURCE_ROOT; };
+		F36D2BC22EBE994B0001B4A8 /* LegacyWebPageDebuggable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LegacyWebPageDebuggable.cpp; path = WebCoreSupport/LegacyWebPageDebuggable.cpp; sourceTree = SOURCE_ROOT; };
+		F36D2BC32EBE994B0001B4A8 /* LegacyWebPageInspectorController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LegacyWebPageInspectorController.h; path = WebCoreSupport/LegacyWebPageInspectorController.h; sourceTree = SOURCE_ROOT; };
+		F36D2BC42EBE994B0001B4A8 /* LegacyWebPageInspectorController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LegacyWebPageInspectorController.cpp; path = WebCoreSupport/LegacyWebPageInspectorController.cpp; sourceTree = SOURCE_ROOT; };
 		F439B1A0284D8C39003DE041 /* WebHTMLViewForTestingMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebHTMLViewForTestingMac.h; sourceTree = "<group>"; };
 		F4C98E5C1DD6476F0012FDEC /* DOMHTMLElementPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMHTMLElementPrivate.h; sourceTree = "<group>"; };
 		F4F665C11DD67672007714B4 /* WebAutocapitalizeTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebAutocapitalizeTypes.h; sourceTree = "<group>"; };
@@ -2529,6 +2537,10 @@
 				FA96E4AF2AAAFA920090C5A3 /* LegacyHistoryItemClient.mm */,
 				5CB05C7F29CA0E7000CC1AA0 /* LegacySocketProvider.cpp */,
 				5CB05C7E29CA0E7000CC1AA0 /* LegacySocketProvider.h */,
+				F36D2BC22EBE994B0001B4A8 /* LegacyWebPageDebuggable.cpp */,
+				F36D2BC12EBE994B0001B4A8 /* LegacyWebPageDebuggable.h */,
+				F36D2BC42EBE994B0001B4A8 /* LegacyWebPageInspectorController.cpp */,
+				F36D2BC32EBE994B0001B4A8 /* LegacyWebPageInspectorController.h */,
 				5CA46E7721F1451D00CE86B4 /* NetworkStorageSessionMap.cpp */,
 				5CA46E7621F1451D00CE86B4 /* NetworkStorageSessionMap.h */,
 				5C9EF2F421F061BE003BDC56 /* PageStorageSessionProvider.h */,
@@ -2862,6 +2874,8 @@
 				9364006F23996E81001E185E /* InProcessIDBServer.h in Headers */,
 				FA96E4B02AAAFA920090C5A3 /* LegacyHistoryItemClient.h in Headers */,
 				5CB05C8229CA0E7000CC1AA0 /* LegacySocketProvider.h in Headers */,
+				F36D2BC52EBE994B0001B4A8 /* LegacyWebPageDebuggable.h in Headers */,
+				F36D2BC62EBE994B0001B4A8 /* LegacyWebPageInspectorController.h in Headers */,
 				5CA46E7821F1451D00CE86B4 /* NetworkStorageSessionMap.h in Headers */,
 				93D4379B1D57ABEF00AB85EA /* ObjCEventListener.h in Headers */,
 				93D4379D1D57ABEF00AB85EA /* ObjCNodeFilterCondition.h in Headers */,
@@ -3474,6 +3488,8 @@
 				1A60519317502A5D00BC62F5 /* HistoryPropertyList.mm in Sources */,
 				9364006E23996E81001E185E /* InProcessIDBServer.cpp in Sources */,
 				FA96E4B12AAAFA920090C5A3 /* LegacyHistoryItemClient.mm in Sources */,
+				F36D2BC82EBE994B0001B4A8 /* LegacyWebPageDebuggable.cpp in Sources */,
+				F36D2BC72EBE994B0001B4A8 /* LegacyWebPageInspectorController.cpp in Sources */,
 				A10C1D601820300E0036883A /* PopupMenuIOS.mm in Sources */,
 				5C40CD2122D8F9C000E9DAD5 /* PopupMenuMac.mm in Sources */,
 				A10C1D611820300E0036883A /* SearchPopupMenuIOS.cpp in Sources */,

--- a/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
+++ b/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
@@ -29,6 +29,7 @@
 #include <WebCore/InspectorFrontendClientLocal.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
+#include <wtf/Assertions.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/cf/TypeCastsCF.h>
 
@@ -64,6 +65,7 @@ static void deleteSetting(const String& key)
 
 void WebInspectorClient::sendMessageToFrontend(const String& message)
 {
+    ASSERT(m_frontendClient);
     m_frontendClient->frontendAPIDispatcher().dispatchMessageAsync(message);
 }
 

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
@@ -30,6 +30,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "LegacyWebPageInspectorController.h"
 #import "WebFrameInternal.h"
 #import "WebInspector.h"
 #import "WebNodeHighlighter.h"
@@ -114,7 +115,7 @@ void WebInspectorClient::didSetSearchingForNode(bool enabled)
 #pragma mark -
 #pragma mark WebInspectorFrontendClient Implementation
 
-WebInspectorFrontendClient::WebInspectorFrontendClient(WebView* inspectedWebView, WebInspectorWindowController* frontendWindowController, PageInspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings> settings)
+WebInspectorFrontendClient::WebInspectorFrontendClient(WebView* inspectedWebView, LegacyWebPageInspectorController& webPageInspectorController, WebInspectorWindowController* frontendWindowController, PageInspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings> settings)
     : InspectorFrontendClientLocal(inspectedPageController, frontendPage, WTFMove(settings))
 {
     // iOS does not have a local inspector, this should not be reached.

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -26,6 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "LegacyWebPageInspectorController.h"
 #import <JavaScriptCore/InspectorFrontendChannel.h>
 #import <WebCore/FloatRect.h>
 #import <WebCore/InspectorBackendClient.h>
@@ -50,6 +51,7 @@ namespace WebCore {
 class CertificateInfo;
 class LocalFrame;
 class Page;
+class PageInspectorController;
 }
 
 class WebInspectorFrontendClient;
@@ -68,10 +70,6 @@ public:
 
     void highlight() override;
     void hideHighlight() override;
-
-#if ENABLE(REMOTE_INSPECTOR)
-    bool allowRemoteInspectionToPageDirectly() const override { return true; }
-#endif
 
 #if PLATFORM(IOS_FAMILY)
     void showInspectorIndication() override;
@@ -113,7 +111,7 @@ private:
 
 class WebInspectorFrontendClient : public WebCore::InspectorFrontendClientLocal {
 public:
-    WebInspectorFrontendClient(WebView*, WebInspectorWindowController*, WebCore::PageInspectorController*, WebCore::Page*, std::unique_ptr<Settings>);
+    WebInspectorFrontendClient(WebView*, LegacyWebPageInspectorController&, WebInspectorWindowController*, WebCore::PageInspectorController*, WebCore::Page*, std::unique_ptr<Settings>);
 
     void attachAvailabilityChanged(bool);
     bool canAttach();
@@ -123,12 +121,11 @@ public:
     void startWindowDrag() override;
 
     String localizedStringsURL() const override;
-    Inspector::DebuggableType debuggableType() const final { return Inspector::DebuggableType::Page; };
+    Inspector::DebuggableType debuggableType() const final { return Inspector::DebuggableType::WebPage; };
     String targetPlatformName() const final { return "macOS"_s; };
     String targetBuildVersion() const final { return "Unknown"_s; };
     String targetProductVersion() const final { return "Unknown"_s; };
     bool targetIsSimulator() const final { return false; }
-
 
     void bringToFront() override;
     void closeWindow() override;
@@ -157,6 +154,8 @@ public:
     void logDiagnosticEvent(const String& eventName, const WebCore::DiagnosticLoggingClient::ValueDictionary&) override;
 #endif
 
+    void sendMessageToBackend(const String& message) final;
+
 private:
     void updateWindowTitle() const;
 
@@ -165,6 +164,7 @@ private:
 
 #if !PLATFORM(IOS_FAMILY)
     WeakObjCPtr<WebView> m_inspectedWebView;
+    WeakPtr<LegacyWebPageInspectorController> m_webPageInspectorController;
     RetainPtr<WebInspectorWindowController> m_frontendWindowController;
     String m_inspectedURL;
     HashMap<String, RetainPtr<NSURL>> m_suggestedToActualURLMap;

--- a/Source/WebKitLegacy/mac/WebView/WebFrameInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFrameInternal.h
@@ -28,6 +28,7 @@
 
 // This header contains WebFrame declarations that can be used anywhere in WebKit, but are neither SPI nor API.
 
+#import "LegacyWebPageInspectorController.h"
 #import "WebFramePrivate.h"
 #import "WebPreferencesPrivate.h"
 #import <WebCore/CaptionUserPreferences.h>
@@ -98,6 +99,7 @@ WebView *getWebView(WebFrame *webFrame);
 #if PLATFORM(IOS_FAMILY)
     BOOL isCommitting;
 #endif
+    WeakPtr<LegacyWebPageInspectorController> webPageInspectorController;
 }
 @end
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.h
@@ -27,6 +27,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "LegacyWebPageDebuggable.h"
+#import "LegacyWebPageInspectorController.h"
 #import "WebDelegateImplementationCaching.h"
 #import "WebUIDelegate.h"
 #if HAVE(TOUCH_BAR)
@@ -326,5 +328,8 @@ class WebSelectionServiceController;
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
     std::unique_ptr<WebMediaPlaybackTargetPicker> m_playbackTargetPicker;
 #endif
+
+    RefPtr<LegacyWebPageInspectorController> inspectorController;
+    RefPtr<LegacyWebPageDebuggable> inspectorDebuggable;
 }
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -94,6 +94,7 @@ struct DragItem;
 
 class WebMediaPlaybackTargetPicker;
 class WebSelectionServiceController;
+class LegacyWebPageInspectorController;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
 #import <WebCore/MediaProducer.h>
@@ -190,6 +191,8 @@ WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 - (void)_windowVisibilityChanged:(NSNotification *)notification;
 
 - (void)_closeWindow;
+
+- (LegacyWebPageInspectorController*)inspectorController;
 
 @end
 


### PR DESCRIPTION
#### 5f614bee7105d19f74d3322b9d15ff62e218a442
<pre>
Web Inspector: Make frame targets compatible with WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=302125">https://bugs.webkit.org/show_bug.cgi?id=302125</a>
<a href="https://rdar.apple.com/problem/164203459">rdar://problem/164203459</a>

Reviewed by BJ Burg.

With our plan to slowly move inspector agent implementations from the
page target + InspectorController to the frame target + FrameInspectorController
for site isolation, we run into the issue that inspecting WK1 uses a WI.DirectBackendTarget
to directly contact the InspectorController, so any domains moving out
of the page will become opaque to that DirectBackendTarget.

To solve this compatibility issue and hopefully prevent having to leave
copies of any old agent code in the page that we must still maintain,
introduce a multi-target support to WK1 so that inspector frontend can
use WI.MultiplexingBackendTarget to inspect either WK1 or WK2. This is
done by adding LegacyWebPage{Debuggable,InspectorController} acting as
destinations of &quot;web-page&quot;-typed debuggable and target in WK1, which
will route commands and events to the appropriate targets just like in
WK2, except without using IPC.

Test: re-enabled target-manager.html for WK1. No new tests otherwise;
inspection of WebKitLegacy should have no observable difference.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/WebCore/inspector/InspectorBackendClient.h:
(WebCore::InspectorBackendClient::allowRemoteInspectionToPageDirectly const): Deleted.
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/page/Page.cpp:
(WebCore::m_mediaSessionManagerFactory):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp: Added.
(LegacyWebPageDebuggable::LegacyWebPageDebuggable):
(LegacyWebPageDebuggable::create):
(LegacyWebPageDebuggable::name const):
(LegacyWebPageDebuggable::url const):
(LegacyWebPageDebuggable::hasLocalDebugger const):
(LegacyWebPageDebuggable::connect):
(LegacyWebPageDebuggable::disconnect):
(LegacyWebPageDebuggable::dispatchMessageFromRemote):
(LegacyWebPageDebuggable::setIndicating):
(LegacyWebPageDebuggable::setNameOverride):
(LegacyWebPageDebuggable::detachFromPage):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.h: Added.
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp: Added.
(PageTarget::identifier):
(PageTarget::PageTarget):
(FrameTarget::identifier):
(FrameTarget::FrameTarget):
(LegacyWebPageInspectorController::create):
(LegacyWebPageInspectorController::LegacyWebPageInspectorController):
(LegacyWebPageInspectorController::frameCreated):
(LegacyWebPageInspectorController::frameDestroying):
(LegacyWebPageInspectorController::pageDestroying):
(LegacyWebPageInspectorController::addTarget):
(LegacyWebPageInspectorController::removeTarget):
(LegacyWebPageInspectorController::connectFrontend):
(LegacyWebPageInspectorController::disconnectFrontend):
(LegacyWebPageInspectorController::hasLocalFrontend const):
(LegacyWebPageInspectorController::disconnectAllFrontends):
(LegacyWebPageInspectorController::dispatchMessageFromFrontend):
(LegacyWebPageInspectorController::sendMessageToInspectorFrontend):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.h: Added.
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj:
* Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp:
(WebInspectorClient::sendMessageToFrontend):
* Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm:
(WebInspectorFrontendClient::WebInspectorFrontendClient):
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorClient::openLocalFrontend):
(WebInspectorFrontendClient::WebInspectorFrontendClient):
(WebInspectorFrontendClient::sendMessageToBackend):
(-[WebInspectorWindowController destroyInspectorView]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(+[WebFrame _createFrameWithPage:frameName:frameView:ownerElement:]):
(+[WebFrame _createMainFrameWithPage:frameName:frameView:]):
(-[WebFrame _clearCoreFrame]):
* Source/WebKitLegacy/mac/WebView/WebFrameInternal.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
(-[WebView initSimpleHTMLDocumentWithStyle:frame:preferences:groupName:]):
(-[WebView _close]):
(-[WebView allowsRemoteInspection]):
(-[WebView setAllowsRemoteInspection:]):
(-[WebView inspectorController]):
* Source/WebKitLegacy/mac/WebView/WebViewData.h:
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:

Canonical link: <a href="https://commits.webkit.org/304467@main">https://commits.webkit.org/304467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/536534e136eacf41853ac4267692b6d0986fed5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86728 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f2ddc900-26d4-4022-b4f2-ee6ea3c0461d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103033 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70326 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83868 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/370724e2-6524-4720-b48f-3790a493ce4f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3014 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2943 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126872 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145048 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133343 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6947 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111415 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111752 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5238 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60878 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20909 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6993 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35351 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166243 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70573 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43449 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7015 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6889 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->