### PR TITLE
Use SIMD in BitSet operations

### DIFF
--- a/Source/WTF/benchmarks/BitSetSpeedTest.cpp
+++ b/Source/WTF/benchmarks/BitSetSpeedTest.cpp
@@ -1,0 +1,458 @@
+/*
+ * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+// On Mac, you can build this like so:
+// xcrun clang++ -o BitSetSpeedTest Source/WTF/benchmarks/BitSetSpeedTest.cpp -O3 -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks -ISource/bmalloc -ISource/bmalloc/bmalloc -ISource/bmalloc/libpas/src/libpas -LWebKitBuild/Debug -lWTF -lbmalloc -lpas -framework Foundation -framework Security -licucore -std=c++23 -fvisibility=hidden -arch arm64e
+
+#include "config.h"
+
+#include <wtf/BitSet.h>
+#include <wtf/DataLog.h>
+#include <wtf/MonotonicTime.h>
+
+namespace {
+[[noreturn]] void usage()
+{
+    dataLogF("BitSetSpeedTest <number of seconds to run each test> <number of times to run each test> [allzeros|allones|alternating|sparse|dense|random|all]\n");
+    exit(1);
+}
+
+constexpr size_t numberOfBitPatterns = 6;
+enum class BitPattern {
+    AllZeros,
+    AllOnes,
+    Alternating,
+    Sparse,
+    Dense,
+    Random
+};
+
+double secondsPerTest;
+unsigned numberOfRuns;
+BitPattern pattern { BitPattern::Random };
+bool runAllBitPatterns { false };
+
+const char* getPatternName()
+{
+    switch (pattern) {
+    case BitPattern::AllZeros:
+        return "allzeros";
+    case BitPattern::AllOnes:
+        return "allones";
+    case BitPattern::Alternating:
+        return "alternating";
+    case BitPattern::Sparse:
+        return "sparse";
+    case BitPattern::Dense:
+        return "sparse";
+    case BitPattern::Random:
+        return "random";
+    };
+}
+
+void parseArgs(int argc, char** argv)
+{
+    if (argc < 3)
+        usage();
+
+    if (!sscanf(argv[1], "%lf", &secondsPerTest))
+        usage();
+    if (!sscanf(argv[2], "%u", &numberOfRuns))
+        usage();
+
+    if (argc > 3) {
+        if (!strcmp(argv[3], "allones")) // NOLINT
+            pattern = BitPattern::AllOnes;
+        else if (!strcmp(argv[3], "allzeros")) // NOLINT
+            pattern = BitPattern::AllZeros;
+        else if (!strcmp(argv[3], "alternating")) // NOLINT
+            pattern = BitPattern::Alternating;
+        else if (!strcmp(argv[3], "sparse")) // NOLINT
+            pattern = BitPattern::Sparse;
+        else if (!strcmp(argv[3], "dense")) // NOLINT
+            pattern = BitPattern::Dense;
+        else if (!strcmp(argv[3], "random")) // NOLINT
+            pattern = BitPattern::Random;
+        else if (!strcmp(argv[3], "all")) // NOLINT
+            runAllBitPatterns = true;
+        else
+            usage();
+    }
+
+}
+
+ALWAYS_INLINE size_t iterationsForOperation(auto operation)
+{
+    // warm up cache
+    WTF::MonotonicTime end = MonotonicTime::now() + WTF::Seconds(0.01);
+    while (MonotonicTime::now() < end)
+        operation();
+
+    end = MonotonicTime::now() + WTF::Seconds(secondsPerTest);
+    size_t iterations { 0 };
+
+    while (MonotonicTime::now() < end) {
+        operation();
+        iterations++;
+    }
+
+    return iterations;
+};
+
+template <size_t T>
+void initializeBitSet(WTF::BitSet<T>& bitSet)
+{
+    if (pattern == BitPattern::AllZeros) {
+        bitSet.clearAll();
+        return;
+    }
+
+    if (pattern == BitPattern::AllOnes) {
+        bitSet.setAll();
+        return;
+    }
+
+    if (pattern == BitPattern::Random) {
+        uint32_t seed = 0x12345678;
+        for (size_t i = 0; i < T; i++) {
+            seed = seed * 1103515245 + 12345;
+            if (seed & 1)
+                bitSet.set(i);
+        }
+        return;
+    }
+
+
+    for (size_t i = 0; i < T; i++) {
+        switch (pattern) {
+        case BitPattern::Alternating:
+            if (!(i % 2))
+                bitSet.set(i);
+            break;
+        case BitPattern::Sparse:
+            if (!(i % 8))
+                bitSet.set(i);
+            break;
+        case BitPattern::Dense:
+            if (i % 8)
+                bitSet.set(i);
+            break;
+        default:
+            break;
+        }
+    }
+};
+
+template <size_t T>
+size_t benchmarkXorEquals()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1 ^= bitSet2;
+    });
+}
+
+template <size_t T>
+size_t benchmarkAndEquals()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    WTF::BitSet<T> originalBitSet = bitSet1;
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1 &= bitSet2;
+        bitSet1 = originalBitSet;
+    });
+}
+
+template <size_t T>
+size_t benchmarkOrEquals()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    WTF::BitSet<T> originalBitSet = bitSet1;
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1 |= bitSet2;
+        bitSet1 = originalBitSet;
+    });
+}
+
+template <size_t T>
+size_t benchmarkEquality()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    volatile bool sink = false; // prevent optimization
+    size_t iterations = iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        sink = (bitSet1 == bitSet2);
+    });
+
+    if (static_cast<int>(sink) == 3) [[unlikely]]
+        dataLogF("impossible\n");
+
+    return iterations;
+}
+
+template <size_t T>
+size_t benchmarkSetAndClear()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    WTF::BitSet<T> originalBitSet1 = bitSet1;
+    WTF::BitSet<T> originalBitSet2 = bitSet2;
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1.setAndClear(bitSet2);
+        bitSet1 = originalBitSet1;
+        bitSet2 = originalBitSet2;
+    });
+}
+
+template <size_t T>
+size_t benchmarkMergeAndClear()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    WTF::BitSet<T> originalBitSet1 = bitSet1;
+    WTF::BitSet<T> originalBitSet2 = bitSet2;
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1.mergeAndClear(bitSet2);
+        bitSet1 = originalBitSet1;
+        bitSet2 = originalBitSet2;
+    });
+}
+
+template <size_t T>
+size_t benchmarkSubsumes()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    volatile bool sink = false; // prevent optimization
+    size_t iterations = iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        sink = bitSet1.subsumes(bitSet2);
+    });
+
+    if (static_cast<int>(sink) == 3) [[unlikely]]
+        dataLogF("impossible\n");
+
+    return iterations;
+}
+
+template <size_t T>
+size_t benchmarkExclude()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    WTF::BitSet<T> originalBitSet = bitSet1;
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1.exclude(bitSet2);
+        bitSet1 = originalBitSet;
+    });
+}
+
+template <size_t T>
+size_t benchmarkIsFull()
+{
+    WTF::BitSet<T> bitSet;
+    initializeBitSet(bitSet);
+    volatile bool sink = false; // prevent optimization
+    size_t iterations = iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        sink = bitSet.isFull();
+    });
+
+    if (static_cast<int>(sink) == 3) [[unlikely]]
+        dataLogF("impossible\n");
+
+    return iterations;
+}
+
+template <size_t T>
+size_t benchmarkIsEmpty()
+{
+    WTF::BitSet<T> bitSet;
+    initializeBitSet(bitSet);
+    volatile bool sink = false; // prevent optimization
+    size_t iterations = iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        sink = bitSet.isEmpty();
+    });
+
+    if (static_cast<int>(sink) == 3) [[unlikely]]
+        dataLogF("impossible\n");
+
+    return iterations;
+}
+
+template <size_t T>
+size_t benchmarkInvert()
+{
+    WTF::BitSet<T> bitSet;
+    initializeBitSet(bitSet);
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet.invert();
+        bitSet.invert(); // back to original
+    });
+}
+
+template <size_t T>
+size_t benchmarkFilter()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    WTF::BitSet<T> originalBitSet = bitSet1;
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1.filter(bitSet2);
+        bitSet1 = originalBitSet;
+    });
+}
+
+template <size_t T>
+size_t benchmarkMerge()
+{
+    WTF::BitSet<T> bitSet1;
+    WTF::BitSet<T> bitSet2;
+    initializeBitSet(bitSet1);
+    initializeBitSet(bitSet2);
+    WTF::BitSet<T> originalBitSet = bitSet1;
+    return iterationsForOperation([&] ALWAYS_INLINE_LAMBDA {
+        bitSet1.merge(bitSet2);
+        bitSet1 = originalBitSet;
+    });
+}
+
+template <size_t T>
+void reportResults(size_t iterations)
+{
+    double opsPerSecond = static_cast<double>(iterations) / secondsPerTest;
+    double nsPerOp = (secondsPerTest * 1e9) / iterations;
+    dataLogF("(%zu bits): %.2f Mops/s, %.2f ns/op\n", T, opsPerSecond / 1e6, nsPerOp);
+}
+
+template <size_t T>
+void runFuncAndReport(auto func)
+{
+    std::vector<size_t> runs;
+    for (size_t i = 0; i < numberOfRuns; i++) {
+        size_t iterations = func.template operator()<T>();
+        runs.push_back(iterations);
+    }
+    std::sort(runs.begin(), runs.end());
+    size_t median = runs[runs.size() / 2];
+    reportResults<T>(median);
+}
+
+template <typename Callback>
+void runBenchmark(const char* name, Callback func)
+{
+    dataLogF("=============== %s ================\n", name);
+    runFuncAndReport<64>(func); // doesn't use SIMD
+    runFuncAndReport<512>(func);
+    runFuncAndReport<511>(func); // doesn't fit evenly into SIMD vector
+    runFuncAndReport<4096>(func);
+    runFuncAndReport<262144>(func); // 32KB - L1/L2 boundary
+    runFuncAndReport<2097152>(func); // 256KB - L2/L3 boundary
+}
+}
+
+int main(int argc, char** argv)
+{
+    parseArgs(argc, argv);
+
+    auto runBenchmarks = []() {
+        runBenchmark("merge", []<size_t T>() {
+            return benchmarkMerge<T>();
+        });
+        runBenchmark("filter", []<size_t T>() {
+            return benchmarkFilter<T>();
+        });
+        runBenchmark("invert", []<size_t T>() {
+            return benchmarkInvert<T>();
+        });
+        runBenchmark("isEmpty", []<size_t T>() {
+            return benchmarkIsEmpty<T>();
+        });
+        runBenchmark("isFull", []<size_t T>() {
+            return benchmarkIsFull<T>();
+        });
+        runBenchmark("exclude", []<size_t T>() {
+            return benchmarkExclude<T>();
+        });
+        runBenchmark("subsumes", []<size_t T>() {
+            return benchmarkSubsumes<T>();
+        });
+        runBenchmark("mergeAndClear", []<size_t T>() {
+            return benchmarkMergeAndClear<T>();
+        });
+        runBenchmark("setAndClear", []<size_t T>() {
+            return benchmarkSetAndClear<T>();
+        });
+        runBenchmark("equality", []<size_t T>() {
+            return benchmarkEquality<T>();
+        });
+        runBenchmark("|=", []<size_t T>() {
+            return benchmarkOrEquals<T>();
+        });
+        runBenchmark("&=", []<size_t T>() {
+            return benchmarkAndEquals<T>();
+        });
+        runBenchmark("^=", []<size_t T>() {
+            return benchmarkXorEquals<T>();
+        });
+    };
+
+    auto printTitle = []() {
+        dataLogF("seconds per test: %lf, number of runs per test: %u, bit pattern: %s\n", secondsPerTest, numberOfRuns, getPatternName());
+    };
+
+    dataLogF("============ STARTING BENCHMARK ==============\n");
+    if (runAllBitPatterns) {
+        for (size_t i = 0; i < numberOfBitPatterns; i++) {
+            pattern = static_cast<BitPattern>(i);
+            printTitle();
+            runBenchmarks();
+        }
+    } else {
+        printTitle();
+        runBenchmarks();
+    }
+
+    return 0;
+}

--- a/Source/WTF/benchmarks/LockSpeedTest.cpp
+++ b/Source/WTF/benchmarks/LockSpeedTest.cpp
@@ -24,7 +24,7 @@
  */
 
 // On Mac, you can build this like so:
-// xcrun clang++ -o LockSpeedTest Source/WTF/benchmarks/LockSpeedTest.cpp -O3 -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks -LWebKitBuild/Release -lWTF -framework Foundation -licucore -std=c++14 -fvisibility=hidden
+// xcrun clang++ -o LockSpeedTest Source/WTF/benchmarks/LockSpeedTest.cpp -O3 -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks -ISource/bmalloc -ISource/bmalloc/bmalloc -ISource/bmalloc/libpas/src/libpas -LWebKitBuild/Debug -lWTF -lbmalloc -lpas -framework Foundation -framework Security -licucore -std=c++23 -fvisibility=hidden -arch arm64e
 
 #include "config.h"
 
@@ -76,7 +76,8 @@ struct Benchmark {
     {
         std::unique_ptr<WithPadding<LockType>[]> locks = makeUniqueWithoutFastMallocCheck<WithPadding<LockType>[]>(numThreadGroups);
         std::unique_ptr<WithPadding<double>[]> words = makeUniqueWithoutFastMallocCheck<WithPadding<double>[]>(numThreadGroups);
-        std::unique_ptr<RefPtr<Thread>[]> threads = makeUniqueWithoutFastMallocCheck<RefPtr<Thread>[]>(numThreadGroups * numThreadsPerGroup);
+        Vector<RefPtr<Thread>> threads;
+        threads.reserveInitialCapacity(numThreadGroups * numThreadsPerGroup);
 
         std::atomic<bool> keepGoing = true;
 
@@ -89,7 +90,7 @@ struct Benchmark {
             words[threadGroupIndex].value = 0;
 
             for (unsigned threadIndex = numThreadsPerGroup; threadIndex--;) {
-                threads[threadGroupIndex * numThreadsPerGroup + threadIndex] = Thread::create(
+                threads.append(Thread::create(
                     "Benchmark thread"_s,
                     [threadGroupIndex, &locks, &words, &keepGoing, &numIterationsLock, &numIterations] () {
                         double localWord = 0;
@@ -110,15 +111,15 @@ struct Benchmark {
                         }
                         Locker locker { numIterationsLock };
                         numIterations += myNumIterations;
-                    });
+                    }));
             }
         }
 
         sleep(Seconds { secondsPerTest });
         keepGoing = false;
-    
-        for (unsigned threadIndex = numThreadGroups * numThreadsPerGroup; threadIndex--;)
-            threads[threadIndex]->waitForCompletion();
+
+        for (auto& thread : threads)
+            thread->waitForCompletion();
 
         MonotonicTime after = MonotonicTime::now();
     

--- a/Source/WTF/benchmarks/ToyLocks.h
+++ b/Source/WTF/benchmarks/ToyLocks.h
@@ -85,8 +85,15 @@ public:
 
     void lock()
     {
-        while (!m_lock.compareExchangeWeak(0, 1, std::memory_order_acquire))
-            asm volatile ("pause");
+        while (!m_lock.compareExchangeWeak(0, 1, std::memory_order_acquire)) {
+#if CPU(ARM64)
+            asm volatile ("yield"); // NOLINT
+#elif CPU(X86_64)
+            asm volatile ("pause"); // NOLINT
+#else
+            Thread::yield();
+#endif
+        }
     }
 
     void unlock()

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -20,11 +20,13 @@
 #pragma once
 
 #include <array>
+#include <bit>
 #include <wtf/Atomics.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/MathExtras.h>
 #include <wtf/PrintStream.h>
+#include <wtf/SIMDHelpers.h>
 #include <wtf/StdIntExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <string.h>
@@ -157,6 +159,9 @@ private:
     // and then casted to unsigned, meaning that set(31) when WordType is
     // a 64 bit unsigned int would give 0xffff8000
     static constexpr WordType one = 1;
+    static constexpr bool useSIMD = words >= 64;
+    using Vec = SIMD::VectorType<WordType>;
+    static constexpr size_t stride = SIMD::stride<WordType>;
 
     std::array<WordType, words> bits { };
 };
@@ -272,8 +277,23 @@ inline constexpr void BitSet<bitSetSize, WordType>::setAll()
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::invert()
 {
-    for (size_t i = 0; i < words; ++i)
-        bits[i] = ~bits[i];
+    if constexpr (words == 1) {
+        bits[0] = ~bits[0];
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec vec = SIMD::load(&bits[index]);
+            Vec notResult = SIMD::bitNot(vec);
+            SIMD::store(notResult, &bits[index]);
+        }
+
+        for (; index < words; ++index)
+            bits[index] = ~bits[index];
+    } else {
+        for (size_t i = 0; i < words; ++i)
+            bits[i] = ~bits[i];
+    }
+
     cleanseLastWord();
 }
 
@@ -324,49 +344,148 @@ inline constexpr size_t BitSet<bitSetSize, WordType>::count(size_t start) const
 template<size_t bitSetSize, typename WordType>
 inline constexpr bool BitSet<bitSetSize, WordType>::isEmpty() const
 {
-    for (size_t i = 0; i < words; ++i)
-        if (bits[i])
-            return false;
+    if constexpr (words == 1) {
+        return !bits[0];
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec vec = SIMD::load(&bits[index]);
+            if (SIMD::isNonZero(vec))
+                return false;
+        }
+
+        for (; index < words; ++index) {
+            if (bits[index])
+                return false;
+        }
+    } else {
+        for (size_t i = 0; i < words; ++i) {
+            if (bits[i])
+                return false;
+        }
+    }
+
     return true;
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr bool BitSet<bitSetSize, WordType>::isFull() const
 {
-    for (size_t i = 0; i < words; ++i)
-        if (~bits[i]) {
+    if constexpr (words == 1) {
+        if (~bits[0]) {
             if constexpr (!!(bitSetSize % wordSize)) {
-                if (i == words - 1) {
-                    constexpr size_t remainingBits = bitSetSize % wordSize;
-                    constexpr WordType mask = (static_cast<WordType>(1) << remainingBits) - 1;
-                    if ((bits[i] & mask) == mask)
-                        return true;
-                }
+                constexpr size_t remainingBits = bitSetSize % wordSize;
+                constexpr WordType mask = (static_cast<WordType>(1) << remainingBits) - 1;
+                if ((bits[0] & mask) == mask)
+                    return true;
             }
             return false;
         }
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec vec = SIMD::load(&bits[index]);
+            Vec notResult = SIMD::bitNot(vec);
+            if (SIMD::isNonZero(notResult))
+                return false;
+        }
+
+        for (; index < words; ++index) {
+            if (~bits[index]) {
+                if constexpr (!!(bitSetSize % wordSize)) {
+                    if (index == words - 1) {
+                        constexpr size_t remainingBits = bitSetSize % wordSize;
+                        constexpr WordType mask = (static_cast<WordType>(1) << remainingBits) - 1;
+                        if ((bits[index] & mask) == mask)
+                            return true;
+                    }
+                }
+                return false;
+            }
+        }
+    } else {
+        for (size_t i = 0; i < words; ++i) {
+            if (~bits[i]) {
+                if constexpr (!!(bitSetSize % wordSize)) {
+                    if (i == words - 1) {
+                        constexpr size_t remainingBits = bitSetSize % wordSize;
+                        constexpr WordType mask = (static_cast<WordType>(1) << remainingBits) - 1;
+                        if ((bits[i] & mask) == mask)
+                            return true;
+                    }
+                }
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::merge(const BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i)
-        bits[i] |= other.bits[i];
+    if constexpr (words == 1) {
+        bits[0] |= other.bits[0];
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec first = SIMD::load(&bits[index]);
+            Vec second = SIMD::load(&other.bits[index]);
+            Vec result = SIMD::merge(first, second);
+            SIMD::store(result, &bits[index]);
+        }
+
+        for (; index < words; ++index)
+            bits[index] |= other.bits[index];
+    } else {
+        for (size_t i = 0; i < words; ++i)
+            bits[i] |= other.bits[i];
+    }
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::filter(const BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i)
-        bits[i] &= other.bits[i];
+    if constexpr (words == 1) {
+        bits[0] &= other.bits[0];
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec first = SIMD::load(&bits[index]);
+            Vec second = SIMD::load(&other.bits[index]);
+            Vec result = SIMD::bitAnd(first, second);
+            SIMD::store(result, &bits[index]);
+        }
+
+        for (; index < words; ++index)
+            bits[index] &= other.bits[index];
+    } else {
+        for (size_t i = 0; i < words; ++i)
+            bits[i] &= other.bits[i];
+    }
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::exclude(const BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i)
-        bits[i] &= ~other.bits[i];
+    if constexpr (words == 1) {
+        bits[0] &= ~other.bits[0];
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec first = SIMD::load(&bits[index]);
+            Vec second = SIMD::bitNot(SIMD::load(&other.bits[index]));
+            Vec result = SIMD::bitAnd(first, second);
+            SIMD::store(result, &bits[index]);
+        }
+
+        for (; index < words; ++index)
+            bits[index] &= ~other.bits[index];
+    } else {
+        for (size_t i = 0; i < words; ++i)
+            bits[i] &= ~other.bits[i];
+    }
 }
 
 template<size_t bitSetSize, typename WordType>
@@ -392,11 +511,35 @@ inline constexpr void BitSet<bitSetSize, WordType>::concurrentFilter(const BitSe
 template<size_t bitSetSize, typename WordType>
 inline constexpr bool BitSet<bitSetSize, WordType>::subsumes(const BitSet& other) const
 {
-    for (size_t i = 0; i < words; ++i) {
-        WordType myBits = bits[i];
-        WordType otherBits = other.bits[i];
+    if constexpr (words == 1) {
+        WordType myBits = bits[0];
+        WordType otherBits = other.bits[0];
         if ((myBits | otherBits) != myBits)
             return false;
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec first = SIMD::load(&bits[index]);
+            Vec second = SIMD::load(&other.bits[index]);
+            Vec orResult = SIMD::bitOr(first, second);
+            Vec equalResult = SIMD::equal(orResult, first);
+            if (SIMD::isNonZero(SIMD::bitNot(equalResult)))
+                return false;
+        }
+
+        for (; index < words; ++index) {
+            WordType myBits = bits[index];
+            WordType otherBits = other.bits[index];
+            if ((myBits | otherBits) != myBits)
+                return false;
+        }
+    } else {
+        for (size_t i = 0; i < words; ++i) {
+            WordType myBits = bits[i];
+            WordType otherBits = other.bits[i];
+            if ((myBits | otherBits) != myBits)
+                return false;
+        }
     }
     return true;
 }
@@ -440,18 +583,54 @@ inline constexpr size_t BitSet<bitSetSize, WordType>::findBit(size_t startIndex,
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::mergeAndClear(BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i) {
-        bits[i] |= other.bits[i];
-        other.bits[i] = 0;
+    if constexpr (words == 1) {
+        bits[0] |= other.bits[0];
+        other.bits[0] = 0;
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec first = SIMD::load(&bits[index]);
+            Vec second = SIMD::load(&other.bits[index]);
+            Vec result = SIMD::merge(first, second);
+            SIMD::store(result, &bits[index]);
+            SIMD::store(SIMD::zero<WordType>(), &other.bits[index]);
+        }
+
+        for (; index < words; ++index) {
+            bits[index] |= other.bits[index];
+            other.bits[index] = 0;
+        }
+    } else {
+        for (size_t i = 0; i < words; ++i) {
+            bits[i] |= other.bits[i];
+            other.bits[i] = 0;
+        }
     }
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::setAndClear(BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i) {
-        bits[i] = other.bits[i];
-        other.bits[i] = 0;
+    if constexpr (words == 1) {
+        bits[0] = other.bits[0];
+        other.bits[0] = 0;
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec second = SIMD::load(&other.bits[index]);
+            SIMD::store(second, &bits[index]);
+            SIMD::store(SIMD::zero<WordType>(), &other.bits[index]);
+        }
+
+        for (; index < words; ++index) {
+            bits[index] = other.bits[index];
+            other.bits[index] = 0;
+        }
+    } else {
+        for (size_t i = 0; i < words; ++i) {
+            bits[i] = other.bits[i];
+            other.bits[i] = 0;
+        }
     }
 }
 
@@ -485,32 +664,69 @@ inline void BitSet<bitSetSize, WordType>::setEachNthBit(size_t n, size_t start, 
 template<size_t bitSetSize, typename WordType>
 inline constexpr bool BitSet<bitSetSize, WordType>::operator==(const BitSet& other) const
 {
-    for (size_t i = 0; i < words; ++i) {
-        if (bits[i] != other.bits[i])
-            return false;
+    if constexpr (words == 1) {
+        if constexpr (!!(bitSetSize % wordSize)) {
+            constexpr size_t remainingBits = bitSetSize % wordSize;
+            constexpr WordType mask = (static_cast<WordType>(1) << remainingBits) - 1;
+            return (bits[0] & mask) == (other.bits[0] & mask);
+        } else
+            return bits[0] == other.bits[0];
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec first = SIMD::load(&bits[index]);
+            Vec second = SIMD::load(&other.bits[index]);
+            Vec result = SIMD::equal(first, second);
+            if (SIMD::isNonZero(SIMD::bitNot(result)))
+                return false;
+        }
+
+        for (; index < words; ++index) {
+            if (bits[index] != other.bits[index])
+                return false;
+        }
+    } else {
+        for (size_t i = 0; i < words; ++i) {
+            if (bits[i] != other.bits[i])
+                return false;
+        }
     }
+
     return true;
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::operator|=(const BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i)
-        bits[i] |= other.bits[i];
+    merge(other);
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::operator&=(const BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i)
-        bits[i] &= other.bits[i];
+    filter(other);
 }
 
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::operator^=(const BitSet& other)
 {
-    for (size_t i = 0; i < words; ++i)
-        bits[i] ^= other.bits[i];
+    if constexpr (words == 1) {
+        bits[0] ^= other.bits[0];
+    } else if constexpr (useSIMD) {
+        size_t index = 0;
+        for (; index + stride <= words; index += stride) {
+            Vec first = SIMD::load(&bits[index]);
+            Vec second = SIMD::load(&other.bits[index]);
+            Vec result = SIMD::bitXor(first, second);
+            SIMD::store(result, &bits[index]);
+        }
+
+        for (; index < words; ++index)
+            bits[index] ^= other.bits[index];
+    } else {
+        for (size_t i = 0; i < words; ++i)
+            bits[i] ^= other.bits[i];
+    }
 }
 
 template<size_t bitSetSize, typename WordType>

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -53,13 +53,21 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include <bit>
+#include <concepts>
 #include <optional>
 #include <wtf/StdLibExtras.h>
 #include <wtf/simde/simde.h>
+#include <wtf/text/Latin1Character.h>
 
 namespace WTF::SIMD {
 
-template<typename LaneType>
+template <typename T> concept Lane =
+    sizeof(T) == sizeof(uint8_t)
+    || sizeof(T) == sizeof(uint16_t)
+    || sizeof(T) == sizeof(uint32_t)
+    || sizeof(T) == sizeof(uint64_t);
+
+template<Lane LaneType>
 struct LaneToVector;
 
 template<>
@@ -82,12 +90,25 @@ struct LaneToVector<uint64_t> {
     using Type = simde_uint64x2_t;
 };
 
-template<typename LaneType>
+template<Lane LaneType>
 using VectorType = typename LaneToVector<LaneType>::Type;
 
 
-template<typename LaneType>
+template<Lane LaneType>
 inline constexpr size_t stride = 16 / sizeof(LaneType);
+
+template<Lane LaneType>
+ALWAYS_INLINE constexpr decltype(auto) zero()
+{
+    if constexpr (sizeof(LaneType) == sizeof(uint8_t))
+        return simde_vdupq_n_u8(0);
+    else if constexpr (sizeof(LaneType) == sizeof(uint16_t))
+        return simde_vdupq_n_u16(0);
+    else if constexpr (sizeof(LaneType) == sizeof(uint32_t))
+        return simde_vdupq_n_u32(0);
+    else
+        return simde_vdupq_n_u64(0);
+}
 
 constexpr simde_uint8x16_t splat8(uint8_t code)
 {
@@ -109,7 +130,7 @@ constexpr simde_uint64x2_t splat64(uint64_t code)
     return simde_uint64x2_t { code, code };
 }
 
-template<typename LaneType>
+template<Lane LaneType>
 ALWAYS_INLINE constexpr decltype(auto) splat(LaneType lane)
 {
     if constexpr (sizeof(LaneType) == sizeof(uint8_t))
@@ -118,10 +139,8 @@ ALWAYS_INLINE constexpr decltype(auto) splat(LaneType lane)
         return splat16(static_cast<uint16_t>(lane));
     else if constexpr (sizeof(LaneType) == sizeof(uint32_t))
         return splat32(static_cast<uint32_t>(lane));
-    else {
-        static_assert(sizeof(LaneType) == sizeof(uint64_t));
+    else
         return splat64(static_cast<uint64_t>(lane));
-    }
 }
 
 ALWAYS_INLINE simde_uint8x16_t load(const uint8_t* ptr)
@@ -279,6 +298,26 @@ ALWAYS_INLINE simde_uint64x2_t bitOr2(simde_uint64x2_t accumulated, simde_uint64
     return simde_vorrq_u64(accumulated, input);
 }
 
+ALWAYS_INLINE simde_uint8x16_t bitXor2(simde_uint8x16_t accumulated, simde_uint8x16_t input)
+{
+    return simde_veorq_u8(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint16x8_t bitXor2(simde_uint16x8_t accumulated, simde_uint16x8_t input)
+{
+    return simde_veorq_u16(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint32x4_t bitXor2(simde_uint32x4_t accumulated, simde_uint32x4_t input)
+{
+    return simde_veorq_u32(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint64x2_t bitXor2(simde_uint64x2_t accumulated, simde_uint64x2_t input)
+{
+    return simde_veorq_u64(accumulated, input);
+}
+
 ALWAYS_INLINE simde_uint8x16_t bitAnd2(simde_uint8x16_t accumulated, simde_uint8x16_t input)
 {
     return simde_vandq_u8(accumulated, input);
@@ -315,6 +354,15 @@ ALWAYS_INLINE decltype(auto) bitOr(VectorType a0, VectorType a1, Args... args)
         return bitOr2(a0, a1);
     else
         return bitOr2(a0, bitOr(a1, std::forward<Args>(args)...));
+}
+
+template<typename VectorType, typename... Args>
+ALWAYS_INLINE decltype(auto) bitXor(VectorType a0, VectorType a1, Args... args)
+{
+    if constexpr (!sizeof...(args))
+        return bitXor2(a0, a1);
+    else
+        return bitXor2(a0, bitXor(a1, std::forward<Args>(args)...));
 }
 
 template<typename VectorType, typename... Args>


### PR DESCRIPTION
#### bc16e5046a17f33cf290c96cd69951b61d38619b
<pre>
Use SIMD in BitSet operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=302131">https://bugs.webkit.org/show_bug.cgi?id=302131</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

This patch adds SIMD to the BitSet operations.
It also adds a few more helper functions to SIMDHelpers.h.

I have written a benchmark in WTF/benchmarks/BitSetSpeedTest.cpp
that tests the performance of the bitsets. The benchmark resulted
in a 1.25x speedup as compared to an auto-vectorized implementation.
Without autovectorization, it is closer to a 1.5-2x improvement. This
speedup is only present with large bitsets.

There are also some changes to previous microbenchmarks to get them
in a running condition again.

* Source/WTF/benchmarks/BitSetSpeedTest.cpp: Added.
(main):
* Source/WTF/benchmarks/LockSpeedTest.cpp:
* Source/WTF/benchmarks/ToyLocks.h:
* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::invert):
(WTF::WordType&gt;::isEmpty const):
(WTF::WordType&gt;::isFull const):
(WTF::WordType&gt;::merge):
(WTF::WordType&gt;::filter):
(WTF::WordType&gt;::exclude):
(WTF::WordType&gt;::subsumes const):
(WTF::WordType&gt;::mergeAndClear):
(WTF::WordType&gt;::setAndClear):
(WTF::= const):
(WTF::=):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::zero):
(WTF::SIMD::splat):
(WTF::SIMD::bitXor2):
(WTF::SIMD::bitXor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc16e5046a17f33cf290c96cd69951b61d38619b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83496 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d41b862-255d-4e28-84f8-fd75653a5664) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100504 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68076 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/feccbec6-d0b2-42f7-8620-a99a3776cc02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0afc47cb-5fe9-4ec3-9b5e-6f960f22e4c7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/856 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82339 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123664 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141793 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130093 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108876 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109120 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2816 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56925 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3776 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32555 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163111 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67187 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3706 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->