### PR TITLE
Video Viewer UI elements overlapping and exits unexpectedly when using media controls

### DIFF
--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -535,6 +535,17 @@ static const String& macOSInlineMediaControlsStyleSheet()
         "    border-radius: 8.5px;"
         "    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);"
         "    margin: -2px;"
+        "}"
+        ".media-controls.mac.inline.narrowviewer:not(.audio) .controls-bar.bottom {"
+        "    padding-inline: 8px;"
+        "    max-width: 100%;"
+        "}"
+        ".media-controls.mac.inline.narrowviewer:not(.audio) .volume-slider-container button[class*=\"mute\"],"
+        ".media-controls.mac.inline.narrowviewer:not(.audio) .volume-slider-container .button.mute {"
+        "    transform: scale(0.8) scaleX(-1);"
+        "}"
+        ".media-controls.mac.inline.narrowviewer:not(.audio) .controls-bar.top-left {"
+        "    left: var(--inline-controls-inside-margin);"
         "}"_s
     };
 


### PR DESCRIPTION
#### ae855de5413dcb4087de19ce4a0693cb7fc5e68c
<pre>
Video Viewer UI elements overlapping and exits unexpectedly when using media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=302130">https://bugs.webkit.org/show_bug.cgi?id=302130</a>
<a href="https://rdar.apple.com/164051864">rdar://164051864</a>

Reviewed by Andy Estes.

Added proper left positioning using --inline-controls-inside-margin to
ensure the top-left controls stay in their designated position and don&apos;t
interfere with the volume slider container.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::macOSInlineMediaControlsStyleSheet):

Canonical link: <a href="https://commits.webkit.org/303256@main">https://commits.webkit.org/303256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f1e82adf76aa70df5eaec07b2d16138a2f37467

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81424 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0a82b724-7536-4311-bbe3-b55758475a18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98970 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66781 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/919a3c67-65e0-4304-bc43-c89ff2567774) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d938a7ed-63c7-49c2-9607-7b614d11a5d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1522 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80594 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139805 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1986 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107477 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107365 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27687 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1587 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112715 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54788 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2059 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31185 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1908 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->