### PR TITLE
[JSC] Support imported wasm builtins in elem instructions

### DIFF
--- a/JSTests/wasm/stress/wasm-js-string-builtins.js
+++ b/JSTests/wasm/stress/wasm-js-string-builtins.js
@@ -671,6 +671,18 @@ async function testImportedStringConstants() {
     assert.eq("this is constant 2", instance.exports.exportedConst2.value);
 }
 
+async function testImportInElem() {
+    const wat = `
+    (module
+        (type (func (param externref) (result i32)))
+        (import "wasm:js-string" "length" (func (type 0)))
+        (table 16 32 funcref)
+        (elem (i32.const 0) func 0)
+    )
+    `;
+    const instance = await instantiate(wat);
+}
+
 await assert.asyncTest(testInstantiation());
 await assert.asyncTest(testInstantiationWithEmptyCompileOptions());
 await assert.asyncTest(testCast());
@@ -687,3 +699,4 @@ await assert.asyncTest(testSubstring());
 await assert.asyncTest(testEquals());
 await assert.asyncTest(testCompare());
 await assert.asyncTest(testImportedStringConstants());
+await assert.asyncTest(testImportInElem());

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -358,6 +358,8 @@ public:
     }
     WriteBarrier<JSObject>& importFunction(unsigned importFunctionNum) { return importFunctionInfo(importFunctionNum)->importFunction; }
 
+    JSObject* getImportFunctionObject(unsigned importFunctionIndex, JSGlobalObject*);
+
     RefPtr<Wasm::BaselineData>& baselineData(Wasm::FunctionCodeIndex index)
     {
         return baselineDatas()[index];

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -555,17 +555,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         //   i. If there is an Exported Function Exotic Object func in funcs whose func.[[Closure]] equals c, then return func.
         //   ii. (Note: At most one wrapper is created for any closure, so func is unique, even if there are multiple occurrences in the list. Moreover, if the item was an import that is already an Exported Function Exotic Object, then the original function object will be found. For imports that are regular JS functions, a new wrapper will be created.)
         if (functionIndexSpace < functionImportCount) {
-            JSObject* functionImport = m_instance->importFunction(functionIndexSpace).get();
-            if (!functionImport) {
-                // No functionImport means the import is a Wasm builtin, and we should use its jsWrapper() as the functionImport.
-                // The boxed callee in callLinkInfo is a WasmBuiltinCallee with a pointer to the builtin.
-                auto* callLinkInfo = m_instance->importFunctionInfo(functionIndexSpace);
-                auto* callee = uncheckedDowncast<Wasm::WasmBuiltinCallee>(uncheckedDowncast<Wasm::Callee>(callLinkInfo->boxedCallee.asNativeCallee()));
-                ASSERT(callee->compilationMode() == Wasm::CompilationMode::WasmBuiltinMode);
-                const WebAssemblyBuiltin* builtin = callee->builtin();
-                functionImport = builtin->jsWrapper(globalObject);
-            }
-
+            JSObject* functionImport = m_instance->getImportFunctionObject(functionIndexSpace, globalObject);
             if (isWebAssemblyHostFunction(functionImport))
                 wrapper = functionImport;
             else {
@@ -822,6 +812,9 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         ASSERT(signature.returnsVoid());
         if (startFunctionIndexSpace < calleeGroup->functionImportCount()) {
             JSObject* startFunction = m_instance->importFunction(startFunctionIndexSpace).get();
+            // startFunction can be nullptr if the import is a Wasm builtin.
+            // Currently there are no nullary Wasm builtins so this is never nullptr.
+            ASSERT(startFunction);
             m_startFunction.set(vm, this, startFunction);
         } else {
             auto& jsToWasmCallee = calleeGroup->jsToWasmCalleeFromFunctionIndexSpace(startFunctionIndexSpace);


### PR DESCRIPTION
#### 23a0006a4e00226f7a764c3ed1315a1275735fe0
<pre>
[JSC] Support imported wasm builtins in elem instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=302134">https://bugs.webkit.org/show_bug.cgi?id=302134</a>
<a href="https://rdar.apple.com/163998659">rdar://163998659</a>

Reviewed by Yusuke Suzuki.

Imported Wasm builtins (like the JS string builtins) should use its JS wrapper,
as the importFunction field is nullptr for those. This was not checked for for
the elem instruction, resulting in nullptr crashes.

A new test case is added to wasm-js-string-builtins.js.

* JSTests/wasm/stress/wasm-js-string-builtins.js:
(async testImportInElem):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::initElementSegment):
(JSC::JSWebAssemblyInstance::getImportFunctionObject):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/302701@main">https://commits.webkit.org/302701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60bc3150101469dba5291161dff952379fcfe662

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81435 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/317e9bb3-ce8b-450d-a354-b3486df2ad47) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98980 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e4cfb2b-b559-43d5-86a1-d8ba1a5e4c67) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132886 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fe74e300-e486-49fa-8672-852868b7cad1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34503 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80602 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139813 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128391 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1994 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1846 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107488 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107376 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31195 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54796 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65436 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161405 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1882 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40225 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1916 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->