### PR TITLE
Stop using WallTime on WKTouchEvent

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -59,20 +59,6 @@ static unsigned incrementingTouchIdentifier = 1;
     RetainPtr<NSMapTable<NSNumber *, UITouch *>>_activeTouchesByIdentifier;
 }
 
-// UITouch's timestamp is a relative system time since startup, minus the time the device was suspended. This
-// function converts it into an estimated wall time (seconds since Epoch).
-static double approximateWallTime(NSTimeInterval timestamp)
-{
-    // mach_absolute_time() provides a relative system time since startup, minus the time the device was suspended.
-    auto elapsedTimeSinceStartup = CACurrentMediaTime();
-
-    auto elapsedTimeSinceTimestamp = elapsedTimeSinceStartup - timestamp;
-
-    // CFAbsoluteTimeGetCurrent() provides the absolute time in seconds since 2001 so we need to add kCFAbsoluteTimeIntervalSince1970
-    // to get a time since Epoch.
-    return kCFAbsoluteTimeIntervalSince1970 + CFAbsoluteTimeGetCurrent() - elapsedTimeSinceTimestamp;
-}
-
 @synthesize defaultPrevented = _defaultPrevented;
 @synthesize dispatchingTouchEvents = _dispatchingTouchEvents;
 
@@ -280,7 +266,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
 
     WebKit::WKTouchEvent event;
     event.type = WebKit::WKTouchEventType::Change;
-    event.timestamp = approximateWallTime(touch.timestamp);
+    event.timestamp = touch.timestamp;
     event.locationInRootViewCoordinates = locationInRootView;
     event.touchPoints = { touchPoint };
 
@@ -307,7 +293,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
     if (_lastTouchEvent.touchPoints.size() != touchCount)
         _lastTouchEvent.touchPoints.resize(touchCount);
 
-    _lastTouchEvent.timestamp = approximateWallTime(touches.anyObject.timestamp);
+    _lastTouchEvent.timestamp = touches.anyObject.timestamp;
 
     _lastTouchEvent.coalescedEvents = { };
     _lastTouchEvent.predictedEvents = { };


### PR DESCRIPTION
#### 4635cf86519a0d5b0ea8274f21854d2b993789e4
<pre>
Stop using WallTime on WKTouchEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=302135">https://bugs.webkit.org/show_bug.cgi?id=302135</a>
<a href="https://rdar.apple.com/164214808">rdar://164214808</a>

Reviewed by Abrar Rahman Protyasha.

The conversion from MonotonicTime to WallTime was removed. The
conversion has been wrong since 299753@main, which changed
WebEvent&apos;s timestamp from WallTime to MonotonicTime.

* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer _touchEventForChildTouch:withParent:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:ofType:forEvent:]):
(approximateWallTime): Deleted.

Canonical link: <a href="https://commits.webkit.org/302718@main">https://commits.webkit.org/302718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f2e103b7f6085a6cbc1640b5b0d9d4e02efc3da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137397 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2155 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132949 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79725 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80667 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/35070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2057 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107425 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27340 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/1639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65499 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->