### PR TITLE
AX: Add initial ariaNotify implementation

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/aria-notify-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/aria-notify-expected.txt
@@ -1,0 +1,17 @@
+This test verifies that aria-notify notifications are properly formatted on iOS devices.
+
+Announcement received, notification: AXAnnouncementRequested, attributed string: Hello{
+    UIAccessibilityARIAInterruptBehavior = None;
+    UIAccessibilityARIAPriority = Normal;
+    UIAccessibilitySpeechAttributeLanguage = en;
+}
+Announcement received, notification: AXAnnouncementRequested, attributed string: World{
+    UIAccessibilityARIAInterruptBehavior = Pending;
+    UIAccessibilityARIAPriority = High;
+    UIAccessibilitySpeechAttributeLanguage = en;
+}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ios-simulator/aria-notify.html
+++ b/LayoutTests/accessibility/ios-simulator/aria-notify.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<script>
+var output = "This test verifies that aria-notify notifications are properly formatted on iOS devices.\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Announcement received, notification: ${notification}, attributed string: ${userInfo["AXAnnouncementRequested"]}\n`;
+        notificationCount++;
+
+        if (notificationCount == 1)
+            document.ariaNotify("World", { priority: "high", interrupt: "pending" });
+        else if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+    document.ariaNotify("Hello");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+ }
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-notify-expected.txt
@@ -1,0 +1,19 @@
+Tests that ariaNotify properly sends notifications.
+
+Received announcement request:
+AnnouncementKey: Hello
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+Received announcement request:
+AnnouncementKey: World
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: Normal
+AXAnnouncementLanguageKey: en
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Press Me

--- a/LayoutTests/accessibility/mac/aria-notify-with-options.html
+++ b/LayoutTests/accessibility/mac/aria-notify-with-options.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<button id="button" lang="da">Hej</button>
+
+<script>
+var output = "Tests that ariaNotify sends the right userInfo when options are specified.\n\n";    
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+        notificationCount++;  
+    }
+
+    if (notificationCount == 1) {
+        // Specify both a priority and interrupt.
+        document.ariaNotify("Chicago", { priority: "high", interrupt: "all" });
+    }
+
+    if (notificationCount == 2)
+        document.getElementById("button").ariaNotify("Boston", { priority: "high", interrupt: "pending" });
+
+    if (notificationCount == 3)
+        document.getElementById("button").ariaNotify("Boston", { priority: "high" });
+	
+    if (notificationCount == 4)
+        testFinished = true;
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    // Just specify a priority.
+    document.ariaNotify("San Francisco", { priority: "high" });
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/aria-notify.html
+++ b/LayoutTests/accessibility/mac/aria-notify.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsARIANotifyEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<button id="button">Press Me</button>
+
+<script>
+var output = "Tests that ariaNotify properly sends notifications.\n\n";    
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAriaNotifyUserInfo(userInfo);
+
+        notificationCount++;  
+    }
+	
+    if (notificationCount == 1)
+        document.getElementById("button").ariaNotify("World");
+    else if (notificationCount == 2)
+        testFinished = true;
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    document.ariaNotify("Hello");
+    
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1049,6 +1049,10 @@ accessibility/youtube-embed-accessibility-hierarchy.html [ Skip ]
 
 accessibility/mac/iframe-hit-testing.html [ Skip ]
 
+# Skipping because ariaNotify is not supported in WK1.
+accessibility/mac/aria-notify-with-options.html [ Skip ]
+accessibility/mac/aria-notify.html [ Skip ]
+
 # DOM paste access requests are not implemented in WebKit1.
 editing/async-clipboard/clipboard-change-data-while-reading.html [ Skip ]
 editing/async-clipboard/clipboard-do-not-read-text-from-platform-if-text-changes.html [ Skip ]

--- a/LayoutTests/platform/mac/accessibility/mac/aria-notify-with-options-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/mac/aria-notify-with-options-expected.txt
@@ -1,0 +1,31 @@
+Tests that ariaNotify sends the right userInfo when options are specified.
+
+Received announcement request:
+AnnouncementKey: San Francisco
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: High
+AXAnnouncementLanguageKey: en
+
+Received announcement request:
+AnnouncementKey: Chicago
+AXARIAAnnouncementInterruptBehavior: All
+AXARIAAnnouncementPriority: High
+AXAnnouncementLanguageKey: en
+
+Received announcement request:
+AnnouncementKey: Boston
+AXARIAAnnouncementInterruptBehavior: Pending
+AXARIAAnnouncementPriority: High
+AXAnnouncementLanguageKey: da
+
+Received announcement request:
+AnnouncementKey: Boston
+AXARIAAnnouncementInterruptBehavior: None
+AXARIAAnnouncementPriority: High
+AXAnnouncementLanguageKey: da
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hej

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -443,3 +443,12 @@ function traverseChildrenToFirstStaticText(startObject) {
     }
     return null;
 }
+
+function formatAriaNotifyUserInfo(userInfo) {
+    var result = "";
+    result += `AnnouncementKey: ${userInfo["AXAnnouncementKey"]}\n`;
+    result += `AXARIAAnnouncementInterruptBehavior: ${userInfo["AXARIAAnnouncementInterruptBehavior"]}\n`;
+    result += `AXARIAAnnouncementPriority: ${userInfo["AXARIAAnnouncementPriority"]}\n`;
+    result += `AXAnnouncementLanguageKey: ${userInfo["AXAnnouncementLanguageKey"]}\n\n`
+    return result;
+}

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4167,6 +4167,19 @@ InvisibleAutoplayNotPermitted:
     WebCore:
       default: false
 
+IsARIANotifyEnabled:
+  type: bool
+  status: unstable
+  humanReadableName: "ariaNotify()"
+  humanReadableDescription: "Enable ariaNotify support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 IsAccessibilityIsolatedTreeEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1136,6 +1136,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/AbortSignal.idl
     dom/AbstractRange.idl
     dom/AddEventListenerOptions.idl
+    dom/AriaNotifyOptions.idl
     dom/Attr.idl
     dom/BeforeUnloadEvent.idl
     dom/BroadcastChannel.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1409,6 +1409,7 @@ $(PROJECT_DIR)/dom/AbortSignal.idl
 $(PROJECT_DIR)/dom/AbstractRange.idl
 $(PROJECT_DIR)/dom/AddEventListenerOptions.idl
 $(PROJECT_DIR)/dom/AnimationEvent.idl
+$(PROJECT_DIR)/dom/AriaNotifyOptions.idl
 $(PROJECT_DIR)/dom/Attr.idl
 $(PROJECT_DIR)/dom/BeforeUnloadEvent.idl
 $(PROJECT_DIR)/dom/BroadcastChannel.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -228,6 +228,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayValidateMerchantEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayValidateMerchantEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAriaAttributes.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAriaAttributes.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAriaNotifyOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAriaNotifyOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAttestationConveyancePreference.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAttestationConveyancePreference.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAttr.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1108,6 +1108,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/AbortSignal.idl \
     $(WebCore)/dom/AbstractRange.idl \
     $(WebCore)/dom/AddEventListenerOptions.idl \
+    $(WebCore)/dom/AriaNotifyOptions.idl \
     $(WebCore)/dom/Attr.idl \
     $(WebCore)/dom/BeforeUnloadEvent.idl \
     $(WebCore)/dom/BroadcastChannel.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3658,6 +3658,7 @@ JSAnimationFrameRatePreset.cpp
 JSAnimationPlaybackEvent.cpp
 JSAnimationPlaybackEventInit.cpp
 JSAnimationTimeline.cpp
+JSAriaNotifyOptions.cpp
 JSAttestationConveyancePreference.cpp
 JSAttr.cpp
 JSAudioBuffer.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -138,6 +138,7 @@ Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm @nonARC
 Modules/system-preview/ARKitBadgeSystemImage.mm @nonARC
 Modules/webdatabase/cocoa/DatabaseManagerCocoa.mm @nonARC
 accessibility/cocoa/AXCoreObjectCocoa.mm @nonARC
+accessibility/cocoa/AXObjectCacheCocoa.mm @nonARC
 accessibility/cocoa/AXTextMarkerCocoa.mm @nonARC
 accessibility/cocoa/AccessibilityObjectCocoa.mm @nonARC
 accessibility/ios/AXObjectCacheIOS.mm @nonARC

--- a/Source/WebCore/accessibility/cocoa/AXObjectCacheCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXObjectCacheCocoa.mm
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "AXObjectCache.h"
+
+#if PLATFORM(COCOA)
+
+#import <wtf/RetainPtr.h>
+
+namespace WebCore {
+
+RetainPtr<NSString> notifyPriorityToAXValueString(NotifyPriority priority)
+{
+    switch (priority) {
+    case NotifyPriority::Normal:
+        return @"Normal";
+    case NotifyPriority::High:
+        return @"High";
+    }
+}
+
+RetainPtr<NSString> interruptBehaviorToAXValueString(InterruptBehavior interruptBehavior)
+{
+    switch (interruptBehavior) {
+    case InterruptBehavior::None:
+        return @"None";
+    case InterruptBehavior::All:
+        return @"All";
+    case InterruptBehavior::Pending:
+        return @"Pending";
+    }
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -245,7 +245,7 @@ std::optional<NSRange> AXIsolatedObject::visibleCharacterRange() const
     const auto* currentRuns = textRuns();
     std::optional stopAtID = idOfNextSiblingIncludingIgnoredOrParent();
     auto advanceCurrent = [&] () {
-        current = findObjectWithRuns(*current, AXDirection::Next, stopAtID);
+        current = Accessibility::findObjectWithRuns(*current, AXDirection::Next, stopAtID);
         currentRuns = current ? current->textRuns() : nullptr;
     };
 
@@ -373,7 +373,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRangeForNSRange(const NSRange& ran
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (AXObjectCache::useAXThreadTextApis()) {
-        if (std::optional markerRange = markerRangeFrom(range, *this)) {
+        if (std::optional markerRange = Accessibility::markerRangeFrom(range, *this)) {
             if (range.length > markerRange->toString().length())
                 return { };
             return WTFMove(*markerRange);

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -497,3 +497,10 @@
 #define NSAccessibilityMathSubscriptAttribute @"AXMathSubscript"
 #define NSAccessibilityMathSuperscriptAttribute @"AXMathSuperscript"
 #define NSAccessibilityMathUnderAttribute @"AXMathUnder"
+
+// ariaNotify notification userInfo attributes.
+#define NSAccessibilityARIAAnnouncementPriority @"AXARIAAnnouncementPriority"
+#define NSAccessibilityARIAAnnouncementInterrupt @"AXARIAAnnouncementInterruptBehavior"
+
+// User info key to specify an announcment's language.
+#define NSAccessibilityAnnouncementLanguageKey @"AXAnnouncementLanguageKey"

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -770,7 +770,7 @@ static BOOL accessibilityShouldRepostNotifications;
 + (void)accessibilitySetShouldRepostNotifications:(BOOL)repost
 {
     accessibilityShouldRepostNotifications = repost;
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
     AXObjectCache::setShouldRepostNotificationsForTests(repost);
 #endif
 }
@@ -788,7 +788,7 @@ static bool isValueTypeSupported(id value)
         return true;
 #endif // PLATFORM(MAC)
 
-    return [value isKindOfClass:[NSString class]] || [value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[WebAccessibilityObjectWrapperBase class]];
+    return [value isKindOfClass:[NSString class]] || [value isKindOfClass:[NSAttributedString class]] || [value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[WebAccessibilityObjectWrapperBase class]];
 }
 
 static NSArray *arrayRemovingNonSupportedTypes(NSArray *array)

--- a/Source/WebCore/dom/AriaNotifyOptions.h
+++ b/Source/WebCore/dom/AriaNotifyOptions.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+
+namespace WebCore {
+
+struct AriaNotifyOptions {
+    enum class NotificationPriority : uint8_t {
+        Normal,
+        High
+    };
+
+    enum class NotificationInterrupt : uint8_t {
+        None,
+        All,
+        Pending
+    };
+
+    std::optional<NotificationPriority> priority { std::nullopt };
+    std::optional<NotificationInterrupt> interrupt { std::nullopt };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/AriaNotifyOptions.idl
+++ b/Source/WebCore/dom/AriaNotifyOptions.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+enum AriaNotificationPriority {
+    "normal",
+    "high"
+};
+
+enum AriaNotificationInterrupt {
+    "none",
+    "all",
+    "pending"
+};
+
+dictionary AriaNotifyOptions {
+    AriaNotificationPriority priority;
+    AriaNotificationInterrupt interrupt;
+};

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -32,6 +32,7 @@
 #include "AXObjectCacheInlines.h"
 #include "AnimationTimelinesController.h"
 #include "ApplicationManifest.h"
+#include "AriaNotifyOptions.h"
 #include "AsyncNodeDeletionQueueInlines.h"
 #include "Attr.h"
 #include "BeforeUnloadEvent.h"
@@ -12101,6 +12102,24 @@ void Document::processSpeculationRulesHeader(const String& headerValue, const UR
                 protectedThis->m_loadableSpeculationRules.append(WTFMove(loadableSpeculationRules));
         });
     }
+}
+
+void Document::ariaNotify(const String& announcement)
+{
+    if (!settings().isARIANotifyEnabled())
+        return;
+
+    if (CheckedPtr cache = axObjectCache())
+        cache->postARIANotifyNotification(*this, announcement, { });
+}
+
+void Document::ariaNotify(const String& announcement, const AriaNotifyOptions& options)
+{
+    if (!settings().isARIANotifyEnabled())
+        return;
+
+    if (CheckedPtr cache = axObjectCache())
+        cache->postARIANotifyNotification(*this, announcement, options);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -289,6 +289,7 @@ class DOMTimerHoldingTank;
 #endif
 
 struct ApplicationManifest;
+struct AriaNotifyOptions;
 struct BoundaryPoint;
 struct CSSParserContext;
 struct CaretPositionFromPointOptions;
@@ -2054,6 +2055,9 @@ public:
     WEBCORE_EXPORT void prefetch(const URL&, const Vector<String>&, std::optional<ReferrerPolicy>, bool lowPriority = false);
 
     void processSpeculationRulesHeader(const String& headerValue, const URL& baseURL);
+
+    WEBCORE_EXPORT void ariaNotify(const String&);
+    WEBCORE_EXPORT void ariaNotify(const String&, const AriaNotifyOptions&);
 
 protected:
     enum class ConstructionFlag : uint8_t {

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -93,6 +93,9 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
 
     // Non standard: It has been dropped from Blink already.
     RenderingContext? getCSSCanvasContext(DOMString contextId, DOMString name, long width, long height);
+
+    [EnabledBySetting=IsARIANotifyEnabled] undefined ariaNotify(DOMString announcement);
+    [EnabledBySetting=IsARIANotifyEnabled] undefined ariaNotify(DOMString announcement, AriaNotifyOptions options);
 };
 
 enum DocumentReadyState { "loading", "interactive", "complete" };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -27,6 +27,7 @@
 #include "Element.h"
 
 #include "AXObjectCache.h"
+#include "AriaNotifyOptions.h"
 #include "Attr.h"
 #include "AttributeChangeInvalidation.h"
 #include "CheckVisibilityOptions.h"
@@ -6857,6 +6858,24 @@ const AtomString& Element::ariaSort() const
     }
 
     return value.isNull() ? nullAtom() : value;
+}
+
+void Element::ariaNotify(const String& announcement)
+{
+    if (!document().settings().isARIANotifyEnabled())
+        return;
+
+    if (CheckedPtr cache = document().axObjectCache())
+        cache->postARIANotifyNotification(*this, announcement, { });
+}
+
+void Element::ariaNotify(const String& announcement, const AriaNotifyOptions& options)
+{
+    if (!document().settings().isARIANotifyEnabled())
+        return;
+
+    if (CheckedPtr cache = document().axObjectCache())
+        cache->postARIANotifyNotification(*this, announcement, options);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -130,6 +130,7 @@ enum class CommandType: uint8_t {
     RequestClose,
 };
 
+struct AriaNotifyOptions;
 struct CheckVisibilityOptions;
 struct FocusEventData;
 struct FullscreenOptions;
@@ -247,6 +248,9 @@ public:
     const AtomString& ariaRequired() const;
     const AtomString& ariaSelected() const;
     const AtomString& ariaSort() const;
+
+    WEBCORE_EXPORT void ariaNotify(const String&);
+    WEBCORE_EXPORT void ariaNotify(const String&, const AriaNotifyOptions&);
 
 #if DUMP_NODE_STATISTICS
     bool hasNamedNodeMap() const;

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -102,6 +102,9 @@
 
     // WebKit extension for DOM wrapper worlds.
     [EnabledForWorld=allowElementUserInfo, CallWith=CurrentGlobalObject] undefined setUserInfo(any userInfo);
+
+    [EnabledBySetting=IsARIANotifyEnabled] undefined ariaNotify(DOMString announcement);
+    [EnabledBySetting=IsARIANotifyEnabled] undefined ariaNotify(DOMString announcement, AriaNotifyOptions options);
 };
 
 Element includes AccessibilityRole;

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -126,6 +126,7 @@ class EmptyChromeClient : public ChromeClient {
     IntRect rootViewToAccessibilityScreen(const IntRect& r) const final { return r; };
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const final { };
+    void relayAriaNotifyNotification(AriaNotifyData&&) const final { };
 #endif
 
     void didFinishLoadingImageForElement(HTMLImageElement&) final { }

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -148,6 +148,11 @@ void Chrome::relayAccessibilityNotification(String&& notificationName, RetainPtr
 {
     return m_client->relayAccessibilityNotification(WTFMove(notificationName), WTFMove(notificationData));
 }
+
+void Chrome::relayAriaNotifyNotification(AriaNotifyData&& notificationData) const
+{
+    return m_client->relayAriaNotifyNotification(WTFMove(notificationData));
+}
 #endif
 
 PlatformPageClient Chrome::platformPageClient() const

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -84,6 +84,7 @@ class SearchPopupMenu;
 class WorkerClient;
 
 struct AppHighlight;
+struct AriaNotifyData;
 struct ContactInfo;
 struct ContactsRequestData;
 struct FocusOptions;
@@ -123,6 +124,7 @@ public:
     PlatformPageClient platformPageClient() const override;
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const override;
+    void relayAriaNotifyNotification(AriaNotifyData&&) const;
 #endif
     void setCursor(const Cursor&) override;
     void setCursorHiddenUntilMouseMoves(bool) override;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -154,6 +154,7 @@ struct GraphicsContextGLAttributes;
 
 struct AppHighlight;
 struct ApplePayAMSUIRequest;
+struct AriaNotifyData;
 struct CharacterRange;
 struct ContactsRequestData;
 struct ContentRuleListMatchedRule;
@@ -287,6 +288,7 @@ public:
     virtual IntRect rootViewToAccessibilityScreen(const IntRect&) const = 0;
 #if PLATFORM(IOS_FAMILY)
     virtual void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const = 0;
+    virtual void relayAriaNotifyNotification(AriaNotifyData&&) const = 0;
 #endif
 
     virtual void mainFrameDidChange() { };

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1016,6 +1016,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WTF::UUID': ['<wtf/UUID.h>'],
         'WallTime': ['<wtf/WallTime.h>'],
         'WebCore::AXDebugInfo': ['<WebCore/AXObjectCache.h>'],
+        'WebCore::AriaNotifyData': ['<WebCore/AXObjectCache.h>'],
         'WebCore::AlternativeTextType': ['<WebCore/AlternativeTextClient.h>'],
         'WebCore::ApplyTrackingPrevention': ['<WebCore/NetworkStorageSession.h>'],
         'WebCore::AttachmentAssociatedElementType': ['<WebCore/AttachmentAssociatedElement.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8934,6 +8934,19 @@ struct WebCore::FocusEventData {
 }
 
 header: <WebCore/AXObjectCache.h>
+[CustomHeader] enum class WebCore::NotifyPriority : uint8_t {
+    Normal,
+    High
+};
+
+header: <WebCore/AXObjectCache.h>
+[CustomHeader] enum class WebCore::InterruptBehavior : uint8_t {
+    None,
+    All,
+    Pending
+};
+
+header: <WebCore/AXObjectCache.h>
 [CustomHeader] struct WebCore::AXDebugInfo {
     bool isAccessibilityEnabled;
     bool isAccessibilityThreadInitialized;
@@ -8941,7 +8954,15 @@ header: <WebCore/AXObjectCache.h>
     String isolatedTree;
     uint64_t remoteTokenHash;
     uint64_t webProcessLocalTokenHash;
-}
+};
+
+header: <WebCore/AXObjectCache.h>
+[CustomHeader] struct WebCore::AriaNotifyData {
+    String message;
+    WebCore::NotifyPriority priority;
+    WebCore::InterruptBehavior interrupt;
+    String language;
+};
 
 header: <WebCore/ScriptTrackingPrivacyCategory.h>
 [OptionSet] enum class WebCore::ScriptTrackingPrivacyFlag : uint16_t {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -132,6 +132,7 @@ enum class DOMPasteRequiresInteraction : bool;
 enum class ScrollIsAnimated : bool;
 
 struct AppHighlight;
+struct AriaNotifyData;
 struct DataDetectorElementInfo;
 struct DictionaryPopupInfo;
 struct ElementContext;
@@ -412,6 +413,7 @@ public:
     virtual WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) = 0;
 #if PLATFORM(IOS_FAMILY)
     virtual void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) = 0;
+    virtual void relayAriaNotifyNotification(const WebCore::AriaNotifyData&) = 0;
 #endif
 #if PLATFORM(MAC)
     virtual WebCore::IntRect rootViewToWindow(const WebCore::IntRect&) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -246,6 +246,7 @@ struct AXDebugInfo;
 struct AppHighlight;
 struct ApplePayAMSUIRequest;
 struct ApplicationManifest;
+struct AriaNotifyData;
 struct AttributedString;
 struct BackForwardItemIdentifierType;
 struct BackForwardFrameItemIdentifierType;
@@ -2987,6 +2988,7 @@ private:
     void rootViewToAccessibilityScreen(const WebCore::IntRect& viewRect, CompletionHandler<void(WebCore::IntRect)>&&);
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, std::span<const uint8_t>);
+    void relayAriaNotifyNotification(WebCore::AriaNotifyData&&);
 #endif
     void runBeforeUnloadConfirmPanel(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, String&& message, CompletionHandler<void(bool)>&&);
     void pageDidScroll(const WebCore::IntPoint&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -55,6 +55,7 @@ messages -> WebPageProxy {
     RootViewToAccessibilityScreen(WebCore::IntRect rect) -> (WebCore::IntRect screenFrame) Synchronous
 #if PLATFORM(IOS_FAMILY)
     RelayAccessibilityNotification(String notificationName, std::span<const uint8_t> notificationData)
+    RelayAriaNotifyNotification(struct WebCore::AriaNotifyData notificationData)
 #endif
     EnableAccessibilityForAllProcesses()
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -132,6 +132,7 @@ private:
     WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&) override;
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) override;
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) override;
+    void relayAriaNotifyNotification(const WebCore::AriaNotifyData&) override;
     void doneWithKeyEvent(const NativeWebKeyboardEvent&, bool wasEventHandled) override;
 #if ENABLE(TOUCH_EVENTS)
     void doneWithTouchEvent(const WebTouchEvent&, bool wasEventHandled) override;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -790,6 +790,12 @@ void WebPageProxy::relayAccessibilityNotification(String&& notificationName, std
         pageClient->relayAccessibilityNotification(WTFMove(notificationName), toNSData(data));
 }
 
+void WebPageProxy::relayAriaNotifyNotification(WebCore::AriaNotifyData&& notificationData)
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->relayAriaNotifyNotification(notificationData);
+}
+
 void WebPageProxy::assistiveTechnologyMakeFirstResponder()
 {
     if (RefPtr pageClient = this->pageClient())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -65,6 +65,7 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const final;
+    void relayAriaNotifyNotification(WebCore::AriaNotifyData&&) const final;
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
@@ -201,6 +201,12 @@ void WebChromeClient::relayAccessibilityNotification(String&& notificationName, 
         page->relayAccessibilityNotification(WTFMove(notificationName), WTFMove(notificationData));
 }
 
+void WebChromeClient::relayAriaNotifyNotification(WebCore::AriaNotifyData&& notificationData) const
+{
+    if (RefPtr page = m_page.get())
+        page->relayAriaNotifyNotification(WTFMove(notificationData));
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -280,6 +280,7 @@ enum class PaginationMode : uint8_t;
 
 struct AXDebugInfo;
 struct AppHighlight;
+struct AriaNotifyData;
 struct AttributedString;
 struct BackForwardItemIdentifierType;
 struct CharacterRange;
@@ -986,6 +987,7 @@ public:
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&);
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&);
+    void relayAriaNotifyNotification(WebCore::AriaNotifyData&&);
 #endif
 
     RefPtr<WebImage> scaledSnapshotWithOptions(const WebCore::IntRect&, double additionalScaleFactor, SnapshotOptions);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -303,6 +303,11 @@ void WebPage::relayAccessibilityNotification(String&& notificationName, RetainPt
     send(Messages::WebPageProxy::RelayAccessibilityNotification(WTFMove(notificationName), span(notificationData.get())));
 }
 
+void WebPage::relayAriaNotifyNotification(WebCore::AriaNotifyData&& notificationData)
+{
+    send(Messages::WebPageProxy::RelayAriaNotifyNotification(WTFMove(notificationData)));
+}
+
 static void computeEditableRootHasContentAndPlainText(const VisibleSelection& selection, EditorState::PostLayoutData& data)
 {
     data.hasContent = false;

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
@@ -105,6 +105,7 @@ private:
     RefPtr<WebCore::PopupMenu> createPopupMenu(WebCore::PopupMenuClient&) const final;
     RefPtr<WebCore::SearchPopupMenu> createSearchPopupMenu(WebCore::PopupMenuClient&) const final;
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const final { }
+    void relayAriaNotifyNotification(WebCore::AriaNotifyData&&) const final { }
     void webAppOrientationsUpdated() final;
     void focusedElementChanged(WebCore::Element*, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement) final;
     void showPlaybackTargetPicker(bool hasVideo, WebCore::RouteSharingPolicy, const String&) final;

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -90,6 +90,8 @@ JSValueRef makeValueRefForValue(JSContextRef context, id value)
 {
     if ([value isKindOfClass:[NSString class]])
         return JSValueMakeString(context, [value createJSStringRef].get());
+    if ([value isKindOfClass:[NSAttributedString class]])
+        return JSValueMakeString(context, [[value description] createJSStringRef].get());
     if ([value isKindOfClass:[NSNumber class]]) {
         if (nsValueHasObjCType<BOOL>((NSValue *)value) || nsValueHasObjCType<char>((NSValue *)value))
             return JSValueMakeBoolean(context, [value boolValue]);


### PR DESCRIPTION
#### 997691b638cb8da31793e0f9f70ee43b8ea6bf49
<pre>
AX: Add initial ariaNotify implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=302136">https://bugs.webkit.org/show_bug.cgi?id=302136</a>
<a href="https://rdar.apple.com/164216162">rdar://164216162</a>

Reviewed by Tyler Wilcock.

This adds initial support for the forthcoming ariaNotify spec on mac and iOS platforms.

On both platforms, this adds a new javascript interface to both Document and Element:
- ariaNotify(&quot;Message&quot;)
- ariaNotify(&quot;Message&quot;, { priority: &quot;high&quot;, interrupt: &quot;pending&quot; })

The intent of these new functions is for web authors to send announcements to screen readers
with specified priority and interruption behavior.

To do this, when this method is called, we now send announcement requested notifications
on both platforms that include both the priority and interrupt behavior specified, alongside
the announcement&apos;s text and language.

On Mac, we directly send this from WebContent. On iOS, we forward this information to the
UI process which handles constructing and sending the notification to the system. This is
done via IPC and a new struct, which packages up the bits that we need to accurately
build the attributed string that the AX notification system will handle.

For testing purposes, we re-post this notification in a way that the tests can parse.

Three new tests (2 mac, 1 iOS) were added to exercise this behavior, and validate both the
document and element implementations.

Tests: accessibility/ios-simulator/aria-notify.html
       accessibility/mac/aria-notify-with-options.html
       accessibility/mac/aria-notify.html

* LayoutTests/accessibility/ios-simulator/aria-notify-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/aria-notify.html: Added.
* LayoutTests/accessibility/mac/aria-notify-expected.txt: Added.
* LayoutTests/accessibility/mac/aria-notify-with-options.html: Added.
* LayoutTests/accessibility/mac/aria-notify.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/accessibility/mac/aria-notify-with-options-expected.txt: Added.
* LayoutTests/resources/accessibility-helper.js:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::setShouldRepostNotificationsForTests):
(WebCore::AXObjectCache::postARIANotifyNotification):
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/cocoa/AXObjectCacheCocoa.mm: Added.
(WebCore::notifyPriorityToAXValueString):
(WebCore::interruptBehaviorToAXValueString):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::postPlatformARIANotifyNotification):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::visibleCharacterRange const):
(WebCore::AXIsolatedObject::textMarkerRangeForNSRange const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXPostNotificationWithUserInfo):
(WebCore::AXObjectCache::postPlatformAnnouncementNotification):
(WebCore::AXObjectCache::postPlatformARIANotifyNotification):
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
(WebCore::AXObjectCache::setShouldRepostNotificationsForTests): Deleted.
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(+[WebAccessibilityObjectWrapperBase accessibilitySetShouldRepostNotifications:]):
(isValueTypeSupported):
* Source/WebCore/dom/AriaNotifyOptions.h: Added.
* Source/WebCore/dom/AriaNotifyOptions.idl: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::ariaNotify):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::ariaNotify):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.idl:
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::relayAriaNotifyNotification const):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::relayAriaNotifyNotification):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::relayAriaNotifyNotification):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm:
(WebKit::WebChromeClient::relayAriaNotifyNotification const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::relayAriaNotifyNotification):
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h:
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::makeValueRefForValue):

Canonical link: <a href="https://commits.webkit.org/302795@main">https://commits.webkit.org/302795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a2952c8b863dd38a0261e4969004702264a1083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81577 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9ff9bb8-69fb-44a1-bdb9-a0506f934b4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99069 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66872 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f57d42c5-85b7-43dc-9ba2-808879f1b2b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79770 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1382e6d3-c500-4cab-8a95-0517205c202d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/129404 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1750 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34614 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80721 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122046 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110144 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139928 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128506 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107575 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31284 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54944 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65551 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161520 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1999 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40263 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2205 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->