### PR TITLE
Wheel event granularity enum types should be scoped

### DIFF
--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -38,7 +38,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WheelEvent);
 
 inline static unsigned determineDeltaMode(const PlatformWheelEvent& event)
 {
-    return event.granularity() == ScrollByPageWheelEvent ? WheelEvent::DOM_DELTA_PAGE : WheelEvent::DOM_DELTA_PIXEL;
+    return event.granularity() == PlatformWheelEventGranularity::ScrollByPageWheelEvent ? WheelEvent::DOM_DELTA_PAGE : WheelEvent::DOM_DELTA_PIXEL;
 }
 
 static double wheelDeltaToDelta(int wheelDelta)

--- a/Source/WebCore/platform/PlatformWheelEvent.cpp
+++ b/Source/WebCore/platform/PlatformWheelEvent.cpp
@@ -49,7 +49,7 @@ PlatformWheelEvent PlatformWheelEvent::createFromGesture(const PlatformGestureEv
     bool ctrlKey = true;
     bool altKey = platformGestureEvent.modifiers().contains(PlatformEvent::Modifier::AltKey);
     bool metaKey = platformGestureEvent.modifiers().contains(PlatformEvent::Modifier::MetaKey);
-    PlatformWheelEvent platformWheelEvent(platformGestureEvent.pos(), platformGestureEvent.globalPosition(), deltaX, deltaY, wheelTicksX, wheelTicksY, ScrollByPixelWheelEvent, shiftKey, ctrlKey, altKey, metaKey);
+    PlatformWheelEvent platformWheelEvent(platformGestureEvent.pos(), platformGestureEvent.globalPosition(), deltaX, deltaY, wheelTicksX, wheelTicksY, PlatformWheelEventGranularity::ScrollByPixelWheelEvent, shiftKey, ctrlKey, altKey, metaKey);
 
     // PlatformEvent
     platformWheelEvent.m_timestamp = platformGestureEvent.timestamp();

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -51,7 +51,7 @@ enum class WheelScrollGestureState : uint8_t {
 // In this case, WebKit built in paging behavior is used to page up and down.
 // This yields the same behavior as clicking in a scrollbar track to page up and down.
 
-enum PlatformWheelEventGranularity : uint8_t {
+enum class PlatformWheelEventGranularity : uint8_t {
     ScrollByPageWheelEvent,
     ScrollByPixelWheelEvent,
 };
@@ -185,7 +185,7 @@ public:
 #endif
 
 protected:
-    PlatformWheelEventGranularity m_granularity { ScrollByPixelWheelEvent };
+    PlatformWheelEventGranularity m_granularity { PlatformWheelEventGranularity::ScrollByPixelWheelEvent };
     bool m_directionInvertedFromDevice { false };
     bool m_hasPreciseScrollingDeltas { false };
 

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -216,7 +216,7 @@ bool ScrollAnimator::handleSteppedScrolling(const PlatformWheelEvent& wheelEvent
             behavior.add(ScrollBehavior::NeverAnimate);
 
         if (deltaY) {
-            if (wheelEvent.granularity() == ScrollByPageWheelEvent)
+            if (wheelEvent.granularity() == PlatformWheelEventGranularity::ScrollByPageWheelEvent)
                 deltaY = std::copysign(Scrollbar::pageStepDelta(scrollableArea->visibleHeight()), deltaY);
 
             auto scrollDelta = verticalScrollbar->pixelStep() * -deltaY; // Wheel deltas are reversed from scrolling direction.
@@ -224,7 +224,7 @@ bool ScrollAnimator::handleSteppedScrolling(const PlatformWheelEvent& wheelEvent
         }
 
         if (deltaX) {
-            if (wheelEvent.granularity() == ScrollByPageWheelEvent)
+            if (wheelEvent.granularity() == PlatformWheelEventGranularity::ScrollByPageWheelEvent)
                 deltaX = std::copysign(Scrollbar::pageStepDelta(scrollableArea->visibleWidth()), deltaX);
 
             auto scrollDelta = horizontalScrollbar->pixelStep() * -deltaX; // Wheel deltas are reversed from scrolling direction.

--- a/Source/WebCore/platform/ScrollingEffectsController.cpp
+++ b/Source/WebCore/platform/ScrollingEffectsController.cpp
@@ -399,7 +399,7 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
         || (deltaY > 0 && scrollOffset.y() <= minPosition.y()))
         deltaY = 0;
 
-    if (wheelEvent.granularity() == ScrollByPageWheelEvent) {
+    if (wheelEvent.granularity() == PlatformWheelEventGranularity::ScrollByPageWheelEvent) {
         if (deltaX) {
             bool negative = deltaX < 0;
             deltaX = Scrollbar::pageStepDelta(extents.contentsSize.width());

--- a/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
@@ -117,7 +117,7 @@ public:
         m_globalPosition = IntPoint(globalPointForEvent(event));
         m_deltaX = event.deltaX;
         m_deltaY = event.deltaY;
-        m_granularity = ScrollByPixelWheelEvent; // iOS only supports continuous (pixel-mode) scrolling.
+        m_granularity = PlatformWheelEventGranularity::ScrollByPixelWheelEvent; // iOS only supports continuous (pixel-mode) scrolling.
     }
 };
 

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -758,7 +758,7 @@ public:
         // PlatformWheelEvent
         m_position = IntPoint(pointForEvent(event, windowView));
         m_globalPosition = IntPoint(globalPointForEvent(event));
-        m_granularity = ScrollByPixelWheelEvent;
+        m_granularity = PlatformWheelEventGranularity::ScrollByPixelWheelEvent;
 
         BOOL continuous;
         getWheelEventDeltas(event, m_deltaX, m_deltaY, continuous);

--- a/Source/WebCore/platform/win/WheelEventWin.cpp
+++ b/Source/WebCore/platform/win/WheelEventWin.cpp
@@ -97,13 +97,13 @@ PlatformWheelEvent::PlatformWheelEvent(HWND hWnd, WPARAM wParam, LPARAM lParam, 
     if (isMouseHWheel || shiftKey()) {
         m_deltaX = delta * static_cast<float>(horizontalScrollChars()) * cScrollbarPixelsPerLine;
         m_deltaY = 0;
-        m_granularity = ScrollByPixelWheelEvent;
+        m_granularity = PlatformWheelEventGranularity::ScrollByPixelWheelEvent;
     } else {
         m_deltaX = 0;
         m_deltaY = delta;
         unsigned verticalMultiplier = verticalScrollLines();
-        m_granularity = (verticalMultiplier == WHEEL_PAGESCROLL) ? ScrollByPageWheelEvent : ScrollByPixelWheelEvent;
-        if (m_granularity == ScrollByPixelWheelEvent)
+        m_granularity = (verticalMultiplier == WHEEL_PAGESCROLL) ? PlatformWheelEventGranularity::ScrollByPageWheelEvent : PlatformWheelEventGranularity::ScrollByPixelWheelEvent;
+        if (m_granularity == PlatformWheelEventGranularity::ScrollByPixelWheelEvent)
             m_deltaY *= static_cast<float>(verticalMultiplier) * cScrollbarPixelsPerLine;
     }
 }

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -308,7 +308,7 @@ public:
         m_deltaY = webEvent.delta().height();
         m_wheelTicksX = webEvent.wheelTicks().width();
         m_wheelTicksY = webEvent.wheelTicks().height();
-        m_granularity = (webEvent.granularity() == WebWheelEvent::ScrollByPageWheelEvent) ? WebCore::ScrollByPageWheelEvent : WebCore::ScrollByPixelWheelEvent;
+        m_granularity = (webEvent.granularity() == WebWheelEvent::Granularity::ScrollByPageWheelEvent) ? WebCore::PlatformWheelEventGranularity::ScrollByPageWheelEvent : WebCore::PlatformWheelEventGranularity::ScrollByPixelWheelEvent;
         m_directionInvertedFromDevice = webEvent.directionInvertedFromDevice();
 #if ENABLE(KINETIC_SCROLLING)
         m_phase = static_cast<WebCore::PlatformWheelEventPhase>(webEvent.phase());

--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -34,7 +34,7 @@ namespace WebKit {
 
 class WebWheelEvent : public WebEvent {
 public:
-    enum Granularity : uint8_t {
+    enum class Granularity : uint8_t {
         ScrollByPageWheelEvent,
         ScrollByPixelWheelEvent
     };
@@ -68,7 +68,7 @@ public:
     const WebCore::IntPoint globalPosition() const { return m_globalPosition; }
     const WebCore::FloatSize delta() const { return m_delta; }
     const WebCore::FloatSize wheelTicks() const { return m_wheelTicks; }
-    Granularity granularity() const { return static_cast<Granularity>(m_granularity); }
+    Granularity granularity() const { return m_granularity; }
     bool directionInvertedFromDevice() const { return m_directionInvertedFromDevice; }
     Phase phase() const { return static_cast<Phase>(m_phase); }
     Phase momentumPhase() const { return static_cast<Phase>(m_momentumPhase); }
@@ -92,7 +92,7 @@ private:
     WebCore::IntPoint m_globalPosition;
     WebCore::FloatSize m_delta;
     WebCore::FloatSize m_wheelTicks;
-    uint32_t m_granularity { ScrollByPageWheelEvent };
+    Granularity m_granularity { Granularity::ScrollByPageWheelEvent };
     uint32_t m_phase { Phase::PhaseNone };
     uint32_t m_momentumPhase { Phase::PhaseNone };
 

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -314,7 +314,7 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(const GdkEvent* event, Vector
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(const GdkEvent* event, const WebCore::IntPoint& position, const WebCore::IntPoint& globalPosition, const WebCore::FloatSize& delta, const WebCore::FloatSize& wheelTicks, WebWheelEvent::Phase phase, WebWheelEvent::Phase momentumPhase, bool hasPreciseDeltas)
 {
-    return WebWheelEvent({ WebEventType::Wheel, modifiersForEvent(event), monotonicTimeForEvent(event) }, position, globalPosition, delta, wheelTicks, WebWheelEvent::ScrollByPixelWheelEvent, phase, momentumPhase, hasPreciseDeltas);
+    return WebWheelEvent({ WebEventType::Wheel, modifiersForEvent(event), monotonicTimeForEvent(event) }, position, globalPosition, delta, wheelTicks, WebWheelEvent::Granularity::ScrollByPixelWheelEvent, phase, momentumPhase, hasPreciseDeltas);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -235,7 +235,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(struct wpe_input_axis_event* 
         }
 
         return WebWheelEvent({ WebEventType::Wheel, OptionSet<WebEventModifier> { }, monotonicTimeForEventTimeInMilliseconds(event->time) }, position, position,
-            delta, wheelTicks, WebWheelEvent::ScrollByPixelWheelEvent, phase, momentumPhase,
+            delta, wheelTicks, WebWheelEvent::Granularity::ScrollByPixelWheelEvent, phase, momentumPhase,
             hasPreciseScrollingDeltas);
     }
 #endif
@@ -268,7 +268,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(struct wpe_input_axis_event* 
     };
 
     return WebWheelEvent({ WebEventType::Wheel, OptionSet<WebEventModifier> { }, monotonicTimeForEventTimeInMilliseconds(event->time) }, position, position,
-        delta, wheelTicks, WebWheelEvent::ScrollByPixelWheelEvent, phase, momentumPhase,
+        delta, wheelTicks, WebWheelEvent::Granularity::ScrollByPixelWheelEvent, phase, momentumPhase,
         hasPreciseScrollingDeltas);
 }
 

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -150,7 +150,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(NSEvent *event, NSView *windo
         deltaY *= static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep());
     }
 
-    WebWheelEvent::Granularity granularity  = WebWheelEvent::ScrollByPixelWheelEvent;
+    WebWheelEvent::Granularity granularity  = WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
     bool directionInvertedFromDevice        = [event isDirectionInvertedFromDevice];
     WebWheelEvent::Phase phase              = phaseForEvent(event);
     WebWheelEvent::Phase momentumPhase      = momentumPhaseForEvent(event);

--- a/Source/WebKit/Shared/win/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -418,7 +418,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(HWND hWnd, UINT message, WPAR
     FloatPoint position = positionPoint;
     position.scale(1 / deviceScaleFactor);
 
-    WebWheelEvent::Granularity granularity = WebWheelEvent::ScrollByPixelWheelEvent;
+    auto granularity = WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
 
     auto modifiers = modifiersForEvent(wParam);
 
@@ -440,15 +440,15 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(HWND hWnd, UINT message, WPAR
     if (isMouseHWheel || (modifiers & WebEventModifier::ShiftKey)) {
         deltaX = delta * static_cast<float>(horizontalScrollChars()) * WebCore::cScrollbarPixelsPerLine;
         deltaY = 0;
-        granularity = WebWheelEvent::ScrollByPixelWheelEvent;
+        granularity = WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
     } else {
         deltaX = 0;
         deltaY = delta;
         unsigned verticalMultiplier = verticalScrollLines();
         if (verticalMultiplier == WHEEL_PAGESCROLL)
-            granularity = WebWheelEvent::ScrollByPageWheelEvent;
+            granularity = WebWheelEvent::Granularity::ScrollByPageWheelEvent;
         else {
-            granularity = WebWheelEvent::ScrollByPixelWheelEvent;
+            granularity = WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
             deltaY *= static_cast<float>(verticalMultiplier) * WebCore::cScrollbarPixelsPerLine;
         }
     }

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -209,7 +209,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(WPEEvent* event, WebWheelEven
     }
 
     return WebWheelEvent({ WebEventType::Wheel, modifiersFromWPEModifiers(wpe_event_get_modifiers(event)), monotonicTimeForEvent(event) },
-        position, position, delta, wheelTicks, WebWheelEvent::ScrollByPixelWheelEvent, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas);
+        position, position, delta, wheelTicks, WebWheelEvent::Granularity::ScrollByPixelWheelEvent, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas);
 }
 
 WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(WPEEvent* event, const String& text, bool isAutoRepeat)

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -183,7 +183,7 @@ void MomentumEventDispatcher::dispatchSyntheticMomentumEvent(WebWheelEvent::Phas
         initiatingEvent->globalPosition(),
         appKitAcceleratedDelta,
         wheelTicks,
-        WebWheelEvent::ScrollByPixelWheelEvent,
+        WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
         initiatingEvent->directionInvertedFromDevice(),
         WebWheelEvent::PhaseNone,
         phase,


### PR DESCRIPTION
#### e0920b51d782f4b19cfacb772a2d446baf1397cb
<pre>
Wheel event granularity enum types should be scoped
<a href="https://bugs.webkit.org/show_bug.cgi?id=302137">https://bugs.webkit.org/show_bug.cgi?id=302137</a>
<a href="https://rdar.apple.com/164222580">rdar://164222580</a>

Reviewed by Michael Catanzaro.

Namely, WebCore::PlatformWheelEventGranularity and
WebKit::WebWheelEvent::Granularity. When they are unscoped, it is easy
to confuse between the identically named cases.

This is a mechanical patch that s/&apos;enum&apos;/&apos;enum class&apos; on said types.

No new tests because no change in functionality.

* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::determineDeltaMode):
* Source/WebCore/platform/PlatformWheelEvent.cpp:
(WebCore::PlatformWheelEvent::createFromGesture):
* Source/WebCore/platform/PlatformWheelEvent.h:
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::handleSteppedScrolling):
* Source/WebCore/platform/ScrollingEffectsController.cpp:
(WebCore::ScrollingEffectsController::handleWheelEvent):
* Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm:
(WebCore::PlatformWheelEventBuilder::PlatformWheelEventBuilder):
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::PlatformWheelEventBuilder::PlatformWheelEventBuilder):
* Source/WebCore/platform/win/WheelEventWin.cpp:
(WebCore::PlatformWheelEvent::PlatformWheelEvent):
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformWheelEvent::WebKit2PlatformWheelEvent):
* Source/WebKit/Shared/WebWheelEvent.h:
(WebKit::WebWheelEvent::granularity const):
* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/libwpe/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/win/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::dispatchSyntheticMomentumEvent):

Canonical link: <a href="https://commits.webkit.org/302810@main">https://commits.webkit.org/302810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acc1465996adae59418ae4c5a8ff3510cd4d130f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81447 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8fdfd4a5-fbf4-44fb-84b1-ac18b57e6259) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98988 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66799 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e8aa5d6-1b9b-40f6-be58-e6bc80ce452f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79681 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1af83b0b-dc4c-4baa-9b0a-7f1857a17161) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34510 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80612 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110048 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35019 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139823 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2004 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1855 "Found 1 new test failure: media/track/webvtt-parser-does-not-leak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107494 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31198 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54815 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65446 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1892 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->