### PR TITLE
REGRESSION(302499@main): [macOS Debug] ASSERTION FAILED: m_didBeginDeletion || deleteException == CheckedPtrDeleteCheckException

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -923,9 +923,9 @@ TEST(PushDatabase, StartsFromScratchOnDowngrade)
     auto path = makeTemporaryDatabasePath();
 
     {
-        SQLiteDatabase db;
-        db.open(path);
-        ASSERT_TRUE(db.executeCommand("PRAGMA user_version = 100000"_s));
+        auto db = makeUniqueRef<SQLiteDatabase>();
+        db->open(path);
+        ASSERT_TRUE(db->executeCommand("PRAGMA user_version = 100000"_s));
     }
 
     {
@@ -934,11 +934,11 @@ TEST(PushDatabase, StartsFromScratchOnDowngrade)
     }
 
     {
-        SQLiteDatabase db;
-        db.open(path);
+        auto db = makeUniqueRef<SQLiteDatabase>();
+        db->open(path);
         {
             int version = 0;
-            auto sql = db.prepareStatement("PRAGMA user_version"_s);
+            auto sql = db->prepareStatement("PRAGMA user_version"_s);
             if (sql && sql->step() == SQLITE_ROW)
                 version = sql->columnInt(0);
             EXPECT_GT(version, 0);
@@ -949,11 +949,11 @@ TEST(PushDatabase, StartsFromScratchOnDowngrade)
 
 static bool createDatabaseFromStatements(String path, ASCIILiteral* statements, size_t count)
 {
-    SQLiteDatabase db;
-    db.open(path);
+    auto db = makeUniqueRef<SQLiteDatabase>();
+    db->open(path);
 
     for (size_t i = 0; i < count; i++) {
-        if (!db.executeCommand(statements[i]))
+        if (!db->executeCommand(statements[i]))
             return false;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
@@ -368,22 +368,22 @@ static void createAndPopulatePCMObservedDomainTable(WebCore::SQLiteDatabase& dat
 
 void setUpFromResourceLoadStatisticsDatabase(void(*addUnattributedPCM)(WebCore::SQLiteDatabase&), void(*addAttributedPCM)(WebCore::SQLiteDatabase&))
 {
-    WebCore::SQLiteDatabase database;
-    EXPECT_TRUE(database.open(emptyObservationsDBPath()));
-    createAndPopulateObservedDomainTable(database);
-    addUnattributedPCM(database);
-    addAttributedPCM(database);
-    database.close();
+    auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(database->open(emptyObservationsDBPath()));
+    createAndPopulateObservedDomainTable(database.get());
+    addUnattributedPCM(database.get());
+    addAttributedPCM(database.get());
+    database->close();
 }
 
 void setUpFromPCMDatabase(void(*addUnattributedPCM)(WebCore::SQLiteDatabase&), void(*addAttributedPCM)(WebCore::SQLiteDatabase&))
 {
-    WebCore::SQLiteDatabase database;
-    EXPECT_TRUE(database.open(emptyPcmDBPath()));
-    createAndPopulatePCMObservedDomainTable(database);
-    addUnattributedPCM(database);
-    addAttributedPCM(database);
-    database.close();
+    auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(database->open(emptyPcmDBPath()));
+    createAndPopulatePCMObservedDomainTable(database.get());
+    addUnattributedPCM(database.get());
+    addAttributedPCM(database.get());
+    database->close();
 }
 
 TEST(PrivateClickMeasurement, MigrateFromResourceLoadStatistics1)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1364,8 +1364,8 @@ TEST(ResourceLoadStatistics, DatabaseSchemeUpdate)
     EXPECT_NULL(error);
     
     NSURL *targetURL = [dataStoreConfiguration.get()._resourceLoadStatisticsDirectory URLByAppendingPathComponent:@"observations.db"];
-    WebCore::SQLiteDatabase database;
-    EXPECT_TRUE(database.open(targetURL.path));
+    auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(database->open(targetURL.path));
 
     constexpr auto createObservedDomain = "CREATE TABLE ObservedDomains ("
         "domainID INTEGER PRIMARY KEY, registrableDomain TEXT NOT NULL UNIQUE ON CONFLICT FAIL, lastSeen REAL NOT NULL, "
@@ -1374,8 +1374,8 @@ TEST(ResourceLoadStatistics, DatabaseSchemeUpdate)
         "timesAccessedAsFirstPartyDueToUserInteraction INTEGER NOT NULL, timesAccessedAsFirstPartyDueToStorageAccessAPI INTEGER NOT NULL,"
         "isScheduledForAllButCookieDataRemoval INTEGER NOT NULL)"_s;
 
-    EXPECT_TRUE(database.executeCommand(createObservedDomain));
-    database.close();
+    EXPECT_TRUE(database->executeCommand(createObservedDomain));
+    database->close();
 
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
@@ -1385,10 +1385,10 @@ TEST(ResourceLoadStatistics, DatabaseSchemeUpdate)
     }];
     TestWebKitAPI::Util::run(&done);
     
-    WebCore::SQLiteDatabase databaseAfterMigration;
-    EXPECT_TRUE(databaseAfterMigration.open(targetURL.path));
+    auto databaseAfterMigration = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(databaseAfterMigration->open(targetURL.path));
     auto columns = columnsForTable(databaseAfterMigration, "ObservedDomains"_s);
-    databaseAfterMigration.close();
+    databaseAfterMigration->close();
     EXPECT_WK_STREQ(columns.last(), "mostRecentWebPushInteractionTime");
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -6139,10 +6139,10 @@ TEST(SiteIsolation, SharedProcessWithResourceLoadStatistics)
     [defaultFileManager copyItemAtPath:sourceFile.path toPath:itpDatabaseFile.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:itpDatabaseFile.path]);
 
-    WebCore::SQLiteDatabase database;
-    EXPECT_TRUE(database.open(itpDatabaseFile.path));
-    EXPECT_TRUE(database.executeCommand("UPDATE ObservedDomains SET hadUserInteraction = 1 WHERE registrableDomain = 'webkit.org'"_s));
-    database.close();
+    auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(database->open(itpDatabaseFile.path));
+    EXPECT_TRUE(database->executeCommand("UPDATE ObservedDomains SET hadUserInteraction = 1 WHERE registrableDomain = 'webkit.org'"_s));
+    database->close();
 
     auto [webView, navigationDelegate] = siteIsolatedViewWithSharedProcess(server, EnableProcessCache::No, dataStoreRoot, itpRoot);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];


### PR DESCRIPTION
#### 4d584f9ce8c415fc1bbbaf1e8030c5b1e035d9d1
<pre>
REGRESSION(302499@main): [macOS Debug] ASSERTION FAILED: m_didBeginDeletion || deleteException == CheckedPtrDeleteCheckException
<a href="https://bugs.webkit.org/show_bug.cgi?id=302132">https://bugs.webkit.org/show_bug.cgi?id=302132</a>
<a href="https://rdar.apple.com/164209878">rdar://164209878</a>

Reviewed by Chris Dumez.

Fix the tests by allocating SQLDatabase in heap.

* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::TEST(PushDatabase, StartsFromScratchOnDowngrade)):
(TestWebKitAPI::createDatabaseFromStatements):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm:
(setUpFromResourceLoadStatisticsDatabase):
(setUpFromPCMDatabase):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, DatabaseSchemeUpdate)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessWithResourceLoadStatistics)):

Canonical link: <a href="https://commits.webkit.org/302712@main">https://commits.webkit.org/302712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ce2fb273c5d995c5d53141500ac47ce0370e620

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137360 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98997 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ee71f038-22a1-4d5b-8504-f3f85f5dfefb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132913 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79691 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34524 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139840 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107504 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107395 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1615 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31209 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54833 "Hash 3ce2fb27 for PR 53575 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20278 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2094 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1909 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2017 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->