### PR TITLE
[blocks-in-inline] Assert in fast/inline/outline-with-continuation-assert.html

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -70,20 +70,18 @@ void layoutWithFormattingContextForBox(const Layout::ElementBox& box, std::optio
 
 void layoutWithFormattingContextForBlockInInline(const Layout::ElementBox& block, LayoutPoint blockLogicalTopLeft, Layout::BlockLayoutState& parentBlockLayoutState, Layout::LayoutState& layoutState)
 {
-    auto* renderer = dynamicDowncast<RenderBlockFlow>(*block.rendererForIntegration());
-    if (!renderer) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
     layoutWithFormattingContextForBox(block, { }, { }, layoutState);
-    ASSERT(!renderer->needsLayout());
+    ASSERT(!block.rendererForIntegration()->needsLayout());
 
-    if (!renderer->containsFloats() || renderer->createsNewFormattingContext())
+    auto* renderBlockFlow = dynamicDowncast<RenderBlockFlow>(*block.rendererForIntegration());
+    if (!renderBlockFlow)
+        return;
+
+    if (!renderBlockFlow->containsFloats() || renderBlockFlow->createsNewFormattingContext())
         return;
 
     auto& placedFloats = parentBlockLayoutState.placedFloats();
-    for (auto& floatingObject : *renderer->floatingObjectSet()) {
+    for (auto& floatingObject : *renderBlockFlow->floatingObjectSet()) {
         if (!floatingObject->isDescendant())
             continue;
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -434,9 +434,9 @@ RenderPtr<RenderObject> RenderTreeBuilder::Block::detach(RenderBlockFlow& parent
     return detach(static_cast<RenderBlock&>(parent), child, willBeDestroyed, canCollapseAnonymousBlock);
 }
 
-RenderPtr<RenderBlock> RenderTreeBuilder::Block::createAnonymousBlockWithStyle(Document& document, const RenderStyle& style)
+RenderPtr<RenderBlockFlow> RenderTreeBuilder::Block::createAnonymousBlockWithStyle(Document& document, const RenderStyle& style)
 {
-    RenderPtr<RenderBlock> newBox = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, RenderStyle::createAnonymousStyleWithDisplay(style, DisplayType::Block));
+    RenderPtr<RenderBlockFlow> newBox = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, RenderStyle::createAnonymousStyleWithDisplay(style, DisplayType::Block));
     newBox->initializeStyle();
     return newBox;
 }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
@@ -48,7 +48,7 @@ public:
     void dropAnonymousBoxChild(RenderBlock& parent, RenderBlock& child);
     void childBecameNonInline(RenderBlock& parent, RenderElement& child);
 
-    static RenderPtr<RenderBlock> createAnonymousBlockWithStyle(Document&, const RenderStyle&);
+    static RenderPtr<RenderBlockFlow> createAnonymousBlockWithStyle(Document&, const RenderStyle&);
 
 private:
     void insertChildToContinuation(RenderBlock& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -443,7 +443,7 @@ void RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock(RenderInline& p
     // Wrap runs of block boxes with an anonymous block so their margins collapse correctly for blocks-in-inline.
     ASSERT(!m_buildsContinuations);
 
-    auto dropNestedAnonymousBlocks = [&](CheckedRef<RenderBlock> anonymousBlock) {
+    auto dropNestedAnonymousBlocks = [&](CheckedRef<RenderBlockFlow> anonymousBlock) {
         ASSERT(anonymousBlock->isAnonymousBlock());
         SingleThreadWeakPtr<RenderObject> nextChild;
         for (SingleThreadWeakPtr<RenderObject> movedChild = anonymousBlock->firstChild(); movedChild; movedChild = nextChild) {
@@ -454,10 +454,10 @@ void RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock(RenderInline& p
         }
     };
 
-    SingleThreadWeakPtr<RenderBlock> firstInRun;
-    SingleThreadWeakPtr<RenderBlock> lastInRun;
+    SingleThreadWeakPtr<RenderBox> firstInRun;
+    SingleThreadWeakPtr<RenderBox> lastInRun;
 
-    auto wrapInAnonymousBlockIfNeeded = [&] {
+    auto wrapRunInAnonymousBlockIfNeeded = [&] {
         // Only wrap if there are multiple consecutive blocks.
         if (firstInRun == lastInRun)
             return;
@@ -474,19 +474,19 @@ void RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock(RenderInline& p
 
     for (CheckedPtr child = parent.firstChild() ; child; child = child->nextSibling()) {
         if (child->isInline()) {
-            wrapInAnonymousBlockIfNeeded();
+            wrapRunInAnonymousBlockIfNeeded();
             firstInRun = nullptr;
             lastInRun = nullptr;
             continue;
         }
-        if (auto* blockChild = dynamicDowncast<RenderBlock>(*child); blockChild && blockChild->isInFlow()) {
+        if (auto* blockChild = dynamicDowncast<RenderBox>(*child); blockChild && blockChild->isInFlow()) {
             // Floats and out-of-flow boxes are wrapped if they are in the middle of a block run.
             if (!firstInRun)
                 firstInRun = blockChild;
             lastInRun = blockChild;
         }
     }
-    wrapInAnonymousBlockIfNeeded();
+    wrapRunInAnonymousBlockIfNeeded();
 }
 
 }


### PR DESCRIPTION
#### e8166aff20a89e39427107c151c1ab5956f11b53
<pre>
[blocks-in-inline] Assert in fast/inline/outline-with-continuation-assert.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=302148">https://bugs.webkit.org/show_bug.cgi?id=302148</a>
<a href="https://rdar.apple.com/164239880">rdar://164239880</a>

Reviewed by Alan Baradlay.

* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp:
(WebCore::LayoutIntegration::layoutWithFormattingContextForBlockInInline):

Not all boxes with display:block are RenderBlockFlows.

* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::RenderTreeBuilder::Block::createAnonymousBlockWithStyle):
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock):

Similarly loosen typing to RenderBox for block run as they may have collapsing margins too.

Canonical link: <a href="https://commits.webkit.org/302721@main">https://commits.webkit.org/302721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f6219aa7033ef36b6ebb02acf8756639d356bb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81495 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e6a2cb73-3777-4d6f-bb50-57b742f64fbc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99017 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/46f860a6-7b69-469a-bf04-6195719d04f4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132938 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79715 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8685a95f-4488-41fc-8d33-7ee457482802) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34548 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80655 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139865 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107522 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54868 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65488 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1934 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1968 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->