### PR TITLE
Annotate MediaPlayerPrivateMediaSourceAVFObjC with threading expectations

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -104,7 +104,7 @@ public:
     void startSeek(const MediaTime&);
     void cancelPendingSeek();
     void completeSeek(const MediaTime&);
-    void setLoadingProgresssed(bool flag) { m_loadingProgressed = flag; }
+    void setLoadingProgresssed(bool);
     void setHasAvailableVideoFrame(bool);
     bool hasAvailableVideoFrame() const override;
     void durationChanged();
@@ -173,7 +173,7 @@ public:
     const Logger& mediaPlayerLogger() { return logger(); }
 #endif
 
-    bool supportsLimitedMatroska() const { return m_loadOptions.supportsLimitedMatroska; }
+    bool supportsLimitedMatroska() const;
 
 private:
     // MediaPlayerPrivateInterface
@@ -283,7 +283,7 @@ private:
 
     void startVideoFrameMetadataGathering() final;
     void stopVideoFrameMetadataGathering() final;
-    std::optional<VideoFrameMetadata> videoFrameMetadata() final { return std::exchange(m_videoFrameMetadata, { }); }
+    std::optional<VideoFrameMetadata> videoFrameMetadata() final;
 
     void setResourceOwner(const ProcessIdentity&) final;
 
@@ -325,56 +325,56 @@ private:
 
     static Ref<AudioVideoRenderer> createRenderer(LoggerHelper&, HTMLMediaElementIdentifier, MediaPlayerIdentifier);
 
-    ThreadSafeWeakPtr<MediaPlayer> m_player;
-    RefPtr<MediaSourcePrivateAVFObjC> m_mediaSourcePrivate;
+    const ThreadSafeWeakPtr<MediaPlayer> m_player;
+    RefPtr<MediaSourcePrivateAVFObjC> m_mediaSourcePrivate; // set on load, immutable after.
 
     struct AudioTrackProperties {
         bool hasAudibleSample { false };
     };
-    HashMap<TrackIdentifier, AudioTrackProperties> m_audioTracksMap;
-    RefPtr<VideoFrame> m_lastVideoFrame;
-    RefPtr<NativeImage> m_lastImage;
+    HashMap<TrackIdentifier, AudioTrackProperties> m_audioTracksMap WTF_GUARDED_BY_CAPABILITY(mainThread);
+    RefPtr<VideoFrame> m_lastVideoFrame WTF_GUARDED_BY_CAPABILITY(mainThread);
+    RefPtr<NativeImage> m_lastImage WTF_GUARDED_BY_CAPABILITY(mainThread);
 
     // Seeking
-    Timer m_seekTimer;
-    bool m_seeking { false };
-    std::optional<SeekTarget> m_pendingSeek;
-    const Ref<NativePromiseRequest> m_rendererSeekRequest;
+    Timer m_seekTimer WTF_GUARDED_BY_CAPABILITY(mainThread);
+    bool m_seeking  WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    std::optional<SeekTarget> m_pendingSeek WTF_GUARDED_BY_CAPABILITY(mainThread);
+    const Ref<NativePromiseRequest> m_rendererSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;
 #endif
-    MediaPlayer::NetworkState m_networkState;
-    MediaPlayer::ReadyState m_readyState;
-    bool m_readyStateIsWaitingForAvailableFrame { false };
-    MediaTime m_duration { MediaTime::invalidTime() };
-    MediaTime m_lastSeekTime;
-    FloatSize m_naturalSize;
-    double m_rate { 1 };
-    mutable bool m_loadingProgressed { false };
-    bool m_hasAvailableVideoFrame { false };
-    bool m_allRenderersHaveAvailableSamples { false };
-    bool m_visible { false };
-    RetainPtr<CVOpenGLTextureRef> m_lastTexture;
+    MediaPlayer::NetworkState m_networkState WTF_GUARDED_BY_CAPABILITY(mainThread);
+    MediaPlayer::ReadyState m_readyState WTF_GUARDED_BY_CAPABILITY(mainThread);
+    bool m_readyStateIsWaitingForAvailableFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    MediaTime m_duration WTF_GUARDED_BY_CAPABILITY(mainThread) { MediaTime::invalidTime() };
+    MediaTime m_lastSeekTime WTF_GUARDED_BY_CAPABILITY(mainThread);
+    FloatSize m_naturalSize; WTF_GUARDED_BY_CAPABILITY(mainThread)
+    double m_rate WTF_GUARDED_BY_CAPABILITY(mainThread) { 1 };
+    mutable bool m_loadingProgressed WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_hasAvailableVideoFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_allRenderersHaveAvailableSamples WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_visible WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    RetainPtr<CVOpenGLTextureRef> m_lastTexture WTF_GUARDED_BY_CAPABILITY(mainThread);
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    RefPtr<MediaPlaybackTarget> m_playbackTarget;
-    bool m_shouldPlayToTarget { false };
+    RefPtr<MediaPlaybackTarget> m_playbackTarget WTF_GUARDED_BY_CAPABILITY(mainThread);
+    bool m_shouldPlayToTarget WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 #endif
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
-    bool m_isGatheringVideoFrameMetadata { false };
-    std::optional<VideoFrameMetadata> m_videoFrameMetadata;
-    uint64_t m_lastConvertedSampleCount { 0 };
+    bool m_isGatheringVideoFrameMetadata WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    std::optional<VideoFrameMetadata> m_videoFrameMetadata WTF_GUARDED_BY_CAPABILITY(mainThread);
+    uint64_t m_lastConvertedSampleCount WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
     ProcessIdentity m_resourceOwner;
-    LoadOptions m_loadOptions;
+    LoadOptions m_loadOptions WTF_GUARDED_BY_CAPABILITY(mainThread);
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;
 #endif
 
-    bool m_layerRequiresFlush { false };
+    bool m_layerRequiresFlush WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 #if PLATFORM(IOS_FAMILY)
-    bool m_applicationIsActive { true };
+    bool m_applicationIsActive WTF_GUARDED_BY_CAPABILITY(mainThread) { true };
 #endif
 
     const MediaPlayerIdentifier m_playerIdentifier;


### PR DESCRIPTION
#### 0a087d513db29bd3f105fe6a58cb142a02e58ee5
<pre>
Annotate MediaPlayerPrivateMediaSourceAVFObjC with threading expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=302149">https://bugs.webkit.org/show_bug.cgi?id=302149</a>
<a href="https://rdar.apple.com/164240301">rdar://164240301</a>

Reviewed by Youenn Fablet.

Add threading access expectations for all member variables.
MediaSourcePrivate access is thread-safe.
AudioVideoRenderer access is thread-safe following 302690@main when used
in the content process.

No functional changes. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/302833@main">https://commits.webkit.org/302833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bed4c7c02fed5baad1987f2cabda70619e8f89e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137820 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a473934-e6b4-4f86-97f2-78f9f70974f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99347 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/efd60054-2330-49fd-a83e-a8add12fa012) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133349 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80046 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b2dfa78c-8a27-4ee1-9396-687be258e7d2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81079 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140297 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107860 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107764 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1920 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31560 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65921 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->