### PR TITLE
Wheel event phase enum types should be scoped

### DIFF
--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -57,15 +57,15 @@ enum class PlatformWheelEventGranularity : uint8_t {
 };
 
 enum class PlatformWheelEventPhase : uint8_t {
-    None        = 0,
+    None,
 #if ENABLE(ASYNC_SCROLLING) || ENABLE(KINETIC_SCROLLING)
-    Began       = 1 << 0,
-    Stationary  = 1 << 1,
-    Changed     = 1 << 2,
-    Ended       = 1 << 3,
-    Cancelled   = 1 << 4,
-    MayBegin    = 1 << 5,
-    WillBegin   = 1 << 6,
+    Began,
+    Stationary,
+    Changed,
+    Ended,
+    Cancelled,
+    MayBegin,
+    WillBegin,
 #endif
 };
 

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -208,15 +208,15 @@ class WebKit::WebGestureEvent : WebKit::WebEvent {
     ScrollByPixelWheelEvent
 };
 
-[Nested] enum class WebKit::WebWheelEvent::Phase : uint32_t {
-    PhaseNone,
-    PhaseBegan,
-    PhaseStationary,
-    PhaseChanged,
-    PhaseEnded,
-    PhaseCancelled,
-    PhaseMayBegin,
-    PhaseWillBegin,
+[Nested] enum class WebKit::WebWheelEvent::Phase : uint8_t {
+    None,
+    Began,
+    Stationary,
+    Changed,
+    Ended,
+    Cancelled,
+    MayBegin,
+    WillBegin,
 };
 
 [Nested] enum class WebKit::WebWheelEvent::MomentumEndType : uint8_t {

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -292,6 +292,32 @@ WebCore::PlatformMouseEvent platform(const WebMouseEvent& webEvent)
     return WebKit2PlatformMouseEvent(webEvent);
 }
 
+#if ENABLE(KINETIC_SCROLLING)
+static WebCore::PlatformWheelEventPhase platform(WebWheelEvent::Phase webPhase)
+{
+    switch (webPhase) {
+    case WebWheelEvent::Phase::None:
+        return WebCore::PlatformWheelEventPhase::None;
+    case WebWheelEvent::Phase::Began:
+        return WebCore::PlatformWheelEventPhase::Began;
+    case WebWheelEvent::Phase::Stationary:
+        return WebCore::PlatformWheelEventPhase::Stationary;
+    case WebWheelEvent::Phase::Changed:
+        return WebCore::PlatformWheelEventPhase::Changed;
+    case WebWheelEvent::Phase::Ended:
+        return WebCore::PlatformWheelEventPhase::Ended;
+    case WebWheelEvent::Phase::Cancelled:
+        return WebCore::PlatformWheelEventPhase::Cancelled;
+    case WebWheelEvent::Phase::MayBegin:
+        return WebCore::PlatformWheelEventPhase::MayBegin;
+    case WebWheelEvent::Phase::WillBegin:
+        return WebCore::PlatformWheelEventPhase::WillBegin;
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::PlatformWheelEventPhase::None;
+}
+#endif
+
 class WebKit2PlatformWheelEvent : public WebCore::PlatformWheelEvent {
 public:
     WebKit2PlatformWheelEvent(const WebWheelEvent& webEvent)
@@ -311,8 +337,8 @@ public:
         m_granularity = (webEvent.granularity() == WebWheelEvent::Granularity::ScrollByPageWheelEvent) ? WebCore::PlatformWheelEventGranularity::ScrollByPageWheelEvent : WebCore::PlatformWheelEventGranularity::ScrollByPixelWheelEvent;
         m_directionInvertedFromDevice = webEvent.directionInvertedFromDevice();
 #if ENABLE(KINETIC_SCROLLING)
-        m_phase = static_cast<WebCore::PlatformWheelEventPhase>(webEvent.phase());
-        m_momentumPhase = static_cast<WebCore::PlatformWheelEventPhase>(webEvent.momentumPhase());
+        m_phase = platform(webEvent.phase());
+        m_momentumPhase = platform(webEvent.momentumPhase());
 #endif
 #if PLATFORM(COCOA) || PLATFORM(GTK) || USE(LIBWPE)
         m_hasPreciseScrollingDeltas = webEvent.hasPreciseScrollingDeltas();

--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -39,15 +39,15 @@ public:
         ScrollByPixelWheelEvent
     };
 
-    enum Phase : uint32_t {
-        PhaseNone        = 0,
-        PhaseBegan       = 1 << 0,
-        PhaseStationary  = 1 << 1,
-        PhaseChanged     = 1 << 2,
-        PhaseEnded       = 1 << 3,
-        PhaseCancelled   = 1 << 4,
-        PhaseMayBegin    = 1 << 5,
-        PhaseWillBegin   = 1 << 6,
+    enum class Phase : uint8_t {
+        None,
+        Began,
+        Stationary,
+        Changed,
+        Ended,
+        Cancelled,
+        MayBegin,
+        WillBegin,
     };
 
     enum class MomentumEndType : uint8_t {
@@ -70,8 +70,8 @@ public:
     const WebCore::FloatSize wheelTicks() const { return m_wheelTicks; }
     Granularity granularity() const { return m_granularity; }
     bool directionInvertedFromDevice() const { return m_directionInvertedFromDevice; }
-    Phase phase() const { return static_cast<Phase>(m_phase); }
-    Phase momentumPhase() const { return static_cast<Phase>(m_momentumPhase); }
+    Phase phase() const { return m_phase; }
+    Phase momentumPhase() const { return m_momentumPhase; }
     MomentumEndType momentumEndType() const { return m_momentumEndType; }
 #if PLATFORM(COCOA) || PLATFORM(GTK) || USE(LIBWPE)
     bool hasPreciseScrollingDeltas() const { return m_hasPreciseScrollingDeltas; }
@@ -83,7 +83,7 @@ public:
     const WebCore::FloatSize& unacceleratedScrollingDelta() const { return m_unacceleratedScrollingDelta; }
 #endif
 
-    bool isMomentumEvent() const { return momentumPhase() != Phase::PhaseNone && momentumPhase() != Phase::PhaseWillBegin; }
+    bool isMomentumEvent() const { return momentumPhase() != Phase::None && momentumPhase() != Phase::WillBegin; }
 
     static bool isWheelEventType(WebEventType);
 
@@ -93,8 +93,8 @@ private:
     WebCore::FloatSize m_delta;
     WebCore::FloatSize m_wheelTicks;
     Granularity m_granularity { Granularity::ScrollByPageWheelEvent };
-    uint32_t m_phase { Phase::PhaseNone };
-    uint32_t m_momentumPhase { Phase::PhaseNone };
+    Phase m_phase { Phase::None };
+    Phase m_momentumPhase { Phase::None };
 
     MomentumEndType m_momentumEndType { MomentumEndType::Unknown };
     bool m_directionInvertedFromDevice { false };

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
@@ -101,10 +101,10 @@ bool WebWheelEventCoalescer::shouldDispatchEventNow(const WebWheelEvent& event) 
     // scrolling session to beginning or end correctly.
     // This is only needed by platforms whose WebWheelEvent has this phase
     // information (Cocoa and GTK+) but Cocoa was fine without it.
-    if (event.phase() == WebWheelEvent::Phase::PhaseNone
-        || event.phase() == WebWheelEvent::Phase::PhaseChanged
-        || event.momentumPhase() == WebWheelEvent::Phase::PhaseNone
-        || event.momentumPhase() == WebWheelEvent::Phase::PhaseChanged)
+    if (event.phase() == WebWheelEvent::Phase::None
+        || event.phase() == WebWheelEvent::Phase::Changed
+        || event.momentumPhase() == WebWheelEvent::Phase::None
+        || event.momentumPhase() == WebWheelEvent::Phase::Changed)
         return true;
 #else
     UNUSED_PARAM(event);

--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
@@ -169,24 +169,25 @@ WebMouseEvent WebIOSEventFactory::createWebMouseEvent(::WebEvent *event)
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
 static WebWheelEvent::Phase toWebPhase(WKBEScrollViewScrollUpdatePhase phase)
 {
+    using enum WebWheelEvent::Phase;
     switch (phase) {
 #if !USE(BROWSERENGINEKIT)
     case UIScrollPhaseNone:
-        return WebWheelEvent::PhaseNone;
+        return None;
     case UIScrollPhaseMayBegin:
-        return WebWheelEvent::PhaseMayBegin;
+        return MayBegin;
 #endif // !USE(BROWSERENGINEKIT)
     case WKBEScrollViewScrollUpdatePhaseBegan:
-        return WebWheelEvent::PhaseBegan;
+        return Began;
     case WKBEScrollViewScrollUpdatePhaseChanged:
-        return WebWheelEvent::PhaseChanged;
+        return Changed;
     case WKBEScrollViewScrollUpdatePhaseEnded:
-        return WebWheelEvent::PhaseEnded;
+        return Ended;
     case WKBEScrollViewScrollUpdatePhaseCancelled:
-        return WebWheelEvent::PhaseCancelled;
+        return Cancelled;
     default:
         ASSERT_NOT_REACHED();
-        return WebWheelEvent::PhaseNone;
+        return None;
     }
 }
 
@@ -217,7 +218,7 @@ WebWheelEvent WebIOSEventFactory::createWebWheelEvent(WKBEScrollViewScrollUpdate
         WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
         false,
         overridePhase.value_or(toWebPhase(update.phase)),
-        WebWheelEvent::PhaseNone,
+        WebWheelEvent::Phase::None,
         true,
         1,
         delta,

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -43,39 +43,42 @@ namespace WebKit {
 
 static WebWheelEvent::Phase phaseForEvent(NSEvent *event)
 {
-    uint32_t phase = WebWheelEvent::PhaseNone;
-    if ([event phase] & NSEventPhaseBegan)
-        phase |= WebWheelEvent::PhaseBegan;
-    if ([event phase] & NSEventPhaseStationary)
-        phase |= WebWheelEvent::PhaseStationary;
-    if ([event phase] & NSEventPhaseChanged)
-        phase |= WebWheelEvent::PhaseChanged;
-    if ([event phase] & NSEventPhaseEnded)
-        phase |= WebWheelEvent::PhaseEnded;
-    if ([event phase] & NSEventPhaseCancelled)
-        phase |= WebWheelEvent::PhaseCancelled;
-    if ([event phase] & NSEventPhaseMayBegin)
-        phase |= WebWheelEvent::PhaseMayBegin;
+    using enum WebWheelEvent::Phase;
 
-    return static_cast<WebWheelEvent::Phase>(phase);
+    auto phase = None;
+    if ([event phase] & NSEventPhaseBegan)
+        phase = Began;
+    if ([event phase] & NSEventPhaseStationary)
+        phase = Stationary;
+    if ([event phase] & NSEventPhaseChanged)
+        phase = Changed;
+    if ([event phase] & NSEventPhaseEnded)
+        phase = Ended;
+    if ([event phase] & NSEventPhaseCancelled)
+        phase = Cancelled;
+    if ([event phase] & NSEventPhaseMayBegin)
+        phase = MayBegin;
+
+    return phase;
 }
 
 static WebWheelEvent::Phase momentumPhaseForEvent(NSEvent *event)
 {
-    uint32_t phase = WebWheelEvent::PhaseNone; 
+    using enum WebWheelEvent::Phase;
+    auto phase = None;
 
     if ([event momentumPhase] & NSEventPhaseBegan)
-        phase |= WebWheelEvent::PhaseBegan;
+        phase = Began;
     if ([event momentumPhase] & NSEventPhaseStationary)
-        phase |= WebWheelEvent::PhaseStationary;
+        phase = Stationary;
     if ([event momentumPhase] & NSEventPhaseChanged)
-        phase |= WebWheelEvent::PhaseChanged;
+        phase = Changed;
     if ([event momentumPhase] & NSEventPhaseEnded)
-        phase |= WebWheelEvent::PhaseEnded;
+        phase = Ended;
     if ([event momentumPhase] & NSEventPhaseCancelled)
-        phase |= WebWheelEvent::PhaseCancelled;
+        phase = Cancelled;
 
-    return static_cast<WebWheelEvent::Phase>(phase);
+    return phase;
 }
 
 static int typeForEvent(NSEvent *event)
@@ -191,15 +194,15 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(NSEvent *event, NSView *windo
         rawPlatformDelta = { WebCore::FloatSize(-IOHIDEventGetFloatValue(ioHIDEvent.get(), kIOHIDEventFieldScrollX), -IOHIDEventGetFloatValue(ioHIDEvent.get(), kIOHIDEventFieldScrollY)) };
 
         if (IOHIDEventGetScrollMomentum(ioHIDEvent.get()) & kIOHIDEventScrollMomentumWillBegin) {
-            ASSERT(momentumPhase == WebWheelEvent::Phase::PhaseNone && phase == WebWheelEvent::Phase::PhaseEnded);
-            momentumPhase = WebWheelEvent::Phase::PhaseWillBegin;
+            ASSERT(momentumPhase == WebWheelEvent::Phase::None && phase == WebWheelEvent::Phase::Ended);
+            momentumPhase = WebWheelEvent::Phase::WillBegin;
         }
 
         bool momentumWasInterrupted = IOHIDEventGetScrollMomentum(ioHIDEvent.get()) & kIOHIDEventScrollMomentumInterrupted;
         momentumEndType = momentumWasInterrupted ? WebWheelEvent::MomentumEndType::Interrupted : WebWheelEvent::MomentumEndType::Natural;
     })();
 
-    if (phase == WebWheelEvent::PhaseCancelled) {
+    if (phase == WebWheelEvent::Phase::Cancelled) {
         deltaX = 0;
         deltaY = 0;
         wheelTicksX = 0;

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -168,7 +168,7 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(WPEEvent* event)
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(WPEEvent* event)
 {
-    auto phase = wpe_event_scroll_is_stop(event) ? WebWheelEvent::Phase::PhaseEnded : WebWheelEvent::Phase::PhaseChanged;
+    auto phase = wpe_event_scroll_is_stop(event) ? WebWheelEvent::Phase::Ended : WebWheelEvent::Phase::Changed;
     return createWebWheelEvent(event, phase);
 }
 
@@ -209,7 +209,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(WPEEvent* event, WebWheelEven
     }
 
     return WebWheelEvent({ WebEventType::Wheel, modifiersFromWPEModifiers(wpe_event_get_modifiers(event)), monotonicTimeForEvent(event) },
-        position, position, delta, wheelTicks, WebWheelEvent::Granularity::ScrollByPixelWheelEvent, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas);
+        position, position, delta, wheelTicks, WebWheelEvent::Granularity::ScrollByPixelWheelEvent, phase, WebWheelEvent::Phase::None, hasPreciseScrollingDeltas);
 }
 
 WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(WPEEvent* event, const String& text, bool isAutoRepeat)

--- a/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
@@ -159,7 +159,7 @@ void WKPageHandleWheelEvent(WKPageRef pageRef, WKWheelEvent event)
         1, static_cast<int32_t>(event.delta.width), 0
     };
 
-    WebKit::toImpl(pageRef)->handleNativeWheelEvent(NativeWebWheelEvent(&xEvent, deviceScaleFactor, WebWheelEvent::Phase::PhaseNone, WebWheelEvent::Phase::PhaseNone));
+    WebKit::toImpl(pageRef)->handleNativeWheelEvent(NativeWebWheelEvent(&xEvent, deviceScaleFactor, WebWheelEvent::Phase::None, WebWheelEvent::Phase::None));
 
     struct wpe_input_axis_event yEvent = {
         wpe_input_axis_event_type_motion,
@@ -167,7 +167,7 @@ void WKPageHandleWheelEvent(WKPageRef pageRef, WKWheelEvent event)
         0, static_cast<int32_t>(event.delta.height), 0
     };
 
-    WebKit::toImpl(pageRef)->handleNativeWheelEvent(NativeWebWheelEvent(&yEvent, deviceScaleFactor, WebWheelEvent::Phase::PhaseNone, WebWheelEvent::Phase::PhaseNone));
+    WebKit::toImpl(pageRef)->handleNativeWheelEvent(NativeWebWheelEvent(&yEvent, deviceScaleFactor, WebWheelEvent::Phase::None, WebWheelEvent::Phase::None));
 }
 
 void WKPagePaint(WKPageRef pageRef, unsigned char* surfaceData, WKSize wkSurfaceSize, WKRect wkPaintRect)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -458,7 +458,7 @@ void PageClientImpl::wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&
         GdkDevice* device = gdk_event_get_source_device(event.nativeEvent());
         GdkInputSource source = gdk_device_get_source(device);
 
-        bool isEnd = event.phase() == WebWheelEvent::Phase::PhaseEnded;
+        bool isEnd = event.phase() == WebWheelEvent::Phase::Ended;
 
         PlatformGtkScrollData scrollData = { .delta = delta, .eventTime = eventTime, .source = source, .isEnd = isEnd };
         controller->wheelEventWasNotHandledByWebCore(&scrollData);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1477,7 +1477,7 @@ static gboolean webkitWebViewBaseScrollEvent(GtkWidget* widget, GdkEventScroll* 
             return GDK_EVENT_STOP;
     }
 
-    auto phase = gdk_event_is_scroll_stop_event(event) ? WebWheelEvent::Phase::PhaseEnded : WebWheelEvent::Phase::PhaseChanged;
+    auto phase = gdk_event_is_scroll_stop_event(event) ? WebWheelEvent::Phase::Ended : WebWheelEvent::Phase::Changed;
     double x, y;
     gdk_event_get_coords(event, &x, &y);
     IntPoint position(clampToInteger(x), clampToInteger(y));
@@ -1530,7 +1530,7 @@ static gboolean webkitWebViewBaseScrollEvent(GtkWidget* widget, GdkEventScroll* 
 
     FloatSize delta = wheelTicks.scaled(stepX, stepY);
 
-    priv->pageProxy->handleNativeWheelEvent(NativeWebWheelEvent(event, position, globalPosition, delta, wheelTicks, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas));
+    priv->pageProxy->handleNativeWheelEvent(NativeWebWheelEvent(event, position, globalPosition, delta, wheelTicks, phase, WebWheelEvent::Phase::None, hasPreciseScrollingDeltas));
 
     return GDK_EVENT_STOP;
 }
@@ -1570,7 +1570,7 @@ static gboolean handleScroll(WebKitWebViewBase* webViewBase, double deltaX, doub
     if (!event)
         return GDK_EVENT_PROPAGATE;
 
-    auto phase = gdk_event_get_event_type(event) != GDK_SCROLL || gdk_scroll_event_is_stop(event) ? WebWheelEvent::Phase::PhaseEnded : WebWheelEvent::Phase::PhaseChanged;
+    auto phase = gdk_event_get_event_type(event) != GDK_SCROLL || gdk_scroll_event_is_stop(event) ? WebWheelEvent::Phase::Ended : WebWheelEvent::Phase::Changed;
     IntPoint position;
     if (priv->lastMotionEvent)
         position = IntPoint(priv->lastMotionEvent->position);
@@ -1606,7 +1606,7 @@ static gboolean handleScroll(WebKitWebViewBase* webViewBase, double deltaX, doub
     delta = wheelTicks.scaled(stepX, stepY);
 #endif
 
-    priv->pageProxy->handleNativeWheelEvent(NativeWebWheelEvent(event, position, position, delta, wheelTicks, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas));
+    priv->pageProxy->handleNativeWheelEvent(NativeWebWheelEvent(event, position, position, delta, wheelTicks, phase, WebWheelEvent::Phase::None, hasPreciseScrollingDeltas));
 
     return GDK_EVENT_STOP;
 }
@@ -3375,17 +3375,17 @@ static inline WebWheelEvent::Phase toWebKitWheelEventPhase(WheelEventPhase phase
 {
     switch (phase) {
     case WheelEventPhase::NoPhase:
-        return WebWheelEvent::Phase::PhaseNone;
+        return WebWheelEvent::Phase::None;
     case WheelEventPhase::Began:
-        return WebWheelEvent::Phase::PhaseBegan;
+        return WebWheelEvent::Phase::Began;
     case WheelEventPhase::Changed:
-        return WebWheelEvent::Phase::PhaseChanged;
+        return WebWheelEvent::Phase::Changed;
     case WheelEventPhase::Ended:
-        return WebWheelEvent::Phase::PhaseEnded;
+        return WebWheelEvent::Phase::Ended;
     case WheelEventPhase::Cancelled:
-        return WebWheelEvent::Phase::PhaseCancelled;
+        return WebWheelEvent::Phase::Cancelled;
     case WheelEventPhase::MayBegin:
-        return WebWheelEvent::Phase::PhaseMayBegin;
+        return WebWheelEvent::Phase::MayBegin;
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2431,7 +2431,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     // "Began" event in the WebCore sense (e.g. for deciding cancelability). Note that
     // this may not be a WKBEScrollViewScrollUpdatePhaseBegin event, nor even necessarily the first WKBEScrollViewScrollUpdatePhaseChanged event.
     if (!_wheelEventCountInCurrentScrollGesture)
-        overridePhase = WebKit::WebWheelEvent::PhaseBegan;
+        overridePhase = WebKit::WebWheelEvent::Phase::Began;
     auto event = WebKit::WebIOSEventFactory::createWebWheelEvent(update, _contentView.get(), overridePhase);
 
     _wheelEventCountInCurrentScrollGesture++;

--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
@@ -82,7 +82,7 @@ TouchGestureController::EventVariant TouchGestureController::handleEvent(const s
         case GesturedEvent::Axis:
         {
             AxisEvent generatedEvent;
-            generatedEvent.phase = WebWheelEvent::Phase::PhaseChanged;
+            generatedEvent.phase = WebWheelEvent::Phase::Changed;
 
 #if WPE_CHECK_VERSION(1, 5, 0)
             generatedEvent.event.base = {
@@ -162,7 +162,7 @@ TouchGestureController::EventVariant TouchGestureController::handleEvent(const s
             m_gesturedEvent = GesturedEvent::None;
 
             AxisEvent generatedEvent;
-            generatedEvent.phase = WebWheelEvent::Phase::PhaseEnded;
+            generatedEvent.phase = WebWheelEvent::Phase::Ended;
 
 #if WPE_CHECK_VERSION(1, 5, 0)
             generatedEvent.event.base = {

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
@@ -167,8 +167,8 @@ ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfigur
             // to a 'stop' event. Motion events with zero motion don't exist naturally,
             // so this allows a backend to express 'stop' events without changing API.
             // The wheel event phase is adjusted accordingly.
-            WebWheelEvent::Phase phase = WebWheelEvent::Phase::PhaseChanged;
-            WebWheelEvent::Phase momentumPhase = WebWheelEvent::Phase::PhaseNone;
+            WebWheelEvent::Phase phase = WebWheelEvent::Phase::Changed;
+            WebWheelEvent::Phase momentumPhase = WebWheelEvent::Phase::None;
 
 #if WPE_CHECK_VERSION(1, 5, 0)
             if (event->type & wpe_input_axis_event_type_mask_2d) {
@@ -176,7 +176,7 @@ ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfigur
                 view.m_horizontalScrollActive = !!event2D->x_axis;
                 view.m_verticalScrollActive = !!event2D->y_axis;
                 if (!view.m_horizontalScrollActive && !view.m_verticalScrollActive)
-                    phase = WebWheelEvent::Phase::PhaseEnded;
+                    phase = WebWheelEvent::Phase::Ended;
 
                 auto& page = view.page();
                 page.handleNativeWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(), phase, momentumPhase));
@@ -196,7 +196,7 @@ ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfigur
             bool shouldDispatch = !!event->value;
             if (!view.m_horizontalScrollActive && !view.m_verticalScrollActive) {
                 shouldDispatch = true;
-                phase = WebWheelEvent::Phase::PhaseEnded;
+                phase = WebWheelEvent::Phase::Ended;
             }
 
             if (shouldDispatch) {
@@ -233,7 +233,7 @@ ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfigur
 #endif
                         if (event->type != wpe_input_axis_event_type_null) {
                             page.handleNativeWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(),
-                                axisEvent.phase, WebWheelEvent::Phase::PhaseNone));
+                                axisEvent.phase, WebWheelEvent::Phase::None));
                             handledThroughGestureController = true;
                         }
                     });

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -486,8 +486,8 @@ void ViewPlatform::handleGesture(WPEEvent* event)
                 m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, static_cast<WPEModifiers>(0), dx, dy, TRUE, FALSE, x, y
             ));
             auto phase = wpe_gesture_controller_is_drag_begin(gestureController)
-                ? WebWheelEvent::Phase::PhaseBegan
-                : (wpe_event_get_event_type(event) == WPE_EVENT_TOUCH_UP) ? WebWheelEvent::Phase::PhaseEnded : WebWheelEvent::Phase::PhaseChanged;
+                ? WebWheelEvent::Phase::Began
+                : (wpe_event_get_event_type(event) == WPE_EVENT_TOUCH_UP) ? WebWheelEvent::Phase::Ended : WebWheelEvent::Phase::Changed;
             page().handleNativeWheelEvent(WebKit::NativeWebWheelEvent(simulatedScrollEvent.get(), phase));
         }
     }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -182,7 +182,7 @@ void RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve(c
     ASSERT(isMainRunLoop());
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    if (wheelEvent.momentumPhase() != WebWheelEvent::PhaseBegan)
+    if (wheelEvent.momentumPhase() != WebWheelEvent::Phase::Began)
         return;
 
     auto curve = ScrollingAccelerationCurve::fromNativeWheelEvent(wheelEvent);
@@ -204,10 +204,10 @@ void RemoteLayerTreeEventDispatcher::handleWheelEvent(const WebWheelEvent& wheel
 
     auto scrollingTree = this->scrollingTree();
     if (scrollingTree && scrollingTree->scrollingPerformanceTestingEnabled()) {
-        if (wheelEvent.phase() == WebWheelEvent::PhaseBegan)
+        if (wheelEvent.phase() == WebWheelEvent::Phase::Began)
             startFingerDownSignpostInterval();
 
-        if (wheelEvent.phase() == WebWheelEvent::PhaseEnded)
+        if (wheelEvent.phase() == WebWheelEvent::Phase::Ended)
             endFingerDownSignpostInterval();
     }
 
@@ -764,10 +764,10 @@ void RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent(PageIdentifier pa
 
     auto scrollingTree = this->scrollingTree();
     if (scrollingTree && scrollingTree->scrollingPerformanceTestingEnabled()) {
-        if (event.momentumPhase() == WebWheelEvent::PhaseBegan)
+        if (event.momentumPhase() == WebWheelEvent::Phase::Began)
             startMomentumSignpostInterval();
 
-        if (m_momentumIntervalIsActive && (!std::abs(event.delta().height()) || event.momentumPhase() == WebWheelEvent::PhaseEnded))
+        if (m_momentumIntervalIsActive && (!std::abs(event.delta().height()) || event.momentumPhase() == WebWheelEvent::Phase::Ended))
             endMomentumSignpostInterval();
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4236,7 +4236,7 @@ void WebPageProxy::continueWheelEventHandling(const WebWheelEvent& wheelEvent, c
     LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::continueWheelEventHandling - " << result);
 
     if (!result.needsMainThreadProcessing()) {
-        if (m_mainFrame && wheelEvent.phase() == WebWheelEvent::Phase::PhaseBegan) {
+        if (m_mainFrame && wheelEvent.phase() == WebWheelEvent::Phase::Began) {
             // When wheel events are handled entirely in the UI process, we still need to tell the web process where the mouse is for cursor updates.
             sendToProcessContainingFrame(m_mainFrame->frameID(), Messages::WebPage::SetLastKnownMousePosition(m_mainFrame->frameID(), wheelEvent.position(), wheelEvent.globalPosition()));
         }
@@ -4345,7 +4345,7 @@ void WebPageProxy::cacheWheelEventScrollingAccelerationCurve(const NativeWebWhee
 
     ASSERT(drawingArea()->shouldSendWheelEventsToEventDispatcher());
 
-    if (nativeWheelEvent.momentumPhase() != WebWheelEvent::PhaseBegan)
+    if (nativeWheelEvent.momentumPhase() != WebWheelEvent::Phase::Began)
         return;
 
     if (!protectedPreferences()->momentumScrollingAnimatorEnabled())
@@ -4360,7 +4360,7 @@ void WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary(WebCore::
 {
     ASSERT(drawingArea()->shouldSendWheelEventsToEventDispatcher());
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    if (event.momentumPhase() != WebWheelEvent::PhaseBegan)
+    if (event.momentumPhase() != WebWheelEvent::Phase::Began)
         return;
 
     if (internals().scrollingAccelerationCurve == internals().lastSentScrollingAccelerationCurve)

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -55,7 +55,7 @@ MomentumEventDispatcher::~MomentumEventDispatcher()
 
 bool MomentumEventDispatcher::eventShouldStartSyntheticMomentumPhase(WebCore::PageIdentifier pageIdentifier, const WebWheelEvent& event) const
 {
-    if (event.momentumPhase() != WebWheelEvent::PhaseBegan)
+    if (event.momentumPhase() != WebWheelEvent::Phase::Began)
         return false;
 
     auto curveIterator = scrollingAccelerationCurveForPage(pageIdentifier);
@@ -85,9 +85,9 @@ bool MomentumEventDispatcher::handleWheelEvent(WebCore::PageIdentifier pageIdent
         // Any incoming wheel event other than a changed event for the current gesture
         // should interrupt the animation; in the usual case, it will be
         // momentumPhase == PhaseEnded that interrupts.
-        bool eventShouldInterruptGesture = !isMomentumEvent || event.momentumPhase() != WebWheelEvent::PhaseChanged;
+        bool eventShouldInterruptGesture = !isMomentumEvent || event.momentumPhase() != WebWheelEvent::Phase::Changed;
 
-        if (event.momentumPhase() == WebWheelEvent::PhaseEnded) {
+        if (event.momentumPhase() == WebWheelEvent::Phase::Ended) {
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
             RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher saw momentum ended phase, interrupted=%d", static_cast<int>(event.momentumEndType()));
 #endif
@@ -106,7 +106,7 @@ bool MomentumEventDispatcher::handleWheelEvent(WebCore::PageIdentifier pageIdent
         }
     }
 
-    if (event.phase() == WebWheelEvent::PhaseBegan || event.phase() == WebWheelEvent::PhaseChanged) {
+    if (event.phase() == WebWheelEvent::Phase::Began || event.phase() == WebWheelEvent::Phase::Changed) {
         didReceiveScrollEvent(event);
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
@@ -125,7 +125,7 @@ bool MomentumEventDispatcher::handleWheelEvent(WebCore::PageIdentifier pageIdent
     // is still running after we finished the synthetic gesture.
     bool shouldIgnoreIncomingPlatformEvent = isMomentumEvent && (m_isInOverriddenPlatformMomentumGesture || m_currentGesture.active);
 
-    if (event.momentumPhase() == WebWheelEvent::PhaseEnded)
+    if (event.momentumPhase() == WebWheelEvent::Phase::Ended)
         m_isInOverriddenPlatformMomentumGesture = false;
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
@@ -185,7 +185,7 @@ void MomentumEventDispatcher::dispatchSyntheticMomentumEvent(WebWheelEvent::Phas
         wheelTicks,
         WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
         initiatingEvent->directionInvertedFromDevice(),
-        WebWheelEvent::PhaseNone,
+        WebWheelEvent::Phase::None,
         phase,
         true,
         initiatingEvent->scrollCount(),
@@ -231,14 +231,14 @@ void MomentumEventDispatcher::didStartMomentumPhase(WebCore::PageIdentifier page
         consumedDelta.scale(-1);
     m_currentGesture.currentOffset += consumedDelta;
     
-    dispatchSyntheticMomentumEvent(WebWheelEvent::PhaseBegan, event.delta());
+    dispatchSyntheticMomentumEvent(WebWheelEvent::Phase::Began, event.delta());
 }
 
 void MomentumEventDispatcher::didEndMomentumPhase()
 {
     ASSERT(m_currentGesture.active);
 
-    dispatchSyntheticMomentumEvent(WebWheelEvent::PhaseEnded, { });
+    dispatchSyntheticMomentumEvent(WebWheelEvent::Phase::Ended, { });
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher ending synthetic momentum phase with total offset %.1f %.1f, duration %f (event offset would have been %.1f %.1f) (tail index %d of %zu)", m_currentGesture.currentOffset.width(), m_currentGesture.currentOffset.height(), (MonotonicTime::now() - m_currentGesture.startTime).seconds(), m_currentGesture.accumulatedEventOffset.width(), m_currentGesture.accumulatedEventOffset.height(), m_currentGesture.currentTailDeltaIndex, m_currentGesture.tailDeltaTable.size());
@@ -369,7 +369,7 @@ void MomentumEventDispatcher::displayDidRefresh(WebCore::PlatformDisplayID displ
         return;
     }
 
-    dispatchSyntheticMomentumEvent(WebWheelEvent::PhaseChanged, *delta);
+    dispatchSyntheticMomentumEvent(WebWheelEvent::Phase::Changed, *delta);
 }
 
 void MomentumEventDispatcher::didReceiveScrollEventWithInterval(WebCore::FloatSize size, Seconds frameInterval)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3796,7 +3796,7 @@ void WebPage::dispatchWheelEventWithoutScrolling(FrameIdentifier frameID, const 
 #if ENABLE(KINETIC_SCROLLING)
     RefPtr localMainFrame = this->localMainFrame();
     auto gestureState =  localMainFrame ? localMainFrame->eventHandler().wheelScrollGestureState() : std::nullopt;
-    bool isCancelable = !gestureState || gestureState == WheelScrollGestureState::Blocking || wheelEvent.phase() == WebWheelEvent::PhaseBegan;
+    bool isCancelable = !gestureState || gestureState == WheelScrollGestureState::Blocking || wheelEvent.phase() == WebWheelEvent::Phase::Began;
 #else
     bool isCancelable = true;
 #endif


### PR DESCRIPTION
#### eaadc438d48abeeda3418f39954398f48667e076
<pre>
Wheel event phase enum types should be scoped
<a href="https://bugs.webkit.org/show_bug.cgi?id=302150">https://bugs.webkit.org/show_bug.cgi?id=302150</a>
<a href="https://rdar.apple.com/164242357">rdar://164242357</a>

Reviewed by Michael Catanzaro.

Namely, WebCore::PlatformWheelEventGranularity and
WebKit::WebWheelEvent::Granularity. When they are unscoped, it is easy
to confuse between the identically named cases.

This is a mostly mechanical patch that s/&apos;enum&apos;/&apos;enum class&apos; on said
types. We also store the event/momentum phases as `Phase` values,
rather than as uint32_t values.

One implication of this patch is that we no longer declare the enum
cases as flags. We were doing this prior to the patch, but the enum was
not being used as an option set anywhere, and hence it was unnecessary
to do so.

No new tests because no change in functionality.

* Source/WebCore/platform/PlatformWheelEvent.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::platform):
(WebKit::WebKit2PlatformWheelEvent::WebKit2PlatformWheelEvent):
* Source/WebKit/Shared/WebWheelEvent.h:
(WebKit::WebWheelEvent::phase const):
(WebKit::WebWheelEvent::momentumPhase const):
(WebKit::WebWheelEvent::isMomentumEvent const):
* Source/WebKit/Shared/WebWheelEventCoalescer.cpp:
(WebKit::WebWheelEventCoalescer::shouldDispatchEventNow const):
* Source/WebKit/Shared/ios/WebIOSEventFactory.mm:
(WebKit::toWebPhase):
(WebKit::WebIOSEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::phaseForEvent):
(WebKit::momentumPhaseForEvent):
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp:
(WKPageHandleWheelEvent):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::wheelEventWasNotHandledByWebCore):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseScrollEvent):
(handleScroll):
(toWebKitWheelEventPhase):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollView:handleScrollUpdate:completion:]):
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp:
(WebKit::TouchGestureController::handleEvent):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp:
(WKWPE::ViewLegacy::ViewLegacy):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::handleGesture):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve):
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueWheelEventHandling):
(WebKit::WebPageProxy::cacheWheelEventScrollingAccelerationCurve):
(WebKit::WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::eventShouldStartSyntheticMomentumPhase const):
(WebKit::MomentumEventDispatcher::handleWheelEvent):
(WebKit::MomentumEventDispatcher::dispatchSyntheticMomentumEvent):
(WebKit::MomentumEventDispatcher::didStartMomentumPhase):
(WebKit::MomentumEventDispatcher::didEndMomentumPhase):
(WebKit::MomentumEventDispatcher::displayDidRefresh):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::dispatchWheelEventWithoutScrolling):

Canonical link: <a href="https://commits.webkit.org/302823@main">https://commits.webkit.org/302823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad8a8815bdc9811340bc8cdea0d96bc3f1750b27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81884 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5d8a3f71-1323-4835-9702-78737d44e883) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99275 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87c53f30-aa2f-4e30-84ed-b3e905445986) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133257 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1902 "Found 1 new test failure: http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79970 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ecf873f-8cc5-4772-bca0-0f8024de480b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80987 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140205 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107793 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107692 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31483 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55325 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20314 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2441 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65828 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2367 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->