### PR TITLE
[Tools][GTK] Performance tests fail if WebKitTestRunner prints something in stderr

### DIFF
--- a/Tools/Scripts/webkitpy/performance_tests/perftest.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftest.py
@@ -266,10 +266,12 @@ class PerfTest(object):
         re.compile(r'com\.apple\.WebKit\.WebContent\.Development\[\d+:\d+\]\s+CoreText note:.+')
     ]
 
-    _errors_to_ignore_in_gtk = [
+    _errors_to_ignore_in_glib = [
         re.compile(r"^libEGL"),
         re.compile(r"^vulkan:"),
         re.compile(r"^Note:"),
+        re.compile(r"^MESA"),
+        re.compile(r"^[0-9:.]+\s.+0x[0-9A-Fa-f]+\s.+msdkcontext")
     ]
 
     def _filter_output(self, output):
@@ -280,8 +282,8 @@ class PerfTest(object):
                 output.error = self.filter_ignored_lines(self._errors_to_ignore_in_sierra, output.error)
             if self._port.name().startswith('mac-sequoia'):
                 output.error = self.filter_ignored_lines(self._errors_to_ignore_in_sequoia, output.error)
-            if self._port.name().startswith('gtk'):
-                output.error = self.filter_ignored_lines(self._errors_to_ignore_in_gtk, output.error)
+            if self._port.name().startswith('gtk') or self._port.name().startswith('wpe'):
+                output.error = self.filter_ignored_lines(self._errors_to_ignore_in_glib, output.error)
 
 
 class SingleProcessPerfTest(PerfTest):


### PR DESCRIPTION
#### e7d54af3a41ef4653db12554e5b3eb20250b1f87
<pre>
[Tools][GTK] Performance tests fail if WebKitTestRunner prints something in stderr
<a href="https://bugs.webkit.org/show_bug.cgi?id=302152">https://bugs.webkit.org/show_bug.cgi?id=302152</a>

Reviewed by Fujii Hironori.

Since we migrated to the new SDK the GTK Performance bot has been failing
all the performance tests in the step `perf-test` because there are some
Mesa related warnings printed and the tooling is marking as failed any
test that has stderr output not matching the ignore filters.

So ignore this warnings by adding them to the list of filters, and also
share the list with the WPE port.

* Tools/Scripts/webkitpy/performance_tests/perftest.py:
(PerfTest):

Canonical link: <a href="https://commits.webkit.org/302728@main">https://commits.webkit.org/302728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d643a3e1c3549839f96b4106b76c35050a49e4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79734 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/129363 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34572 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80679 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139887 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1915 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107435 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54898 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20283 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2141 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->