### PR TITLE
[blocks-in-inline] fast/inline/continuation-with-anon-wrappers.html fails

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-split-table-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-split-table-expected.html
@@ -1,0 +1,11 @@
+<style>
+.cell { display: table-cell }
+</style>
+<div class=cell>a</div>
+<div id=t class=cell>b</div>
+<div class=cell>c</div>
+<script>
+document.body.offsetLeft;
+t.classList.remove("cell");
+</script>
+

--- a/LayoutTests/fast/inline/blocks-in-inline-split-table.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-split-table.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<style>
+.cell { display: table-cell }
+</style>
+<div class=cell>a</div>
+<div id=t class=cell>b</div>
+<div class=cell>c</div>
+<script>
+document.body.offsetLeft;
+t.classList.remove("cell");
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -783,7 +783,7 @@ void RenderTreeBuilder::createAnonymousWrappersForInlineContent(RenderBlock& par
     parent.repaint();
 }
 
-RenderObject* RenderTreeBuilder::splitAnonymousBoxesAroundChild(RenderBox& parent, RenderObject& originalBeforeChild)
+RenderObject* RenderTreeBuilder::splitAnonymousBoxesAroundChild(RenderBoxModelObject& parent, RenderObject& originalBeforeChild)
 {
     // Adjust beforeChild if it is a column spanner and has been moved out of its original position.
     auto* beforeChild = RenderTreeBuilder::MultiColumn::adjustBeforeChildForMultiColumnSpannerIfNeeded(originalBeforeChild);
@@ -799,7 +799,7 @@ RenderObject* RenderTreeBuilder::splitAnonymousBoxesAroundChild(RenderBox& paren
             auto newPostBox = createAnonymousBoxWithSameTypeAndWithStyle(boxToSplit, parent.style());
             auto& postBox = *newPostBox;
             postBox.setChildrenInline(boxToSplit.childrenInline());
-            RenderBox* parentBox = downcast<RenderBox>(boxToSplit.parent());
+            auto* parentBox = downcast<RenderBoxModelObject>(boxToSplit.parent());
             // We need to invalidate the |parentBox| before inserting the new node
             // so that the table repainting logic knows the structure is dirty.
             // See for example RenderTableCell:clippedOverflowRectForRepaint.
@@ -1124,7 +1124,7 @@ void RenderTreeBuilder::reportVisuallyNonEmptyContent(const RenderElement& paren
     }
 }
 
-void RenderTreeBuilder::markBoxForRelayoutAfterSplit(RenderBox& box)
+void RenderTreeBuilder::markBoxForRelayoutAfterSplit(RenderBoxModelObject& box)
 {
     // FIXME: The table code should handle that automatically. If not,
     // we should fix it and remove the table part checks.

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -71,7 +71,7 @@ public:
     bool hasBrokenContinuation() const { return m_hasBrokenContinuation; }
 
 private:
-    static void markBoxForRelayoutAfterSplit(RenderBox&);
+    static void markBoxForRelayoutAfterSplit(RenderBoxModelObject&);
 
     void attachInternal(RenderElement& parent, RenderPtr<RenderObject>, RenderObject* beforeChild);
 
@@ -96,7 +96,7 @@ private:
 
     void removeFloatingObjects(RenderBlock&);
 
-    RenderObject* splitAnonymousBoxesAroundChild(RenderBox& parent, RenderObject& originalBeforeChild);
+    RenderObject* splitAnonymousBoxesAroundChild(RenderBoxModelObject& parent, RenderObject& originalBeforeChild);
     void createAnonymousWrappersForInlineContent(RenderBlock& parent, RenderObject* insertionPoint = nullptr);
     void removeAnonymousWrappersForInlineChildrenIfNeeded(RenderElement& parent);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -214,6 +214,12 @@ void RenderTreeBuilder::Inline::attachIgnoringContinuation(RenderInline& parent,
         return;
     }
 
+    if (!m_buildsContinuations) {
+        // In blocks-in-inline case we allow blocks that may need splitting.
+        if (beforeChild && beforeChild->parent() != &parent)
+            beforeChild = m_builder.splitAnonymousBoxesAroundChild(parent, *beforeChild);
+    }
+
     auto& childToAdd = *child;
     m_builder.attachToRenderElement(parent, WTFMove(child), beforeChild);
     childToAdd.setNeedsLayoutAndPreferredWidthsUpdate();


### PR DESCRIPTION
#### 119afc56994d8c4e39f7b0636f7f343d44a95b40
<pre>
[blocks-in-inline] fast/inline/continuation-with-anon-wrappers.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=302155">https://bugs.webkit.org/show_bug.cgi?id=302155</a>
<a href="https://rdar.apple.com/164251236">rdar://164251236</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-split-table.html
* LayoutTests/fast/inline/blocks-in-inline-split-table-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-split-table.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::splitAnonymousBoxesAroundChild):

Parent is no longer always a block.

(WebCore::RenderTreeBuilder::markBoxForRelayoutAfterSplit):
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::attachIgnoringContinuation):

With blocks-in-inline beforeChild may be inside an anonymous block that needs to be split.
Call splitAnonymousBoxesAroundChild if needed.

Canonical link: <a href="https://commits.webkit.org/302725@main">https://commits.webkit.org/302725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4418c9192b7d47409ada1776cd6ac49177c73e5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81515 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/624aa847-548c-469c-a526-984339b2fc88) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99032 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b03d2f6-0277-4d14-b2ec-c61499cb678a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132955 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79732 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0dabe199-a59f-48e1-badb-1163197557ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34569 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80674 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139882 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1910 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27346 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31247 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54887 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65505 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1952 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1985 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2059 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->