### PR TITLE
[threaded-animations] fully accelerated scroll-driven animations should not update styles while scrolling

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/scroll-animation-style-updates-while-scrolling-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-animation-style-updates-while-scrolling-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Style updates of a scroll-driven animation happen selectively depending on the acceleration statuts.
+

--- a/LayoutTests/webanimations/threaded-animations/scroll-animation-style-updates-while-scrolling.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-animation-style-updates-while-scrolling.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const scroll = async (scroller, progress) => {
+    const maxScrollTop = scroller.scrollHeight - window.innerHeight;
+    const scrollTop = progress * maxScrollTop;
+    window.scrollTo(0, scrollTop);
+    await UIHelper.renderingUpdate();
+};
+
+promise_test(async t => { 
+    const scroller = document.documentElement;
+    const timeline = new ScrollTimeline({ source : scroller });
+
+    const animations = {
+        unaccelerated: target.animate({ marginLeft: "100px" }, { timeline }),
+        partiallyAccelerated: target.animate({ marginLeft: "100px", rotate: "90deg" }, { timeline }),
+        completelyAccelerated: target.animate({ translate: "100px" }, { timeline })
+    };
+
+    await animationAcceleration(animations.completelyAccelerated);
+
+    const styleUpdates = () => {
+        return {
+            unaccelerated: internals?.numberOfAnimationStyleUpdates(animations.unaccelerated),
+            partiallyAccelerated: internals?.numberOfAnimationStyleUpdates(animations.partiallyAccelerated),
+            completelyAccelerated: internals?.numberOfAnimationStyleUpdates(animations.completelyAccelerated)
+        }
+    };
+
+    const before = styleUpdates();
+
+    await scroll(scroller, 0);
+    await scroll(scroller, 0.5);
+    await scroll(scroller, 0.25);
+    await scroll(scroller, 0.75);
+
+    const after = styleUpdates();
+
+    assert_not_equals(before.unaccelerated, after.unaccelerated, "A scroll-driven animation that is not accelerated updates its style while scrolling");
+    assert_not_equals(before.partiallyAccelerated, after.partiallyAccelerated, "A scroll-driven animation that is partially accelerated updates its style while scrolling");
+    assert_equals(before.completelyAccelerated, after.completelyAccelerated, "A scroll-driven animation that is completely accelerated updates its style while scrolling");
+}, "Style updates of a scroll-driven animation happen selectively depending on the acceleration statuts.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1621,6 +1621,11 @@ OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const
     if (!m_target)
         return impact;
 
+#if ENABLE(THREADED_ANIMATIONS)
+    if (m_acceleratedRepresentation && isCompletelyAccelerated())
+        return impact;
+#endif
+
     updateBlendingKeyframes(targetStyle, resolutionContext);
 
     auto computedTiming = getComputedTiming(UseCachedCurrentTime::Yes, endpointInclusiveActiveInterval);
@@ -1638,6 +1643,7 @@ OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const
 
     ASSERT(computedTiming.currentIteration);
     setAnimatedPropertiesInStyle(targetStyle, computedTiming);
+    m_numberOfStyleUpdatesForTesting++;
     return impact;
 }
 

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -195,6 +195,8 @@ public:
 
     WebAnimationType animationType() const { return m_animationType; }
 
+    unsigned numberOfStyleUpdatesForTesting() const { return m_numberOfStyleUpdatesForTesting; }
+
 #if ENABLE(THREADED_ANIMATIONS)
     const AcceleratedEffect* acceleratedRepresentation() const { return m_acceleratedRepresentation.get(); }
     void setAcceleratedRepresentation(const AcceleratedEffect* acceleratedRepresentation) { m_acceleratedRepresentation = acceleratedRepresentation; }
@@ -332,6 +334,7 @@ private:
     bool m_animatesSizeAndSizeDependentTransform { false };
     bool m_isAssociatedWithProgressBasedTimeline { false };
     bool m_needsComputedKeyframeOffsetsUpdate { false };
+    unsigned m_numberOfStyleUpdatesForTesting { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -85,7 +85,7 @@ public:
     virtual void setBindingsEffect(RefPtr<AnimationEffect>&&);
     AnimationEffect* effect() const { return m_effect.get(); }
     void setEffect(RefPtr<AnimationEffect>&&);
-    KeyframeEffect* keyframeEffect() const;
+    WEBCORE_EXPORT KeyframeEffect* keyframeEffect() const;
 
     virtual AnimationTimeline* bindingsTimeline() const { return timeline(); }
     virtual void setBindingsTimeline(RefPtr<AnimationTimeline>&&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -144,6 +144,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSFile.h"
 #include "JSInternals.h"
+#include "KeyframeEffect.h"
 #include "LegacySchemeRegistry.h"
 #include "LoaderStrategy.h"
 #include "LocalDOMWindow.h"
@@ -1447,6 +1448,13 @@ unsigned Internals::numberOfAnimationTimelineInvalidations() const
 {
     RefPtr localFrame = frame();
     return localFrame ? localFrame->document()->timeline().numberOfAnimationTimelineInvalidationsForTesting() : 0;
+}
+
+unsigned Internals::numberOfAnimationStyleUpdates(const WebAnimation& animation) const
+{
+    if (RefPtr effect = Ref { animation }->keyframeEffect())
+        return effect->numberOfStyleUpdatesForTesting();
+    return 0;
 }
 
 double Internals::timeToNextAnimationTick(WebAnimation& animation) const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -324,6 +324,7 @@ public:
     };
     Vector<AcceleratedAnimation> acceleratedAnimationsForElement(Element&);
     unsigned numberOfAnimationTimelineInvalidations() const;
+    unsigned numberOfAnimationStyleUpdates(const WebAnimation&) const;
     double timeToNextAnimationTick(WebAnimation&) const;
 
     // For animations testing, we need a way to get at pseudo elements.

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -565,6 +565,7 @@ enum ContentsFormat {
     // Web Animations testing.
     sequence<AcceleratedAnimation> acceleratedAnimationsForElement(Element element);
     unsigned long numberOfAnimationTimelineInvalidations();
+    unsigned long numberOfAnimationStyleUpdates(WebAnimation effect);
     double timeToNextAnimationTick(WebAnimation animation);
 
     // For animations testing, we need a way to get at pseudo elements.


### PR DESCRIPTION
#### 6a2b2f826ff34c5bb99348cc339a1381bc4f93f0
<pre>
[threaded-animations] fully accelerated scroll-driven animations should not update styles while scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=302156">https://bugs.webkit.org/show_bug.cgi?id=302156</a>
<a href="https://rdar.apple.com/164253776">rdar://164253776</a>

Reviewed by NOBODY (OOPS!).

When a scroll-driven animation only affects properties that can be animated in the remote layer tree,
we must make sure not to update styles on the main thread in the web process as scrolling occurs.

To check that is indeed the case, we add a counter that tracks the number of times `KeyframeEffect::apply()`
is called and expose it through the `internals` testing object.

Test: webanimations/threaded-animations/scroll-animation-style-updates-while-scrolling.html

* LayoutTests/webanimations/threaded-animations/scroll-animation-style-updates-while-scrolling-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-animation-style-updates-while-scrolling.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::apply):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::numberOfAnimationStyleUpdates const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a2b2f826ff34c5bb99348cc339a1381bc4f93f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81520 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3610d51c-0f73-4ad3-b9eb-4c15cf9e927b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66843 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/546ebe0a-0a99-4c72-8110-61e6dbe6d263) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79736 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4eb2b84f-4546-449e-a537-ae98d9f9531a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34574 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80678 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139886 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107541 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107434 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31252 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54897 "Hash 6a2b2f82 for PR 53588 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2140 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65509 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1956 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->