### PR TITLE
[threaded-animations] scroll-driven animations should remain in the remote layer tree even at 100% progress

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
@@ -59,6 +59,7 @@ promise_test(async t => {
 
     await scrollAndCheckTimeline(scroller, 0);
     await scrollAndCheckTimeline(scroller, 0.5);
+    await scrollAndCheckTimeline(scroller, 1);
     await scrollAndCheckTimeline(scroller, 0.25);
     await scrollAndCheckTimeline(scroller, 0.75);
 }, "The timeline current time updates as its source is scrolled with a nested scroller");

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
@@ -53,6 +53,7 @@ promise_test(async t => {
 
     await scrollAndCheckTimeline(scroller, 0);
     await scrollAndCheckTimeline(scroller, 0.5);
+    await scrollAndCheckTimeline(scroller, 1);
     await scrollAndCheckTimeline(scroller, 0.25);
     await scrollAndCheckTimeline(scroller, 0.75);
 }, "The timeline current time updates as its source is scrolled with a root scroller");

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1647,9 +1647,11 @@ bool KeyframeEffect::isRunningAccelerated() const
     if (threadedAnimationsEnabled()) {
         if (!m_inTargetEffectStack || !canBeAccelerated())
             return false;
-        RefPtr animation = this->animation();
-        ASSERT(animation);
-        return !animation->isSuspended() && animation->playState() == WebAnimation::PlayState::Running;
+        ASSERT(animation());
+        Ref animation = *this->animation();
+        if (animation->isSuspended())
+            return false;
+        return m_isAssociatedWithProgressBasedTimeline || animation->playState() == WebAnimation::PlayState::Running;
     }
 #endif
     return m_runningAccelerated == RunningAccelerated::Yes;


### PR DESCRIPTION
#### b504d00848ba28dc6796db4219fe67af932acb50
<pre>
[threaded-animations] scroll-driven animations should remain in the remote layer tree even at 100% progress
<a href="https://bugs.webkit.org/show_bug.cgi?id=302157">https://bugs.webkit.org/show_bug.cgi?id=302157</a>
<a href="https://rdar.apple.com/164255640">rdar://164255640</a>

Reviewed by Simon Fraser.

Scroll-driven animations are currently removed from the remote layer tree once they reach 100% as at
that point they are in the finished play state [0]. It makes sense to remove monotonic animations once
they&apos;re in the finished state as they won&apos;t naturally progress out of that state, but progress-based
animations may return to the running [1] state by virtue of the scroll position of the timeline&apos;s source
moving backwards.

To address this we add an additional condition in `KeyframeEffect::isRunningAccelerated()` such that
effects associated with an animation associated with a progress-based timeline are always considered
to be running as far as acceleration is concerned.

We also update existing tests to scroll to a location where 100% progress would be reached and check
that a remote layer tree animation is still present. Previously, these tests would have failed.

[0] <a href="https://drafts.csswg.org/web-animations-1/#play-state-finished">https://drafts.csswg.org/web-animations-1/#play-state-finished</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#play-state-running">https://drafts.csswg.org/web-animations-1/#play-state-running</a>

* LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html:
* LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::isRunningAccelerated const):

Canonical link: <a href="https://commits.webkit.org/302729@main">https://commits.webkit.org/302729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d70a789ae66e99c9de3cf05b86dd7f734f36546b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81529 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/78004646-01f6-48a1-bc46-b57548b27a7e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/82b88785-6198-4776-ab22-ada51f24d500) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79738 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2856defc-5d44-4148-b605-951993a7e597) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34573 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80682 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139890 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107437 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31251 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54902 "Hash d70a789a for PR 53589 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20284 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65513 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1960 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1993 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->