### PR TITLE
[JSC] GreedyRegAlloc: adjust the spill cost heuristic

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -46,6 +46,7 @@ namespace JSC { namespace B3 { namespace Air {
     macro(numStoreSpill)                        \
     macro(numMoveSpillSpillInsts)               \
     macro(numRematerializeConst)                \
+    macro(maxLiveRangeSize)                     \
 
 class AirAllocateRegistersStats {
     WTF_MAKE_NONCOPYABLE(AirAllocateRegistersStats);


### PR DESCRIPTION
#### d95cccd380319456aeb26450070e32b897e14c05
<pre>
[JSC] GreedyRegAlloc: adjust the spill cost heuristic
<a href="https://bugs.webkit.org/show_bug.cgi?id=302159">https://bugs.webkit.org/show_bug.cgi?id=302159</a>
<a href="https://rdar.apple.com/164259068">rdar://164259068</a>

Reviewed by Keith Miller and Yusuke Suzuki.

The spillCostSizeBias parameter had the wrong type, causing it to
always be 1 when the intention was for it to be 1000. Regardless,
both 1 and 1000 perform similarly and are too small.

It&apos;s better to decrease the influence of the live range size (which
is the sum of the distances of the intervals that make up the range)
since this is just a crude approximation for the degree of interference.

Also, add a new register allocator metric that helped guide the
selection of this value.

Tests: covered by existing JSC tests
Canonical link: <a href="https://commits.webkit.org/302735@main">https://commits.webkit.org/302735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25f43acdbcb14878c57e2d2c8ff6a28eacb41397

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81534 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/03aaf28f-4291-4e7f-b835-a2f67a2d7fb2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99045 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80999586-7039-40b1-80d7-62ba1fda2d05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132970 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79745 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5751ec96-28a1-4323-93e6-c5bc1d75d429) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34584 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80689 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122015 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139897 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128475 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1925 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107552 "Found 1 new test failure: http/wpt/mediastream/getDisplayMedia-deviceid-persistency.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107445 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1656 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54909 "Hash 25f43acd for PR 53591 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20285 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65520 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161489 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1967 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40252 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2000 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->