### PR TITLE
[MSE][GStreamer] Early reset m_isEndReached (EOS) when about to seek

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -174,6 +174,13 @@ void MediaPlayerPrivateGStreamerMSE::pause()
     player->playbackStateChanged();
 }
 
+void MediaPlayerPrivateGStreamerMSE::willSeekToTarget(const MediaTime& time)
+{
+    MediaPlayerPrivateInterface::willSeekToTarget(time);
+    // Don't consider the stream as EOS anymore after a seek.
+    m_isEndReached = false;
+}
+
 void MediaPlayerPrivateGStreamerMSE::checkPlayingConsistency()
 {
     MediaPlayerPrivateGStreamer::checkPlayingConsistency();

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -56,6 +56,7 @@ public:
 
     void play() override;
     void pause() override;
+    void willSeekToTarget(const MediaTime&) override;
     void seekToTarget(const SeekTarget&) override;
     bool doSeek(const SeekTarget&, float rate, bool isAsync = false) override;
 


### PR DESCRIPTION
#### 4b36b57f526142f82a46e3ca116a25454e7b73e3
<pre>
[MSE][GStreamer] Early reset m_isEndReached (EOS) when about to seek
<a href="https://bugs.webkit.org/show_bug.cgi?id=302160">https://bugs.webkit.org/show_bug.cgi?id=302160</a>

Reviewed by Alicia Boya Garcia.

This specific issue related to seek after EOS was seen downstream:

1. EOS is reached: m_isEndReached becomes true. HTMLMediaElement marks
   itself as paused. It also transitions to HaveCurrentData as a result
   of the EOS, which pauses the GStreamer pipeline.

2. Seek from JS occurs: A seek in HTMLMediaElement coming from the DOM
   does the following:

2.1. Synchronously sets m_lastSeekTime (which is read by
     MediaSource::currentTime()).

2.2. Synchronously calls MediaPlayerPrivate::willSeekToTarget().

2.3. Schedules an asynchronous call to
     MediaPlayerPrivate::seekToTarget() which hasn&apos;t happened yet.

3. monitorSourceBuffers() notices the new currentTime (i.e. the seek
   target time) is in the buffered ranges and therefore upgrades ready
   state to HaveEnoughData:

   The GStreamer player reacts and the pipeline is now set to PLAYING,
   but critically, because m_isEndReached hasn&apos;t been reset yet,
   paused() returns still true.

   From now on until the completion of the seek we are in an invalid
   state where the multiplatform code will (reasonably) assume its
   request to play has been honored and that the if our player is
   paused, that has been intentionally done for some platform specific
   reason, which it will try to synchronize to, preventing playback from
   resuming.

   Clearing m_isEndReached synchronously fixes the race.

This change resets m_isEndReached as soon as possible (on
willSeekToTarget()), so the seek can happen.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1568#issuecomment-3448502697">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1568#issuecomment-3448502697</a>

* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::willSeekToTarget): Reset m_isEndReached as soon as we know that a seek will happen.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h: Override willSeekToTarget().

Canonical link: <a href="https://commits.webkit.org/303186@main">https://commits.webkit.org/303186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4addea8504b3f15d85511b50bff1a3cc156943f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139129 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100484 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134566 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81292 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108859 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109103 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2800 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56901 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32539 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67168 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->