### PR TITLE
Implement JSC-YarrJIT: /<script|<style|<link/i in c++

### DIFF
--- a/LayoutTests/fast/regex/html-tag-test-expected.txt
+++ b/LayoutTests/fast/regex/html-tag-test-expected.txt
@@ -1,0 +1,39 @@
+This test checks the SIMD-optimized HTML tag pattern for correctness
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS htmlTagPattern.test("<script>alert(1)</script>") is true
+PASS htmlTagPattern.test("<SCRIPT>code</SCRIPT>") is true
+PASS htmlTagPattern.test("<style>css</style>") is true
+PASS htmlTagPattern.test("<STYLE>CSS</STYLE>") is true
+PASS htmlTagPattern.test("<link rel=\"stylesheet\">") is true
+PASS htmlTagPattern.test("<LINK href=\"file\">") is true
+PASS htmlTagPattern.test("<sCrIpT>mixed case</sCrIpT>") is true
+PASS htmlTagPattern.test("Just plain text") is false
+PASS htmlTagPattern.test("<div><span>") is false
+PASS htmlTagPattern.test("script without bracket") is false
+PASS htmlTagPattern.test("") is false
+PASS htmlTagPatternCaseSensitive.test("<script>code</script>") is true
+PASS htmlTagPatternCaseSensitive.test("<style>css</style>") is true
+PASS htmlTagPatternCaseSensitive.test("<link>") is true
+PASS htmlTagPatternCaseSensitive.test("<SCRIPT>") is false
+PASS htmlTagPatternCaseSensitive.test("<STYLE>") is false
+PASS htmlTagPatternCaseSensitive.test("<LINK>") is false
+PASS htmlTagPattern.test("<script>at start") is true
+PASS htmlTagPattern.test("at end<script>") is true
+PASS htmlTagPattern.test("in<script>middle") is true
+PASS htmlTagPattern.test(longStringWithTag) is true
+PASS htmlTagPattern.test(longStringNoMatch) is false
+PASS pattern8Tags.test("<div>") is true
+PASS pattern8Tags.test("<li>") is true
+PASS pattern8Tags.test("<h1>") is false
+PASS patternAlphanumeric.test("<h2test>") is true
+PASS patternAlphanumeric.test("<h2>") is false
+PASS patternLongTag.test("<script>") is true
+PASS patternLongTag.test("<verylongtagnameover16chars>") is true
+PASS patternLongTag.test("<style>") is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/regex/html-tag-test.html
+++ b/LayoutTests/fast/regex/html-tag-test.html
@@ -1,0 +1,3 @@
+<!DOCTYPE HTML>
+<script src='../../resources/js-test.js'></script>
+<script src="script-tests/html-tag-test.js"></script>

--- a/LayoutTests/fast/regex/script-tests/html-tag-test.js
+++ b/LayoutTests/fast/regex/script-tests/html-tag-test.js
@@ -1,0 +1,48 @@
+description(
+"This test checks the SIMD-optimized HTML tag pattern for correctness"
+);
+
+var htmlTagPattern = /<script|<style|<link/i;
+var htmlTagPatternCaseSensitive = /<script|<style|<link/;
+
+shouldBeTrue('htmlTagPattern.test("<script>alert(1)</script>")');
+shouldBeTrue('htmlTagPattern.test("<SCRIPT>code</SCRIPT>")');
+shouldBeTrue('htmlTagPattern.test("<style>css</style>")');
+shouldBeTrue('htmlTagPattern.test("<STYLE>CSS</STYLE>")');
+shouldBeTrue('htmlTagPattern.test("<link rel=\\"stylesheet\\">")');
+shouldBeTrue('htmlTagPattern.test("<LINK href=\\"file\\">")');
+shouldBeTrue('htmlTagPattern.test("<sCrIpT>mixed case</sCrIpT>")');
+shouldBeFalse('htmlTagPattern.test("Just plain text")');
+shouldBeFalse('htmlTagPattern.test("<div><span>")');
+shouldBeFalse('htmlTagPattern.test("script without bracket")');
+shouldBeFalse('htmlTagPattern.test("")');
+
+shouldBeTrue('htmlTagPatternCaseSensitive.test("<script>code</script>")');
+shouldBeTrue('htmlTagPatternCaseSensitive.test("<style>css</style>")');
+shouldBeTrue('htmlTagPatternCaseSensitive.test("<link>")');
+shouldBeFalse('htmlTagPatternCaseSensitive.test("<SCRIPT>")');
+shouldBeFalse('htmlTagPatternCaseSensitive.test("<STYLE>")');
+shouldBeFalse('htmlTagPatternCaseSensitive.test("<LINK>")');
+
+shouldBeTrue('htmlTagPattern.test("<script>at start")');
+shouldBeTrue('htmlTagPattern.test("at end<script>")');
+shouldBeTrue('htmlTagPattern.test("in<script>middle")');
+
+var longStringWithTag = 'x'.repeat(1000) + '<script>' + 'y'.repeat(1000);
+shouldBeTrue('htmlTagPattern.test(longStringWithTag)');
+var longStringNoMatch = 'a'.repeat(10000);
+shouldBeFalse('htmlTagPattern.test(longStringNoMatch)');
+
+var pattern8Tags = /<div|<span|<p|<a|<img|<br|<ul|<li/i;
+shouldBeTrue('pattern8Tags.test("<div>")');
+shouldBeTrue('pattern8Tags.test("<li>")');
+shouldBeFalse('pattern8Tags.test("<h1>")');
+
+var patternAlphanumeric = /<h1|<h2test|<div3/i;
+shouldBeTrue('patternAlphanumeric.test("<h2test>")');
+shouldBeFalse('patternAlphanumeric.test("<h2>")');
+
+var patternLongTag = /<verylongtagnameover16chars|<script/i;
+shouldBeTrue('patternLongTag.test("<script>")');
+shouldBeTrue('patternLongTag.test("<verylongtagnameover16chars>")');
+shouldBeFalse('patternLongTag.test("<style>")');

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -165,6 +165,7 @@ void RegExp::finishCreation(VM& vm)
     }
 
     m_atom = WTFMove(pattern.m_atom);
+    m_tagInfo = pattern.m_tagInfo;
     m_specificPattern = pattern.m_specificPattern;
 
     m_numSubpatterns = pattern.m_numSubpatterns;
@@ -227,6 +228,7 @@ void RegExp::byteCodeCompileIfNecessary(VM* vm)
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
     m_atom = WTFMove(pattern.m_atom);
+    m_tagInfo = pattern.m_tagInfo;
     m_specificPattern = pattern.m_specificPattern;
 
     m_regExpBytecode = byteCodeCompilePattern(vm, pattern, m_constructionErrorCode);
@@ -248,6 +250,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
     m_atom = WTFMove(pattern.m_atom);
+    m_tagInfo = pattern.m_tagInfo;
     m_specificPattern = pattern.m_specificPattern;
 
     if (!hasCode()) {
@@ -316,6 +319,7 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
     m_atom = WTFMove(pattern.m_atom);
+    m_tagInfo = pattern.m_tagInfo;
     m_specificPattern = pattern.m_specificPattern;
 
     if (!hasCode()) {
@@ -377,6 +381,7 @@ void RegExp::deleteCode()
         return;
     m_state = NotCompiled;
     m_atom = String();
+    m_tagInfo = std::nullopt;
     m_specificPattern = Yarr::SpecificPattern::None;
 #if ENABLE(YARR_JIT)
     if (m_regExpJITCode)

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -170,6 +170,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bool hasValidAtom() const { return !m_atom.isNull(); }
     const String& atom() const { return m_atom; }
     Yarr::SpecificPattern specificPattern() const { return m_specificPattern; }
+    const std::optional<Yarr::YarrPattern::TagInfo>& tagInfo() const { return m_tagInfo; }
 
 private:
     friend class RegExpCache;
@@ -219,6 +220,7 @@ private:
 
     String m_patternString;
     String m_atom;
+    std::optional<Yarr::YarrPattern::TagInfo> m_tagInfo;
     RegExpState m_state { NotCompiled };
     Yarr::SpecificPattern m_specificPattern { Yarr::SpecificPattern::None };
     OptionSet<Yarr::Flags> m_flags;

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -156,6 +156,68 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncTest, (JSGlobalObject* globalObject, Cal
             return throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
         auto strValue = str->value(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
+
+        // Fast path for HTML tag pattern: /<tag1|<tag2|.../[i]
+        if (regExp->regExp()->specificPattern() == Yarr::SpecificPattern::HTMLTags) {
+            const auto& tagInfoOpt = regExp->regExp()->tagInfo();
+            if (tagInfoOpt) {
+                const auto& tagInfo = *tagInfoOpt;
+                bool ignoreCase = regExp->regExp()->ignoreCase();
+
+                bool found = false;
+
+                switch (tagInfo.count) {
+                case 2:
+                    if (strValue->is8Bit())
+                        found = WTF::containsHTMLTag<2>(strValue->span8(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    else
+                        found = WTF::containsHTMLTag<2>(strValue->span16(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    break;
+                case 3:
+                    if (strValue->is8Bit())
+                        found = WTF::containsHTMLTag<3>(strValue->span8(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    else
+                        found = WTF::containsHTMLTag<3>(strValue->span16(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    break;
+                case 4:
+                    if (strValue->is8Bit())
+                        found = WTF::containsHTMLTag<4>(strValue->span8(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    else
+                        found = WTF::containsHTMLTag<4>(strValue->span16(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    break;
+                case 5:
+                    if (strValue->is8Bit())
+                        found = WTF::containsHTMLTag<5>(strValue->span8(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    else
+                        found = WTF::containsHTMLTag<5>(strValue->span16(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    break;
+                case 6:
+                    if (strValue->is8Bit())
+                        found = WTF::containsHTMLTag<6>(strValue->span8(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    else
+                        found = WTF::containsHTMLTag<6>(strValue->span16(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    break;
+                case 7:
+                    if (strValue->is8Bit())
+                        found = WTF::containsHTMLTag<7>(strValue->span8(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    else
+                        found = WTF::containsHTMLTag<7>(strValue->span16(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    break;
+                case 8:
+                    if (strValue->is8Bit())
+                        found = WTF::containsHTMLTag<8>(strValue->span8(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    else
+                        found = WTF::containsHTMLTag<8>(strValue->span16(), tagInfo.tags, tagInfo.minTagLength, ignoreCase);
+                    break;
+                default:
+                    ASSERT_NOT_REACHED();
+                    break;
+                }
+
+                return JSValue::encode(jsBoolean(found));
+            }
+        }
+
         if (!strValue->isNull() && regExp->getLastIndex().isNumber()) [[likely]]
             RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(regExp->test(globalObject, str))));
     }

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1108,6 +1108,7 @@ static ALWAYS_INLINE JSString* tryTrimSpaces(VM& vm, JSGlobalObject* globalObjec
     case Yarr::SpecificPattern::LeadingSpacesStar:
     case Yarr::SpecificPattern::Atom:
     case Yarr::SpecificPattern::Newlines:
+    case Yarr::SpecificPattern::HTMLTags:
     case Yarr::SpecificPattern::None:
         break;
     }
@@ -1292,6 +1293,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
         }
         case Yarr::SpecificPattern::Atom:
         case Yarr::SpecificPattern::Newlines:
+        case Yarr::SpecificPattern::HTMLTags:
         case Yarr::SpecificPattern::None:
             break;
         }

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -83,6 +83,7 @@ enum class SpecificPattern : uint8_t {
     TrailingSpacesStar,
     TrailingSpacesPlus,
     Newlines,
+    HTMLTags,
 };
 
 struct BytecodePattern;

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -33,6 +33,7 @@
 #include "YarrCanonicalize.h"
 #include "YarrParser.h"
 #include <limits>
+#include <wtf/ASCIICType.h>
 #include <wtf/BitSet.h>
 #include <wtf/DataLog.h>
 #include <wtf/StackCheck.h>
@@ -2186,10 +2187,10 @@ public:
             return;
         if (m_pattern.eitherUnicode())
             return;
-        if (m_pattern.ignoreCase())
-            return;
 
         auto tryExtractAtom = [&]() -> bool {
+            if (m_pattern.ignoreCase())
+                return false;
             if (m_pattern.m_containsBOL)
                 return false;
             PatternDisjunction* disjunction = m_pattern.m_body;
@@ -2226,6 +2227,8 @@ public:
         };
 
         auto tryExtractSpaces = [&]() -> bool {
+            if (m_pattern.ignoreCase())
+                return false;
             PatternDisjunction* disjunction = m_pattern.m_body;
             auto& alternatives = disjunction->m_alternatives;
             if (alternatives.size() != 1)
@@ -2354,6 +2357,8 @@ public:
 
             if (alternatives.size() != 2)
                 return false;
+            if (m_pattern.ignoreCase())
+                return false;
 
             auto isCROptionalLF = [](PatternAlternative* alternative) -> bool {
                 if (alternative->m_terms.size() != 2)
@@ -2413,6 +2418,85 @@ public:
             return false;
         };
 
+        auto tryExtractHTMLTags = [&]() -> bool {
+            // Detect pattern: /<tag1|<tag2|...|<tagN with 2-8 alternatives (case-sensitive or insensitive)
+            // Each alternative must be '<' followed by alphanumeric tag name
+            constexpr size_t MAX_HTML_TAG_ARITY = 8;
+
+            PatternDisjunction* disjunction = m_pattern.m_body;
+            auto& alternatives = disjunction->m_alternatives;
+
+            if (alternatives.size() < 2 || alternatives.size() > MAX_HTML_TAG_ARITY)
+                return false;
+
+            Vector<String> tags;
+
+            for (auto& alternative : alternatives) {
+                auto& terms = alternative->m_terms;
+
+                if (terms.isEmpty())
+                    return false;
+
+                if (terms[0].type != PatternTerm::Type::PatternCharacter)
+                    return false;
+                if (terms[0].quantityType != QuantifierType::FixedCount)
+                    return false;
+                if (terms[0].quantityMinCount != 1 || terms[0].quantityMaxCount != 1)
+                    return false;
+                if (terms[0].patternCharacter != '<')
+                    return false;
+                if (terms.size() < 2)
+                    return false;
+
+                StringBuilder tagBuilder;
+                for (size_t i = 1; i < terms.size(); ++i) {
+                    auto& term = terms[i];
+                    if (term.type != PatternTerm::Type::PatternCharacter)
+                        return false;
+                    if (term.quantityType != QuantifierType::FixedCount)
+                        return false;
+                    if (term.quantityMinCount != 1 || term.quantityMaxCount != 1)
+                        return false;
+
+                    char32_t ch = term.patternCharacter;
+
+                    if (!isASCIIAlphanumeric(ch))
+                        return false;
+
+                    ch = toASCIILower(ch);
+                    tagBuilder.append(static_cast<char>(ch));
+                }
+
+                String tag = tagBuilder.toString();
+                if (tag.isEmpty())
+                    return false;
+                if (tag.length() > 16)
+                    return false;
+
+                tags.append(tag);
+            }
+
+            YarrPattern::TagInfo info;
+            info.count = static_cast<uint8_t>(tags.size());
+            info.minTagLength = UINT8_MAX;
+
+            for (size_t i = 0; i < tags.size(); ++i) {
+                const String& tag = tags[i];
+                uint8_t tagLength = static_cast<uint8_t>(tag.length());
+                info.tags[i].length = tagLength;
+
+                for (size_t j = 0; j < tagLength && j < 16; ++j)
+                    info.tags[i].data[j] = tag[j];
+
+                if (tagLength < info.minTagLength)
+                    info.minTagLength = tagLength;
+            }
+
+            m_pattern.m_tagInfo = info;
+            m_pattern.m_specificPattern = SpecificPattern::HTMLTags;
+            return true;
+        };
+
         if (tryExtractAtom())
             return;
 
@@ -2420,6 +2504,9 @@ public:
             return;
 
         if (tryExtractNewlines())
+            return;
+
+        if (tryExtractHTMLTags())
             return;
     }
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -756,6 +756,20 @@ struct YarrPattern {
     Vector<unsigned> m_duplicateNamedGroupForSubpatternId;
     String m_atom;
 
+    struct TagInfo {
+        struct Tag {
+            char data[16];
+            uint8_t length;
+        };
+
+        uint8_t count { 0 };
+        uint8_t minTagLength { 0 };
+        Tag tags[8];
+    };
+    std::optional<TagInfo> m_tagInfo;
+
+    const std::optional<TagInfo>& tagInfo() const { return m_tagInfo; }
+
 private:
     ErrorCode compile(StringView patternString);
 

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1448,12 +1448,82 @@ inline NewlinePosition findNextNewline(std::span<const CharacterType> span, size
     return { startPosition + pos, 1 };
 }
 
+template<uint8_t TagCount, typename CharacterType, typename TagType>
+inline bool containsHTMLTag(std::span<const CharacterType> span, const TagType* tags, uint8_t minTagLength, bool ignoreCase)
+{
+    // Check if string contains any of the specified HTML tags
+    // Used to optimize RegExp test() for patterns like /<tag1|<tag2|.../[i]
+
+    if (span.size() < 1u + minTagLength)
+        return false;
+
+    using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
+
+    auto ltVector = SIMD::splat<UnsignedType>('<');
+
+    auto vectorMatch = [&](auto value) ALWAYS_INLINE_LAMBDA {
+        auto mask = SIMD::equal(value, ltVector);
+        return SIMD::findFirstNonZeroIndex(mask);
+    };
+
+    auto scalarMatch = [&](auto current) ALWAYS_INLINE_LAMBDA {
+        return current == '<';
+    };
+
+    constexpr size_t threshold = 32;
+    size_t position = 0;
+
+    while (position < span.size()) {
+        auto searchSpan = span.subspan(position);
+        auto* ptr = SIMD::find<CharacterType, threshold>(searchSpan, vectorMatch, scalarMatch);
+
+        if (ptr == searchSpan.data() + searchSpan.size())
+            return false;
+
+        size_t ltPos = ptr - searchSpan.data();
+        auto remainingSpan = searchSpan.subspan(ltPos + 1);
+
+        for (uint8_t i = 0; i < TagCount; ++i) {
+            const auto& tag = tags[i];
+            uint8_t len = tag.length;
+
+            if (remainingSpan.size() < len)
+                continue;
+
+            bool match = true;
+            if (ignoreCase) {
+                for (uint8_t j = 0; j < len; ++j) {
+                    if (toASCIILower(remainingSpan[j]) != tag.data[j]) {
+                        match = false;
+                        break;
+                    }
+                }
+            } else {
+                for (uint8_t j = 0; j < len; ++j) {
+                    if (remainingSpan[j] != tag.data[j]) {
+                        match = false;
+                        break;
+                    }
+                }
+            }
+
+            if (match)
+                return true;
+        }
+
+        position += ltPos + 1;
+    }
+
+    return false;
+}
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 }
 
 using WTF::charactersContain;
 using WTF::contains;
+using WTF::containsHTMLTag;
 using WTF::containsIgnoringASCIICase;
 using WTF::endsWith;
 using WTF::endsWithLettersIgnoringASCIICase;


### PR DESCRIPTION
#### 169ec5602ba6075891f04dd763bf9727604a79c4
<pre>
Implement JSC-YarrJIT: /&lt;script|&lt;style|&lt;link/i in c++
<a href="https://rdar.apple.com/164098885">rdar://164098885</a>

Reviewed by NOBODY (OOPS!).

Add SIMD-accelerated fast path for the more general case of
detecting HTML tags when using RegExp.prototype.test() with
the pattern /&lt;tag1|&lt;tag2|...|&lt;tag8/[i]. This pattern is commonly
used in jQuery&apos;s minified code.

* LayoutTests/fast/regex/html-tag-test-expected.txt: Added.
* LayoutTests/fast/regex/html-tag-test.html: Added.
* LayoutTests/fast/regex/script-tests/html-tag-test.js: Added.
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
(JSC::RegExp::byteCodeCompileIfNecessary):
(JSC::RegExp::compile):
(JSC::RegExp::compileMatchOnly):
(JSC::RegExp::deleteCode):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::tryTrimSpaces):
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::extractSpecificPattern):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::YarrPattern::tagInfo const):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::containsHTMLTag):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/169ec5602ba6075891f04dd763bf9727604a79c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101169 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68449 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83077 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124405 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142503 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130845 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109728 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3409 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114817 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57778 "Hash 169ec560 for PR 53593 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4556 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33183 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163812 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68006 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42562 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4647 "Hash 169ec560 for PR 53593 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->