### PR TITLE
[ macOS Tahoe ] fast/repaint/block-inputrange-repaint.html is a constant text failure

### DIFF
--- a/LayoutTests/fast/repaint/block-inputrange-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/block-inputrange-repaint-expected.txt
@@ -1,4 +1,4 @@
-PASS repaintRects.indexOf('493 8 17 17') is not -1
+PASS Slider thumb was repainted after movement.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/repaint/block-inputrange-repaint.html
+++ b/LayoutTests/fast/repaint/block-inputrange-repaint.html
@@ -2,7 +2,7 @@
 <head>
 <title>This tests when input=range is block we issue correct repaint rects</title>
 <script>jsTestIsAsync = true;</script>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style>
   input[type="range"] {
     display: block;
@@ -13,19 +13,34 @@
 <body>
 <input id=moveme type=range>
 <script>
-  window.internals.startTrackingRepaints();
+  window.internals?.startTrackingRepaints();
   document.getElementById("moveme").value = 100;
   document.body.offsetHeight;
   function repaintTest() {
     if (window.internals) {
       repaintRects = window.internals.repaintRectsAsText();
       window.internals.stopTrackingRepaints();
-      shouldNotBe("repaintRects.indexOf('493 8 17 17')", "-1");
+
+      const sliderThumb = internals.shadowRoot(moveme).querySelector('[useragentpart="-webkit-slider-thumb"]');
+      const sliderThumbRect = sliderThumb.getBoundingClientRect();
+
+      let passed = false;
+      const tolerance = 2;
+      for (let i = 0; i <= tolerance; i++) {
+          const rectInfo = `${sliderThumbRect.x - i} ${sliderThumbRect.y - i} ${sliderThumbRect.width + i*2} ${sliderThumbRect.height + i*2}`;
+          if (repaintRects.indexOf(rectInfo) !== -1) {
+            passed = true;
+            testPassed("Slider thumb was repainted after movement.");
+            break;
+          }
+      }
+
+      if (!passed)
+        testFailed("Slider thumb was not repainted after movement.");
     }
     finishJSTest();
   }
   setTimeout(repaintTest, 0);
 </script>
 </body>
-<script src="../../resources/js-test-post.js"></script>
 </html>

--- a/LayoutTests/platform/glib/fast/repaint/block-inputrange-repaint-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/block-inputrange-repaint-expected.txt
@@ -1,5 +1,0 @@
-FAIL repaintRects.indexOf('493 8 17 17') should not be -1.
-PASS successfullyParsed is true
-
-TEST COMPLETE
-

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2556,9 +2556,6 @@ webkit.org/b/300997 webrtc/filtering-ice-candidate-after-reload.html [ Pass Fail
 [ Tahoe Debug ] fast/forms/switch/click-animation-redundant-disabled.html [ ImageOnlyFailure ]
 [ Tahoe Debug ] fast/forms/switch/click-animation-redundant-checked.html  [ ImageOnlyFailure ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=301000 [ macOS Tahoe ] 3x fast/ tests (layout-tests) are constant text failures
-[ Tahoe Debug ] fast/repaint/block-inputrange-repaint.html [ Failure ]
-
 # https://bugs.webkit.org/show_bug.cgi?id=301002 [ macOS Tahoe ] fast/css/apple-system-control-colors.html is a constant text failure
 [ Tahoe Debug ] fast/css/apple-system-control-colors.html [ Failure ]
 


### PR DESCRIPTION
#### 27fc80667d2b6ba12277da367ee378c6ca04ab62
<pre>
[ macOS Tahoe ] fast/repaint/block-inputrange-repaint.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=301000">https://bugs.webkit.org/show_bug.cgi?id=301000</a>
<a href="https://rdar.apple.com/162884649">rdar://162884649</a>

Reviewed by Wenson Hsieh.

With the redesigned controls in macOS Tahoe, the size of the slider thumb
changed. This means that the repaint rect expected by the test is no longer
accurate.

Fix by using `getBoundingClientRect()` to determine the size and position
of the thumb, which provides an accurate repaint rect.

* LayoutTests/fast/repaint/block-inputrange-repaint-expected.txt:
* LayoutTests/fast/repaint/block-inputrange-repaint.html:

A &quot;tolerance&quot; of 2px is used to inflate the repaint rect. This is necessary
since some ports (macOS) adjust the repaint rect to account for shadows.

* LayoutTests/platform/glib/fast/repaint/block-inputrange-repaint-expected.txt: Removed.
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/302739@main">https://commits.webkit.org/302739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d10cdb1f2ac271f098a000a62ca59839010b830

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81545 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d74377a9-5c5f-4439-b85c-4647b509b43b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99051 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1677 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116464 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79751 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34594 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80699 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139906 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2087 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1934 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107557 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107450 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31263 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54920 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20288 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2160 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2009 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->