### PR TITLE
Emit signposts for evaluateJavaScript

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -288,6 +288,7 @@ WTF_EXTERN_C_END
     M(NetworkCacheHit) \
     M(NetworkCacheMiss) \
     M(PLTSubresourceLoading) \
+    M(EvaluateJavaScript) \
 
 #define DECLARE_WTF_SIGNPOST_NAME_ENUM(name) WTFOSSignpostName ## name,
 


### PR DESCRIPTION
#### da8bc5867a4df3fe85a89627274fb42c32b3ec16
<pre>
Emit signposts for evaluateJavaScript
<a href="https://bugs.webkit.org/show_bug.cgi?id=302163">https://bugs.webkit.org/show_bug.cgi?id=302163</a>
<a href="https://rdar.apple.com/164266865">rdar://164266865</a>

Reviewed by Per Arne Vollan.

We are moving more browser-specific logic out of the injected bundle and in to injected JavaScript
via `WKUserScript` and `-[WKWebView evaluateJavaScript:...]`. We already have signposts around the
former but not the latter. This adds signposts around evaluateJavaScript.

* Source/WTF/wtf/SystemTracing.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):

Canonical link: <a href="https://commits.webkit.org/302769@main">https://commits.webkit.org/302769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24e61f55c88718e0be74997ed740d74a0fccf12b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81630 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c9d7aba3-d811-4151-8a8e-5e669f5d3154) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66911 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eea9f9f0-76f9-4888-9807-2be0d418a118) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79790 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5dce3e8-46a4-405a-bc39-3efb25e9ab09) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80758 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122081 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139964 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128541 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2144 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2018 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107617 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2189 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27371 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31321 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54994 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65622 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161555 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2034 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40274 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->