### PR TITLE
[Safe CPP] Address warnings in rendering/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -52,7 +52,6 @@ rendering/RenderDescendantIterator.h
 rendering/RenderFlexibleBox.cpp
 rendering/RenderFragmentContainer.h
 rendering/RenderGeometryMap.h
-rendering/RenderHighlight.h
 rendering/RenderIterator.h
 rendering/RenderLayer.h
 rendering/RenderLayerBacking.cpp
@@ -61,12 +60,10 @@ rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerCompositor.h
 rendering/RenderLayerScrollableArea.h
 rendering/RenderLayoutState.h
-rendering/RenderSelection.h
 rendering/RenderSelectionGeometry.h
 rendering/RenderTableSection.h
 rendering/RenderText.cpp
 rendering/TableLayout.h
-rendering/TextBoxPainter.h
 rendering/TextDecorationPainter.h
 [ iOS ] rendering/ios/RenderThemeIOS.mm
 rendering/line/BreakingContext.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -59,7 +59,6 @@ platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediastream/AudioMediaStreamTrackRenderer.h
 platform/mock/ScrollbarsControllerMock.h
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.h
-rendering/TextBoxPainter.h
 rendering/style/StyleGeneratedImage.cpp
 rendering/updating/RenderTreeUpdater.h
 style/ClassChangeInvalidation.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -499,7 +499,6 @@ rendering/RenderFrameSet.cpp
 rendering/RenderGeometryMap.cpp
 rendering/RenderGrid.cpp
 rendering/RenderHTMLCanvas.cpp
-rendering/RenderHighlight.cpp
 rendering/RenderImage.cpp
 rendering/RenderImage.h
 rendering/RenderImageResource.cpp
@@ -529,7 +528,6 @@ rendering/RenderReplaced.cpp
 rendering/RenderReplica.cpp
 rendering/RenderScrollbar.cpp
 rendering/RenderSearchField.cpp
-rendering/RenderSelection.cpp
 rendering/RenderSelectionGeometry.cpp
 rendering/RenderTable.cpp
 rendering/RenderTableCaption.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -336,7 +336,6 @@ rendering/RenderFragmentedFlow.cpp
 rendering/RenderFrameSet.cpp
 rendering/RenderGeometryMap.cpp
 rendering/RenderGrid.cpp
-rendering/RenderHighlight.cpp
 rendering/RenderImage.cpp
 rendering/RenderImageResourceStyleImage.cpp
 rendering/RenderInline.cpp
@@ -364,7 +363,6 @@ rendering/RenderReplaced.cpp
 rendering/RenderReplica.cpp
 rendering/RenderScrollbar.cpp
 rendering/RenderSearchField.cpp
-rendering/RenderSelection.cpp
 rendering/RenderTable.cpp
 rendering/RenderTableCaption.cpp
 rendering/RenderTableCell.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -395,7 +395,6 @@ rendering/RenderTextControlSingleLine.cpp
 rendering/RenderTheme.cpp
 rendering/RenderTreeAsText.cpp
 rendering/RenderWidget.cpp
-rendering/TextBoxPainter.cpp
 [ iOS ] rendering/ios/RenderThemeIOS.mm
 rendering/mathml/MathMLStyle.cpp
 rendering/style/RenderStyle.cpp

--- a/Source/WebCore/rendering/RenderHighlight.h
+++ b/Source/WebCore/rendering/RenderHighlight.h
@@ -70,11 +70,11 @@ public:
     RenderRangeIterator(RenderObject* start);
     RenderObject* current() const;
     RenderObject* next();
-    
+
 private:
     void checkForSpanner();
-    
-    RenderObject* m_current { nullptr };
+
+    CheckedPtr<RenderObject> m_current;
     Vector<RenderMultiColumnSpannerPlaceholder*> m_spannerStack;
 };
 

--- a/Source/WebCore/rendering/RenderSelection.h
+++ b/Source/WebCore/rendering/RenderSelection.h
@@ -50,7 +50,7 @@ public:
     IntRect boundsClippedToVisibleContent() const { return collectBounds(ClipToVisibleContent::Yes); }
     
 private:
-    const RenderView& m_renderView;
+    const CheckedRef<const RenderView> m_renderView;
 #if ENABLE(SERVICE_CONTROLS)
     SelectionGeometryGatherer m_selectionGeometryGatherer;
 #endif

--- a/Source/WebCore/rendering/RenderSelectionGeometry.h
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.h
@@ -39,6 +39,7 @@ class RenderSelectionGeometryBase {
 public:
     explicit RenderSelectionGeometryBase(RenderObject& renderer);
     const RenderLayerModelObject* repaintContainer() const { return m_repaintContainer; }
+    CheckedPtr<const RenderLayerModelObject> checkedRepaintContainer() const { return m_repaintContainer; }
     RenderObject::HighlightState state() const { return m_state; }
 
 protected:

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -85,13 +85,13 @@ protected:
     std::pair<unsigned, unsigned> selectionStartEnd() const;
     MarkedText createMarkedTextFromSelectionInBox();
     const FontCascade& fontCascade() const;
-    WritingMode writingMode() const { return m_style.writingMode(); }
+    WritingMode writingMode() const { return m_style->writingMode(); }
     FloatPoint textOriginFromPaintRect(const FloatRect&) const;
     bool isInsideShapedContent() const;
 
     struct DecoratingBox {
         InlineIterator::InlineBoxIterator inlineBox;
-        const RenderStyle& style;
+        const CheckedRef<const RenderStyle> style;
         TextDecorationPainter::Styles textDecorationStyles;
         FloatPoint location;
     };
@@ -100,9 +100,9 @@ protected:
 
     // FIXME: We could just talk to the display box directly.
     const InlineIterator::BoxModernPath m_textBox;
-    const RenderText& m_renderer;
-    const Document& m_document;
-    const RenderStyle& m_style;
+    const CheckedRef<const RenderText> m_renderer;
+    const CheckedRef<const Document> m_document;
+    const CheckedRef<const RenderStyle> m_style;
     const FloatRect m_logicalRect;
     const TextRun m_paintTextRun;
     PaintInfo& m_paintInfo;


### PR DESCRIPTION
#### e1a0394f3485c6932633210588bcc464d2b96c5f
<pre>
[Safe CPP] Address warnings in rendering/
<a href="https://bugs.webkit.org/show_bug.cgi?id=302167">https://bugs.webkit.org/show_bug.cgi?id=302167</a>
<a href="https://rdar.apple.com/problem/164270032">rdar://problem/164270032</a>

Reviewed by Chris Dumez.

Address warnings in RenderHighlight, RenderSelection, and TextBoxPainter cpp and header files.

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
* Source/WebCore/rendering/RenderHighlight.cpp
* Source/WebCore/rendering/RenderHighlight.h
* Source/WebCore/rendering/RenderSelection.cpp
* Source/WebCore/rendering/RenderSelection.h
* Source/WebCore/rendering/RenderSelectionGeometry.h
* Source/WebCore/rendering/TextBoxPainter.cpp
* Source/WebCore/rendering/TextBoxPainter.h

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/rendering/RenderHighlight.cpp:
(WebCore::RenderRangeIterator::current const):
(WebCore::RenderRangeIterator::next):
(WebCore::RenderRangeIterator::checkForSpanner):
(WebCore::rendererAfterOffset):
(WebCore::RenderHighlight::setRenderRange):
(WebCore::RenderHighlight::highlightStateForRenderer):
* Source/WebCore/rendering/RenderHighlight.h:
* Source/WebCore/rendering/RenderSelection.cpp:
(WebCore::rendererAfterOffset):
(WebCore::containingBlockBelowView):
(WebCore::collectSelectionData):
(WebCore::RenderSelection::set):
(WebCore::RenderSelection::clear):
(WebCore::RenderSelection::repaint const):
(WebCore::RenderSelection::collectBounds const):
(WebCore::RenderSelection::apply):
* Source/WebCore/rendering/RenderSelection.h:
* Source/WebCore/rendering/RenderSelectionGeometry.h:
(WebCore::RenderSelectionGeometryBase::checkedRepaintContainer const):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::m_isCombinedText):
(WebCore::m_haveSelection):
(WebCore::TextBoxPainter::paint):
(WebCore::TextBoxPainter::selectionStartEnd const):
(WebCore::TextBoxPainter::paintCompositionForeground):
(WebCore::TextBoxPainter::paintForegroundAndDecorations):
(WebCore::TextBoxPainter::paintBackgroundFill):
(WebCore::TextBoxPainter::selectionRectForRange const):
(WebCore::TextBoxPainter::paintBackgroundFillForRange):
(WebCore::TextBoxPainter::paintForeground):
(WebCore::TextBoxPainter::paintForegroundForShapeRange):
(WebCore::TextBoxPainter::createDecorationPainter):
(WebCore::isDecoratingBoxForBackground):
(WebCore::TextBoxPainter::collectDecoratingBoxesForBackgroundPainting):
(WebCore::TextBoxPainter::paintBackgroundDecorations):
(WebCore::TextBoxPainter::paintForegroundDecorations):
(WebCore::TextBoxPainter::fillCompositionUnderline const):
(WebCore::TextBoxPainter::paintCompositionUnderlines):
(WebCore::TextBoxPainter::paintCompositionUnderline):
(WebCore::TextBoxPainter::paintPlatformDocumentMarker):
(WebCore::TextBoxPainter::computeHaveSelection const):
(WebCore::TextBoxPainter::fontCascade const):
(WebCore::TextBoxPainter::textOriginFromPaintRect const):
* Source/WebCore/rendering/TextBoxPainter.h:
(WebCore::TextBoxPainter::writingMode const):

Canonical link: <a href="https://commits.webkit.org/303440@main">https://commits.webkit.org/303440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d900e37facd919093c9a58933cdc04b20151b5fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84372 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2db87e00-aebe-460c-895a-0fde2a40b224) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8ceee16-b895-4819-9bf3-8858f1ee7b34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135361 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82019 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83157 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142582 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4580 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109603 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109782 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3465 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57856 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4634 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33234 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4466 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68085 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4591 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->