### PR TITLE
[threaded-animations] JS-originated scroll-driven animations force animation resolution on each rendering update

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animation resolution in the web process isn't scheduled once a scroll-driven animation has been accelerated
+

--- a/LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+#target {
+    width: 100px;
+    height: 100px;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+promise_test(async t => { 
+    const timeline = new ScrollTimeline({ source : document.documentElement });
+    const animation = target.animate({ opacity: [0, 1] }, { timeline });
+
+    await animationAcceleration(animation);
+
+    // Wait a few animation frames to check that animations were not resolved
+    // once the scroll-driven animation was accelerated.
+    const before = window.internals?.numberOfAnimationTimelineInvalidations();
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    const after = window.internals?.numberOfAnimationTimelineInvalidations();
+
+    assert_equals(before, after);
+}, "Animation resolution in the web process isn't scheduled once a scroll-driven animation has been accelerated");
+
+</script>
+</body>

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -64,6 +64,7 @@ public:
     ExceptionOr<void> updateTiming(Document&, std::optional<OptionalEffectTiming>);
 
     virtual void animationDidTick() { };
+    virtual void animationBecameReady() { };
     virtual void animationDidChangeTimingProperties() { };
     virtual void animationWasCanceled() { };
     virtual void animationSuspensionStateDidChange(bool) { };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2089,13 +2089,16 @@ void KeyframeEffect::animationDidTick()
     invalidate();
     updateAcceleratedActions();
 
+    if (RefPtr viewTimeline = activeViewTimeline())
+        computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline.get(), animation());
+}
+
+void KeyframeEffect::animationBecameReady()
+{
 #if ENABLE(THREADED_ANIMATIONS)
     if (threadedAnimationsEnabled())
         updateAcceleratedAnimationIfNecessary();
 #endif
-
-    if (RefPtr viewTimeline = activeViewTimeline())
-        computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline.get(), animation());
 }
 
 void KeyframeEffect::animationDidChangeTimingProperties()

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -273,6 +273,7 @@ private:
     // AnimationEffect
     bool isKeyframeEffect() const final { return true; }
     void animationDidTick() final;
+    void animationBecameReady() final;
     void animationDidChangeTimingProperties() final;
     void animationWasCanceled() final;
     void animationSuspensionStateDidChange(bool) final;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1536,6 +1536,8 @@ bool WebAnimation::needsTick() const
 
 void WebAnimation::tick()
 {
+    auto wasPending = pending();
+
     // https://drafts.csswg.org/scroll-animations-1/#event-loop
     // When updating timeline current time, the start time of any attached animation is
     // conditionally updated. For each attached animation, run the procedure for calculating
@@ -1549,8 +1551,11 @@ void WebAnimation::tick()
     updateFinishedState(DidSeek::No, SynchronouslyNotify::Yes);
     m_shouldSkipUpdatingFinishedStateWhenResolving = true;
 
-    if (!isEffectInvalidationSuspended() && m_effect)
+    if (!isEffectInvalidationSuspended() && m_effect) {
         m_effect->animationDidTick();
+        if (wasPending && !pending())
+            m_effect->animationBecameReady();
+    }
 }
 
 void WebAnimation::maybeMarkAsReady()


### PR DESCRIPTION
#### 93d628d634775d4b04e14b9b6490b15f367f4377
<pre>
[threaded-animations] JS-originated scroll-driven animations force animation resolution on each rendering update
<a href="https://bugs.webkit.org/show_bug.cgi?id=302170">https://bugs.webkit.org/show_bug.cgi?id=302170</a>
<a href="https://rdar.apple.com/164274737">rdar://164274737</a>

Reviewed by Simon Fraser.

In 302634@main we added support for JS-originated scroll-driven animations to be accelerated. To do that,
we made sure to update the accelerated effect stack when an animation ticked. However, we only need to do
this for the tick that transitions the animation from pending [0] to ready [1]. Indeed, otherwise we keep
scheduling animation resolution on each rendering update in a loop.

To test this, we use an existing `internals` testing API to check that once an animation has been accelerated
the number of timeline invalidations does not increase.

[0] <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-pending">https://drafts.csswg.org/web-animations-1/#dom-animation-pending</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#ready">https://drafts.csswg.org/web-animations-1/#ready</a>

Test: webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration.html

* LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration.html: Added.
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::animationBecameReady):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationDidTick):
(WebCore::KeyframeEffect::animationBecameReady):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::tick):

Canonical link: <a href="https://commits.webkit.org/302761@main">https://commits.webkit.org/302761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38ff06d0249017d84e2748f967872e5d8061ac35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81572 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e33b410-36d8-4ed6-9b39-a3509e8040af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99070 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66876 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e96cce4d-9df7-40b8-a6f4-121c982189ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79771 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e25cae4-4950-43ec-a878-ac4f5e30ad0b) 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1633 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Passed layout tests; layout-tests (exception)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80722 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110147 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139929 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1956 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107576 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107469 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54945 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20300 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2183 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65552 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2000 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2207 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->