### PR TITLE
Update DDScannerResult serialization to use WKSecureCoding interface

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
@@ -156,6 +156,11 @@ struct __DDScanQuery {
 
 #endif // !USE(APPLE_INTERNAL_SDK)
 
+@interface DDScannerResult(WKSecureCoding)
+- (NSDictionary *)_webKitPropertyListData;
+- (instancetype)_initWithWebKitPropertyListData:(NSDictionary *)plist;
+@end
+
 static_assert(sizeof(DDQueryOffset) == 8, "DDQueryOffset is no longer 8 bytes. Update the definition of DDQueryOffset in this file to match the new size.");
 
 typedef struct __DDScanQuery *DDScanQueryRef;

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -93,9 +93,6 @@ enum class NSType : uint8_t {
     CNPhoneNumber,
     CNPostalAddress,
 #endif
-#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-    DDScannerResult,
-#endif
     NSDateComponents,
     Data,
     Date,

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -409,10 +409,6 @@ NSType typeFromObject(id object)
     SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<CNPostalAddress>()])
         return NSType::CNPostalAddress;
 #endif
-#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<DDScannerResult>()])
-        return NSType::DDScannerResult;
-#endif
     if ([object isKindOfClass:[NSDateComponents class]])
         return NSType::NSDateComponents;
     // Not all CF types are toll-free-bridged to NS types.

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+
+#include "EditingRange.h"
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/cocoa/TypeCastsCocoa.h>
+
+OBJC_CLASS DDScannerResult;
+
+namespace WebKit {
+
+struct CoreIPCDDScannerResultData {
+    EditingRange AR;
+    RetainPtr<NSString> MS;
+    RetainPtr<NSString> T;
+    RetainPtr<NSNumber> P;
+    RetainPtr<NSNumber> VN;
+    std::optional<Vector<RetainPtr<DDScannerResult>>> SR; // Recursive
+    std::optional<RetainPtr<NSString>> V;
+    std::optional<RetainPtr<NSNumber>> CF;
+
+    // "C" dictionary values
+    std::optional<RetainPtr<NSString>> AddressBookUID;
+    std::optional<RetainPtr<NSString>> Domain;
+    std::optional<RetainPtr<NSString>> UUID;
+    std::optional<RetainPtr<NSNumber>> UrlificationBegin;
+    std::optional<RetainPtr<NSNumber>> UrlificationLength;
+};
+
+class CoreIPCDDScannerResult {
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCDDScannerResult);
+public:
+    CoreIPCDDScannerResult(DDScannerResult*);
+    CoreIPCDDScannerResult(CoreIPCDDScannerResultData&&);
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCDDScannerResult>;
+    CoreIPCDDScannerResultData m_data;
+};
+
+} // namespace WebKit
+
+
+#endif // ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCDDScannerResult.h"
+
+#import <pal/cocoa/DataDetectorsCoreSoftLink.h>
+
+#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+
+namespace WebKit {
+
+CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *d)
+{
+    if (!d)
+        return;
+
+    RetainPtr dictionary = [d _webKitPropertyListData];
+
+    if (auto *AR = dynamic_objc_cast<NSValue>([dictionary objectForKey:@"AR"])) {
+        RetainPtr NSRangeTypeString = [NSString stringWithCString:@encode(NSRange) encoding:NSASCIIStringEncoding];
+        RetainPtr type = [NSString stringWithCString:AR.objCType encoding:NSASCIIStringEncoding];
+        if ([type.get() isEqual:NSRangeTypeString.get()])
+            m_data.AR = [AR rangeValue];
+    }
+
+    if (auto *MS = dynamic_objc_cast<NSString>([dictionary objectForKey:@"MS"]))
+        m_data.MS = MS;
+
+    if (auto *T = dynamic_objc_cast<NSString>([dictionary objectForKey:@"T"]))
+        m_data.T = T;
+
+    if (auto *P = dynamic_objc_cast<NSNumber>([dictionary objectForKey:@"P"]))
+        m_data.P = P;
+
+    if (auto *VN = dynamic_objc_cast<NSNumber>([dictionary objectForKey:@"VN"]))
+        m_data.VN = VN;
+
+    if (auto *SR = dynamic_objc_cast<NSArray>([dictionary objectForKey:@"SR"])) {
+        Vector<RetainPtr<DDScannerResult>> result;
+        result.reserveInitialCapacity(SR.count);
+        for (id item in SR) {
+            if ([item isKindOfClass:PAL::getDDScannerResultClassSingleton()])
+                result.append((DDScannerResult *)item);
+        }
+        m_data.SR = WTFMove(result);
+    }
+
+    if (auto *V = dynamic_objc_cast<NSString>([dictionary objectForKey:@"V"]))
+        m_data.V = V;
+
+    if (auto *CF = dynamic_objc_cast<NSNumber>([dictionary objectForKey:@"CF"]))
+        m_data.CF = CF;
+
+    if (auto *C = dynamic_objc_cast<NSDictionary>([dictionary objectForKey:@"C"])) {
+#if ASSERT_ENABLED
+        // Validate that the contextual data dictionary only contains known keys.
+        // This will catch if DataDetectorsCore's serialization changes underneath us.
+        RetainPtr allowedKeys = [NSSet setWithObjects:@"C", @"D", @"U", @"urlificationBegin", @"urlificationLength", nil];
+        for (NSString *key in C)
+            ASSERT_WITH_MESSAGE([allowedKeys.get() containsObject:key], "Unexpected key '%s' in DDScannerResult contextual data dictionary. Expected only: C, D, U, urlificationBegin, urlificationLength", [key UTF8String]);
+#endif
+
+        if (auto *addressBookUID = dynamic_objc_cast<NSString>([C objectForKey:@"C"]))
+            m_data.AddressBookUID = addressBookUID;
+
+        if (auto *domain = dynamic_objc_cast<NSString>([C objectForKey:@"D"]))
+            m_data.Domain = domain;
+
+        if (auto *uuid = dynamic_objc_cast<NSString>([C objectForKey:@"U"]))
+            m_data.UUID = uuid;
+
+        if (auto *urlificationBegin = dynamic_objc_cast<NSNumber>([C objectForKey:@"urlificationBegin"]))
+            m_data.UrlificationBegin = urlificationBegin;
+
+        if (auto *urlificationLength = dynamic_objc_cast<NSNumber>([C objectForKey:@"urlificationLength"]))
+            m_data.UrlificationLength = urlificationLength;
+    }
+}
+
+CoreIPCDDScannerResult::CoreIPCDDScannerResult(CoreIPCDDScannerResultData&& data)
+    : m_data(WTFMove(data)) { }
+
+RetainPtr<id> CoreIPCDDScannerResult::toID() const
+{
+    RetainPtr propertyList = [NSMutableDictionary dictionaryWithCapacity:9];
+
+    propertyList.get()[@"AR"] = [NSValue valueWithRange:m_data.AR];
+    if (m_data.MS)
+        propertyList.get()[@"MS"] = m_data.MS.get();
+    if (m_data.T)
+        propertyList.get()[@"T"] = m_data.T.get();
+    if (m_data.P)
+        propertyList.get()[@"P"] = m_data.P.get();
+    if (m_data.VN)
+        propertyList.get()[@"VN"] = m_data.VN.get();
+
+    if (m_data.SR) {
+        RetainPtr arr = [NSMutableArray arrayWithCapacity:m_data.SR->size()];
+        for (auto& element : *m_data.SR)
+            [arr addObject:element.get()];
+        propertyList.get()[@"SR"] = arr.get();
+    }
+
+    if (m_data.V)
+        propertyList.get()[@"V"] = m_data.V->get();
+    if (m_data.CF)
+        propertyList.get()[@"CF"] = m_data.CF->get();
+
+    if (m_data.AddressBookUID || m_data.Domain || m_data.UUID
+        || m_data.UrlificationBegin || m_data.UrlificationLength) {
+        auto contextualData = [NSMutableDictionary dictionary];
+
+        if (m_data.AddressBookUID)
+            contextualData[@"C"] = m_data.AddressBookUID->get();
+        if (m_data.Domain)
+            contextualData[@"D"] = m_data.Domain->get();
+        if (m_data.UUID)
+            contextualData[@"U"] = m_data.UUID->get();
+        if (m_data.UrlificationBegin)
+            contextualData[@"urlificationBegin"] = m_data.UrlificationBegin->get();
+        if (m_data.UrlificationLength)
+            contextualData[@"urlificationLength"] = m_data.UrlificationLength->get();
+
+        propertyList.get()[@"C"] = contextualData;
+    }
+
+    return adoptNS([[PAL::getDDScannerResultClassSingleton() alloc] _initWithWebKitPropertyListData:propertyList.get()]);
+}
+
+}
+
+#endif // ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
@@ -21,16 +21,29 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-secure_coding_header: <pal/cocoa/DataDetectorsCoreSoftLink.h>
-[WebKitSecureCodingClass=PAL::getDDScannerResultClassSingleton()] webkit_secure_coding DDScannerResult {
-    AR: NSValue
-    MS: String
-    T: String
-    P: Number
-    VN: Number
-    SR: Array<DDScannerResult>?
-    V: String?
-    C: Dictionary?
-    CF: Number?
-}
+
+webkit_platform_headers: "CoreIPCDDScannerResult.h"
+
+header: "CoreIPCDDScannerResult.h"
+[CustomHeader, WebKitPlatform] struct WebKit::CoreIPCDDScannerResultData {
+    WebKit::EditingRange AR;
+    RetainPtr<NSString> MS;
+    RetainPtr<NSString> T;
+    RetainPtr<NSNumber> P;
+    RetainPtr<NSNumber> VN;
+    std::optional<Vector<RetainPtr<DDScannerResult>>> SR;
+    std::optional<RetainPtr<NSString>> V;
+    std::optional<RetainPtr<NSNumber>> CF;
+
+    std::optional<RetainPtr<NSString>> AddressBookUID;
+    std::optional<RetainPtr<NSString>> Domain;
+    std::optional<RetainPtr<NSString>> UUID;
+    std::optional<RetainPtr<NSNumber>> UrlificationBegin;
+    std::optional<RetainPtr<NSNumber>> UrlificationLength;
+};
+
+[WebKitPlatform] class WebKit::CoreIPCDDScannerResult {
+    WebKit::CoreIPCDDScannerResultData m_data;
+};
+
 #endif // ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -50,9 +50,6 @@ class CoreIPCCNContact;
 class CoreIPCCNPhoneNumber;
 class CoreIPCCNPostalAddress;
 #endif
-#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-class CoreIPCDDScannerResult;
-#endif
 class CoreIPCData;
 class CoreIPCDate;
 class CoreIPCDateComponents;
@@ -96,9 +93,6 @@ using ObjectValue = Variant<
     CoreIPCCNContact,
     CoreIPCCNPhoneNumber,
     CoreIPCCNPostalAddress,
-#endif
-#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-    CoreIPCDDScannerResult,
 #endif
     CoreIPCDateComponents,
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -71,10 +71,6 @@ static ObjectValue valueFromID(id object)
     case IPC::NSType::CNPostalAddress:
         return CoreIPCCNPostalAddress((CNPostalAddress *)object);
 #endif
-#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-    case IPC::NSType::DDScannerResult:
-        return CoreIPCDDScannerResult((DDScannerResult *)object);
-#endif
     case IPC::NSType::NSDateComponents:
         return CoreIPCDateComponents((NSDateComponents *)object);
     case IPC::NSType::Data:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -56,9 +56,6 @@ using WebKit::ObjectValue = Variant<
     WebKit::CoreIPCCNPhoneNumber,
     WebKit::CoreIPCCNPostalAddress,
 #endif
-#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-    WebKit::CoreIPCDDScannerResult,
-#endif
     WebKit::CoreIPCDateComponents,
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     WebKit::CoreIPCSecureCoding,

--- a/Source/WebKit/Shared/EditingRange.serialization.in
+++ b/Source/WebKit/Shared/EditingRange.serialization.in
@@ -25,7 +25,9 @@ enum class WebKit::EditingRangeIsRelativeTo : uint8_t {
     Paragraph,
 }
 
-struct WebKit::EditingRange {
+webkit_platform_headers: "EditingRange.h"
+
+[WebKitPlatform] struct WebKit::EditingRange {
     uint64_t location;
     [Validator='!(Checked<uint64_t> { *location } + *length).hasOverflowed()'] uint64_t length;
 };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2545,6 +2545,8 @@
 		F4E28A362C923814008120DD /* ScriptTrackingPrivacyFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E28A352C923814008120DD /* ScriptTrackingPrivacyFilter.h */; };
 		F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */; };
 		F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */; };
+		F4E2A3832EB5416C00D7A783 /* CoreIPCDDScannerResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E2A3822EB5415B00D7A783 /* CoreIPCDDScannerResult.mm */; };
+		F4E2A3842EB5417300D7A783 /* CoreIPCDDScannerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E2A3812EB5415B00D7A783 /* CoreIPCDDScannerResult.h */; };
 		F4E44EB72DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
@@ -8721,6 +8723,8 @@
 		F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDSecureActionContext.h; sourceTree = "<group>"; };
 		F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDSecureActionContext.mm; sourceTree = "<group>"; };
 		F4E2A38D2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCDDSecureActionContext.serialization.in; sourceTree = "<group>"; };
+		F4E2A3812EB5415B00D7A783 /* CoreIPCDDScannerResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDScannerResult.h; sourceTree = "<group>"; };
+		F4E2A3822EB5415B00D7A783 /* CoreIPCDDScannerResult.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDScannerResult.mm; sourceTree = "<group>"; };
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift"; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
@@ -12877,6 +12881,9 @@
 				5181988E2B7585E30084E292 /* CoreIPCDateComponents.h */,
 				5181988F2B7585E30084E292 /* CoreIPCDateComponents.mm */,
 				5181988D2B7585E30084E292 /* CoreIPCDateComponents.serialization.in */,
+				51AD56892B1C3BA1001A0ECB /* CoreIPCDDActionContext.serialization.in */,
+				F4E2A3812EB5415B00D7A783 /* CoreIPCDDScannerResult.h */,
+				F4E2A3822EB5415B00D7A783 /* CoreIPCDDScannerResult.mm */,
 				51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */,
 				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
 				5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */,
@@ -17641,6 +17648,7 @@
 				F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */,
 				518198902B7585EB0084E292 /* CoreIPCDateComponents.h in Headers */,
 				F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */,
+				F4E2A3842EB5417300D7A783 /* CoreIPCDDScannerResult.h in Headers */,
 				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
 				F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */,
 				F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */,
@@ -21226,6 +21234,7 @@
 				52B060F92B745E4D009B1666 /* CoreIPCCVPixelBufferRef.mm in Sources */,
 				518198912B7585F80084E292 /* CoreIPCDateComponents.mm in Sources */,
 				F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */,
+				F4E2A3832EB5416C00D7A783 /* CoreIPCDDScannerResult.mm in Sources */,
 				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,
 				F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */,
 				F4A30A6D2B08255B004E1F24 /* CoreIPCLocale.mm in Sources */,


### PR DESCRIPTION
#### c08e7921040fa7ef760d48b984b8f771d42754af
<pre>
Update DDScannerResult serialization to use WKSecureCoding interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=302168">https://bugs.webkit.org/show_bug.cgi?id=302168</a>
<a href="https://rdar.apple.com/158248064">rdar://158248064</a>

Reviewed by Alex Christensen.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm: Added.
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
(WebKit::CoreIPCDDScannerResult::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in:
* Source/WebKit/Shared/EditingRange.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(fakeDataDetectorResultWithContextualData):
(TEST(IPCSerialization, DDScannerResultPlist)):

Canonical link: <a href="https://commits.webkit.org/302946@main">https://commits.webkit.org/302946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50a2e55b8df78c7679f3f9ef76c2cae82e887c31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82136 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/326d5862-bbfb-42a6-a499-c25b7e26f34c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67320 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d7daee7-6778-4e38-9eaa-4baa33e7b472) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f099f870-93d5-4488-9266-7574c2c5cba7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34993 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81180 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140400 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107940 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107852 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31646 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66022 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2453 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2655 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2560 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->