### PR TITLE
[JSC] describe function attempts to create a WTF::String larger than WTF::String::MaxLength

### DIFF
--- a/JSTests/stress/describe-huge-strings.js
+++ b/JSTests/stress/describe-huge-strings.js
@@ -1,0 +1,27 @@
+//@ skip if $memoryLimited
+
+// This test should not crash
+
+testCases = [
+   // under the limits after describe(...)
+   { "len": 2147483586, "shouldThrow": false },
+    // for the following:
+    // original string is fine, but result of describe(...) is too long
+   { "len": 2147483587, "shouldThrow": true },
+   { "len": 2147483588, "shouldThrow": true },
+   { "len": 2147483647, "shouldThrow": true },
+    // caught by bounds check in padEnd
+   { "len": 2147483648, "shouldThrow": true },
+];
+
+for (const tc of testCases) {
+    try {
+        // debug("Trying to describe string of length " + tc['len']);
+        const string = ' '.padEnd(tc['len']);
+        describe(string);
+    } catch (e) {
+        if (!tc['shouldThrow']) {
+            throw new Error(`Calling describe on a string of length ${tc['len']} threw an exception \'${e}\' when it shouldn't have.`);
+        }
+    }
+}

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1712,9 +1712,13 @@ JSC_DEFINE_HOST_FUNCTION(functionDebug, (JSGlobalObject* globalObject, CallFrame
 JSC_DEFINE_HOST_FUNCTION(functionDescribe, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(jsUndefined());
-    return JSValue::encode(jsString(vm, toString(callFrame->argument(0))));
+    std::optional<String> string = toStringWithBoundsCheck(callFrame->argument(0));
+    if (!string)
+        return JSValue::encode(throwException(globalObject, scope, createRangeError(globalObject, "Out of memory."_s)));
+    return JSValue::encode(jsString(vm, *string));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionDescribeArray, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/WTF/wtf/StringPrintStream.h
+++ b/Source/WTF/wtf/StringPrintStream.h
@@ -72,8 +72,19 @@ String toString(const Types&... values)
     return stream.toString();
 }
 
+template<typename... Types>
+std::optional<String> toStringWithBoundsCheck(const Types&... values)
+{
+    StringPrintStream stream;
+    stream.print(values...);
+    if (stream.length() > WTF::String::MaxLength)
+        return std::nullopt;
+    return stream.toString();
+}
+
 } // namespace WTF
 
 using WTF::StringPrintStream;
 using WTF::toCString;
 using WTF::toString;
+using WTF::toStringWithBoundsCheck;


### PR DESCRIPTION
#### 11dd0ceefa42351e7a07195edb52563364db8dac
<pre>
[JSC] describe function attempts to create a WTF::String larger than WTF::String::MaxLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=302183">https://bugs.webkit.org/show_bug.cgi?id=302183</a>
<a href="https://rdar.apple.com/160097620">rdar://160097620</a>

Reviewed by Keith Miller.

The `describe` JS function returns a String that contains additional
metadata to &quot;describe&quot; the original entity passed in. For example,
`describe(“hello”)` results in a string that looks like
`String (atomic),8Bit:(1),length:(5): hello, StructureID: 16777808`.
Under the hood, `describe` constructs a new string with additional
metadata and converts it to a `WTF::String`.

The problem is that while the original string passed into `describe`
is under the `WTF::String` limit (`WTF::String::MaxLength`), it&apos;s
possible for the extra metadata to push the length of the resulting
string over the limit. Then, when `describe` goes to convert the
result into a `WTF::String` JSC can crash from a `RELEASE_ASSERT`
enforcing the size of the resulting string.

This patch adds a bounds check before a `StringPrintStream` that&apos;s
too large attempts to be converted to a `WTF::String`. Importantly,
this bounds check happens after the additional metadata information
is added to the resulting `StringPrintStream` (see `JSCJSValue.cpp`
`JSValue::dumpInContextAssumingStructure`). If the resulting
`StringPrintStream` would have been too much for a `WTF::String`,
then we gracefully throw a RangeError Exception as opposed to
hitting a `RELEASE_ASSERT` during the `WTF::String` creation.

Test: JSTests/stress/describe-huge-strings.js

* JSTests/stress/describe-huge-strings.js: Added.
(const.tc.of.testCases.catch):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/StringPrintStream.h:
(WTF::toStringWithBoundsCheck):

Canonical link: <a href="https://commits.webkit.org/302798@main">https://commits.webkit.org/302798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f21a70ffcf4230589de270814a2612d33460e5d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81663 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57a0ca67-6c49-409d-897a-ebf8c5556ce7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99130 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66935 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/97138e50-dcda-4090-8920-eea685231127) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79824 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/feee2e9a-5fa0-4f1c-b0b7-1355a05a3622) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80799 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122128 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140004 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128577 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107653 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107531 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1740 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31346 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55066 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65643 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161592 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2073 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40288 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2277 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2182 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->