### PR TITLE
[WTF] Make WTF::flatMap work with truthy/falsy types

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1930,8 +1930,19 @@ Vector<typename CompactMapTraits<typename std::invoke_result<MapFunction, typena
     return result;
 }
 
+template<typename T>
+concept IsCollection = requires(T collection)
+{
+    collection.begin();
+    collection.end();
+};
+
 template<typename MapFunction, typename SourceType>
-struct FlatMapper {
+struct FlatMapper;
+
+template<typename MapFunction, typename SourceType>
+requires IsCollection<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&>::type>
+struct FlatMapper<MapFunction, SourceType> {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using DestinationItemType = typename CollectionInspector<typename std::invoke_result<MapFunction, SourceItemType&>::type>::SourceItemType;
 
@@ -1946,7 +1957,8 @@ struct FlatMapper {
 };
 
 template<typename MapFunction, typename SourceType>
-    requires (std::is_rvalue_reference_v<SourceType&&>)
+    requires std::is_rvalue_reference_v<SourceType&&>
+        && IsCollection<typename std::invoke_result_t<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&>>
 struct FlatMapper<MapFunction, SourceType> {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using DestinationItemType = typename CollectionInspector<typename std::invoke_result<MapFunction, SourceItemType&&>::type>::SourceItemType;
@@ -1956,6 +1968,26 @@ struct FlatMapper<MapFunction, SourceType> {
         Vector<DestinationItemType> result;
         for (auto&& item : source)
             result.appendVector(mapFunction(WTFMove(item)));
+        result.shrinkToFit();
+        return result;
+    }
+};
+
+template<typename MapFunction, typename SourceType>
+    requires std::is_same_v<
+        typename CollectionInspector<SourceType>::SourceItemType,
+        typename std::invoke_result_t<MapFunction, typename CollectionInspector<SourceType>::SourceItemType>>
+struct FlatMapper<MapFunction, SourceType> {
+    using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
+    using DestinationItemType = typename CollectionInspector<typename std::invoke_result<MapFunction, SourceItemType&>::type>::SourceItemType;
+
+    static Vector<DestinationItemType> flatMap(const SourceType& source, const MapFunction& mapFunction)
+    {
+        Vector<DestinationItemType> result;
+        for (auto&& item : source) {
+            if (auto i = mapFunction(item))
+                result.append(i);
+        }
         result.shrinkToFit();
         return result;
     }


### PR DESCRIPTION
#### 444495458eaa1385a71efb2a46ccc0f77f9ff8c3
<pre>
[WTF] Make WTF::flatMap work with truthy/falsy types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302191">https://bugs.webkit.org/show_bug.cgi?id=302191</a>

Reviewed by NOBODY (OOPS!).

This allows WTF::flatMap to work with types that override operator bool:

fn : &apos;a -&gt; &apos;a
flatMap fn xs =&gt; xs.map(fn).filter(x =&gt; !!x)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/444495458eaa1385a71efb2a46ccc0f77f9ff8c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130092 "Passed style check") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2360 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Hash 44449545 for PR 53619 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/41040 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137489 "Hash 44449545 for PR 53619 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81627 "Hash 44449545 for PR 53619 does not build (failure)") 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2322 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2245 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/137489 "Hash 44449545 for PR 53619 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/81627 "Hash 44449545 for PR 53619 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133039 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/2322 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/41040 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/137489 "Hash 44449545 for PR 53619 does not build (failure)") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/2322 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/41040 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80761 "Hash 44449545 for PR 53619 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122084 "Built successfully and passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/2322 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41040 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139967 "Hash 44449545 for PR 53619 does not build (failure)") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/128544 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2147 "Hash 44449545 for PR 53619 does not build (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/2245 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/139967 "Hash 44449545 for PR 53619 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2192 "Hash 44449545 for PR 53619 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/41040 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/139967 "Hash 44449545 for PR 53619 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41040 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54998 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/2220 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65607 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161558 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2037 "Hash 44449545 for PR 53619 does not build (failure)") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/40276 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (cancelled)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2237 "Hash 44449545 for PR 53619 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2143 "Hash 44449545 for PR 53619 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->