### PR TITLE
Make Integer Range Optimization see through for of pattern

### DIFF
--- a/JSTests/microbenchmarks/for-of-vs-for-each-2.js
+++ b/JSTests/microbenchmarks/for-of-vs-for-each-2.js
@@ -1,0 +1,83 @@
+//@ $skipModes << :lockdown
+"use strict"
+const consoleStub = console || {
+  log: print
+}
+var console = consoleStub
+
+function testForOf(arr) {
+    let sum = 0|0
+    for (const item of arr) {
+        sum = ((sum|0) + (item|0))|0
+    }
+    return sum
+}
+noInline(testForOf)
+
+function testForEach(arr) {
+    let sum = 0|0
+    arr.forEach(item => sum = ((sum|0) + (item|0))|0)
+    return sum
+}
+noInline(testForEach)
+
+const warmup = 10000
+const test = 5000
+let run = 1
+
+let arr = Array.from({length: 1}, (_, i) => i);
+
+function runTest() {
+  let resultsTotal = []
+  let resultsForOf = []
+  let resultsForEach = []
+  
+  for (let i = 0; i < test; ++i) {
+      {
+          let start = performance.now()
+          for (let i = 0; i < run; i++) {
+            testForOf(arr)
+            testForEach(arr)
+          }
+          resultsTotal.push(performance.now() - start)
+      }
+  
+      {
+          let start = performance.now()
+          for (let i = 0; i < run; i++) {
+            testForEach(arr)
+          }
+          resultsForEach.push(performance.now() - start)
+      }
+  
+      {
+          let start = performance.now()
+          for (let i = 0; i < run; i++) {
+            testForOf(arr)
+          }
+          resultsForOf.push(performance.now() - start)
+      }
+  }
+  return [
+    resultsTotal.reduce((a, b) => a + b, 0) / resultsTotal.length,
+    resultsForOf.reduce((a, b) => a + b, 0) / resultsForOf.length,
+    resultsForEach.reduce((a, b) => a + b, 0) / resultsForEach.length
+  ]
+}
+noInline(runTest)
+
+for (let i = 0; i < warmup; i++) {
+  runTest()
+  run = (run + i) % 3 // make sure it isn't a constant
+  arr = Array.from({length: (run + i) % 3}, (_, i) => i);
+}
+run = 10
+arr = Array.from({length: 100000}, (_, i) => i);
+
+console.log("Warmup complete")
+
+let [resultsTotal, resultsForOf, resultsForEach] = runTest()
+
+console.log("Total:", resultsTotal)
+console.log("ForOf:", resultsForOf)
+console.log("ForEach:", resultsForEach)

--- a/JSTests/microbenchmarks/for-of-vs-for-each.js
+++ b/JSTests/microbenchmarks/for-of-vs-for-each.js
@@ -1,0 +1,100 @@
+//@ $skipModes << :lockdown
+"use strict"
+const consoleStub = console || {
+  log: print
+}
+var console = consoleStub
+
+function testFor(arr) {
+    let sum = 0|0
+    for (let i = 0; i < arr.length; i++) {
+        sum = ((sum|0) + (arr[i]|0))|0
+    }
+    return sum
+}
+noInline(testFor)
+
+function testForOf(arr) {
+    let sum = 0|0
+    for (const item of arr) {
+        sum = ((sum|0) + (item|0))|0
+    }
+    return sum
+}
+noInline(testForOf)
+
+function testForEach(arr) {
+    let sum = 0|0
+    arr.forEach(item => sum = ((sum|0) + (item|0))|0)
+    return sum
+}
+noInline(testForEach)
+
+const warmup = 5000
+const test = 20
+let run = 1
+
+const arr1 = [1, 2, 3, 4, 5]
+
+function runTest() {
+  let resultsTotal = []
+  let resultsFor = []
+  let resultsForOf = []
+  let resultsForEach = []
+  
+  for (let i = 0; i < test; ++i) {
+      {
+          let start = performance.now()
+          for (let i = 0; i < run; i++) {
+            testFor(arr1)
+            testForOf(arr1)
+            testForEach(arr1)
+          }
+          resultsTotal.push(performance.now() - start)
+      }
+      {
+          let start = performance.now()
+          for (let i = 0; i < run; i++) {
+            testFor(arr1)
+          }
+          resultsFor.push(performance.now() - start)
+      }
+      {
+          let start = performance.now()
+          for (let i = 0; i < run; i++) {
+            testForEach(arr1)
+          }
+          resultsForEach.push(performance.now() - start)
+      }
+  
+      {
+          let start = performance.now()
+          for (let i = 0; i < run; i++) {
+            testForOf(arr1)
+          }
+          resultsForOf.push(performance.now() - start)
+      }
+  }
+  return [
+    resultsTotal.reduce((a, b) => a + b, 0) / resultsTotal.length,
+    resultsFor.reduce((a, b) => a + b, 0) / resultsFor.length,
+    resultsForOf.reduce((a, b) => a + b, 0) / resultsForOf.length,
+    resultsForEach.reduce((a, b) => a + b, 0) / resultsForEach.length
+  ]
+}
+noInline(runTest)
+
+for (let i = 0; i < warmup; i++) {
+  runTest()
+  run = (run + i) % 10 // make sure it isn't a constant
+}
+run = 1_000_000
+
+console.log("Warmup complete")
+
+let [resultsTotal, resultsFor, resultsForOf, resultsForEach] = runTest()
+
+console.log("Total:", resultsTotal)
+console.log("For:", resultsFor)
+console.log("ForOf:", resultsForOf)
+console.log("ForEach:", resultsForEach)

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2995,7 +2995,7 @@ public:
     
     bool isBinaryUseKind(UseKind left, UseKind right)
     {
-        return child1().useKind() == left && child2().useKind() == right;
+        return !hasVarArgs() && child1() && child1().useKind() == left && child2() && child2().useKind() == right;
     }
     
     bool isBinaryUseKind(UseKind useKind)


### PR DESCRIPTION
#### 2d4d8ad1273ab2997fa0736c0db51123256d2db9
<pre>
Make Integer Range Optimization see through for of pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=302192">https://bugs.webkit.org/show_bug.cgi?id=302192</a>

Reviewed by Yijia Huang.

We emit:

Branch(ArithBitOr(BooleanToNumber(Compare*), BooleanToNumber(Compare*)))

in the bytecode parser for iterator_next. This patch lets IRO see through
this and extract the cases, at least for the false side of the branch.

This removes the checks in the provided microbenchmarks.

* JSTests/microbenchmarks/for-of-vs-for-each-2.js: Added.
(console.consoleStub.testForOf):
(noInline.testForOf.testForEach):
(runTest):
(noInline.runTest):
* JSTests/microbenchmarks/for-of-vs-for-each.js: Added.
(console.consoleStub.testForOf):
(noInline.testForOf.testForEach):
(5.runTest):
(noInline.runTest):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::isBinaryUseKind):

Canonical link: <a href="https://commits.webkit.org/303542@main">https://commits.webkit.org/303542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/597fbcd83fa484480df8d9000f0e8e64951ca7e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84336 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101199 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135329 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81989 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1187 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83124 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124453 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142549 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130891 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109577 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109753 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27899 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3441 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57824 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33213 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163858 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4434 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68053 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42573 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/omg-tail-call-clobber-scratch-register.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->