### PR TITLE
RELEASE_ASSERT under ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didResolveToBlob()

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -93,7 +93,7 @@ private:
 
         String m_type;
         BufferOrString m_data;
-        std::unique_ptr<FileReaderLoader> m_blobLoader;
+        RefPtr<FileReaderLoader> m_blobLoader;
         CompletionHandler<void()> m_completionHandler;
         WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_writingDestination;
     };

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -192,8 +192,6 @@ editing/cocoa/WebContentReaderCocoa.mm
 [ Mac ] editing/mac/EditorMac.mm
 editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
-fileapi/BlobLoader.h
-fileapi/FileReader.cpp
 history/CachedFrame.cpp
 html/CachedHTMLCollection.h
 html/CachedHTMLCollectionInlines.h

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -356,7 +356,7 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
 
     private:
         BlobStreamSource(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
-            : m_loader(makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadType::ReadAsBinaryChunks, this))
+            : m_loader(FileReaderLoader::create(FileReaderLoader::ReadType::ReadAsBinaryChunks, this))
         {
             relaxAdoptionRequirement();
             m_loader->start(&scriptExecutionContext, blob);
@@ -451,7 +451,7 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
             return didSucceed;
         }
 
-        const UniqueRef<FileReaderLoader> m_loader;
+        const Ref<FileReaderLoader> m_loader;
         Deque<Ref<FragmentedSharedBuffer>> m_queue;
         std::optional<Exception> m_exception;
         enum class StreamState : uint8_t { NotStarted, Started, Waiting };

--- a/Source/WebCore/fileapi/BlobLoader.h
+++ b/Source/WebCore/fileapi/BlobLoader.h
@@ -69,7 +69,7 @@ private:
     void didFail(ExceptionCode errorCode) final;
     void complete();
 
-    std::unique_ptr<FileReaderLoader> m_loader;
+    const RefPtr<FileReaderLoader> m_loader;
     CompleteCallback m_completeCallback;
 };
 
@@ -94,14 +94,14 @@ inline void BlobLoader::cancel()
 inline void BlobLoader::start(Blob& blob, ScriptExecutionContext* context, FileReaderLoader::ReadType readType)
 {
     ASSERT(!m_loader);
-    m_loader = makeUnique<FileReaderLoader>(readType, this);
+    lazyInitialize(m_loader, FileReaderLoader::create(readType, this));
     m_loader->start(context, blob);
 }
 
 inline void BlobLoader::start(const URL& blobURL, ScriptExecutionContext* context, FileReaderLoader::ReadType readType)
 {
     ASSERT(!m_loader);
-    m_loader = makeUnique<FileReaderLoader>(readType, this);
+    lazyInitialize(m_loader, FileReaderLoader::create(readType, this));
     m_loader->start(context, blobURL);
 }
 

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -108,7 +108,7 @@ private:
     RefPtr<Blob> m_blob;
     FileReaderLoader::ReadType m_readType { FileReaderLoader::ReadAsBinaryString };
     String m_encoding;
-    std::unique_ptr<FileReaderLoader> m_loader;
+    RefPtr<FileReaderLoader> m_loader;
     RefPtr<DOMException> m_error;
     MonotonicTime m_lastProgressNotificationTime { MonotonicTime::nan() };
     HashMap<uint64_t, Function<void(FileReader&)>> m_pendingTasks;

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -63,6 +63,11 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FileReaderLoader);
 
 const int defaultBufferLength = 32768;
 
+Ref<FileReaderLoader> FileReaderLoader::create(ReadType readType, FileReaderLoaderClient* client)
+{
+    return adoptRef(*new FileReaderLoader(readType, client));
+}
+
 FileReaderLoader::FileReaderLoader(ReadType readType, FileReaderLoaderClient* client)
     : m_readType(readType)
     , m_client(client)

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -54,7 +54,7 @@ class TextResourceDecoder;
 class ThreadableLoader;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FileReaderLoader);
-class FileReaderLoader final : public ThreadableLoaderClient {
+class FileReaderLoader final : public ThreadableLoaderClient, public RefCounted<FileReaderLoader> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FileReaderLoader, FileReaderLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FileReaderLoader);
 public:
@@ -68,7 +68,7 @@ public:
     };
 
     // If client is given, do the loading asynchronously. Otherwise, load synchronously.
-    WEBCORE_EXPORT FileReaderLoader(ReadType, FileReaderLoaderClient*);
+    WEBCORE_EXPORT static Ref<FileReaderLoader> create(ReadType, FileReaderLoaderClient*);
     ~FileReaderLoader();
 
     WEBCORE_EXPORT void start(ScriptExecutionContext*, Blob&);
@@ -95,6 +95,9 @@ public:
     bool isCompleted() const;
 
 private:
+    // If client is given, do the loading asynchronously. Otherwise, load synchronously.
+    FileReaderLoader(ReadType, FileReaderLoaderClient*);
+
     void terminate();
     void cleanup();
     void failed(ExceptionCode);

--- a/Source/WebCore/fileapi/FileReaderSync.cpp
+++ b/Source/WebCore/fileapi/FileReaderSync.cpp
@@ -46,8 +46,8 @@ FileReaderSync::FileReaderSync()
 
 ExceptionOr<RefPtr<ArrayBuffer>> FileReaderSync::readAsArrayBuffer(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    auto loader = makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsArrayBuffer, nullptr);
-    auto result = startLoading(scriptExecutionContext, CheckedRef { loader.get() }.get(), blob);
+    Ref loader = FileReaderLoader::create(FileReaderLoader::ReadAsArrayBuffer, nullptr);
+    auto result = startLoading(scriptExecutionContext, loader, blob);
     if (result.hasException())
         return result.releaseException();
     return loader->arrayBufferResult();
@@ -55,22 +55,22 @@ ExceptionOr<RefPtr<ArrayBuffer>> FileReaderSync::readAsArrayBuffer(ScriptExecuti
 
 ExceptionOr<String> FileReaderSync::readAsBinaryString(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    auto loader = makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsBinaryString, nullptr);
-    return startLoadingString(scriptExecutionContext, CheckedRef { loader.get() }.get(), blob);
+    Ref loader = FileReaderLoader::create(FileReaderLoader::ReadAsBinaryString, nullptr);
+    return startLoadingString(scriptExecutionContext, loader, blob);
 }
 
 ExceptionOr<String> FileReaderSync::readAsText(ScriptExecutionContext& scriptExecutionContext, Blob& blob, const String& encoding)
 {
-    auto loader = makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsText, nullptr);
+    Ref loader = FileReaderLoader::create(FileReaderLoader::ReadAsText, nullptr);
     loader->setEncoding(encoding);
-    return startLoadingString(scriptExecutionContext, CheckedRef { loader.get() }.get(), blob);
+    return startLoadingString(scriptExecutionContext, loader, blob);
 }
 
 ExceptionOr<String> FileReaderSync::readAsDataURL(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    auto loader = makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsDataURL, nullptr);
+    Ref loader = FileReaderLoader::create(FileReaderLoader::ReadAsDataURL, nullptr);
     loader->setDataType(blob.type());
-    return startLoadingString(scriptExecutionContext, CheckedRef { loader.get() }.get(), blob);
+    return startLoadingString(scriptExecutionContext, loader, blob);
 }
 
 ExceptionOr<void> FileReaderSync::startLoading(ScriptExecutionContext& scriptExecutionContext, FileReaderLoader& loader, Blob& blob)

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -796,7 +796,7 @@ public:
 private:
     PendingImageBitmap(ScriptExecutionContext& scriptExecutionContext, RefPtr<Blob>&& blob, ImageBitmapOptions&& options, std::optional<IntRect> rect, ImageBitmap::ImageBitmapCompletionHandler&& completionHandler)
         : ActiveDOMObject(&scriptExecutionContext)
-        , m_blobLoader(makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsArrayBuffer, this))
+        , m_blobLoader(FileReaderLoader::create(FileReaderLoader::ReadAsArrayBuffer, this))
         , m_blob(WTFMove(blob))
         , m_options(WTFMove(options))
         , m_rect(WTFMove(rect))
@@ -846,7 +846,7 @@ private:
         ImageBitmap::createFromBuffer(*scriptExecutionContext(), m_arrayBufferToProcess.releaseNonNull(), m_blob->type(), m_blob->size(), m_blobLoader->url(), WTFMove(m_options), WTFMove(m_rect), WTFMove(m_completionHandler));
     }
 
-    const UniqueRef<FileReaderLoader> m_blobLoader;
+    const Ref<FileReaderLoader> m_blobLoader;
     RefPtr<Blob> m_blob;
     ImageBitmapOptions m_options;
     std::optional<IntRect> m_rect;

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -772,7 +772,7 @@ void WebSocketChannel::processOutgoingFrameQueue()
                 ref(); // Will be derefed after didFinishLoading() or didFail().
                 ASSERT(!m_blobLoader);
                 ASSERT(frame->blobData);
-                m_blobLoader = makeUnique<FileReaderLoader>(FileReaderLoader::ReadAsArrayBuffer, this);
+                m_blobLoader = FileReaderLoader::create(FileReaderLoader::ReadAsArrayBuffer, this);
                 m_blobLoaderStatus = BlobLoaderStarted;
                 m_blobLoader->start(m_document.get(), *frame->blobData);
                 m_outgoingFrameQueue.prepend(WTFMove(frame));

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -210,7 +210,7 @@ private:
     OutgoingFrameQueueStatus m_outgoingFrameQueueStatus { OutgoingFrameQueueOpen };
 
     // FIXME: Load two or more Blobs simultaneously for better performance.
-    std::unique_ptr<FileReaderLoader> m_blobLoader;
+    RefPtr<FileReaderLoader> m_blobLoader;
     BlobLoaderStatus m_blobLoaderStatus { BlobLoaderNotStarted };
 
     WebSocketDeflateFramer m_deflateFramer;


### PR DESCRIPTION
#### 5d7cc5b2e05d81543a860b89b8dd839baf8bfe32
<pre>
RELEASE_ASSERT under ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didResolveToBlob()
<a href="https://bugs.webkit.org/show_bug.cgi?id=302196">https://bugs.webkit.org/show_bug.cgi?id=302196</a>
<a href="https://rdar.apple.com/164271413">rdar://164271413</a>

Reviewed by Anne van Kesteren.

Make FileReaderLoader refcounted instead of relying on CheckedPtr/CheckedRef
for lifetime guarantees. From the crash trace, we can tell that in
ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didResolveToBlob()
at least, it is possible for the FileReaderLoader to get destroyed while
we&apos;re calling `start()` on it, synchronously. The CheckedPtr we had on the
stack caused a RELEASE_ASSERT to guarantee there could be no use-after-free.

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::~ClipboardItemTypeLoader):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didFinishLoading):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didResolveToBlob):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::stream):
* Source/WebCore/fileapi/BlobLoader.h:
(WebCore::BlobLoader::start):
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::~FileReader):
(WebCore::FileReader::stop):
(WebCore::FileReader::readInternal):
(WebCore::FileReader::result const):
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::create):
* Source/WebCore/fileapi/FileReaderLoader.h:
* Source/WebCore/fileapi/FileReaderSync.cpp:
(WebCore::FileReaderSync::readAsArrayBuffer):
(WebCore::FileReaderSync::readAsBinaryString):
(WebCore::FileReaderSync::readAsText):
(WebCore::FileReaderSync::readAsDataURL):
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::processOutgoingFrameQueue):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/302772@main">https://commits.webkit.org/302772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55c973b168ea8ae5ac89b144f175202d6a021894

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81654 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e4f40f0-b7b8-4f13-a5a4-be08dbd08157) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99125 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66924 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d38b046-2de4-4221-90e4-27d24ae13690) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79819 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3455301-2386-4143-8e95-48bf1968b098) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34673 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80793 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139998 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107645 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107524 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27375 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55055 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65637 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2067 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->