### PR TITLE
Regression(301243@main?) Potential null dereference of m_target in ResizeObservation::computeTargetLocation()

### DIFF
--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -92,6 +92,9 @@ auto ResizeObservation::computeObservedSizes() const -> std::optional<BoxSizes>
 
 LayoutPoint ResizeObservation::computeTargetLocation() const
 {
+    if (!m_target)
+        return { };
+
     if (!m_target->isSVGElement()) {
         if (auto box = m_target->renderBox())
             return LayoutPoint(box->paddingLeft(), box->paddingTop());

--- a/Source/WebCore/page/ResizeObserverEntry.h
+++ b/Source/WebCore/page/ResizeObserverEntry.h
@@ -40,27 +40,27 @@ class ResizeObserverSize;
 class ResizeObserverEntry : public RefCounted<ResizeObserverEntry> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(ResizeObserverEntry);
 public:
-    static Ref<ResizeObserverEntry> create(Element* target, const FloatRect& contentRect, FloatSize borderBoxSize, FloatSize contentBoxSize)
+    static Ref<ResizeObserverEntry> create(Ref<Element>&& target, const FloatRect& contentRect, FloatSize borderBoxSize, FloatSize contentBoxSize)
     {
-        return adoptRef(*new ResizeObserverEntry(target, contentRect, borderBoxSize, contentBoxSize));
+        return adoptRef(*new ResizeObserverEntry(WTFMove(target), contentRect, borderBoxSize, contentBoxSize));
     }
 
-    Element* target() const { return m_target.get(); }
+    Element& target() const { return m_target.get(); }
     DOMRectReadOnly* contentRect() const { return m_contentRect.ptr(); }
     
     const Vector<Ref<ResizeObserverSize>>& borderBoxSize() const { return m_borderBoxSizes; }
     const Vector<Ref<ResizeObserverSize>>& contentBoxSize() const { return m_contentBoxSizes; }
 
 private:
-    ResizeObserverEntry(Element* target, const FloatRect& contentRect, FloatSize borderBoxSize, FloatSize contentBoxSize)
-        : m_target(target)
+    ResizeObserverEntry(Ref<Element>&& target, const FloatRect& contentRect, FloatSize borderBoxSize, FloatSize contentBoxSize)
+        : m_target(WTFMove(target))
         , m_contentRect(DOMRectReadOnly::create(contentRect.x(), contentRect.y(), contentRect.width(), contentRect.height()))
         , m_borderBoxSizes({ ResizeObserverSize::create(borderBoxSize.width(), borderBoxSize.height()) })
         , m_contentBoxSizes({ ResizeObserverSize::create(contentBoxSize.width(), contentBoxSize.height()) })
     {
     }
 
-    const RefPtr<Element> m_target;
+    const Ref<Element> m_target;
     const Ref<DOMRectReadOnly> m_contentRect;
     // The spec is designed to allow mulitple boxes for multicol scenarios, but for now these vectors only ever contain one entry.
     Vector<Ref<ResizeObserverSize>> m_borderBoxSizes;


### PR DESCRIPTION
#### a1c0f13ff6a03165d4f4fce97103a52783d9e18b
<pre>
Regression(301243@main?) Potential null dereference of m_target in ResizeObservation::computeTargetLocation()
<a href="https://bugs.webkit.org/show_bug.cgi?id=302197">https://bugs.webkit.org/show_bug.cgi?id=302197</a>
<a href="https://rdar.apple.com/164271295">rdar://164271295</a>

Reviewed by Ryosuke Niwa.

From the crash, we can tell that we&apos;re doing a null dereference of m_target
in ResizeObservation::computeTargetLocation(), m_target being a WeakPtr.

I suspect this is a regression from 301243@main. The targets used to be kept
alive via the `m_activeObservationTargets` Vector, which used to contain
`GCReacheableRef&lt;Element&gt;` types. 301243@main updated the Vector to contain
`WeakPtr&lt;Element&gt;` and then relied on `JSResizeObserver::visitAdditionalChildren()`
to visit the targets in the Vector. Something must be wrong with the leak fix in
301243@main. In particular, I think that updating the stack Vectors in
`ResizeObserver::deliverObservations()` to also use WeakPtr instead of GCReacheableRef
was a mistake. The Vectors seemed useless after 301243@main as they contained
WeakPtrs and were unused. I think those vectors have to keep using GCReacheableRef
to make sure the targets and their JS wrappers are kept alive while we deliver the
observations. We need those vectors on the stack because the function clears
`m_activeObservationTargets` before delivering the observations and thus
`JSResizeObserver::visitAdditionalChildren()` will no longer be able to visit the
targets on the GC thread.

Because my fix above may be insufficient and is speculative since we do not have
a reproduction case, I also  added a null check in ResizeObservation::computeTargetLocation()
to avoid the null dereference. I also updated the call site to avoid constructing a
ResizeObserverEntry for a target that has already been destroyed, since there
is no point and it may cause trouble later on since the code may expect the
target to be still alive.

* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::computeTargetLocation const):
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::deliverObservations):
* Source/WebCore/page/ResizeObserverEntry.h:
(WebCore::ResizeObserverEntry::create):
(WebCore::ResizeObserverEntry::target const):
(WebCore::ResizeObserverEntry::ResizeObserverEntry):

Canonical link: <a href="https://commits.webkit.org/302765@main">https://commits.webkit.org/302765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c175df1641f02e6e664761483426f34aeabc5650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81653 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f828f90e-e116-435a-af81-78130a991aa3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99122 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66922 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9609fa2-f7f2-41b1-a645-51c7d96d57d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79816 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/13ab7411-3806-48cb-a776-04f1cfcf4797) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80792 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139997 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107647 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27368 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1734 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31339 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55054 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65636 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2175 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->