### PR TITLE
[JSC] Optimize `Array#lastIndexOf` in DFG/FTL

### DIFF
--- a/JSTests/stress/array-prototype-lastIndeOf-large-fromIndex.js
+++ b/JSTests/stress/array-prototype-lastIndeOf-large-fromIndex.js
@@ -1,0 +1,38 @@
+function main() {
+  const v5 = [-268435456, -268435456, -268435456, -268435456];
+  function v58(v59, v60, v61, v62) {
+    function v85(v86, v87, v88, v89) {
+      const v111 = [];
+      const v113 = {
+      };
+      const v117 = [
+      ];
+      const v118 = ['global', v117, 1293649203];
+      function v125(v126, v127, v128, v129) {
+        const v143 = [
+          'ӫ\uD83E\uDE56\uD83D\uDF5A\uD83F\uDF23\uD83F\uDC34౪㩤͂\uE61Bଃ\uD83E\uDE69ħ', -766168.2306857926, -423640.9401722138
+        ];
+        const v144 = v143;
+        const v146 = v144['lastIndexOf']('lastIndexOf', 854335000, {'g': 5}, {'g': 5}, {'g': 5}, {'g': 5}, {'g': 5}, {'g': 5});
+      }
+      const v157 = Object();
+      const v158 = v125(v157, v118, v111, 531471.299396279);
+    }
+    for (let v173 = 0; v173 < 100; v173++) {
+      const v175 = {
+      };
+      const v177 = {
+      };
+      const v178 = v85(v175, 290281212n, v177, 290281212n);
+    }
+  };
+  for (let v193 = 0; v193 < 100; v193++) {
+    this.g ??= createGlobalObject();
+    const v203 = new this.g.ArrayBuffer(0);
+    const v205 = new DataView(v203);
+    const v206 = {
+    };
+    const v207 = v58(v205, 100, v5, v206);
+  };
+}
+main();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3215,11 +3215,12 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         setNonCellTypeForNode(node, SpecBoolean);
         break;
 
-    case ArrayIndexOf: {
+    case ArrayIndexOf:
+    case ArrayLastIndexOf: {
         setNonCellTypeForNode(node, SpecInt32Only);
         break;
     }
-            
+
     case ArrayPop:
         clobberWorld();
         makeHeapTopForNode(node);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2816,7 +2816,8 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
         }
 
         case ArrayIncludesIntrinsic:
-        case ArrayIndexOfIntrinsic: {
+        case ArrayIndexOfIntrinsic:
+        case ArrayLastIndexOfIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;
 
@@ -2861,7 +2862,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
                     Node* node = intrinsic == ArrayIncludesIntrinsic
                         ? addToGraph(Node::VarArg, ArrayIncludes, OpInfo(arrayMode.asWord()), OpInfo())
-                        : addToGraph(Node::VarArg, ArrayIndexOf, OpInfo(arrayMode.asWord()), OpInfo());
+                        : intrinsic == ArrayIndexOfIntrinsic
+                            ? addToGraph(Node::VarArg, ArrayIndexOf, OpInfo(arrayMode.asWord()), OpInfo())
+                            : addToGraph(Node::VarArg, ArrayLastIndexOf, OpInfo(arrayMode.asWord()), OpInfo());
                     setResult(node);
                     return CallOptimizationResult::Inlined;
                 }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -173,6 +173,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case ArrayPop:
         case ArrayIncludes:
         case ArrayIndexOf:
+        case ArrayLastIndexOf:
         case HasIndexedProperty:
         case AtomicsAdd:
         case AtomicsAnd:
@@ -695,7 +696,8 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case ArrayIncludes:
-    case ArrayIndexOf: {
+    case ArrayIndexOf:
+    case ArrayLastIndexOf: {
         // FIXME: Should support a CSE rule.
         // https://bugs.webkit.org/show_bug.cgi?id=173173
         read(MiscFields);

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -461,6 +461,7 @@ bool doesGC(Graph& graph, Node* node)
     case ArraySlice:
     case ArrayIncludes:
     case ArrayIndexOf:
+    case ArrayLastIndexOf:
     case ParseInt: // We might resolve a rope even though we don't clobber anything.
     case SetAdd:
     case MapSet:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1702,6 +1702,7 @@ private:
 
         case ArrayIncludes:
         case ArrayIndexOf:
+        case ArrayLastIndexOf:
             fixupArrayIndexOfOrArrayIncludes(node);
             break;
             
@@ -5177,7 +5178,7 @@ private:
 
     void fixupArrayIndexOfOrArrayIncludes(Node* node)
     {
-        ASSERT(node->op() == ArrayIndexOf || node->op() == ArrayIncludes);
+        ASSERT(node->op() == ArrayIndexOf || node->op() == ArrayIncludes || node->op() == ArrayLastIndexOf);
 
         bool isArrayIncludes = node->op() == ArrayIncludes;
 

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -333,7 +333,8 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
             break;
         return Exits;
 
-    case ArrayIndexOf: {
+    case ArrayIndexOf:
+    case ArrayLastIndexOf: {
         Edge& searchElementEdge = graph.child(node, 1);
         switch (searchElementEdge.useKind()) {
         case Int32Use:
@@ -425,6 +426,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
             
             switch (node->op()) {
             case ArrayIndexOf:
+            case ArrayLastIndexOf:
                 break;
             default: {
                 switch (edge.useKind()) {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2674,6 +2674,7 @@ public:
         case ArrayPop:
         case ArrayIncludes:
         case ArrayIndexOf:
+        case ArrayLastIndexOf:
         case HasIndexedProperty:
         case AtomicsAdd:
         case AtomicsAnd:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -340,6 +340,7 @@ namespace JSC { namespace DFG {
     macro(ArraySlice, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(ArrayIncludes, NodeResultBoolean | NodeHasVarArgs) \
     macro(ArrayIndexOf, NodeResultInt32 | NodeHasVarArgs) \
+    macro(ArrayLastIndexOf, NodeResultInt32 | NodeHasVarArgs) \
     macro(ArraySplice, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     \
     /* Optimizations for regular expression matching. */\

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4304,6 +4304,168 @@ JSC_DEFINE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32
     OPERATION_RETURN(scope, arrayIndexOfString(globalObject, butterfly, searchElement, index));
 }
 
+static ALWAYS_INLINE UCPUStrictInt32 arrayLastIndexOfString(JSGlobalObject* globalObject, Butterfly* butterfly, JSString* searchElement, int32_t index)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    int32_t length = butterfly->publicLength();
+    auto data = butterfly->contiguous().data();
+
+    if (index >= length)
+        index = length - 1;
+
+    for (; index >= 0; --index) {
+        JSValue value = data[index].get();
+        if (!value || !value.isString())
+            continue;
+        auto* string = asString(value);
+        if (string == searchElement)
+            return toUCPUStrictInt32(index);
+        if (string->equalInline(globalObject, searchElement)) {
+            scope.assertNoExceptionExceptTermination();
+            return toUCPUStrictInt32(index);
+        }
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    return toUCPUStrictInt32(-1);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArrayLastIndexOfString, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, JSString* searchElement, int32_t index))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, arrayLastIndexOfString(globalObject, butterfly, searchElement, index));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArrayLastIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, EncodedJSValue encodedValue, int32_t index))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue searchElement = JSValue::decode(encodedValue);
+
+    if (searchElement.isString())
+        OPERATION_RETURN(scope, arrayLastIndexOfString(globalObject, butterfly, asString(searchElement), index));
+
+    int32_t length = butterfly->publicLength();
+    auto data = butterfly->contiguous().data();
+
+    if (index < 0)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    if (index >= length)
+        index = length - 1;
+
+    if (searchElement.isObject()) {
+        for (; index >= 0; --index) {
+            JSValue value = data[index].get();
+            if (value == searchElement)
+                OPERATION_RETURN(scope, toUCPUStrictInt32(index));
+        }
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+    }
+
+    if (searchElement.isInt32()) {
+        for (; index >= 0; --index) {
+            JSValue value = data[index].get();
+            if (!value || !value.isNumber())
+                continue;
+            if (searchElement.asInt32() == value.asNumber())
+                OPERATION_RETURN(scope, toUCPUStrictInt32(index));
+        }
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+    }
+
+    for (; index >= 0; --index) {
+        JSValue value = data[index].get();
+        if (!value)
+            continue;
+        bool isEqual = JSValue::strictEqual(globalObject, searchElement, value);
+        OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+        if (isEqual)
+            OPERATION_RETURN(scope, toUCPUStrictInt32(index));
+    }
+    OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArrayLastIndexOfValueInt32, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, EncodedJSValue encodedValue, int32_t index))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    int32_t length = butterfly->publicLength();
+    auto data = butterfly->contiguous().data();
+
+    if (index < 0)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    if (index >= length)
+        index = length - 1;
+
+    JSValue searchElement = JSValue::decode(encodedValue);
+
+    int32_t int32Value = 0;
+    if (searchElement.isInt32AsAnyInt())
+        int32Value = searchElement.asInt32AsAnyInt();
+    else if (!searchElement.isNumber() || searchElement.asNumber() != 0.0)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    EncodedJSValue encodedSearchElement = JSValue::encode(jsNumber(int32Value));
+    for (; index >= 0; --index) {
+        if (JSValue::encode(data[index].get()) == encodedSearchElement)
+            OPERATION_RETURN(scope, toUCPUStrictInt32(index));
+    }
+    OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayLastIndexOfValueDouble, UCPUStrictInt32, (Butterfly* butterfly, EncodedJSValue encodedValue, int32_t index))
+{
+    JSValue searchElement = JSValue::decode(encodedValue);
+
+    if (!searchElement.isNumber())
+        return toUCPUStrictInt32(-1);
+    double number = searchElement.asNumber();
+
+    int32_t length = butterfly->publicLength();
+    const double* data = butterfly->contiguousDouble().data();
+
+    if (index >= length)
+        index = length - 1;
+
+    for (; index >= 0; --index) {
+        // This comparison ignores NaN.
+        if (data[index] == number)
+            return toUCPUStrictInt32(index);
+    }
+    return toUCPUStrictInt32(-1);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayLastIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly* butterfly, EncodedJSValue searchElement, int32_t index))
+{
+    int32_t length = butterfly->publicLength();
+    auto data = butterfly->contiguous().data();
+
+    if (index < 0)
+        return toUCPUStrictInt32(-1);
+
+    if (index >= length)
+        index = length - 1;
+
+    for (; index >= 0; --index) {
+        if (JSValue::encode(data[index].get()) == searchElement)
+            return toUCPUStrictInt32(index);
+    }
+    return toUCPUStrictInt32(-1);
+}
+
 JSC_DEFINE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, EncodedJSValue encodedValue, int32_t index))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -408,6 +408,12 @@ JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStric
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 
+JSC_DECLARE_JIT_OPERATION(operationArrayLastIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayLastIndexOfValueDouble, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationArrayLastIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationArrayLastIndexOfValueInt32, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayLastIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
+
 JSC_DECLARE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSpreadSlow, JSCell*, (JSGlobalObject*, void*, uint32_t));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1147,6 +1147,7 @@ private:
 
         case GetRestLength:
         case ArrayIndexOf:
+        case ArrayLastIndexOf:
         case RegExpSearch: {
             setPrediction(SpecInt32Only);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -355,7 +355,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
 
     case ArraySlice:
     case ArrayIncludes:
-    case ArrayIndexOf: {
+    case ArrayIndexOf:
+    case ArrayLastIndexOf: {
         // You could plausibly move this code around as long as you proved the
         // incoming array base structure is an original array at the hoisted location.
         // Instead of doing that extra work, we just conservatively return false.

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9644,9 +9644,10 @@ void SpeculativeJIT::compileArraySplice(Node* node)
 
 void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
 {
-    ASSERT(node->op() == ArrayIndexOf || node->op() == ArrayIncludes);
+    ASSERT(node->op() == ArrayIndexOf || node->op() == ArrayIncludes || node->op() == ArrayLastIndexOf);
 
     bool isArrayIncludes = node->op() == ArrayIncludes;
+    bool isArrayLastIndexOf = node->op() == ArrayLastIndexOf;
 
     StorageOperand storage(this, m_graph.varArgChild(node, node->numChildren() == 3 ? 2 : 3));
     GPRTemporary index(this);
@@ -9658,10 +9659,19 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
 
     load32(Address(storageGPR, Butterfly::offsetOfPublicLength()), lengthGPR);
 
-    if (node->numChildren() == 4)
+    if (node->numChildren() == 4) {
         emitPopulateSliceIndex(m_graph.varArgChild(node, 2), std::nullopt, lengthGPR, indexGPR);
-    else
-        move(TrustedImm32(0), indexGPR);
+        if (isArrayLastIndexOf) {
+            auto indexInRange = branch32(LessThan, indexGPR, lengthGPR);
+            sub32(lengthGPR, TrustedImm32(1), indexGPR);
+            indexInRange.link(this);
+        }
+    } else {
+        if (isArrayLastIndexOf)
+            sub32(lengthGPR, TrustedImm32(1), indexGPR);
+        else
+            move(TrustedImm32(0), indexGPR);
+    }
 
     Edge& searchElementEdge = m_graph.varArgChild(node, 1);
     switch (searchElementEdge.useKind()) {
@@ -9675,11 +9685,18 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             zeroExtend32ToWord(indexGPR, indexGPR);
 
             auto loop = label();
-            auto notFound = branch32(Equal, indexGPR, lengthGPR);
+            Jump notFound;
+            if (isArrayLastIndexOf)
+                notFound = branch32(LessThan, indexGPR, TrustedImm32(0));
+            else
+                notFound = branch32(Equal, indexGPR, lengthGPR);
 
             auto found = emitCompare();
 
-            add32(TrustedImm32(1), indexGPR);
+            if (isArrayLastIndexOf)
+                sub32(TrustedImm32(1), indexGPR);
+            else
+                add32(TrustedImm32(1), indexGPR);
             jump().linkTo(loop, this);
 
             if (isArrayIncludes) {
@@ -9741,10 +9758,17 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         zeroExtend32ToWord(indexGPR, indexGPR);
 
         auto loop = label();
-        auto notFound = branch32(Equal, indexGPR, lengthGPR);
+        Jump notFound;
+        if (isArrayLastIndexOf)
+            notFound = branch32(LessThan, indexGPR, TrustedImm32(0));
+        else
+            notFound = branch32(Equal, indexGPR, lengthGPR);
         loadDouble(BaseIndex(storageGPR, indexGPR, TimesEight), tempFPR);
         auto found = branchDouble(DoubleEqualAndOrdered, tempFPR, searchElementFPR);
-        add32(TrustedImm32(1), indexGPR);
+        if (isArrayLastIndexOf)
+            sub32(TrustedImm32(1), indexGPR);
+        else
+            add32(TrustedImm32(1), indexGPR);
         jump().linkTo(loop, this);
 
         if (isArrayIncludes) {
@@ -9778,6 +9802,9 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         if (isArrayIncludes) {
             callOperation(operationArrayIncludesString, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementGPR, indexGPR);
             unblessedBooleanResult(lengthGPR, node);
+        } else if (isArrayLastIndexOf) {
+            callOperation(operationArrayLastIndexOfString, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementGPR, indexGPR);
+            strictInt32Result(lengthGPR, node);
         } else {
             callOperation(operationArrayIndexOfString, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementGPR, indexGPR);
             strictInt32Result(lengthGPR, node);
@@ -9806,7 +9833,7 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
 
         JumpList slowCase;
 
-        auto operation = operationArrayIndexOfString;
+        auto indexOfOperation = operationArrayIndexOfString;
 
         auto isCopyOnWriteArrayWithContiguous = [&]() {
             Edge& baseEdge = m_graph.varArgChild(node, 0);
@@ -9822,7 +9849,7 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         };
 
         if (isCopyOnWriteArrayWithContiguous()) {
-            operation = operationCopyOnWriteArrayIndexOfString;
+            indexOfOperation = operationCopyOnWriteArrayIndexOfString;
             loadLinkableConstant(LinkableConstant(*this, vm().cellButterflyOnlyAtomStringsStructure.get()), compareLengthGPR);
             emitEncodeStructureID(compareLengthGPR, compareLengthGPR);
             addPtr(TrustedImm32(-static_cast<ptrdiff_t>(JSCellButterfly::offsetOfData())), storageGPR, leftStringGPR);
@@ -9844,11 +9871,18 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
 #endif
             Label loop = label();
 
-            Jump notFound = branch32(Equal, indexGPR, lengthGPR);
+            Jump notFound;
+            if (isArrayLastIndexOf)
+                notFound = branch32(LessThan, indexGPR, TrustedImm32(0));
+            else
+                notFound = branch32(Equal, indexGPR, lengthGPR);
 
             JumpList found = emitCompare();
 
-            add32(TrustedImm32(1), indexGPR);
+            if (isArrayLastIndexOf)
+                sub32(TrustedImm32(1), indexGPR);
+            else
+                add32(TrustedImm32(1), indexGPR);
             jump().linkTo(loop, this);
 
             if (isArrayIncludes) {
@@ -9926,7 +9960,7 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             unblessedBooleanResult(indexGPR, node);
         } else {
             addSlowPathGenerator(slowPathCall(
-                slowCase, this, operation,
+                slowCase, this, isArrayLastIndexOf ? operationArrayLastIndexOfString : indexOfOperation,
                 indexGPR, LinkableConstant::globalObject(*this, node),
                 storageGPR, searchElementGPR, indexGPR
             ));
@@ -9951,6 +9985,9 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         if (isArrayIncludes) {
             callOperationWithoutExceptionCheck(operationArrayIncludesNonStringIdentityValueContiguous, lengthGPR, storageGPR, valueRegs, indexGPR);
             unblessedBooleanResult(lengthGPR, node);
+        } else if (isArrayLastIndexOf) {
+            callOperationWithoutExceptionCheck(operationArrayLastIndexOfNonStringIdentityValueContiguous, lengthGPR, storageGPR, valueRegs, indexGPR);
+            strictInt32Result(lengthGPR, node);
         } else {
             callOperationWithoutExceptionCheck(operationArrayIndexOfNonStringIdentityValueContiguous, lengthGPR, storageGPR, valueRegs, indexGPR);
             strictInt32Result(lengthGPR, node);
@@ -9968,18 +10005,24 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         case Array::Double:
             if (isArrayIncludes)
                 callOperation(operationArrayIncludesValueDouble, lengthGPR, storageGPR, searchElementRegs, indexGPR);
+            else if (isArrayLastIndexOf)
+                callOperation(operationArrayLastIndexOfValueDouble, lengthGPR, storageGPR, searchElementRegs, indexGPR);
             else
                 callOperation(operationArrayIndexOfValueDouble, lengthGPR, storageGPR, searchElementRegs, indexGPR);
             break;
         case Array::Int32:
             if (isArrayIncludes)
                 callOperation(operationArrayIncludesValueInt32, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
+            else if (isArrayLastIndexOf)
+                callOperation(operationArrayLastIndexOfValueInt32, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
             else
                 callOperation(operationArrayIndexOfValueInt32, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
             break;
         case Array::Contiguous:
             if (isArrayIncludes)
                 callOperation(operationArrayIncludesValueInt32OrContiguous, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
+            else if (isArrayLastIndexOf)
+                callOperation(operationArrayLastIndexOfValueInt32OrContiguous, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
             else
                 callOperation(operationArrayIndexOfValueInt32OrContiguous, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2947,7 +2947,8 @@ void SpeculativeJIT::compile(Node* node)
     }
 
     case ArrayIncludes:
-    case ArrayIndexOf: {
+    case ArrayIndexOf:
+    case ArrayLastIndexOf: {
         compileArrayIndexOfOrArrayIncludes(node);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4240,7 +4240,8 @@ void SpeculativeJIT::compile(Node* node)
     }
 
     case ArrayIncludes:
-    case ArrayIndexOf: {
+    case ArrayIndexOf:
+    case ArrayLastIndexOf: {
         compileArrayIndexOfOrArrayIncludes(node);
         break;
     }

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -436,6 +436,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ArraySplice:
     case ArrayIncludes:
     case ArrayIndexOf:
+    case ArrayLastIndexOf:
     case ArrayPop:
     case ArrayPush:
     case ParseInt:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1176,6 +1176,7 @@ private:
             break;
         case ArrayIncludes:
         case ArrayIndexOf:
+        case ArrayLastIndexOf:
             compileArrayIndexOfOrArrayIncludes();
             break;
         case CreateActivation:
@@ -8305,12 +8306,15 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileArrayIndexOfOrArrayIncludes()
     {
-        ASSERT(m_node->op() == ArrayIncludes || m_node->op() == ArrayIndexOf);
+        ASSERT(m_node->op() == ArrayIncludes || m_node->op() == ArrayIndexOf || m_node->op() == ArrayLastIndexOf);
 
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         LValue base = lowCell(m_graph.varArgChild(m_node, 0));
         LValue storage = lowStorage(m_node->numChildren() == 3 ? m_graph.varArgChild(m_node, 2) : m_graph.varArgChild(m_node, 3));
         LValue length = m_out.load32(storage, m_heaps.Butterfly_publicLength);
+
+        bool isArrayIncludes = m_node->op() == ArrayIncludes;
+        bool isArrayLastIndexOf = m_node->op() == ArrayLastIndexOf;
 
         LValue startIndex;
         if (m_node->numChildren() == 4) {
@@ -8318,10 +8322,14 @@ IGNORE_CLANG_WARNINGS_END
             startIndex = m_out.select(m_out.greaterThanOrEqual(startIndex, m_out.int32Zero),
                 m_out.select(m_out.above(startIndex, length), length, startIndex),
                 m_out.select(m_out.lessThan(m_out.add(length, startIndex), m_out.int32Zero), m_out.int32Zero, m_out.add(length, startIndex)));
-        } else
-            startIndex = m_out.int32Zero;
-
-        bool isArrayIncludes = m_node->op() == ArrayIncludes;
+            if (isArrayLastIndexOf)
+                startIndex = m_out.select(m_out.greaterThanOrEqual(startIndex, length), m_out.sub(length, m_out.int32One), startIndex);
+        } else {
+            if (isArrayLastIndexOf)
+                startIndex = m_out.sub(length, m_out.int32One);
+            else
+                startIndex = m_out.int32Zero;
+        }
 
         Edge& searchElementEdge = m_graph.varArgChild(m_node, 1);
         switch (searchElementEdge.useKind()) {
@@ -8357,7 +8365,10 @@ IGNORE_CLANG_WARNINGS_END
 
             LBasicBlock lastNext = m_out.appendTo(loopHeader, loopBody);
             LValue index = m_out.phi(pointerType(), initialStartIndex);
-            m_out.branch(m_out.notEqual(index, length), unsure(loopBody), unsure(notFound));
+            if (isArrayLastIndexOf)
+                m_out.branch(m_out.greaterThanOrEqual(index, m_out.constIntPtr(0)), unsure(loopBody), unsure(notFound));
+            else
+                m_out.branch(m_out.notEqual(index, length), unsure(loopBody), unsure(notFound));
 
             m_out.appendTo(loopBody, loopNext);
             ValueFromBlock foundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(true)) : m_out.anchor(index);
@@ -8380,7 +8391,7 @@ IGNORE_CLANG_WARNINGS_END
             }
 
             m_out.appendTo(loopNext, notFound);
-            LValue nextIndex = m_out.add(index, m_out.intPtrOne);
+            LValue nextIndex = isArrayLastIndexOf ? m_out.sub(index, m_out.intPtrOne) : m_out.add(index, m_out.intPtrOne);
             m_out.addIncomingToPhi(index, m_out.anchor(nextIndex));
             m_out.jump(loopHeader);
 
@@ -8428,7 +8439,7 @@ IGNORE_CLANG_WARNINGS_END
 
             ValueFromBlock initialStartIndex = m_out.anchor(startIndex);
 
-            auto operation = operationArrayIndexOfString;
+            auto indexOfOperation = operationArrayIndexOfString;
 
             auto isCopyOnWriteArrayWithContiguous = [&]() {
                 Edge& baseEdge = m_graph.varArgChild(m_node, 0);
@@ -8444,7 +8455,7 @@ IGNORE_CLANG_WARNINGS_END
             };
 
             if (isCopyOnWriteArrayWithContiguous()) {
-                operation = operationCopyOnWriteArrayIndexOfString;
+                indexOfOperation = operationCopyOnWriteArrayIndexOfString;
                 LValue targetStructureID = encodeStructureID(weakPointer(vm().cellButterflyOnlyAtomStringsStructure.get()));
                 LValue butterflyStructureID = m_out.load32(m_out.add(storage, m_out.constIntPtr(-JSCellButterfly::offsetOfData())), m_heaps.JSCell_structureID);
                 m_out.branch(m_out.equal(butterflyStructureID, targetStructureID), unsure(slowCase), unsure(checkSearchRopeString));
@@ -8460,7 +8471,10 @@ IGNORE_CLANG_WARNINGS_END
 
             m_out.appendTo(loopHeader, fastCheckElementEmpty);
             LValue index = m_out.phi(pointerType(), initialStartIndex);
-            m_out.branch(m_out.notEqual(index, length), unsure(fastCheckElementEmpty), unsure(notFound));
+            if (isArrayLastIndexOf)
+                m_out.branch(m_out.greaterThanOrEqual(index, m_out.constIntPtr(0)), unsure(fastCheckElementEmpty), unsure(notFound));
+            else
+                m_out.branch(m_out.notEqual(index, length), unsure(fastCheckElementEmpty), unsure(notFound));
 
             m_out.appendTo(fastCheckElementEmpty, fastCheckElementCell);
             LValue element = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, storage, index));
@@ -8517,7 +8531,7 @@ IGNORE_CLANG_WARNINGS_END
             m_out.branch(m_out.notZero32(compareBytesLoopIndexInLoop), unsure(compareBytesLoop), unsure(continuation));
 
             m_out.appendTo(loopNext,  notFound);
-            LValue nextIndex = m_out.add(index, m_out.intPtrOne);
+            LValue nextIndex = isArrayLastIndexOf ? m_out.sub(index, m_out.intPtrOne) : m_out.add(index, m_out.intPtrOne);
             m_out.addIncomingToPhi(index, m_out.anchor(nextIndex));
             m_out.jump(loopHeader);
 
@@ -8526,7 +8540,7 @@ IGNORE_CLANG_WARNINGS_END
             m_out.jump(continuation);
 
             m_out.appendTo(slowCase, continuation);
-            ValueFromBlock slowCaseResult = isArrayIncludes ? m_out.anchor(vmCall(Int32, operationArrayIncludesString, weakPointer(globalObject), storage, searchElement, startIndex)) : m_out.anchor(vmCall(Int64, operation, weakPointer(globalObject), storage, searchElement, startIndex));
+            ValueFromBlock slowCaseResult = isArrayIncludes ? m_out.anchor(vmCall(Int32, operationArrayIncludesString, weakPointer(globalObject), storage, searchElement, startIndex)) : m_out.anchor(vmCall(Int64, isArrayLastIndexOf ? operationArrayLastIndexOfString : indexOfOperation, weakPointer(globalObject), storage, searchElement, startIndex));
             m_out.jump(continuation);
 
             m_out.appendTo(continuation, lastNext);
@@ -8561,6 +8575,8 @@ IGNORE_CLANG_WARNINGS_END
             }
             if (isArrayIncludes)
                 setBoolean(vmCall(Int32, operationArrayIncludesNonStringIdentityValueContiguous, storage, searchElement, startIndex));
+            else if (isArrayLastIndexOf)
+                setInt32(vmCall(Int32, operationArrayLastIndexOfNonStringIdentityValueContiguous, storage, searchElement, startIndex));
             else
                 setInt32(vmCall(Int32, operationArrayIndexOfNonStringIdentityValueContiguous, storage, searchElement, startIndex));
             return;
@@ -8571,6 +8587,8 @@ IGNORE_CLANG_WARNINGS_END
             case Array::Double:
                 if (isArrayIncludes)
                     setBoolean(vmCall(Int32, operationArrayIncludesValueDouble, storage, lowJSValue(searchElementEdge), startIndex));
+                else if (isArrayLastIndexOf)
+                    setInt32(vmCall(Int32, operationArrayLastIndexOfValueDouble, storage, lowJSValue(searchElementEdge), startIndex));
                 else
                     setInt32(vmCall(Int32, operationArrayIndexOfValueDouble, storage, lowJSValue(searchElementEdge), startIndex));
                 return;
@@ -8579,12 +8597,16 @@ IGNORE_CLANG_WARNINGS_END
                 ensureStillAliveHere(base);
                 if (isArrayIncludes)
                     setBoolean(vmCall(Int32, operationArrayIncludesValueInt32OrContiguous, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
+                else if (isArrayLastIndexOf)
+                    setInt32(vmCall(Int32, operationArrayLastIndexOfValueInt32OrContiguous, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
                 else
                     setInt32(vmCall(Int32, operationArrayIndexOfValueInt32OrContiguous, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
                 return;
             case Array::Int32:
                 if (isArrayIncludes)
                     setBoolean(vmCall(Int32, operationArrayIncludesValueInt32, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
+                else if (isArrayLastIndexOf)
+                    setInt32(vmCall(Int32, operationArrayLastIndexOfValueInt32, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
                 else
                     setInt32(vmCall(Int32, operationArrayIndexOfValueInt32, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
                 return;

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -115,7 +115,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().forEachPublicName(), arrayPrototypeForEachCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().somePublicName(), arrayPrototypeSomeCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().indexOfPublicName(), arrayProtoFuncIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayIndexOfIntrinsic);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("lastIndexOf"_s, arrayProtoFuncLastIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("lastIndexOf"_s, arrayProtoFuncLastIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayLastIndexOfIntrinsic);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().filterPublicName(), arrayPrototypeFilterCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatPublicName(), arrayPrototypeFlatCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatMapPublicName(), arrayPrototypeFlatMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -58,6 +58,7 @@ namespace JSC {
     macro(ArraySpliceIntrinsic) \
     macro(ArrayIncludesIntrinsic) \
     macro(ArrayIndexOfIntrinsic) \
+    macro(ArrayLastIndexOfIntrinsic) \
     macro(ArrayValuesIntrinsic) \
     macro(ArrayKeysIntrinsic) \
     macro(ArrayEntriesIntrinsic) \


### PR DESCRIPTION
#### 4a99a165c178cf6ec0a8ce5bc1ab3bea1ba859f2
<pre>
[JSC] Optimize `Array#lastIndexOf` in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=300170">https://bugs.webkit.org/show_bug.cgi?id=300170</a>

Reviewed by NOBODY (OOPS!).

This reverts commit <a href="https://commits.webkit.org/302763@main">302763@main</a> to reland <a href="https://commits.webkit.org/302157@main">302157@main</a>.

When `fromIndex &gt;= array.length`, the code uses `emitPopulateSliceIndex`
which clamps large values to length. However, `lastIndexOf` should start
searching from `length - 1`, not length. This caused the loop to access
`array[length]`, which is out of bounds.

So this new patch changes to add additional clamping logic specifically
for `lastIndexOf` to ensure that when `fromIndex &gt;= length`, it gets
clamped to `length - 1` instead of `length`.

-----
(original commit message)

This patch changes to optimize `Array#lastIndexOf` in DFG/FTL.

                                                  TipOfTree                  Patched

array-prototype-lastIndexOf-string-16           0.7393+-0.0963            0.6353+-0.0238          might be 1.1637x faster
array-prototype-lastIndexOf-double-from-contiguous
                                                0.7476+-0.3292            0.6312+-0.0984          might be 1.1845x faster
array-prototype-lastIndexOf-int32               3.8388+-0.8260     ^      2.3827+-0.3433        ^ definitely 1.6111x faster
array-prototype-lastIndexOf-bigint              9.9618+-0.7504     ^      8.3997+-0.4838        ^ definitely 1.1860x faster
array-prototype-lastIndexOf-contiguous          5.4971+-1.0560     ^      2.1412+-0.1266        ^ definitely 2.5673x faster
array-prototype-lastIndexOf-string-const        3.7607+-0.1203     ^      2.9016+-0.1071        ^ definitely 1.2961x faster
array-prototype-lastIndexOf-untyped-int32
                                               80.1997+-0.6415     ^     42.8832+-0.8174        ^ definitely 1.8702x faster
array-prototype-lastIndexOf-int32-from-contiguous
                                                0.6262+-0.1345            0.6172+-0.0809          might be 1.0146x faster
array-prototype-lastIndexOf-double              2.3190+-0.0583     ^      1.3878+-0.0684        ^ definitely 1.6711x faster
array-prototype-lastIndexOf-string              0.7423+-0.1096            0.6556+-0.1410          might be 1.1323x faster

* JSTests/stress/array-prototype-lastIndeOf-large-fromIndex.js: Added.
(main.v125):
(main.v85):
(main.v58):
(main):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::fixupArrayIndexOfOrArrayIncludes):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasArrayMode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::arrayLastIndexOfString):
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
* Source/JavaScriptCore/runtime/Intrinsic.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a99a165c178cf6ec0a8ce5bc1ab3bea1ba859f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82008 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99367 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67220 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133363 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1969 "Found 1 new test failure: http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81093 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122419 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140311 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128869 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107782 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31573 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55436 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65935 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161884 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2365 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40370 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->