### PR TITLE
Blob ReadableStream should allow a byob reader

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any-expected.txt
@@ -4,5 +4,5 @@ PASS Blob.stream() empty Blob
 PASS Blob.stream() non-unicode input
 PASS Blob.stream() garbage collection of blob shouldn't break stream consumption
 PASS Blob.stream() garbage collection of stream shouldn't break stream consumption
-FAIL Reading Blob.stream() with BYOB reader promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+PASS Reading Blob.stream() with BYOB reader
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any.worker-expected.txt
@@ -4,5 +4,5 @@ PASS Blob.stream() empty Blob
 PASS Blob.stream() non-unicode input
 PASS Blob.stream() garbage collection of blob shouldn't break stream consumption
 PASS Blob.stream() garbage collection of stream shouldn't break stream consumption
-FAIL Reading Blob.stream() with BYOB reader promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+PASS Reading Blob.stream() with BYOB reader
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -89,7 +89,9 @@ public:
     void error(JSDOMGlobalObject&, const Exception&);
     void error(JSDOMGlobalObject&, JSC::JSValue);
     void close(JSDOMGlobalObject&);
+    void closeAndRespondToPendingPullIntos(JSDOMGlobalObject&);
     ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBufferView&);
+    ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBuffer&);
 
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
@@ -102,6 +104,8 @@ public:
 private:
     friend ReadableStream;
     ReadableByteStreamController(ReadableStream&, JSC::JSValue, RefPtr<UnderlyingSourcePullCallback>&&, RefPtr<UnderlyingSourceCancelCallback>&&, double highWaterMark, size_t autoAllocateChunkSize);
+
+    ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength);
 
     using Callback = Function<void(JSDOMGlobalObject&, std::optional<JSC::JSValue>&&)>;
     ReadableByteStreamController(ReadableStream&, PullAlgorithm&&, CancelAlgorithm&&, double highWaterMark, size_t autoAllocateChunkSize);

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -323,6 +323,9 @@ void ReadableStream::fulfillReadRequest(JSDOMGlobalObject& globalObject, RefPtr<
         return;
     }
 
+    auto& vm = globalObject.vm();
+    JSC::JSLockHolder lock(vm);
+
     auto chunk = toJS<IDLNullable<IDLArrayBufferView>>(globalObject, globalObject, WTFMove(filledView));
     readRequest->runChunkSteps(chunk);
 }
@@ -347,6 +350,9 @@ void ReadableStream::fulfillReadIntoRequest(JSDOMGlobalObject& globalObject, Ref
     ASSERT(byobReader->readIntoRequestsSize());
 
     Ref readRequest = byobReader->takeFirstReadIntoRequest();
+
+    auto& vm = globalObject.vm();
+    JSC::JSLockHolder lock(vm);
 
     auto chunk = toJS<IDLNullable<IDLArrayBufferView>>(globalObject, globalObject, WTFMove(filledView));
     if (done) {
@@ -558,6 +564,12 @@ void ReadableStream::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)
         m_controller->underlyingSourceConcurrently().visit(visitor);
         m_controller->storedErrorConcurrently().visit(visitor);
     }
+}
+
+JSDOMGlobalObject* ReadableStream::globalObject()
+{
+    RefPtr context = scriptExecutionContext();
+    return context ? JSC::jsCast<JSDOMGlobalObject*>(context->globalObject()) : nullptr;
 }
 
 template<typename Visitor>

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -128,6 +128,8 @@ public:
     };
     virtual Type type() const { return Type::Default; }
 
+    JSDOMGlobalObject* globalObject();
+
 protected:
     static ExceptionOr<Ref<ReadableStream>> createFromJSValues(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);
     static ExceptionOr<Ref<InternalReadableStream>> createInternalReadableStream(JSDOMGlobalObject&, Ref<ReadableStreamSource>&&);


### PR DESCRIPTION
#### 07b1c640309bedfa57e6ea975b2bb2123b3bb9fa
<pre>
Blob ReadableStream should allow a byob reader
<a href="https://rdar.apple.com/164307723">rdar://164307723</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302201">https://bugs.webkit.org/show_bug.cgi?id=302201</a>

Reviewed by Chris Dumez.

Blob stream was using the non-byte version of ReadableStream.
This disallows calling getReader({mode:&apos;byob&apos;}) on it.

We migrate to ReadableStream::createReadableByteStream, which takes a cancel and a pull algorithms.
Both algorithms are implemented using BlobStreamSource which does no longer need to derive from ReadableStreamSource.

BlobStreamSource, when being asked to pull by the ReadableStream will keep a reference to the controller and to the promise that controls whether pulling or not.
Both are either null together or non null together.
Whenever being asked to pull, BlobStreamSource will enqueue a chunk provided by FileReaderLoader.

We update the controller to be able to directly enqueue an ArrayBuffer instead of a view.
We add a getter to the ReadableStream globalObject as we sometimes have to get it to enqueue/close a stream from native C++ code.

To fully work, we also have to update the ReadableStream implementation:
- Allow closing a byob readable stream, following <a href="https://streams.spec.whatwg.org/#readablestream-close.">https://streams.spec.whatwg.org/#readablestream-close.</a>
- Lock the VM when calling toJS from native C++ code.

Covered by existing tests, in particular WPT FileAPI/blob/Blob-stream.any.js.

Canonical link: <a href="https://commits.webkit.org/302787@main">https://commits.webkit.org/302787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8079a1b58eefc9a0e7eec03bd801b54a13330586

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81715 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d30fa04f-21c1-4e68-98f7-97443c77cdf8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99166 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67009 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0990414b-1e98-4436-850f-594827ec2abf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116585 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79859 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/379abb54-ab54-47ee-b9ef-fb5d8ffdfa83) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80839 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110259 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35220 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140053 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2226 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2081 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107690 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112928 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107568 "Found 1 new API test failure: TestWebKit:WebKit.GeolocationTransitionToLowAccuracy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55161 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65683 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2113 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->