### PR TITLE
GitHub.com: Brief flash of gradient content when loading certain pages.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/after-with-animation-removed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/after-with-animation-removed-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/after-with-animation-removed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/after-with-animation-removed.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#container {
+  display: flex;
+}
+@keyframes keyframe { }
+</style>
+
+<style id="remove">
+#container::after {
+  animation: keyframe 1s infinite;
+  content: '';
+  width: 100px;
+  height: 100px;
+  background-color: red;
+}
+</style>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div style="width: 100px; height: 100px; position: absolute; background-color: green; z-index: -1;"></div>
+  <div id="container"></div>
+</body>
+</head>
+<script>
+document.body.offsetHeight;
+document.getElementById("remove").remove();
+</script>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -195,6 +195,13 @@ void RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement(Eleme
 
     auto* updateStyle = (elementUpdate.style && elementUpdate.style->hasCachedPseudoStyles()) ? elementUpdate.style->getCachedPseudoStyle({ pseudoElementType }) : nullptr;
 
+    // If we end up losing a previous pseudo because the style got removed we need to
+    // cancel any animations that were on it so we do not end up thinking we need to keep
+    // the renderer around. We cannot completely rely on needsPseudoElement because
+    // we may need to animate a box with display: none.
+    if (!updateStyle)
+        Styleable { current, Style::PseudoElementIdentifier { pseudoElementType } }.cancelStyleOriginatedAnimations();
+
     ASSERT(!is<PseudoElement>(current));
     if (!needsPseudoElement(updateStyle) && !needsPseudoElementForAnimation(current, pseudoElementType)) {
         if (pseudoElement) {


### PR DESCRIPTION
#### 36150a6e113939ba18b3f6039b4cdc9e4d0728f8
<pre>
GitHub.com: Brief flash of gradient content when loading certain pages.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302367">https://bugs.webkit.org/show_bug.cgi?id=302367</a>
<a href="https://rdar.apple.com/133846547">rdar://133846547</a>

Reviewed by Antoine Quint and Antti Koivisto.

On GitHub.com, if you navigate to certain pages, such as loading the
commits for a repository, there will be a brief flash of gradient
content as the page loads. Specifically, this content is a CSS gradient
that is on an after pseudo element. Due to some DOM/style mutations,
this pseudo content ends up getting resized and repositioned before its
parent ends up getting removed from the DOM, which is what causes the
flash.

What occurs on the commits pages is the following:

1.) The initial content loads, and the gradients appear in the correct
location. They appear on each row and are animated as the content is
loading.

2.) The style tag which holds all of the rules for much of the content
on the page, including the after pseudo elements, is removed from the
DOM via Element.removeChild().

3.) We perform layout after this and end up computing the position and
sizes of the pseudo content, and it moves from appearing small in each
row to becoming much bigger and on the side of the screen.

4.) The host of the pseudo element is removed from the DOM, and the page
basically reaches its final state with all the content loaded.

The bug is that during 3, we still see the pseudo content during layout
when rules targeting this content were removed in 2. This seems to be
because inside RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement,
we end up thinking that we need to keep around the renderer for the
pseudo element for an animation because we still have a keyframe effect
stack for the pseudo element. However, 2 removed the rule targeting the
pseudo element, which also included associated animation.

To address this, we can attempt to detect this case in RenderTreeBuilder::GeneratedContent::updateBeforeOrAfterPseudoElement
by checking to see if we do not have a RenderStyle associated with the
pseudo content. If that happens then we try to cancel any animations
that came from style for that pseudo element since it no longer exists.
Note that we cannot just completely rely on needsPseudoElement to
determine if we need to cancel animations because we may need to keep
one around to animate display: none.

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/after-with-animation-removed-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/after-with-animation-removed.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolvePseudoElement):

Canonical link: <a href="https://commits.webkit.org/303042@main">https://commits.webkit.org/303042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db7e5e0fed74ac6e4d7cf4b2efc5fa95aed47351

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82320 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99564 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67427 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6beebff5-dd93-4509-8ec5-8aef1e0eb626) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80272 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35157 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81366 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140590 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2750 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2484 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108069 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55747 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66209 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2640 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2841 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2746 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->