### PR TITLE
Suppress static analyzer warning in WebLocalizableStrings.h

### DIFF
--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -13,7 +13,6 @@ mac/History/WebHistory.h
 mac/History/WebHistoryItem.h
 mac/Misc/WebDownload.h
 mac/Misc/WebElementDictionary.h
-mac/Misc/WebLocalizableStrings.h
 [ Mac ] mac/Misc/WebSharingServicePickerController.h
 mac/Misc/WebUserContentURLPattern.h
 [ Mac ] mac/Panels/WebAuthenticationPanel.h

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.h
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 #ifdef __OBJC__
 #import <Foundation/Foundation.h>
 typedef NSString *WebLocalizedStringType;
@@ -42,7 +44,7 @@ typedef CFStringRef WebLocalizedStringType;
 
 typedef struct {
     const char *identifier;
-    __unsafe_unretained NSBundle *bundle;
+    SUPPRESS_UNRETAINED_MEMBER __unsafe_unretained NSBundle *bundle;
 } WebLocalizableStringsBundle;
 
 #ifdef __cplusplus


### PR DESCRIPTION
#### 7a6041bc0f666cd46bed0ddeaa0f0f6062bc8b64
<pre>
Suppress static analyzer warning in WebLocalizableStrings.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302206">https://bugs.webkit.org/show_bug.cgi?id=302206</a>

Reviewed by NOBODY (OOPS!).

Suppress the unretained member variable warning to avoid hitting an assertion failure in clang.

* Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a6041bc0f666cd46bed0ddeaa0f0f6062bc8b64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130140 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2411 "Hash 7a6041bc for PR 53636 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81681 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f2b32d7-bcec-49ba-b7d3-aeea9f56697b) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2383 "Hash 7a6041bc for PR 53636 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2299 "Hash 7a6041bc for PR 53636 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99144 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66952 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/15f84219-0df1-4046-acf3-db02d87488ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133087 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/2383 "Hash 7a6041bc for PR 53636 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79838 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/35c2a669-5e2d-4b53-8210-5725d595318d) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/2383 "Hash 7a6041bc for PR 53636 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34693 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80814 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/2383 "Hash 7a6041bc for PR 53636 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140019 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2201 "Hash 7a6041bc for PR 53636 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/2299 "Hash 7a6041bc for PR 53636 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107667 "Failure limit exceed. At least found 2 new test failures: imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.full.mode.alpha.html imported/w3c/web-platform-tests/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-001.html (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2245 "Hash 7a6041bc for PR 53636 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107545 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55105 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2271 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65658 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2088 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2292 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->