### PR TITLE
Address incorrect uses of WTFMove() with const values

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -672,7 +672,7 @@ template<size_t I, typename V> constexpr bool holdsAlternative(const V& v)
     }                                                                                \
     template<typename T> friend const T&& get(const Self&& self)                     \
     {                                                                                \
-        return std::get<T>(WTFMove(self.name));                                      \
+        return std::get<T>(std::move(self.name));                                    \
     }                                                                                \
     template<typename T> friend std::add_pointer_t<T> get_if(Self* self)             \
     {                                                                                \

--- a/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.cpp
+++ b/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.cpp
@@ -62,13 +62,13 @@ static Vector<KeyValuePair<int32_t, WGPUDDMeshPart>> convertToBacking(const Vect
 {
     Vector<KeyValuePair<int32_t, WGPUDDMeshPart>> result;
     for (auto& p : parts) {
-        result.append(KeyValuePair(WTFMove(p.key), WGPUDDMeshPart {
+        result.append(KeyValuePair(int32_t { p.key }, WGPUDDMeshPart {
             .indexOffset = p.value.indexOffset,
             .indexCount = p.value.indexCount,
             .topology = p.value.topology,
             .materialIndex = p.value.materialIndex,
-            .boundsMin = WTFMove(p.value.boundsMin),
-            .boundsMax = WTFMove(p.value.boundsMax)
+            .boundsMin = p.value.boundsMin,
+            .boundsMax = p.value.boundsMax
         }));
     }
     return result;
@@ -79,7 +79,7 @@ static Vector<WGPUDDReplaceVertices> convertToBacking(const Vector<DDReplaceVert
     for (auto& p : vertices) {
         result.append(WGPUDDReplaceVertices {
             .bufferIndex = p.bufferIndex,
-            .buffer = WTFMove(p.buffer)
+            .buffer = p.buffer
         });
     }
     return result;
@@ -142,12 +142,12 @@ void DDMeshImpl::update(const DDUpdateMeshDescriptor& descriptor)
     WGPUDDUpdateMeshDescriptor backingDescriptor {
         .partCount = descriptor.partCount,
         .parts = convertToBacking(descriptor.parts),
-        .renderFlags = WTFMove(descriptor.renderFlags),
+        .renderFlags = descriptor.renderFlags,
         .vertices = convertToBacking(descriptor.vertices),
-        .indices = WTFMove(descriptor.indices),
-        .transform = WTFMove(descriptor.transform),
+        .indices = descriptor.indices,
+        .transform = descriptor.transform,
         .instanceTransforms4x4 = toVector(descriptor.instanceTransforms4x4),
-        .materialIds = WTFMove(descriptor.materialIds),
+        .materialIds = descriptor.materialIds,
         .identifier = descriptor.identifier
     };
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -293,7 +293,7 @@ void CredentialRequestCoordinator::finalizeDigitalCredential(const DigitalCreden
     Ref credential = DigitalCredential::create(
         { returnValue->vm(), returnValue },
         responseData.protocol);
-    m_currentPromise->resolve(WTFMove(credential.ptr()));
+    m_currentPromise->resolve(credential.ptr());
     m_currentPromise.reset();
 }
 

--- a/Source/WebCore/accessibility/AXAttachmentHelpers.cpp
+++ b/Source/WebCore/accessibility/AXAttachmentHelpers.cpp
@@ -53,13 +53,13 @@ void AXAttachmentHelpers::accessibilityText(const HTMLAttachmentElement& attachm
     auto& action = attachmentElement.getAttribute(actionAttr);
 
     if (action.length())
-        textOrder.append(AccessibilityText(WTFMove(action), AccessibilityTextSource::Action));
+        textOrder.append(AccessibilityText(action, AccessibilityTextSource::Action));
 
     if (title.length())
         textOrder.append(AccessibilityText(WTFMove(title), AccessibilityTextSource::Title));
 
     if (subtitle.length())
-        textOrder.append(AccessibilityText(WTFMove(subtitle), AccessibilityTextSource::Subtitle));
+        textOrder.append(AccessibilityText(subtitle, AccessibilityTextSource::Subtitle));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5586,7 +5586,7 @@ void Page::setDefaultSpatialTrackingLabel(const String& label)
 {
     if (m_defaultSpatialTrackingLabel == label)
         return;
-    m_defaultSpatialTrackingLabel = WTFMove(label);
+    m_defaultSpatialTrackingLabel = label;
 
     forEachDocument([&] (Document& document) {
         document.defaultSpatialTrackingLabelChanged(m_defaultSpatialTrackingLabel);

--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -174,7 +174,7 @@ void ContentFilterUnblockHandler::requestUnblockAsync(DecisionHandlerFunction&& 
 #else
         auto& filter = WebCore::ParentalControlsURLFilter::singleton();
 #endif
-        filter.allowURL(*m_evaluatedURL, [decisionHandler = WTFMove(decisionHandler)](bool didAllow) {
+        filter.allowURL(*m_evaluatedURL, [decisionHandler = WTFMove(decisionHandler)](bool didAllow) mutable {
             callOnMainThread([decisionHandler = WTFMove(decisionHandler), didAllow]() {
                 decisionHandler(didAllow);
             });
@@ -184,7 +184,7 @@ void ContentFilterUnblockHandler::requestUnblockAsync(DecisionHandlerFunction&& 
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     if (RetainPtr evaluator = webFilterEvaluator()) {
-        [evaluator unblockWithCompletion:[decisionHandler = WTFMove(decisionHandler)](BOOL unblocked, NSError *) {
+        [evaluator unblockWithCompletion:[decisionHandler = WTFMove(decisionHandler)](BOOL unblocked, NSError *) mutable {
             callOnMainThread([decisionHandler = WTFMove(decisionHandler), unblocked] {
                 LOG(ContentFiltering, "WebFilterEvaluator %s the unblock request.\n", unblocked ? "allowed" : "did not allow");
                 decisionHandler(unblocked);
@@ -200,7 +200,7 @@ void ContentFilterUnblockHandler::requestUnblockAsync(DecisionHandlerFunction&& 
         };
     }
     if (unblockRequester) {
-        unblockRequester([decisionHandler = WTFMove(decisionHandler)](bool unblocked) {
+        unblockRequester([decisionHandler = WTFMove(decisionHandler)](bool unblocked) mutable {
             callOnMainThread([decisionHandler = WTFMove(decisionHandler), unblocked] {
                 decisionHandler(unblocked);
             });

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
@@ -217,7 +217,7 @@ RemoteCommandListenerCocoa::RemoteCommandListenerCocoa(RemoteCommandListenerClie
             status = MRMediaRemoteCommandHandlerStatusCommandFailed;
         };
 
-        ensureOnMainThread([weakThis = WTFMove(weakThis), platformCommand, argument] {
+        ensureOnMainThread([weakThis, platformCommand, argument] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->client().didReceiveRemoteControlCommand(platformCommand, argument);
         });

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4046,7 +4046,7 @@ void MediaPlayerPrivateAVFoundationObjC::setDefaultSpatialTrackingLabel(const St
 {
     if (m_defaultSpatialTrackingLabel == defaultSpatialTrackingLabel)
         return;
-    m_defaultSpatialTrackingLabel = WTFMove(defaultSpatialTrackingLabel);
+    m_defaultSpatialTrackingLabel = defaultSpatialTrackingLabel;
     updateSpatialTrackingLabel();
 }
 
@@ -4059,7 +4059,7 @@ void MediaPlayerPrivateAVFoundationObjC::setSpatialTrackingLabel(const String& s
 {
     if (m_spatialTrackingLabel == spatialTrackingLabel)
         return;
-    m_spatialTrackingLabel = WTFMove(spatialTrackingLabel);
+    m_spatialTrackingLabel = spatialTrackingLabel;
     updateSpatialTrackingLabel();
 }
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -469,7 +469,7 @@ void MediaRecorderPrivateEncoder::appendVideoFrame(MediaTime sampleTime, Ref<Vid
         VideoEncoder::Config config { static_cast<uint64_t>(frame->presentationSize().width()), static_cast<uint64_t>(frame->presentationSize().height()), false, videoBitRate() };
 
         Ref promise = VideoEncoder::create(codecStringForMediaVideoCodecId(m_videoCodec), config, [weakThis = ThreadSafeWeakPtr { *this }, config](auto&& configuration) mutable {
-            queueSingleton().dispatch([weakThis, config = WTFMove(config), configuration] {
+            queueSingleton().dispatch([weakThis, config = WTFMove(config), configuration = WTFMove(configuration)]() mutable {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->processVideoEncoderActiveConfiguration(config, WTFMove(configuration));
             });

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -117,7 +117,7 @@ void CommandBuffer::makeInvalidDueToCommit(NSString* lastError)
     m_cachedCommandBuffer = m_commandBuffer;
     [m_commandBuffer addCompletedHandler:[protectedThis = Ref { *this }](id<MTLCommandBuffer>) {
         protectedThis->m_commandBufferComplete.signal();
-        protectedThis->m_device->protectedQueue()->scheduleWork([protectedThis = WTFMove(protectedThis)]() mutable {
+        protectedThis->m_device->protectedQueue()->scheduleWork([protectedThis]() mutable {
             protectedThis->m_cachedCommandBuffer = nil;
             protectedThis->m_commandEncoder = nullptr;
         });

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
@@ -77,7 +77,7 @@ Vector<uint8_t> activityAccessToken()
 
 - (void)begin
 {
-    [m_downloadMonitor beginMonitoring:makeBlockPtr([weakDownload = WeakPtr { m_download }](BEDownloadMonitorLocation *location, NSError *error) {
+    [m_downloadMonitor beginMonitoring:makeBlockPtr([weakDownload = WeakPtr { m_download }](BEDownloadMonitorLocation *location, NSError *error) mutable {
         RELEASE_LOG(Network, "Download begin for url %{sensitive}s, error %s", location.url.absoluteString.UTF8String, error.localizedDescription.UTF8String);
         ensureOnMainRunLoop([weakDownload = WTFMove(weakDownload), location = RetainPtr { location }] {
             if (!weakDownload)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -681,7 +681,7 @@ String NetworkDataTaskCocoa::description() const
 void NetworkDataTaskCocoa::setH2PingCallback(const URL& url, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&& completionHandler)
 {
     ASSERT(m_task.get()._preconnect);
-    auto handler = CompletionHandlerWithFinalizer<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>(WTFMove(completionHandler), [url = url.isolatedCopy()] (Function<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>& completionHandler) {
+    auto handler = CompletionHandlerWithFinalizer<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>(WTFMove(completionHandler), [url = url.isolatedCopy()] (Function<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>& completionHandler) mutable {
         ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), url = WTFMove(url).isolatedCopy()]() mutable {
             completionHandler(makeUnexpected(WebCore::internalError(url)));
         });

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1545,7 +1545,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if HAVE(NW_PROXY_CONFIG)
     if (parameters.proxyConfigData)
-        setProxyConfigData(WTFMove(*parameters.proxyConfigData));
+        setProxyConfigData(*parameters.proxyConfigData);
 #endif
 }
 

--- a/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
@@ -121,7 +121,7 @@ void NetworkConnectionToWebProcess::checkInWebProcess(const CoreIPCAuditToken& a
 
     RELEASE_LOG(Process, "Launch Services checkin starting, infoDictionary = %{public}@", (__bridge NSDictionary *)infoDictionary.get());
 
-    auto block = makeBlockPtr([weakThis = WeakPtr { *this }, auditToken](CFDictionaryRef result, CFErrorRef error) mutable {
+    auto block = makeBlockPtr([weakThis = WeakPtr { *this }, auditToken = auditToken](CFDictionaryRef result, CFErrorRef error) mutable {
         NSDictionary *dictionary = (__bridge NSDictionary *)result;
         RELEASE_LOG(Process, "Launch Services checkin completed, result = %{public}@, error = %{public}@", dictionary, (__bridge NSError *)error);
 

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -164,7 +164,7 @@ static void didReceiveServerTrustChallenge(NetworkConnectionToWebProcess& connec
         auto decisionHandler = makeBlockPtr([
             connectionToWebProcess = Ref { connectionToWebProcess },
             pageID = WTFMove(pageID),
-            clientOrigin = WTFMove(clientOrigin),
+            clientOrigin,
             challengeCompletionHandler = WTFMove(challengeCompletionHandler)
         ] (NSURLAuthenticationChallenge *challenge, OSStatus trustResult) mutable {
             if (trustResult == noErr) {
@@ -199,7 +199,7 @@ static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess
         pageID = WTFMove(pageID),
         hashes = WTFMove(hashes),
         clientOrigin = WTFMove(clientOrigin)
-    ](nw_protocol_options_t options) {
+    ](nw_protocol_options_t options) mutable {
         RetainPtr securityOptions = adoptNS(nw_tls_copy_sec_protocol_options(options));
         sec_protocol_options_set_peer_authentication_required(securityOptions.get(), true);
         sec_protocol_options_set_verify_block(securityOptions.get(), makeBlockPtr([

--- a/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
@@ -71,7 +71,7 @@ RetainPtr<PKDisbursementPaymentRequest> platformDisbursementRequest(const AppleP
 
     // FIXME: we should consolidate the types for various contact fields in the system(WebCore::ApplePayContactField, WebCore::ApplePaySessionPaymentRequest::ContactFields etc.)
     if (requiredRecipientContactFields)
-        [disbursementRequest setRequiredRecipientContactFields:createNSArray(WTFMove(*requiredRecipientContactFields), platformContactField).get()];
+        [disbursementRequest setRequiredRecipientContactFields:createNSArray(*requiredRecipientContactFields, platformContactField).get()];
 
     auto disbursementPaymentRequest = adoptNS([PAL::allocPKDisbursementPaymentRequestInstance() initWithDisbursementRequest:disbursementRequest.get()]);
     [disbursementPaymentRequest setOriginatingURL:originatingURL.createNSURL().get()];

--- a/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp
@@ -93,7 +93,7 @@ void WebPushDaemonConnection::unsubscribeFromPushService(const WTF::URL& scopeUR
 void WebPushDaemonConnection::getPushSubscription(const WTF::URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& completionHandler)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushSubscription(WTFMove(scopeURL)), WTFMove(completionHandler));
+    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushSubscription(scopeURL), WTFMove(completionHandler));
 #else
     completionHandler(std::optional<WebCore::PushSubscriptionData> { });
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6797,7 +6797,7 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
     }
 #endif // PLATFORM(MAC)
 
-    page->handleTextExtractionInteraction(WTFMove(interaction), [weakSelf = WeakObjCPtr<WKWebView>(self), weakPage = WeakPtr { *page }, completionHandler = makeBlockPtr(WTFMove(completionHandler))](bool success, String&& description) {
+    page->handleTextExtractionInteraction(WTFMove(interaction), [weakSelf = WeakObjCPtr<WKWebView>(self), weakPage = WeakPtr { *page }, completionHandler = makeBlockPtr(WTFMove(completionHandler))](bool success, String&& description) mutable {
         RetainPtr<NSString> errorDescription;
         if (!success)
             errorDescription = description.createNSString();
@@ -6957,7 +6957,7 @@ static HashMap<String, HashMap<WebCore::JSHandleIdentifier, String>> extractClie
         return completionHandler([NSString stringWithFormat:@"Select popup menu item labeled '%s'", interaction.text.utf8().data()], nil);
 #endif
 
-    page->describeTextExtractionInteraction(WTFMove(interaction), [weakSelf = WeakObjCPtr<WKWebView>(self), weakPage = WeakPtr { *page }, completionHandler = makeBlockPtr(WTFMove(completionHandler))](auto&& result) {
+    page->describeTextExtractionInteraction(WTFMove(interaction), [weakSelf = WeakObjCPtr<WKWebView>(self), weakPage = WeakPtr { *page }, completionHandler = makeBlockPtr(WTFMove(completionHandler))](auto&& result) mutable {
         auto [description, stringsToValidate] = WTFMove(result);
         auto valid = Box<bool>::create(true);
         Ref aggregator = MainRunLoopCallbackAggregator::create([completionHandler = WTFMove(completionHandler), description, valid] {

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -389,7 +389,7 @@ ProcessAssertion::ProcessAssertion(pid_t pid, const String& reason, ProcessAsser
     if (extensionProcess) {
         ASCIILiteral runningBoardAssertionName = runningBoardNameForAssertionType(m_assertionType);
         ASCIILiteral runningBoardDomain = runningBoardDomainForAssertionType(m_assertionType);
-        auto didInvalidateBlock = [weakThis = ThreadSafeWeakPtr { *this }, runningBoardAssertionName] () {
+        auto didInvalidateBlock = [weakThis = ThreadSafeWeakPtr { *this }, runningBoardAssertionName]() mutable {
             RunLoop::mainSingleton().dispatch([weakThis = WTFMove(weakThis), runningBoardAssertionName = WTFMove(runningBoardAssertionName)] {
                 auto strongThis = weakThis.get();
                 RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion: RBS %{public}s assertion for process with PID=%d was invalidated", strongThis.get(), runningBoardAssertionName.characters(), strongThis ? strongThis->m_pid : 0);
@@ -397,7 +397,7 @@ ProcessAssertion::ProcessAssertion(pid_t pid, const String& reason, ProcessAsser
                     strongThis->processAssertionWasInvalidated();
             });
         };
-        auto willInvalidateBlock = [weakThis = ThreadSafeWeakPtr { *this }, runningBoardAssertionName] () {
+        auto willInvalidateBlock = [weakThis = ThreadSafeWeakPtr { *this }, runningBoardAssertionName]() mutable {
             RunLoop::mainSingleton().dispatch([weakThis = WTFMove(weakThis), runningBoardAssertionName = WTFMove(runningBoardAssertionName)] {
                 auto strongThis = weakThis.get();
                 RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion() RBS %{public}s assertion for process with PID=%d will be invalidated", strongThis.get(), runningBoardAssertionName.characters(), strongThis ? strongThis->m_pid : 0);

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1532,7 +1532,7 @@ void WebPageProxy::setTextIndicatorFromFrame(FrameIdentifier frameID, const WebC
         return;
 
     auto rect = indicatorData.textBoundingRectInRootViewCoordinates;
-    convertRectToMainFrameCoordinates(rect, frame->rootFrame().frameID(), [weakThis = WeakPtr { *this }, indicatorData = WTFMove(indicatorData), lifetime] (std::optional<FloatRect> convertedRect) mutable {
+    convertRectToMainFrameCoordinates(rect, frame->rootFrame().frameID(), [weakThis = WeakPtr { *this }, indicatorData = indicatorData, lifetime](std::optional<FloatRect> convertedRect) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !convertedRect)
             return;
@@ -1567,7 +1567,7 @@ void WebPageProxy::setTextIndicator(const WebCore::TextIndicatorData& indicatorD
         m_textIndicatorFadeTimer.startOneShot(WebCore::timeBeforeFadeStarts);
 }
 
-void WebPageProxy::updateTextIndicatorFromFrame(FrameIdentifier frameID, const RefPtr<WebCore::TextIndicator>&& textIndicator)
+void WebPageProxy::updateTextIndicatorFromFrame(FrameIdentifier frameID, RefPtr<WebCore::TextIndicator>&& textIndicator)
 {
     RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (!frame)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -730,7 +730,7 @@ void WebProcessPool::hardwareKeyboardAvailabilityChanged()
 
 void WebProcessPool::initializeHardwareKeyboardAvailability()
 {
-    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr([weakThis = WeakPtr { *this }] {
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr([weakThis = WeakPtr { *this }]() mutable {
         auto keyboardState = currentHardwareKeyboardState();
         callOnMainRunLoop([weakThis = WTFMove(weakThis), keyboardState] {
             RefPtr protectedThis = weakThis.get();
@@ -1623,7 +1623,7 @@ void WebProcessPool::registerAssetFonts(WebProcessProxy& process)
     for (auto& fontName : assetFonts)
         [descriptions addObject:(__bridge id)fontDescription(fontName).get()];
 
-    auto blockPtr = makeBlockPtr([assetFonts = WTFMove(assetFonts), weakProcess = WeakPtr { process }, weakThis = WeakPtr { *this }](CTFontDescriptorMatchingState state, CFDictionaryRef progressParameter) {
+    auto blockPtr = makeBlockPtr([assetFonts = WTFMove(assetFonts), weakProcess = WeakPtr { process }, weakThis = WeakPtr { *this }](CTFontDescriptorMatchingState state, CFDictionaryRef progressParameter) mutable {
         if (state != kCTFontDescriptorMatchingDidFinish)
             return true;
         RELEASE_LOG(Process, "Font matching finished, progress parameter = %@", (__bridge id)progressParameter);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -237,7 +237,7 @@ void WebExtensionContext::scriptingRegisterContentScripts(const Vector<WebExtens
     }
 
     auto serializedScripts = toJSONSerialization(scripts);
-    registeredContentScriptsStore()->addScripts(serializedScripts, [this, protectedThis = Ref { *this }, scripts = WTFMove(scripts), injectedContentsMap = WTFMove(injectedContentsMap), completionHandler = WTFMove(completionHandler)](const String& errorMessage) mutable {
+    registeredContentScriptsStore()->addScripts(serializedScripts, [this, protectedThis = Ref { *this }, scripts, injectedContentsMap = WTFMove(injectedContentsMap), completionHandler = WTFMove(completionHandler)](const String& errorMessage) mutable {
         if (!errorMessage.isEmpty()) {
             completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
             return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -219,19 +219,19 @@ void WebExtensionContext::tabsUpdate(WebPageProxyIdentifier webPageProxyIdentifi
             return;
         }
 
-        updateURL(tab, parameters, [tab, parameters = WTFMove(parameters), updatePinned = WTFMove(updatePinned), updateMuted = WTFMove(updateMuted), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& urlResult) mutable {
+        updateURL(tab, parameters, [tab, parameters, updatePinned = WTFMove(updatePinned), updateMuted = WTFMove(updateMuted), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& urlResult) mutable {
             if (!urlResult) {
                 completionHandler(makeUnexpected(urlResult.error()));
                 return;
             }
 
-            updatePinned(tab, parameters, [tab, parameters = WTFMove(parameters), updateMuted = WTFMove(updateMuted), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& pinnedResult) mutable {
+            updatePinned(tab, parameters, [tab, parameters, updateMuted = WTFMove(updateMuted), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& pinnedResult) mutable {
                 if (!pinnedResult) {
                     completionHandler(makeUnexpected(pinnedResult.error()));
                     return;
                 }
 
-                updateMuted(tab, parameters, [tab, parameters = WTFMove(parameters), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& mutedResult) mutable {
+                updateMuted(tab, parameters, [tab, parameters, updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& mutedResult) mutable {
                     if (!mutedResult) {
                         completionHandler(makeUnexpected(mutedResult.error()));
                         return;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -132,21 +132,21 @@ static void launchWithExtensionKit(ProcessLauncher& processLauncher, ProcessLaun
 
     switch (processType) {
     case ProcessLauncher::ProcessType::Web: {
-        auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BEWebContentProcess *_Nullable process, NSError *_Nullable error) {
+        auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BEWebContentProcess *_Nullable process, NSError *_Nullable error) mutable {
             handler(WTFMove(weakProcessLauncher), process, name, error);
         });
         [BEWebContentProcess webContentProcessWithBundleID:identifier.get() interruptionHandler:^{ } completion:block.get()];
         break;
     }
     case ProcessLauncher::ProcessType::Network: {
-        auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BENetworkingProcess *_Nullable process, NSError *_Nullable error) {
+        auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BENetworkingProcess *_Nullable process, NSError *_Nullable error) mutable {
             handler(WTFMove(weakProcessLauncher), process, name, error);
         });
         [BENetworkingProcess networkProcessWithBundleID:identifier.get() interruptionHandler:^{ } completion:block.get()];
         break;
     }
     case ProcessLauncher::ProcessType::GPU: {
-        auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BERenderingProcess *_Nullable process, NSError *_Nullable error) {
+        auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BERenderingProcess *_Nullable process, NSError *_Nullable error) mutable {
             handler(WTFMove(weakProcessLauncher), process, name, error);
         });
         [BERenderingProcess renderingProcessWithBundleID:identifier.get() interruptionHandler:^{ } completion:block.get()];

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -133,7 +133,7 @@ void CtapAuthenticator::makeCredential()
         if (!m_pinAuth.isEmpty())
             pinParameters = PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth };
         Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rp.id, requestData().hash, m_batches[m_currentBatch], pinParameters);
-        protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+        protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) mutable {
             ASSERT(RunLoop::isMain());
             if (!weakThis)
                 return;
@@ -300,7 +300,7 @@ void CtapAuthenticator::getAssertion()
         if (!m_pinAuth.isEmpty())
             pinParameters = PinParameters { static_cast<uint8_t>(selectPinProtocol()), m_pinAuth };
         Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rpId, requestData().hash, m_batches[m_currentBatch], pinParameters);
-        protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+        protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) mutable {
             ASSERT(RunLoop::isMain());
             if (!weakThis)
                 return;
@@ -713,7 +713,7 @@ void CtapAuthenticator::continueSetupPinAfterGetKeyAgreement(Vector<uint8_t>&& d
     }
     m_pinAuth = setPinRequest->pinAuth();
     auto cborCmd = encodeAsCBOR(*setPinRequest);
-    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, pin, peerKey = WTFMove( keyAgreement->peerKey)](Vector<uint8_t>&& response) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, pin, peerKey = WTFMove( keyAgreement->peerKey)](Vector<uint8_t>&& response) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -728,7 +728,7 @@ void CtapAuthenticator::setupPin()
         return;
     CTAP_RELEASE_LOG("setupPin: Requesting new pin from delegate");
     uint64_t minLength = m_info.minPINLength().value_or(4);
-    observer->requestNewPin(minLength, [weakThis = WeakPtr { *this }] (const String& pin) {
+    observer->requestNewPin(minLength, [weakThis = WeakPtr { *this }] (const String& pin) mutable {
         ASSERT(RunLoop::isMain());
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10305,7 +10305,7 @@ void WebPageProxy::setTextIndicator(const TextIndicatorData& indicatorData, WebC
     notImplemented();
 }
 
-void WebPageProxy::updateTextIndicatorFromFrame(FrameIdentifier frameID, const RefPtr<WebCore::TextIndicator>&& textIndicator)
+void WebPageProxy::updateTextIndicatorFromFrame(FrameIdentifier frameID, RefPtr<WebCore::TextIndicator>&& textIndicator)
 {
     notImplemented();
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3440,7 +3440,7 @@ private:
     void drawFrameToSnapshot(WebCore::FrameIdentifier, const WebCore::IntRect&, RemoteSnapshotIdentifier, CompletionHandler<void(bool)>&&);
 
     void setTextIndicatorFromFrame(WebCore::FrameIdentifier, const WebCore::TextIndicatorData&, WebCore::TextIndicatorLifetime);
-    void updateTextIndicatorFromFrame(WebCore::FrameIdentifier, const RefPtr<WebCore::TextIndicator>&&);
+    void updateTextIndicatorFromFrame(WebCore::FrameIdentifier, RefPtr<WebCore::TextIndicator>&&);
 
     void frameNameChanged(IPC::Connection&, WebCore::FrameIdentifier, const String& frameName);
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11304,7 +11304,7 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
     for (auto& previewView : previewViews)
         [previewView setAlpha:0];
 
-    [animator addCompletion:[protectedSelf = retainPtr(self), previewViews = WTFMove(previewViews), page = _page] (UIViewAnimatingPosition finalPosition) {
+    [animator addCompletion:[protectedSelf = retainPtr(self), previewViews = WTFMove(previewViews), page = _page] (UIViewAnimatingPosition finalPosition) mutable {
         RELEASE_LOG(DragAndDrop, "Drag interaction willAnimateCancelWithAnimator (animation completion block fired)");
         for (auto& previewView : previewViews)
             [previewView setAlpha:1];

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.h
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.h
@@ -52,7 +52,7 @@ class WebFrameProxy;
     WeakObjCPtr<NSPrintOperation> _printOperation;
     RetainPtr<NSView> _wkView;
 
-    const RefPtr<WebKit::WebFrameProxy> _webFrame;
+    RefPtr<WebKit::WebFrameProxy> _webFrame;
     Vector<WebCore::IntRect> _printingPageRects;
     double _totalScaleFactorForPrinting;
     HashMap<WebCore::IntRect, RefPtr<WebCore::ShareableBitmap>> _pagePreviews;

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
@@ -149,7 +149,7 @@
         RefPtr menuProxy = _menuProxy.get();
         WeakPtr weakPage = menuProxy ? menuProxy->page() : nullptr;
         RetainPtr<NSString> itemUTI = itemProvider.get().registeredTypeIdentifiers.firstObject;
-        [itemProvider loadDataRepresentationForTypeIdentifier:itemUTI.get() completionHandler:[weakPage, attachmentID = _attachmentID, itemUTI](NSData *data, NSError *error) {
+        [itemProvider loadDataRepresentationForTypeIdentifier:itemUTI.get() completionHandler:[weakPage, attachmentID = _attachmentID, itemUTI](NSData *data, NSError *error) mutable {
             ensureOnMainRunLoop([weakPage = WTFMove(weakPage), attachmentID, itemUTI, data = RetainPtr { data }, error = RetainPtr { error }] {
                 RefPtr webPage = weakPage.get();
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4337,7 +4337,7 @@ static bool handleLegacyFilesPromisePasteboard(id<NSDraggingInfo> draggingInfo, 
     Ref protectedPage { page };
     [draggingInfo enumerateDraggingItemsWithOptions:0 forView:view.get() classes:@[NSFilePromiseReceiver.class] searchOptions:@{ } usingBlock:[&](NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
         auto queue = adoptNS([NSOperationQueue new]);
-        [retainPtr(draggingItem.item) receivePromisedFilesAtDestination:dropDestination.get() options:@{ } operationQueue:queue.get() reader:[protectedPage, fileNames, fileCount, dragData, pasteboardName](NSURL *fileURL, NSError *errorOrNil) {
+        [retainPtr(draggingItem.item) receivePromisedFilesAtDestination:dropDestination.get() options:@{ } operationQueue:queue.get() reader:[protectedPage, fileNames, fileCount, dragData, pasteboardName](NSURL *fileURL, NSError *errorOrNil) mutable {
             if (errorOrNil)
                 return;
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1792,7 +1792,7 @@ void MediaPlayerPrivateRemote::setDefaultSpatialTrackingLabel(const String& defa
     if (defaultSpatialTrackingLabel == m_defaultSpatialTrackingLabel)
         return;
 
-    m_defaultSpatialTrackingLabel = WTFMove(defaultSpatialTrackingLabel);
+    m_defaultSpatialTrackingLabel = defaultSpatialTrackingLabel;
     protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetDefaultSpatialTrackingLabel(m_defaultSpatialTrackingLabel), m_id);
 }
 
@@ -1806,7 +1806,7 @@ void MediaPlayerPrivateRemote::setSpatialTrackingLabel(const String& spatialTrac
     if (spatialTrackingLabel == m_spatialTrackingLabel)
         return;
 
-    m_spatialTrackingLabel = WTFMove(spatialTrackingLabel);
+    m_spatialTrackingLabel = spatialTrackingLabel;
     protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetSpatialTrackingLabel(m_spatialTrackingLabel), m_id);
 }
 #endif

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
@@ -51,12 +51,17 @@
 
 @end
 
+static Ref<WebCore::Document> protectedImpl(WKDOMDocument *document)
+{
+    return downcast<WebCore::Document>(*document->_impl);
+}
+
 @implementation WKDOMDocument
 
 - (WKDOMElement *)createElement:(NSString *)tagName
 {
     // FIXME: Do something about the exception.
-    auto result = downcast<WebCore::Document>(*_impl).createElementForBindings(tagName);
+    auto result = protectedImpl(self)->createElementForBindings(tagName);
     if (result.hasException())
         return nil;
     return WebKit::toWKDOMElement(result.releaseReturnValue().ptr());
@@ -64,27 +69,27 @@
 
 - (WKDOMText *)createTextNode:(NSString *)data
 {
-    return WebKit::toWKDOMText(downcast<WebCore::Document>(*_impl).createTextNode(data).ptr());
+    return WebKit::toWKDOMText(protectedImpl(self)->createTextNode(data).ptr());
 }
 
 - (WKDOMElement *)body
 {
-    return WebKit::toWKDOMElement(downcast<WebCore::Document>(*_impl).protectedBodyOrFrameset().get());
+    return WebKit::toWKDOMElement(protectedImpl(self)->protectedBodyOrFrameset().get());
 }
 
 - (WKDOMNode *)createDocumentFragmentWithMarkupString:(NSString *)markupString baseURL:(NSURL *)baseURL
 {
-    return WebKit::toWKDOMNode(createFragmentFromMarkup(downcast<WebCore::Document>(*_impl), markupString, baseURL.absoluteString).ptr());
+    return WebKit::toWKDOMNode(createFragmentFromMarkup(protectedImpl(self), markupString, baseURL.absoluteString).ptr());
 }
 
 - (WKDOMNode *)createDocumentFragmentWithText:(NSString *)text
 {
-    return WebKit::toWKDOMNode(createFragmentFromText(makeRangeSelectingNodeContents(downcast<WebCore::Document>(*_impl)), text).ptr());
+    return WebKit::toWKDOMNode(createFragmentFromText(makeRangeSelectingNodeContents(protectedImpl(self)), text).ptr());
 }
 
 - (id)parserYieldToken
 {
-    return adoptNS([[WKDOMDocumentParserYieldToken alloc] initWithDocument:downcast<WebCore::Document>(*_impl)]).autorelease();
+    return adoptNS([[WKDOMDocumentParserYieldToken alloc] initWithDocument:protectedImpl(self)]).autorelease();
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
@@ -30,26 +30,31 @@
 #import <WebCore/Element.h>
 #import <WebCore/ExceptionOr.h>
 
+static Ref<WebCore::Element> protectedImpl(WKDOMElement *element)
+{
+    return downcast<WebCore::Element>(*element->_impl);
+}
+
 @implementation WKDOMElement
 
 - (BOOL)hasAttribute:(NSString *)attribute
 {
-    return downcast<WebCore::Element>(*_impl).hasAttribute(attribute);
+    return protectedImpl(self)->hasAttribute(attribute);
 }
 
 - (NSString *)getAttribute:(NSString *)attribute
 {
-    return downcast<WebCore::Element>(*_impl).getAttribute(attribute).createNSString().autorelease();
+    return protectedImpl(self)->getAttribute(attribute).createNSString().autorelease();
 }
 
 - (void)setAttribute:(NSString *)name value:(NSString *)value
 {
-    downcast<WebCore::Element>(*_impl).setAttribute(name, AtomString { value });
+    protectedImpl(self)->setAttribute(name, AtomString { value });
 }
 
 - (NSString *)tagName
 {
-    return downcast<WebCore::Element>(*_impl).tagName().createNSString().autorelease();
+    return protectedImpl(self)->tagName().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
@@ -40,7 +40,7 @@ class Document;
 
 @interface WKDOMNode () {
 @package
-    const RefPtr<WebCore::Node> _impl;
+    RefPtr<WebCore::Node> _impl;
 }
 
 - (id)_initWithImpl:(WebCore::Node*)impl;
@@ -48,7 +48,7 @@ class Document;
 
 @interface WKDOMRange () {
 @package
-    const RefPtr<WebCore::Range> _impl;
+    RefPtr<WebCore::Range> _impl;
 }
 
 - (id)_initWithImpl:(WebCore::Range*)impl;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm
@@ -29,16 +29,21 @@
 #import "WKDOMInternals.h"
 #import <WebCore/Text.h>
 
+static Ref<WebCore::Text> protectedImpl(WKDOMText *text)
+{
+    return downcast<WebCore::Text>(*text->_impl);
+}
+
 @implementation WKDOMText
 
 - (NSString *)data
 {
-    return downcast<WebCore::Text>(*_impl).data().createNSString().autorelease();
+    return protectedImpl(self)->data().createNSString().autorelease();
 }
 
 - (void)setData:(NSString *)data
 {
-    downcast<WebCore::Text>(*_impl).setData(data);
+    protectedImpl(self)->setData(data);
 }
 
 @end

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm
@@ -85,7 +85,7 @@ template <typename Type>
 bool annotationCheckerInternal(PDFAnnotation *annotation, std::initializer_list<Type>&& types, AnnotationToTypeConverter<Type> converter)
 {
     auto checker = [annotation = RetainPtr { annotation }, converter = WTFMove(converter)](auto&& type) {
-        return annotationCheckerInternal(annotation.get(), std::forward<decltype(type)>(type), WTFMove(converter));
+        return annotationCheckerInternal(annotation.get(), std::forward<decltype(type)>(type), converter);
     };
     ASSERT(std::ranges::count_if(types, checker) <= 1);
     return std::ranges::any_of(WTFMove(types), WTFMove(checker));

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2209,7 +2209,7 @@ void WebChromeClient::abortApplePayAMSUISession()
 void WebChromeClient::beginSystemPreview(const URL& url, const SecurityOriginData& topOrigin, const SystemPreviewInfo& systemPreviewInfo, CompletionHandler<void()>&& completionHandler)
 {
     if (RefPtr page = m_page.get())
-        page->sendWithAsyncReply(Messages::WebPageProxy::BeginSystemPreview(WTFMove(url), topOrigin, WTFMove(systemPreviewInfo)), WTFMove(completionHandler));
+        page->sendWithAsyncReply(Messages::WebPageProxy::BeginSystemPreview(url, topOrigin, systemPreviewInfo), WTFMove(completionHandler));
     else
         completionHandler();
 }

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -131,7 +131,7 @@ namespace ax = WebCore::Accessibility;
                 return [protectedSelf accessibilityPluginObject];
         }
 
-        RefPtr frame = protectedFrame ? WTFMove(protectedFrame) : [protectedSelf focusedLocalFrame];
+        RefPtr frame = protectedFrame ? protectedFrame : [protectedSelf focusedLocalFrame];
         if (RefPtr document = frame ? frame->document() : nullptr) {
             if (CheckedPtr cache = document->axObjectCache()) {
                 if (RefPtr root = cache->rootObjectForFrame(*frame))
@@ -143,7 +143,7 @@ namespace ax = WebCore::Accessibility;
             // It's possible we were given a null frame (this is explicitly expected when off the main-thread, since
             // we can't access the webpage off the main-thread to get a frame). Now that we are actually on the main-thread,
             // try again if necessary.
-            RefPtr frame = protectedFrame ? WTFMove(protectedFrame) : [protectedSelf focusedLocalFrame];
+            RefPtr frame = protectedFrame ? protectedFrame : [protectedSelf focusedLocalFrame];
 
             if (RefPtr root = frame ? cache->rootObjectForFrame(*frame) : nullptr)
                 return root->wrapper();

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -574,7 +574,7 @@ void AccessibilityUIElement::elementAtPointResolvingRemoteFrame(JSContextRef con
 {
     JSValueProtect(context, jsCallback);
     s_controller->executeOnAXThreadAndWait([x, y, protectedThis = Ref { *this }, jsCallback = WTFMove(jsCallback), context = JSRetainPtr { JSContextGetGlobalContext(context) }] () mutable {
-        auto callback = [jsCallback = WTFMove(jsCallback), context = WTFMove(context)](NSString *result) {
+        auto callback = [jsCallback = WTFMove(jsCallback), context = WTFMove(context)](NSString *result) mutable {
             s_controller->executeOnMainThread([result = WTFMove(result), jsCallback = WTFMove(jsCallback), context = WTFMove(context)] () {
                 JSValueRef arguments[1];
                 arguments[0] = makeValueRefForValue(context.get(), result);


### PR DESCRIPTION
#### 0247f755348be4376109b26bc1e031d5c49c3bf5
<pre>
Address incorrect uses of WTFMove() with const values
<a href="https://bugs.webkit.org/show_bug.cgi?id=302207">https://bugs.webkit.org/show_bug.cgi?id=302207</a>

Reviewed by Mike Wyrzykowski and Darin Adler.

* Source/WTF/wtf/StdLibExtras.h:
* Source/WebCore/Modules/Model/Implementation/DDMeshImpl.cpp:
(WebCore::DDModel::convertToBacking):
(WebCore::DDModel::DDMeshImpl::update):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::finalizeDigitalCredential):
* Source/WebCore/accessibility/AXAttachmentHelpers.cpp:
(WebCore::AXAttachmentHelpers::accessibilityText):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setDefaultSpatialTrackingLabel):
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync):
* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm:
(WebCore::RemoteCommandListenerCocoa::RemoteCommandListenerCocoa):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::setDefaultSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setSpatialTrackingLabel):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::makeInvalidDueToCommit):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::checkForIndirectDrawDeviceLost):
(WebGPU::RenderPassEncoder::executeBundles):
* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm:
(-[WKModernDownloadProgress begin]):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::setH2PingCallback):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
* Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm:
(WebKit::NetworkConnectionToWebProcess::checkInWebProcess):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::didReceiveServerTrustChallenge):
(WebKit::createParameters):
* Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm:
(WebKit::platformDisbursementRequest):
* Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp:
(API::WebPushDaemonConnection::getPushSubscription):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _performInteraction:completionHandler:]):
(-[WKWebView _describeInteraction:completionHandler:]):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::ProcessAssertion):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setTextIndicatorFromFrame):
(WebKit::WebPageProxy::updateTextIndicatorFromFrame):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::initializeHardwareKeyboardAvailability):
(WebKit::WebProcessPool::registerAssetFonts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingRegisterContentScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsUpdate):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::launchWithExtensionKit):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::getAssertion):
(WebKit::CtapAuthenticator::continueSetupPinAfterGetKeyAgreement):
(WebKit::CtapAuthenticator::setupPin):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateTextIndicatorFromFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView dragInteraction:item:willAnimateCancelWithAnimator:]):
* Source/WebKit/UIProcess/mac/WKPrintingView.h:
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(protectedWebFrame):
(-[WKPrintingView initWithFrameProxy:view:]):
(-[WKPrintingView dealloc]):
(-[WKPrintingView _delayedResumeAutodisplayTimerFired]):
(-[WKPrintingView _adjustPrintingMarginsForHeaderAndFooter]):
(-[WKPrintingView _preparePDFDataForPrintingOnSecondaryThread]):
(-[WKPrintingView _askPageToComputePageRects]):
(-[WKPrintingView knowsPageRange:]):
(-[WKPrintingView _drawPreview:]):
(-[WKPrintingView drawPageBorderWithSize:]):
(-[WKPrintingView rectForPage:]):
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm:
(-[WKSharingServicePickerDelegate sharingService:didShareItems:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::handleLegacyFilesPromisePasteboard):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setDefaultSpatialTrackingLabel):
(WebKit::MediaPlayerPrivateRemote::setSpatialTrackingLabel):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm:
(protectedImpl):
(-[WKDOMDocument createElement:]):
(-[WKDOMDocument createTextNode:]):
(-[WKDOMDocument body]):
(-[WKDOMDocument createDocumentFragmentWithMarkupString:baseURL:]):
(-[WKDOMDocument createDocumentFragmentWithText:]):
(-[WKDOMDocument parserYieldToken]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm:
(protectedImpl):
(-[WKDOMElement hasAttribute:]):
(-[WKDOMElement getAttribute:]):
(-[WKDOMElement setAttribute:value:]):
(-[WKDOMElement tagName]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm:
(protectedImpl):
(-[WKDOMNode _initWithImpl:]):
(-[WKDOMNode dealloc]):
(-[WKDOMNode insertNode:before:]):
(-[WKDOMNode appendChild:]):
(-[WKDOMNode removeChild:]):
(-[WKDOMNode document]):
(-[WKDOMNode parentNode]):
(-[WKDOMNode firstChild]):
(-[WKDOMNode lastChild]):
(-[WKDOMNode previousSibling]):
(-[WKDOMNode nextSibling]):
(-[WKDOMNode textRects]):
(-[WKDOMNode _copyBundleNodeHandleRef]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm:
(protectedImpl):
(-[WKDOMRange _initWithImpl:]):
(-[WKDOMRange dealloc]):
(-[WKDOMRange setStart:offset:]):
(-[WKDOMRange setEnd:offset:]):
(-[WKDOMRange collapse:]):
(-[WKDOMRange selectNode:]):
(-[WKDOMRange selectNodeContents:]):
(-[WKDOMRange startContainer]):
(-[WKDOMRange startOffset]):
(-[WKDOMRange endContainer]):
(-[WKDOMRange endOffset]):
(-[WKDOMRange text]):
(-[WKDOMRange isCollapsed]):
(-[WKDOMRange textRects]):
(-[WKDOMRange rangeByExpandingToWordBoundaryByCharacters:inDirection:]):
(-[WKDOMRange _copyBundleRangeHandleRef]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm:
(protectedImpl):
(-[WKDOMText data]):
(-[WKDOMText setData:]):
* Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm:
(WebKit::PDFAnnotationTypeHelpers::annotationCheckerInternal):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::beginSystemPreview):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::elementAtPointResolvingRemoteFrame):

Canonical link: <a href="https://commits.webkit.org/302773@main">https://commits.webkit.org/302773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31a4157d6c22f949b9078947821315b6b18e0f09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130152 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81698 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bad8d39f-2772-4071-b6d8-82e856e4f0d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99153 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66980 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e6e17460-7193-4e57-8e98-934bfca3c3ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1806 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116576 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79847 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7954c034-5f18-4145-a66e-3064dc8b6048) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34704 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80826 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122155 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140031 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128604 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107677 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107554 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31369 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55142 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65670 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161619 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2100 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40301 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->