### PR TITLE
[experimental] Add test for new macOS PCM app-to-web

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -936,6 +936,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_setSmartListsEnabled:(BOOL)flag WK_API_AVAILABLE(macos(WK_MAC_TBA));
 - (void)_toggleSmartLists:(id)sender WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
+- (void)_storePrivateClickMeasurementWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destinationURL reportEndpoint:(NSURL *)reportEndpoint WK_API_AVAILABLE(macos(WK_MAC_TBA));
 @end
 
 @interface WKWebView (WKWindowSnapshot)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -2118,6 +2118,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _impl->toggleSmartLists();
 }
 
+- (void)_storePrivateClickMeasurementWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destinationURL reportEndpoint:(NSURL *)reportEndpoint
+{
+    WebCore::PrivateClickMeasurement measurement(
+        WebCore::PrivateClickMeasurement::SourceID(sourceID),
+        WebCore::PCM::SourceSite(reportEndpoint),
+        WebCore::PCM::AttributionDestinationSite(destinationURL),
+        applicationBundleIdentifier(),
+        WallTime::now(),
+        WebCore::PCM::AttributionEphemeral::No
+    );
+    _page->setPrivateClickMeasurement(WTFMove(measurement));
+}
+
 @end // WKWebView (WKPrivateMac)
 
 @implementation WKWebView (WKWindowSnapshot)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -385,6 +385,126 @@ TEST(PrivateClickMeasurement, Basic)
     });
 }
 
+TEST(PrivateClickMeasurement, MeasureSafariIsDefault)
+{
+    runBasicPCMTest(nil, [](WKWebView *webView, const HTTPServer& server) {
+        [webView _storePrivateClickMeasurementWithSourceID:42 destinationURL:exampleURL() reportEndpoint:server.request().URL];
+    });
+}
+
+static BOOL forwardToEywa(NSData *body)
+{
+    NSURL *eywa = [NSURL URLWithString:@"https://supportmetrics.apple.com/content/services/pcm"];
+    NSMutableURLRequest * req = [NSMutableURLRequest requestWithURL:eywa];
+    req.HTTPMethod = @"POST";
+    [req setValue:@"text/plain" forHTTPHeaderField:@"Content-Type"];
+    req.HTTPBody = body;
+
+    NSURLSessionConfiguration *cfg = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    cfg.timeoutIntervalForRequest = 7.0;
+    NSURLSession * session = [NSURLSession sessionWithConfiguration:cfg];
+
+    __block BOOL ok = NO;
+    __block bool finished = false;
+
+    [[session dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *resp, NSError *err) {
+        if (!err && [resp isKindOfClass:[NSHTTPURLResponse class]]) {
+            NSHTTPURLResponse *http = (NSHTTPURLResponse *)resp;
+            ok = (http.statusCode >= 200 && http.statusCode < 300);
+            // fprintf(stderr, "Eywa status: %ld\n", (long)http.statusCode);
+        }
+        finished = true;
+    }] resume];
+    TestWebKitAPI::Util::run(&finished);
+    return ok;
+}
+
+static void runEywaPCMTest(WKWebViewConfiguration *configuration, Function<void(WKWebView *, const HTTPServer&)>&& addAttributionToWebView, bool setTestAppBundleID = true)
+{
+    [WKWebsiteDataStore _setNetworkProcessSuspensionAllowedForTesting:NO];
+    bool done = false;
+    HTTPServer server([&done, connectionCount = 0](Connection connection) mutable {
+        switch (++connectionCount) {
+        case 1: // conversion trigger
+            connection.receiveHTTPRequest([connection] (Vector<char>&& request1) {
+                EXPECT_TRUE(contains(request1.span(), "GET /conversionRequestBeforeRedirect HTTP/1.1\r\n"_span));
+                constexpr auto redirect =
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /.well-known/private-click-measurement/trigger-attribution/12\r\n"
+                    "Content-Length: 0\r\n\r\n"_s;
+                connection.send(redirect, [connection] {
+                    connection.receiveHTTPRequest([connection] (Vector<char>&& request2) {
+                        EXPECT_TRUE(contains(request2.span(), "GET /.well-known/private-click-measurement/trigger-attribution/12 HTTP/1.1\r\n"_span));
+                        constexpr auto response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"_s;
+                        connection.send(response);
+                    });
+                });
+            });
+            break;
+
+        case 2: // attribution report arrives here; forward body to Eywa
+            connection.receiveHTTPRequest([&done, connection] (Vector<char>&& request3) {
+                EXPECT_TRUE(contains(request3.span(), "POST / HTTP/1.1\r\n"_span)); //
+
+                auto span = request3.span();
+                size_t bodyBegin = find(span, "\r\n\r\n"_span);
+                EXPECT_NE(bodyBegin, WTF::notFound); //
+                bodyBegin += strlen("\r\n\r\n");
+                auto bodySpan = span.subspan(bodyBegin);
+
+                NSData *bodyData = [NSData dataWithBytes:bodySpan.data() length:bodySpan.size()];
+                BOOL eywaOK = forwardToEywa(bodyData);
+
+                constexpr auto okResp = "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n\r\n"_s;
+                connection.send(okResp, [&, connection, eywaOK] {
+                    EXPECT_TRUE(eywaOK);
+                    done = true;
+                });
+            });
+            break;
+        }
+    }, HTTPServer::Protocol::Https);
+
+    NSURL *serverURL = server.request().URL;
+
+    auto webView = configuration
+        ? adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration])
+        : webViewWithoutUsingDaemon();
+    webView.get().navigationDelegate = delegateAllowingAllTLS();
+    addAttributionToWebView(webView.get(), server);
+    [[webView configuration].websiteDataStore _setResourceLoadStatisticsEnabled:YES];
+    [[webView configuration].websiteDataStore _trustServerForLocalPCMTesting:secTrustFromCertificateChain(@[(id)testCertificate().get()]).get()];
+
+    __block bool cleared = false;
+    [[webView configuration].websiteDataStore removeDataOfTypes:[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate] modifiedSince:[NSDate distantPast] completionHandler:^{
+        cleared = true;
+    }];
+    Util::run(&cleared);
+
+    [webView _setPrivateClickMeasurementAttributionReportURLsForTesting:serverURL destinationURL:exampleURL() completionHandler:^{
+        [webView _setPrivateClickMeasurementOverrideTimerForTesting:YES completionHandler:^{
+            NSString *html = [NSString stringWithFormat:
+                @"<script>fetch('%@conversionRequestBeforeRedirect',{mode:'no-cors'})</script>", serverURL];
+            if (setTestAppBundleID) {
+                [webView _setPrivateClickMeasurementAppBundleIDForTesting:@"test.bundle.id" completionHandler:^{
+                    [webView loadHTMLString:html baseURL:exampleURL()];
+                }];
+            } else
+                [webView loadHTMLString:html baseURL:exampleURL()];
+        }];
+    }];
+
+    Util::run(&done);
+}
+
+TEST(PrivateClickMeasurement, SendConversionReportToEywa)
+{
+    runEywaPCMTest(nil, [](WKWebView *webView, const HTTPServer& server) {
+        [webView _storePrivateClickMeasurementWithSourceID:42 destinationURL:exampleURL() reportEndpoint:server.request().URL];
+    });
+}
+
 TEST(PrivateClickMeasurement, EphemeralWithAttributedBundleIdentifier)
 {
     auto configuration = configurationWithoutUsingDaemon();


### PR DESCRIPTION
#### 85afba90ca036ba637e385f959a42310be87e433
<pre>
[experimental] Add test for new macOS PCM app-to-web
<a href="https://rdar.apple.com/163961938">rdar://163961938</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302208">https://bugs.webkit.org/show_bug.cgi?id=302208</a>

Reviewed by NOBODY (OOPS!).

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _storePrivateClickMeasurementWithSourceID:destinationURL:reportEndpoint:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::TEST(PrivateClickMeasurement, MeasureSafariIsDefault)):
(TestWebKitAPI::forwardToEywa):
(TestWebKitAPI::runEywaPCMTest):
(TestWebKitAPI::TEST(PrivateClickMeasurement, SendConversionReportToEywa)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85afba90ca036ba637e385f959a42310be87e433

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130145 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2416 "Hash 85afba90 for PR 53638 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81691 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f7dc5f5a-2472-4f66-8dae-6496d04cab29) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132016 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2388 "Hash 85afba90 for PR 53638 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99149 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66971 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1362d500-1257-451c-9abc-c374118ed319) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133092 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/2388 "Hash 85afba90 for PR 53638 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116571 "Found 1 new API test failure: TestWebKitAPI.PrivateClickMeasurement.SendConversionReportToEywa (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1327587c-aa8f-43da-835b-d3a02c2e76f9) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/2388 "Hash 85afba90 for PR 53638 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80819 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/2388 "Hash 85afba90 for PR 53638 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140024 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2206 "Hash 85afba90 for PR 53638 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107672 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2250 "Hash 85afba90 for PR 53638 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107550 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31364 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55117 "The change is no longer eligible for processing.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2276 "Hash 85afba90 for PR 53638 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65663 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2093 "Hash 85afba90 for PR 53638 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2297 "Hash 85afba90 for PR 53638 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2202 "Hash 85afba90 for PR 53638 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->