### PR TITLE
Port WebExtensionAPITest to CPP

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -169,7 +169,6 @@ set(WebKit_BINDINGS_IN_FILES
     WebProcess/Extensions/Interfaces/WebExtensionAPIStorage
     WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea
     WebProcess/Extensions/Interfaces/WebExtensionAPITabs
-    WebProcess/Extensions/Interfaces/WebExtensionAPITest
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace
@@ -178,6 +177,10 @@ set(WebKit_BINDINGS_IN_FILES
     WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent
     WebProcess/Extensions/Interfaces/WebExtensionAPIWindows
     WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent
+)
+
+set(WebKit_CPP_BINDINGS_IN_FILES
+    WebProcess/Extensions/Interfaces/WebExtensionAPITest
 )
 
 set(WebKit_MESSAGES_IN_FILES
@@ -1094,7 +1097,8 @@ list(APPEND WebKit_UNIFIED_SOURCE_EXCLUDES "^[A-Za-z0-9_]+MessageReceiver\\.cpp"
 # Helper macro which wraps the bindings script
 #   _output_source is a list name which will contain generated sources.(eg. WebKit_SOURCES)
 #   _inputs are .idl files to generate.
-macro(GENERATE_IDL_BINDINGS _output_source _inputs)
+#   _cpp_inputs are .idl files to generate (CPP sources only).
+macro(GENERATE_IDL_BINDINGS _output_source _inputs _cpp_inputs)
     unset(_input_files)
     unset(_outputs)
     unset(_import_names)
@@ -1107,6 +1111,17 @@ macro(GENERATE_IDL_BINDINGS _output_source _inputs)
             ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.h
         )
         list(APPEND _import_names JS${_name}.mm)
+        list(APPEND ${_output_source} ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.h)
+    endforeach ()
+    foreach (_file IN ITEMS ${_cpp_inputs})
+        get_filename_component(_name ${_file} NAME_WE)
+        list(APPEND _input_files ${WEBKIT_DIR}/${_file}.idl)
+
+        list(APPEND _outputs
+            ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.cpp
+
+            ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.h
+        )
         list(APPEND ${_output_source} ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.h)
     endforeach ()
 
@@ -1129,7 +1144,7 @@ macro(GENERATE_IDL_BINDINGS _output_source _inputs)
         VERBATIM
     )
 endmacro()
-GENERATE_IDL_BINDINGS(WebKit_DERIVED_SOURCES "${WebKit_BINDINGS_IN_FILES}")
+GENERATE_IDL_BINDINGS(WebKit_DERIVED_SOURCES "${WebKit_BINDINGS_IN_FILES}" "${WebKit_CPP_BINDINGS_IN_FILES}")
 
 foreach (in_file ${WebKit_SERIALIZATION_IN_FILES})
     list(APPEND WebKit_SERIALIZATION_DEPENDENCIES "${WEBKIT_DIR}/${in_file}")

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -581,7 +581,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIStorageArea.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITabs.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITabs.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIUnified.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.mm

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -1034,6 +1034,7 @@ EXTENSIONS_SCRIPTS_DIR = $(EXTENSIONS_DIR)/Bindings/Scripts
 EXTENSIONS_INTERFACES_DIR = $(EXTENSIONS_DIR)/Interfaces
 IDL_ATTRIBUTES_FILE = $(EXTENSIONS_SCRIPTS_DIR)/IDLAttributes.json
 IDL_FILE_NAMES_LIST = WebExtensionIDLFileNamesList.txt
+CPP_IDL_FILE_NAMES_LIST = WebExtensionCPPIDLFileNamesList.txt
 
 BINDINGS_SCRIPTS = \
     $(WebCorePrivateHeaders)/generate-bindings.pl \
@@ -1071,7 +1072,6 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIStorage \
     WebExtensionAPIStorageArea \
     WebExtensionAPITabs \
-    WebExtensionAPITest \
     WebExtensionAPIWebNavigation \
     WebExtensionAPIWebNavigationEvent \
     WebExtensionAPIWebPageNamespace \
@@ -1082,18 +1082,29 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIWindowsEvent \
 #
 
+CPP_EXTENSION_INTERFACES = \
+    WebExtensionAPITest \
+#
+
 $(IDL_FILE_NAMES_LIST) : $(EXTENSION_INTERFACES:%=%.idl)
+	echo $^ | tr " " "\n" > $@
+
+$(CPP_IDL_FILE_NAMES_LIST) : $(CPP_EXTENSION_INTERFACES:%=%.idl)
 	echo $^ | tr " " "\n" > $@
 
 JS%.h JS%.mm : %.idl $(BINDINGS_SCRIPTS) $(IDL_ATTRIBUTES_FILE) $(FEATURE_AND_PLATFORM_FLAGS_RESPONSE_FILE) $(IDL_FILE_NAMES_LIST)
 	@echo Generating bindings for $*...
 	$(PERL) -I $(WebCorePrivateHeaders) -I $(EXTENSIONS_SCRIPTS_DIR) $(WebCorePrivateHeaders)/generate-bindings.pl --defines "$(FEATURE_AND_PLATFORM_DEFINES)" --outputDir . --generator Extensions --idlAttributesFile $(IDL_ATTRIBUTES_FILE) --idlFileNamesList $(IDL_FILE_NAMES_LIST) $<
 
+JS%.h JS%.cpp : %.idl $(BINDINGS_SCRIPTS) $(IDL_ATTRIBUTES_FILE) $(FEATURE_AND_PLATFORM_FLAGS_RESPONSE_FILE) $(CPP_IDL_FILE_NAMES_LIST)
+	@echo Generating bindings for $*...
+	$(PERL) -I $(WebCorePrivateHeaders) -I $(EXTENSIONS_SCRIPTS_DIR) $(WebCorePrivateHeaders)/generate-bindings.pl --defines "$(FEATURE_AND_PLATFORM_DEFINES)" --outputDir . --generator Extensions --idlAttributesFile $(IDL_ATTRIBUTES_FILE) --idlFileNamesList $(CPP_IDL_FILE_NAMES_LIST) $<
+
 JSWebExtensionAPIUnified.mm: $(BINDINGS_SCRIPTS) $(EXTENSION_INTERFACES:%=JS%.mm)
 	@echo "Generating $@..."
 	$(PERL) $(EXTENSIONS_SCRIPTS_DIR)/GenerateImports.pl $@ $(EXTENSION_INTERFACES:%=JS%.mm)
 
-all : JSWebExtensionAPIUnified.mm $(EXTENSION_INTERFACES:%=JS%.h) $(EXTENSION_INTERFACES:%=JS%.mm)
+all : JSWebExtensionAPIUnified.mm $(EXTENSION_INTERFACES:%=JS%.h) $(EXTENSION_INTERFACES:%=JS%.mm) $(CPP_EXTENSION_INTERFACES:%=JS%.cpp)
 
 ifeq ($(USE_INTERNAL_SDK),YES)
 WEBKIT_ADDITIONS_SWIFT_FILES = \

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
@@ -67,6 +67,9 @@ inline String toDebugString(WebExtensionContentWorldType contentWorldType)
         return "inspector"_s;
 #endif
     }
+
+    ASSERT_NOT_REACHED();
+    return emptyString();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
@@ -230,6 +230,9 @@ inline String toAPIString(WebExtensionEventListenerType eventType)
     case WebExtensionEventListenerType::WindowsOnRemoved:
         return "onRemoved"_s;
     }
+
+    ASSERT_NOT_REACHED();
+    return emptyString();
 }
 
 using WebExtensionEventListenerTypeWorldPair = std::pair<WebExtensionEventListenerType, WebExtensionContentWorldType>;

--- a/Source/WebKit/Shared/Protected.h
+++ b/Source/WebKit/Shared/Protected.h
@@ -65,6 +65,8 @@ public:
 
     T get() const { return m_value; }
 
+    JSRetainPtr<JSGlobalContextRef> context() const { return m_context; }
+
     explicit operator bool() const { return !!m_value; }
 
     bool operator==(const Protected& other) const { return m_value == other.m_value; }

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -706,6 +706,8 @@ WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 WebProcess/Extensions/WebExtensionContextProxy.cpp
 WebProcess/Extensions/WebExtensionControllerProxy.cpp
 
+WebProcess/Extensions/API/WebExtensionAPITest.cpp
+
 WebProcess/FileAPI/BlobRegistryProxy.cpp
 
 WebProcess/FullScreen/WebFullScreenManager.cpp @cost:8

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1768,6 +1768,7 @@
 		7E70A07B501701FB501FB516 /* GeneratedSerializersSharedWebCoreArgumentCodersPayment.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7E70A07B501701FB501FB517 /* GeneratedSerializersSharedWebCoreArgumentCodersPayment.mm */; };
 		7E70A07B501701FB501FB518 /* GeneratedSerializersSharedWebCoreArgumentCodersStorage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7E70A07B501701FB501FB519 /* GeneratedSerializersSharedWebCoreArgumentCodersStorage.mm */; };
 		7EB6760501701FB501FB7E05 /* GeneratedSerializersSharedWebGPU.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7EB6760501701FB501FB7E06 /* GeneratedSerializersSharedWebGPU.mm */; };
+		7DF6CAA12EC06B0D00AE220C /* JSWebExtensionAPITest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.cpp */; };
 		8310428B1BD6B66F00A715E4 /* NetworkCacheSubresourcesEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 831042891BD6B66F00A715E4 /* NetworkCacheSubresourcesEntry.h */; };
 		8313F7EC1F7DAE0800B944EB /* SharedStringHashStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 8313F7E91F7DAE0300B944EB /* SharedStringHashStore.h */; };
 		8313F7EE1F7DAE0800B944EB /* SharedStringHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 8313F7E71F7DAE0300B944EB /* SharedStringHashTable.h */; };
@@ -4187,7 +4188,7 @@
 		1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPITestCocoa.mm; sourceTree = "<group>"; };
 		1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPITest.h; sourceTree = "<group>"; };
 		1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPITest.h; sourceTree = "<group>"; };
-		1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPITest.mm; sourceTree = "<group>"; };
+		1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPITest.cpp; sourceTree = "<group>"; };
 		1C1549812926E7CC001B9E5B /* WebExtensionControllerAPITestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionControllerAPITestCocoa.mm; sourceTree = "<group>"; };
 		1C1549832926F04E001B9E5B /* WKWebExtensionControllerDelegatePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebExtensionControllerDelegatePrivate.h; sourceTree = "<group>"; };
 		1C1549CE293812F8001B9E5B /* WebExtensionControllerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerConfiguration.h; sourceTree = "<group>"; };
@@ -7259,6 +7260,7 @@
 		7E70A07B501701FB501FB517 /* GeneratedSerializersSharedWebCoreArgumentCodersPayment.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializersSharedWebCoreArgumentCodersPayment.mm; sourceTree = "<group>"; };
 		7E70A07B501701FB501FB519 /* GeneratedSerializersSharedWebCoreArgumentCodersStorage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializersSharedWebCoreArgumentCodersStorage.mm; sourceTree = "<group>"; };
 		7EB6760501701FB501FB7E06 /* GeneratedSerializersSharedWebGPU.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializersSharedWebGPU.mm; sourceTree = "<group>"; };
+		7DF6CAA52EC1365500AE220C /* WebExtensionAPITest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionAPITest.cpp; sourceTree = "<group>"; };
 		7EC4F0F918E4A945008056AF /* NetworkProcessCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkProcessCocoa.mm; sourceTree = "<group>"; };
 		816C18758ACB9F66D87FBE39 /* WKImmersiveEnvironmentInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKImmersiveEnvironmentInternal.h; sourceTree = "<group>"; };
 		831042891BD6B66F00A715E4 /* NetworkCacheSubresourcesEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkCacheSubresourcesEntry.h; sourceTree = "<group>"; };
@@ -11108,6 +11110,7 @@
 				B651BC5B2B460C9C009654A9 /* WebExtensionAPIStorage.h */,
 				B651BC5A2B460C9C009654A9 /* WebExtensionAPIStorageArea.h */,
 				1C5ACFAD2A96F9D300C041C0 /* WebExtensionAPITabs.h */,
+				7DF6CAA52EC1365500AE220C /* WebExtensionAPITest.cpp */,
 				1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */,
 				3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */,
 				33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */,
@@ -17286,8 +17289,8 @@
 				B63C10362B51C0E5004A69B8 /* JSWebExtensionAPIStorageArea.mm */,
 				1C5ACFAA2A96F8D500C041C0 /* JSWebExtensionAPITabs.h */,
 				1C5ACFA92A96F8D400C041C0 /* JSWebExtensionAPITabs.mm */,
+				1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.cpp */,
 				1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */,
-				1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */,
 				1C0F05BD2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm */,
 				3399E14F2B59EFD6008BFB60 /* JSWebExtensionAPIWebNavigation.h */,
 				3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */,
@@ -22138,6 +22141,7 @@
 				074D6A652F385435006089F6 /* IntRectCG.swift in Sources */,
 				5CF250AF2EE06491006A7172 /* IPCTesterReceiver.swift in Sources */,
 				5C448C662EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift in Sources */,
+				7DF6CAA12EC06B0D00AE220C /* JSWebExtensionAPITest.cpp in Sources */,
 				1C0F05BE2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm in Sources */,
 				E385F3672E86D6C900461B0C /* LaunchLogHook.mm in Sources */,
 				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -58,6 +58,37 @@ void WebExtensionAPIEvent::invokeListeners()
         listener->call();
 }
 
+void WebExtensionAPIEvent::invokeListenersWithJSONArgument(const String& argument)
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    // Copy the listeners since call() can trigger a mutation of the listeners.
+    auto listenersCopy = m_listeners;
+
+    for (RefPtr listener : listenersCopy) {
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG listener->call(!argument.isEmpty() ? JSValueMakeFromJSONString(listener->globalContext(), toJSString(argument).get()) : JSValueMakeUndefined(listener->globalContext()));
+    }
+}
+
+void WebExtensionAPIEvent::invokeListenersWithJSONArgument(const String& argument1, const String& argument2)
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    // Copy the listeners since call() can trigger a mutation of the listeners.
+    auto listenersCopy = m_listeners;
+
+    for (RefPtr listener : listenersCopy) {
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG listener->call(
+            toJSValueRef(listener->globalContext(), argument1),
+            !argument2.isEmpty() ? JSValueMakeFromJSONString(listener->globalContext(), toJSString(argument2).get()) : JSValueMakeUndefined(listener->globalContext())
+        );
+    }
+}
+
 void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1)
 {
     if (m_listeners.isEmpty())

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,280 +32,58 @@
 #import "WebExtensionAPITest.h"
 
 #import "CocoaHelpers.h"
-#import "MessageSenderInlines.h"
-#import "WebExtensionAPINamespace.h"
-#import "WebExtensionAPIWebPageNamespace.h"
 #import "WebExtensionControllerMessages.h"
 #import "WebExtensionControllerProxy.h"
-#import "WebExtensionEventListenerType.h"
-#import "WebFrame.h"
-#import "WebPage.h"
-#import "WebProcess.h"
-#import <JavaScriptCore/APICast.h>
-#import <JavaScriptCore/ScriptCallStack.h>
-#import <JavaScriptCore/ScriptCallStackFactory.h>
-#import <WebCore/LocalFrameInlines.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 namespace WebKit {
 
-static std::pair<String, unsigned> scriptLocation(JSContextRef context)
-{
-    auto callStack = Inspector::createScriptCallStack(toJS(context));
-    if (const Inspector::ScriptCallFrame* frame = callStack->firstNonNativeCallFrame()) {
-        auto sourceURL = frame->sourceURL();
-        if (sourceURL.isEmpty())
-            sourceURL = "global code"_s;
-        return { sourceURL, frame->lineNumber() };
-    }
-
-    return { "unknown"_s, 0 };
-}
-
-void WebExtensionAPITest::notifyFail(JSContextRef context, NSString *message)
-{
-    auto location = scriptLocation(context);
-
-    RefPtr page = toWebPage(context);
-    if (!page)
-        return;
-
-    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
-    if (!webExtensionControllerProxy)
-        return;
-
-    WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(nullString(), false, message, location.first, location.second), webExtensionControllerProxy->identifier());
-}
-
-void WebExtensionAPITest::notifyPass(JSContextRef context, NSString *message)
-{
-    auto location = scriptLocation(context);
-
-    RefPtr page = toWebPage(context);
-    if (!page)
-        return;
-
-    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
-    if (!webExtensionControllerProxy)
-        return;
-
-    WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(nullString(), true, message, location.first, location.second), webExtensionControllerProxy->identifier());
-}
-
-void WebExtensionAPITest::sendMessage(JSContextRef context, NSString *message, JSValue *argument)
-{
-    auto location = scriptLocation(context);
-
-    RefPtr page = toWebPage(context);
-    if (!page)
-        return;
-
-    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
-    if (!webExtensionControllerProxy)
-        return;
-
-    WebProcess::singleton().send(Messages::WebExtensionController::TestSentMessage(message, toSortedJSONString(context, argument.JSValueRef), location.first, location.second), webExtensionControllerProxy->identifier());
-}
-
-WebExtensionAPIEvent& WebExtensionAPITest::onMessage()
-{
-    if (!m_onMessage)
-        m_onMessage = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TestOnMessage);
-
-    return *m_onMessage;
-}
-
-WebExtensionAPIEvent& WebExtensionAPITest::onTestStarted()
-{
-    if (!m_onTestStarted)
-        m_onTestStarted = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TestOnTestStarted);
-
-    return *m_onTestStarted;
-}
-
-WebExtensionAPIEvent& WebExtensionAPITest::onTestFinished()
-{
-    if (!m_onTestFinished)
-        m_onTestFinished = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TestOnTestFinished);
-
-    return *m_onTestFinished;
-}
-
-JSValue *WebExtensionAPITest::runWithUserGesture(WebFrame& frame, JSValue *function)
-{
-    RefPtr coreFrame = frame.coreLocalFrame();
-    WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, coreFrame ? coreFrame->document() : nullptr);
-
-    return [function callWithArguments:@[ ]];
-}
-
-bool WebExtensionAPITest::isProcessingUserGesture()
-{
-    return WebCore::UserGestureIndicator::processingUserGesture();
-}
-
-inline NSString *debugString(JSValue *value)
-{
-    JSGlobalContextRef contextRef = value.context.JSGlobalContextRef;
-    JSValueRef valueRef = value.JSValueRef;
-
-    if (isRegularExpression(contextRef, valueRef) || isFunction(contextRef, valueRef))
-        return toString(contextRef, valueRef).createNSString().get();
-    auto sortedJSON = toSortedJSONString(contextRef, valueRef);
-    if (!sortedJSON.isEmpty())
-        return sortedJSON.createNSString().get();
-    return @"undefined";
-}
-
-void WebExtensionAPITest::log(JSContextRef context, JSValue *value)
-{
-    auto location = scriptLocation(context);
-
-    RefPtr page = toWebPage(context);
-    if (!page)
-        return;
-
-    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
-    if (!webExtensionControllerProxy)
-        return;
-
-    WebProcess::singleton().send(Messages::WebExtensionController::TestLogMessage(debugString(value), location.first, location.second), webExtensionControllerProxy->identifier());
-}
-
-void WebExtensionAPITest::fail(JSContextRef context, NSString *message)
-{
-    assertTrue(context, false, message, nil);
-}
-
-void WebExtensionAPITest::succeed(JSContextRef context, NSString *message)
-{
-    assertTrue(context, true, message, nil);
-}
-
-void WebExtensionAPITest::assertTrue(JSContextRef context, bool actualValue, NSString *message, NSString **outExceptionString)
-{
-    auto location = scriptLocation(context);
-
-    RefPtr page = toWebPage(context);
-    if (!page)
-        return;
-
-    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
-    if (!webExtensionControllerProxy)
-        return;
-
-    recordAssertionIfNeeded(actualValue, message, location, outExceptionString);
-
-    WebProcess::singleton().send(Messages::WebExtensionController::TestResult(actualValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
-}
-
-void WebExtensionAPITest::assertFalse(JSContextRef context, bool actualValue, NSString *message, NSString **outExceptionString)
-{
-    assertTrue(context, !actualValue, message, outExceptionString);
-}
-
-void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString)
-{
-    NSString *expectedJSONValue = debugString(expectedValue);
-    NSString *actualJSONValue = debugString(actualValue);
-
-    // FIXME: Comparing JSON is a quick attempt that works, but can still fail due to any non-JSON values.
-    // See Firefox's implementation: https://searchfox.org/mozilla-central/source/toolkit/components/extensions/child/ext-test.js#78
-    BOOL strictEqual = [expectedValue isEqualToObject:actualValue];
-    BOOL deepEqual = strictEqual || [expectedJSONValue isEqualToString:actualJSONValue];
-
-    auto location = scriptLocation(context);
-
-    RefPtr page = toWebPage(context);
-    if (!page)
-        return;
-
-    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
-    if (!webExtensionControllerProxy)
-        return;
-
-    recordAssertionIfNeeded(deepEqual, message, location, outExceptionString);
-
-    WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(deepEqual, expectedJSONValue, actualJSONValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
-}
-
-static NSString *combineMessages(NSString *messageOne, NSString *messageTwo)
-{
-    if (messageOne.length && messageTwo.length)
-        return [[messageOne stringByAppendingString:@"\n"] stringByAppendingString:messageTwo];
-    if (messageOne.length && !messageTwo.length)
-        return messageOne;
-    return messageTwo;
-}
-
-void WebExtensionAPITest::assertEquals(JSContextRef context, bool result, NSString *expectedString, NSString *actualString, NSString *message, NSString **outExceptionString)
-{
-    auto location = scriptLocation(context);
-
-    RefPtr page = toWebPage(context);
-    if (!page)
-        return;
-
-    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
-    if (!webExtensionControllerProxy)
-        return;
-
-    recordAssertionIfNeeded(result, message, location, outExceptionString);
-
-    WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(result, expectedString, actualString, message, location.first, location.second), webExtensionControllerProxy->identifier());
-}
-
-void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString)
-{
-    NSString *expectedJSONValue = debugString(expectedValue);
-    NSString *actualJSONValue = debugString(actualValue);
-
-    BOOL strictEqual = [expectedValue isEqualToObject:actualValue];
-    if (!strictEqual && [expectedJSONValue isEqualToString:actualJSONValue])
-        actualJSONValue = [actualJSONValue stringByAppendingString:@" (different)"];
-
-    assertEquals(context, strictEqual, expectedJSONValue, actualJSONValue, message, outExceptionString);
-}
-
-JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promise, JSValue *expectedError, NSString *message)
+JSValueRef WebExtensionAPITest::assertRejects(JSContextRef context, JSValueRef promiseRef, JSValueRef expectedError, const String& message)
 {
     __block JSValue *resolveCallback;
     __block JSValue *rejectCallback;
-    JSValue *resultPromise = [JSValue valueWithNewPromiseInContext:promise.context fromExecutor:^(JSValue *resolve, JSValue *reject) {
+    JSValue *resultPromise = [JSValue valueWithNewPromiseInContext:toJSContext(context) fromExecutor:^(JSValue *resolve, JSValue *reject) {
         resolveCallback = resolve;
         rejectCallback = reject;
     }];
 
     // Wrap in a native promise for consistency.
-    promise = [JSValue valueWithNewPromiseResolvedWithResult:promise inContext:promise.context];
+    JSValue *promise = [JSValue valueWithNewPromiseResolvedWithResult:toJSValue(context, promiseRef) inContext:toJSContext(context)];
 
     if (!isThenable(context, promise.JSValueRef))
-        return nil;
+        return JSValueMakeNull(context);
 
+    auto *nsMessage = message.createNSString().get();
     auto promiseHandler = ^(JSValue *result, JSValue *error) {
         if (result || !error) {
-            assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any error)", result ? debugString(result) : @"(no error)", combineMessages(message, @"Promise did not reject with an error"), nil);
+            String falseException = nullString();
+            assertEquals(context, false, expectedError ? debugString(context, expectedError) : "(any error)"_s, result ? debugString(context, result.JSValueRef) : "(no error)"_s, combineMessages(nsMessage, "Promise did not reject with an error"_s), falseException);
             [rejectCallback callWithArguments:nil];
             return;
         }
 
-        JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
+        JSValueRef errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"].JSValueRef : error.JSValueRef;
 
-        if (!expectedError) {
-            assertEquals(context, true, @"(any error)", debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error"), nil);
+        // By default, JSValueRef is set to an undefined value in the JS implementation.
+        // It should not be possible to get a null value here.
+        if (JSValueIsUndefined(context, expectedError) || !expectedError) {
+            String falseException = nullString();
+            assertEquals(context, true, "(any error)"_s, debugString(context, errorMessageValue), combineMessages(nsMessage, "Promise rejected with an error"_s), falseException);
             [resolveCallback callWithArguments:nil];
             return;
         }
 
-        if (isRegularExpression(context, expectedError.JSValueRef)) {
-            JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ errorMessageValue ]];
-            assertEquals(context, testResult.toBool, debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't match the regular expression"), nil);
+        if (isRegularExpression(context, expectedError)) {
+            String falseException = nullString();
+            JSValueRef testResult = invokeMethod<1>(context, expectedError, "test"_s, { errorMessageValue });
+            assertEquals(context, JSValueToBoolean(context, testResult), debugString(context, expectedError), debugString(context, errorMessageValue), combineMessages(nsMessage, "Promise rejected with an error that didn't match the regular expression"_s), falseException);
             [resolveCallback callWithArguments:nil];
             return;
         }
 
-        assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:errorMessageValue], debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't equal"), nil);
+        String falseException = nullString();
+        assertEquals(context, JSValueIsEqual(context, expectedError, errorMessageValue, nullptr), debugString(context, expectedError), debugString(context, errorMessageValue), combineMessages(nsMessage, "Promise rejected with an error that didn't equal"_s), falseException);
         [resolveCallback callWithArguments:nil];
     };
 
@@ -318,21 +97,21 @@ JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promi
         },
     ]];
 
-    return resultPromise;
+    return resultPromise.JSValueRef;
 }
 
-JSValue *WebExtensionAPITest::assertResolves(JSContextRef context, JSValue *promise, NSString *message)
+JSValueRef WebExtensionAPITest::assertResolves(JSContextRef context, JSValueRef promiseRef, const String& message)
 {
     __block JSValue *resolveCallback;
-    JSValue *resultPromise = [JSValue valueWithNewPromiseInContext:promise.context fromExecutor:^(JSValue *resolve, JSValue *reject) {
+    JSValue *resultPromise = [JSValue valueWithNewPromiseInContext:toJSContext(context) fromExecutor:^(JSValue *resolve, JSValue *reject) {
         resolveCallback = resolve;
     }];
 
     // Wrap in a native promise for consistency.
-    promise = [JSValue valueWithNewPromiseResolvedWithResult:promise inContext:promise.context];
+    JSValue *promise = [JSValue valueWithNewPromiseResolvedWithResult:toJSValue(context, promiseRef) inContext:toJSContext(context)];
 
-    if (!isThenable(context, promise.JSValueRef))
-        return nil;
+    if (!isThenable(context, promiseRef))
+        return JSValueMakeNull(context);
 
     auto promiseHandler = ^(JSValue *result, JSValue *error) {
         if (!error) {
@@ -342,7 +121,7 @@ JSValue *WebExtensionAPITest::assertResolves(JSContextRef context, JSValue *prom
         }
 
         JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
-        fail(context, combineMessages(message, adoptNS([[NSString alloc] initWithFormat:@"Promise rejected with an error: %@", debugString(errorMessageValue)]).get()));
+        fail(context, combineMessages(message, makeString("Promise rejected with an error: "_s, debugString(context, errorMessageValue.JSValueRef))));
 
         [resolveCallback callWithArguments:nil];
     };
@@ -357,98 +136,29 @@ JSValue *WebExtensionAPITest::assertResolves(JSContextRef context, JSValue *prom
         },
     ]];
 
-    return resultPromise;
+    return resultPromise.JSValueRef;
 }
 
-void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, JSValue *expectedError, NSString *message, NSString **outExceptionString)
+JSValueRef WebExtensionAPITest::addTest(JSContextRef context, JSValueRef testFunctionRef, String callingAPIName)
 {
-    [function callWithArguments:@[ ]];
+    if (!JSValueIsObject(context, testFunctionRef))
+        return [JSValue valueWithNewPromiseRejectedWithReason:toErrorString(callingAPIName, nullString(), "Error creating a new test."_s).createNSString().get() inContext:toJSContext(context)].JSValueRef;
 
-    JSValue *exceptionValue = function.context.exception;
-    if (!exceptionValue) {
-        assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any exception)", @"(no exception)", combineMessages(message, @"Function did not throw an exception"), outExceptionString);
-        return;
-    }
-
-    JSValue *exceptionMessageValue = exceptionValue.isObject && [exceptionValue hasProperty:@"message"] ? exceptionValue[@"message"] : exceptionValue;
-
-    // Clear the exception since it was caught.
-    function.context.exception = nil;
-
-    if (!expectedError) {
-        assertEquals(context, true, @"(any exception)", debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception"), outExceptionString);
-        return;
-    }
-
-    if (isRegularExpression(context, expectedError.JSValueRef)) {
-        JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ exceptionMessageValue ]];
-        assertEquals(context, testResult.toBool, debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't match the regular expression"), outExceptionString);
-        return;
-    }
-
-    assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:exceptionMessageValue], debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't equal"), outExceptionString);
-}
-
-JSValue *WebExtensionAPITest::assertSafe(JSContextRef context, JSValue *function, NSString *message)
-{
-    JSValue *result = [function callWithArguments:@[ ]];
-
-    JSValue *exceptionValue = function.context.exception;
-    if (!exceptionValue) {
-        succeed(context, @"Function did not throw an exception");
-        return result;
-    }
-
-    // Clear the exception since it was caught.
-    function.context.exception = nil;
-
-    JSValue *exceptionMessageValue = exceptionValue.isObject && [exceptionValue hasProperty:@"message"] ? exceptionValue[@"message"] : exceptionValue;
-    fail(context, combineMessages(message, adoptNS([[NSString alloc] initWithFormat:@"Function threw an exception: %@", debugString(exceptionMessageValue)]).get()));
-
-    return [JSValue valueWithUndefinedInContext:function.context];
-}
-
-JSValue *WebExtensionAPITest::assertSafeResolve(JSContextRef context, JSValue *function, NSString *message)
-{
-    JSValue *result = assertSafe(context, function, message);
-    if (!isThenable(context, function.JSValueRef))
-        return result;
-
-    return assertResolves(context, result, message);
-}
-
-JSValue *WebExtensionAPITest::addTest(JSContextRef context, JSValue *testFunction)
-{
-    return addTest(context, testFunction, "test.addTest()"_s);
-}
-
-JSValue *WebExtensionAPITest::runTests(JSContextRef context, NSArray *testFunctions)
-{
-    JSValue *testResultPromises = [JSValue valueWithNewArrayInContext:toJSContext(context)];
-
-    for (JSValue *testFunction in testFunctions)
-        [testResultPromises invokeMethod:@"push" withArguments:@[ addTest(context, testFunction, "test.runTests()"_s) ]];
-
-    return [toJSContext(context)[@"Promise"] invokeMethod:@"all" withArguments:@[ testResultPromises ]];
-}
-
-JSValue *WebExtensionAPITest::addTest(JSContextRef context, JSValue *testFunction, String callingAPIName)
-{
-    auto testName = testFunction[@"name"].toString;
-    if (!testName.length)
-        return [JSValue valueWithNewPromiseRejectedWithReason:toErrorString(callingAPIName, nullString(), "The supplied test function must be named."_s).createNSString().get() inContext:toJSContext(context)];
+    JSValueRef testName = JSObjectGetProperty(context, JSValueToObject(context, testFunctionRef, nullptr), toJSString("name"_s).get(), nullptr);
+    if (toString(context, testName).isEmpty())
+        return [JSValue valueWithNewPromiseRejectedWithReason:toErrorString(callingAPIName, nullString(), "The supplied test function must be named."_s).createNSString().get() inContext:toJSContext(context)].JSValueRef;
 
     RefPtr page = toWebPage(context);
     if (!page)
-        return [JSValue valueWithNewPromiseRejectedWithReason:toErrorString(callingAPIName, nullString(), "Error creating a new test."_s).createNSString().get() inContext:toJSContext(context)];
+        return [JSValue valueWithNewPromiseRejectedWithReason:toErrorString(callingAPIName, nullString(), "Error creating a new test."_s).createNSString().get() inContext:toJSContext(context)].JSValueRef;
 
     RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
     if (!webExtensionControllerProxy)
-        return [JSValue valueWithNewPromiseRejectedWithReason:toErrorString(callingAPIName, nullString(), "Error creating a new test."_s).createNSString().get() inContext:toJSContext(context)];
+        return [JSValue valueWithNewPromiseRejectedWithReason:toErrorString(callingAPIName, nullString(), "Error creating a new test."_s).createNSString().get() inContext:toJSContext(context)].JSValueRef;
 
     __block JSValue *resolveCallback;
     __block JSValue *rejectCallback;
-    JSValue *resultPromise = [JSValue valueWithNewPromiseInContext:testFunction.context fromExecutor:^(JSValue *resolve, JSValue *reject) {
+    JSValue *resultPromise = [JSValue valueWithNewPromiseInContext:toJSContext(context) fromExecutor:^(JSValue *resolve, JSValue *reject) {
         resolveCallback = resolve;
         rejectCallback = reject;
     }];
@@ -456,16 +166,19 @@ JSValue *WebExtensionAPITest::addTest(JSContextRef context, JSValue *testFunctio
     auto location = scriptLocation(context);
     auto webExtensionControllerIdentifier = webExtensionControllerProxy->identifier();
 
+    JSValueRef resolveCallbackRef = resolveCallback.JSValueRef;
+    JSValueRef rejectCallbackRef = rejectCallback.JSValueRef;
+
     m_testQueue.append({
-        testName,
+        toString(context, testName),
         location,
         webExtensionControllerIdentifier,
-        testFunction,
-        resolveCallback,
-        rejectCallback
+        Protected(JSContextGetGlobalContext(context), testFunctionRef),
+        Protected(JSContextGetGlobalContext(context), resolveCallbackRef),
+        Protected(JSContextGetGlobalContext(context), rejectCallbackRef)
     });
 
-    WebProcess::singleton().send(Messages::WebExtensionController::TestAdded(testName, location.first, location.second), webExtensionControllerIdentifier);
+    WebProcess::singleton().send(Messages::WebExtensionController::TestAdded(toString(context, testName), location.first, location.second), webExtensionControllerIdentifier);
 
     if (!m_runningTest) {
         m_runningTest = true;
@@ -475,7 +188,7 @@ JSValue *WebExtensionAPITest::addTest(JSContextRef context, JSValue *testFunctio
         });
     }
 
-    return resultPromise;
+    return resultPromise.JSValueRef;
 }
 
 void WebExtensionAPITest::startNextTest()
@@ -484,31 +197,30 @@ void WebExtensionAPITest::startNextTest()
 
     WebProcess::singleton().send(Messages::WebExtensionController::TestStarted(test.testName, test.location.first, test.location.second), test.webExtensionControllerIdentifier);
 
-    JSValue *result = [test.testFunction callWithArguments:nil];
+    JSValueRef exception = nullptr;
+    JSValueRef result = callObjectWithArguments<0>(test.testFunction.get(), test.testFunction.context().get(), { }, &exception);
 
     auto testComplete = [this, protectedThis = Ref { *this }, test](JSValue *result, JSValue *error) {
         if (error || m_hitAssertion) {
             NSString *errorMessage;
             if (error) {
                 JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
-                errorMessage = debugString(errorMessageValue);
+                errorMessage = debugString(test.testFunction.context().get(), errorMessageValue.JSValueRef).createNSString().get();
             } else if (!m_assertionMessage.isNull())
                 errorMessage = m_assertionMessage.createNSString().get();
 
-            errorMessage = errorMessage ? combineMessages(@"Promise rejected with an error: ", errorMessage) : @"Promise rejected without an error";
+            errorMessage = errorMessage ? combineMessages("Promise rejected with an error: "_s, errorMessage).createNSString().get() : @"Promise rejected without an error";
 
             WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(test.testName, false, errorMessage, test.location.first, test.location.second), test.webExtensionControllerIdentifier);
 
-            [test.rejectCallback callWithArguments:nil];
+            callObjectWithArguments<0>(test.rejectCallback.get(), test.rejectCallback.context().get(), { });
         } else {
-            WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(test.testName, true, @"Promise resolved without an error.", test.location.first, test.location.second), test.webExtensionControllerIdentifier);
-            [test.resolveCallback callWithArguments:@[ result ]];
+            WebProcess::singleton().send(Messages::WebExtensionController::TestFinished
+            (test.testName, true, @"Promise resolved without an error.", test.location.first, test.location.second), test.webExtensionControllerIdentifier);
+            callObjectWithArguments<1>(test.resolveCallback.get(), test.resolveCallback.context().get(), { result.JSValueRef });
         }
 
         m_hitAssertion = false;
-
-        // Clear the exception since it was caught.
-        test.testFunction.get().context.exception = nil;
 
         if (!m_testQueue.isEmpty())
             startNextTest();
@@ -516,7 +228,7 @@ void WebExtensionAPITest::startNextTest()
             m_runningTest = false;
     };
 
-    if (isThenable(result.context.JSGlobalContextRef, result.JSValueRef)) {
+    if (isThenable(test.testFunction.context().get(), result)) {
         auto resolveBlock = ^(JSValue *result) {
             testComplete(result, nil);
         };
@@ -525,79 +237,9 @@ void WebExtensionAPITest::startNextTest()
             testComplete(nil, error);
         };
 
-        [result invokeMethod:@"then" withArguments:@[ resolveBlock, rejectBlock ]];
+        [toJSValue(test.testFunction.context().get(), result) invokeMethod:@"then" withArguments:@[ resolveBlock, rejectBlock ]];
     } else
-        testComplete(result, test.testFunction.get().context.exception);
-}
-
-void WebExtensionAPITest::recordAssertionIfNeeded(bool result, const String& message, std::pair<String, unsigned> location, NSString **outExceptionString)
-
-{
-    if (!m_runningTest || (m_runningTest && result))
-        return;
-
-    m_hitAssertion = true;
-    m_assertionMessage = message;
-
-    if (!outExceptionString)
-        return;
-
-    auto *locationString = [NSString stringWithFormat:@"%@:%u", location.first.createNSString().get(), location.second];
-    *outExceptionString = message.isNull()
-        ? [NSString stringWithFormat:@"Assertion Failed: %@", locationString]
-        : [NSString stringWithFormat:@"Assertion Failed: %@. %@", message.createNSString().get(), locationString];
-}
-
-void WebExtensionContextProxy::dispatchTestMessageEvent(const String& message, const String& argumentJSON, WebExtensionContentWorldType contentWorldType)
-{
-    id argument = parseJSON(argumentJSON.createNSString().get(), JSONOptions::FragmentsAllowed);
-
-    RetainPtr nsMessage = message.createNSString();
-    if (contentWorldType == WebExtensionContentWorldType::WebPage) {
-        enumerateFramesAndWebPageNamespaceObjects([&](auto&, auto& namespaceObject) {
-            namespaceObject.test().onMessage().invokeListenersWithArgument(nsMessage.get(), argument);
-        });
-
-        return;
-    }
-
-    enumerateFramesAndNamespaceObjects([&](auto&, auto& namespaceObject) {
-        namespaceObject.test().onMessage().invokeListenersWithArgument(nsMessage.get(), argument);
-    }, toDOMWrapperWorld(contentWorldType));
-}
-
-void WebExtensionContextProxy::dispatchTestStartedEvent(const String& argumentJSON, WebExtensionContentWorldType contentWorldType)
-{
-    id argument = parseJSON(argumentJSON.createNSString().get(), JSONOptions::FragmentsAllowed);
-
-    if (contentWorldType == WebExtensionContentWorldType::WebPage) {
-        enumerateFramesAndWebPageNamespaceObjects([&](auto&, auto& namespaceObject) {
-            namespaceObject.test().onTestStarted().invokeListenersWithArgument(argument);
-        });
-
-        return;
-    }
-
-    enumerateFramesAndNamespaceObjects([&](auto&, auto& namespaceObject) {
-        namespaceObject.test().onTestStarted().invokeListenersWithArgument(argument);
-    }, toDOMWrapperWorld(contentWorldType));
-}
-
-void WebExtensionContextProxy::dispatchTestFinishedEvent(const String& argumentJSON, WebExtensionContentWorldType contentWorldType)
-{
-    id argument = parseJSON(argumentJSON.createNSString().get(), JSONOptions::FragmentsAllowed);
-
-    if (contentWorldType == WebExtensionContentWorldType::WebPage) {
-        enumerateFramesAndWebPageNamespaceObjects([&](auto&, auto& namespaceObject) {
-            namespaceObject.test().onTestFinished().invokeListenersWithArgument(argument);
-        });
-
-        return;
-    }
-
-    enumerateFramesAndNamespaceObjects([&](auto&, auto& namespaceObject) {
-        namespaceObject.test().onTestFinished().invokeListenersWithArgument(argument);
-    }, toDOMWrapperWorld(contentWorldType));
+        testComplete(toJSValue(test.testFunction.context().get(), result), exception ? toJSValue(test.testFunction.context().get(), exception) : nil);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -48,6 +48,8 @@ public:
     void invokeListenersWithArgument(id argument1, id argument2);
     void invokeListenersWithArgument(id argument1, id argument2, id argument3);
 #endif
+    void invokeListenersWithJSONArgument(const String& argument1);
+    void invokeListenersWithJSONArgument(const String& argument1, const String& argument2);
 
     const ListenerVector& listeners() const LIFETIME_BOUND { return m_listeners; }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -95,7 +95,9 @@ public:
 #endif
     WebExtensionAPIStorage& storage();
     WebExtensionAPITabs& tabs();
+#endif
     WebExtensionAPITest& test();
+#if PLATFORM(COCOA)
     WebExtensionAPIWindows& windows();
     WebExtensionAPIWebNavigation& webNavigation();
     WebExtensionAPIWebRequest& webRequest();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.cpp
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.cpp
@@ -1,0 +1,443 @@
+/*
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionAPITest.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "MessageSenderInlines.h"
+#include "WebExtensionAPINamespace.h"
+#include "WebExtensionAPIWebPageNamespace.h"
+#include "WebExtensionControllerMessages.h"
+#include "WebExtensionControllerProxy.h"
+#include "WebExtensionEventListenerType.h"
+#include "WebFrame.h"
+#include "WebPage.h"
+#include "WebProcess.h"
+#include <JavaScriptCore/APICast.h>
+#include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <WebCore/LocalFrameInlines.h>
+
+namespace WebKit {
+
+std::pair<String, unsigned> WebExtensionAPITest::scriptLocation(JSContextRef context)
+{
+    auto callStack = Inspector::createScriptCallStack(toJS(context));
+    if (const Inspector::ScriptCallFrame* frame = callStack->firstNonNativeCallFrame()) {
+        auto sourceURL = frame->sourceURL();
+        if (sourceURL.isEmpty())
+            sourceURL = "global code"_s;
+        return { sourceURL, frame->lineNumber() };
+    }
+
+    return { "unknown"_s, 0 };
+}
+
+template<size_t ArgumentCount>
+JSValueRef WebExtensionAPITest::invokeMethod(JSContextRef context, JSValueRef value, const String& method, std::array<JSValueRef, ArgumentCount>&& arguments, JSValueRef* exception)
+{
+    if (!context || !value)
+        return JSValueMakeUndefined(context);
+
+    if (!JSValueIsObject(context, value))
+        return JSValueMakeUndefined(context);
+
+    JSObjectRef thisObject = JSValueToObject(context, value, exception);
+    if (!thisObject || (exception && *exception))
+        return JSValueMakeUndefined(context);
+
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSValueRef function = JSObjectGetProperty(context, thisObject, toJSString(method).get(), exception);
+    if (!function || (exception && *exception))
+        return JSValueMakeUndefined(context);
+
+    JSObjectRef funcObject = JSValueToObject(context, function, exception);
+    if (!funcObject || (exception && *exception))
+        return JSValueMakeUndefined(context);
+
+    return JSObjectCallAsFunction(context, funcObject, thisObject, ArgumentCount, arguments.data(), exception);
+}
+
+void WebExtensionAPITest::notifyFail(JSContextRef context, const String& message)
+{
+    auto location = scriptLocation(context);
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(nullString(), false, message, location.first, location.second), webExtensionControllerProxy->identifier());
+}
+
+void WebExtensionAPITest::notifyPass(JSContextRef context, const String& message)
+{
+    auto location = scriptLocation(context);
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(nullString(), true, message, location.first, location.second), webExtensionControllerProxy->identifier());
+}
+
+void WebExtensionAPITest::sendMessage(JSContextRef context, const String& message, JSValueRef argument)
+{
+    auto location = scriptLocation(context);
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestSentMessage(message, toSortedJSONString(context, argument), location.first, location.second), webExtensionControllerProxy->identifier());
+}
+
+WebExtensionAPIEvent& WebExtensionAPITest::onMessage()
+{
+    if (!m_onMessage)
+        m_onMessage = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TestOnMessage);
+
+    return *m_onMessage;
+}
+
+WebExtensionAPIEvent& WebExtensionAPITest::onTestStarted()
+{
+    if (!m_onTestStarted)
+        m_onTestStarted = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TestOnTestStarted);
+
+    return *m_onTestStarted;
+}
+
+WebExtensionAPIEvent& WebExtensionAPITest::onTestFinished()
+{
+    if (!m_onTestFinished)
+        m_onTestFinished = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TestOnTestFinished);
+
+    return *m_onTestFinished;
+}
+
+JSValueRef WebExtensionAPITest::runWithUserGesture(WebFrame& frame, JSContextRef context, JSValueRef function)
+{
+    RefPtr coreFrame = frame.coreLocalFrame();
+    WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, coreFrame ? coreFrame->document() : nullptr);
+
+    return callObjectWithArguments<0>(function, context, { });
+}
+
+bool WebExtensionAPITest::isProcessingUserGesture()
+{
+    return WebCore::UserGestureIndicator::processingUserGesture();
+}
+
+String WebExtensionAPITest::debugString(JSContextRef contextRef, JSValueRef valueRef)
+{
+    if (isRegularExpression(contextRef, valueRef) || isFunction(contextRef, valueRef))
+        return toString(contextRef, valueRef);
+    auto sortedJSON = toSortedJSONString(contextRef, valueRef);
+    if (!sortedJSON.isEmpty())
+        return sortedJSON;
+    return "undefined"_s;
+}
+
+void WebExtensionAPITest::log(JSContextRef context, JSValueRef value)
+{
+    auto location = scriptLocation(context);
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestLogMessage(debugString(context, value), location.first, location.second), webExtensionControllerProxy->identifier());
+}
+
+void WebExtensionAPITest::fail(JSContextRef context, const String& message)
+{
+    String empty = nullString();
+    assertTrue(context, false, message, empty);
+}
+
+void WebExtensionAPITest::succeed(JSContextRef context, const String& message)
+{
+    String empty = nullString();
+    assertTrue(context, true, message, empty);
+}
+
+void WebExtensionAPITest::assertTrue(JSContextRef context, bool actualValue, const String& message, String& outExceptionString)
+{
+    auto location = scriptLocation(context);
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    recordAssertionIfNeeded(actualValue, message, location, outExceptionString);
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestResult(actualValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
+}
+
+void WebExtensionAPITest::assertFalse(JSContextRef context, bool actualValue, const String& message, String& outExceptionString)
+{
+    assertTrue(context, !actualValue, message, outExceptionString);
+}
+
+void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValueRef actualValue, JSValueRef expectedValue, const String& message, String& outExceptionString)
+{
+    String expectedJSONValue = debugString(context, expectedValue);
+    String actualJSONValue = debugString(context, actualValue);
+
+    // FIXME: Comparing JSON is a quick attempt that works, but can still fail due to any non-JSON values.
+    // See Firefox's implementation: https://searchfox.org/mozilla-central/source/toolkit/components/extensions/child/ext-test.js#78
+    bool strictEqual = JSValueIsStrictEqual(context, expectedValue, actualValue);
+    bool deepEqual = strictEqual || expectedJSONValue == actualJSONValue;
+
+    auto location = scriptLocation(context);
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    recordAssertionIfNeeded(deepEqual, message, location, outExceptionString);
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(deepEqual, expectedJSONValue, actualJSONValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
+}
+
+String WebExtensionAPITest::combineMessages(const String& messageOne, const String& messageTwo)
+{
+    if (!messageOne.isEmpty() && !messageTwo.isEmpty()) {
+        Vector<String> stringList = { messageOne, messageTwo };
+        return makeStringByJoining(stringList, "\n"_s);
+    }
+
+    if (!messageOne.isEmpty() && messageTwo.isEmpty())
+        return messageOne;
+    return messageTwo;
+}
+
+void WebExtensionAPITest::assertEquals(JSContextRef context, bool result, const String& expectedString, const String& actualString, const String& message, String& outExceptionString)
+{
+    auto location = scriptLocation(context);
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    recordAssertionIfNeeded(result, message, location, outExceptionString);
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(result, expectedString, actualString, message, location.first, location.second), webExtensionControllerProxy->identifier());
+}
+
+void WebExtensionAPITest::assertEq(JSContextRef context, JSValueRef actualValue, JSValueRef expectedValue, const String& message, String& outExceptionString)
+{
+    String expectedJSONValue = debugString(context, expectedValue);
+    String actualJSONValue = debugString(context, actualValue);
+
+    bool strictEqual = JSValueIsStrictEqual(context, expectedValue, actualValue);
+    if (!strictEqual && expectedJSONValue == actualJSONValue)
+        actualJSONValue = makeString(actualJSONValue, " (different)"_s);
+
+    assertEquals(context, strictEqual, expectedJSONValue, actualJSONValue, message, outExceptionString);
+}
+
+void WebExtensionAPITest::assertThrows(JSContextRef context, JSValueRef function, JSValueRef expectedError, const String& message, String& outExceptionString)
+{
+    JSValueRef exceptionValue = nullptr;
+    callObjectWithArguments<0>(function, context, { }, &exceptionValue, false);
+
+    if (!exceptionValue) {
+        assertEquals(context, false, expectedError ? debugString(context, expectedError) : "(any exception)"_s, "(no exception)"_s, combineMessages(message, "Function did not throw an exception"_s), outExceptionString);
+        return;
+    }
+
+    JSValueRef exceptionMessageValue = exceptionValue;
+    if (JSValueIsObject(context, exceptionValue)) {
+        JSObjectRef object = JSValueToObject(context, exceptionValue, nullptr);
+
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG if (JSObjectHasProperty(context, object, toJSString("message"_s).get()))
+            SUPPRESS_UNCOUNTED_ARG exceptionMessageValue = JSObjectGetProperty(context, object, toJSString("message"_s).get(), 0);
+    }
+
+    // Clear the exception since it was caught.
+    exceptionValue = nullptr;
+
+    if (JSValueIsUndefined(context, expectedError) || !expectedError) {
+        assertEquals(context, true, "(any exception)"_s, debugString(context, exceptionMessageValue), combineMessages(message, "Function threw an exception"_s), outExceptionString);
+        return;
+    }
+
+    if (isRegularExpression(context, expectedError)) {
+        JSValueRef testResult = invokeMethod<1>(context, expectedError, "test"_s, { exceptionMessageValue });
+        assertEquals(context, JSValueToBoolean(context, testResult), debugString(context, expectedError), debugString(context, exceptionMessageValue), combineMessages(message, "Function threw an exception that didn't match the regular expression"_s), outExceptionString);
+        return;
+    }
+
+    assertEquals(context, JSValueIsEqual(context, expectedError, exceptionMessageValue, nullptr), debugString(context, expectedError), debugString(context, exceptionMessageValue), combineMessages(message, "Function threw an exception that didn't equal"_s), outExceptionString);
+}
+
+JSValueRef WebExtensionAPITest::assertSafe(JSContextRef context, JSValueRef function, const String& message)
+{
+    JSValueRef exceptionValue = nullptr;
+    JSValueRef result = callObjectWithArguments<0>(function, context, { }, &exceptionValue, false);
+
+    if (!exceptionValue) {
+        succeed(context, "Function did not throw an exception"_s);
+        return result;
+    }
+
+    JSValueRef exceptionMessageValue = exceptionValue;
+    if (JSValueIsObject(context, exceptionValue)) {
+        JSObjectRef object = JSValueToObject(context, exceptionValue, nullptr);
+
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG if (JSObjectHasProperty(context, object, toJSString("message"_s).get()))
+            SUPPRESS_UNCOUNTED_ARG exceptionMessageValue = JSObjectGetProperty(context, object, toJSString("message"_s).get(), 0);
+    }
+
+    // Clear the exception since it was caught.
+    exceptionValue = nullptr;
+
+    fail(context, combineMessages(message, makeString("Function threw an exception: "_s, debugString(context, exceptionMessageValue))));
+
+    return JSValueMakeUndefined(context);
+}
+
+JSValueRef WebExtensionAPITest::assertSafeResolve(JSContextRef context, JSValueRef function, const String& message)
+{
+    JSValueRef result = assertSafe(context, function, message);
+    if (!isThenable(context, function))
+        return result;
+
+    return assertResolves(context, result, message);
+}
+
+JSValueRef WebExtensionAPITest::addTest(JSContextRef context, JSValueRef testFunction)
+{
+    return addTest(context, testFunction, "test.addTest()"_s);
+}
+
+JSValueRef WebExtensionAPITest::runTests(JSContextRef context, Vector<Protected<JSValueRef>> testFunctions)
+{
+    JSObjectRef testResultPromises = JSObjectMakeArray(context, 0, nullptr, nullptr);
+
+    for (Protected<JSValueRef> testFunction : testFunctions)
+        invokeMethod<1>(context, testResultPromises, "push"_s, { addTest(context, testFunction.get(), "test.runTests()"_s) });
+
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG return invokeMethod<1>(context, JSObjectGetProperty(context, JSContextGetGlobalObject(context), toJSString("Promise"_s).get(), nullptr), "all"_s, { testResultPromises });
+}
+
+void WebExtensionAPITest::recordAssertionIfNeeded(bool result, const String& message, std::pair<String, unsigned> location, String& outExceptionString)
+{
+    if (!m_runningTest || (m_runningTest && result))
+        return;
+
+    m_hitAssertion = true;
+    m_assertionMessage = message;
+
+    Vector<String> locationVector = { location.first, String::number(location.second) };
+    auto locationString = makeStringByJoining(locationVector, ":"_s);
+    outExceptionString = message.isNull()
+        ? makeString("Assertion Failed: "_s, locationString)
+        : makeString("Assertion Failed: "_s, message, ". "_s, locationString);
+}
+
+void WebExtensionContextProxy::dispatchTestMessageEvent(const String& message, const String& argumentJSON, WebExtensionContentWorldType contentWorldType)
+{
+    if (contentWorldType == WebExtensionContentWorldType::WebPage) {
+        enumerateFramesAndWebPageNamespaceObjects([&](auto&, auto& namespaceObject) {
+            namespaceObject.test().onMessage().invokeListenersWithJSONArgument(message, argumentJSON);
+        });
+
+        return;
+    }
+
+    enumerateFramesAndNamespaceObjects([&](auto&, auto& namespaceObject) {
+        namespaceObject.test().onMessage().invokeListenersWithJSONArgument(message, argumentJSON);
+    }, toDOMWrapperWorld(contentWorldType));
+}
+
+void WebExtensionContextProxy::dispatchTestStartedEvent(const String& argumentJSON, WebExtensionContentWorldType contentWorldType)
+{
+    if (contentWorldType == WebExtensionContentWorldType::WebPage) {
+        enumerateFramesAndWebPageNamespaceObjects([&](auto&, auto& namespaceObject) {
+            namespaceObject.test().onTestStarted().invokeListenersWithJSONArgument(argumentJSON);
+        });
+
+        return;
+    }
+
+    enumerateFramesAndNamespaceObjects([&](auto&, auto& namespaceObject) {
+        namespaceObject.test().onTestStarted().invokeListenersWithJSONArgument(argumentJSON);
+    }, toDOMWrapperWorld(contentWorldType));
+}
+
+void WebExtensionContextProxy::dispatchTestFinishedEvent(const String& argumentJSON, WebExtensionContentWorldType contentWorldType)
+{
+    if (contentWorldType == WebExtensionContentWorldType::WebPage) {
+        enumerateFramesAndWebPageNamespaceObjects([&](auto&, auto& namespaceObject) {
+            namespaceObject.test().onTestFinished().invokeListenersWithJSONArgument(argumentJSON);
+        });
+
+        return;
+    }
+
+    enumerateFramesAndNamespaceObjects([&](auto&, auto& namespaceObject) {
+        namespaceObject.test().onTestFinished().invokeListenersWithJSONArgument(argumentJSON);
+    }, toDOMWrapperWorld(contentWorldType));
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -33,47 +33,44 @@
 #include "WebExtensionAPIWebNavigationEvent.h"
 #include <wtf/Deque.h>
 
-OBJC_CLASS NSString;
-
 namespace WebKit {
 
 class WebExtensionAPITest : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITest, test, test);
 
 public:
-#if PLATFORM(COCOA)
-    void notifyFail(JSContextRef, NSString *message);
-    void notifyPass(JSContextRef, NSString *message);
+    void notifyFail(JSContextRef, const String& message);
+    void notifyPass(JSContextRef, const String& message);
 
-    void sendMessage(JSContextRef, NSString *message, JSValue *argument);
+    void sendMessage(JSContextRef, const String& message, JSValueRef argument);
     WebExtensionAPIEvent& onMessage();
     WebExtensionAPIEvent& onTestStarted();
     WebExtensionAPIEvent& onTestFinished();
 
-    JSValue *runWithUserGesture(WebFrame&, JSValue *function);
+    JSValueRef runWithUserGesture(WebFrame&, JSContextRef, JSValueRef function);
     bool isProcessingUserGesture();
 
-    void log(JSContextRef, JSValue *);
+    void log(JSContextRef, JSValueRef);
 
-    void fail(JSContextRef, NSString *message);
-    void succeed(JSContextRef, NSString *message);
+    void fail(JSContextRef, const String& message);
+    void succeed(JSContextRef, const String& message);
 
-    void assertTrue(JSContextRef, bool testValue, NSString *message, NSString **outExceptionString);
-    void assertFalse(JSContextRef, bool testValue, NSString *message, NSString **outExceptionString);
+    void assertTrue(JSContextRef, bool testValue, const String& message, String& outExceptionString);
+    void assertFalse(JSContextRef, bool testValue, const String& message, String& outExceptionString);
 
-    void assertDeepEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString);
-    void assertEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString);
+    void assertDeepEq(JSContextRef, JSValueRef actualValue, JSValueRef expectedValue, const String& message, String& outExceptionString);
+    void assertEq(JSContextRef, JSValueRef actualValue, JSValueRef expectedValue, const String& message, String& outExceptionString);
 
-    JSValue *assertRejects(JSContextRef, JSValue *promise, JSValue *expectedError, NSString *message);
-    JSValue *assertResolves(JSContextRef, JSValue *promise, NSString *message);
+    JSValueRef assertRejects(JSContextRef, JSValueRef promise, JSValueRef expectedError, const String& message);
+    JSValueRef assertResolves(JSContextRef, JSValueRef promise, const String& message);
 
-    void assertThrows(JSContextRef, JSValue *function, JSValue *expectedError, NSString *message, NSString **outExceptionString);
-    JSValue *assertSafe(JSContextRef, JSValue *function, NSString *message);
+    void assertThrows(JSContextRef, JSValueRef function, JSValueRef expectedError, const String& message, String& outExceptionString);
+    JSValueRef assertSafe(JSContextRef, JSValueRef function, const String& message);
 
-    JSValue *assertSafeResolve(JSContextRef, JSValue *function, NSString *message);
+    JSValueRef assertSafeResolve(JSContextRef, JSValueRef function, const String& message);
 
-    JSValue *addTest(JSContextRef, JSValue *testFunction);
-    JSValue *runTests(JSContextRef, NSArray *testFunctions);
+    JSValueRef addTest(JSContextRef, JSValueRef testFunction);
+    JSValueRef runTests(JSContextRef, Vector<Protected<JSValueRef>> testFunctions);
 
 private:
     RefPtr<WebExtensionAPIEvent> m_onMessage;
@@ -84,9 +81,9 @@ private:
         String testName;
         std::pair<String, unsigned> location;
         WebExtensionControllerIdentifier webExtensionControllerIdentifier;
-        RetainPtr<JSValue> testFunction;
-        RetainPtr<JSValue> resolveCallback;
-        RetainPtr<JSValue> rejectCallback;
+        Protected<JSValueRef> testFunction;
+        Protected<JSValueRef> resolveCallback;
+        Protected<JSValueRef> rejectCallback;
     };
 
     Deque<Test> m_testQueue;
@@ -94,11 +91,16 @@ private:
     bool m_hitAssertion { false };
     String m_assertionMessage;
 
-    JSValue *addTest(JSContextRef, JSValue *testFunction, String callingAPIName);
-    void assertEquals(JSContextRef, bool result, NSString *expectedString, NSString *actualString, NSString *message, NSString **outExceptionString);
+    template<size_t ArgumentCount>
+    JSValueRef invokeMethod(JSContextRef, JSValueRef, const String& method, std::array<JSValueRef, ArgumentCount>&& arguments, JSValueRef* exception = nullptr);
+    std::pair<String, unsigned> scriptLocation(JSContextRef);
+    String debugString(JSContextRef, JSValueRef);
+    String combineMessages(const String& messageOne, const String& messageTwo);
+
+    JSValueRef addTest(JSContextRef, JSValueRef testFunction, String callingAPIName);
+    void assertEquals(JSContextRef, bool result, const String& expectedString, const String& actualString, const String& message, String& outExceptionString);
     void startNextTest();
-    void recordAssertionIfNeeded(bool result, const String& message, std::pair<String, unsigned> location, NSString **outExceptionString);
-#endif
+    void recordAssertionIfNeeded(bool result, const String& message, std::pair<String, unsigned> location, String& outExceptionString);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
@@ -45,12 +45,14 @@ public:
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
     WebExtensionAPIWebPageRuntime& runtime() const;
+#endif
     WebExtensionAPITest& test();
 
 private:
+#if PLATFORM(COCOA)
     mutable RefPtr<WebExtensionAPIWebPageRuntime> m_runtime;
-    RefPtr<WebExtensionAPITest> m_test;
 #endif
+    RefPtr<WebExtensionAPITest> m_test;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -111,12 +111,12 @@ template<size_t ArgumentCount>
 JSValueRef callWithArguments(JSObjectRef callbackFunction, JSRetainPtr<JSGlobalContextRef>& globalContext, std::array<JSValueRef, ArgumentCount>&& arguments)
 {
     if (!globalContext || !callbackFunction)
-        return nil;
+        return nullptr;
 
     auto* globalObject = toJS(globalContext.get());
     RefPtr context = globalObject ? downcast<WebCore::JSDOMGlobalObject>(globalObject)->scriptExecutionContext() : nullptr;
     if (!context || context->activeDOMObjectsAreStopped())
-        return nil;
+        return nullptr;
 
     JSValueRef exception = nullptr;
     JSValueRef result = JSObjectCallAsFunction(globalContext.get(), callbackFunction, nullptr, ArgumentCount, arguments.data(), &exception);
@@ -129,6 +129,7 @@ JSValueRef callWithArguments(JSObjectRef callbackFunction, JSRetainPtr<JSGlobalC
 
     return result;
 }
+
 
 void WebExtensionCallbackHandler::reportError(const String& message)
 {
@@ -602,6 +603,32 @@ bool isThenable(JSContextRef context, JSValueRef value)
     SUPPRESS_UNCOUNTED_ARG JSValueRef thenableObject = JSObjectGetProperty(context, valueObject, thenableString.get(), nullptr);
 
     return isFunction(context, thenableObject);
+}
+
+template<>
+Vector<Protected<JSValueRef>> toVector<Protected<JSValueRef>>(JSContextRef context, JSValueRef value)
+{
+    ASSERT(context);
+
+    if (!value)
+        return { };
+
+    if (!JSValueIsArray(context, value))
+        return { };
+
+    JSObjectRef object = JSValueToObject(context, value, nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG int32_t length = JSValueToInt32(context, JSObjectGetProperty(context, object, toJSString("length"_s).get(), nullptr), nullptr);
+    Vector<Protected<JSValueRef>> result;
+
+    if (length >= 0) {
+        for (size_t i = 0; i < static_cast<size_t>(length); ++i) {
+            JSValueRef itemValue = JSObjectGetPropertyAtIndex(context, object, i, nullptr);
+            result.append(Protected(JSContextGetGlobalContext(context), itemValue));
+        }
+    }
+
+    return result;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -28,12 +28,19 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "Protected.h"
+#include <JavaScriptCore/APICast.h>
+#include <JavaScriptCore/JSCJSValuePropertyInlines.h>
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/JSRetainPtr.h>
 #if PLATFORM(COCOA)
 #include <JavaScriptCore/JavaScriptCore.h>
 #else
 #include <JavaScriptCore/JavaScript.h>
 #endif
+#include <WebCore/JSDOMExceptionHandling.h>
+#include <WebCore/JSDOMGlobalObject.h>
+#include <WebCore/ScriptExecutionContext.h>
 #include <wtf/JSONValues.h>
 #include <wtf/WeakPtr.h>
 
@@ -133,6 +140,42 @@ inline Ref<WebExtensionCallbackHandler> toJSErrorCallbackHandler(JSContextRef co
 {
     return WebExtensionCallbackHandler::create(context, runtime);
 }
+
+template<size_t ArgumentCount>
+JSValueRef callObjectWithArguments(JSValueRef callbackFunction, JSContextRef context, std::array<JSValueRef, ArgumentCount>&& arguments, JSValueRef* exception = nullptr, bool reportException = true)
+{
+    if (!context || !callbackFunction)
+        return nullptr;
+
+    if (!JSValueIsObject(context, callbackFunction))
+        return nullptr;
+
+    JSObjectRef callbackObject = JSValueToObject(context, callbackFunction, exception);
+    if (!callbackObject)
+        return nullptr;
+
+    auto* globalObject = toJS(JSContextGetGlobalContext(context));
+    RefPtr executionContext = globalObject ? downcast<WebCore::JSDOMGlobalObject>(globalObject)->scriptExecutionContext() : nullptr;
+    if (!executionContext || executionContext->activeDOMObjectsAreStopped())
+        return nullptr;
+
+    JSValueRef internalException = nullptr;
+    JSValueRef result = JSObjectCallAsFunction(context, callbackObject, nullptr, ArgumentCount, arguments.data(), &internalException);
+    if (internalException && reportException) {
+        JSC::JSLockHolder lock(globalObject->vm());
+        auto exceptionValue = toJS(globalObject, internalException);
+        WebCore::reportException(globalObject, exceptionValue);
+    }
+
+    if (exception && internalException)
+        *exception = internalException;
+
+    return result;
+}
+
+template<typename T> Vector<T> toVector(JSContextRef, JSValueRef);
+
+template<> Vector<Protected<JSValueRef>> toVector<Protected<JSValueRef>>(JSContextRef, JSValueRef);
 
 RefPtr<WebExtensionCallbackHandler> toJSCallbackHandler(JSContextRef, JSValueRef callback, WebExtensionAPIRuntimeBase&);
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -287,17 +287,20 @@ sub _generateImplementationFile
     my $idlType = $interface->type;
     my $className = _className($idlType);
     my $implementationClassName = _implementationClassName($idlType);
-    my $filename = $className . ".mm";
+    my $filename = $interface->extendedAttributes->{"UseCPPAPI"} ? $className . ".cpp" : $className . ".mm";
 
     push(@contentsPrefix, $self->_licenseBlock());
     push(@contentsPrefix, "\n\n");
 
-    push(@contentsPrefix, <<EOF);
+    if (!$interface->extendedAttributes->{"UseCPPAPI"})
+    {
+        push(@contentsPrefix, <<EOF);
 #if !__has_feature(objc_arc)
 #error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
 #endif
 
 EOF
+    }
 
     push(@contentsPrefix, "#include \"config.h\"\n\n");
 
@@ -545,10 +548,10 @@ EOF
                 die "Property functions can't take optional arguments" if $isPropertyFunction;
 
                 foreach my $parameter (@specifiedParameters) {
-                    push(@contents, "    " . $self->_platformTypeVariableDeclaration($parameter, $parameter->name) . "\n");
+                    push(@contents, "    " . $self->_platformTypeVariableDeclaration($interface, $parameter, $parameter->name) . "\n");
                     push(@parameters, $parameter->name . ".releaseNonNull()") if $parameter->extendedAttributes->{"CallbackHandler"} && $parameter->extendedAttributes->{"Optional"};
-                    push(@parameters, $parameter->name . ".createNSString().get()") if $parameter->type->name eq "DOMString" && !$parameter->extendedAttributes->{"URL"};
-                    push(@parameters, $parameter->name) unless ($parameter->extendedAttributes->{"CallbackHandler"} && $parameter->extendedAttributes->{"Optional"}) || ($parameter->type->name eq "DOMString" && !$parameter->extendedAttributes->{"URL"});
+                    push(@parameters, $parameter->name . ".createNSString().get()") if $parameter->type->name eq "DOMString" && !$parameter->extendedAttributes->{"URL"} && !$interface->extendedAttributes->{"UseCPPAPI"};
+                    push(@parameters, $parameter->name) unless ($parameter->extendedAttributes->{"CallbackHandler"} && $parameter->extendedAttributes->{"Optional"}) || ($parameter->type->name eq "DOMString" && !$parameter->extendedAttributes->{"URL"} && !$interface->extendedAttributes->{"UseCPPAPI"});
                 }
 
                 push(@contents, "\n");
@@ -564,7 +567,7 @@ EOF
 
                 foreach my $i (0..$#specifiedParameters) {
                     my $parameter = $specifiedParameters[$i];
-                    push(@contents, "        " . $self->_platformTypeVariableDeclaration($parameter, $parameter->name, "arguments[${i}]", undef, 1) . "\n");
+                    push(@contents, "        " . $self->_platformTypeVariableDeclaration($interface, $parameter, $parameter->name, "arguments[${i}]", undef, 1) . "\n");
                 }
 
                 if ($hasSimpleOptionalArgumentHandling && $argumentCount > 1) {
@@ -578,13 +581,13 @@ EOF
 
                     foreach my $i (0..$#specifiedParameters - 1) {
                         my $parameter = $specifiedParameters[$i];
-                        push(@contents, "        " . $self->_platformTypeVariableDeclaration($parameter, $parameter->name, "arguments[${i}]", undef, 1) . "\n");
+                        push(@contents, "        " . $self->_platformTypeVariableDeclaration($interface, $parameter, $parameter->name, "arguments[${i}]", undef, 1) . "\n");
                     }
 
                     if ($hasOptionalAsLastArgument && $requiredArgumentCount ne ($argumentCount - 1)) {
                         push(@contents, "    } else if (argumentCount == 1) {\n");
                         $self->_installArgumentTypeExceptions(\@contents, $lastParameter, $idlType, "arguments[0]", $lastParameter->name, $defaultEarlyReturnValue, \%contentsIncludes, $function, 1, 2);
-                        push(@contents, "        " . $self->_platformTypeVariableDeclaration($lastParameter, $lastParameter->name, "arguments[0]", undef, 1) . "\n");
+                        push(@contents, "        " . $self->_platformTypeVariableDeclaration($interface, $lastParameter, $lastParameter->name, "arguments[0]", undef, 1) . "\n");
                     }
                 } elsif ($argumentCount > 1) {
                     push(@contents, "    } else {\n");
@@ -601,7 +604,7 @@ EOF
                         my $optionalCondition = $requiredArgumentCount ? "allowedOptionalArgumentCount && " : "";
                         push(@contents, "\n");
                         push(@contents, "        if ($optionalCondition(currentArgument = arguments[argumentCount - 1]) && (" . $self->_javaScriptTypeCondition($parameter, "currentArgument") . ")) {\n");
-                        push(@contents, "            " . $self->_platformTypeVariableDeclaration($parameter, $parameter->name, "currentArgument", undef, 1) . "\n");
+                        push(@contents, "            " . $self->_platformTypeVariableDeclaration($interface, $parameter, $parameter->name, "currentArgument", undef, 1) . "\n");
                         push(@contents, "            --allowedOptionalArgumentCount;\n") if $requiredArgumentCount;
                         push(@contents, "            if (argumentCount)\n");
                         push(@contents, "                --argumentCount;\n");
@@ -624,13 +627,13 @@ EOF
 
                         if ($parameter->extendedAttributes->{"Optional"}) {
                             push(@contents, "            if (" . $self->_javaScriptTypeCondition($parameter, "currentArgument") . ") {\n");
-                            push(@contents, "                " . $self->_platformTypeVariableDeclaration($parameter, $parameter->name, "currentArgument", undef, 1) . "\n");
+                            push(@contents, "                " . $self->_platformTypeVariableDeclaration($interface, $parameter, $parameter->name, "currentArgument", undef, 1) . "\n");
                             push(@contents, "                ++processedOptionalArgumentCount;\n") if $requiredArgumentCount;
                             push(@contents, "                $nextArgumentIndex;\n");
                             push(@contents, "            }\n");
                         } else {
                             $self->_installArgumentTypeExceptions(\@contents, $parameter, $idlType, "currentArgument", $parameter->name, $defaultEarlyReturnValue, \%contentsIncludes, $function, 1, 3);
-                            push(@contents, "            " . $self->_platformTypeVariableDeclaration($parameter, $parameter->name, "currentArgument", undef, 1) . "\n");
+                            push(@contents, "            " . $self->_platformTypeVariableDeclaration($interface, $parameter, $parameter->name, "currentArgument", undef, 1) . "\n");
                             push(@contents, "            $nextArgumentIndex;\n");
                         }
 
@@ -655,7 +658,7 @@ EOF
 
                         die "GetProperty and DeleteProperty functions only take one argument" if $isGetPropertyFunction || $isDeletePropertyFunction;
 
-                        push(@contents, "    " . $self->_platformTypeVariableDeclaration($parameter, $parameter->name, $argument) . "\n");
+                        push(@contents, "    " . $self->_platformTypeVariableDeclaration($interface, $parameter, $parameter->name, $argument) . "\n");
                     }
 
                     push(@parameters, $parameter->name . ".releaseNonNull()") if $parameter->extendedAttributes->{"CallbackHandler"} && $parameter->extendedAttributes->{"Optional"};
@@ -672,7 +675,7 @@ EOF
             my @methodSignatureNames = map(&$mapFunction, @specifiedParameters);
 
             foreach my $parameter (@specifiedParameters) {
-                $self->_installAutomaticExceptions(\@contents, $parameter, $idlType, $parameter->name, $parameter->name, $defaultEarlyReturnValue, \%contentsIncludes, $function, 1);
+                $self->_installAutomaticExceptions(\@contents, $interface, $parameter, $idlType, $parameter->name, $parameter->name, $defaultEarlyReturnValue, \%contentsIncludes, $function, 1);
             }
 
             if (!$hasSimpleOptionalArgumentHandling) {
@@ -815,7 +818,7 @@ ${functionSignature}
 EOF
 
                 my $keyArgumentName = $specifiedParameters[0]->name;
-                push(@contents, "    auto ${keyArgumentName} = toJSString(argumentCount > 0 ? " . $self->_platformTypeConstructor($specifiedParameters[0], "arguments[0]") . "_s : emptyString());\n");
+                push(@contents, "    auto ${keyArgumentName} = toJSString(argumentCount > 0 ? " . $self->_platformTypeConstructor($interface, $specifiedParameters[0], "arguments[0]") . "_s : emptyString());\n");
 
                 if ($isGetPropertyFunction) {
                     push(@contents, "\n");
@@ -964,10 +967,10 @@ EOF
                 my $platformValue;
                 if ($self->_hasAutomaticExceptions($attribute)) {
                     $platformValue = "platformValue";
-                    push(@contents, "    " . $self->_platformTypeVariableDeclaration($attribute, "platformValue", "value") . "\n");
-                    $self->_installAutomaticExceptions(\@contents, $attribute, $idlType, "platformValue", $attribute->name, "false", \%contentsIncludes, $attribute);
+                    push(@contents, "    " . $self->_platformTypeVariableDeclaration($interface, $attribute, "platformValue", "value") . "\n");
+                    $self->_installAutomaticExceptions(\@contents, $interface, $attribute, $idlType, "platformValue", $attribute->name, "false", \%contentsIncludes, $attribute);
                 } else {
-                    $platformValue = $self->_platformTypeConstructor($attribute, "value");
+                    $platformValue = $self->_platformTypeConstructor($interface, $attribute, "value");
                 }
 
                 if ($needsPage || $needsPageIdentifier) {
@@ -1207,7 +1210,7 @@ EOF
 
 sub _installAutomaticExceptions
 {
-    my ($self, $contents, $signature, $classIDLType, $variable, $variableLabel, $result, $contentsIncludes, $functionOrAttribute, $isFunction) = @_;
+    my ($self, $contents, $interface, $signature, $classIDLType, $variable, $variableLabel, $result, $contentsIncludes, $functionOrAttribute, $isFunction) = @_;
 
     my $call = _callString($classIDLType, $functionOrAttribute, $isFunction);
 
@@ -1264,7 +1267,7 @@ EOF
 EOF
     }
 
-    if ($signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
+    if (!$interface->extendedAttributes->{"UseCPPAPI"} && $signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1276,7 +1279,19 @@ EOF
 EOF
     }
 
-    if ($signature->type->name eq "array" && !$signature->extendedAttributes->{"Optional"}) {
+    if ($interface->extendedAttributes->{"UseCPPAPI"} && $signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
+        $hasExceptions = 1;
+
+        push(@$contents, <<EOF);
+
+    if ($variable && !JSValueIsObject(context, $variable)) [[unlikely]] {
+        *exception = toJSError(context, "${call}"_s, "${variableLabel}"_s, "an object is expected"_s);
+        return ${result};
+    }
+EOF
+    }
+
+    if (!$signature->extendedAttributes->{"Vector"} && $signature->type->name eq "array" && !$signature->extendedAttributes->{"Optional"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1426,19 +1441,24 @@ sub _javaScriptTypeCondition
 
 sub _platformType
 {
-    my ($self, $idlType, $signature) = @_;
+    my ($self, $idlType, $interface, $signature) = @_;
 
     return undef unless defined $idlType;
 
     my $idlTypeName = $idlType;
     $idlTypeName = $idlType->name if ref($idlType) eq "IDLType";
 
+    my $arrayType = $signature->extendedAttributes->{"Vector"};
+
     return "RefPtr<WebExtensionCallbackHandler>" if $idlTypeName eq "function" && $signature->extendedAttributes->{"CallbackHandler"};
-    return "NSArray" if $idlTypeName eq "array";
+    return "NSArray" if !$interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array";
+    return "Vector<$arrayType>" if $interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array" && $arrayType ne "JSValueRef";
+    return "Vector<Protected<$arrayType>>" if $interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array" && $arrayType eq "JSValueRef";
     return "String" if $idlTypeName eq "any" && $signature->extendedAttributes->{"Serialization"};
     return "NSDictionary" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSDictionary"};
     return "NSObject" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSObject"};
-    return "JSValue" if $idlTypeName eq "DOMWindow" || $idlTypeName eq "function" || $idlTypeName eq "any";
+    return "JSValue" if !$interface->extendedAttributes->{"UseCPPAPI"} && ($idlTypeName eq "DOMWindow" || $idlTypeName eq "function" || $idlTypeName eq "any");
+    return "JSValueRef" if $interface->extendedAttributes->{"UseCPPAPI"} && ($idlTypeName eq "DOMWindow" || $idlTypeName eq "function" || $idlTypeName eq "any");
     return "bool" if $idlTypeName eq "boolean";
 
     return unless ref($idlType) eq "IDLType";
@@ -1452,7 +1472,7 @@ sub _platformType
 
 sub _platformTypeConstructor
 {
-    my ($self, $signature, $argumentName) = @_;
+    my ($self, $interface, $signature, $argumentName) = @_;
 
     my $idlType = $signature->type;
 
@@ -1460,7 +1480,7 @@ sub _platformTypeConstructor
     $idlTypeName = $idlType->name if ref($idlType) eq "IDLType";
 
     my $nullStringPolicy = _nullStringPolicy($signature);
-    my $arrayType = $signature->extendedAttributes->{"NSArray"};
+    my $arrayType = $interface->extendedAttributes->{"UseCPPAPI"} ? $signature->extendedAttributes->{"Vector"} : $signature->extendedAttributes->{"NSArray"};
 
     if ($idlTypeName eq "any") {
         return "serializeJSObject(context, $argumentName, exception)" if $signature->extendedAttributes->{"Serialization"} && $signature->extendedAttributes->{"Serialization"} eq "JSON";
@@ -1470,13 +1490,17 @@ sub _platformTypeConstructor
         return "toNSObject(context, $argumentName, Nil, NullValuePolicy::Allowed, ValuePolicy::StopAtTopLevel)" if $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"NSObject"} eq "StopAtTopLevel";
         return "toNSObject(context, $argumentName, Nil, NullValuePolicy::Allowed)" if $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"NSObject"} eq "NullAllowed";
         return "toNSObject(context, $argumentName)" if $signature->extendedAttributes->{"NSObject"};
+        return "$argumentName" if $interface->extendedAttributes->{"UseCPPAPI"};
         return "toJSValue(context, $argumentName)";
     }
 
     return "toJSCallbackHandler(context, $argumentName, protect(impl->runtime()))" if $idlTypeName eq "function" && $signature->extendedAttributes->{"CallbackHandler"};
-    return "toNSArray(context, $argumentName, $arrayType.class)" if $idlTypeName eq "array" && $arrayType;
-    return "toNSArray(context, $argumentName)" if $idlTypeName eq "array";
+    return "toNSArray(context, $argumentName, $arrayType.class)" if !$interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array" && $arrayType;
+    return "toNSArray(context, $argumentName)" if !$interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array";
+    return "toVector<$arrayType>(context, $argumentName)" if $interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array" && $arrayType ne "JSValueRef";
+    return "toVector<Protected<$arrayType>>(context, $argumentName)" if $interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array" && $arrayType eq "JSValueRef";
     return "JSValueToBoolean(context, $argumentName)" if $idlTypeName eq "boolean";
+    return "$argumentName" if $interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "function";
     return "toJSValue(context, $argumentName)" if $idlTypeName eq "function";
 
     return unless ref($idlType) eq "IDLType";
@@ -1489,12 +1513,12 @@ sub _platformTypeConstructor
 
 sub _platformTypeVariableDeclaration
 {
-    my ($self, $signature, $variableName, $argumentName, $condition, $hideType) = @_;
+    my ($self, $interface, $signature, $variableName, $argumentName, $condition, $hideType) = @_;
 
     my $idlType = $signature->type;
     my $idlTypeName = $idlType->name;
-    my $platformType = $self->_platformType($idlType, $signature);
-    my $constructor = $self->_platformTypeConstructor($signature, $argumentName) if $argumentName;
+    my $platformType = $self->_platformType($idlType, $interface, $signature);
+    my $constructor = $self->_platformTypeConstructor($interface, $signature, $argumentName) if $argumentName;
 
     my %objCTypes = (
         "JSValue"       => 1,
@@ -1520,7 +1544,7 @@ sub _platformTypeVariableDeclaration
         die "DefaultValue extended attribute is currently only supported for numeric types";
     }
 
-    if ($platformType eq "JSValueRef" or $platformType eq "JSObjectRef" or $platformType eq "RefPtr<WebExtensionCallbackHandler>" or $platformType eq "double" or $platformType eq "bool" or $platformType eq "String") {
+    if ($platformType eq "JSValueRef" or $platformType eq "JSObjectRef" or $platformType eq "RefPtr<WebExtensionCallbackHandler>" or $platformType eq "double" or $platformType eq "bool" or $platformType eq "String" or $signature->extendedAttributes->{"Vector"}) {
         $platformType .= " ";
     } else {
         $platformType .= $isObjCType ? " *" : "* ";

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
@@ -106,6 +106,9 @@
         "NSArray": {
             "contextsAllowed": ["argument", "attribute", "operation"]
         },
+        "Vector": {
+            "contextsAllowed": ["argument", "attribute", "operation"]
+        },
         "NSDictionary": {
             "contextsAllowed": ["argument", "attribute", "operation"]
         },
@@ -126,6 +129,9 @@
         },
         "ReturnsPromiseWhenCallbackIsOmitted": {
             "contextsAllowed": ["interface", "operation"]
+        },
+        "UseCPPAPI": {
+            "contextsAllowed": ["interface"]
         },
         "Serialization": {
             "contextsAllowed": ["argument"],

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -26,6 +26,7 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,
+    UseCPPAPI,
 ] interface WebExtensionAPITest {
 
     // Notifies that test failed.
@@ -47,7 +48,7 @@
     readonly attribute WebExtensionAPIEvent onTestFinished;
 
     // Runs the provided function in the context of a user gesture.
-    [NeedsFrame] any runWithUserGesture([ValuesAllowed] any function);
+    [NeedsScriptContext, NeedsFrame] any runWithUserGesture([ValuesAllowed] any function);
 
     // Returns if a user gesture is active.
     boolean isProcessingUserGesture();
@@ -62,16 +63,16 @@
     [NeedsScriptContext] void succeed([Optional] DOMString message);
 
     // Asserts the test value is `true`.
-    [RaisesException, NeedsScriptContext] void assertTrue(boolean actualValue, [Optional] DOMString message);
+    [RaisesStringException, NeedsScriptContext] void assertTrue(boolean actualValue, [Optional] DOMString message);
 
     // Asserts the test value is `false`.
-    [RaisesException, NeedsScriptContext] void assertFalse(boolean actualValue, [Optional] DOMString message);
+    [RaisesStringException, NeedsScriptContext] void assertFalse(boolean actualValue, [Optional] DOMString message);
 
     // Asserts the test value is deeply equal to the expected value.
-    [RaisesException, NeedsScriptContext] void assertDeepEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
+    [RaisesStringException, NeedsScriptContext] void assertDeepEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
 
     // Asserts the test value is equal to the expected value.
-    [RaisesException, NeedsScriptContext] void assertEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
+    [RaisesStringException, NeedsScriptContext] void assertEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
 
     // Asserts the promise is rejected.
     [NeedsScriptContext, ProcessArgumentsLeftToRight] any assertRejects(any promise, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
@@ -80,7 +81,7 @@
     [NeedsScriptContext] any assertResolves(any promise, [Optional] DOMString message);
 
     // Asserts the function throws an exception.
-    [RaisesException, NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
+    [RaisesStringException, NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
 
     // Asserts the function does not throw an exception.
     [NeedsScriptContext] any assertSafe(any function, [Optional] DOMString message);
@@ -92,6 +93,6 @@
     [NeedsScriptContext] any addTest(any function);
 
     // Adds multiple tests to the queue to be ran and returns a promise. If all tests pass, the promise is resolved; if any test fails, the promise is rejected.
-    [NeedsScriptContext] any runTests([NSArray=JSValue] array tests);
+    [NeedsScriptContext] any runTests([Vector=JSValueRef] array tests);
 
 };

--- a/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
@@ -31,6 +31,7 @@
 #include "Logging.h"
 #include "WasmDebuggerDispatcherMessages.h"
 #include "WebProcess.h"
+#include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/WasmDebugServer.h>
 #include <wtf/WorkQueue.h>
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -462,7 +462,7 @@ class VideoPresentationManager;
 class VisibleContentRectUpdateInfo;
 #endif
 class WebBackForwardListItem;
-#if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
+#if ENABLE(WK_WEB_EXTENSIONS)
 class WebExtensionControllerProxy;
 #endif
 class WebFrame;
@@ -1835,8 +1835,15 @@ public:
 
     inline UserContentControllerIdentifier userContentControllerIdentifier() const;
 
-#if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
-    WebExtensionControllerProxy* webExtensionControllerProxy() const { return m_webExtensionController.get(); }
+#if ENABLE(WK_WEB_EXTENSIONS)
+    WebExtensionControllerProxy* webExtensionControllerProxy() const
+    {
+#if PLATFORM(COCOA)
+        return m_webExtensionController.get();
+#else
+        return nullptr;
+#endif
+    }
 #endif
 
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() const { return m_userInterfaceLayoutDirection; }

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -207,6 +207,11 @@ _PATH_RULES_SPECIFIER = [
      ["-readability/naming/acronym", "-readability/naming/underscores"]),
 
     ([
+        # Style checker assumes that all files that have Test as a suffix do not have a primary header.
+        os.path.join('Source', 'WebKit', 'WebProcess', 'Extensions', 'API', 'WebExtensionAPITest.cpp')],
+     ["-build/include_order"]),
+
+    ([
       # The GTK+ and WPE APIs use upper case, underscore separated, words in
       # certain types of enums (e.g. signals, properties).
       os.path.join('Source', 'JavaScriptCore', 'API', 'glib'),


### PR DESCRIPTION
#### 1163f500e455c86ebf318d2d8db7e03310970ada
<pre>
Port WebExtensionAPITest to CPP
<a href="https://bugs.webkit.org/show_bug.cgi?id=302211">https://bugs.webkit.org/show_bug.cgi?id=302211</a>

Reviewed by Timothy Hatcher.

Port the WebExtensionAPITest JavaScript API to C++. Some components, namely any that use a Promise, are still in Cocoa for now as most Promise handling is mostly platform-specific in JavaScriptCore (and thus it’s easier to just leave any promise or callback code in Cocoa). As well, this provides a way to generate the JS interfaces in C++, allowing for them to be built on more platforms besides Cocoa. This does not unify the files, as there’s only one API built at the moment.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h:
(WebKit::toDebugString):
* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h:
(WebKit::toAPIString):
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::invokeListenersWithJSONArgument):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::assertRejects):
(WebKit::WebExtensionAPITest::assertResolves):
(WebKit::WebExtensionAPITest::addTest):
(WebKit::WebExtensionAPITest::startNextTest):
(WebKit::scriptLocation): Deleted.
(WebKit::WebExtensionAPITest::notifyFail): Deleted.
(WebKit::WebExtensionAPITest::notifyPass): Deleted.
(WebKit::WebExtensionAPITest::sendMessage): Deleted.
(WebKit::WebExtensionAPITest::onMessage): Deleted.
(WebKit::WebExtensionAPITest::onTestStarted): Deleted.
(WebKit::WebExtensionAPITest::onTestFinished): Deleted.
(WebKit::WebExtensionAPITest::runWithUserGesture): Deleted.
(WebKit::WebExtensionAPITest::isProcessingUserGesture): Deleted.
(WebKit::debugString): Deleted.
(WebKit::WebExtensionAPITest::log): Deleted.
(WebKit::WebExtensionAPITest::fail): Deleted.
(WebKit::WebExtensionAPITest::succeed): Deleted.
(WebKit::WebExtensionAPITest::assertTrue): Deleted.
(WebKit::WebExtensionAPITest::assertFalse): Deleted.
(WebKit::WebExtensionAPITest::assertDeepEq): Deleted.
(WebKit::combineMessages): Deleted.
(WebKit::WebExtensionAPITest::assertEquals): Deleted.
(WebKit::WebExtensionAPITest::assertEq): Deleted.
(WebKit::WebExtensionAPITest::assertThrows): Deleted.
(WebKit::WebExtensionAPITest::assertSafe): Deleted.
(WebKit::WebExtensionAPITest::assertSafeResolve): Deleted.
(WebKit::WebExtensionAPITest::runTests): Deleted.
(WebKit::WebExtensionAPITest::recordAssertionIfNeeded): Deleted.
(WebKit::WebExtensionContextProxy::dispatchTestMessageEvent): Deleted.
(WebKit::WebExtensionContextProxy::dispatchTestStartedEvent): Deleted.
(WebKit::WebExtensionContextProxy::dispatchTestFinishedEvent): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.cpp: Added.
(WebKit::WebExtensionAPITest::scriptLocation):
(WebKit::WebExtensionAPITest::invokeMethod):
(WebKit::WebExtensionAPITest::notifyFail):
(WebKit::WebExtensionAPITest::notifyPass):
(WebKit::WebExtensionAPITest::sendMessage):
(WebKit::WebExtensionAPITest::onMessage):
(WebKit::WebExtensionAPITest::onTestStarted):
(WebKit::WebExtensionAPITest::onTestFinished):
(WebKit::WebExtensionAPITest::runWithUserGesture):
(WebKit::WebExtensionAPITest::isProcessingUserGesture):
(WebKit::WebExtensionAPITest::debugString):
(WebKit::WebExtensionAPITest::log):
(WebKit::WebExtensionAPITest::fail):
(WebKit::WebExtensionAPITest::succeed):
(WebKit::WebExtensionAPITest::assertTrue):
(WebKit::WebExtensionAPITest::assertFalse):
(WebKit::WebExtensionAPITest::assertDeepEq):
(WebKit::WebExtensionAPITest::combineMessages):
(WebKit::WebExtensionAPITest::assertEquals):
(WebKit::WebExtensionAPITest::assertEq):
(WebKit::WebExtensionAPITest::assertThrows):
(WebKit::WebExtensionAPITest::assertSafe):
(WebKit::WebExtensionAPITest::assertSafeResolve):
(WebKit::WebExtensionAPITest::addTest):
(WebKit::WebExtensionAPITest::runTests):
(WebKit::WebExtensionAPITest::recordAssertionIfNeeded):
(WebKit::WebExtensionContextProxy::dispatchTestMessageEvent):
(WebKit::WebExtensionContextProxy::dispatchTestStartedEvent):
(WebKit::WebExtensionContextProxy::dispatchTestFinishedEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::callWithArguments):
(WebKit::toVector&lt;JSValueRef&gt;):
(WebKit::toVector&lt;Protected&lt;JSValueRef&gt;&gt;):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::callObjectWithArguments):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_installAutomaticExceptions):
(_platformType):
(_platformTypeConstructor):
(_platformTypeVariableDeclaration):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/Scripts/webkitpy/style/checker.py:
* Source/WebKit/Shared/Protected.h:
(WebKit::Protected::context const):

Canonical link: <a href="https://commits.webkit.org/317383@main">https://commits.webkit.org/317383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a6b764681853913dc5be86407a8d4398c687fb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136092 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96047 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116571 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174201 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36553 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32937 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186884 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40754 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145023 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48479 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144881 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32998 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114970 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39756 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121264 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47665 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11348 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->