### PR TITLE
Address more Safer CPP warnings in generated WebExtensions code

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,38 +1,4 @@
 AutomationProtocolObjects.h
-JSWebExtensionAPIAction.mm
-JSWebExtensionAPIAlarms.mm
-JSWebExtensionAPICommands.mm
-JSWebExtensionAPICookies.mm
-JSWebExtensionAPIDOM.mm
-JSWebExtensionAPIDeclarativeNetRequest.mm
-JSWebExtensionAPIDevTools.mm
-JSWebExtensionAPIDevToolsExtensionPanel.mm
-JSWebExtensionAPIDevToolsInspectedWindow.mm
-JSWebExtensionAPIDevToolsNetwork.mm
-JSWebExtensionAPIDevToolsPanels.mm
-JSWebExtensionAPIEvent.mm
-JSWebExtensionAPIExtension.mm
-JSWebExtensionAPILocalization.mm
-JSWebExtensionAPIMenus.mm
-JSWebExtensionAPINamespace.mm
-JSWebExtensionAPINotifications.mm
-JSWebExtensionAPIPermissions.mm
-JSWebExtensionAPIPort.mm
-JSWebExtensionAPIRuntime.mm
-JSWebExtensionAPIScripting.mm
-JSWebExtensionAPIStorage.mm
-JSWebExtensionAPIStorageArea.mm
-JSWebExtensionAPITabs.mm
-JSWebExtensionAPITest.mm
-JSWebExtensionAPIWebNavigation.mm
-JSWebExtensionAPIWebNavigationEvent.mm
-JSWebExtensionAPIWebPageNamespace.mm
-JSWebExtensionAPIWebPageRuntime.mm
-JSWebExtensionAPIWebRequest.mm
-JSWebExtensionAPIWebRequestEvent.mm
-JSWebExtensionAPIWindows.mm
-JSWebExtensionAPIWindowsEvent.mm
-WebDriverBidiProtocolObjects.h
 [ iOS ] NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
 [ iOS ] Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 [ iOS ] UIProcess/API/ios/WKWebViewIOS.mm
@@ -47,4 +13,5 @@ WebDriverBidiProtocolObjects.h
 [ iOS ] UIProcess/ios/forms/WKFormPeripheralBase.mm
 [ iOS ] UIProcess/ios/forms/WKFormSelectPicker.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+WebDriverBidiProtocolObjects.h
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -83,4 +83,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIAction, action);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
@@ -58,4 +58,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIAlarms, alarms);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
@@ -62,4 +62,6 @@ public:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIBookmarks, bookmarks);
+
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICommands.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICommands.h
@@ -51,4 +51,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPICommands, commands);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICookies.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICookies.h
@@ -61,4 +61,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPICookies, cookies);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDOM.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDOM.h
@@ -45,4 +45,6 @@ public:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIDOM, dom);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
@@ -74,4 +74,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIDeclarativeNetRequest, declarativeNetRequest);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevTools.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevTools.h
@@ -53,4 +53,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIDevTools, devTools);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsExtensionPanel.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsExtensionPanel.h
@@ -49,4 +49,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIDevToolsExtensionPanel, devToolsExtensionPanel);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
@@ -53,4 +53,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIDevToolsInspectedWindow, devToolsInspectedWindow);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsNetwork.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsNetwork.h
@@ -47,4 +47,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIDevToolsNetwork, devToolsNetwork);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
@@ -58,4 +58,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIDevToolsPanels, devToolsPanels);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -77,4 +77,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIEvent, event);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
@@ -64,4 +64,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIExtension, extension);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
@@ -47,4 +47,6 @@ public:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPILocalization, localization);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
@@ -68,4 +68,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIMenus, menus);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -136,4 +136,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPINamespace, namespace);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h
@@ -49,4 +49,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPINotifications, notifications);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -134,7 +134,7 @@ private: \
         setPropertyPath(#PropertyName##_s, &parentObject); \
     } \
 \
-    JSClassRef wrapperClass() final { return JS##ImplClass::ScriptClass##Class(); } \
+    JSClassRef wrapperClass() const final { return JS##ImplClass::ScriptClass##Class(); } \
 \
     using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h
@@ -59,4 +59,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIPermissions, permissions);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -154,4 +154,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIPort, port);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -127,4 +127,7 @@ NSDictionary *toWebAPI(const WebExtensionMessageSenderParameters&);
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIRuntime, runtime);
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWebPageRuntime, webPageRuntime);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -74,4 +74,6 @@ String toWebAPI(WebExtension::InjectionTime);
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIScripting, scripting);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidePanel.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidePanel.h
@@ -49,4 +49,6 @@ public:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPISidePanel, sidePanel);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
@@ -82,4 +82,6 @@ public:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPISidebarAction, sidebarAction);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
@@ -64,4 +64,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIStorage, storage);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -78,4 +78,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIStorageArea, storageArea);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -121,4 +121,6 @@ NSDictionary *toWebAPI(const WebExtensionTabParameters&);
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPITabs, tabs);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -103,4 +103,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPITest, test);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h
@@ -60,4 +60,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWebNavigation, webNavigation);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -81,4 +81,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWebNavigationEvent, webNavigationEvent);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
@@ -56,4 +56,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWebPageNamespace, webPageNamespace);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h
@@ -66,4 +66,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWebRequest, webRequest);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -87,4 +87,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWebRequestEvent, webRequestEvent);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
@@ -89,4 +89,6 @@ bool isValid(std::optional<WebExtensionWindowIdentifier>, NSString **outExceptio
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWindows, windows);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -77,4 +77,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(WebExtensionAPIWindowsEvent, windowsEvent);
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrappable.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrappable.h
@@ -37,9 +37,14 @@ class JSWebExtensionWrappable : public RefCounted<JSWebExtensionWrappable> {
 public:
     virtual ~JSWebExtensionWrappable() { }
 
-    virtual JSClassRef wrapperClass() = 0;
+    virtual JSClassRef wrapperClass() const = 0;
 };
 
 } // namespace WebKit
+
+#define SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(ImplClass, ScriptClass) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::ImplClass) \
+static bool isType(const WebKit::JSWebExtensionWrappable& wrappable) { return wrappable.wrapperClass() == WebKit::JS##ImplClass::ScriptClass##Class(); } \
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -326,7 +326,7 @@ ${implementationClassName}* to${implementationClassName}(JSContextRef context, J
 {
     if (!context || !value || !${className}::${classRefGetter}() || !JSValueIsObjectOfClass(context, value, ${className}::${classRefGetter}()))
         return nullptr;
-    return static_cast<${implementationClassName}*>(JSWebExtensionWrapper::unwrap(context, value));
+    return downcast<${implementationClassName}>(JSWebExtensionWrapper::unwrap(context, value));
 }
 
 JSClassRef ${className}::${classRefGetter}()


### PR DESCRIPTION
#### 7770114b9d455b0b501b8de4f8b680b7783abf05
<pre>
Address more Safer CPP warnings in generated WebExtensions code
<a href="https://bugs.webkit.org/show_bug.cgi?id=302224">https://bugs.webkit.org/show_bug.cgi?id=302224</a>
<a href="https://rdar.apple.com/164368484">rdar://164368484</a>

Reviewed by Geoffrey Garen, Timothy Hatcher, and Anne van Kesteren.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICommands.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICookies.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDOM.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevTools.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsExtensionPanel.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsNetwork.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidePanel.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrappable.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):

Canonical link: <a href="https://commits.webkit.org/302777@main">https://commits.webkit.org/302777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24e7e21628959f9adb2f893eff07501be238c36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81735 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f9ce1a0-821a-4104-b838-fefa89756b08) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99174 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cef19239-50e4-4535-838a-0e90631b7a58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133129 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79867 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc78061d-766e-4867-a565-b09e985124ca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80856 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107698 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31386 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55182 "Hash f24e7e21 for PR 53645 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65700 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2130 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2239 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->