### PR TITLE
WebTransport datagrams readable stream should have a byte source

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -928,6 +928,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/websockets/CloseEvent.idl
     Modules/websockets/WebSocket.idl
 
+    Modules/webtransport/DatagramsReadableMode.idl
     Modules/webtransport/WebTransport.idl
     Modules/webtransport/WebTransportBidirectionalStream.idl
     Modules/webtransport/WebTransportCloseInfo.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1096,6 +1096,7 @@ $(PROJECT_DIR)/Modules/webdatabase/SQLTransactionErrorCallback.idl
 $(PROJECT_DIR)/Modules/webdriver/Navigator+WebDriver.idl
 $(PROJECT_DIR)/Modules/websockets/CloseEvent.idl
 $(PROJECT_DIR)/Modules/websockets/WebSocket.idl
+$(PROJECT_DIR)/Modules/webtransport/DatagramsReadableMode.idl
 $(PROJECT_DIR)/Modules/webtransport/WebTransport.idl
 $(PROJECT_DIR)/Modules/webtransport/WebTransportBidirectionalStream.idl
 $(PROJECT_DIR)/Modules/webtransport/WebTransportCloseInfo.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -866,6 +866,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDatabase.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDatabase.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDatabaseCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDatabaseCallback.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDatagramsReadableMode.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDatagramsReadableMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDecompressionStream.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDecompressionStream.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDecompressionStreamDecoder.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -831,6 +831,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webdriver/Navigator+WebDriver.idl \
     $(WebCore)/Modules/websockets/CloseEvent.idl \
     $(WebCore)/Modules/websockets/WebSocket.idl \
+    $(WebCore)/Modules/webtransport/DatagramsReadableMode.idl \
     $(WebCore)/Modules/webtransport/WebTransport.idl \
     $(WebCore)/Modules/webtransport/WebTransportBidirectionalStream.idl \
     $(WebCore)/Modules/webtransport/WebTransportCloseInfo.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -847,6 +847,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/websockets/WebSocketIdentifier.h
     Modules/websockets/WorkerThreadableWebSocketChannel.h
 
+    Modules/webtransport/DatagramsReadableMode.h
     Modules/webtransport/WebTransportCongestionControl.h
     Modules/webtransport/WebTransportConnectionStats.h
     Modules/webtransport/WebTransportDatagramStats.h

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -92,6 +92,7 @@ public:
     void error(JSDOMGlobalObject&, JSC::JSValue);
     void close(JSDOMGlobalObject&);
     void closeAndRespondToPendingPullIntos(JSDOMGlobalObject&);
+    size_t pullFromBytes(JSDOMGlobalObject&, JSC::ArrayBuffer&, size_t offset);
     ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBufferView&);
     ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBuffer&);
 

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DatagramByteSource.h"
+
+#include "JSDOMPromiseDeferred.h"
+#include "ReadableByteStreamController.h"
+#include "ReadableStream.h"
+#include "ReadableStreamBYOBRequest.h"
+#include <JavaScriptCore/ArrayBuffer.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+DatagramByteSource::DatagramByteSource()
+{
+}
+
+DatagramByteSource::~DatagramByteSource() = default;
+
+void DatagramByteSource::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<Exception>&& exception)
+{
+    if (m_isCancelled || m_isClosed)
+        return;
+
+    if (exception) {
+        m_exception = WTFMove(exception);
+        closeStreamIfPossible();
+        return;
+    }
+
+    auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(datagram.size(), 1);
+    if (!arrayBuffer) {
+        // FIXME: error the stream.
+        return;
+    }
+
+    memcpySpan(arrayBuffer->mutableSpan(), datagram);
+
+    if (!m_promise || !m_queue.isEmpty()) {
+        // FIXME: https://www.w3.org/TR/webtransport/#receivedatagrams tells us to remove datagrams:
+        // - If incomingHighWaterMark is reached
+        // - If datagrams are too old.
+        m_queue.append(arrayBuffer.releaseNonNull());
+        m_isClosed = withFin;
+        return;
+    }
+
+    RefPtr controller = m_controller;
+    auto* globalObject = controller->protectedStream()->globalObject();
+    if (!globalObject)
+        return;
+
+    ASSERT(!m_currentOffset);
+    tryEnqueuing(*arrayBuffer, *controller, m_promise.releaseNonNull().get(), globalObject);
+    if (!withFin)
+        return;
+
+    m_isClosed = true;
+    closeStreamIfPossible();
+}
+
+void DatagramByteSource::pull(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller, Ref<DeferredPromise>&& promise)
+{
+    if (closeStreamIfNeeded(globalObject, controller, promise.get()))
+        return;
+
+    if (m_queue.isEmpty()) {
+        m_promise = WTFMove(promise);
+        m_controller = &controller;
+        return;
+    }
+
+    tryEnqueuing(m_queue.takeFirst().get(), controller, WTFMove(promise), &globalObject);
+}
+
+void DatagramByteSource::cancel(Ref<DeferredPromise>&& promise)
+{
+    m_isCancelled = true;
+    m_queue.clear();
+    m_promise = nullptr;
+    m_controller = nullptr;
+    promise->resolve();
+}
+
+void DatagramByteSource::closeStreamIfPossible()
+{
+    RefPtr promise = std::exchange(m_promise, { });
+    if (!promise)
+        return;
+
+    RefPtr controller = m_controller;
+    auto* globalObject = controller->protectedStream()->globalObject();
+    if (!globalObject)
+        return;
+
+    closeStream(*globalObject, *controller, *promise);
+}
+
+bool DatagramByteSource::closeStreamIfNeeded(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller, DeferredPromise& promise)
+{
+    if (!m_isClosed || !m_queue.isEmpty())
+        return false;
+
+    closeStream(globalObject, controller, promise);
+    return true;
+}
+
+void DatagramByteSource::closeStream(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller, DeferredPromise& promise)
+{
+    if (m_exception)
+        controller.error(globalObject, *m_exception);
+    else
+        controller.closeAndRespondToPendingPullIntos(globalObject);
+
+    promise.resolve();
+}
+
+void DatagramByteSource::tryEnqueuing(JSC::ArrayBuffer& buffer, ReadableByteStreamController& controller, Ref<DeferredPromise>&& promise, JSDOMGlobalObject* globalObject)
+{
+    if (!globalObject) {
+        globalObject = controller.protectedStream()->globalObject();
+        if (!globalObject) {
+            // FIXME: We should probably error.
+            promise->resolve();
+            return;
+        }
+    }
+
+    size_t byteLength = buffer.byteLength();
+    ASSERT(byteLength > m_currentOffset);
+    if (RefPtr request = controller.getByobRequest()) {
+        RefPtr view = request->view();
+        // If view’s byte length is less than the size of datagram, return a promise rejected with a RangeError.
+        if (view->byteLength() < byteLength - m_currentOffset) {
+            promise->reject(Exception { ExceptionCode::RangeError, "BYOB request buffer is too small"_s });
+            return;
+        }
+
+        size_t elementSize = 0;
+        auto viewType = view->getType();
+        if (viewType != JSC::TypedArrayType::TypeDataView)
+            elementSize = JSC::elementSize(viewType);
+
+        if (elementSize != 1) {
+            promise->reject(Exception { ExceptionCode::TypeError, "BYOB request view element size is not 1"_s });
+            return;
+        }
+    }
+
+    auto newOffset = controller.pullFromBytes(*globalObject, buffer, m_currentOffset);
+    if (newOffset != byteLength) {
+        m_queue.prepend(buffer);
+        m_currentOffset = newOffset;
+    } else
+        m_currentOffset = 0;
+
+    if (m_exception || (m_isClosed && m_queue.isEmpty()))
+        closeStream(*globalObject, controller, WTFMove(promise));
+    else
+        promise->resolve();
+}
+
+}

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DatagramSource.h"
+
+namespace JSC {
+class ArrayBuffer;
+}
+
+namespace WebCore {
+
+class WebTransport;
+class DeferredPromise;
+class Exception;
+class JSDOMGlobalObject;
+class ReadableByteStreamController;
+
+class DatagramByteSource final : public DatagramSource, public RefCounted<DatagramByteSource> {
+public:
+    static Ref<DatagramByteSource> create() { return adoptRef(*new DatagramByteSource()); }
+    ~DatagramByteSource();
+
+    void ref() const final { return RefCounted::ref(); }
+    void deref() const final { return RefCounted::deref(); }
+
+    void pull(JSDOMGlobalObject&, ReadableByteStreamController&, Ref<DeferredPromise>&&);
+    void cancel(Ref<DeferredPromise>&&);
+
+private:
+    DatagramByteSource();
+
+    void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
+
+    void closeStreamIfPossible();
+    bool closeStreamIfNeeded(JSDOMGlobalObject&, ReadableByteStreamController&, DeferredPromise&);
+    void closeStream(JSDOMGlobalObject&, ReadableByteStreamController&, DeferredPromise&);
+    void tryEnqueuing(JSC::ArrayBuffer&, ReadableByteStreamController&, Ref<DeferredPromise>&&, JSDOMGlobalObject*);
+
+    bool m_isCancelled { false };
+    bool m_isClosed { false };
+    std::optional<Exception> m_exception;
+    Deque<Ref<JSC::ArrayBuffer>> m_queue;
+    size_t m_currentOffset { 0 };
+    RefPtr<DeferredPromise> m_promise;
+    RefPtr<ReadableByteStreamController> m_controller;
+};
+
+}

--- a/Source/WebCore/Modules/webtransport/DatagramSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.cpp
@@ -31,11 +31,11 @@
 
 namespace WebCore {
 
-DatagramSource::DatagramSource() = default;
+DatagramDefaultSource::DatagramDefaultSource() = default;
 
-DatagramSource::~DatagramSource() = default;
+DatagramDefaultSource::~DatagramDefaultSource() = default;
 
-void DatagramSource::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<Exception>&& exception)
+void DatagramDefaultSource::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<Exception>&& exception)
 {
     if (m_isCancelled || m_isClosed)
         return;
@@ -58,7 +58,7 @@ void DatagramSource::receiveDatagram(std::span<const uint8_t> datagram, bool wit
     }
 }
 
-void DatagramSource::doCancel()
+void DatagramDefaultSource::doCancel()
 {
     m_isCancelled = true;
 }

--- a/Source/WebCore/Modules/webtransport/DatagramSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.h
@@ -26,20 +26,32 @@
 #pragma once
 
 #include "ReadableStreamSource.h"
+#include <wtf/AbstractRefCounted.h>
 
 namespace WebCore {
 
 class WebTransport;
 class Exception;
 
-class DatagramSource : public RefCountedReadableStreamSource {
+class DatagramSource : public AbstractRefCounted {
 public:
-    static Ref<DatagramSource> create() { return adoptRef(*new DatagramSource()); }
-    ~DatagramSource();
-    void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&);
+    DatagramSource() = default;
+    virtual ~DatagramSource() = default;
+    virtual void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) = 0;
+};
+
+class DatagramDefaultSource final : public DatagramSource, public RefCountedReadableStreamSource {
+public:
+    static Ref<DatagramDefaultSource> create() { return adoptRef(*new DatagramDefaultSource()); }
+    ~DatagramDefaultSource();
+
+    void ref() const final { return RefCountedReadableStreamSource::ref(); }
+    void deref() const final { return RefCountedReadableStreamSource::deref(); }
 
 private:
-    DatagramSource();
+    DatagramDefaultSource();
+
+    void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
 
     void setActive() final { }
     void setInactive() final { }

--- a/Source/WebCore/Modules/webtransport/DatagramsReadableMode.h
+++ b/Source/WebCore/Modules/webtransport/DatagramsReadableMode.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class DatagramsReadableMode : uint8_t { Bytes };
+
+}

--- a/Source/WebCore/Modules/webtransport/DatagramsReadableMode.idl
+++ b/Source/WebCore/Modules/webtransport/DatagramsReadableMode.idl
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+enum DatagramsReadableMode { "bytes" };

--- a/Source/WebCore/Modules/webtransport/WebTransportOptions.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportOptions.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/DatagramsReadableMode.h>
 #include <WebCore/WebTransportCongestionControl.h>
 #include <WebCore/WebTransportHash.h>
 
@@ -35,6 +36,7 @@ struct WebTransportOptions {
     bool requireUnreliable { false };
     Vector<WebTransportHash> serverCertificateHashes;
     WebTransportCongestionControl congestionControl { WebTransportCongestionControl::Default };
+    std::optional<DatagramsReadableMode> datagramsReadableMode;
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportOptions.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportOptions.idl
@@ -30,4 +30,5 @@
     boolean requireUnreliable = false;
     sequence<WebTransportHash> serverCertificateHashes;
     WebTransportCongestionControl congestionControl = "default";
+    DatagramsReadableMode datagramsReadableMode;
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportSendGroup.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendGroup.cpp
@@ -29,6 +29,8 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebTransportSendStreamStats.h"
 #include "WebTransportSendStreamStats.h"
+#include "WebTransportSession.h"
+#include "WebTransport.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webtransport/WebTransportSendGroup.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendGroup.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class DeferredPromise;
+class ScriptExecutionContext;
 class WebTransport;
 
 struct WebTransportSendGroupIdentifierType;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -525,6 +525,7 @@ Modules/websockets/WebSocketHandshake.cpp
 Modules/websockets/WorkerThreadableWebSocketChannel.cpp
 Modules/webtransport/DatagramSink.cpp
 Modules/webtransport/DatagramSource.cpp
+Modules/webtransport/DatagramByteSource.cpp
 Modules/webtransport/WebTransport.cpp
 Modules/webtransport/WebTransportBidirectionalStream.cpp
 Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
@@ -3974,6 +3975,7 @@ JSDataCue.cpp
 JSDataTransfer.cpp
 JSDataTransferItem.cpp
 JSDataTransferItemList.cpp
+JSDatagramsReadableMode.cpp
 JSDatabase.cpp
 JSDatabaseCallback.cpp
 JSDecompressionStream.cpp

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -40,6 +40,8 @@ namespace WebCore {
 
 auto DOMPromise::whenSettled(Function<void()>&& callback) -> IsCallbackRegistered
 {
+    if (isSuspended())
+        return IsCallbackRegistered::No;
     return whenPromiseIsSettled(globalObject(), promise(), WTFMove(callback));
 }
 

--- a/Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in
+++ b/Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in
@@ -63,10 +63,15 @@ struct WebCore::WebTransportOptions {
     bool requireUnreliable
     Vector<WebCore::WebTransportHash> serverCertificateHashes
     WebCore::WebTransportCongestionControl congestionControl
+    std::optional<WebCore::DatagramsReadableMode> datagramsReadableMode;
 };
 
 enum class WebCore::WebTransportCongestionControl : uint8_t {
     Default,
     Throughput,
     LowLatency,
+};
+
+enum class WebCore::DatagramsReadableMode : uint8_t {
+    Bytes
 };


### PR DESCRIPTION
#### a3132606650e5bd78421d7ce1ace511cbdb52b94
<pre>
WebTransport datagrams readable stream should have a byte source
<a href="https://rdar.apple.com/164368616">rdar://164368616</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302225">https://bugs.webkit.org/show_bug.cgi?id=302225</a>

Reviewed by Alex Christensen.

We add support for datagram byob sources.
As per spec, this is controlled by DatagramsReadableMode.
We keep the normal sources if DatagramsReadableMode is not provided.
Otherwise, we use a byob source and implement the algorithm defined in <a href="https://w3c.github.io/webtransport/#pulldatagrams.">https://w3c.github.io/webtransport/#pulldatagrams.</a>

Manually tested on a local server.
This should be covered by WPT datagrams test once web transport server is up and running.

Canonical link: <a href="https://commits.webkit.org/303336@main">https://commits.webkit.org/303336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0393cb69461e14229e3c2610b7f0eb2cbb475a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131870 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83757 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72174328-2358-467b-ab36-9bc49e37c755) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100799 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68205 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7255ef34-732d-4906-b3c5-a84c6ddfb5e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134816 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81588 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db8f53a7-8c04-43af-9ed1-18a9dd076380) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/814 "Found 1 new API test failure: TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82602 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142026 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4031 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109173 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109339 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3068 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57252 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20528 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4085 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32791 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3917 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4177 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->