### PR TITLE
Use std::fmax() for proper NaN handling

### DIFF
--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -35,6 +35,7 @@
 #include "GeometryUtilities.h"
 #include "RenderObjectInlines.h"
 #include "RenderTheme.h"
+#include <cmath>
 #include <pal/spi/cf/CoreTextSPI.h>
 #include <wtf/cocoa/TypeCastsCocoa.h>
 
@@ -261,7 +262,7 @@ static CGFloat attachmentDynamicTypeScaleFactor()
     CGFloat dynamicPointSize = shortCaptionPointSizeWithContentSizeCategory(contentSizeCategory());
     if (!dynamicPointSize || !fixedPointSize)
         return 1;
-    return std::max<CGFloat>(1, dynamicPointSize / fixedPointSize);
+    return std::fmax(1, dynamicPointSize / fixedPointSize);
 }
 
 AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -190,6 +190,7 @@
 #import <WebCore/WebCorePersistentCoders.h>
 #import <WebCore/WebViewVisualIdentificationOverlay.h>
 #import <WebCore/WritingMode.h>
+#import <cmath>
 #import <wtf/BlockPtr.h>
 #import <wtf/Box.h>
 #import <wtf/CallbackAggregator.h>
@@ -3212,7 +3213,7 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
         if (WebCore::PageColorSampler::colorsAreSimilar(_page->underPageBackgroundColor(), topFixedColor))
             return 0;
 
-        return std::max<CGFloat>(-obscuredInsets.top - [_scrollView contentOffset].y, 0);
+        return std::fmax(-obscuredInsets.top - [_scrollView contentOffset].y, 0);
     }();
 
     return WebCore::FloatBoxExtent {

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -76,6 +76,7 @@
 #import <WebCore/LocalCurrentTraitCollection.h>
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebCore/UserInterfaceLayoutDirection.h>
+#import <cmath>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 #import <ranges>
@@ -826,10 +827,10 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
         safeAreaInsets = UIEdgeInsetsAdd(safeAreaInsets, self._contentInsetsFromSystemMinimumLayoutMargins, self._effectiveObscuredInsetEdgesAffectedBySafeArea);
 #endif
         if (_haveSetObscuredInsets) {
-            safeAreaInsets.top = std::max<CGFloat>(0., safeAreaInsets.top - _obscuredInsets.top);
-            safeAreaInsets.left = std::max<CGFloat>(0., safeAreaInsets.left - _obscuredInsets.left);
-            safeAreaInsets.bottom = std::max<CGFloat>(0., safeAreaInsets.bottom - _obscuredInsets.bottom);
-            safeAreaInsets.right = std::max<CGFloat>(0., safeAreaInsets.right - _obscuredInsets.right);
+            safeAreaInsets.top = std::fmax(0., safeAreaInsets.top - _obscuredInsets.top);
+            safeAreaInsets.left = std::fmax(0., safeAreaInsets.left - _obscuredInsets.left);
+            safeAreaInsets.bottom = std::fmax(0., safeAreaInsets.bottom - _obscuredInsets.bottom);
+            safeAreaInsets.right = std::fmax(0., safeAreaInsets.right - _obscuredInsets.right);
         }
         return safeAreaInsets;
     }
@@ -3806,32 +3807,32 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     CGRect contentViewFrame = [_contentView frame];
     CGFloat minX = std::min<CGFloat>(0, scrollView.contentOffset.x);
     CGFloat minY = std::min<CGFloat>(0, scrollView.contentOffset.y);
-    CGFloat maxX = std::max<CGFloat>(scrollView.bounds.size.width + scrollView.contentOffset.x, contentViewBounds.size.width);
-    CGFloat maxY = std::max<CGFloat>(scrollView.bounds.size.height + scrollView.contentOffset.y, contentViewBounds.size.height);
+    CGFloat maxX = std::fmax(scrollView.bounds.size.width + scrollView.contentOffset.x, contentViewBounds.size.width);
+    CGFloat maxY = std::fmax(scrollView.bounds.size.height + scrollView.contentOffset.y, contentViewBounds.size.height);
 
     [_findOverlaysOutsideContentView->top setFrame:CGRectMake(
         CGRectGetMinX(contentViewFrame),
         minY,
-        std::max<CGFloat>(maxX - CGRectGetMinX(contentViewFrame), 0),
-        std::max<CGFloat>(CGRectGetMinY(contentViewFrame) - minY, 0))];
+        std::fmax(maxX - CGRectGetMinX(contentViewFrame), 0),
+        std::fmax(CGRectGetMinY(contentViewFrame) - minY, 0))];
 
     [_findOverlaysOutsideContentView->right setFrame:CGRectMake(
         CGRectGetMaxX(contentViewFrame),
         CGRectGetMinY(contentViewFrame),
-        std::max<CGFloat>(maxX - CGRectGetMaxX(contentViewFrame), 0),
-        std::max<CGFloat>(maxY - CGRectGetMinY(contentViewFrame), 0))];
+        std::fmax(maxX - CGRectGetMaxX(contentViewFrame), 0),
+        std::fmax(maxY - CGRectGetMinY(contentViewFrame), 0))];
 
     [_findOverlaysOutsideContentView->bottom setFrame:CGRectMake(
         minX,
         CGRectGetMaxY(contentViewFrame),
-        std::max<CGFloat>(CGRectGetMaxX(contentViewFrame) - minX, 0),
-        std::max<CGFloat>(maxY - CGRectGetMaxY(contentViewFrame), 0))];
+        std::fmax(CGRectGetMaxX(contentViewFrame) - minX, 0),
+        std::fmax(maxY - CGRectGetMaxY(contentViewFrame), 0))];
 
     [_findOverlaysOutsideContentView->left setFrame:CGRectMake(
         minX,
         minY,
-        std::max<CGFloat>(CGRectGetMinX(contentViewFrame) - minX, 0),
-        std::max<CGFloat>(CGRectGetMaxY(contentViewFrame) - minY, 0))];
+        std::fmax(CGRectGetMinX(contentViewFrame) - minX, 0),
+        std::fmax(CGRectGetMaxY(contentViewFrame) - minY, 0))];
 }
 
 - (void)_showFindOverlay

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -81,6 +81,7 @@
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/UserAgent.h>
 #import <WebCore/ValidationBubble.h>
+#import <cmath>
 #import <pal/spi/ios/MobileGestaltSPI.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/RuntimeApplicationChecks.h>
@@ -238,7 +239,7 @@ WebCore::FloatRect WebPageProxy::computeLayoutViewportRect(const FloatRect& unob
     bool isBelowMinimumScale = displayedContentScale < minimumScale && !WebKit::scalesAreEssentiallyEqual(displayedContentScale, minimumScale);
     if (isBelowMinimumScale) {
         const CGFloat slope = 12;
-        CGFloat factor = std::max<CGFloat>(1 - slope * (minimumScale - displayedContentScale), 0);
+        CGFloat factor = std::fmax(1 - slope * (minimumScale - displayedContentScale), 0);
 
         constrainedUnobscuredRect.setX(adjustedUnexposedEdge(documentRect.x(), constrainedUnobscuredRect.x(), factor));
         constrainedUnobscuredRect.setY(adjustedUnexposedEdge(documentRect.y(), constrainedUnobscuredRect.y(), factor));

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -33,6 +33,7 @@
 #import "WebPreferencesDefaultValues.h"
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
+#import <cmath>
 #import <pal/spi/mac/NSColorSPI.h>
 
 constexpr CGFloat dropdownTopMargin = 3;
@@ -471,7 +472,7 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     CGFloat width = std::min<CGFloat>(std::max(rect.width(), rect.height()), screenRect.size.width);
     CGFloat height = std::min<CGFloat>(totalIntercellSpacingAndPadding + std::min(totalCellHeight, maximumTotalHeightForDropdownCells), screenRect.size.height);
     CGFloat originX = std::max<CGFloat>(NSMinX(windowRect), 0);
-    CGFloat originY = std::max<CGFloat>(NSMinY(windowRect) - height - dropdownTopMargin, 0);
+    CGFloat originY = std::fmax(NSMinY(windowRect) - height - dropdownTopMargin, 0);
 
     return NSMakeRect(originX, originY, width, height);
 }


### PR DESCRIPTION
#### cb50d840384eb09d673baff19a2124afcc074800
<pre>
Use std::fmax() for proper NaN handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=302227">https://bugs.webkit.org/show_bug.cgi?id=302227</a>
<a href="https://rdar.apple.com/164368984">rdar://164368984</a>

Reviewed by NOBODY (OOPS!).

std::max&lt;CGFloat&gt;() propagates NaN when first argument is NaN, returning NaN
instead of the other argument. Fix by using std::fmax() to return
the non-NaN value when first argument is NaN.

* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::attachmentDynamicTypeScaleFactor):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _obscuredInsetsForFixedColorExtension]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _computedUnobscuredSafeAreaInset]):
(-[WKWebView _updateFindOverlayPosition]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::computeLayoutViewportRect const):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionsController dropdownRectForElementRect:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb50d840384eb09d673baff19a2124afcc074800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130329 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81907 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99292 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67156 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34838 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140224 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2390 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2206 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107808 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107707 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55345 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2460 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65847 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->