### PR TITLE
REGRESSION (iOS 26): Edit menu isn’t shown when tapping inside a text field with looping animation

### DIFF
--- a/LayoutTests/editing/selection/ios/show-edit-menu-in-text-field-with-animation-expected.txt
+++ b/LayoutTests/editing/selection/ios/show-edit-menu-in-text-field-with-animation-expected.txt
@@ -1,0 +1,9 @@
+Verifies that edit menu can be shown when tapping in a text field with a looping animation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Revealed edit menu
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/show-edit-menu-in-text-field-with-animation.html
+++ b/LayoutTests/editing/selection/ios/show-edit-menu-in-text-field-with-animation.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+@keyframes test {
+    to { content: "" }
+}
+
+p {
+    position: relative;
+    block-size: 2rem;
+    transform: translate3d(0, 0, 0);
+    top: 0;
+}
+
+p:first-child {
+    animation: test 400ms infinite;
+}
+
+input {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    font-size: 18px;
+    padding: 4px;
+    height: 100px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that edit menu can be shown when tapping in a text field with a looping animation.");
+
+    const container = document.querySelector(".input-container");
+
+    await UIHelper.activateElementAndWaitForInputSession(container);
+    await UIHelper.waitForDoubleTapDelay();
+    await UIHelper.activateElement(container);
+    await UIHelper.waitForMenuToShow();
+
+    testPassed("Revealed edit menu");
+    document.querySelector("input").blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<p class="input-container"><input placeholder="Try to paste here" /></p>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -278,6 +278,13 @@ struct WKSelectionDrawingInfo {
     Vector<WebCore::SelectionGeometry> selectionGeometries;
     WebCore::IntRect selectionClipRect;
     std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
+
+    enum class ComparisonResult : uint8_t {
+        VisuallyDistinct,
+        EquivalentExceptForEnclosingLayer,
+        EquivalentIncludingEnclosingLayer,
+    };
+    ComparisonResult compare(const WKSelectionDrawingInfo&) const;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const WKSelectionDrawingInfo&);


### PR DESCRIPTION
#### db75ea4ed5c1a67c155c3aa859f250af348d7af2
<pre>
REGRESSION (iOS 26): Edit menu isn’t shown when tapping inside a text field with looping animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=302153">https://bugs.webkit.org/show_bug.cgi?id=302153</a>
<a href="https://rdar.apple.com/164290305">rdar://164290305</a>

Reviewed by Abrar Rahman Protyasha.

When `SelectionHonorsOverflowScrolling` (composited selection UI on iOS) is enabled, it&apos;s possible
to end up in a scenario where the edit menu timer (triggered when tapping inside an already-focused
editable element) is indefinitely debounced — one easy way to trigger this is to (1) ensure that the
selection caret is composited in a layer that&apos;s not the root layer, and (2) add an infinitely
looping `content` animation to that enclosing compositing layer, whose duration is shorter than the
debounce delay of the edit menu timer + edit menu appearance animation (i.e. about 1 second).

In this case, the layer containing the animation changes with every loop; this, in turn, causes the
selection drawing info (which now includes a composited layer ID) to change every loop, which then
makes us call into `-selectionChanged` in `-_updateChangedSelection:`. While it&apos;s necessary to move
the selection container in this case to the new compositing view, it&apos;s _not_ necessary to debounce
or reset the edit menu timer.

To fix this, we make the `selectionDrawingInfo != _lastSelectionDrawingInfo` check a bit more
nuanced, such that it returns a 3-state enum instead describing the comparison result; this allows
us to only call `-selectionChanged` in the case where the selection actually, visually changed
(ignoring which compositing view it&apos;s hosted in).

Test: editing/selection/ios/show-edit-menu-in-text-field-with-animation.html

* LayoutTests/editing/selection/ios/show-edit-menu-in-text-field-with-animation-expected.txt: Added.
* LayoutTests/editing/selection/ios/show-edit-menu-in-text-field-with-animation.html: Added.

Add a layout test to verify that the edit menu appears after (1) tapping to focus a text field with
an infinitely looping animation, and (2) tapping again inside that focused text field.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(WebKit::WKSelectionDrawingInfo::compare const):

Make this return a tri-state enum, representing the comparison result (visually distinct, visually
equivalent except for the containing compositing layer, and visually equivalent including the
containing layer).

(-[WKContentView _updateChangedSelection:]):
(WebKit::operator==): Deleted.

Canonical link: <a href="https://commits.webkit.org/302794@main">https://commits.webkit.org/302794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bf55fc20b91200076121727f4ad90ccab0e477c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bcbe36ef-ee88-4fe0-aedd-df4aecf3079c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99169 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67036 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e870de50-ef32-44ef-b9ff-241f3150e123) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79862 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/382e32fd-86d2-4862-bea7-2dfbfd71b37e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80845 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140058 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107692 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1773 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55170 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65689 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2119 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2323 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->