### PR TITLE
Crash: com.apple.WebKit.WebContent at AVFCore:  -[AVAssetWriterInputHelper requestMediaDataWhenReadyOnQueue:usingBlock:]

### DIFF
--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
@@ -56,6 +56,7 @@ private:
     RetainPtr<AVAssetWriterInput> m_audioAssetWriterInput;
     RetainPtr<AVAssetWriterInput> m_videoAssetWriterInput;
     bool m_hasAddedVideoFrame { false };
+    bool m_writerStarted { false };
 
     uint8_t m_currentTrackIndex { 0 };
     uint8_t m_audioTrackIndex { 0 };


### PR DESCRIPTION
#### cbd4da15ac4adaaa94a11afc1337a0d8aa9b1f92
<pre>
Crash: com.apple.WebKit.WebContent at AVFCore:  -[AVAssetWriterInputHelper requestMediaDataWhenReadyOnQueue:usingBlock:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=302226">https://bugs.webkit.org/show_bug.cgi?id=302226</a>
<a href="https://rdar.apple.com/164271457">rdar://164271457</a>

Reviewed by Youenn Fablet and Eric Carlson.

Don&apos;t attempt to write to the AVAssetWriter when closing when an error occurred.
From the documentation &quot;Before calling this method, you must ensure that the receiver is attached to an AVAssetWriter via a prior call to -addInput: and that -startWriting has been called on the asset writer.&quot;
so also add handling to ignore any remaining samples if it&apos;s not possible to use the writer any longer.

* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
(WebCore::MediaRecorderPrivateWriterAVFObjC::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterAVFObjC::addVideoTrack):
(WebCore::MediaRecorderPrivateWriterAVFObjC::allTracksAdded):
(WebCore::MediaRecorderPrivateWriterAVFObjC::close):

Canonical link: <a href="https://commits.webkit.org/302779@main">https://commits.webkit.org/302779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8be0613936a49031cd14f119948471e9bd3fb9ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81726 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a289e6de-22cb-4475-9e8c-ad749d0de976) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99171 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01da8997-0e18-4b75-a800-7b4826d7fc56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133121 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116588 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79864 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/360fa2bc-ffa0-4145-b57a-1be315b1b461) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80848 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140061 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107694 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27380 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55173 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65692 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2231 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->