### PR TITLE
Fix ref churn and conform to safer CPP guidelines for updateWithFrame.

### DIFF
--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.h
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.h
@@ -42,7 +42,7 @@ WEBCORE_EXPORT @interface WebTextIndicatorLayer : CALayer {
 
 - (instancetype)initWithFrame:(CGRect)frame textIndicator:(RefPtr<WebCore::TextIndicator>)textIndicator margin:(CGSize)margin offset:(CGPoint)offset;
 
-- (void)updateWithFrame:(CGRect)frame textIndicator:(RefPtr<WebCore::TextIndicator>)textIndicator margin:(CGSize)margin offset:(CGPoint)offset updatingIndicator:(BOOL)updatingIndicator;
+- (void)updateWithFrame:(CGRect)frame textIndicator:(WebCore::TextIndicator*)textIndicator margin:(CGSize)margin offset:(CGPoint)offset updatingIndicator:(BOOL)updatingIndicator;
 
 - (void)present;
 - (void)hideWithCompletionHandler:(void(^)(void))completionHandler;

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
@@ -91,7 +91,7 @@ static bool indicatorWantsFadeIn(const WebCore::TextIndicator& indicator)
     return false;
 }
 
-- (void)updateWithFrame:(CGRect)frame textIndicator:(RefPtr<WebCore::TextIndicator>)textIndicator margin:(CGSize)margin offset:(CGPoint)offset updatingIndicator:(BOOL)updatingIndicator
+- (void)updateWithFrame:(CGRect)frame textIndicator:(WebCore::TextIndicator*)textIndicator margin:(CGSize)margin offset:(CGPoint)offset updatingIndicator:(BOOL)updatingIndicator
 {
     self.anchorPoint = CGPointZero;
     self.frame = frame;
@@ -210,7 +210,7 @@ static bool indicatorWantsFadeIn(const WebCore::TextIndicator& indicator)
 
     self.name = @"WebTextIndicatorLayer";
 
-    [self updateWithFrame:frame textIndicator:textIndicator margin:margin offset:offset updatingIndicator:NO];
+    [self updateWithFrame:frame textIndicator:textIndicator.get() margin:margin offset:offset updatingIndicator:NO];
 
     return self;
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1586,7 +1586,7 @@ void WebPageProxy::updateTextIndicatorFromFrame(FrameIdentifier frameID, RefPtr<
 void WebPageProxy::updateTextIndicator(RefPtr<WebCore::TextIndicator>&& textIndicator)
 {
     if (m_textIndicator && m_textIndicatorLayer)
-        [m_textIndicatorLayer updateWithFrame:m_textIndicator->textBoundingRectInRootViewCoordinates() textIndicator:textIndicator margin:CGSizeZero offset:CGPointZero updatingIndicator:YES];
+        [m_textIndicatorLayer updateWithFrame:m_textIndicator->textBoundingRectInRootViewCoordinates() textIndicator:textIndicator.get() margin:CGSizeZero offset:CGPointZero updatingIndicator:YES];
 }
 
 void WebPageProxy::clearTextIndicator()

--- a/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
@@ -163,7 +163,8 @@ void TextIndicatorWindow::updateTextIndicator(Ref<WebCore::TextIndicator>&& text
 
     NSRect frame = NSMakeRect(0, 0, [m_textIndicatorWindow frame].size.width, [m_textIndicatorWindow frame].size.height);
 
-    [m_textIndicatorLayer updateWithFrame:frame textIndicator:m_textIndicator  margin:NSMakeSize(horizontalMargin, verticalMargin) offset:fractionalTextOffset updatingIndicator:YES];
+    RefPtr<WebCore::TextIndicator> protectedTextIndicator = m_textIndicator.get();
+    [m_textIndicatorLayer updateWithFrame:frame textIndicator:protectedTextIndicator.get() margin:NSMakeSize(horizontalMargin, verticalMargin) offset:fractionalTextOffset updatingIndicator:YES];
 }
 
 void TextIndicatorWindow::closeWindow()


### PR DESCRIPTION
#### 41e5dc72070c00177587df53e0a660498e17653d
<pre>
Fix ref churn and conform to safer CPP guidelines for updateWithFrame.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302229">https://bugs.webkit.org/show_bug.cgi?id=302229</a>
<a href="https://rdar.apple.com/164373056">rdar://164373056</a>

Reviewed by Wenson Hsieh.

It was pointed out in the review for 302681@main
that we had some unneeded ref churn in passing a RefPtr
unnecessarily. Looking into updating this also found a
situation in which we needed to conform to our safer CPP
practices in passing member variables.

* Source/WebCore/page/cocoa/WebTextIndicatorLayer.h:
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm:
(-[WebTextIndicatorLayer updateWithFrame:textIndicator:margin:offset:updatingIndicator:]):
(-[WebTextIndicatorLayer initWithFrame:textIndicator:margin:offset:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::updateTextIndicator):
* Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm:
(TextIndicatorWindow::updateTextIndicator):

Canonical link: <a href="https://commits.webkit.org/302793@main">https://commits.webkit.org/302793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f2fe90e3b650c824e6df1104178fc576beace96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81784 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5a7e01d-6333-4dd7-87a5-0aad1555afce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99198 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f5ce085b-7060-491a-b072-838160511e67) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79890 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2adb8648-193a-4447-a965-3f8eb2c38410) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34747 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80886 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140107 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107722 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55217 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65730 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2160 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2364 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->