### PR TITLE
Address Safer CPP warnings in generated WebInspector code

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -41,7 +41,6 @@ heap/SlotVisitor.cpp
 heap/VerifierSlotVisitor.cpp
 heap/WeakBlock.h
 heap/WeakInlines.h
-inspector/InspectorProtocolObjects.h
 inspector/JSInjectedScriptHost.cpp
 inspector/JSJavaScriptCallFrame.cpp
 inspector/agents/InspectorDebuggerAgent.cpp

--- a/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
@@ -199,17 +199,25 @@ private:
 };""")
 
     ProtocolObjectBuilderDeclarationPrelude = (
-"""    template<int STATE>
+"""    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
+    template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<${objectType}> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*${objectType}*/JSON::Object>&& object)
+        Builder(Ref<${objectType}>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -224,19 +232,21 @@ private:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(${objectType}) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<${objectType}>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    ${objectType}() = default;
+
+public:
     /*
      * Synthetic constructor:
 ${constructorExample}
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new ${objectType}));
     }""")
 
     ProtocolObjectRuntimeCast = (

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -665,17 +665,25 @@ public:
         AllFieldsSet = (MessageSet | CodeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<Error> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*Error*/JSON::Object>&& object)
+        Builder(Ref<Error>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -702,12 +710,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(Error) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<Error>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    Error() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<Error> result = Error::create()
@@ -717,7 +727,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new Error));
     }
 };
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -579,17 +579,25 @@ public:
         AllFieldsSet = (MessageSet | CodeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<Error> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*Error*/JSON::Object>&& object)
+        Builder(Ref<Error>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -616,12 +624,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(Error) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<Error>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    Error() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<Error> result = Error::create()
@@ -631,7 +641,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new Error));
     }
 };
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
@@ -514,17 +514,25 @@ public:
         AllFieldsSet = (MessageSet | CodeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<NetworkError> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*NetworkError*/JSON::Object>&& object)
+        Builder(Ref<NetworkError>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -551,12 +559,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(NetworkError) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<NetworkError>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    NetworkError() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<NetworkError> result = NetworkError::create()
@@ -566,7 +576,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new NetworkError));
     }
 };
 #endif // TYPE-MAC

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -695,17 +695,25 @@ public:
         AllFieldsSet = (MessageSet | CodeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<Error> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*Error*/JSON::Object>&& object)
+        Builder(Ref<Error>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -732,12 +740,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(Error) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<Error>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    Error() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<Error> result = Error::create()
@@ -747,7 +757,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new Error));
     }
 };
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
@@ -451,17 +451,25 @@ public:
         AllFieldsSet = (MessageSet | CodeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<Error> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*Error*/JSON::Object>&& object)
+        Builder(Ref<Error>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -488,12 +496,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(Error) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<Error>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    Error() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<Error> result = Error::create()
@@ -503,7 +513,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new Error));
     }
 };
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-command-targetTypes-value.json-error
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-command-targetTypes-value.json-error
@@ -1,1 +1,1 @@
-ERROR: Malformed domain specification: targetTypes list for command PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, frame, worker
+ERROR: Malformed domain specification: targetTypes list for command PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, wasm-debugger, frame, worker

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-debuggableTypes-value.json-error
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-debuggableTypes-value.json-error
@@ -1,1 +1,1 @@
-ERROR: Malformed domain specification: debuggableTypes for domain WebOnly is an unsupported string. Was: "['webb']", Allowed values: itml, javascript, page, service-worker, web-page
+ERROR: Malformed domain specification: debuggableTypes for domain WebOnly is an unsupported string. Was: "['webb']", Allowed values: itml, javascript, page, service-worker, web-page, wasm-debugger

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-targetTypes-value.json-error
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-targetTypes-value.json-error
@@ -1,1 +1,1 @@
-ERROR: Malformed domain specification: targetTypes for domain PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, frame, worker
+ERROR: Malformed domain specification: targetTypes for domain PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, wasm-debugger, frame, worker

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-event-targetTypes-value.json-error
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-event-targetTypes-value.json-error
@@ -1,1 +1,1 @@
-ERROR: Malformed domain specification: targetTypes for event PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, frame, worker
+ERROR: Malformed domain specification: targetTypes for event PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, wasm-debugger, frame, worker

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
@@ -487,17 +487,25 @@ public:
         AllFieldsSet = (MessageSet | CodeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<NetworkError> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*NetworkError*/JSON::Object>&& object)
+        Builder(Ref<NetworkError>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -524,12 +532,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(NetworkError) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<NetworkError>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    NetworkError() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<NetworkError> result = NetworkError::create()
@@ -539,7 +549,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new NetworkError));
     }
 };
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
@@ -383,17 +383,25 @@ public:
         AllFieldsSet = (TypeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<KeyPath> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*KeyPath*/JSON::Object>&& object)
+        Builder(Ref<KeyPath>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -413,12 +421,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(KeyPath) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<KeyPath>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    KeyPath() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<KeyPath> result = KeyPath::create()
@@ -427,7 +437,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new KeyPath));
     }
 
     void setString(const String& in_opt_string)

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -405,17 +405,25 @@ public:
         AllFieldsSet = (MessageSet | CodeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<Error> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*Error*/JSON::Object>&& object)
+        Builder(Ref<Error>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -442,12 +450,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(Error) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<Error>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    Error() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<Error> result = Error::create()
@@ -457,7 +467,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new Error));
     }
 };
 
@@ -482,17 +492,25 @@ public:
         AllFieldsSet = 0
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<OptionalParameterBundle> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*OptionalParameterBundle*/JSON::Object>&& object)
+        Builder(Ref<OptionalParameterBundle>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -505,12 +523,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(OptionalParameterBundle) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<OptionalParameterBundle>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    OptionalParameterBundle() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<OptionalParameterBundle> result = OptionalParameterBundle::create()
@@ -518,7 +538,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new OptionalParameterBundle));
     }
 
     void setColumnNames(Ref<JSON::ArrayOf<String>>&& in_opt_columnNames)
@@ -589,17 +609,25 @@ public:
         AllFieldsSet = (ColumnNamesSet | ButtonsSet | DirectionalitySet | NotesSet | TimestampSet | ValuesSet | PayloadSet | ErrorSet | ErrorListSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<ParameterBundle> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*ParameterBundle*/JSON::Object>&& object)
+        Builder(Ref<ParameterBundle>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -675,12 +703,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(ParameterBundle) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<ParameterBundle>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    ParameterBundle() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<ParameterBundle> result = ParameterBundle::create()
@@ -697,7 +727,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new ParameterBundle));
     }
 };
 
@@ -714,17 +744,25 @@ public:
         AllFieldsSet = (IntegerSet | ArraySet | StringSet | ValueSet | ObjectSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<ObjectWithPropertyNameConflicts> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*ObjectWithPropertyNameConflicts*/JSON::Object>&& object)
+        Builder(Ref<ObjectWithPropertyNameConflicts>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -772,12 +810,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(ObjectWithPropertyNameConflicts) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<ObjectWithPropertyNameConflicts>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    ObjectWithPropertyNameConflicts() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<ObjectWithPropertyNameConflicts> result = ObjectWithPropertyNameConflicts::create()
@@ -790,7 +830,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new ObjectWithPropertyNameConflicts));
     }
 };
 
@@ -802,17 +842,25 @@ public:
         AllFieldsSet = 0
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<DummyObject> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*DummyObject*/JSON::Object>&& object)
+        Builder(Ref<DummyObject>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -825,12 +873,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(DummyObject) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<DummyObject>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    DummyObject() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<DummyObject> result = DummyObject::create()
@@ -838,7 +888,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new DummyObject));
     }
 };
 
@@ -851,17 +901,25 @@ public:
         AllFieldsSet = (NullableObjectSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<ObjectWithNullableProperties> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*ObjectWithNullableProperties*/JSON::Object>&& object)
+        Builder(Ref<ObjectWithNullableProperties>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -888,12 +946,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(ObjectWithNullableProperties) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<ObjectWithNullableProperties>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    ObjectWithNullableProperties() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<ObjectWithNullableProperties> result = ObjectWithNullableProperties::create()
@@ -902,7 +962,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new ObjectWithNullableProperties));
     }
 
     void setNullableObject(Ref<Protocol::Database::DummyObject>&& in_opt_nullableObject)
@@ -951,17 +1011,25 @@ public:
         AllFieldsSet = (DirectionalitySet | ButtonsSet | ColumnNamesSet | NotesSet | TimestampSet | ValuesSet | PayloadSet | ErrorSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<ParameterBundle> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*ParameterBundle*/JSON::Object>&& object)
+        Builder(Ref<ParameterBundle>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -1030,12 +1098,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(ParameterBundle) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<ParameterBundle>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    ParameterBundle() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<ParameterBundle> result = ParameterBundle::create()
@@ -1051,7 +1121,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new ParameterBundle));
     }
 };
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -401,17 +401,25 @@ public:
         AllFieldsSet = (StringSet | NumberSet | AnimalsSet | IdSet | TreeSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<TypeNeedingCast> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*TypeNeedingCast*/JSON::Object>&& object)
+        Builder(Ref<TypeNeedingCast>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -459,12 +467,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(TypeNeedingCast) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<TypeNeedingCast>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    TypeNeedingCast() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<TypeNeedingCast> result = TypeNeedingCast::create()
@@ -477,7 +487,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new TypeNeedingCast));
     }
 };
 
@@ -502,17 +512,25 @@ public:
         AllFieldsSet = 0
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<RecursiveObject1> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*RecursiveObject1*/JSON::Object>&& object)
+        Builder(Ref<RecursiveObject1>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -525,12 +543,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(RecursiveObject1) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<RecursiveObject1>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    RecursiveObject1() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<RecursiveObject1> result = RecursiveObject1::create()
@@ -538,7 +558,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new RecursiveObject1));
     }
 
     void setObj(Ref<Protocol::Test::RecursiveObject2>&& in_opt_obj)
@@ -554,17 +574,25 @@ public:
         AllFieldsSet = 0
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<RecursiveObject2> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*RecursiveObject2*/JSON::Object>&& object)
+        Builder(Ref<RecursiveObject2>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -577,12 +605,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(RecursiveObject2) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<RecursiveObject2>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    RecursiveObject2() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<RecursiveObject2> result = RecursiveObject2::create()
@@ -590,7 +620,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new RecursiveObject2));
     }
 
     void setObj(Ref<Protocol::Test::RecursiveObject1>&& in_opt_obj)

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
@@ -366,17 +366,25 @@ public:
         AllFieldsSet = (OneSet | TwoSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<NoOpenParameters> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*NoOpenParameters*/JSON::Object>&& object)
+        Builder(Ref<NoOpenParameters>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -403,12 +411,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(NoOpenParameters) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<NoOpenParameters>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    NoOpenParameters() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<NoOpenParameters> result = NoOpenParameters::create()
@@ -418,7 +428,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new NoOpenParameters));
     }
 };
 
@@ -431,17 +441,25 @@ public:
         AllFieldsSet = (AlphaSet | BetaSet)
     };
 
+    using JSON::ObjectBase::setBoolean;
+    using JSON::ObjectBase::setInteger;
+    using JSON::ObjectBase::setDouble;
+    using JSON::ObjectBase::setString;
+    using JSON::ObjectBase::setValue;
+    using JSON::ObjectBase::setObject;
+    using JSON::ObjectBase::setArray;
+
     template<int STATE>
     class Builder {
     private:
-        RefPtr<JSON::Object> m_result;
+        RefPtr<OpenParameters> m_result;
 
         template<int STEP> Builder<STATE | STEP>& castState()
         {
-            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+            SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Builder<STATE | STEP>*>(this);
         }
 
-        Builder(Ref</*OpenParameters*/JSON::Object>&& object)
+        Builder(Ref<OpenParameters>&& object)
             : m_result(WTFMove(object))
         {
             static_assert(STATE == NoFieldsSet, "builder created in non init state");
@@ -468,12 +486,14 @@ public:
             static_assert(STATE == AllFieldsSet, "result is not ready");
             static_assert(sizeof(OpenParameters) == sizeof(JSON::Object), "cannot cast");
 
-            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
-            auto result = WTFMove(*reinterpret_cast<Ref<OpenParameters>*>(&jsonResult));
-            return result;
+            return m_result.releaseNonNull();
         }
     };
 
+private:
+    OpenParameters() = default;
+
+public:
     /*
      * Synthetic constructor:
      * Ref<OpenParameters> result = OpenParameters::create()
@@ -483,7 +503,7 @@ public:
      */
     static Builder<NoFieldsSet> create()
     {
-        return Builder<NoFieldsSet>(JSON::Object::create());
+        return Builder<NoFieldsSet>(adoptRef(*new OpenParameters));
     }
 };
 

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -225,7 +225,7 @@ protected:
     WTF_EXPORT_PRIVATE bool getValue(const String& name, RefPtr<Value>& output) const;
 
 protected:
-    ObjectBase();
+    WTF_EXPORT_PRIVATE ObjectBase();
 
 private:
     size_t memoryCostImpl() const;

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,4 +1,3 @@
-AutomationProtocolObjects.h
 [ iOS ] NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
 [ iOS ] Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 [ iOS ] UIProcess/API/ios/WKWebViewIOS.mm
@@ -13,5 +12,4 @@ AutomationProtocolObjects.h
 [ iOS ] UIProcess/ios/forms/WKFormPeripheralBase.mm
 [ iOS ] UIProcess/ios/forms/WKFormSelectPicker.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
-WebDriverBidiProtocolObjects.h
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm


### PR DESCRIPTION
#### 5381af5edfeb548ca2df36b4a4672b1d7838e925
<pre>
Address Safer CPP warnings in generated WebInspector code
<a href="https://bugs.webkit.org/show_bug.cgi?id=302230">https://bugs.webkit.org/show_bug.cgi?id=302230</a>

Reviewed by Darin Adler.

Address Safer CPP warnings in generated WebInspector code. In particular, this
gets rid of a reinterpret_cast in `Builder&lt;T&gt;::release()`.

* Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-command-targetTypes-value.json-error:
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-debuggableTypes-value.json-error:
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-targetTypes-value.json-error:
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-event-targetTypes-value.json-error:
* Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result:
* Source/WTF/wtf/JSONValues.h:
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/302815@main">https://commits.webkit.org/302815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c69feab338bab19575001daea4aa2c0bd993f5f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130211 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81769 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/91931a74-f374-479a-893f-5b76473a9ac1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2372 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99200 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/event-timing/timingconditions.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67047 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c43fe12-dc02-4f81-aad7-c26df35554af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133158 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79891 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6bd5d539-07c8-444a-87af-b4ea0e705053) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34748 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80885 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122214 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140106 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128663 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107723 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107611 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27410 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31413 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55216 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65729 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161678 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2159 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40320 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2268 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->