### PR TITLE
Address Safer CPP warnings in RunLoopCF.cpp & StringConcatenateCF.h

### DIFF
--- a/Source/WTF/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,1 +1,0 @@
-usr/local/include/wtf/text/cf/StringConcatenateCF.h

--- a/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,2 +1,0 @@
-usr/local/include/wtf/text/cf/StringConcatenateCF.h
-wtf/cf/RunLoopCF.cpp

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -50,7 +50,9 @@ public:
 #endif
 
     CFRunLoopRef runLoop() const { return m_runLoop.get(); }
+    RetainPtr<CFRunLoopRef> protectedRunLoop() const { return m_runLoop; }
     CFStringRef mode() const { return m_mode.get(); }
+    RetainPtr<CFStringRef> protectedMode() const { return m_mode; }
 
     WTF_EXPORT_PRIVATE bool operator==(const SchedulePair& other) const;
 

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -96,7 +96,7 @@ void RunLoop::dispatch(const SchedulePairHashSet& schedulePairs, Function<void()
     }, function.leak());
 
     for (auto& schedulePair : schedulePairs)
-        CFRunLoopAddTimer(schedulePair->runLoop(), timer.get(), schedulePair->mode());
+        CFRunLoopAddTimer(schedulePair->protectedRunLoop().get(), timer.get(), schedulePair->protectedMode().get());
 }
 
 // RunLoop::Timer

--- a/Source/WTF/wtf/text/cf/StringConcatenateCF.h
+++ b/Source/WTF/wtf/text/cf/StringConcatenateCF.h
@@ -36,12 +36,12 @@ namespace WTF {
 template<> class StringTypeAdapter<CFStringRef> {
 public:
     StringTypeAdapter(CFStringRef);
-    unsigned length() const { return m_string ? CFStringGetLength(m_string) : 0; }
-    bool is8Bit() const { return !m_string || CFStringGetCStringPtr(m_string, kCFStringEncodingISOLatin1); }
+    unsigned length() const { return m_string ? CFStringGetLength(m_string.get()) : 0; }
+    bool is8Bit() const { return !m_string || CFStringGetCStringPtr(m_string.get(), kCFStringEncodingISOLatin1); }
     template<typename CharacterType> void writeTo(std::span<CharacterType>) const;
 
 private:
-    CFStringRef m_string;
+    const RetainPtr<CFStringRef> m_string;
 };
 
 inline StringTypeAdapter<CFStringRef>::StringTypeAdapter(CFStringRef string)
@@ -52,13 +52,13 @@ inline StringTypeAdapter<CFStringRef>::StringTypeAdapter(CFStringRef string)
 template<> inline void StringTypeAdapter<CFStringRef>::writeTo<Latin1Character>(std::span<Latin1Character> destination) const
 {
     if (m_string)
-        memcpySpan(destination, CFStringGetLatin1CStringSpan(m_string));
+        memcpySpan(destination, CFStringGetLatin1CStringSpan(m_string.get()));
 }
 
 template<> inline void StringTypeAdapter<CFStringRef>::writeTo<char16_t>(std::span<char16_t> destination) const
 {
     if (m_string)
-        CFStringGetCharacters(m_string, CFRangeMake(0, CFStringGetLength(m_string)), reinterpret_cast<UniChar*>(destination.data()));
+        CFStringGetCharacters(m_string.get(), CFRangeMake(0, CFStringGetLength(m_string.get())), reinterpret_cast<UniChar*>(destination.data()));
 }
 
 #ifdef __OBJC__


### PR DESCRIPTION
#### 1874bb22ee56c0592e36c262fdbb209072be166d
<pre>
Address Safer CPP warnings in RunLoopCF.cpp &amp; StringConcatenateCF.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302231">https://bugs.webkit.org/show_bug.cgi?id=302231</a>

Reviewed by Darin Adler.

* Source/WTF/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WTF/wtf/SchedulePair.h:
(WTF::SchedulePair::protectedRunLoop const):
(WTF::SchedulePair::protectedMode const):
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::RunLoop::dispatch):
* Source/WTF/wtf/text/cf/StringConcatenateCF.h:
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::length const):
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::is8Bit const):
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::writeTo&lt;Latin1Character&gt; const):
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::writeTo&lt;char16_t&gt; const):

Canonical link: <a href="https://commits.webkit.org/302782@main">https://commits.webkit.org/302782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d896bd2533c9db59fac490b256c76c40b460d36f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81736 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/376765c4-138a-429a-a7ca-ddb483efbdd9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67020 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4d67842-9726-4554-b42c-3a7f05c9108d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133130 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79868 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dee166bc-2c24-4637-95a9-6dbb525d5aa8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80857 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122186 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140070 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128635 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2093 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107699 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27382 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55183 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65701 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161650 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2131 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40307 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2240 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->