### PR TITLE
Web Inspector: Uncaught Exception: TypeError: snapshot.element.toDataURL is not a function. (In 'snapshot.element.toDataURL()', 'snapshot.element.toDataURL' is undefined)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Recording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Recording.js
@@ -551,22 +551,27 @@ WI.Recording = class Recording extends WI.Object
     createContext()
     {
         let createCanvasContext = (type) => {
-            let canvas = document.createElement("canvas");
+            let element = document.createElement("canvas");
             if ("width" in this._initialState.attributes)
-                canvas.width = this._initialState.attributes.width;
+                element.width = this._initialState.attributes.width;
             if ("height" in this._initialState.attributes)
-                canvas.height = this._initialState.attributes.height;
-            return canvas.getContext(type, ...this._initialState.parameters);
+                element.height = this._initialState.attributes.height;
+            return {
+                context: element.getContext(type, ...this._initialState.parameters),
+                element,
+            };
         };
         let createOffscreenCanvasContext = (type) => {
-            let width = 1;
-            let height = 1;
+            let element = document.createElement("canvas");
             if ("width" in this._initialState.attributes)
-                width = this._initialState.attributes.width;
+                element.width = this._initialState.attributes.width;
             if ("height" in this._initialState.attributes)
-                height = this._initialState.attributes.height;
-            let canvas = new OffscreenCanvas(width, height);
-            return canvas.getContext(type, ...this._initialState.parameters);
+                element.height = this._initialState.attributes.height;
+            let canvas = element.transferControlToOffscreen();
+            return {
+                context: canvas.getContext(type, ...this._initialState.parameters),
+                element,
+            };
         };
 
         switch (this._type) {
@@ -888,7 +893,7 @@ WI.Recording = class Recording extends WI.Object
     async _process()
     {
         if (!this._processContext) {
-            this._processContext = this.createContext();
+            this._processContext = this.createContext().context;
 
             if (this.isCanvas2D) {
                 let initialContent = await WI.ImageUtilities.promisifyLoad(this._initialState.content);

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingContentView.js
@@ -268,11 +268,13 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
             let saveCount = 0;
             snapshot.context.save();
 
+            let canvas = snapshot.context.canvas;
+
             for (let attribute in snapshot.attributes)
-                snapshot.element[attribute] = snapshot.attributes[attribute];
+                canvas[attribute] = snapshot.attributes[attribute];
 
             if (snapshot.content) {
-                snapshot.context.clearRect(0, 0, snapshot.element.width, snapshot.element.height);
+                snapshot.context.clearRect(0, 0, canvas.width, canvas.height);
                 snapshot.context.drawImage(snapshot.content, 0, 0);
             }
 
@@ -304,14 +306,14 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
                     this._pathContext = pathCanvas.getContext("2d");
                 }
 
-                this._pathContext.canvas.width = snapshot.element.width;
-                this._pathContext.canvas.height = snapshot.element.height;
-                this._pathContext.clearRect(0, 0, snapshot.element.width, snapshot.element.height);
+                this._pathContext.canvas.width = canvas.width;
+                this._pathContext.canvas.height = canvas.height;
+                this._pathContext.clearRect(0, 0, canvas.width, canvas.height);
 
                 this._pathContext.save();
 
                 this._pathContext.fillStyle = "hsla(0, 0%, 100%, 0.75)";
-                this._pathContext.fillRect(0, 0, snapshot.element.width, snapshot.element.height);
+                this._pathContext.fillRect(0, 0, canvas.width, canvas.height);
 
                 function actionModifiesPath(action) {
                     switch (action.name) {
@@ -377,8 +379,9 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
             while (snapshot.index && actions[snapshot.index].name !== "beginPath")
                 --snapshot.index;
 
-            snapshot.context = this.representedObject.createContext();
-            snapshot.element = snapshot.context.canvas;
+            let {context, element} = this.representedObject.createContext();
+            snapshot.context = context;
+            snapshot.element = element;
 
             let lastSnapshotIndex = snapshotIndex;
             while (--lastSnapshotIndex >= 0) {


### PR DESCRIPTION
#### 9b02b96117db60c61c40bfa2e42e011a6e82f5f3
<pre>
Web Inspector: Uncaught Exception: TypeError: snapshot.element.toDataURL is not a function. (In &apos;snapshot.element.toDataURL()&apos;, &apos;snapshot.element.toDataURL&apos; is undefined)
<a href="https://bugs.webkit.org/show_bug.cgi?id=302234">https://bugs.webkit.org/show_bug.cgi?id=302234</a>

Reviewed by BJ Burg.

`OffscreenCanvas` doesn&apos;t have a `toDataURL` method (nor does it have a `toBlob`, though there is a close-but-not-identical `convertToBlob`).

Additionally, in order to preview the `OffscreenCanvas` we need to either transfer to an `ImageBitmap` (which means we can&apos;t reuse the state of the `OffscreenCanvas` later on) or have it be created from a `&lt;canvas&gt;` (which already works).

* Source/WebInspectorUI/UserInterface/Models/Recording.js:
(WI.Recording.prototype.createContext.createCanvasContext):
(WI.Recording.prototype.createContext.createOffscreenCanvasContext):
(WI.Recording.prototype.async _process):
* Source/WebInspectorUI/UserInterface/Views/RecordingContentView.js:
(WI.RecordingContentView.prototype._generateContentCanvas2D):

Canonical link: <a href="https://commits.webkit.org/303229@main">https://commits.webkit.org/303229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dc95f8f3f8147f3cde1c575746777ba1a385781

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81771 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99180 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1748 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107703 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107582 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1785 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55190 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2320 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2137 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65707 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->