### PR TITLE
[JSC] Add fast path for `Array.from(arguments)`

### DIFF
--- a/JSTests/microbenchmarks/array-from-direct-arguments.js
+++ b/JSTests/microbenchmarks/array-from-direct-arguments.js
@@ -1,0 +1,9 @@
+function test() {
+  const args = Array.from(arguments);
+  return args;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+  test(i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6);
+}

--- a/JSTests/microbenchmarks/array-from-scoped-arguments.js
+++ b/JSTests/microbenchmarks/array-from-scoped-arguments.js
@@ -1,0 +1,10 @@
+function test(a)
+{
+    (function() { return a; })();
+    const args = Array.from(arguments);
+    return args;
+}
+
+for (let i = 0; i < 1e5; i++) {
+  test(i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6);
+}

--- a/JSTests/stress/array-from-direct-arguments.js
+++ b/JSTests/stress/array-from-direct-arguments.js
@@ -1,0 +1,48 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test() {
+  return Array.from(arguments);
+}
+noInline(test);
+
+
+// contiguous
+{
+  const value1 = { value: 1 };
+  const value2 = { value: 2 };
+  const value3 = { value: 3 };
+  const value4 = { value: 4 };
+  const value5 = { value: 5 };
+  const array = test(value1, value2, value3, value4, value5);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], value1);
+  shouldBe(array[1], value2);
+  shouldBe(array[2], value3);
+  shouldBe(array[3], value4);
+  shouldBe(array[4], value5);
+}
+
+// double
+{
+  const array = test(1.1, 2.1, 3.1, 4.1, 5.1);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1.1);
+  shouldBe(array[1], 2.1);
+  shouldBe(array[2], 3.1);
+  shouldBe(array[3], 4.1);
+  shouldBe(array[4], 5.1);
+}
+
+// int32
+{
+  const array = test(1, 2, 3, 4, 5);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3);
+  shouldBe(array[3], 4);
+  shouldBe(array[4], 5);
+}

--- a/JSTests/stress/array-from-scoped-arguments.js
+++ b/JSTests/stress/array-from-scoped-arguments.js
@@ -1,0 +1,49 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(x) {
+  (function () { return x; })();
+  return Array.from(arguments);
+}
+noInline(test);
+
+
+// contiguous
+{
+  const value1 = { value: 1 };
+  const value2 = { value: 2 };
+  const value3 = { value: 3 };
+  const value4 = { value: 4 };
+  const value5 = { value: 5 };
+  const array = test(value1, value2, value3, value4, value5);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], value1);
+  shouldBe(array[1], value2);
+  shouldBe(array[2], value3);
+  shouldBe(array[3], value4);
+  shouldBe(array[4], value5);
+}
+
+// double
+{
+  const array = test(1.1, 2.1, 3.1, 4.1, 5.1);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1.1);
+  shouldBe(array[1], 2.1);
+  shouldBe(array[2], 3.1);
+  shouldBe(array[3], 4.1);
+  shouldBe(array[4], 5.1);
+}
+
+// int32
+{
+  const array = test(1, 2, 3, 4, 5);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3);
+  shouldBe(array[3], 4);
+  shouldBe(array[4], 5);
+}

--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -41,7 +41,7 @@ function from(items /*, mapFn, thisArg */)
     var arrayLike = @toObject(items, "Array.from requires an array-like object - not null or undefined");
 
     if (mapFn === @undefined) {
-        var fastResult = @arrayFromFastFillWithUndefined(this, arrayLike);
+        var fastResult = @arrayFromFastWithoutMapFn(this, arrayLike);
         if (fastResult)
             return fastResult;
     }

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -212,7 +212,7 @@ namespace JSC {
     macro(sentinelString) \
     macro(createRemoteFunction) \
     macro(isRemoteFunction) \
-    macro(arrayFromFastFillWithUndefined) \
+    macro(arrayFromFastWithoutMapFn) \
     macro(jsonParse) \
     macro(jsonStringify) \
     macro(String) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -144,7 +144,7 @@ class JSGlobalObject;
     v(sentinelString, nullptr) \
     v(createRemoteFunction, nullptr) \
     v(isRemoteFunction, nullptr) \
-    v(arrayFromFastFillWithUndefined, nullptr) \
+    v(arrayFromFastWithoutMapFn, nullptr) \
     v(jsonParse, nullptr) \
     v(jsonStringify, nullptr) \
     v(String, nullptr) \

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.h
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.h
@@ -56,6 +56,7 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(ArrayConstructor, InternalFunction);
 
 JSArray* constructArrayWithSizeQuirk(JSGlobalObject*, ArrayAllocationProfile*, JSValue length, JSValue prototype = JSValue());
 
+JSC_DECLARE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn);
 JSC_DECLARE_HOST_FUNCTION(arrayConstructorPrivateFuncIsArraySlow);
 bool isArraySlow(JSGlobalObject*, ProxyObject* argument);
 

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1577,27 +1577,6 @@ static JSArray* concatAppendArray(JSGlobalObject* globalObject, VM& vm, JSArray*
     return JSArray::createWithButterfly(vm, nullptr, resultStructure, butterfly);
 }
 
-JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithUndefined, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue constructor = callFrame->uncheckedArgument(0);
-    if (constructor != globalObject->arrayConstructor() && constructor.isObject()) [[unlikely]]
-        return JSValue::encode(jsUndefined());
-
-    JSValue arrayValue = callFrame->uncheckedArgument(1);
-    if (!isJSArray(arrayValue)) [[unlikely]]
-        return JSValue::encode(jsUndefined());
-
-    JSArray* array = tryCloneArrayFromFast<ArrayFillMode::Undefined>(globalObject, arrayValue);
-    RETURN_IF_EXCEPTION(scope, { });
-    if (array)
-        return JSValue::encode(array);
-
-    return JSValue::encode(jsUndefined());
-}
-
 JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.h
@@ -48,6 +48,5 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(ArrayPrototype, ArrayPrototype::Base);
 
 JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncToString);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncValues);
-JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithUndefined);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -35,6 +35,7 @@
 #include "AggregateError.h"
 #include "AggregateErrorConstructorInlines.h"
 #include "AggregateErrorPrototypeInlines.h"
+#include "ArrayConstructor.h"
 #include "ArrayConstructorInlines.h"
 #include "ArrayIteratorPrototypeInlines.h"
 #include "ArrayPrototypeInlines.h"
@@ -1984,8 +1985,8 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayFromFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "typedArrayViewTypedArrayFromFast"_s, typedArrayViewPrivateFuncTypedArrayFromFast, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arrayFromFastFillWithUndefined)].initLater([] (const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "arrayFromFastFillWithUndefined"_s, arrayProtoPrivateFuncFromFastFillWithUndefined, ImplementationVisibility::Private));
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arrayFromFastWithoutMapFn)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "arrayFromFastWithoutMapFn"_s, arrayConstructorPrivateFromFastWithoutMapFn, ImplementationVisibility::Private));
     });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isDetached)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsDetached"_s, typedArrayViewPrivateFuncIsDetached, ImplementationVisibility::Private));


### PR DESCRIPTION
#### 12bbbd4b4f3c62309dd8bbd5acd81e8e46b96aab
<pre>
[JSC] Add fast path for `Array.from(arguments)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302236">https://bugs.webkit.org/show_bug.cgi?id=302236</a>

Reviewed by Yusuke Suzuki.

This patch changes to add fast path for `Array.from(arguments)`.

note: This patch only supports `DirectArguments` and `ScopedArguments`.
I&apos;ll add support for `ClonedArguments` in next patch.

                                        TipOfTree                  Patched

array-from-scoped-arguments           9.1958+-0.1530     ^      3.6832+-0.2937        ^ definitely 2.4967x faster
array-from-direct-arguments           8.2003+-0.1391     ^      2.8755+-0.0549        ^ definitely 2.8518x faster

Test: JSTests/microbenchmarks/array-from-direct-arguments.js

* JSTests/microbenchmarks/array-from-direct-arguments.js: Added.
(test):
* JSTests/microbenchmarks/array-from-scoped-arguments.js: Added.
(test):
* JSTests/stress/array-from-direct-arguments.js: Added.
(shouldBe):
(test):
(noInline):
* JSTests/stress/array-from-scoped-arguments.js: Added.
(shouldBe):
(test):
(noInline):
* Source/JavaScriptCore/builtins/ArrayConstructor.js:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::tryCreateArrayFromArguments):
(JSC::tryCreateArrayFromScopedArguments):
(JSC::tryCreateArrayFromDirectArguments):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayConstructor.h:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
* Source/JavaScriptCore/runtime/ArrayPrototype.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/302891@main">https://commits.webkit.org/302891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ad81ad721876a7c22b1bfad012ee7b8502126b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81793 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99204 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67062 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79895 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34751 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80896 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122225 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140117 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128674 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2283 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2123 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107615 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55229 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65740 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161689 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2170 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40322 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->