### PR TITLE
[WebDriver][BiDi] Process incoming frame handles before calling WebAutomationSession

### DIFF
--- a/Source/WebKit/Shared/Automation/WebAutomationSessionMacros.h
+++ b/Source/WebKit/Shared/Automation/WebAutomationSessionMacros.h
@@ -40,6 +40,7 @@
 
 #define AUTOMATION_COMMAND_ERROR_WITH_NAME(errorName) AutomationCommandError(Inspector::Protocol::Automation::ErrorMessage::errorName)
 #define AUTOMATION_COMMAND_ERROR_WITH_MESSAGE(errorString) AutomationCommandError(VALIDATED_ERROR_MESSAGE(errorString))
+#define AUTOMATION_COMMAND_ERROR_WITH_NAME_AND_MESSAGE(errorName, errorString) AutomationCommandError(Inspector::Protocol::Automation::ErrorMessage::errorName, errorString)
 
 // Convenience macros for filling in the error string of synchronous commands in bailout branches.
 #define SYNC_FAIL_WITH_PREDEFINED_ERROR(errorName) \
@@ -73,6 +74,15 @@ do { \
         return; \
     } \
 } while (false)
+
+#define ASYNC_FAIL_IF_UNEXPECTED_RESULT(expected) \
+do { \
+    if (!expected) { \
+        callback(makeUnexpected(expected.error().toProtocolString())); \
+        return; \
+    } \
+} while (false)
+
 
 
 #define ASYNC_FAIL_WITH_PREDEFINED_ERROR(errorName) \

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -112,6 +112,8 @@ public:
 
 using AutomationCompletionHandler = WTF::CompletionHandler<void(std::optional<AutomationCommandError>)>;
 
+using PageAndFrameHandle = std::pair<Inspector::Protocol::Automation::BrowsingContextHandle, Inspector::Protocol::Automation::FrameHandle>;
+
 class WebAutomationSession final : public API::ObjectImpl<API::Object::Type::AutomationSession>
     , public IPC::MessageReceiver
     , public Inspector::AutomationBackendDispatcherHandler
@@ -311,6 +313,8 @@ public:
     String effectiveHandleForWebFrameProxy(const WebFrameProxy&);
     String handleForWebFrameID(std::optional<WebCore::FrameIdentifier>);
     String handleForWebPageProxy(const WebPageProxy&);
+
+    Expected<PageAndFrameHandle, AutomationCommandError> extractBrowsingContextHandles(const String&);
 
 private:
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);


### PR DESCRIPTION
#### b65e8b5c00089d016853e8d6583ec69873988665
<pre>
[WebDriver][BiDi] Process incoming frame handles before calling WebAutomationSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=301932">https://bugs.webkit.org/show_bug.cgi?id=301932</a>

Reviewed by BJ Burg.

Some WebDriver-BiDi commands allow targeting specific browsing contexts,
including child ones (e.g. frames). But, at least for
`script.callFunction` and `script.evaluate`, currently we require the
incoming context to be a top level context.

This commit ensures we translate the incoming handle to the browsing
context handle / frame handle pair that `evaluateJavaScriptFunction`
expects, so the code gets executed on the proper child context.

This is also required by a test on subscribing to child contexts.

Another included fix is that the new spec returns FrameNotFound when it
fails to get a navigable, instead of the current WindowNotFound.

* Source/WebKit/Shared/Automation/WebAutomationSessionMacros.h:
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::callFunction):
(WebKit::BidiScriptAgent::evaluate):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::extractBrowsingContextHandles):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:

Canonical link: <a href="https://commits.webkit.org/303294@main">https://commits.webkit.org/303294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/919abe103dc070c960c8122a050e49e3955ba338

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100024 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2521 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/240 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81971 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111121 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141221 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3351 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108487 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2529 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56496 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3413 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32270 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66821 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->