### PR TITLE
REGRESSION (301503@main?): Web process sometimes crashes under WebCore::stringForRange when copying Live Text

### DIFF
--- a/Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm
+++ b/Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm
@@ -55,8 +55,13 @@ RetainPtr<NSAttributedString> stringForRange(const TextRecognitionResult& result
     if (!result.imageAnalysisData)
         return nil;
 
-    auto everything = result.imageAnalysisData->nsAttributedString();
-    return [everything attributedSubstringFromRange:range];
+    RetainPtr wholeString = result.imageAnalysisData->nsAttributedString();
+    NSUInteger stringLength = [wholeString length];
+    if (range.location >= stringLength)
+        return nil;
+
+    NSUInteger clampedLength = std::min<NSUInteger>(range.length, stringLength - range.location);
+    return [wholeString attributedSubstringFromRange:NSMakeRange(range.location, clampedLength)];
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)


### PR DESCRIPTION
#### e9564da9c8d9a1b545c7f2164dff0d7f86ddaefd
<pre>
REGRESSION (301503@main?): Web process sometimes crashes under WebCore::stringForRange when copying Live Text
<a href="https://bugs.webkit.org/show_bug.cgi?id=302243">https://bugs.webkit.org/show_bug.cgi?id=302243</a>
<a href="https://rdar.apple.com/164306409">rdar://164306409</a>

Reviewed by Aditya Keerthi.

Add a missing bounds check to prevent the call to `-attributedSubstringFromRange:` from running past
the end of the attributed string. This is a speculative fix, since I was not able to reproduce the
crash locally.

* Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm:
(WebCore::stringForRange):

Canonical link: <a href="https://commits.webkit.org/302805@main">https://commits.webkit.org/302805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dce051d588b76b2f6144582bbc39062b257439ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81775 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c5b1521e-0737-4148-ba81-0fdeb1d8da41) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99202 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67055 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/51a67baf-c221-472e-b69e-07dd8150ce16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116621 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79893 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f46cbc93-6769-4f67-8eaa-b72919886378) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140111 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107725 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107613 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55221 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65734 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2164 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2368 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->