### PR TITLE
[WPE] Use WebKitImage to implement web view snapshot

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -35,6 +35,9 @@
 #include <@API_INCLUDE_PREFIX@/WebKitFindController.h>
 #include <@API_INCLUDE_PREFIX@/WebKitFormSubmissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitHitTestResult.h>
+#if !PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitImage.h>
+#endif
 #include <@API_INCLUDE_PREFIX@/WebKitInputMethodContext.h>
 #if !ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitJavascriptResult.h>
@@ -186,7 +189,6 @@ typedef enum {
     WEBKIT_INSECURE_CONTENT_DISPLAYED
 } WebKitInsecureContentEvent;
 
-#if PLATFORM(GTK)
 /**
  * WebKitSnapshotOptions:
  * @WEBKIT_SNAPSHOT_OPTIONS_NONE: Do not include any special options.
@@ -217,7 +219,6 @@ typedef enum {
   WEBKIT_SNAPSHOT_REGION_VISIBLE = 0,
   WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT,
 } WebKitSnapshotRegion;
-#endif
 
 /**
  * WebKitWebProcessTerminationReason:
@@ -777,7 +778,6 @@ webkit_web_view_get_tls_info                         (WebKitWebView             
                                                       GTlsCertificate          **certificate,
                                                       GTlsCertificateFlags      *errors);
 
-#if PLATFORM(GTK)
 WEBKIT_API void
 webkit_web_view_get_snapshot                         (WebKitWebView             *web_view,
                                                       WebKitSnapshotRegion       region,
@@ -785,6 +785,7 @@ webkit_web_view_get_snapshot                         (WebKitWebView             
                                                       GCancellable              *cancellable,
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
+#if PLATFORM(GTK)
 #if USE(GTK4)
 WEBKIT_API GdkTexture *
 webkit_web_view_get_snapshot_finish                  (WebKitWebView             *web_view,
@@ -796,6 +797,11 @@ webkit_web_view_get_snapshot_finish                  (WebKitWebView             
                                                       GAsyncResult              *result,
                                                       GError                   **error);
 #endif
+#else
+WEBKIT_API WebKitImage *
+webkit_web_view_get_snapshot_finish                  (WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                   **error);
 #endif
 
 WEBKIT_API WebKitUserContentManager *


### PR DESCRIPTION
#### 7b65cbcb4ba60ded37c0797ecab148f54ed2c2ee
<pre>
[WPE] Use WebKitImage to implement web view snapshot
<a href="https://bugs.webkit.org/show_bug.cgi?id=302257">https://bugs.webkit.org/show_bug.cgi?id=302257</a>

Reviewed by Adrian Perez de Castro and Patrick Griffis.

This uses the new WebKitImage when available to implement WebView
snapshots, and enables tests that were previously only running for GTK.

Co-Authored-By: Adrian Perez de Castro &lt;aperez@igalia.com&gt;

Tests: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFindController.cpp
       Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFindController.cpp:
(testFindControllerHide):
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(testWebViewSnapshot):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/303449@main">https://commits.webkit.org/303449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff5dd0b91b332462d23a0f175caf655485e14b02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68324 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3109 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142243 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109336 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4325 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3695 "Found 3 new test failures: fast/webgpu/present-without-compute-pipeline.html http/tests/webgpu/webgpu/api/operation/sampling/anisotropy.html imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109510 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3222 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114576 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57487 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4298 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4129 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67744 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->