### PR TITLE
[WebXR] XRSession::environmentBlendMode always returns "opaque"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrSession_environmentBlendMode.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrSession_environmentBlendMode.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Tests environmentBlendMode for an AR device - webgl
+PASS Tests environmentBlendMode for an AR device - webgl2
+PASS Tests environmentBlendMode for a VR device - webgl
+PASS Tests environmentBlendMode for a VR device - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrSession_environmentBlendMode.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrSession_environmentBlendMode.https.html
@@ -5,19 +5,32 @@
   <script src="../resources/webxr_util.js"></script>
   <script src="../resources/webxr_test_constants.js"></script>
   <script>
+    let testARFunction = (testSession) => new Promise((resolve) => {
+      function onFrame(time, xrFrame) {
+        assert_not_equals(testSession.environmentBlendMode, "opaque");
+        assert_in_array(testSession.environmentBlendMode, ["alpha-blend", "additive"]);
+        resolve();
+      }
+      testSession.requestAnimationFrame(onFrame);
+    });
+
+    let testVRFunction = (testSession) => new Promise((resolve) => {
+      function onFrame(time, xrFrame) {
+        assert_not_equals(testSession.environmentBlendMode, "alpha-blend");
+        assert_in_array(testSession.environmentBlendMode, ["opaque", "additive"]);
+        resolve();
+      }
+      testSession.requestAnimationFrame(onFrame);
+    });
+
     xr_session_promise_test(
       "Tests environmentBlendMode for an AR device",
-      (session) => {
-        assert_not_equals(session.environmentBlendMode, "opaque");
-        assert_in_array(session.environmentBlendMode, ["alpha-blend", "additive"]);
-      }, IMMERSIVE_AR_DEVICE, 'immersive-ar', {});
-
+      testARFunction, IMMERSIVE_AR_DEVICE, 'immersive-ar');
 
     xr_session_promise_test(
       "Tests environmentBlendMode for a VR device",
-      (session) => {
-        assert_not_equals(session.environmentBlendMode, "alpha-blend");
-        assert_in_array(session.environmentBlendMode, ["opaque", "additive"]);
-      }, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', {});
+      testVRFunction, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr');
+
 </script>
 </body>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2867,6 +2867,8 @@ imported/w3c/web-platform-tests/webxr/hand-input/ [ Pass ]
 
 imported/w3c/web-platform-tests/webxr/hit-test [ Pass ]
 
+imported/w3c/web-platform-tests/webxr/ar-module/xrSession_environmentBlendMode.https.html [ Pass ]
+
 http/wpt/webxr [ Pass ]
 webxr [ Pass ]
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -106,7 +106,7 @@ WebXRSession::~WebXRSession()
 
 XREnvironmentBlendMode WebXRSession::environmentBlendMode() const
 {
-    return m_environmentBlendMode;
+    return m_frameData.environmentBlendMode;
 }
 
 XRInteractionMode WebXRSession::interactionMode() const

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -161,7 +161,6 @@ private:
     void applyPendingRenderState();
     void minimalUpdateRendering();
 
-    XREnvironmentBlendMode m_environmentBlendMode { XREnvironmentBlendMode::Opaque };
     XRInteractionMode m_interactionMode { XRInteractionMode::WorldSpace };
     XRVisibilityState m_visibilityState { XRVisibilityState::Visible };
     const UniqueRef<WebXRInputSourceArray> m_inputSources;

--- a/Source/WebCore/Modules/webxr/XREnvironmentBlendMode.h
+++ b/Source/WebCore/Modules/webxr/XREnvironmentBlendMode.h
@@ -27,13 +27,11 @@
 
 #if ENABLE(WEBXR)
 
+#include "PlatformXR.h"
+
 namespace WebCore {
 
-enum class XREnvironmentBlendMode {
-    Opaque,
-    Additive,
-    AlphaBlend
-};
+using XREnvironmentBlendMode = PlatformXR::XREnvironmentBlendMode;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webxr/XREnvironmentBlendMode.idl
+++ b/Source/WebCore/Modules/webxr/XREnvironmentBlendMode.idl
@@ -29,6 +29,6 @@
     EnabledBySetting=WebXREnabled&WebXRAugmentedRealityModuleEnabled,
 ] enum XREnvironmentBlendMode {
     "opaque",
-    "additive",
-    "alpha-blend"
+    "alpha-blend",
+    "additive"
 };

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -130,6 +130,12 @@ enum class XRTargetRayMode : uint8_t {
     TransientPointer,
 };
 
+enum class XREnvironmentBlendMode : uint8_t {
+    Opaque,
+    AlphaBlend,
+    Additive
+};
+
 // https://immersive-web.github.io/webxr/#feature-descriptor
 enum class SessionFeature : uint8_t {
     ReferenceSpaceTypeViewer,
@@ -437,6 +443,7 @@ struct FrameData {
     HashMap<TransientInputHitTestSource, Vector<TransientInputHitTestResult>> transientInputHitTestResults;
 #endif
     Vector<InputSource> inputSources;
+    XREnvironmentBlendMode environmentBlendMode { XREnvironmentBlendMode::Opaque };
 
     FrameData copy() const;
 };
@@ -555,6 +562,7 @@ inline FrameData FrameData::copy() const
     frameData.stageParameters = stageParameters;
     frameData.views = views;
     frameData.inputSources = inputSources;
+    frameData.environmentBlendMode = environmentBlendMode;
     return frameData;
 }
 

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -110,7 +110,7 @@ WebCore::IntSize SimulatedXRDevice::recommendedResolution(PlatformXR::SessionMod
     return IntSize(32, 32);
 }
 
-void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&)
+void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&)
 {
     if (m_trackingAndRenderingClient) {
         // WebXR FakeDevice waits for simulateInputConnection calls to add input sources-
@@ -125,6 +125,7 @@ void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOr
                 m_trackingAndRenderingClient->sessionDidInitializeInputSources({ });
         });
     }
+    m_frameData.environmentBlendMode = (sessionMode == PlatformXR::SessionMode::ImmersiveAr) ? PlatformXR::XREnvironmentBlendMode::AlphaBlend : PlatformXR::XREnvironmentBlendMode::Opaque;
 }
 
 void SimulatedXRDevice::shutDownTrackingAndRendering()

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -62,6 +62,12 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
     TransientPointer,
 };
 
+enum class PlatformXR::XREnvironmentBlendMode : uint8_t {
+    Opaque,
+    AlphaBlend,
+    Additive,
+};
+
 [Nested] struct PlatformXR::DepthRange {
     float near;
     float far;
@@ -238,6 +244,7 @@ header: <WebCore/PlatformXR.h>
     HashMap<PlatformXR::TransientInputHitTestSource, Vector<PlatformXR::FrameData::TransientInputHitTestResult>> transientInputHitTestResults;
 #endif
     Vector<PlatformXR::FrameData::InputSource> inputSources;
+    PlatformXR::XREnvironmentBlendMode environmentBlendMode;
 };
 
 #if USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -100,6 +100,7 @@ private:
     void beginFrame(Box<RenderState>);
     void endFrame(Box<RenderState>, Vector<XRDeviceLayer>&&);
     void renderLoop(Box<RenderState>);
+    XrEnvironmentBlendMode blendModeForSessionMode(Box<RenderState>) const;
 
     XRDeviceIdentifier m_deviceIdentifier { XRDeviceIdentifier::generate() };
     XrInstance m_instance { XR_NULL_HANDLE };


### PR DESCRIPTION
#### 1c728046611ca5d5550b542f3041db07ab9feb0f
<pre>
[WebXR] XRSession::environmentBlendMode always returns &quot;opaque&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=302262">https://bugs.webkit.org/show_bug.cgi?id=302262</a>

Reviewed by Dan Glastonbury.

The environmentBlendMode attribute of the XRSession was never updated
with the blend technique used by the XR compositor and thus was always
returning &quot;opaque&quot; as it was the value used for initialization.

A new attribute was added to the FrameData structure that carries the
blend mode currently used by the compositor. Note that it makes sense to
report it per frame as the compositor might decide to switch the blend
mode (for example as a result of specifying hints like
XRRenderState::passthroughFullyObscured). The specs even mention &quot;The
environmentBlendMode attribute MUST report the XREnvironmentBlendMode
value that matches blend technique currently being performed by the XR
Compositor.&quot;

Then environment blend mode test PASS now for both immersive-vr and
immersive-ar sessions. The test was updated because it was trying to
read the attribute value without requesting frames which does not make
much sense as the environment blend mode might change over time.

* LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrSession_environmentBlendMode.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrSession_environmentBlendMode.https.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::environmentBlendMode const):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/XREnvironmentBlendMode.h:
* Source/WebCore/Modules/webxr/XREnvironmentBlendMode.idl:
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::FrameData::copy const):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::initializeTrackingAndRendering):
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::blendModeForSessionMode const):
(WebKit::OpenXRCoordinator::populateFrameData):
(WebKit::OpenXRCoordinator::endFrame):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/302836@main">https://commits.webkit.org/302836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d6cacd4c271f51a68bd3bd47e3ed5aed310600b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99238 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67106 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34779 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80933 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140152 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27424 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55271 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65775 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2205 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->