### PR TITLE
Unreviewed. [GTK][WPE] Fix clang build

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -376,7 +376,7 @@ void OpenXRCoordinator::requestHitTestSource(WebPageProxy& page, const PlatformX
                 return;
             }
 
-            active.renderQueue->dispatch([this, renderState = active.renderState, completionHandler = WTFMove(completionHandler)]() mutable {
+            active.renderQueue->dispatch([renderState = active.renderState, completionHandler = WTFMove(completionHandler)]() mutable {
                 auto addResult = renderState->hitTestSources.add(renderState->nextHitTestSource);
                 ASSERT_UNUSED(addResult.isNewEntry, addResult);
                 callOnMainRunLoop([source = renderState->nextHitTestSource, completionHandler = WTFMove(completionHandler)] mutable {
@@ -405,7 +405,7 @@ void OpenXRCoordinator::deleteHitTestSource(WebPageProxy& page, PlatformXR::HitT
                 return;
             }
 
-            active.renderQueue->dispatch([this, renderState = active.renderState, source]() mutable {
+            active.renderQueue->dispatch([renderState = active.renderState, source]() {
                 bool removed = renderState->hitTestSources.remove(source);
                 ASSERT_UNUSED(removed, removed);
             });


### PR DESCRIPTION
#### 84fb12ff79e45aaa60230ac6cf2cd5480cc30ffb
<pre>
Unreviewed. [GTK][WPE] Fix clang build

Clang was complaining about &quot;error: lambda capture &apos;this&apos; is not used&quot;.
The build fix is as easy as removing &quot;this&quot; from two lambda capture lists.

* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::requestHitTestSource):
(WebKit::OpenXRCoordinator::deleteHitTestSource):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84fb12ff79e45aaa60230ac6cf2cd5480cc30ffb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130268 "Failed to checkout and rebase branch from PR 53682") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2539 "Failed to checkout and rebase branch from PR 53682") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41222 "Failed to checkout and rebase branch from PR 53682") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/2539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2430 "Failed to checkout and rebase branch from PR 53682") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/137686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133215 "Failed to checkout and rebase branch from PR 53682") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/2539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/41222 "Failed to checkout and rebase branch from PR 53682") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/2539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/41222 "Failed to checkout and rebase branch from PR 53682") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/2539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/41222 "Failed to checkout and rebase branch from PR 53682") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140163 "Failed to checkout and rebase branch from PR 53682") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/2430 "Failed to checkout and rebase branch from PR 53682") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/140163 "Failed to checkout and rebase branch from PR 53682") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/41222 "Failed to checkout and rebase branch from PR 53682") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/140163 "Failed to checkout and rebase branch from PR 53682") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27398 "Failed to checkout and rebase branch from PR 53682") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/41222 "Failed to checkout and rebase branch from PR 53682") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/2399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/65786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->