### PR TITLE
Organize remaining RemoteLayerTreeTransaction members

### DIFF
--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -97,22 +97,22 @@ public:
 
     // Comparison operators for callers that have already verified that
     // the objects originate from the same process.
-    bool lessThanSameProcess(const ProcessQualified& other)
+    bool lessThanSameProcess(const ProcessQualified& other) const
     {
         ASSERT(processIdentifier() == other.processIdentifier());
         return object() < other.object();
     }
-    bool lessThanOrEqualSameProcess(const ProcessQualified& other)
+    bool lessThanOrEqualSameProcess(const ProcessQualified& other) const
     {
         ASSERT(processIdentifier() == other.processIdentifier());
         return object() <= other.object();
     }
-    bool greaterThanSameProcess(const ProcessQualified& other)
+    bool greaterThanSameProcess(const ProcessQualified& other) const
     {
         ASSERT(processIdentifier() == other.processIdentifier());
         return object() > other.object();
     }
-    bool greaterThanOrEqualSameProcess(const ProcessQualified& other)
+    bool greaterThanOrEqualSameProcess(const ProcessQualified& other) const
     {
         ASSERT(processIdentifier() == other.processIdentifier());
         return object() >= other.object();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -111,34 +111,12 @@ header: "RemoteLayerBackingStore.h"
 
     Vector<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties> m_createdLayers;
     Vector<WebCore::PlatformLayerIdentifier> m_destroyedLayerIDs;
-    Vector<WebCore::PlatformLayerIdentifier> m_videoLayerIDsPendingFullscreen;
     Vector<WebCore::PlatformLayerIdentifier> m_layerIDsWithNewlyUnreachableBackingStore;
 
     WebCore::IntSize m_contentsSize;
     WebCore::IntSize m_scrollGeometryContentSize;
     WebCore::IntPoint m_scrollOrigin;
-    WebCore::LayoutSize m_baseLayoutViewportSize;
-    WebCore::LayoutPoint m_minStableLayoutViewportOrigin;
-    WebCore::LayoutPoint m_maxStableLayoutViewportOrigin;
     WebCore::IntPoint m_scrollPosition;
-
-    double m_pageScaleFactor;
-    double m_minimumScaleFactor;
-    double m_maximumScaleFactor;
-    double m_initialScaleFactor;
-    double m_viewportMetaTagWidth;
-    WebCore::InteractiveWidget m_viewportMetaTagInteractiveWidget;
-    uint64_t m_renderTreeSize;
-    WebKit::TransactionID m_transactionID;
-    bool m_scaleWasSetByUIProcess;
-    bool m_allowsUserScaling;
-    bool m_avoidsUnsafeArea;
-    bool m_viewportMetaTagWidthWasExplicit;
-    bool m_viewportMetaTagCameFromImageDocument;
-
-#if PLATFORM(IOS_FAMILY)
-    std::optional<uint64_t> m_dynamicViewportSizeUpdateID;
-#endif
 
 #if ENABLE(THREADED_ANIMATIONS)
     HashSet<Ref<WebCore::AcceleratedTimeline>> m_timelines;
@@ -274,21 +252,42 @@ using WebKit::PageData::TransactionCallbackID = IPC::AsyncReplyID;
 
 [CustomHeader] struct WebKit::PageData {
     Vector<WebKit::PageData::TransactionCallbackID> callbackIDs;
+    uint64_t renderTreeSize;
 };
 
 [CustomHeader] struct WebKit::MainFrameData {
-    WebKit::ActivityStateChangeID activityStateChangeID;
+    WebCore::LayoutSize baseLayoutViewportSize;
+    WebCore::LayoutPoint minStableLayoutViewportOrigin;
+    WebCore::LayoutPoint maxStableLayoutViewportOrigin;
     WebCore::Color themeColor;
     WebCore::Color pageExtendedBackgroundColor;
     WebCore::Color sampledPageTopColor;
-    std::optional<WebKit::EditorState> editorState;
-    OptionSet<WebCore::LayoutMilestone> newlyReachedPaintingMilestones;
     std::optional<WebCore::FixedContainerEdges> fixedContainerEdges;
-    bool isInStableState;
+
 #if PLATFORM(MAC)
     Markable<WebCore::PlatformLayerIdentifier> pageScalingLayerID;
     Markable<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID;
     Markable<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID;
+#endif
+
+    double pageScaleFactor;
+    double minimumScaleFactor;
+    double maximumScaleFactor;
+    double initialScaleFactor;
+    double viewportMetaTagWidth;
+    WebKit::ActivityStateChangeID activityStateChangeID;
+    OptionSet<WebCore::LayoutMilestone> newlyReachedPaintingMilestones;
+    bool scaleWasSetByUIProcess;
+    bool allowsUserScaling;
+    bool avoidsUnsafeArea;
+    bool viewportMetaTagWidthWasExplicit;
+    bool viewportMetaTagCameFromImageDocument;
+    bool isInStableState;
+    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget;
+
+    std::optional<WebKit::EditorState> editorState;
+#if PLATFORM(IOS_FAMILY)
+    std::optional<uint64_t> dynamicViewportSizeUpdateID;
 #endif
 };
 
@@ -298,5 +297,7 @@ struct WebKit::RemoteLayerTreeCommitBundle {
     Vector<WebKit::RemoteLayerTreeCommitBundle::RootFrameData> transactions;
     WebKit::PageData pageData;
     std::optional<WebKit::MainFrameData> mainFrameData;
+    
+    WebKit::TransactionID transactionID;
     MonotonicTime startTime;
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -29,10 +29,22 @@
 #include "EditorState.h"
 #include "RemoteLayerTreeTransaction.h"
 #include "RemoteScrollingCoordinatorTransaction.h"
+#include "TransactionID.h"
 #include <WebCore/Color.h>
+#include <WebCore/FixedContainerEdges.h>
 #include <WebCore/LayoutMilestone.h>
+#include <WebCore/LayoutUnit.h>
+#include <WebCore/ViewportArguments.h>
 #include <optional>
 #include <wtf/Vector.h>
+
+#if !defined(NDEBUG) || !LOG_DISABLED
+#include <wtf/text/WTFString.h>
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+#include "DynamicViewportSizeUpdate.h"
+#endif
 
 namespace WebKit {
 
@@ -40,21 +52,50 @@ struct PageData {
     using TransactionCallbackID = IPC::AsyncReplyID;
 
     Vector<TransactionCallbackID> callbackIDs;
+    uint64_t renderTreeSize { 0 };
+
+#if !defined(NDEBUG) || !LOG_DISABLED
+    String description() const;
+#endif
 };
 
 struct MainFrameData {
-    ActivityStateChangeID activityStateChangeID { ActivityStateChangeAsynchronous };
+    WebCore::LayoutSize baseLayoutViewportSize;
+    WebCore::LayoutPoint minStableLayoutViewportOrigin;
+    WebCore::LayoutPoint maxStableLayoutViewportOrigin;
     WebCore::Color themeColor;
     WebCore::Color pageExtendedBackgroundColor;
     WebCore::Color sampledPageTopColor;
-    std::optional<EditorState> editorState;
-    OptionSet<WebCore::LayoutMilestone> newlyReachedPaintingMilestones;
     std::optional<WebCore::FixedContainerEdges> fixedContainerEdges;
-    bool isInStableState { false };
+
 #if PLATFORM(MAC)
-    Markable<WebCore::PlatformLayerIdentifier> pageScalingLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> pageScalingLayerID; // Only used for non-delegated scaling.
     Markable<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID;
     Markable<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID;
+#endif
+
+    double pageScaleFactor { 1 };
+    double minimumScaleFactor { 1 };
+    double maximumScaleFactor { 1 };
+    double initialScaleFactor { 1 };
+    double viewportMetaTagWidth { -1 };
+    ActivityStateChangeID activityStateChangeID { ActivityStateChangeAsynchronous };
+    OptionSet<WebCore::LayoutMilestone> newlyReachedPaintingMilestones;
+    bool scaleWasSetByUIProcess { false };
+    bool allowsUserScaling { false };
+    bool avoidsUnsafeArea { true };
+    bool viewportMetaTagWidthWasExplicit { false };
+    bool viewportMetaTagCameFromImageDocument { false };
+    bool isInStableState { false };
+    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget { WebCore::InteractiveWidget::ResizesVisual };
+
+    std::optional<EditorState> editorState;
+#if PLATFORM(IOS_FAMILY)
+    std::optional<DynamicViewportSizeUpdateID> dynamicViewportSizeUpdateID;
+#endif
+
+#if !defined(NDEBUG) || !LOG_DISABLED
+    String description() const;
 #endif
 };
 
@@ -64,7 +105,13 @@ struct RemoteLayerTreeCommitBundle {
     Vector<RootFrameData> transactions;
     PageData pageData;
     std::optional<MainFrameData> mainFrameData;
+
+    TransactionID transactionID;
     MonotonicTime startTime;
+
+#if !defined(NDEBUG) || !LOG_DISABLED
+    String description() const;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.mm
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RemoteLayerTreeCommitBundle.h"
+
+#if !defined(NDEBUG) || !LOG_DISABLED
+
+#import <wtf/text/TextStream.h>
+
+namespace WebKit {
+
+String PageData::description() const
+{
+    TextStream ts;
+
+    ts.startGroup();
+    ts << "PageData"_s;
+
+    ts.dumpProperty("renderTreeSize"_s, renderTreeSize);
+
+    ts.endGroup();
+
+    return ts.release();
+}
+
+String MainFrameData::description() const
+{
+    TextStream ts;
+
+    ts.startGroup();
+    ts << "MainFrameData"_s;
+
+    ts.dumpProperty("baseLayoutViewportSize"_s, WebCore::FloatSize(baseLayoutViewportSize));
+
+    if (minStableLayoutViewportOrigin != WebCore::LayoutPoint::zero())
+        ts.dumpProperty("minStableLayoutViewportOrigin"_s, WebCore::FloatPoint(minStableLayoutViewportOrigin));
+    ts.dumpProperty("maxStableLayoutViewportOrigin"_s, WebCore::FloatPoint(maxStableLayoutViewportOrigin));
+
+    if (pageScaleFactor != 1)
+        ts.dumpProperty("pageScaleFactor"_s, pageScaleFactor);
+
+#if PLATFORM(MAC)
+    ts.dumpProperty("pageScalingLayer"_s, pageScalingLayerID);
+    ts.dumpProperty("scrolledContentsLayerID"_s, scrolledContentsLayerID);
+    ts.dumpProperty("mainFrameClipLayerID"_s, mainFrameClipLayerID);
+#endif
+
+    ts.dumpProperty("minimumScaleFactor"_s, minimumScaleFactor);
+    ts.dumpProperty("maximumScaleFactor"_s, maximumScaleFactor);
+    ts.dumpProperty("initialScaleFactor"_s, initialScaleFactor);
+    ts.dumpProperty("viewportMetaTagWidth"_s, viewportMetaTagWidth);
+    ts.dumpProperty("viewportMetaTagWidthWasExplicit"_s, viewportMetaTagWidthWasExplicit);
+    ts.dumpProperty("viewportMetaTagCameFromImageDocument"_s, viewportMetaTagCameFromImageDocument);
+    ts.dumpProperty("allowsUserScaling"_s, allowsUserScaling);
+    ts.dumpProperty("avoidsUnsafeArea"_s, avoidsUnsafeArea);
+    ts.dumpProperty("isInStableState"_s, isInStableState);
+
+    if (editorState) {
+        TextStream::GroupScope scope(ts);
+        ts << "EditorState"_s;
+        ts << *editorState;
+    }
+
+    ts.endGroup();
+
+    return ts.release();
+}
+
+String RemoteLayerTreeCommitBundle::description() const
+{
+    TextStream ts;
+
+    ts.startGroup();
+    ts << "RemoteLayerTreeCommitBundle"_s;
+
+    ts.dumpProperty("transactionID"_s, transactionID);
+    ts.dumpProperty("startTime"_s, startTime.secondsSinceEpoch().milliseconds());
+
+    ts.endGroup();
+
+    return ts.release();
+}
+
+} // namespace WebKit
+
+#endif // !defined(NDEBUG) || !LOG_DISABLED

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -25,33 +25,22 @@
 
 #pragma once
 
-#include "Connection.h"
 #include "DrawingAreaInfo.h"
-#include "EditorState.h"
 #include "PlatformCAAnimationRemote.h"
 #include "PlaybackSessionContextIdentifier.h"
 #include "RemoteLayerBackingStore.h"
-#include "TransactionID.h"
-#include <WebCore/Color.h>
-#include <WebCore/FixedContainerEdges.h>
 #include <WebCore/FloatPoint3D.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
-#include <WebCore/LayoutMilestone.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/ScrollTypes.h>
-#include <WebCore/ViewportArguments.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
-
-#if PLATFORM(IOS_FAMILY)
-#include "DynamicViewportSizeUpdate.h"
-#endif
 
 #if ENABLE(THREADED_ANIMATIONS)
 #include <WebCore/AcceleratedTimeline.h>
@@ -139,7 +128,7 @@ public:
 #endif
     };
 
-    explicit RemoteLayerTreeTransaction(TransactionID);
+    RemoteLayerTreeTransaction();
     ~RemoteLayerTreeTransaction();
     RemoteLayerTreeTransaction(RemoteLayerTreeTransaction&&);
     RemoteLayerTreeTransaction& operator=(RemoteLayerTreeTransaction&&);
@@ -169,7 +158,6 @@ public:
 
     void setRemoteContextHostedIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostedIdentifier = identifier; }
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }
-    bool isMainFrameProcessTransaction() const { return !m_remoteContextHostedIdentifier; }
 
     WebCore::IntSize contentsSize() const { return m_contentsSize; }
     void setContentsSize(const WebCore::IntSize& size) { m_contentsSize = size; };
@@ -180,60 +168,8 @@ public:
     WebCore::IntPoint scrollOrigin() const { return m_scrollOrigin; }
     void setScrollOrigin(const WebCore::IntPoint& origin) { m_scrollOrigin = origin; };
 
-    WebCore::LayoutSize baseLayoutViewportSize() const { return m_baseLayoutViewportSize; }
-    void setBaseLayoutViewportSize(const WebCore::LayoutSize& size) { m_baseLayoutViewportSize = size; };
-    
-    WebCore::LayoutPoint minStableLayoutViewportOrigin() const { return m_minStableLayoutViewportOrigin; }
-    void setMinStableLayoutViewportOrigin(const WebCore::LayoutPoint& point) { m_minStableLayoutViewportOrigin = point; };
-    
-    WebCore::LayoutPoint maxStableLayoutViewportOrigin() const { return m_maxStableLayoutViewportOrigin; }
-    void setMaxStableLayoutViewportOrigin(const WebCore::LayoutPoint& point) { m_maxStableLayoutViewportOrigin = point; };
-
     WebCore::IntPoint scrollPosition() const { return m_scrollPosition; }
     void setScrollPosition(WebCore::IntPoint p) { m_scrollPosition = p; }
-
-    double pageScaleFactor() const { return m_pageScaleFactor; }
-    void setPageScaleFactor(double pageScaleFactor) { m_pageScaleFactor = pageScaleFactor; }
-
-    bool scaleWasSetByUIProcess() const { return m_scaleWasSetByUIProcess; }
-    void setScaleWasSetByUIProcess(bool scaleWasSetByUIProcess) { m_scaleWasSetByUIProcess = scaleWasSetByUIProcess; }
-
-    uint64_t renderTreeSize() const { return m_renderTreeSize; }
-    void setRenderTreeSize(uint64_t renderTreeSize) { m_renderTreeSize = renderTreeSize; }
-
-    double minimumScaleFactor() const { return m_minimumScaleFactor; }
-    void setMinimumScaleFactor(double scale) { m_minimumScaleFactor = scale; }
-
-    double maximumScaleFactor() const { return m_maximumScaleFactor; }
-    void setMaximumScaleFactor(double scale) { m_maximumScaleFactor = scale; }
-
-    double initialScaleFactor() const { return m_initialScaleFactor; }
-    void setInitialScaleFactor(double scale) { m_initialScaleFactor = scale; }
-
-    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget() const { return m_viewportMetaTagInteractiveWidget; }
-    void setViewportMetaTagInteractiveWidget(WebCore::InteractiveWidget interactiveWidgetValue) { m_viewportMetaTagInteractiveWidget = interactiveWidgetValue; }
-
-    double viewportMetaTagWidth() const { return m_viewportMetaTagWidth; }
-    void setViewportMetaTagWidth(double width) { m_viewportMetaTagWidth = width; }
-
-    bool viewportMetaTagWidthWasExplicit() const { return m_viewportMetaTagWidthWasExplicit; }
-    void setViewportMetaTagWidthWasExplicit(bool widthWasExplicit) { m_viewportMetaTagWidthWasExplicit = widthWasExplicit; }
-
-    bool viewportMetaTagCameFromImageDocument() const { return m_viewportMetaTagCameFromImageDocument; }
-    void setViewportMetaTagCameFromImageDocument(bool cameFromImageDocument) { m_viewportMetaTagCameFromImageDocument = cameFromImageDocument; }
-
-    bool allowsUserScaling() const { return m_allowsUserScaling; }
-    void setAllowsUserScaling(bool allowsUserScaling) { m_allowsUserScaling = allowsUserScaling; }
-
-    bool avoidsUnsafeArea() const { return m_avoidsUnsafeArea; }
-    void setAvoidsUnsafeArea(bool avoidsUnsafeArea) { m_avoidsUnsafeArea = avoidsUnsafeArea; }
-
-    TransactionID transactionID() const { return m_transactionID; }
-
-#if PLATFORM(IOS_FAMILY)
-    std::optional<DynamicViewportSizeUpdateID> dynamicViewportSizeUpdateID() const { return m_dynamicViewportSizeUpdateID; }
-    void setDynamicViewportSizeUpdateID(DynamicViewportSizeUpdateID resizeID) { m_dynamicViewportSizeUpdateID = resizeID; }
-#endif
 
 #if ENABLE(THREADED_ANIMATIONS)
     const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelines() const { return m_timelines; }
@@ -243,9 +179,6 @@ public:
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction>;
 
-    // Do not use, IPC constructor only
-    explicit RemoteLayerTreeTransaction();
-
     Markable<WebCore::PlatformLayerIdentifier> m_rootLayerID;
     ChangedLayers m_changedLayers;
 
@@ -253,34 +186,13 @@ private:
 
     Vector<LayerCreationProperties> m_createdLayers;
     Vector<WebCore::PlatformLayerIdentifier> m_destroyedLayerIDs;
-    Vector<WebCore::PlatformLayerIdentifier> m_videoLayerIDsPendingFullscreen;
     Vector<WebCore::PlatformLayerIdentifier> m_layerIDsWithNewlyUnreachableBackingStore;
 
     WebCore::IntSize m_contentsSize;
     WebCore::IntSize m_scrollGeometryContentSize;
     WebCore::IntPoint m_scrollOrigin;
-    WebCore::LayoutSize m_baseLayoutViewportSize;
-    WebCore::LayoutPoint m_minStableLayoutViewportOrigin;
-    WebCore::LayoutPoint m_maxStableLayoutViewportOrigin;
     WebCore::IntPoint m_scrollPosition;
 
-    double m_pageScaleFactor { 1 };
-    double m_minimumScaleFactor { 1 };
-    double m_maximumScaleFactor { 1 };
-    double m_initialScaleFactor { 1 };
-    double m_viewportMetaTagWidth { -1 };
-    uint64_t m_renderTreeSize { 0 };
-    TransactionID m_transactionID;
-    bool m_scaleWasSetByUIProcess { false };
-    bool m_allowsUserScaling { false };
-    bool m_avoidsUnsafeArea { true };
-    bool m_viewportMetaTagWidthWasExplicit { false };
-    bool m_viewportMetaTagCameFromImageDocument { false };
-    WebCore::InteractiveWidget m_viewportMetaTagInteractiveWidget { WebCore::InteractiveWidget::ResizesVisual };
-
-#if PLATFORM(IOS_FAMILY)
-    std::optional<DynamicViewportSizeUpdateID> m_dynamicViewportSizeUpdateID;
-#endif
 #if ENABLE(THREADED_ANIMATIONS)
     HashSet<Ref<WebCore::AcceleratedTimeline>> m_timelines;
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -53,13 +53,7 @@ RemoteLayerTreeTransaction::RemoteLayerTreeTransaction(RemoteLayerTreeTransactio
 
 RemoteLayerTreeTransaction& RemoteLayerTreeTransaction::operator=(RemoteLayerTreeTransaction&&) = default;
 
-RemoteLayerTreeTransaction::RemoteLayerTreeTransaction(TransactionID transactionID)
-    : m_transactionID(transactionID)
-{ }
-
-RemoteLayerTreeTransaction::RemoteLayerTreeTransaction()
-    : m_transactionID(TransactionIdentifier(), WebCore::Process::identifier())
-{ }
+RemoteLayerTreeTransaction::RemoteLayerTreeTransaction() = default;
 
 RemoteLayerTreeTransaction::~RemoteLayerTreeTransaction() = default;
 
@@ -267,30 +261,11 @@ String RemoteLayerTreeTransaction::description() const
     ts.startGroup();
     ts << "layer tree"_s;
 
-    ts.dumpProperty("transactionID"_s, m_transactionID);
     ts.dumpProperty("contentsSize"_s, m_contentsSize);
     ts.dumpProperty("scrollGeometryContentSize"_s, m_scrollGeometryContentSize);
     if (m_scrollOrigin != WebCore::IntPoint::zero())
         ts.dumpProperty("scrollOrigin"_s, m_scrollOrigin);
 
-    ts.dumpProperty("baseLayoutViewportSize"_s, WebCore::FloatSize(m_baseLayoutViewportSize));
-
-    if (m_minStableLayoutViewportOrigin != WebCore::LayoutPoint::zero())
-        ts.dumpProperty("minStableLayoutViewportOrigin"_s, WebCore::FloatPoint(m_minStableLayoutViewportOrigin));
-    ts.dumpProperty("maxStableLayoutViewportOrigin"_s, WebCore::FloatPoint(m_maxStableLayoutViewportOrigin));
-
-    if (m_pageScaleFactor != 1)
-        ts.dumpProperty("pageScaleFactor"_s, m_pageScaleFactor);
-
-    ts.dumpProperty("minimumScaleFactor"_s, m_minimumScaleFactor);
-    ts.dumpProperty("maximumScaleFactor"_s, m_maximumScaleFactor);
-    ts.dumpProperty("initialScaleFactor"_s, m_initialScaleFactor);
-    ts.dumpProperty("viewportMetaTagWidth"_s, m_viewportMetaTagWidth);
-    ts.dumpProperty("viewportMetaTagWidthWasExplicit"_s, m_viewportMetaTagWidthWasExplicit);
-    ts.dumpProperty("viewportMetaTagCameFromImageDocument"_s, m_viewportMetaTagCameFromImageDocument);
-    ts.dumpProperty("allowsUserScaling"_s, m_allowsUserScaling);
-    ts.dumpProperty("avoidsUnsafeArea"_s, m_avoidsUnsafeArea);
-    ts.dumpProperty("renderTreeSize"_s, m_renderTreeSize);
     ts.dumpProperty("root-layer"_s, m_rootLayerID);
 
     if (!m_createdLayers.isEmpty()) {

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -241,6 +241,7 @@ Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm @nonARC
 Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm @nonARC
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm @nonARC
 Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm @nonARC
+Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.mm @nonARC
 Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm @nonARC
 Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
 Shared/RemoteLayerTree/RemoteScrollingUIState.cpp

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -68,7 +68,7 @@ enum class TapHandlingResult : uint8_t;
 - (UIView *)_currentContentView;
 
 - (void)_didCommitLoadForMainFrame;
-- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData;
+- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData pageData:(const WebKit::PageData&)pageData transactionID:(const WebKit::TransactionID&)transactionID;
 - (void)_layerTreeCommitComplete;
 
 - (void)_couldNotRestorePageState;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -102,7 +102,8 @@ public:
     void storeAppHighlight(const WebCore::AppHighlight&) final;
 #endif
 
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&) override;
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&) override;
+    void didCommitMainFrameData(const MainFrameData&) override;
 
     void microphoneCaptureWillChange() final;
     void cameraCaptureWillChange() final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -451,11 +451,15 @@ void PageClientImplCocoa::setFullScreenClientForTesting(std::unique_ptr<WebFullS
 }
 #endif
 
-void PageClientImplCocoa::didCommitLayerTree(const RemoteLayerTreeTransaction& transaction, const std::optional<MainFrameData>& mainFrameData)
+void PageClientImplCocoa::didCommitLayerTree(const RemoteLayerTreeTransaction& transaction, const std::optional<MainFrameData>&, const PageData&, const TransactionID&)
 {
-    if (mainFrameData && mainFrameData->fixedContainerEdges)
-        [webView() _updateFixedContainerEdges:*mainFrameData->fixedContainerEdges];
     [webView() _updateScrollGeometryWithContentOffset:transaction.scrollPosition() contentSize:transaction.scrollGeometryContentSize()];
+}
+
+void PageClientImplCocoa::didCommitMainFrameData(const MainFrameData& mainFrameData)
+{
+    if (mainFrameData.fixedContainerEdges)
+        [webView() _updateFixedContainerEdges:*mainFrameData.fixedContainerEdges];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -30,6 +30,7 @@
 #include "PDFPluginIdentifier.h"
 #include "PasteboardAccessIntent.h"
 #include "SameDocumentNavigationType.h"
+#include "TransactionID.h"
 #include "WebPopupMenuProxy.h"
 #include "WindowKind.h"
 #include <WebCore/ActivityState.h>
@@ -212,6 +213,7 @@ struct FrameInfoData;
 struct InteractionInformationAtPosition;
 struct KeyEventInterpretationContext;
 struct MainFrameData;
+struct PageData;
 struct WebAutocorrectionContext;
 struct WebHitTestResultData;
 
@@ -545,7 +547,8 @@ public:
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(COCOA)
-    virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&) = 0;
+    virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&) = 0;
+    virtual void didCommitMainFrameData(const MainFrameData&) = 0;
     virtual void layerTreeCommitComplete() { }
 
     virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -44,6 +44,7 @@ class RemotePageDrawingAreaProxy;
 class RemoteScrollingCoordinatorProxy;
 class RemoteScrollingCoordinatorTransaction;
 struct MainFrameData;
+struct PageData;
 struct RemoteLayerTreeCommitBundle;
 
 #if ENABLE(THREADED_ANIMATIONS)
@@ -191,8 +192,8 @@ private:
 
     void notifyPendingCommitLayerTree(IPC::Connection&, std::optional<TransactionID>);
     void commitLayerTree(IPC::Connection&, const RemoteLayerTreeCommitBundle&, HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&&);
-    void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&);
-    virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&) { }
+    void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&);
+    virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&, const TransactionID&) { }
 
     void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, RemoteLayerBackingStoreProperties&&);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -170,7 +170,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     if (!rootNode)
         REMOTE_LAYER_TREE_HOST_RELEASE_LOG("%p RemoteLayerTreeHost::updateLayerTree - failed to find root layer with ID %llu", this, transaction.rootLayerID() ? transaction.rootLayerID()->object().toUInt64() : 0);
 
-    if (m_rootNode.get() != rootNode.get() && transaction.isMainFrameProcessTransaction()) {
+    if (m_rootNode.get() != rootNode.get() && mainFrameData) {
         m_rootNode = rootNode;
         rootLayerChanged = true;
     }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -70,7 +70,7 @@ private:
 
     void layoutBannerLayers(const RemoteLayerTreeTransaction&);
 
-    void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&) override;
+    void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&, const TransactionID&) override;
 
     void adjustTransientZoom(double, WebCore::FloatPoint originInLayerForPageScale, WebCore::FloatPoint originInVisibleRect) override;
     void commitTransientZoom(double, WebCore::FloatPoint) override;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3735,7 +3735,11 @@ void WebPageProxy::activateMediaStreamCaptureInPage()
 }
 
 #if !PLATFORM(COCOA)
-void WebPageProxy::didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&)
+void WebPageProxy::didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&)
+{
+}
+
+void WebPageProxy::didCommitMainFrameData(const MainFrameData&, const TransactionID&)
 {
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -575,6 +575,7 @@ struct JSHandleInfo;
 struct KeyEventInterpretationContext;
 struct LoadParameters;
 struct MainFrameData;
+struct PageData;
 struct ModelIdentifier;
 struct NavigationActionData;
 struct NetworkResourceLoadIdentifierType;
@@ -1274,11 +1275,11 @@ public:
     void setDataDetectionResult(DataDetectionResult&&);
     void handleClickForDataDetectionResult(const WebCore::DataDetectorElementInfo&, const WebCore::IntPoint&);
 #endif
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&);
-    void didCommitMainFrameData(const MainFrameData&);
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&);
+    void didCommitMainFrameData(const MainFrameData&, const TransactionID&);
     void layerTreeCommitComplete();
 
-    bool updateLayoutViewportParameters(const RemoteLayerTreeTransaction&);
+    bool updateLayoutViewportParameters(const MainFrameData&);
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void cancelComposition(const String& compositionString);

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -179,7 +179,8 @@ private:
     void commitPotentialTapFailed() override;
     void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) override;
 
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&) final;
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&) final;
+    void didCommitMainFrameData(const MainFrameData&) final;
     void layerTreeCommitComplete() override;
         
     void didPerformDictionaryLookup(const WebCore::DictionaryPopupInfo&) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -690,11 +690,16 @@ void PageClientImpl::didGetTapHighlightGeometries(WebKit::TapIdentifier requestI
     [contentView() _didGetTapHighlightForRequest:requestID color:color quads:highlightedQuads topLeftRadius:topLeftRadius topRightRadius:topRightRadius bottomLeftRadius:bottomLeftRadius bottomRightRadius:bottomRightRadius nodeHasBuiltInClickHandling:nodeHasBuiltInClickHandling];
 }
 
-void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction, const std::optional<MainFrameData>& mainFrameData)
+void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction, const std::optional<MainFrameData>& mainFrameData, const PageData& pageData, const TransactionID& transactionID)
 {
-    PageClientImplCocoa::didCommitLayerTree(layerTreeTransaction, mainFrameData);
+    PageClientImplCocoa::didCommitLayerTree(layerTreeTransaction, mainFrameData, pageData, transactionID);
 
-    [contentView() _didCommitLayerTree:layerTreeTransaction mainFrameData:mainFrameData];
+    [contentView() _didCommitLayerTree:layerTreeTransaction mainFrameData:mainFrameData pageData:pageData transactionID:transactionID];
+}
+
+void PageClientImpl::didCommitMainFrameData(const MainFrameData& mainFrameData)
+{
+    PageClientImplCocoa::didCommitMainFrameData(mainFrameData);
 }
 
 void PageClientImpl::layerTreeCommitComplete()

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "TransactionID.h"
 #import "WKApplicationStateTrackingView.h"
 #import "WKBase.h"
 #import "WKBrowsingContextController.h"
@@ -49,6 +50,7 @@ class WebPageProxy;
 class WebProcessProxy;
 class WebProcessPool;
 struct MainFrameData;
+struct PageData;
 enum class ViewStabilityFlag : uint8_t;
 }
 
@@ -128,7 +130,7 @@ enum class ViewStabilityFlag : uint8_t;
 - (void)_showInspectorHighlight:(const WebCore::InspectorOverlay::Highlight&)highlight;
 - (void)_hideInspectorHighlight;
 
-- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData;
+- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData pageData:(const WebKit::PageData&)pageData transactionID:(const WebKit::TransactionID&)transactionID;
 - (void)_layerTreeCommitComplete;
 
 - (void)_setAccessibilityWebProcessToken:(NSData *)data;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -38,6 +38,7 @@
 #import "PageClientImplIOS.h"
 #import "PickerDismissalReason.h"
 #import "PrintInfo.h"
+#import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeDrawingAreaProxyIOS.h"
 #import "SmartMagnificationController.h"
 #import "UIKitSPI.h"
@@ -999,20 +1000,20 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 #endif // USE(EXTENSIONKIT)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
-- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData
+- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData pageData:(const WebKit::PageData&)pageData transactionID:(const WebKit::TransactionID&)transactionID
 {
-    BOOL transactionMayChangeBounds = layerTreeTransaction.isMainFrameProcessTransaction();
+    BOOL transactionMayChangeBounds = mainFrameData.has_value();
     CGSize contentsSize = layerTreeTransaction.contentsSize();
     CGPoint scrollOrigin = -layerTreeTransaction.scrollOrigin();
     CGRect contentBounds = { scrollOrigin, contentsSize };
 
-    LOG_WITH_STREAM(VisibleRects, stream << "-[WKContentView _didCommitLayerTree:] transactionID " <<  layerTreeTransaction.transactionID() << " contentBounds " << WebCore::FloatRect(contentBounds));
+    LOG_WITH_STREAM(VisibleRects, stream << "-[WKContentView _didCommitLayerTree:] transactionID " << transactionID << " contentBounds " << WebCore::FloatRect(contentBounds));
 
     BOOL boundsChanged = transactionMayChangeBounds && !CGRectEqualToRect([self bounds], contentBounds);
     if (boundsChanged)
         [self setBounds:contentBounds];
 
-    [_webView _didCommitLayerTree:layerTreeTransaction mainFrameData:mainFrameData];
+    [_webView _didCommitLayerTree:layerTreeTransaction mainFrameData:mainFrameData pageData:pageData transactionID:transactionID];
 
     if (_interactionViewsContainerView) {
         WebCore::FloatPoint scaledOrigin = layerTreeTransaction.scrollOrigin();

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -50,6 +50,7 @@
 #import "PaymentAuthorizationController.h"
 #import "PrintInfo.h"
 #import "ProvisionalPageProxy.h"
+#import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeHost.h"
 #import "RemoteLayerTreeNode.h"
 #import "RemoteLayerTreeTransaction.h"
@@ -366,15 +367,15 @@ void WebPageProxy::setOverrideViewportArguments(const std::optional<ViewportArgu
         m_legacyMainFrameProcess->send(Messages::WebPage::SetOverrideViewportArguments(viewportArguments), webPageIDInMainFrameProcess());
 }
 
-bool WebPageProxy::updateLayoutViewportParameters(const RemoteLayerTreeTransaction& layerTreeTransaction)
+bool WebPageProxy::updateLayoutViewportParameters(const MainFrameData& mainFrameData)
 {
-    if (internals().baseLayoutViewportSize == layerTreeTransaction.baseLayoutViewportSize()
-        && internals().minStableLayoutViewportOrigin == layerTreeTransaction.minStableLayoutViewportOrigin()
-        && internals().maxStableLayoutViewportOrigin == layerTreeTransaction.maxStableLayoutViewportOrigin())
+    if (internals().baseLayoutViewportSize == mainFrameData.baseLayoutViewportSize
+        && internals().minStableLayoutViewportOrigin == mainFrameData.minStableLayoutViewportOrigin
+        && internals().maxStableLayoutViewportOrigin == mainFrameData.maxStableLayoutViewportOrigin)
         return false;
-    internals().baseLayoutViewportSize = layerTreeTransaction.baseLayoutViewportSize();
-    internals().minStableLayoutViewportOrigin = layerTreeTransaction.minStableLayoutViewportOrigin();
-    internals().maxStableLayoutViewportOrigin = layerTreeTransaction.maxStableLayoutViewportOrigin();
+    internals().baseLayoutViewportSize = mainFrameData.baseLayoutViewportSize;
+    internals().minStableLayoutViewportOrigin = mainFrameData.minStableLayoutViewportOrigin;
+    internals().maxStableLayoutViewportOrigin = mainFrameData.maxStableLayoutViewportOrigin;
     LOG_WITH_STREAM(VisibleRects, stream << "WebPageProxy::updateLayoutViewportParameters: baseLayoutViewportSize: " << internals().baseLayoutViewportSize << " minStableLayoutViewportOrigin: " << internals().minStableLayoutViewportOrigin << " maxStableLayoutViewportOrigin: " << internals().maxStableLayoutViewportOrigin);
     return true;
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6693,6 +6693,7 @@
 		6BE969C81E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceLoadStatisticsClassifierCocoa.cpp; sourceTree = "<group>"; };
 		6BE969C91E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLoadStatisticsClassifierCocoa.h; sourceTree = "<group>"; };
 		6BE969CC1E54E054008B7483 /* ResourceLoadStatisticsClassifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLoadStatisticsClassifier.h; sourceTree = "<group>"; };
+		6C34CFE92ECBCF1C00DB2185 /* RemoteLayerTreeCommitBundle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerTreeCommitBundle.mm; sourceTree = "<group>"; };
 		6D77DBC22D80D3D6008ED0DD /* ScreenTimeWebsiteDataSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScreenTimeWebsiteDataSupport.h; sourceTree = "<group>"; };
 		6D77DBC32D80D3EC008ED0DD /* ScreenTimeWebsiteDataSupport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScreenTimeWebsiteDataSupport.mm; sourceTree = "<group>"; };
 		6D8A91A511F0EFD100DD01FE /* com.apple.WebProcess.sb.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = com.apple.WebProcess.sb.in; path = WebProcess/com.apple.WebProcess.sb.in; sourceTree = "<group>"; };
@@ -11568,6 +11569,7 @@
 				2DDF731418E95060004F5A66 /* RemoteLayerBackingStoreCollection.mm */,
 				5CE77801297BA396000BA9CF /* RemoteLayerTree.serialization.in */,
 				A6EB76B251B844C7BCAAAF04 /* RemoteLayerTreeCommitBundle.h */,
+				6C34CFE92ECBCF1C00DB2185 /* RemoteLayerTreeCommitBundle.mm */,
 				2DDE0AF818298CC900F97EAA /* RemoteLayerTreePropertyApplier.h */,
 				2DDE0AF918298CC900F97EAA /* RemoteLayerTreePropertyApplier.mm */,
 				1AF1AC6A1651759E00C17D7F /* RemoteLayerTreeTransaction.h */,

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -92,7 +92,7 @@ private:
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) final;
 
     void dispatchAfterEnsuringDrawing(IPC::AsyncReplyID) final;
-    virtual void willCommitLayerTree(MainFrameData&) { }
+    virtual void willCommitMainFrameData(MainFrameData&) { }
 
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) final;
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -641,7 +641,7 @@ public:
 
 #if PLATFORM(COCOA)
     void willCommitLayerTree(RemoteLayerTreeTransaction&, WebCore::FrameIdentifier);
-    void willCommitMainFrameData(MainFrameData&);
+    void willCommitMainFrameData(MainFrameData&, const TransactionID&);
     void didFlushLayerTreeAtTime(MonotonicTime, bool flushSucceeded);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
@@ -62,7 +62,7 @@ private:
 
     void adjustTransientZoom(double scale, WebCore::FloatPoint origin) final;
 
-    void willCommitLayerTree(MainFrameData&) final;
+    void willCommitMainFrameData(MainFrameData&) final;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -84,7 +84,7 @@ void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::F
     prepopulateRectForZoom(totalScale, origin);
 }
 
-void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(MainFrameData& data)
+void RemoteLayerTreeDrawingAreaMac::willCommitMainFrameData(MainFrameData& data)
 {
     // FIXME: Probably need something here for PDF.
     RefPtr frameView = protectedWebPage()->localMainFrameView();


### PR DESCRIPTION
#### 5001daca24e7c29db01073cc27011c9928abc781
<pre>
Organize remaining RemoteLayerTreeTransaction members
<a href="https://bugs.webkit.org/show_bug.cgi?id=302267">https://bugs.webkit.org/show_bug.cgi?id=302267</a>
<a href="https://rdar.apple.com/164407141">rdar://164407141</a>

Reviewed by Matt Woodrow.

Right now RemoteLayerTreeDrawingAreaProxy::commitLayerTree currently receives a Vector&lt;std::pair&lt;RemoteLayerTreeTransaction,
RemoteScrollingCoordinatorTransaction&gt;&gt;, one pair per root frame. However, some aspects of the transaction are
scoped to the root frame. Some are scoped to the page. And some are scoped to the main frame. We want to accordingly
introduce some separation/organization here to reduce duplication and remove unnecessary isMainFrameProcessTransaction() checks.

This PR builds on <a href="https://github.com/WebKit/WebKit/pull/52671">https://github.com/WebKit/WebKit/pull/52671</a> and <a href="https://github.com/WebKit/WebKit/pull/52839.">https://github.com/WebKit/WebKit/pull/52839.</a> In this PR, we move
the last relevant members from transaction scope to main frame, page, and bundle scope accordingly. WCP propagation
is adjusted to fit this. And where appropriate, processing on the UIProcess side is separated to ensure that mainframe specific
data is only processed once rather than per transaction.

We should only be using bundle.mainFrameData now as the sole source of truth for checking for main frame identity, so isMainFrameProcessTransaction()
is removed. Furthermore, since these members got migrated, some logging was removed from RemoteLayerTreeTransaction. We add it back
in RemoteLayerTreeCommitBundle.mm.

No new functionality is added. This is a simple refactoring. Existing test coverage is enough.
As a result, no new tests are added.

* Source/WebCore/platform/ProcessQualified.h:
(WebCore::ProcessQualified::lessThanSameProcess const):
(WebCore::ProcessQualified::lessThanOrEqualSameProcess const):
(WebCore::ProcessQualified::greaterThanSameProcess const):
(WebCore::ProcessQualified::greaterThanOrEqualSameProcess const):
(WebCore::ProcessQualified::lessThanSameProcess): Deleted.
(WebCore::ProcessQualified::lessThanOrEqualSameProcess): Deleted.
(WebCore::ProcessQualified::greaterThanSameProcess): Deleted.
(WebCore::ProcessQualified::greaterThanOrEqualSameProcess): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.mm: Added.
(WebKit::PageData::description const):
(WebKit::MainFrameData::description const):
(WebKit::RemoteLayerTreeCommitBundle::description const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
(WebKit::RemoteLayerTreeTransaction::RemoteLayerTreeTransaction): Deleted.
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTreeDuringAnimatedResize:mainFrameData:]):
(-[WKWebView _trackTransactionCommit:]):
(-[WKWebView _updateScrollViewForTransaction:]):
(-[WKWebView _restoreScrollAndZoomStateForTransaction:]):
(-[WKWebView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
(-[WKWebView _didCommitLayerTreeDuringAnimatedResize:]): Deleted.
(-[WKWebView _didCommitLayerTree:mainFrameData:]): Deleted.
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didCommitLayerTree):
(WebKit::PageClientImplCocoa::didCommitMainFrameData):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
(WebKit::WebPageProxy::didCommitMainFrameData):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::didCommitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLayerTree):
(WebKit::WebPageProxy::didCommitMainFrameData):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didCommitLayerTree):
(WebKit::PageClientImpl::didCommitMainFrameData):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
(-[WKContentView _didCommitLayerTree:mainFrameData:]): Deleted.
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::updateLayoutViewportParameters):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::willCommitMainFrameData):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::willCommitMainFrameData):
(WebKit::RemoteLayerTreeDrawingArea::willCommitLayerTree): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitMainFrameData):
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitLayerTree): Deleted.

Canonical link: <a href="https://commits.webkit.org/303348@main">https://commits.webkit.org/303348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2964a02d77a3cbce761fb6352edfa456dbe3f0a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83896 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100898 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae5f1259-29f7-40cb-8269-324b42bb06e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3050 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82726 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142153 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4156 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109268 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27746 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3147 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57377 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4209 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32889 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67656 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->