### PR TITLE
[blocks-in-inline] Fix paint order of blocks

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-paint-order-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-paint-order-expected.html
@@ -1,0 +1,24 @@
+<style>
+div {
+    background: yellow;
+    height: 100px;
+    position: relative;
+    width: 100px;
+}
+span {
+    background: blue;
+    position: relative;
+    top: 100px;
+}
+span div {
+    background: orange;
+    width: 100px;
+}
+</style>
+<div>
+<span>span start
+<div>div</div>
+span end
+</span>
+</div>
+</html>

--- a/LayoutTests/fast/inline/blocks-in-inline-paint-order.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-paint-order.html
@@ -1,0 +1,25 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<style>
+div {
+    background: yellow;
+    height: 100px;
+    position: relative;
+    width: 100px;
+}
+span {
+    background: blue;
+    position: relative;
+    top: 100px;
+}
+span div {
+    background: orange;
+    width: 100px;
+}
+</style>
+<div>
+<span>span start
+<div>div</div>
+span end
+</span>
+</div>
+</html>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -79,6 +79,7 @@ public:
     float firstLinePaginationOffset() const { return m_firstLinePaginationOffset.value_or(0.f); }
     float clearBeforeAfterGaps() const { return m_clearGapBeforeFirstLine + m_clearGapAfterLastLine; }
     float clearGapBeforeFirstLine() const { return m_clearGapBeforeFirstLine; }
+    bool hasBlockLevelBoxes() const { return m_hasBlockLevelBoxes; }
 
     IteratorRange<const InlineDisplay::Box*> boxesForRect(const LayoutRect&) const;
 
@@ -107,6 +108,8 @@ private:
     void setClearGapBeforeFirstLine(float clearGapBeforeFirstLine) { m_clearGapBeforeFirstLine = clearGapBeforeFirstLine; }
     void setClearGapAfterLastLine(float clearGapAfterLastLine) { m_clearGapAfterLastLine = clearGapAfterLastLine; }
     void setFirstLinePaginationOffset(float firstLinePaginationOffset) { m_firstLinePaginationOffset = firstLinePaginationOffset; }
+    void setHasBlockLevelBoxes() { m_hasBlockLevelBoxes = true; }
+
     const Vector<size_t>& nonRootInlineBoxIndexesForLayoutBox(const Layout::Box&) const;
 
     CheckedRef<const RenderBlockFlow> m_formattingContextRoot;
@@ -124,6 +127,7 @@ private:
     std::optional<float> m_firstLinePaginationOffset { };
 
     bool m_hasMultilinePaintOverlap { false };
+    bool m_hasBlockLevelBoxes { false };
 
     Vector<Vector<SVGTextFragment>> m_svgTextFragmentsForBoxes;
 };

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -206,6 +206,11 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
             if (box.isInlineBox()) {
                 if (!downcast<RenderElement>(*box.layoutBox().rendererForIntegration()).hasSelfPaintingLayer())
                     lineInkOverflowRect.unite(box.inkOverflow());
+                continue;
+            }
+            if (box.isBlockLevelBox()) {
+                inlineContent.setHasBlockLevelBoxes();
+                continue;
             }
         }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -75,7 +75,7 @@ private:
 class LayerPaintScope {
 public:
     LayerPaintScope(const RenderInline* inlineBoxWithLayer);
-    bool includes(const InlineDisplay::Box&);
+    bool testIsIncludesAndUpdate(const InlineDisplay::Box&);
 
 private:
     const Layout::ElementBox* const m_inlineBoxWithLayer;

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -257,6 +257,8 @@ public:
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint& accumulatedOffset) const override;
     void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const override;
 
+    PaintInfo paintInfoForBlockChildren(const PaintInfo&) const;
+
 protected:
     RenderFragmentedFlow* locateEnclosingFragmentedFlow() const override;
     bool establishesIndependentFormattingContextIgnoringDisplayType(const RenderStyle&) const;


### PR DESCRIPTION
#### 98705549462a0f7d6715942398bbc28fd7eb0e49
<pre>
[blocks-in-inline] Fix paint order of blocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=302268">https://bugs.webkit.org/show_bug.cgi?id=302268</a>
<a href="https://rdar.apple.com/164407663">rdar://164407663</a>

Reviewed by Alan Baradlay.

Currently they paint line inline-blocks but this is not correct. Blocks-in-inline should
follow regular paint phases.

Test: fast/inline/blocks-in-inline-paint-order.html
* LayoutTests/fast/inline/blocks-in-inline-paint-order-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-paint-order.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
(WebCore::LayoutIntegration::InlineContent::hasBlockLevelBoxes const):
(WebCore::LayoutIntegration::InlineContent::setHasBlockLevelBoxes):

Add a bit so we can skip unneeded paint phases.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::adjustDisplayLines const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):

Paint block level boxes using a different path that respect paint phases.

(WebCore::LayoutIntegration::InlineContentPainter::paint):

Support more paint phases.

Test for if we should skip due to baing insider layer first.
The function also updates the state so if we skip due to paint phase we fail
to update correctly.

(WebCore::LayoutIntegration::LayerPaintScope::testIsIncludesAndUpdate):
(WebCore::LayoutIntegration::LayerPaintScope::includes): Deleted.

Rename for clarity.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::paint):

We need to handle additional paint phases if there is inline content.

(WebCore::LayoutIntegration::LineLayout::hitTest):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintInfoForBlockChildren const):

Factor into a function.

(WebCore::RenderBlock::paintContents):
* Source/WebCore/rendering/RenderBlock.h:

Canonical link: <a href="https://commits.webkit.org/302804@main">https://commits.webkit.org/302804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50067c75459b9297276afddf05a12ea08648b9e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137688 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2634e5bd-3d60-4a17-b8c4-786473958ea6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99246 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b31c5588-70ef-4bfd-8c7a-28f26774a1dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133217 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116661 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79939 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/storage (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/83f36b39-2388-47da-ac9c-ca634511e8cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34789 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80945 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140165 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107763 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55284 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65788 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2327 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->