### PR TITLE
Unify Font Serialization

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -71,5 +71,5 @@ selectors = [
 request = "rdar://161241270"
 cleanup = "rdar://161241477"
 symbols = [
-    "CTFontDescriptorCreateMatchingFontDescriptorsWithOptions",
+    "CTFontGetUIFontType",
 ]

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -244,7 +244,7 @@ bool CTFontIsAppleColorEmoji(CTFontRef);
 CTFontRef CTFontCreateForCharacters(CTFontRef currentFont, const UTF16Char *characters, CFIndex length, CFIndex *coveredLength);
 CGFloat CTFontGetSbixImageSizeForGlyphAndContentsScale(CTFontRef, const CGGlyph, CGFloat contentsScale);
 
-CFArrayRef _Nullable CTFontDescriptorCreateMatchingFontDescriptorsWithOptions(CTFontDescriptorRef, CFSetRef _Nullable, CTFontDescriptorMatchingOptions);
+CTFontUIFontType CTFontGetUIFontType(CTFontRef font);
 CTFontDescriptorOptions CTFontDescriptorGetOptions(CTFontDescriptorRef);
 
 CFBitVectorRef CTFontCopyColorGlyphCoverage(CTFontRef);

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -209,23 +209,13 @@ struct WEBCORE_EXPORT AttributedString {
         Color color;
     };
 
-    struct FontWrapper {
-        Ref<Font> font;
-
-        String postScriptName() const;
-        double pointSize() const;
-        CTFontDescriptorOptions fontDescriptorOptions() const;
-        std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes() const;
-        static std::optional<FontWrapper> createFromIPCData(const String& postScriptName, double pointSize, const CTFontDescriptorOptions&, const std::optional<WebCore::FontPlatformSerializedAttributes>&);
-    };
-
     struct AttributeValue {
 
         using AttributeType = Variant<
             double,
             String,
             URL,
-            FontWrapper,
+            InstalledFont,
             Vector<String>,
             Vector<double>,
             ParagraphStyle,

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -110,7 +110,6 @@ public:
     WEBCORE_EXPORT static Ref<Font> create(const FontPlatformData&, Origin = Origin::Local, IsInterstitial = IsInterstitial::No, Visibility = Visibility::Visible, IsOrientationFallback = IsOrientationFallback::No, std::optional<RenderingResourceIdentifier> = std::nullopt);
     WEBCORE_EXPORT static Ref<Font> create(Ref<SharedBuffer>&& fontFaceData, Font::Origin, float fontSize, bool syntheticBold, bool syntheticItalic);
     WEBCORE_EXPORT static Ref<Font> create(WebCore::FontInternalAttributes&&, WebCore::FontPlatformData&&);
-
     WEBCORE_EXPORT ~Font();
 
     static Ref<Font> createSystemFallbackFontPlaceholder() { return adoptRef(*new Font(IsSystemFallbackFontPlaceholder::Yes)); }
@@ -259,7 +258,12 @@ public:
     std::optional<BitVector> findOTSVGGlyphs(std::span<const GlyphBufferGlyph>) const;
 
     bool hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph>) const;
-
+#if USE(CORE_TEXT)
+    using IPCFontData = Variant<WebCore::InstalledFont, WebCore::CustomFontCreationData>;
+    WEBCORE_EXPORT static std::optional<Ref<Font>> fromIPCData(const WebCore::FontInternalAttributes&, IPCFontData&&);
+    WEBCORE_EXPORT IPCFontData toSerializableFont() const;
+    WEBCORE_EXPORT std::optional<InstalledFont> toSerializableInstalledFont() const;
+#endif
 #if PLATFORM(WIN)
     SCRIPT_CACHE* scriptCache() const { return &m_scriptCache; }
 #endif
@@ -269,6 +273,7 @@ public:
 
     using Attributes = FontInternalAttributes;
     const Attributes& attributes() const { return m_attributes; }
+    void setAttributes(Attributes attributes) { m_attributes = attributes; }
 
     ColorGlyphType colorGlyphType(Glyph) const;
 

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -80,6 +80,7 @@ interface IDWriteFontFace;
 
 namespace WebCore {
 
+class Font;
 class FontDescription;
 struct FontCustomPlatformData;
 struct FontSizeAdjust;
@@ -87,81 +88,10 @@ struct FontSizeAdjust;
 class SkiaHarfBuzzFont;
 #endif
 
-struct FontPlatformDataAttributes {
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
-        { }
-
 #if USE(CORE_TEXT)
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, RetainPtr<CFDictionaryRef> attributes, CTFontDescriptorOptions options, RetainPtr<CFStringRef> url, RetainPtr<CFStringRef> psName)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
-        , m_attributes(attributes)
-        , m_options(options)
-        , m_url(url)
-        , m_psName(psName)
-        { }
-#endif
 
-#if PLATFORM(WIN) && USE(CAIRO)
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, LOGFONT font)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
-        , m_font(font)
-        { }
-#endif
-
-#if USE(SKIA)
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, SkString familyName, SkFontStyle style, Vector<hb_feature_t>&& features)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
-        , m_familyName(familyName)
-        , m_style(style)
-        , m_features(WTFMove(features))
-        { }
-#endif
-
-    float m_size { 0 };
-
-    FontOrientation m_orientation { FontOrientation::Horizontal };
-    FontWidthVariant m_widthVariant { FontWidthVariant::RegularWidth };
-    TextRenderingMode m_textRenderingMode { TextRenderingMode::AutoTextRendering };
-
-    bool m_syntheticBold { false };
-    bool m_syntheticOblique { false };
-
-#if PLATFORM(WIN) && USE(CAIRO)
-    LOGFONT m_font;
-#elif USE(CORE_TEXT)
-    RetainPtr<CFDictionaryRef> m_attributes;
-    CTFontDescriptorOptions m_options { (CTFontDescriptorOptions)0 }; // FIXME: <rdar://121670125>
-    RetainPtr<CFStringRef> m_url;
-    RetainPtr<CFStringRef> m_psName;
-#elif USE(SKIA)
-    SkString m_familyName;
-    SkFontStyle m_style;
-    Vector<hb_feature_t> m_features;
-#endif
-};
-
-#if USE(CORE_TEXT)
+using SystemUIFontType = uint32_t;
+#define SystemUIFontTypeNone UINT32_MAX
 
 // FIXME: Some of these structures have std::optional<RetainPtr<>> which seems weird,
 // but generated encode/decode of RetainPtrs doesn't currently handle null values very well.
@@ -220,20 +150,51 @@ struct FontPlatformSerializedAttributes {
 #endif
 };
 
-struct FontPlatformSerializedCreationData {
-    Vector<uint8_t> fontFaceData;
-    std::optional<FontPlatformSerializedAttributes> attributes;
-    String itemInCollection;
-};
-
 struct FontPlatformSerializedData {
     CTFontDescriptorOptions options { 0 }; // <rdar://121670125>
     RetainPtr<CFStringRef> referenceURL;
     RetainPtr<CFStringRef> postScriptName;
     std::optional<FontPlatformSerializedAttributes> attributes;
 };
+
+struct FontMetadata {
+    double pointSize = { 0.0 };
+    WebCore::FontOrientation orientation = FontOrientation::Horizontal;
+    WebCore::FontWidthVariant widthVariant = FontWidthVariant::RegularWidth;
+    WebCore::TextRenderingMode textRenderingMode = TextRenderingMode::AutoTextRendering;
+    bool syntheticBold = false;
+    bool syntheticOblique = false;
+};
+
+struct InstalledFont {
+    struct SystemUIFont {
+        SystemUIFontType systemUIFontType { SystemUIFontTypeNone };
+        String language;
+        RetainPtr<CTFontRef> toCTFont(double pointSize) const;
+    };
+
+    struct PostScriptFont {
+        String postScriptName;
+        CTFontDescriptorOptions fontDescriptorOptions;
+        std::optional<FontPlatformSerializedAttributes> fontSerializedAttributes;
+        RetainPtr<CTFontRef> toCTFont(double pointSize) const;
+    };
+
+    Variant<SystemUIFont, PostScriptFont> font;
+    FontMetadata metadata;
+    WEBCORE_EXPORT RetainPtr<CTFontRef> toCTFont() const;
+    Ref<Font> toFont() const;
+};
+
+struct CustomFontCreationData {
+    FontMetadata metadata;
+    Vector<uint8_t> fontFaceData;
+    std::optional<FontPlatformSerializedAttributes> attributes;
+    String itemInCollection;
+};
+
 #elif USE(SKIA)
-struct FontPlatformSerializedCreationData {
+struct CustomFontCreationData {
     Vector<uint8_t> fontFaceData;
     String itemInCollection;
 };
@@ -242,7 +203,7 @@ struct FontPlatformSerializedData {
     sk_sp<SkData> typefaceData;
 };
 #elif USE(CAIRO)
-struct FontPlatformSerializedCreationData {
+struct CustomFontCreationData {
     Vector<uint8_t> fontFaceData;
     String itemInCollection;
 };
@@ -303,10 +264,6 @@ public:
     WEBCORE_EXPORT FontPlatformData(sk_sp<SkTypeface>&&, float size, bool syntheticBold, bool syntheticOblique, FontOrientation, FontWidthVariant, TextRenderingMode, Vector<hb_feature_t>&&, const FontCustomPlatformData* = nullptr);
 #endif
 
-    using Attributes = FontPlatformDataAttributes;
-
-    WEBCORE_EXPORT static FontPlatformData create(const Attributes&, const FontCustomPlatformData*);
-
     WEBCORE_EXPORT FontPlatformData(const FontPlatformData&);
     WEBCORE_EXPORT FontPlatformData& operator=(const FontPlatformData&);
     WEBCORE_EXPORT ~FontPlatformData();
@@ -321,7 +278,7 @@ public:
     HFONT hfont() const { return m_hfont ? m_hfont->get() : 0; }
 #endif
 
-    using IPCData = Variant<FontPlatformSerializedData, FontPlatformSerializedCreationData>;
+    using IPCData = Variant<FontPlatformSerializedData, CustomFontCreationData>;
 #if USE(CORE_TEXT)
     WEBCORE_EXPORT FontPlatformData(float size, FontOrientation&&, FontWidthVariant&&, TextRenderingMode&&, bool syntheticBold, bool syntheticOblique, RetainPtr<CTFontRef>&&, RefPtr<FontCustomPlatformData>&&);
 #elif USE(SKIA)
@@ -429,8 +386,6 @@ public:
         return m_customPlatformData.get();
     }
     inline RefPtr<const FontCustomPlatformData> protectedCustomPlatformData() const; // Defined in FontCustomPlatformData.h
-
-    WEBCORE_EXPORT Attributes attributes() const;
 
 private:
     bool platformIsEqual(const FontPlatformData&) const;

--- a/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
@@ -66,5 +66,4 @@ Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(Shou
     });
 }
 
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -58,6 +58,8 @@
 
 namespace WebCore {
 
+using IPCFontData = Variant<WebCore::InstalledFont, WebCore::CustomFontCreationData>;
+
 static inline bool caseInsensitiveCompare(CFStringRef a, CFStringRef b)
 {
     return a && CFStringCompare(a, b, kCFCompareCaseInsensitive) == kCFCompareEqualTo;
@@ -986,6 +988,97 @@ bool Font::hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph> glyp
             return true;
     }
     return false;
+}
+
+std::optional<Ref<Font>> Font::fromIPCData(const WebCore::FontInternalAttributes& attributes, IPCFontData&& data)
+{
+    auto font = WTF::switchOn(data,
+        [] (const InstalledFont& installedFont) -> std::optional<Ref<Font>> {
+            return installedFont.toFont();
+        },
+        [] (const CustomFontCreationData& creationData) -> std::optional<Ref<Font>> {
+            Ref fontFaceData = SharedBuffer::create(WTFMove(creationData.fontFaceData));
+            RefPtr<FontCustomPlatformData> customPlatformData = FontCustomPlatformData::create(fontFaceData, creationData.itemInCollection);
+            if (!customPlatformData)
+                return std::nullopt;
+
+            RetainPtr baseFontDescriptor = customPlatformData->fontDescriptor.get();
+            if (!baseFontDescriptor)
+                return std::nullopt;
+
+            RetainPtr<CFDictionaryRef> attributesDictionary = creationData.attributes ? creationData.attributes->toCFDictionary() : nullptr;
+            RetainPtr fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(baseFontDescriptor.get(), attributesDictionary.get()));
+
+            RetainPtr font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), creationData.metadata.pointSize, nullptr));
+
+            return Font::create(FontPlatformData(creationData.metadata.pointSize, FontOrientation(creationData.metadata.orientation), FontWidthVariant(creationData.metadata.widthVariant), TextRenderingMode(creationData.metadata.textRenderingMode), creationData.metadata.syntheticBold, creationData.metadata.syntheticOblique, WTFMove(font), WTFMove(customPlatformData)));
+        }
+    );
+
+    if (font)
+        (*font)->setAttributes(attributes);
+
+    return font;
+}
+
+std::optional<InstalledFont> Font::toSerializableInstalledFont() const
+{
+    RetainPtr ctFont = this->ctFont();
+    if (!ctFont || m_platformData.creationData())
+        return std::nullopt;
+
+    FontMetadata fontData = {
+        CTFontGetSize(ctFont.get()),
+        platformData().orientation(),
+        platformData().widthVariant(),
+        platformData().textRenderingMode(),
+        platformData().syntheticBold(),
+        platformData().syntheticOblique()
+    };
+
+    if ((SystemUIFontType)CTFontGetUIFontType(ctFont.get()) != SystemUIFontTypeNone) {
+        return InstalledFont {
+            InstalledFont::SystemUIFont {
+                (SystemUIFontType)CTFontGetUIFontType(ctFont.get()),
+                adoptCF(checked_cf_cast<CFStringRef>(CTFontCopyAttribute(ctFont.get(), kCTFontDescriptorLanguageAttribute))).get()
+            },
+            fontData
+        };
+    }
+
+    RetainPtr fontDescriptor = adoptCF(CTFontCopyFontDescriptor(ctFont.get()));
+    RetainPtr attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
+    return InstalledFont {
+        InstalledFont::PostScriptFont {
+            String(adoptCF(CTFontCopyPostScriptName(ctFont.get())).get()),
+            CTFontDescriptorGetOptions(fontDescriptor.get()),
+            FontPlatformSerializedAttributes::fromCF(attributes.get())
+        },
+        fontData
+    };
+}
+
+IPCFontData Font::toSerializableFont() const
+{
+    std::optional<InstalledFont> installedFont = toSerializableInstalledFont();
+    if (installedFont)
+        return { *installedFont };
+
+    RetainPtr font = ctFont();
+    RetainPtr fontDescriptor = adoptCF(CTFontCopyFontDescriptor(font.get()));
+    RetainPtr attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
+
+    const auto& data = m_platformData.creationData();
+    FontMetadata fontData = {
+        CTFontGetSize(font.get()),
+        m_platformData.orientation(),
+        m_platformData.widthVariant(),
+        m_platformData.textRenderingMode(),
+        m_platformData.syntheticBold(),
+        m_platformData.syntheticOblique()
+    };
+
+    return { CustomFontCreationData { fontData, { data->fontFaceData->span() }, FontPlatformSerializedAttributes::fromCF(attributes.get()), data->itemInCollection } };
 }
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -27,6 +27,7 @@
 #include "FontCustomPlatformData.h"
 #include "SharedBuffer.h"
 #include <CoreText/CoreText.h>
+#include <WebCore/Font.h>
 #include <pal/spi/cf/CoreTextSPI.h>
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/text/MakeString.h>
@@ -126,20 +127,6 @@ RetainPtr<CTFontRef> createCTFont(CFDictionaryRef attributes, float size, CTFont
     return adoptCF(CTFontCreateWithFontDescriptorAndOptions(fontDescriptor.get(), size, nullptr, options));
 }
 
-FontPlatformData FontPlatformData::create(const Attributes& data, const FontCustomPlatformData* custom)
-{
-    RetainPtr<CTFontRef> ctFont;
-    if (custom) {
-        RetainPtr baseFontDescriptor = custom->fontDescriptor.get();
-        RELEASE_ASSERT(baseFontDescriptor);
-        RetainPtr fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(baseFontDescriptor.get(), data.m_attributes.get()));
-        ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), data.m_size, nullptr));
-    } else
-        ctFont = createCTFont(data.m_attributes.get(), data.m_size, data.m_options, data.m_url.get(), data.m_psName.get());
-
-    return WebCore::FontPlatformData(ctFont.get(), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, data.m_widthVariant, data.m_textRenderingMode, custom);
-}
-
 bool isSystemFont(CTFontRef font)
 {
     return CTFontIsSystemUIFont(font);
@@ -211,58 +198,6 @@ void FontPlatformData::updateSize(float size)
     m_font = adoptCF(CTFontCreateCopyWithAttributes(m_font.get(), m_size, nullptr, nullptr));
 }
 
-FontPlatformData::Attributes FontPlatformData::attributes() const
-{
-    Attributes result(m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique);
-
-    auto fontDescriptor = adoptCF(CTFontCopyFontDescriptor(m_font.get()));
-    result.m_attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
-
-    if (!m_customPlatformData) {
-        result.m_options = CTFontDescriptorGetOptions(fontDescriptor.get());
-        auto referenceURL = adoptCF(checked_cf_cast<CFURLRef>(CTFontCopyAttribute(m_font.get(), kCTFontReferenceURLAttribute)));
-        result.m_url = CFURLGetString(referenceURL.get());
-        result.m_psName = adoptCF(CTFontCopyPostScriptName(m_font.get()));
-    }
-
-    return result;
-}
-
-std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, WebCore::FontOrientation&& orientation, WebCore::FontWidthVariant&& widthVariant, WebCore::TextRenderingMode&& textRenderingMode, bool syntheticBold, bool syntheticOblique, FontPlatformData::IPCData&& toIPCData)
-{
-    RetainPtr<CTFontRef> font;
-    RefPtr<FontCustomPlatformData> customPlatformData;
-
-    bool dataError = WTF::switchOn(toIPCData,
-        [&] (const FontPlatformSerializedData& d) {
-            RetainPtr<CFDictionaryRef> attributesDictionary = d.attributes ? d.attributes->toCFDictionary() : nullptr;
-            font = WebCore::createCTFont(attributesDictionary.get(), size, d.options, d.referenceURL.get(), d.postScriptName.get());
-            if (!font)
-                return true;
-            return false;
-        },
-        [&] (FontPlatformSerializedCreationData& d) {
-            Ref fontFaceData = SharedBuffer::create(WTFMove(d.fontFaceData));
-            RefPtr fontCustomPlatformData = FontCustomPlatformData::create(fontFaceData, d.itemInCollection);
-            if (!fontCustomPlatformData)
-                return true;
-            RetainPtr baseFontDescriptor = fontCustomPlatformData->fontDescriptor.get();
-            if (!baseFontDescriptor)
-                return true;
-            RetainPtr<CFDictionaryRef> attributesDictionary = d.attributes ? d.attributes->toCFDictionary() : nullptr;
-            RetainPtr fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(baseFontDescriptor.get(), attributesDictionary.get()));
-
-            font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
-            customPlatformData = fontCustomPlatformData;
-            return false;
-        }
-    );
-    if (dataError)
-        return std::nullopt;
-
-    return FontPlatformData(size, WTFMove(orientation), WTFMove(widthVariant), WTFMove(textRenderingMode), syntheticBold, syntheticOblique, WTFMove(font), WTFMove(customPlatformData));
-}
-
 FontPlatformData::FontPlatformData(float size, WebCore::FontOrientation&& orientation, WebCore::FontWidthVariant&& widthVariant, WebCore::TextRenderingMode&& textRenderingMode, bool syntheticBold, bool syntheticOblique, RetainPtr<CTFontRef>&& font, RefPtr<FontCustomPlatformData>&& customPlatformData)
     : m_font(font)
     , m_size(size)
@@ -289,8 +224,18 @@ FontPlatformData::IPCData FontPlatformData::toIPCData() const
     RetainPtr attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
 
     const auto& data = creationData();
-    if (data)
-        return FontPlatformSerializedCreationData { { data->fontFaceData->span() }, FontPlatformSerializedAttributes::fromCF(attributes.get()), data->itemInCollection };
+    if (data) {
+        FontMetadata fontData = {
+            CTFontGetSize(font.get()),
+            orientation(),
+            widthVariant(),
+            textRenderingMode(),
+            syntheticBold(),
+            syntheticOblique()
+        };
+
+        return CustomFontCreationData { fontData, { data->fontFaceData->span() }, FontPlatformSerializedAttributes::fromCF(attributes.get()), data->itemInCollection };
+    }
 
     auto options = CTFontDescriptorGetOptions(fontDescriptor.get());
     RetainPtr referenceURL = adoptCF(checked_cf_cast<CFURLRef>(CTFontCopyAttribute(font.get(), kCTFontReferenceURLAttribute)));
@@ -485,6 +430,50 @@ RetainPtr<CFTypeRef> FontPlatformOpticalSize::toCF() const
     }, [] (const String& string) -> RetainPtr<CFTypeRef> {
         return string.createCFString();
     });
+}
+
+RetainPtr<CTFontRef> InstalledFont::SystemUIFont::toCTFont(double pointSize) const
+{
+    return adoptCF(CTFontCreateUIFontForLanguage((CTFontUIFontType)systemUIFontType, pointSize, language.createCFString().get()));
+}
+
+RetainPtr<CTFontRef> InstalledFont::PostScriptFont::toCTFont(double pointSize) const
+{
+    RetainPtr<CTFontDescriptorRef> fontDescriptor;
+    if (fontSerializedAttributes)
+        fontDescriptor = adoptCF(CTFontDescriptorCreateWithAttributesAndOptions(fontSerializedAttributes->toCFDictionary().get(), fontDescriptorOptions));
+    else
+        fontDescriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(postScriptName.createCFString().get(), pointSize));
+
+    RetainPtr matchedFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), pointSize, nullptr));
+    if (String(adoptCF(CTFontCopyPostScriptName(matchedFont.get())).get()) != postScriptName)
+        return nullptr;
+
+    return matchedFont;
+}
+
+RetainPtr<CTFontRef> InstalledFont::toCTFont() const
+{
+    return WTF::switchOn(font,
+        [this] (const SystemUIFont& systemFont) -> RetainPtr<CTFontRef> {
+            return systemFont.toCTFont(metadata.pointSize);
+        },
+        [this] (const PostScriptFont& postScriptFont) -> RetainPtr<CTFontRef> {
+            return postScriptFont.toCTFont(metadata.pointSize);
+        }
+    );
+}
+
+Ref<Font> InstalledFont::toFont() const
+{
+    return WTF::switchOn(font,
+        [this] (const SystemUIFont& systemFont) -> Ref<Font> {
+            return Font::create(FontPlatformData(systemFont.toCTFont(metadata.pointSize).get(), metadata.pointSize, metadata.syntheticBold, metadata.syntheticOblique, metadata.orientation, metadata.widthVariant, metadata.textRenderingMode));
+        },
+        [this] (const PostScriptFont& postScriptFont) -> Ref<Font> {
+            return Font::create(FontPlatformData(postScriptFont.toCTFont(metadata.pointSize).get(), metadata.pointSize, metadata.syntheticBold, metadata.syntheticOblique, metadata.orientation, metadata.widthVariant, metadata.textRenderingMode));
+        }
+    );
 }
 
 #undef INJECT_STRING_VALUE

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -148,7 +148,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 
             return std::nullopt;
         },
-        [&] (FontPlatformSerializedCreationData& d) -> std::optional<FontPlatformData> {
+        [&] (CustomFontCreationData& d) -> std::optional<FontPlatformData> {
             auto fontFaceData = SharedBuffer::create(WTFMove(d.fontFaceData));
             if (RefPtr fontCustomPlatformData = FontCustomPlatformData::create(fontFaceData, d.itemInCollection))
                 return FontPlatformData(size, WTFMove(orientation), WTFMove(widthVariant), WTFMove(textRenderingMode), syntheticBold, syntheticOblique, WTFMove(fontCustomPlatformData));
@@ -161,7 +161,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 FontPlatformData::IPCData FontPlatformData::toIPCData() const
 {
     if (auto* data = creationData())
-        return FontPlatformSerializedCreationData { { data->fontFaceData->span() }, data->itemInCollection };
+        return CustomFontCreationData { { data->fontFaceData->span() }, data->itemInCollection };
 
     return FontPlatformSerializedData { m_font.getTypeface()->serialize() };
 }

--- a/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
@@ -88,7 +88,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 
             return std::nullopt;
         },
-        [&] (FontPlatformSerializedCreationData& d) -> std::optional<FontPlatformData> {
+        [&] (CustomFontCreationData& d) -> std::optional<FontPlatformData> {
             auto fontFaceData = SharedBuffer::create(WTFMove(d.fontFaceData));
             if (RefPtr fontCustomPlatformData = FontCustomPlatformData::create(fontFaceData, d.itemInCollection))
                 return FontPlatformData(size, syntheticBold, syntheticOblique, WTFMove(orientation), WTFMove(widthVariant), WTFMove(textRenderingMode), fontCustomPlatformData.get());
@@ -101,7 +101,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 FontPlatformData::IPCData FontPlatformData::toIPCData() const
 {
     if (auto* data = creationData())
-        return FontPlatformSerializedCreationData { { data->fontFaceData->span() }, data->itemInCollection };
+        return CustomFontCreationData { { data->fontFaceData->span() }, data->itemInCollection };
 
     LOGFONT logFont;
     GetObject(hfont(), sizeof logFont, &logFont);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -406,20 +406,9 @@ void RemoteRenderingBackend::releaseNativeImage(RenderingResourceIdentifier iden
     MESSAGE_CHECK(success, "NativeImage released before being cached.");
 }
 
-void RemoteRenderingBackend::cacheFont(const Font::Attributes& fontAttributes, FontPlatformDataAttributes platformData, std::optional<RenderingResourceIdentifier> fontCustomPlatformDataIdentifier)
+void RemoteRenderingBackend::cacheFont(Ref<Font>&& font)
 {
     ASSERT(!RunLoop::isMain());
-
-    RefPtr<FontCustomPlatformData> customPlatformData = nullptr;
-    if (fontCustomPlatformDataIdentifier) {
-        customPlatformData = m_remoteResourceCache.cachedFontCustomPlatformData(*fontCustomPlatformDataIdentifier);
-        MESSAGE_CHECK(customPlatformData, "CacheFont without caching custom data");
-    }
-
-    FontPlatformData platform = FontPlatformData::create(platformData, customPlatformData.get());
-
-    Ref<Font> font = Font::create(platform, fontAttributes.origin, fontAttributes.isInterstitial, fontAttributes.visibility, fontAttributes.isTextOrientationFallback, fontAttributes.renderingResourceIdentifier);
-
     m_remoteResourceCache.cacheFont(WTFMove(font));
 }
 
@@ -428,23 +417,6 @@ void RemoteRenderingBackend::releaseFont(WebCore::RenderingResourceIdentifier id
     assertIsCurrent(workQueue());
     bool success = m_remoteResourceCache.releaseFont(identifier);
     MESSAGE_CHECK(success, "Font released before being cached.");
-}
-
-void RemoteRenderingBackend::cacheFontCustomPlatformData(WebCore::FontCustomPlatformSerializedData&& fontCustomPlatformSerializedData)
-{
-    ASSERT(!RunLoop::isMain());
-
-    auto customPlatformData = FontCustomPlatformData::tryMakeFromSerializationData(WTFMove(fontCustomPlatformSerializedData), shouldUseLockdownFontParser());
-    MESSAGE_CHECK(customPlatformData.has_value(), "cacheFontCustomPlatformData couldn't deserialize FontCustomPlatformData");
-
-    m_remoteResourceCache.cacheFontCustomPlatformData(WTFMove(customPlatformData.value()));
-}
-
-void RemoteRenderingBackend::releaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier identifier)
-{
-    assertIsCurrent(workQueue());
-    bool success = m_remoteResourceCache.releaseFontCustomPlatformData(identifier);
-    MESSAGE_CHECK(success, "FontCustomPlatformData released before being cached.");
 }
 
 void RemoteRenderingBackend::cacheGradient(Ref<Gradient>&& gradient, RemoteGradientIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -166,10 +166,8 @@ private:
     void releaseGradient(RemoteGradientIdentifier);
     void cacheFilter(Ref<WebCore::Filter>&&);
     void releaseFilter(WebCore::RenderingResourceIdentifier);
-    void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformDataAttributes, std::optional<WebCore::RenderingResourceIdentifier>);
+    void cacheFont(Ref<WebCore::Font>&&);
     void releaseFont(WebCore::RenderingResourceIdentifier);
-    void cacheFontCustomPlatformData(WebCore::FontCustomPlatformSerializedData&&);
-    void releaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier);
     void releaseMemory();
     void finalizeRenderingUpdate(RenderingUpdateID);
     void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<std::pair<ImageBufferSetIdentifier, OptionSet<BufferInSetType>>>&, bool forcePurge);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -39,10 +39,8 @@ messages -> RemoteRenderingBackend Stream {
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     CacheNativeImageFromSharedNativeImage(WebCore::RenderingResourceIdentifier sharedNativeImageIdentifier)
     ReleaseNativeImage(WebCore::RenderingResourceIdentifier identifier)
-    CacheFont(struct WebCore::FontInternalAttributes data, struct WebCore::FontPlatformDataAttributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable
+    CacheFont(Ref<WebCore::Font> font) NotStreamEncodable
     ReleaseFont(WebCore::RenderingResourceIdentifier identifier)
-    CacheFontCustomPlatformData(struct WebCore::FontCustomPlatformSerializedData fontCustomPlatformData) NotStreamEncodable
-    ReleaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier identifier)
     CacheGradient(Ref<WebCore::Gradient> gradient, WebKit::RemoteGradientIdentifier identifier)
     ReleaseGradient(WebKit::RemoteGradientIdentifier identifier)
     CacheFilter(Ref<WebCore::Filter> filter) NotStreamEncodable

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -104,22 +104,6 @@ RefPtr<Font> RemoteResourceCache::cachedFont(RenderingResourceIdentifier identif
     return m_fonts.get(identifier);
 }
 
-void RemoteResourceCache::cacheFontCustomPlatformData(Ref<FontCustomPlatformData>&& customPlatformData)
-{
-    auto identifier = customPlatformData->m_renderingResourceIdentifier;
-    m_fontCustomPlatformDatas.add(identifier, WTFMove(customPlatformData));
-}
-
-bool RemoteResourceCache::releaseFontCustomPlatformData(RenderingResourceIdentifier identifier)
-{
-    return m_fontCustomPlatformDatas.remove(identifier);
-}
-
-RefPtr<FontCustomPlatformData> RemoteResourceCache::cachedFontCustomPlatformData(RenderingResourceIdentifier identifier) const
-{
-    return m_fontCustomPlatformDatas.get(identifier);
-}
-
 bool RemoteResourceCache::cacheDisplayList(RemoteDisplayListIdentifier identifier, Ref<const DisplayList::DisplayList> displayList)
 {
     return m_displayLists.add(identifier, displayList).isNewEntry;
@@ -147,7 +131,6 @@ void RemoteResourceCache::releaseMemory()
     m_gradients.clear();
     m_filters.clear();
     m_fonts.clear();
-    m_fontCustomPlatformDatas.clear();
     m_displayLists.clear();
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -68,10 +68,6 @@ public:
     bool releaseFont(WebCore::RenderingResourceIdentifier);
     RefPtr<WebCore::Font> cachedFont(WebCore::RenderingResourceIdentifier) const;
 
-    void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
-    bool releaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier);
-    RefPtr<WebCore::FontCustomPlatformData> cachedFontCustomPlatformData(WebCore::RenderingResourceIdentifier) const;
-
     bool cacheDisplayList(RemoteDisplayListIdentifier, Ref<const WebCore::DisplayList::DisplayList>);
     RefPtr<const WebCore::DisplayList::DisplayList> cachedDisplayList(RemoteDisplayListIdentifier) const;
     bool releaseDisplayList(RemoteDisplayListIdentifier);
@@ -85,7 +81,6 @@ private:
     HashMap<RemoteGradientIdentifier, Ref<WebCore::Gradient>> m_gradients;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::Filter>> m_filters;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::Font>> m_fonts;
-    HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::FontCustomPlatformData>> m_fontCustomPlatformDatas;
     HashMap<RemoteDisplayListIdentifier, Ref<const WebCore::DisplayList::DisplayList>> m_displayLists;
 };
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1090,7 +1090,6 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::FillLightMode': ['<WebCore/FillLightMode.h>'],
         'WebCore::FirstPartyWebsiteDataRemovalMode': ['<WebCore/NetworkStorageSession.h>'],
         'WebCore::FontChanges': ['<WebCore/FontAttributeChanges.h>'],
-        'WebCore::FontPlatformDataAttributes': ['<WebCore/FontPlatformData.h>'],
         'WebCore::FontCustomPlatformSerializedData': ['<WebCore/FontCustomPlatformData.h>'],
         'WebCore::FontSmoothingMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::FoundElementInRemoteFrame': ['<WebCore/FocusControllerTypes.h>'],

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -180,24 +180,16 @@ header: <WebCore/AttributedString.h>
     Vector<WebCore::TextTab> textTabs;
 }
 
-[Nested, CreateUsing=createFromIPCData] struct WebCore::AttributedString::FontWrapper {
-    String postScriptName();
-    double pointSize();
-    CTFontDescriptorOptions fontDescriptorOptions();
-    std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes();
-}
-
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
 [Nested] struct WebCore::AttributedString::AttributeValue {
-    Variant<double, String, URL, WebCore::AttributedString::FontWrapper, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::MultiRepresentationHEICAttachmentData, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+    Variant<double, String, URL, WebCore::InstalledFont, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::MultiRepresentationHEICAttachmentData, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
 }
 #endif
 #if !ENABLE(MULTI_REPRESENTATION_HEIC)
 [Nested] struct WebCore::AttributedString::AttributeValue {
-    Variant<double, String, URL, WebCore::AttributedString::FontWrapper, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+    Variant<double, String, URL, WebCore::InstalledFont, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
 }
 #endif
-
 
 [Nested] struct WebCore::AttributedString::ColorFromPlatformColor {
     WebCore::Color color

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -136,3 +136,86 @@ using WebCore::ScrollOffset = WebCore::IntPoint;
     bool enclosingLayerUsesContentsLayer;
 #endif
 };
+
+[Nested] enum class WebCore::FontAttributes::SubscriptOrSuperscript : uint8_t {
+    None,
+    Subscript,
+    Superscript
+};
+
+[Nested] enum class WebCore::FontAttributes::HorizontalAlignment : uint8_t {
+    Left,
+    Center,
+    Right,
+    Justify,
+    Natural
+};
+
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType::NoneData {
+};
+
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType::StringData {
+    AtomString identifier;
+};
+
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType::CounterStyleData {
+    AtomString identifier;
+};
+
+header: <WebCore/StyleListStyleType.h>
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType {
+    Variant<WebCore::Style::ListStyleType::NoneData, WebCore::Style::ListStyleType::StringData, WebCore::Style::ListStyleType::CounterStyleData> ipcData()
+};
+
+header: <WebCore/FontAttributes.h>
+[CustomHeader] struct WebCore::TextList {
+    WebCore::Style::ListStyleType styleType;
+    int startingItemNumber
+    bool ordered
+};
+
+struct WebCore::FontShadow {
+    WebCore::Color color;
+    WebCore::FloatSize offset;
+    double blurRadius;
+};
+
+[CustomHeader] struct WebCore::FontAttributes {
+    RefPtr<WebCore::Font> font
+    WebCore::Color backgroundColor
+    WebCore::Color foregroundColor
+    WebCore::FontShadow fontShadow
+    WebCore::FontAttributes::SubscriptOrSuperscript subscriptOrSuperscript
+    WebCore::FontAttributes::HorizontalAlignment horizontalAlignment
+    Vector<WebCore::TextList> textLists
+    bool hasUnderline
+    bool hasStrikeThrough
+    bool hasMultipleFonts
+};
+
+header: <WebCore/FontAttributeChanges.h>
+enum class WebCore::VerticalAlignChange : uint8_t {
+    Superscript,
+    Baseline,
+    Subscript
+};
+
+header: <WebCore/FontAttributeChanges.h>
+[CustomHeader] class WebCore::FontChanges {
+    String m_fontName;
+    String m_fontFamily;
+    std::optional<double> m_fontSize;
+    [Validator='!*m_fontSize || !*m_fontSizeDelta'] std::optional<double> m_fontSizeDelta;
+    std::optional<bool> m_bold;
+    std::optional<bool> m_italic;
+};
+
+class WebCore::FontAttributeChanges {
+    std::optional<WebCore::VerticalAlignChange> m_verticalAlign;
+    std::optional<WebCore::Color> m_backgroundColor;
+    std::optional<WebCore::Color> m_foregroundColor;
+    std::optional<WebCore::FontShadow> m_shadow;
+    std::optional<bool> m_strikeThrough;
+    std::optional<bool> m_underline;
+    WebCore::FontChanges m_fontChanges;
+};

--- a/Source/WebKit/Shared/PlatformPopupMenuData.h
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.h
@@ -34,8 +34,7 @@ namespace WebKit {
 
 struct PlatformPopupMenuData {
 #if PLATFORM(COCOA)
-    String postScriptName;
-    double pointSize { 0.0 };
+    WebCore::InstalledFont font;
     bool shouldPopOver { false };
     bool hideArrows { false };
     WebCore::PopupMenuStyle::Size menuSize { WebCore::PopupMenuStyle::Size::Normal };

--- a/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
@@ -22,8 +22,7 @@
 
 struct WebKit::PlatformPopupMenuData {
 #if PLATFORM(COCOA)
-    String postScriptName;
-    double pointSize;
+    WebCore::InstalledFont font;
     bool shouldPopOver;
     bool hideArrows;
     WebCore::PopupMenuStyle::Size menuSize;

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -51,49 +51,6 @@ enum class WebCore::TextRenderingMode : uint8_t {
     GeometricPrecision
 };
 
-using WebCore::FontPlatformData::IPCData = Variant<WebCore::FontPlatformSerializedData, WebCore::FontPlatformSerializedCreationData>;
-
-[CreateUsing=fromIPCData] class WebCore::FontPlatformData {
-    float size();
-    WebCore::FontOrientation orientation();
-    WebCore::FontWidthVariant widthVariant();
-    WebCore::TextRenderingMode textRenderingMode();
-    bool syntheticBold();
-    bool syntheticOblique();
-    WebCore::FontPlatformData::IPCData toIPCData();
-}
-
-header: <WebCore/FontPlatformData.h>
-[CustomHeader] struct WebCore::FontPlatformDataAttributes {
-    float m_size;
-    WebCore::FontOrientation m_orientation;
-    WebCore::FontWidthVariant m_widthVariant;
-    WebCore::TextRenderingMode m_textRenderingMode;
-    bool m_syntheticBold;
-    bool m_syntheticOblique;
-#if PLATFORM(WIN) && USE(CAIRO)
-    LOGFONT m_font;
-#endif
-#if USE(CORE_TEXT)
-    RetainPtr<CFDictionaryRef> m_attributes;
-    CTFontDescriptorOptions m_options;
-    RetainPtr<CFStringRef> m_url;
-    RetainPtr<CFStringRef> m_psName;
-#endif
-#if USE(SKIA)
-    SkString m_familyName;
-    SkFontStyle m_style;
-    Vector<hb_feature_t> m_features;
-#endif
-};
-
-header: <WebCore/FontCustomPlatformData.h>
-[CustomHeader] struct WebCore::FontCustomPlatformSerializedData {
-    Ref<WebCore::SharedBuffer> fontFaceData;
-    String itemInCollection;
-    WebCore::RenderingResourceIdentifier renderingResourceIdentifier;
-};
-
 #if USE(CORE_TEXT)
 
 header: <WebCore/FontPlatformData.h>
@@ -142,104 +99,63 @@ header: <WebCore/FontPlatformData.h>
 #endif
 };
 
-[CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
+[CustomHeader] struct WebCore::CustomFontCreationData {
+    WebCore::FontMetadata metadata;
     Vector<uint8_t> fontFaceData;
     std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
     String itemInCollection;
 };
 
-[CustomHeader] struct WebCore::FontPlatformSerializedData {
-    CTFontDescriptorOptions options;
-    RetainPtr<CFStringRef> referenceURL;
-    RetainPtr<CFStringRef> postScriptName;
-    std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
-};
+[CustomHeader] struct WebCore::FontMetadata {
+    double pointSize;
+    WebCore::FontOrientation orientation;
+    WebCore::FontWidthVariant widthVariant;
+    WebCore::TextRenderingMode textRenderingMode;
+    bool syntheticBold;
+    bool syntheticOblique;
+}
+
+using WebCore::SystemUIFontType = uint32_t;
+
+[CustomHeader, Nested] struct WebCore::InstalledFont::SystemUIFont {
+    WebCore::SystemUIFontType systemUIFontType;
+    String language;
+}
+
+[CustomHeader, Nested] struct WebCore::InstalledFont::PostScriptFont {
+    String postScriptName;
+    CTFontDescriptorOptions fontDescriptorOptions;
+    std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes
+}
+
+[CustomHeader] struct WebCore::InstalledFont {
+    Variant<WebCore::InstalledFont::SystemUIFont, WebCore::InstalledFont::PostScriptFont> font;
+    WebCore::FontMetadata metadata;
+}
+
+
+[RefCounted, CreateUsing=fromIPCData] class WebCore::Font {
+    WebCore::FontInternalAttributes attributes();
+    Variant<WebCore::InstalledFont, WebCore::CustomFontCreationData> toSerializableFont();
+}
+
 #endif // USE(CORE_TEXT)
+
+#if !USE(CORE_TEXT)
+using WebCore::FontPlatformData::IPCData = Variant<WebCore::FontPlatformSerializedData, WebCore::CustomFontCreationData>;
+
+[CreateUsing=fromIPCData] class WebCore::FontPlatformData {
+    float size();
+    WebCore::FontOrientation orientation();
+    WebCore::FontWidthVariant widthVariant();
+    WebCore::TextRenderingMode textRenderingMode();
+    bool syntheticBold();
+    bool syntheticOblique();
+    WebCore::FontPlatformData::IPCData toIPCData();
+}
 
 [RefCounted] class WebCore::Font {
     WebCore::FontInternalAttributes attributes();
     WebCore::FontPlatformData platformData();
 }
-
-[Nested] enum class WebCore::FontAttributes::SubscriptOrSuperscript : uint8_t {
-    None,
-    Subscript,
-    Superscript
-};
-
-[Nested] enum class WebCore::FontAttributes::HorizontalAlignment : uint8_t {
-    Left,
-    Center,
-    Right,
-    Justify,
-    Natural
-};
-
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType::NoneData {
-};
-
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType::StringData {
-    AtomString identifier;
-};
-
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType::CounterStyleData {
-    AtomString identifier;
-};
-
-header: <WebCore/StyleListStyleType.h>
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType {
-    Variant<WebCore::Style::ListStyleType::NoneData, WebCore::Style::ListStyleType::StringData, WebCore::Style::ListStyleType::CounterStyleData> ipcData()
-};
-
-header: <WebCore/FontAttributes.h>
-[CustomHeader] struct WebCore::TextList {
-    WebCore::Style::ListStyleType styleType;
-    int startingItemNumber
-    bool ordered
-};
-
-struct WebCore::FontShadow {
-    WebCore::Color color;
-    WebCore::FloatSize offset;
-    double blurRadius;
-};
-
-[CustomHeader] struct WebCore::FontAttributes {
-    RefPtr<WebCore::Font> font
-    WebCore::Color backgroundColor
-    WebCore::Color foregroundColor
-    WebCore::FontShadow fontShadow
-    WebCore::FontAttributes::SubscriptOrSuperscript subscriptOrSuperscript
-    WebCore::FontAttributes::HorizontalAlignment horizontalAlignment
-    Vector<WebCore::TextList> textLists
-    bool hasUnderline
-    bool hasStrikeThrough
-    bool hasMultipleFonts
-};
-
-header: <WebCore/FontAttributeChanges.h>
-enum class WebCore::VerticalAlignChange : uint8_t {
-    Superscript,
-    Baseline,
-    Subscript
-};
-
-header: <WebCore/FontAttributeChanges.h>
-[CustomHeader] class WebCore::FontChanges {
-    String m_fontName;
-    String m_fontFamily;
-    std::optional<double> m_fontSize;
-    [Validator='!*m_fontSize || !*m_fontSizeDelta'] std::optional<double> m_fontSizeDelta;
-    std::optional<bool> m_bold;
-    std::optional<bool> m_italic;
-};
-
-class WebCore::FontAttributeChanges {
-    std::optional<WebCore::VerticalAlignChange> m_verticalAlign;
-    std::optional<WebCore::Color> m_backgroundColor;
-    std::optional<WebCore::Color> m_foregroundColor;
-    std::optional<WebCore::FontShadow> m_shadow;
-    std::optional<bool> m_strikeThrough;
-    std::optional<bool> m_underline;
-    WebCore::FontChanges m_fontChanges;
-};
+#endif

--- a/Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in
+++ b/Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in
@@ -30,7 +30,7 @@ headers: "CoreIPCLOGFONT.h"
 #endif
 
 header: <WebCore/FontPlatformData.h>
-[CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
+[CustomHeader] struct WebCore::CustomFontCreationData {
     Vector<uint8_t> fontFaceData;
     String itemInCollection;
 };

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
@@ -23,7 +23,7 @@
 #if USE(SKIA)
 
 header: <WebCore/FontPlatformData.h>
-[CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
+[CustomHeader] struct WebCore::CustomFontCreationData {
     Vector<uint8_t> fontFaceData;
     String itemInCollection;
 };

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -110,15 +110,10 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    auto scaledFontSize = data.pointSize * pageScaleFactor;
-    
-    RetainPtr descriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(data.postScriptName.createCFString().get(), scaledFontSize));
-    RetainPtr matched = adoptCF(CTFontDescriptorCreateMatchingFontDescriptorsWithOptions(descriptor.get(), NULL, kCTFontDescriptorMatchingOptionIncludeHiddenFonts));
-
-    if (matched && CFArrayGetCount(matched.get())) {
-        RetainPtr matchedDescriptor = dynamic_cf_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(matched.get(), 0));
-        font = adoptCF(CTFontCreateWithFontDescriptor(matchedDescriptor.get(), scaledFontSize, NULL));
-    }
+    PlatformPopupMenuData mutableData = data;
+    auto scaledFontSize = mutableData.font.metadata.pointSize * pageScaleFactor;
+    mutableData.font.metadata.pointSize = scaledFontSize;
+    font = mutableData.font.toCTFont();
 
     // font will be nil when using a custom font. However, we should still
     // honor the font size, matching other browsers.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -425,11 +425,6 @@ void RemoteRenderingBackendProxy::releaseNativeImage(RenderingResourceIdentifier
     send(Messages::RemoteRenderingBackend::ReleaseNativeImage(identifier));
 }
 
-void RemoteRenderingBackendProxy::cacheFont(const WebCore::Font::Attributes& fontAttributes, const WebCore::FontPlatformDataAttributes& platformData, std::optional<WebCore::RenderingResourceIdentifier> ident)
-{
-    send(Messages::RemoteRenderingBackend::CacheFont(fontAttributes, platformData, ident));
-}
-
 void RemoteRenderingBackendProxy::releaseFont(RenderingResourceIdentifier identifier)
 {
     if (!m_connection)
@@ -437,17 +432,9 @@ void RemoteRenderingBackendProxy::releaseFont(RenderingResourceIdentifier identi
     send(Messages::RemoteRenderingBackend::ReleaseFont(identifier));
 }
 
-void RemoteRenderingBackendProxy::cacheFontCustomPlatformData(Ref<const FontCustomPlatformData>&& customPlatformData)
+void RemoteRenderingBackendProxy::cacheFont(const Ref<WebCore::Font>& font)
 {
-    Ref<FontCustomPlatformData> data = adoptRef(const_cast<FontCustomPlatformData&>(customPlatformData.leakRef()));
-    send(Messages::RemoteRenderingBackend::CacheFontCustomPlatformData(data->serializedData()));
-}
-
-void RemoteRenderingBackendProxy::releaseFontCustomPlatformData(RenderingResourceIdentifier identifier)
-{
-    if (!m_connection)
-        return;
-    send(Messages::RemoteRenderingBackend::ReleaseFontCustomPlatformData(identifier));
+    send(Messages::RemoteRenderingBackend::CacheFont(font));
 }
 
 void RemoteRenderingBackendProxy::cacheGradient(Ref<Gradient>&& gradient, RemoteGradientIdentifier identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -111,10 +111,8 @@ public:
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void cacheNativeImageFromSharedNativeImage(const RemoteNativeImageProxy&);
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
-    void cacheFont(const WebCore::Font::Attributes&, const WebCore::FontPlatformDataAttributes&, std::optional<WebCore::RenderingResourceIdentifier>);
+    void cacheFont(const Ref<WebCore::Font>&);
     void releaseFont(WebCore::RenderingResourceIdentifier);
-    void cacheFontCustomPlatformData(Ref<const WebCore::FontCustomPlatformData>&&);
-    void releaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, RemoteGradientIdentifier);
     void releaseGradient(RemoteGradientIdentifier);
     void cacheFilter(Ref<WebCore::Filter>&&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -162,14 +162,10 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image, const De
 
 void RemoteResourceCacheProxy::recordFontUse(Font& font)
 {
-    if (RefPtr platformData = font.platformData().customPlatformData())
-        recordFontCustomPlatformDataUse(*platformData);
-
     auto result = m_fonts.add(font.renderingResourceIdentifier(), m_renderingUpdateID);
 
     if (result.isNewEntry) {
-        auto renderingResourceIdentifier = font.platformData().customPlatformData() ? std::optional(font.platformData().customPlatformData()->m_renderingResourceIdentifier) : std::nullopt;
-        m_remoteRenderingBackendProxy->cacheFont(font.attributes(), font.platformData().attributes(), renderingResourceIdentifier);
+        m_remoteRenderingBackendProxy->cacheFont(font);
         ++m_numberOfFontsUsedInCurrentRenderingUpdate;
         return;
     }
@@ -178,23 +174,6 @@ void RemoteResourceCacheProxy::recordFontUse(Font& font)
     if (currentState != m_renderingUpdateID) {
         currentState = m_renderingUpdateID;
         ++m_numberOfFontsUsedInCurrentRenderingUpdate;
-    }
-}
-
-void RemoteResourceCacheProxy::recordFontCustomPlatformDataUse(const FontCustomPlatformData& customPlatformData)
-{
-    auto result = m_fontCustomPlatformDatas.add(customPlatformData.m_renderingResourceIdentifier, m_renderingUpdateID);
-
-    if (result.isNewEntry) {
-        m_remoteRenderingBackendProxy->cacheFontCustomPlatformData(customPlatformData);
-        ++m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate;
-        return;
-    }
-
-    auto& currentState = result.iterator->value;
-    if (currentState != m_renderingUpdateID) {
-        currentState = m_renderingUpdateID;
-        ++m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate;
     }
 }
 
@@ -277,12 +256,6 @@ void RemoteResourceCacheProxy::releaseFonts()
     m_numberOfFontsUsedInCurrentRenderingUpdate = 0;
 }
 
-void RemoteResourceCacheProxy::releaseFontCustomPlatformDatas()
-{
-    m_fontCustomPlatformDatas.clear();
-    m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate = 0;
-}
-
 void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
 {
     static constexpr unsigned minimumRenderingUpdateCountToKeepFontAlive = 4;
@@ -304,22 +277,7 @@ void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
         });
     }
 
-    totalFontCount = m_fontCustomPlatformDatas.size();
-    RELEASE_ASSERT(m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate <= totalFontCount);
-    if (totalFontCount != m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate) {
-        HashSet<WebCore::RenderingResourceIdentifier> toRemove;
-        auto renderingUpdateID = m_renderingUpdateID;
-        for (auto& item : m_fontCustomPlatformDatas) {
-            if (renderingUpdateID - item.value >= minimumRenderingUpdateCountToKeepFontAlive) {
-                toRemove.add(item.key);
-                m_remoteRenderingBackendProxy->releaseFontCustomPlatformData(item.key);
-            }
-        }
-
-        m_fontCustomPlatformDatas.removeIf([&](const auto& bucket) {
-            return toRemove.contains(bucket.key);
-        });
-    }
+    totalFontCount = m_fonts.size();
 }
 
 void RemoteResourceCacheProxy::didPaintLayers()
@@ -338,7 +296,6 @@ void RemoteResourceCacheProxy::releaseMemory()
     m_gradients.clear();
     m_displayLists.clear();
     releaseFonts();
-    releaseFontCustomPlatformDatas();
 }
 
 void RemoteResourceCacheProxy::disconnect()
@@ -348,7 +305,6 @@ void RemoteResourceCacheProxy::disconnect()
     m_gradients.clear();
     m_displayLists.clear();
     releaseFonts();
-    releaseFontCustomPlatformDatas();
 
     for (auto& value : m_nativeImages.values())
         value.existsInRemote = false;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -66,7 +66,6 @@ public:
     void recordFontUse(WebCore::Font&);
     RemoteGradientIdentifier recordGradientUse(WebCore::Gradient&);
     void recordFilterUse(WebCore::Filter&);
-    void recordFontCustomPlatformDataUse(const WebCore::FontCustomPlatformData&);
     RemoteDisplayListIdentifier recordDisplayListUse(const WebCore::DisplayList::DisplayList&);
     void didPaintLayers();
 
@@ -97,7 +96,6 @@ private:
     void finalizeRenderingUpdateForFonts();
     void prepareForNextRenderingUpdate();
     void releaseFonts();
-    void releaseFontCustomPlatformDatas();
 
     struct NativeImageEntry {
         RefPtr<WebCore::ShareableBitmap> bitmap; // Reused across GPUP crashes, held through the associated NativeImage lifetime.
@@ -113,7 +111,6 @@ private:
 
     using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
     FontHashMap m_fonts;
-    FontHashMap m_fontCustomPlatformDatas;
 
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };
     unsigned m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate { 0 };


### PR DESCRIPTION
#### 8503be0db9c871e6cf572f626dc03b076fdc6641
<pre>
Unify Font Serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=302266">https://bugs.webkit.org/show_bug.cgi?id=302266</a>
<a href="https://rdar.apple.com/164085378">rdar://164085378</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSObject):
(WebCore::extractValue):
(WebCore::AttributedString::FontWrapper::createFromIPCData): Deleted.
(WebCore::AttributedString::FontWrapper::postScriptName const): Deleted.
(WebCore::AttributedString::FontWrapper::pointSize const): Deleted.
(WebCore::AttributedString::FontWrapper::fontDescriptorOptions const): Deleted.
(WebCore::AttributedString::FontWrapper::fontSerializedAttributes const): Deleted.
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::setAttributes):
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformDataAttributes::FontPlatformDataAttributes): Deleted.
* Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::fromIPCData):
(WebCore::Font::toSerializableInstalledFont const):
(WebCore::Font::toSerializableFont const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::toIPCData const):
(WebCore::InstalledFont::SystemUIFont::toCTFont const):
(WebCore::InstalledFont::PostScriptFont::toCTFont const):
(WebCore::InstalledFont::toCTFont const):
(WebCore::InstalledFont::toFont const):
(WebCore::FontPlatformData::create): Deleted.
(WebCore::FontPlatformData::attributes const): Deleted.
(WebCore::FontPlatformData::fromIPCData): Deleted.
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::toIPCData const):
* Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp:
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::toIPCData const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheFont):
(WebKit::RemoteRenderingBackend::cacheFontCustomPlatformData): Deleted.
(WebKit::RemoteRenderingBackend::releaseFontCustomPlatformData): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::releaseMemory):
(WebKit::RemoteResourceCache::cacheFontCustomPlatformData): Deleted.
(WebKit::RemoteResourceCache::releaseFontCustomPlatformData): Deleted.
(WebKit::RemoteResourceCache::cachedFontCustomPlatformData const): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/Shared/PlatformPopupMenuData.h:
* Source/WebKit/Shared/PlatformPopupMenuData.serialization.in:
* Source/WebKit/Shared/WebCoreFont.serialization.in:
* Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in:
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in:
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::showPopupMenu):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheFont):
(WebKit::RemoteRenderingBackendProxy::cacheFontCustomPlatformData): Deleted.
(WebKit::RemoteRenderingBackendProxy::releaseFontCustomPlatformData): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordFontUse):
(WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
(WebKit::RemoteResourceCacheProxy::releaseMemory):
(WebKit::RemoteResourceCacheProxy::disconnect):
(WebKit::RemoteResourceCacheProxy::recordFontCustomPlatformDataUse): Deleted.
(WebKit::RemoteResourceCacheProxy::releaseFontCustomPlatformDatas): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm:
(WebKit::WebPopupMenu::setUpPlatformData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8503be0db9c871e6cf572f626dc03b076fdc6641

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130271 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41225 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137689 "Hash 8503be0d for PR 53685 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81840 "Hash 8503be0d for PR 53685 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/06adca4d-c1c1-4e4f-825b-e78369b97491) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2433 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/137689 "Hash 8503be0d for PR 53685 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/81840 "Hash 8503be0d for PR 53685 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1db5d167-9311-4eee-b6cf-55c2e89941dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133218 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1872 "Found 60 new test failures: compositing/ios/clip-nested-fixed-in-sticky-container.html css2.1/20110323/c541-word-sp-001.htm css2.1/20110323/text-indent-014.htm css3/font-feature-settings-rendering.html editing/selection/ios/become-first-responder-after-relinquishing-focus.html fast/attachment/attachment-truncated-action.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-composite-text-alpha.html fast/css-grid-layout/min-width-height-auto-overflow.html fast/css/abs-pos-child-inside-rel-pos-inline-001.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116660 "Found 1 new API test failure: TestWebKitAPI.WKAttachmentTestsMac.DragAttachmentAsFilePromise (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/137689 "Hash 8503be0d for PR 53685 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/06d3b5fc-aa50-4e16-8754-7fad5ca1b389) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/129621 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1794 "Found 60 new test failures: imported/w3c/web-platform-tests/content-security-policy/reporting-api/report-to-directive-allowed-in-meta.https.sub.html imported/w3c/web-platform-tests/css/CSS2/linebox/border-padding-bleed-003.xht imported/w3c/web-platform-tests/css/CSS2/linebox/inline-formatting-context-008.xht imported/w3c/web-platform-tests/css/CSS2/linebox/inline-formatting-context-009.xht imported/w3c/web-platform-tests/css/CSS2/linebox/inline-formatting-context-011.xht imported/w3c/web-platform-tests/css/CSS2/linebox/inline-formatting-context-013.xht imported/w3c/web-platform-tests/css/CSS2/linebox/leading-001.xht imported/w3c/web-platform-tests/css/CSS2/linebox/line-height-002.xht imported/w3c/web-platform-tests/css/CSS2/linebox/line-height-004.xht imported/w3c/web-platform-tests/css/CSS2/linebox/line-height-005.xht ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34788 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80946 "Hash 8503be0d for PR 53685 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110337 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35295 "Found 60 new test failures: accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html css2.1/20110323/c541-word-sp-001.htm css2.1/20110323/text-indent-014.htm css3/font-feature-settings-rendering.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-composite-text-alpha.html fast/css-grid-layout/min-width-height-auto-overflow.html fast/css/abs-pos-child-inside-rel-pos-inline-001.html fast/css/abs-pos-child-inside-rel-pos-inline-offset-001.html fast/css/aspect-ratio-min-height-replaced.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140166 "Hash 8503be0d for PR 53685 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2332 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2159 "Found 60 new test failures: accessibility/auto-fill-crash.html accessibility/insert-children-assert.html accessibility/mac/attributed-string-for-text-marker-range-using-webarea.html accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html compositing/geometry/limit-layer-bounds-fixed-positioned.html css2.1/20110323/absolute-non-replaced-height-003.htm css2.1/20110323/absolute-non-replaced-height-009.htm css2.1/20110323/absolute-non-replaced-max-height-008.htm css2.1/20110323/absolute-non-replaced-width-010.htm css2.1/20110323/absolute-non-replaced-width-013.htm ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/140166 "Hash 8503be0d for PR 53685 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113003 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/140166 "Hash 8503be0d for PR 53685 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1836 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31453 "Found 60 new test failures: compositing/scrolling/async-overflow-scrolling/negative-z-in-scroller-hidden-scrollbar.html css2.1/20110323/c541-word-sp-001.htm css2.1/20110323/text-indent-014.htm css3/font-feature-settings-rendering.html css3/masking/clip-path-inset-corners.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-composite-text-alpha.html fast/css-grid-layout/min-width-height-auto-overflow.html fast/css/abs-pos-child-inside-rel-pos-inline-001.html fast/css/abs-pos-child-inside-rel-pos-inline-offset-001.html ... (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55285 "Hash 8503be0d for PR 53685 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65789 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2219 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2423 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2328 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->