### PR TITLE
[Style] Convert the 'position-visibility' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3258,6 +3258,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/align/StyleOverflowPosition.h
 
     style/values/anchor-position/StyleAnchorName.h
+    style/values/anchor-position/StylePositionVisibility.h
 
     style/values/animations/StyleAnimation.h
     style/values/animations/StyleAnimations.h

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -46,6 +46,7 @@
 #include "ScrollAxis.h"
 #include "ScrollTypes.h"
 #include "StyleImageOrientation.h"
+#include "StylePositionVisibility.h"
 #include "StyleScrollBehavior.h"
 #include "StyleTextDecorationLine.h"
 #include "StyleWebKitLineBoxContain.h"
@@ -2521,7 +2522,7 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-#define TYPE PositionVisibility
+#define TYPE Style::PositionVisibilityValue
 #define FOR_EACH(CASE) CASE(AnchorsValid) CASE(AnchorsVisible) CASE(NoOverflow)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12196,7 +12196,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningEnabled",
-                "style-converter": "PositionVisibility",
+                "style-converter": "StyleType<PositionVisibility>",
                 "parser-grammar": "always | [ anchors-valid || anchors-visible || no-overflow ]@(no-single-item-opt)"
             },
             "specification": {

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -947,6 +947,11 @@ template<typename Derived, typename T, typename K> struct EnumSetOrKeywordBase {
     {
     }
 
+    constexpr EnumSetOrKeywordBase(value_type value)
+        : EnumSetOrKeywordBase { EnumSet { value } }
+    {
+    }
+
     constexpr EnumSetOrKeywordBase(std::initializer_list<value_type> initializerList)
         : EnumSetOrKeywordBase { EnumSet { initializerList } }
     {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -165,7 +165,6 @@ enum class PaginationMode : uint8_t;
 enum class PaintBehavior : uint32_t;
 enum class PointerEvents : uint8_t;
 enum class PositionType : uint8_t;
-enum class PositionVisibility : uint8_t;
 enum class PrintColorAdjust : bool;
 enum class PseudoId : uint8_t;
 enum class Resize : uint8_t;
@@ -318,6 +317,7 @@ struct PaddingEdge;
 struct PageSize;
 struct Perspective;
 struct Position;
+struct PositionVisibility;
 struct PositionX;
 struct PositionY;
 struct PositionTryFallback;
@@ -2420,9 +2420,9 @@ public:
     std::optional<size_t> usedPositionOptionIndex() const;
     void setUsedPositionOptionIndex(std::optional<size_t>);
 
-    static constexpr OptionSet<PositionVisibility> initialPositionVisibility();
-    inline OptionSet<PositionVisibility> positionVisibility() const;
-    inline void setPositionVisibility(OptionSet<PositionVisibility>);
+    static constexpr Style::PositionVisibility initialPositionVisibility();
+    inline Style::PositionVisibility positionVisibility() const;
+    inline void setPositionVisibility(Style::PositionVisibility);
 
     inline AlignmentBaseline alignmentBaseline() const;
     inline void setAlignmentBaseline(AlignmentBaseline);

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1521,16 +1521,6 @@ TextStream& operator<<(TextStream& ts, OverflowContinue overflowContinue)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, PositionVisibility positionVisibility)
-{
-    switch (positionVisibility) {
-    case PositionVisibility::AnchorsValid: ts << "anchors-valid"; break;
-    case PositionVisibility::AnchorsVisible: ts << "anchors-visible"; break;
-    case PositionVisibility::NoOverflow: ts << "no-overflow"; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, StyleDifferenceContextSensitiveProperty property)
 {
     switch (property) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1149,12 +1149,6 @@ enum class FieldSizing : bool {
     Content
 };
 
-enum class PositionVisibility : uint8_t {
-    AnchorsValid   = 1 << 0,
-    AnchorsVisible = 1 << 1,
-    NoOverflow     = 1 << 2
-};
-
 enum class NinePieceImageRule : uint8_t {
     Stretch,
     Round,
@@ -1333,7 +1327,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, OverflowAlignment);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowWrap);
 WTF::TextStream& operator<<(WTF::TextStream&, PointerEvents);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionType);
-WTF::TextStream& operator<<(WTF::TextStream&, PositionVisibility);
 WTF::TextStream& operator<<(WTF::TextStream&, PrintColorAdjust);
 WTF::TextStream& operator<<(WTF::TextStream&, PseudoElementType);
 WTF::TextStream& operator<<(WTF::TextStream&, QuoteType);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -532,7 +532,7 @@ inline std::optional<Style::ScopedName> RenderStyle::initialPositionAnchor() { r
 inline std::optional<PositionArea> RenderStyle::initialPositionArea() { return { }; }
 inline FixedVector<Style::PositionTryFallback> RenderStyle::initialPositionTryFallbacks() { return { }; }
 constexpr Style::PositionTryOrder RenderStyle::initialPositionTryOrder() { return Style::PositionTryOrder::Normal; }
-constexpr OptionSet<PositionVisibility> RenderStyle::initialPositionVisibility() { return PositionVisibility::AnchorsVisible; }
+constexpr Style::PositionVisibility RenderStyle::initialPositionVisibility() { return Style::PositionVisibilityValue::AnchorsVisible; }
 constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
 inline Style::Quotes RenderStyle::initialQuotes() { return CSS::Keyword::Auto { }; }
 constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
@@ -759,7 +759,7 @@ inline const Style::PerspectiveOriginY& RenderStyle::perspectiveOriginY() const 
 inline const std::optional<Style::ScopedName>& RenderStyle::positionAnchor() const { return m_nonInheritedData->rareData->positionAnchor; }
 inline std::optional<PositionArea> RenderStyle::positionArea() const { return m_nonInheritedData->rareData->positionArea; }
 inline Style::PositionTryOrder RenderStyle::positionTryOrder() const { return static_cast<Style::PositionTryOrder>(m_nonInheritedData->rareData->positionTryOrder); }
-inline OptionSet<PositionVisibility> RenderStyle::positionVisibility() const { return OptionSet<PositionVisibility>::fromRaw(m_nonInheritedData->rareData->positionVisibility); }
+inline Style::PositionVisibility RenderStyle::positionVisibility() const { return Style::PositionVisibility::fromRaw(m_nonInheritedData->rareData->positionVisibility); }
 inline bool RenderStyle::preserveNewline() const { return preserveNewline(whiteSpaceCollapse()); }
 inline bool RenderStyle::preserves3D() const { return usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
 inline const Style::Quotes& RenderStyle::quotes() const { return m_rareInheritedData->quotes; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -257,7 +257,7 @@ inline void RenderStyle::setPerspectiveOriginY(Style::PerspectiveOriginY&& origi
 inline void RenderStyle::setPositionAnchor(const std::optional<Style::ScopedName>& anchor) { SET_NESTED(m_nonInheritedData, rareData, positionAnchor, anchor); }
 inline void RenderStyle::setPositionArea(std::optional<PositionArea> value) { SET_NESTED(m_nonInheritedData, rareData, positionArea, value); }
 inline void RenderStyle::setPositionTryOrder(Style::PositionTryOrder order) { SET_NESTED(m_nonInheritedData, rareData, positionTryOrder, static_cast<unsigned>(order)); }
-inline void RenderStyle::setPositionVisibility(OptionSet<PositionVisibility> value) { SET_NESTED(m_nonInheritedData, rareData, positionVisibility, value.toRaw()); }
+inline void RenderStyle::setPositionVisibility(Style::PositionVisibility value) { SET_NESTED(m_nonInheritedData, rareData, positionVisibility, value.toRaw()); }
 inline void RenderStyle::setResize(Resize r) { SET_NESTED(m_nonInheritedData, miscData, resize, static_cast<unsigned>(r)); }
 inline void RenderStyle::setRight(Style::InsetEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, inset.right(), WTFMove(edge)); }
 inline void RenderStyle::setRotate(Style::Rotate&& rotate) { SET_NESTED(m_nonInheritedData, rareData, rotate, WTFMove(rotate)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -50,6 +50,7 @@
 #include <WebCore/StylePageSize.h>
 #include <WebCore/StylePerspective.h>
 #include <WebCore/StylePerspectiveOrigin.h>
+#include <WebCore/StylePositionVisibility.h>
 #include <WebCore/StylePrimitiveNumericTypes.h>
 #include <WebCore/StyleProgressTimelineAxes.h>
 #include <WebCore/StyleProgressTimelineName.h>
@@ -258,7 +259,7 @@ public:
     PREFERRED_TYPE(TextBoxTrim) unsigned textBoxTrim : 2;
     PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
     PREFERRED_TYPE(Style::PositionTryOrder) unsigned positionTryOrder : 3;
-    PREFERRED_TYPE(OptionSet<PositionVisibility>) unsigned positionVisibility : 3;
+    PREFERRED_TYPE(Style::PositionVisibility) unsigned positionVisibility : 3;
     PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;
     PREFERRED_TYPE(bool) unsigned nativeAppearanceDisabled : 1;
 #if HAVE(CORE_MATERIAL)

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -282,7 +282,7 @@ void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored, bool i
         return clearAnchorScrollSnapshots(anchored);
 
     if (!anchored.style().positionTryFallbacks().isEmpty()
-        || anchored.style().positionVisibility().contains(PositionVisibility::NoOverflow))
+        || anchored.style().positionVisibility().contains(PositionVisibilityValue::NoOverflow))
         adjuster.setFallbackLimits(anchored);
 
     auto captureDiff = anchored.layoutContext().registerAnchorScrollAdjuster(WTFMove(adjuster));
@@ -319,10 +319,10 @@ void AnchorPositionEvaluator::updateScrollAdjustments(RenderView& renderView)
                     anchored->setNeedsLayout();
                     needsInvalidation = true;
                 } else
-                    shouldBeHidden = anchored->style().positionVisibility().contains(PositionVisibility::NoOverflow);
+                    shouldBeHidden = anchored->style().positionVisibility().contains(PositionVisibilityValue::NoOverflow);
             }
         }
-        if (!shouldBeHidden && anchored->style().positionVisibility().contains(PositionVisibility::AnchorsVisible))
+        if (!shouldBeHidden && anchored->style().positionVisibility().contains(PositionVisibilityValue::AnchorsVisible))
             shouldBeHidden = AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes(*anchored);
 
         if (needsInvalidation || shouldBeHidden != adjuster.isHidden()) {
@@ -1323,7 +1323,7 @@ void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPosi
 
     // `position-visibility: no-overflow` should also work for non-anchor positioned out-of-flow boxes.
     // Create an empty anchor positioning state for it so we perform the required layout interleaving.
-    auto hasPositionVisibilityNoOverflow = generatesBox(style) && style.hasOutOfFlowPosition() && style.positionVisibility().contains(PositionVisibility::NoOverflow);
+    auto hasPositionVisibilityNoOverflow = generatesBox(style) && style.hasOutOfFlowPosition() && style.positionVisibility().contains(PositionVisibilityValue::NoOverflow);
 
     if (!shouldResolveDefaultAnchor && !hasPositionVisibilityNoOverflow)
         return;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -134,7 +134,6 @@ public:
 
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
     static std::optional<PositionArea> convertPositionArea(BuilderState&, const CSSValue&);
-    static OptionSet<PositionVisibility> convertPositionVisibility(BuilderState&, const CSSValue&);
 
     static NameScope convertNameScope(BuilderState&, const CSSValue&);
 
@@ -804,23 +803,6 @@ inline std::optional<PositionArea> BuilderConverter::convertPositionArea(Builder
     }
 
     return area;
-}
-
-inline OptionSet<PositionVisibility> BuilderConverter::convertPositionVisibility(BuilderState& builderState, const CSSValue& value)
-{
-    if (value.valueID() == CSSValueAlways)
-        return { };
-
-    auto maybeList = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!maybeList)
-        return { };
-    auto list = *maybeList;
-
-    OptionSet<PositionVisibility> result;
-    for (const auto& value : list)
-        result.add(fromCSSValue<PositionVisibility>(value));
-
-    return result;
 }
 
 inline NameScope BuilderConverter::convertNameScope(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -146,7 +146,6 @@ public:
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const std::optional<PositionArea>&);
     static Ref<CSSValue> convertNameScope(ExtractorState&, const NameScope&);
-    static Ref<CSSValue> convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility>);
 
     // MARK: MaskLayer property conversions
 
@@ -617,22 +616,6 @@ inline Ref<CSSValue> ExtractorConverter::convertNameScope(ExtractorState&, const
 
     ASSERT_NOT_REACHED();
     return CSSPrimitiveValue::create(CSSValueNone);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility> positionVisibility)
-{
-    CSSValueListBuilder list;
-    if (positionVisibility & PositionVisibility::AnchorsValid)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsValid));
-    if (positionVisibility & PositionVisibility::AnchorsVisible)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsVisible));
-    if (positionVisibility & PositionVisibility::NoOverflow)
-        list.append(CSSPrimitiveValue::create(CSSValueNoOverflow));
-
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAlways);
-
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 // MARK: - MaskLayer property conversions

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -82,7 +82,6 @@ public:
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
     static void serializeNameScope(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const NameScope&);
-    static void serializePositionVisibility(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<PositionVisibility>);
 
     // MARK: MaskLayer property serializations
 
@@ -498,25 +497,6 @@ inline void ExtractorSerializer::serializeNameScope(ExtractorState& state, Strin
     }
 
     RELEASE_ASSERT_NOT_REACHED();
-}
-
-inline void ExtractorSerializer::serializePositionVisibility(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<PositionVisibility> positionVisibility)
-{
-    bool listEmpty = true;
-    auto appendOption = [&](PositionVisibility test, CSSValueID value) {
-        if (positionVisibility & test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(PositionVisibility::AnchorsValid, CSSValueAnchorsValid);
-    appendOption(PositionVisibility::AnchorsVisible, CSSValueAnchorsVisible);
-    appendOption(PositionVisibility::NoOverflow, CSSValueNoOverflow);
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Always { });
 }
 
 // MARK: - MaskLayer property serializations

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1805,16 +1805,16 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
         if (!anchored)
             return false;
 
-        if (style.positionVisibility().contains(PositionVisibility::AnchorsVisible)) {
+        if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsVisible)) {
             // "If the box has a default anchor box but that anchor box is invisible or clipped by intervening boxes, the box’s visibility property computes to force-hidden."
             if (AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes(*anchored))
                 return true;
         }
-        if (style.positionVisibility().contains(PositionVisibility::NoOverflow)) {
+        if (style.positionVisibility().contains(PositionVisibilityValue::NoOverflow)) {
             if (AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock(*anchored))
                 return true;
         }
-        if (style.positionVisibility().contains(PositionVisibility::AnchorsValid)) {
+        if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsValid)) {
             auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
             if (anchorPositionedState) {
                 for (auto& anchorElement : anchorPositionedState->anchorElements.values()) {

--- a/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
+++ b/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'position-visibility'> = always | [ anchors-valid || anchors-visible || no-overflow ]
+// https://drafts.csswg.org/css-anchor-position-1/#propdef-position-visibility
+
+enum class PositionVisibilityValue : uint8_t {
+    AnchorsValid,
+    AnchorsVisible,
+    NoOverflow,
+};
+
+using PositionVisibilityValueEnumSet = SpaceSeparatedEnumSet<PositionVisibilityValue>;
+
+struct PositionVisibility : EnumSetOrKeywordBase<PositionVisibility, PositionVisibilityValueEnumSet, CSS::Keyword::Always> {
+    using Base::Base;
+    constexpr bool isAlways() const { return isKeyword(); }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::PositionVisibility)


### PR DESCRIPTION
#### 35d14393e73ee5c9daefe61c935a03de2f068bcd
<pre>
[Style] Convert the &apos;position-visibility&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302271">https://bugs.webkit.org/show_bug.cgi?id=302271</a>

Reviewed by Darin Adler.

Converts the &apos;position-visibility&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/values/anchor-position/StylePositionVisibility.h: Added.

Canonical link: <a href="https://commits.webkit.org/302909@main">https://commits.webkit.org/302909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a6fbde68e606743ae4462188baa8c7130d9e3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99421 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80120 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107934 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107844 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55532 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66012 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->