### PR TITLE
[Style] Convert the 'font-family' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3330,6 +3330,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/flexbox/StyleWebKitBoxFlexGroup.h
     style/values/flexbox/StyleWebKitBoxOrdinalGroup.h
 
+    style/values/fonts/StyleFontFamily.h
+    style/values/fonts/StyleFontFamilyName.h
     style/values/fonts/StyleFontFeatureSettings.h
     style/values/fonts/StyleFontPalette.h
     style/values/fonts/StyleFontSizeAdjust.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -85,7 +85,6 @@ style/StyleCustomProperty.cpp
 style/Styleable.cpp
 style/values/StyleValueTypes.h
 style/values/backgrounds/StyleFillLayers.h
-style/values/fonts/StyleFontFeatureSettings.cpp
 style/values/fonts/StyleFontVariationSettings.cpp
 style/values/images/StyleGradient.cpp
 style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3232,6 +3232,8 @@ style/values/filter-effects/StyleOpacityFunction.cpp
 style/values/filter-effects/StyleSaturateFunction.cpp
 style/values/filter-effects/StyleSepiaFunction.cpp
 style/values/flexbox/StyleFlexBasis.cpp
+style/values/fonts/StyleFontFamily.cpp
+style/values/fonts/StyleFontFamilyName.cpp
 style/values/fonts/StyleFontFeatureSettings.cpp
 style/values/fonts/StyleFontPalette.cpp
 style/values/fonts/StyleFontSizeAdjust.cpp

--- a/Source/WebCore/css/CSSFontValue.h
+++ b/Source/WebCore/css/CSSFontValue.h
@@ -47,7 +47,7 @@ public:
     RefPtr<CSSPrimitiveValue> width;
     RefPtr<CSSPrimitiveValue> size;
     RefPtr<CSSPrimitiveValue> lineHeight;
-    RefPtr<CSSValueList> family;
+    RefPtr<CSSValue> family;
 
 private:
     CSSFontValue()

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -591,10 +591,8 @@
                 }
             ],
             "codegen-properties": {
-                "animation-wrapper": "FontFamilyWrapper",
-                "animation-wrapper-requires-override-parameters": [],
-                "style-builder-custom": "All",
                 "style-extractor-custom": true,
+                "style-builder-custom": "All",
                 "high-priority": true,
                 "parser-function": "consumeFontFamily",
                 "parser-grammar-unused": "[ <family-name> | <generic-family> | <-webkit-generic-family> ]#",

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -94,6 +94,7 @@ public:
     void setOneFamily(const AtomString& family) { ASSERT(m_families->size() == 1); m_families.get()[0] = family; }
     void setFamilies(const Vector<AtomString>& families) { m_families = RefCountedFixedVector<AtomString>::createFromVector(families); }
     void setFamilies(RefCountedFixedVector<AtomString>& families) { m_families = families; }
+    void setFamilies(Ref<RefCountedFixedVector<AtomString>>&& families) { m_families = WTFMove(families); }
     void setSpecifiedSize(float s) { m_specifiedSize = clampToFloat(s); }
     void setIsAbsoluteSize(bool s) { m_isAbsoluteSize = s; }
     void setKerning(Kerning kerning) { m_kerning = static_cast<unsigned>(kerning); }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2538,6 +2538,13 @@ void RenderStyle::setFontOpticalSizing(FontOpticalSizing opticalSizing)
     setFontDescription(WTFMove(description));
 }
 
+void RenderStyle::setFontFamily(Style::FontFamilies&& families)
+{
+    auto description = fontDescription();
+    description.setFamilies(families.takePlatform());
+    setFontDescription(WTFMove(description));
+}
+
 void RenderStyle::setFontFeatureSettings(Style::FontFeatureSettings&& settings)
 {
     auto description = fontDescription();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -264,6 +264,8 @@ struct Cursor;
 struct DynamicRangeLimit;
 struct Filter;
 struct FlexBasis;
+struct FontFamilies;
+struct FontFamiliesView;
 struct FontFeatureSettings;
 struct FontPalette;
 struct FontSizeAdjust;
@@ -728,6 +730,7 @@ public:
     float computedFontSize() const;
     std::pair<FontOrientation, NonCJKGlyphOrientation> fontAndGlyphOrientation();
 
+    inline Style::FontFamilies fontFamily() const;
     inline FontOpticalSizing fontOpticalSizing() const;
     inline Style::FontFeatureSettings fontFeatureSettings() const;
     inline Style::FontVariationSettings fontVariationSettings() const;
@@ -1377,6 +1380,7 @@ public:
     // Only used for blending font sizes when animating, for MathML anonymous blocks, and for text autosizing.
     void setFontSize(float);
     void setFontOpticalSizing(FontOpticalSizing);
+    void setFontFamily(Style::FontFamilies&&);
     void setFontFeatureSettings(Style::FontFeatureSettings&&);
     void setFontVariationSettings(Style::FontVariationSettings&&);
     void setFontPalette(Style::FontPalette&&);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -44,6 +44,7 @@
 #include <WebCore/StyleFilterData.h>
 #include <WebCore/StyleFlexibleBoxData.h>
 #include <WebCore/StyleFontData.h>
+#include <WebCore/StyleFontFamily.h>
 #include <WebCore/StyleFontFeatureSettings.h>
 #include <WebCore/StyleFontPalette.h>
 #include <WebCore/StyleFontSizeAdjust.h>
@@ -230,6 +231,7 @@ inline FlexDirection RenderStyle::flexDirection() const { return static_cast<Fle
 inline Style::FlexGrow RenderStyle::flexGrow() const { return m_nonInheritedData->miscData->flexibleBox->flexGrow; }
 inline Style::FlexShrink RenderStyle::flexShrink() const { return m_nonInheritedData->miscData->flexibleBox->flexShrink; }
 inline FlexWrap RenderStyle::flexWrap() const { return static_cast<FlexWrap>(m_nonInheritedData->miscData->flexibleBox->flexWrap); }
+inline Style::FontFamilies RenderStyle::fontFamily() const { return { fontDescription().families(), fontDescription().isSpecifiedFont() }; }
 inline Style::FontPalette RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
 inline Style::FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
 inline Style::FontStyle RenderStyle::fontStyle() const { return { fontDescription().fontStyleSlope(), fontDescription().fontStyleAxis() }; }

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -38,7 +38,6 @@
 #include <WebCore/StyleForVisitedLink.h>
 #include <WebCore/TextFlags.h>
 #include <wtf/BitSet.h>
-#include <wtf/RefCountedFixedVector.h>
 
 namespace WebCore {
 
@@ -56,6 +55,7 @@ namespace Style {
 
 class BuilderState;
 struct Color;
+struct FontFamilies;
 struct FontFeatureSettings;
 struct FontPalette;
 struct FontSizeAdjust;
@@ -172,9 +172,7 @@ public:
     void setFontDescriptionKeywordSizeFromIdentifier(CSSValueID);
     void setFontDescriptionIsAbsoluteSize(bool);
     void setFontDescriptionFontSize(float);
-    void setFontDescriptionFamilies(RefCountedFixedVector<AtomString>&);
-    void setFontDescriptionFamilies(Vector<AtomString>&);
-    void setFontDescriptionIsSpecifiedFont(bool);
+    void setFontDescriptionFamilies(FontFamilies&&);
     void setFontDescriptionFeatureSettings(FontFeatureSettings&&);
     void setFontDescriptionFontPalette(FontPalette&&);
     void setFontDescriptionFontSizeAdjust(FontSizeAdjust);

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -75,35 +75,16 @@ inline void BuilderState::setFontDescriptionFontSize(float fontSize)
     }
 }
 
-inline void BuilderState::setFontDescriptionFamilies(RefCountedFixedVector<AtomString>& families)
+inline void BuilderState::setFontDescriptionFamilies(FontFamilies&& families)
 {
-    if (m_style.fontDescription().families() == families)
+    if (m_style.fontDescription().families() == families.toPlatform() && m_style.fontDescription().isSpecifiedFont() == families.isSpecifiedFont())
         return;
 
     m_fontDirty = true;
     auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
-    fontCascade.mutableFontDescription().setFamilies(families);
+    fontCascade.mutableFontDescription().setFamilies(families.takePlatform());
+    fontCascade.mutableFontDescription().setIsSpecifiedFont(families.isSpecifiedFont());
     fontCascade.updateUseBackslashAsYenSymbol();
-}
-
-inline void BuilderState::setFontDescriptionFamilies(Vector<AtomString>& families)
-{
-    if (m_style.fontDescription().families() == families)
-        return;
-
-    m_fontDirty = true;
-    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
-    fontCascade.mutableFontDescription().setFamilies(families);
-    fontCascade.updateUseBackslashAsYenSymbol();
-}
-
-inline void BuilderState::setFontDescriptionIsSpecifiedFont(bool isSpecifiedFont)
-{
-    if (m_style.fontDescription().isSpecifiedFont() == isSpecifiedFont)
-        return;
-
-    m_fontDirty = true;
-    m_style.mutableFontDescriptionWithoutUpdate().setIsSpecifiedFont(isSpecifiedFont);
 }
 
 inline void BuilderState::setFontDescriptionFeatureSettings(FontFeatureSettings&& featureSettings)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -153,10 +153,6 @@ public:
     static Ref<CSSValue> convertSingleWebkitMaskComposite(ExtractorState&, CompositeOperator);
     static Ref<CSSValue> convertSingleMaskMode(ExtractorState&, MaskMode);
     static Ref<CSSValue> convertSingleWebkitMaskSourceType(ExtractorState&, MaskMode);
-
-    // MARK: Font conversions
-
-    static Ref<CSSValue> convertFontFamily(ExtractorState&, const AtomString&);
 };
 
 // MARK: - Strong value conversions
@@ -657,35 +653,6 @@ inline Ref<CSSValue> ExtractorConverter::convertSingleWebkitMaskSourceType(Extra
     }
     ASSERT_NOT_REACHED();
     return CSSPrimitiveValue::create(CSSValueAlpha);
-}
-
-// MARK: - Font conversions
-
-inline Ref<CSSValue> ExtractorConverter::convertFontFamily(ExtractorState& state, const AtomString& family)
-{
-    auto identifierForFamily = [](const auto& family) {
-        if (family == cursiveFamily)
-            return CSSValueCursive;
-        if (family == fantasyFamily)
-            return CSSValueFantasy;
-        if (family == monospaceFamily)
-            return CSSValueMonospace;
-        if (family == mathFamily)
-            return CSSValueMath;
-        if (family == pictographFamily)
-            return CSSValueWebkitPictograph;
-        if (family == sansSerifFamily)
-            return CSSValueSansSerif;
-        if (family == serifFamily)
-            return CSSValueSerif;
-        if (family == systemUiFamily)
-            return CSSValueSystemUi;
-        return CSSValueInvalid;
-    };
-
-    if (auto familyIdentifier = identifierForFamily(family))
-        return CSSPrimitiveValue::create(familyIdentifier);
-    return state.pool.createFontFamilyValue(family);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -89,11 +89,6 @@ public:
     static void serializeSingleWebkitMaskComposite(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, CompositeOperator);
     static void serializeSingleMaskMode(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, MaskMode);
     static void serializeSingleWebkitMaskSourceType(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, MaskMode);
-
-    // MARK: Font serializations
-
-    static void serializeFontFamily(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const AtomString&);
-
 };
 
 // MARK: - Strong value serializations
@@ -542,36 +537,6 @@ inline void ExtractorSerializer::serializeSingleWebkitMaskSourceType(ExtractorSt
         return;
     }
     RELEASE_ASSERT_NOT_REACHED();
-}
-
-// MARK: - Font serializations
-
-inline void ExtractorSerializer::serializeFontFamily(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext&, const AtomString& family)
-{
-    auto identifierForFamily = [](const auto& family) {
-        if (family == cursiveFamily)
-            return CSSValueCursive;
-        if (family == fantasyFamily)
-            return CSSValueFantasy;
-        if (family == monospaceFamily)
-            return CSSValueMonospace;
-        if (family == mathFamily)
-            return CSSValueMath;
-        if (family == pictographFamily)
-            return CSSValueWebkitPictograph;
-        if (family == sansSerifFamily)
-            return CSSValueSansSerif;
-        if (family == serifFamily)
-            return CSSValueSerif;
-        if (family == systemUiFamily)
-            return CSSValueSystemUi;
-        return CSSValueInvalid;
-    };
-
-    if (auto familyIdentifier = identifierForFamily(family))
-        builder.append(nameLiteralForSerialization(familyIdentifier));
-    else
-        builder.append(WebCore::serializeFontFamily(family));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -277,64 +277,6 @@ public:
     }
 };
 
-class DiscreteFontDescriptionWrapper : public WrapperBase {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DiscreteFontDescriptionWrapper, Animation);
-public:
-    DiscreteFontDescriptionWrapper(CSSPropertyID property)
-        : WrapperBase(property)
-    {
-    }
-
-    bool equals(const RenderStyle& a, const RenderStyle& b) const override
-    {
-        return propertiesInFontDescriptionAreEqual(a.fontDescription(), b.fontDescription());
-    }
-
-    bool canInterpolate(const RenderStyle&, const RenderStyle&, CompositeOperation) const override
-    {
-        return false;
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const override
-    {
-        ASSERT(!context.progress || context.progress == 1.0);
-        auto destinationDescription = destination.fontDescription();
-        auto& sourceDescription = (context.progress ? to : from).fontDescription();
-        setPropertiesInFontDescription(sourceDescription, destinationDescription);
-        destination.setFontDescription(WTFMove(destinationDescription));
-    }
-
-#if !LOG_DISABLED
-    void log(const RenderStyle&, const RenderStyle&, const RenderStyle&, double) const override
-    {
-    }
-#endif
-
-protected:
-    virtual bool propertiesInFontDescriptionAreEqual(const FontCascadeDescription&, const FontCascadeDescription&) const { return false; }
-    virtual void setPropertiesInFontDescription(const FontCascadeDescription&, FontCascadeDescription&) const { }
-};
-
-class FontFamilyWrapper final : public DiscreteFontDescriptionWrapper {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontFamilyWrapper, Animation);
-public:
-    FontFamilyWrapper()
-        : DiscreteFontDescriptionWrapper(CSSPropertyFontFamily)
-    {
-    }
-
-private:
-    bool propertiesInFontDescriptionAreEqual(const FontCascadeDescription& a, const FontCascadeDescription& b) const override
-    {
-        return a.families() == b.families();
-    }
-
-    void setPropertiesInFontDescription(const FontCascadeDescription& source, FontCascadeDescription& destination) const override
-    {
-        destination.setFamilies(source.families());
-    }
-};
-
 // MARK: - Color Property Wrappers
 
 class ColorWrapper final : public WrapperWithGetter<const WebCore::Color&> {

--- a/Source/WebCore/style/values/fonts/StyleFontFamily.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontFamily.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleFontFamily.h"
+
+#include "CSSPropertyParserConsumer+Font.h"
+#include "Document.h"
+#include "Settings.h"
+#include "StyleBuilderChecking.h"
+#include "SystemFontDatabase.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<FontFamilies>::operator()(BuilderState& state, const CSSValue& value) -> FontFamilies
+{
+    using namespace CSSPropertyParserHelpers;
+
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->isFontFamily()) {
+            return {
+                AtomString { primitiveValue->stringValue() },
+                FontFamilyKind::Specified
+            };
+        }
+
+        auto valueID = primitiveValue->valueID();
+        if (valueID == CSSValueWebkitBody) {
+            return {
+                AtomString { state.document().settings().standardFontFamily() },
+                FontFamilyKind::Specified
+            };
+        }
+
+        if (auto family = genericFontFamily(valueID); !family.isNull()) {
+            return {
+                family,
+                FontFamilyKind::Generic
+            };
+        }
+
+        if (isSystemFontShorthand(valueID)) {
+            auto family = SystemFontDatabase::singleton().systemFontShorthandFamily(lowerFontShorthand(valueID));
+            ASSERT(!family.isEmpty());
+
+            return {
+                WTFMove(family),
+                FontFamilyKind::Generic
+            };
+        }
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return { nullAtom(), FontFamilyKind::Generic };
+    }
+
+    auto valueList = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!valueList)
+        return { nullAtom(), FontFamilyKind::Generic };
+
+    std::optional<FontFamilyKind> firstFontKind;
+    auto families = WTF::compactMap(*valueList, [&](auto& contentValue) -> std::optional<AtomString> {
+        auto [family, kind] = [&] -> std::pair<AtomString, FontFamilyKind> {
+            if (contentValue.isFontFamily())
+                return { AtomString { contentValue.stringValue() }, FontFamilyKind::Specified };
+
+            auto valueID = contentValue.valueID();
+            if (valueID == CSSValueWebkitBody)
+                return { AtomString { state.document().settings().standardFontFamily() }, FontFamilyKind::Specified };
+
+            return { genericFontFamily(valueID), FontFamilyKind::Generic };
+        }();
+
+        if (family.isNull())
+            return std::nullopt;
+
+        if (!firstFontKind)
+            firstFontKind = kind;
+
+        return family;
+    });
+
+    if (families.isEmpty()) {
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return { nullAtom(), FontFamilyKind::Generic };
+    }
+
+    return {
+        RefCountedFixedVector<AtomString>::createFromVector(WTFMove(families)),
+        *firstFontKind
+    };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/fonts/StyleFontFamily.h
+++ b/Source/WebCore/style/values/fonts/StyleFontFamily.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleFontFamilyName.h>
+#include <WebCore/StyleValueTypes.h>
+#include <WebCore/WebKitFontFamilyNames.h>
+#include <ranges>
+
+namespace WebCore {
+namespace Style {
+
+enum class FontFamilyKind : bool { Specified, Generic };
+
+// <single-font-family> = [ <family-name> | <generic-family> ]
+// https://drafts.csswg.org/css-fonts-4/#propdef-font-family
+struct SingleFontFamily {
+    AtomString value;
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        using namespace WebKitFontFamilyNames;
+
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        // <generic-family>
+        if (value == cursiveFamily)
+            return visitor(CSS::Keyword::Cursive { });
+        if (value == fantasyFamily)
+            return visitor(CSS::Keyword::Fantasy { });
+        if (value == monospaceFamily)
+            return visitor(CSS::Keyword::Monospace { });
+        if (value == mathFamily)
+            return visitor(CSS::Keyword::Math { });
+        if (value == pictographFamily)
+            return visitor(CSS::Keyword::WebkitPictograph { });
+        if (value == sansSerifFamily)
+            return visitor(CSS::Keyword::SansSerif { });
+        if (value == serifFamily)
+            return visitor(CSS::Keyword::Serif { });
+        if (value == systemUiFamily)
+            return visitor(CSS::Keyword::SystemUi { });
+        // <family-name>
+        return visitor(FontFamilyName { value });
+    }
+
+    bool operator==(const SingleFontFamily&) const = default;
+};
+
+// <'font-family'> = [ <family-name> | <generic-family> ]#
+// https://drafts.csswg.org/css-fonts-4/#propdef-font-family
+struct FontFamilies {
+    FontFamilies(Ref<RefCountedFixedVector<AtomString>>&& families, FontFamilyKind firstFontKind)
+        : m_families { WTFMove(families) }
+        , m_firstFontKind { firstFontKind }
+    {
+    }
+
+    FontFamilies(Ref<RefCountedFixedVector<AtomString>>&& families, bool isSpecifiedFont)
+        : FontFamilies { WTFMove(families), isSpecifiedFont ? FontFamilyKind::Specified : FontFamilyKind::Generic }
+    {
+    }
+
+    FontFamilies(AtomString family, FontFamilyKind firstFontKind)
+        : FontFamilies { RefCountedFixedVector<AtomString>::create({ WTFMove(family) }), firstFontKind }
+    {
+    }
+
+    class const_iterator {
+    public:
+        using inner_iterator = RefCountedFixedVector<AtomString>::const_iterator;
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = SingleFontFamily;
+        using difference_type = std::ptrdiff_t;
+
+        const_iterator(inner_iterator it) : m_it { it } { }
+
+        value_type operator*() const { return SingleFontFamily { *m_it }; }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        const_iterator& operator++() { ++m_it; return *this; }
+        const_iterator operator++(int) { auto result = *this; ++(*this); return result; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+        bool operator==(const const_iterator&) const = default;
+
+    private:
+        inner_iterator m_it;
+    };
+
+    const_iterator begin() const LIFETIME_BOUND { return const_iterator(m_families->begin()); }
+    const_iterator end() const LIFETIME_BOUND { return const_iterator(m_families->end()); }
+
+    unsigned size() const { return m_families->size(); }
+
+    SingleFontFamily first() const { return SingleFontFamily { m_families.get()[0] }; }
+    SingleFontFamily last() const { return SingleFontFamily { m_families.get()[size() - 1] }; }
+
+    RefCountedFixedVector<AtomString>& toPlatform() LIFETIME_BOUND { return m_families.get(); }
+    const RefCountedFixedVector<AtomString>& toPlatform() const LIFETIME_BOUND { return m_families.get(); }
+    Ref<RefCountedFixedVector<AtomString>> takePlatform() { return WTFMove(m_families); }
+
+    FontFamilyKind firstFontKind() const { return m_firstFontKind; }
+    bool isSpecifiedFont() const { return m_firstFontKind == FontFamilyKind::Specified; }
+
+    bool operator==(const FontFamilies& other) const
+    {
+        return arePointingToEqualData(m_families, other.m_families)
+            && m_firstFontKind == other.m_firstFontKind;
+    }
+
+private:
+    Ref<RefCountedFixedVector<AtomString>> m_families;
+    FontFamilyKind m_firstFontKind { FontFamilyKind::Generic };
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<FontFamilies> { auto operator()(BuilderState&, const CSSValue&) -> FontFamilies; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_COMMA_SEPARATED_RANGE_LIKE_CONFORMANCE(WebCore::Style::FontFamilies)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SingleFontFamily)

--- a/Source/WebCore/style/values/fonts/StyleFontFamilyName.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontFamilyName.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleFontFamilyName.h"
+
+#include "CSSMarkup.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSValuePool.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+Ref<CSSValue> CSSValueCreation<FontFamilyName>::operator()(CSSValuePool& pool, const RenderStyle&, const FontFamilyName& value)
+{
+    return pool.createFontFamilyValue(value.value);
+}
+
+// MARK: - Serialization
+
+void Serialize<FontFamilyName>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle&, const FontFamilyName& value)
+{
+    builder.append(WebCore::serializeFontFamily(value.value));
+}
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream& ts, const FontFamilyName& value)
+{
+    return ts << WebCore::serializeFontFamily(value.value);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/fonts/StyleFontFamilyName.h
+++ b/Source/WebCore/style/values/fonts/StyleFontFamilyName.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <family-name> = <string> | <custom-ident>+
+// NOTE: Per spec, "If a sequence of identifiers is given as a <family-name>, the computed value is the name converted to a string by joining all the identifiers in the sequence by single spaces."
+// https://drafts.csswg.org/css-fonts-4/#family-name-syntax
+struct FontFamilyName {
+    AtomString value;
+
+    bool operator==(const FontFamilyName&) const = default;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueCreation<FontFamilyName> { auto operator()(CSSValuePool&, const RenderStyle&, const FontFamilyName&) -> Ref<CSSValue>; };
+
+// MARK: - Serialization
+
+template<> struct Serialize<FontFamilyName> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const FontFamilyName&); };
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream&, const FontFamilyName&);
+
+} // namespace Style
+} // namespace WebCore


### PR DESCRIPTION
#### 29fea9f69f1c02064656297f999e2fe4d87eac12
<pre>
[Style] Convert the &apos;font-family&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302279">https://bugs.webkit.org/show_bug.cgi?id=302279</a>

Reviewed by NOBODY

Converts the &apos;font-family&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSFontValue.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/fonts/StyleFontFamily.cpp: Added.
* Source/WebCore/style/values/fonts/StyleFontFamily.h: Added.
* Source/WebCore/style/values/fonts/StyleFontFamilyName.cpp: Added.
* Source/WebCore/style/values/fonts/StyleFontFamilyName.h: Added.

Canonical link: <a href="https://commits.webkit.org/303001@main">https://commits.webkit.org/303001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40d6d4cedf16b9ede9b828becc6ff107af494d1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130847 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35298 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81529 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110783 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35801 "Found 1 new test failure: fast/files/blob-stream-error.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140752 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55948 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2982 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66374 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->