### PR TITLE
filter-build-webkit add a quiet mode

### DIFF
--- a/Tools/Scripts/filter-build-webkit
+++ b/Tools/Scripts/filter-build-webkit
@@ -123,6 +123,7 @@ Output Options:
                   text: Plain text
                   color: Plain text with colors
                   oneline: Plain text with colors on one line
+                  quiet: Only show errors and final result
                   debug: Prefix lines with message class 
 Unfiltered Logging Options:
   -l|--log      Save unfiltered output to file (see --log-file)
@@ -322,6 +323,15 @@ sub printLine($$$$)
 {
     my ($line, $target, $project, $style) = @_;
 
+    # In quiet mode, only show errors and success messages (suppress warnings)
+    if ($outputFormat eq "quiet") {
+        return if ($style == STYLE_PLAIN || $style == STYLE_HEADER);
+        # Suppress warnings, only show errors
+        if ($style == STYLE_ALERT && $line =~ /^\s*warning:/i) {
+            return;
+        }
+    }
+
     if ($outputFormat eq "html") {
         $line = escapeHTML($line);
         if    ($style == STYLE_HEADER)  { print OUTPUT_HANDLE "<h2>$line</h2>"; }
@@ -336,7 +346,7 @@ sub printLine($$$$)
     my $color = "";
     my $reset = "";
     my $endl = "\n";
-    if ($outputFormat eq "color" or $outputFormat eq "oneline") {
+    if ($outputFormat eq "color" or $outputFormat eq "oneline" or $outputFormat eq "quiet") {
         if ($target && $project) {
             my $checksum = crc16($target . $project);
             # Pick an ANSI color other than white or black (so, colors 1-6 and 9-14).
@@ -372,8 +382,8 @@ sub setOutputFormatOption($$)
 {
     my ($opt, $value) = @_;
     $value = lc($value);
-    if ($value ne "html" && $value ne "text" && $value ne "color" && $value ne "oneline" && $value ne "debug") {
-        die "The $opt option must be either \"html\", \"text\", \”color\", \”oneline\" or \"debug\"";
+    if ($value ne "html" && $value ne "text" && $value ne "color" && $value ne "oneline" && $value ne "quiet" && $value ne "debug") {
+        die "The $opt option must be either \"html\", \"text\", \"color\", \"oneline\", \"quiet\" or \"debug\"";
     }
     $outputFormat = $value;
 }


### PR DESCRIPTION
#### 517c891151ebb8463a41e04479e7c9bd789463fb
<pre>
filter-build-webkit add a quiet mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=302286">https://bugs.webkit.org/show_bug.cgi?id=302286</a>
<a href="https://rdar.apple.com/problem/164429716">rdar://problem/164429716</a>

Reviewed by Jonathan Bedard.

Add a quiet mode to suppress unneeded messages.

* Tools/Scripts/filter-build-webkit

Canonical link: <a href="https://commits.webkit.org/302820@main">https://commits.webkit.org/302820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fa2b6810b26c22437e1c7f36b75c786c0049343

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137740 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d6fa7a4d-3328-45d5-baf7-d732326093b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99284 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a3a1fca-233a-48cb-a4e5-f195b91e7d58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133269 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79979 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c0adfd16-088f-4fe0-a4e5-505fec0239ae) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80999 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140217 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107802 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107701 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27414 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/1866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55337 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2453 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2270 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->