### PR TITLE
[SaferCPP] Eliminate some raw pointers in IndexedDB

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -194,26 +194,25 @@ void IDBConnectionToClient::didGetAllDatabaseNamesAndVersions(const IDBResourceI
 
 void IDBConnectionToClient::registerDatabaseConnection(UniqueIDBDatabaseConnection& connection)
 {
-    ASSERT(!m_databaseConnections.contains(&connection));
-    m_databaseConnections.add(&connection);
+    ASSERT(!m_databaseConnections.contains(connection));
+    m_databaseConnections.add(connection);
 }
 
 void IDBConnectionToClient::unregisterDatabaseConnection(UniqueIDBDatabaseConnection& connection)
 {
-    m_databaseConnections.remove(&connection);
+    m_databaseConnections.remove(connection);
 }
 
 void IDBConnectionToClient::connectionToClientClosed()
 {
     m_isClosed = true;
-    auto databaseConnections = m_databaseConnections;
 
-    for (RefPtr connection : databaseConnections) {
-        ASSERT(m_databaseConnections.contains(connection.get()));
-        connection->connectionClosedFromClient();
-    }
+    m_databaseConnections.forEach([&](UniqueIDBDatabaseConnection& connection) {
+        ASSERT(m_databaseConnections.contains(connection));
+        connection.connectionClosedFromClient();
+    });
 
-    ASSERT(m_databaseConnections.isEmpty());
+    ASSERT(m_databaseConnections.isEmptyIgnoringNullReferences());
 }
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
@@ -29,6 +29,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -87,7 +88,7 @@ private:
     IDBConnectionToClient(IDBConnectionToClientDelegate&);
     
     CheckedPtr<IDBConnectionToClientDelegate> m_delegate;
-    HashSet<UniqueIDBDatabaseConnection*> m_databaseConnections;
+    WeakHashSet<UniqueIDBDatabaseConnection> m_databaseConnections;
     bool m_isClosed { false };
 };
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -618,7 +618,6 @@ void IDBServer::closeAndDeleteDatabasesModifiedSince(WallTime modificationTime)
     if (modificationTime > WallTime::now())
         return;
 
-    HashSet<UniqueIDBDatabase*> openDatabases;
     for (auto& database : m_uniqueIDBDatabaseMap.values())
         database->immediateClose();
 
@@ -635,7 +634,7 @@ void IDBServer::closeDatabasesForOrigins(const Vector<SecurityOriginData>& targe
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    HashSet<UniqueIDBDatabase*> openDatabases;
+    HashSet<CheckedPtr<UniqueIDBDatabase>> openDatabases;
     for (auto& database : m_uniqueIDBDatabaseMap.values()) {
         const auto& databaseOrigin = database->identifier().origin();
         bool filtered = std::ranges::any_of(targetOrigins, [&databaseOrigin, &filter](auto& targetOrigin) {


### PR DESCRIPTION
#### 9aa9b62d542c6f4aa70fb9d14e6e1c6dc7fa24d1
<pre>
[SaferCPP] Eliminate some raw pointers in IndexedDB
<a href="https://bugs.webkit.org/show_bug.cgi?id=302292">https://bugs.webkit.org/show_bug.cgi?id=302292</a>
<a href="https://rdar.apple.com/164435040">rdar://164435040</a>

Reviewed by Chris Dumez.

* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp:
(WebCore::IDBServer::IDBConnectionToClient::registerDatabaseConnection):
(WebCore::IDBServer::IDBConnectionToClient::unregisterDatabaseConnection):
(WebCore::IDBServer::IDBConnectionToClient::connectionToClientClosed):
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h: Use WeakHashSet
to avoid a manually managed raw pointer HashSet.

* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp: Use CheckedPtr instead
of raw pointer

(WebCore::IDBServer::IDBServer::closeAndDeleteDatabasesModifiedSince):
(WebCore::IDBServer::IDBServer::closeDatabasesForOrigins):
* Source/WebCore/Modules/webdatabase/Database.cpp: Instead of manually managing
a raw pointer HashSet, which was only used as a counter, remove the HashSet and
keep an explicit count in the GUID map.

Canonical link: <a href="https://commits.webkit.org/302879@main">https://commits.webkit.org/302879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea1ac3cda06f86d5752729a460e8e7f3676acc0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82062 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/946e2133-9794-4264-ad1c-152c0d770977) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d5a7e46-0ba0-4729-8fac-2e552227c216) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80095 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/35485ca5-4b14-49db-b463-2075858f4413) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81142 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140362 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107823 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1965 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31620 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55502 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20331 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65984 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2415 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->