### PR TITLE
REGRESSION(302409@main): Broke http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/eme2016.js
+++ b/LayoutTests/http/tests/media/fairplay/eme2016.js
@@ -66,19 +66,26 @@ async function startEME(options) {
 }
 
 async function fetchAndAppend(sourceBuffer, url, options) {
-    let buffer = await fetchBuffer(url, options);
+    const buffer = await fetchBuffer(url, options);
     sourceBuffer.appendBuffer(buffer);
     await waitFor(sourceBuffer, 'updateend', options && options.silent);
 }
 
-async function runAndWaitForLicenseRequest(session, callback) {
+async function fetchAndSilentAppend(sourceBuffer, url, options) {
+    const buffer = await fetchBuffer(url, options);
+    sourceBuffer.appendBuffer(buffer);
+    await waitFor(sourceBuffer, 'updateend', true);
+}
+
+async function runAndWaitForLicenseRequest(session, callback, options) {
     var licenseRequestPromise = waitFor(session, 'message');
     await callback();
     let message = await licenseRequestPromise;
 
     let response = await getResponse(message, options);
     await session.update(response);
-    consoleWrite('PROMISE: session.update() resolved');
+    if (!options || options.silent)
+        consoleWrite('PROMISE: session.update() resolved');
 }
 
 async function fetchAndWaitForLicenseRequest(session, sourceBuffer, url) {
@@ -88,7 +95,7 @@ async function fetchAndWaitForLicenseRequest(session, sourceBuffer, url) {
 }
 
 async function fetchAppendAndWaitForEncrypted(video, mediaKeys, sourceBuffer, url, options) {
-    let updateEndPromise = fetchAndAppend(sourceBuffer, url, options);
+    let updateEndPromise = fetchAndSilentAppend(sourceBuffer, url, options);
     let encryptedEvent = await waitFor(video, 'encrypted', options && options.silent);
 
     let session = mediaKeys.createSession();

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange-expected.txt
@@ -1,3 +1,4 @@
+
 PROMISE: requestMediaKeySystemAccess resolved
 PROMISE: createMediaKeys resolved
 FETCH: resources/cert.der OK

--- a/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v2-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v2-expected.txt
@@ -7,6 +7,7 @@ FETCH: content/elementary-stream-video-header-keyid-1.m4v OK
 EVENT(webkitneedkey)
 EVENT(webkitkeymessage)
 EXPECTED (uInt8ArrayToString(event.message) == 'certificate') OK
+EVENT(updateend)
 FETCH: resources/cert.der OK
 EVENT(webkitkeymessage)
 PROMISE: licenseResponse resolved

--- a/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v3-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v3-expected.txt
@@ -7,6 +7,7 @@ FETCH: content/elementary-stream-video-header-keyid-1.m4v OK
 EVENT(webkitneedkey)
 EVENT(webkitkeymessage)
 EXPECTED (uInt8ArrayToString(event.message) == 'certificate') OK
+EVENT(updateend)
 FETCH: resources/cert.der OK
 EVENT(webkitkeymessage)
 PROMISE: licenseResponse resolved


### PR DESCRIPTION
#### 9acb0a39dad968a4693d2ba90a7f8b2bc3b9383f
<pre>
REGRESSION(302409@main): Broke http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=302295">https://bugs.webkit.org/show_bug.cgi?id=302295</a>
<a href="https://rdar.apple.com/164409827">rdar://164409827</a>

Reviewed by Youenn Fablet.

An error was introduced in 302409@main which made all tests using eme2016.js to
log the `updateend` event twice.

* LayoutTests/http/tests/media/fairplay/eme2016.js:
(async fetchAndSilentAppend): Added new method as the ability to configure logging via `options` isn&apos;t sufficient to force waitFor to not log.
* LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange-expected.txt: Rebase expectations
* LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v2-expected.txt: Rebase expectations
* LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v3-expected.txt: Rebase expectations

Canonical link: <a href="https://commits.webkit.org/302870@main">https://commits.webkit.org/302870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9182496f16619c1827bdf45a4be564dcdc2a2740

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/2809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2689 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133473 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/2809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80143 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/2809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35008 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81203 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/2809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/35513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140423 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2587 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107870 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27448 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2657 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->