### PR TITLE
[iOS] Remove use of `-[UIScreen mainScreen]` in `WKContentView`

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -88,6 +88,8 @@ enum class ViewStabilityFlag : uint8_t;
 - (void)didInterruptScrolling;
 - (void)didZoomToScale:(CGFloat)scale;
 - (void)willStartZoomOrScroll;
+
+- (CGFloat)intrinsicDeviceScaleFactor;
 - (BOOL)screenIsBeingCaptured;
 
 - (void)_webViewDestroyed;

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -131,6 +131,7 @@ IGNORE_WARNINGS_END
         self._inputDelegate = self;
         self.focusStartsInputSessionPolicy = _WKFocusStartsInputSessionPolicyAuto;
         self.supportedInterfaceOrientations = UIInterfaceOrientationMaskAll;
+        self.traitOverrides.displayScale = 2.0f;
 #endif
     }
     return self;

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -179,7 +179,6 @@ void TestController::platformInitialize(const Options& options)
     cocoaPlatformInitialize(options);
 
     [UIApplication sharedApplication].idleTimerDisabled = YES;
-    [[UIScreen mainScreen] _setScale:2.0];
 
     auto center = CFNotificationCenterGetLocalCenter();
     CFNotificationCenterAddObserver(center, this, handleKeyboardWillHideNotification, (CFStringRef)UIKeyboardWillHideNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
@@ -321,7 +320,6 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
     [UIKeyboardImpl.activeInstance setCorrectionLearningAllowed:NO];
     [pasteboardConsistencyEnforcer() clearPasteboard];
     [[UIApplication sharedApplication] _cancelAllTouches];
-    [[UIScreen mainScreen] _setScale:2.0];
     [[HIDEventGenerator sharedHIDEventGenerator] resetActiveModifiers];
 
     restorePortraitOrientationIfNeeded();


### PR DESCRIPTION
#### eeee3a57785bca1656e063b64bf9cc6e6b13be63
<pre>
[iOS] Remove use of `-[UIScreen mainScreen]` in `WKContentView`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302298">https://bugs.webkit.org/show_bug.cgi?id=302298</a>
<a href="https://rdar.apple.com/164439913">rdar://164439913</a>

Reviewed by Wenson Hsieh.

`-[UIScreen mainScreen]` was deprecated in iOS 26. Work towards removing its
use in WebKit.

`WKContentView` uses `UIScreen` to determine display scale and scene capture
state. Use equivalent methods on `UITraitCollection` and register for trait
changes, to respond to changes.

* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
(-[WKContentView didMoveToWindow]):

Trait changes are triggered (if necessary) when a view moves windows, making
the existing code no longer necessary.

(-[WKContentView intrinsicDeviceScaleFactor]):

`displayScale` can be zero (unspecified). In that case, use
`WebCore::screenScaleFactor` (which still falls back to use of `UIScreen`).

This scenario is not expected to be common, but trait collections can be
overridden by clients.

(-[WKContentView screenIsBeingCaptured]):
(-[WKContentView _updateForScreen:]):
(-[WKContentView _displayScaleDidChange]):
(-[WKContentView _sceneCaptureStateDidChange]):
(-[WKContentView _screenCapturedDidChange:]): Deleted.
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView initWithFrame:configuration:]):

Now that the trait collection is used to determine display scale, force a scale
using a trait override.

* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformInitialize):
(WTR::TestController::platformResetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/302852@main">https://commits.webkit.org/302852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbf094ed88b740a972b0c4d204e7deb690c09dc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81999 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2680def6-5810-4e47-9e36-56a1f701b97b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99354 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c688bfe7-cafd-4f77-81f6-da3c3f246127) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133356 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1964 "Found 1 new test failure: http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80053 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa10fbb7-196d-43c0-b3fb-d4444a041b70) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81086 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110441 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140304 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2470 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2265 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107867 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107771 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55428 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20321 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65928 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2358 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->