### PR TITLE
[ macOS wk2 arm64 ] http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/tests/xmlhttprequest/chunked-progress-event-expectedLength-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/chunked-progress-event-expectedLength-expected.txt
@@ -1,7 +1,12 @@
 Test case for bug 36156: XHR 'progress' event code assumes wrongly that expectedLength >= 0
 
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
 Verify that the progress event total property is 0 when the expected overall length can't be computed.
+PASS Length is not computable
+PASS gotRelevantProgressEvent is true
+PASS successfullyParsed is true
 
-PASS should appear below:
+TEST COMPLETE
 
-PASS

--- a/LayoutTests/http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html
+++ b/LayoutTests/http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html
@@ -1,22 +1,13 @@
+<!DOCTYPE html>
 <html>
-<head>
-<title>Test case for bug 36156</title>
-</head>
 <body>
-<p> Test case for <a href="https://bugs.webkit.org/show_bug.cgi?id=36156"> bug 36156</a>: XHR 'progress' event code assumes wrongly that expectedLength >= 0</p>
-<p> Verify that the progress event total property is 0 when the expected overall length can't be computed.<p>
-<p>PASS should appear below:</p>
-<p id=console></p>
-<script type="text/javascript">
-if (window.testRunner) {
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
-}
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Test case for bug 36156: XHR 'progress' event code assumes wrongly that expectedLength >= 0");
+debug("Verify that the progress event total property is 0 when the expected overall length can't be computed.");
+jsTestIsAsync = true;
 
-function log(message)
-{
-    document.getElementById('console').appendChild(document.createTextNode(message + '\n'));
-}
+gotRelevantProgressEvent = false;
 
 function test()
 {
@@ -24,23 +15,27 @@ function test()
     xhr.open("GET", "resources/chunked-transfer.py", true);
 
     xhr.onprogress = function(e) {
-        if (e.loaded >= 4 && e.total == 0 && !e.lengthComputable)
-            log("PASS");
-        else if (e.total != 0 && !e.lengthComputable)
-            log("FAIL: XMLHttpRequestProgressEvent lengthComputable=false but total is non-zero: " + e.total);
+        if (e.loaded >= 4 && e.total == 0 && !e.lengthComputable) {
+            testPassed("Length is not computable");
+            gotRelevantProgressEvent = true;
+        } else if (e.total != 0 && !e.lengthComputable) {
+            testFailed("XMLHttpRequestProgressEvent lengthComputable=false but total is non-zero: " + e.total);
+            gotRelevantProgressEvent = true;
+        }
     }
 
     xhr.onreadystatechange = function(e) {
-        if (xhr.readyState == xhr.DONE) 
-        {
-            if (window.testRunner)
-                testRunner.notifyDone();
+        if (xhr.readyState == xhr.DONE) {
+            shouldBeTrue("gotRelevantProgressEvent");
+            finishJSTest();
         }
     }
 
     xhr.send();
 }
 
-test();
+onload = () => {
+    setTimeout(test, 0);
+};
 </script>
 </body>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2323,8 +2323,6 @@ webkit.org/b/297007 media/webaudio-background-playback.html [ Pass Failure ]
 
 webkit.org/b/292402 http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/297063 [ arm64 ] http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html [ Pass Failure ]
-
 webkit.org/b/297078 [ Debug arm64 ] fast/parser/entity-comment-in-style.html [ Pass Timeout ]
 
 webkit.org/b/297121 fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html [ Failure ]


### PR DESCRIPTION
#### f420b718bfc94a55281da38ba2beb05cb13976c7
<pre>
[ macOS wk2 arm64 ] http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=297063">https://bugs.webkit.org/show_bug.cgi?id=297063</a>
<a href="https://rdar.apple.com/157765880">rdar://157765880</a>

Reviewed by Per Arne Vollan.

Attempt to address the test flakiness by rewriting the test using
js-test.js and waiting until after the load event has fired to trigger
the XHR.

* LayoutTests/http/tests/xmlhttprequest/chunked-progress-event-expectedLength-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/302878@main">https://commits.webkit.org/302878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b662ddcdf661bc0bd15661faec543b731fa84360

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81931 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bf35e992-09f8-4310-8f44-da52c3dc3e14) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99310 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67167 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd06359d-77ff-4f0d-ade6-f796bfdd45e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80008 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01312e0f-9a87-4513-bae3-20c1e3dab91e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34864 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81027 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140245 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107826 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107727 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27454 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55366 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2481 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2502 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->