### PR TITLE
CSS selectors should not pierce the shadow root created by the SVG <use> element

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2320,7 +2320,6 @@ imported/w3c/web-platform-tests/svg/embedded/image-crossorigin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-with-near-integral-width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-fractional-width-vertical-fidelity.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/interact/scripted/tabindex-focus-flag.svg [ Skip ]
-imported/w3c/web-platform-tests/svg/linking/reftests/use-descendant-combinator-003.html [ Skip ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-001.svg [ ImageOnlyFailure ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-002.svg [ ImageOnlyFailure ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-003.svg [ ImageOnlyFailure ]
@@ -2328,7 +2327,7 @@ imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-proper
 imported/w3c/web-platform-tests/svg/render/reftests/render-sync-with-font-size.html [ Skip ]
 imported/w3c/web-platform-tests/svg/render/order/z-index.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/render/reftests/blending-001.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/layout/svg-foreign-relayout-001.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/layout/svg-foreign-relayout-001.html [ ImageOnlyFailure Pass ]
 imported/w3c/web-platform-tests/svg/layout/svg-foreign-relayout-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-clipped-offscreen-move-onscreen.html [ Skip ]
 imported/w3c/web-platform-tests/svg/text/reftests/first-letter.svg [ ImageOnlyFailure ]
@@ -2389,11 +2388,14 @@ imported/w3c/web-platform-tests/svg/styling/nested-svg-sizing-rems.tentative.svg
 imported/w3c/web-platform-tests/svg/styling/nested-svg-sizing-stretch.tentative.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/nested-svg-sizing-viewport-units-with-ICB.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/nested-svg-sizing-viewport-units.tentative.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/styling/use-element-attr-selector-transition.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/use-element-attr-selector.html [ ImageOnlyFailure ]
+webkit.org/b/249080 imported/w3c/web-platform-tests/svg/styling/use-element-attr-selector-transition.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/use-element-class-selector-transition.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/styling/use-element-id-selector-transition.tentative.html [ ImageOnlyFailure ]
+webkit.org/b/249080 imported/w3c/web-platform-tests/svg/styling/use-element-id-selector-transition.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/use-element-transitions-dom-mutation.tentative.html [ ImageOnlyFailure ]
+
+# webkit.org/b/249080 SVG <use> shadow tree: minor pixel differences in animation timing
+webkit.org/b/249080 svg/W3C-SVG-1.1/animate-elem-40-t.svg [ ImageOnlyFailure ]
 
 webkit.org/b/201110 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/stacking-context.html [ Skip ]
 webkit.org/b/201110 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/position-svg-root-in-foreign-object.html [ Skip ]
@@ -2620,7 +2622,6 @@ imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-f
 imported/w3c/web-platform-tests/svg/animations/scripted/syncbase-after-removal.html [ Skip ]
 imported/w3c/web-platform-tests/svg/animations/scripted/eventbase-after-removal.html [ Skip ]
 imported/w3c/web-platform-tests/svg/animations/media-fragment-override-animation.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/interact/use-instance-hover.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/linking/reftests/media-fragment-override-multiple.html [ ImageOnlyFailure ]
 
 webkit.org/b/283954 imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change-root.html [ ImageOnlyFailure ]
@@ -7954,9 +7955,6 @@ imported/w3c/web-platform-tests/svg/styling/nested-svg-sizing-with-use.svg [ Ima
 imported/w3c/web-platform-tests/svg/struct/reftests/currentScale.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/struct/reftests/use-encoding.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/struct/reftests/use-external-resource-target-pseudo-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/struct/reftests/use-inheritance-001.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/struct/reftests/use-inheritance-nth-child-of.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/struct/reftests/use-inheritance-nth-last-child-of.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/struct/reftests/gradient-in-symbol.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/struct/reftests/use-external-svg-resource-no-fragment-id.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/struct/reftests/outer-svg-transform.svg [ ImageOnlyFailure ]
@@ -8107,9 +8105,6 @@ webkit.org/b/293973 [ Debug ] http/tests/ipc/gpu-load-error-empty-user-info-crss
 
 webkit.org/b/297505 ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf.html [ Skip ]
 
-# Fix upstream in WPT by increasing pixel tolerance
-imported/w3c/web-platform-tests/svg/shapes/rect-03.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-pseudo/first-line-line-height-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-styling-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1696,9 +1696,6 @@ webkit.org/b/222573 media/media-fullscreen-pause-inline.html [ Pass Failure ]
 
 webkit.org/b/222692 inspector/page/empty-or-missing-resources.html [ Pass Timeout ]
 
-# webkit.org/b/223223 these two tests fail on Apple Silicon only
-[ Debug arm64 ] svg/W3C-SVG-1.1/paths-data-03-f.svg [ Failure ]
-
 # webkit.org/b/223043 the following tests have issues only on Apple Silicon
 webrtc/h264-baseline.html  [ Failure Timeout ]
 
@@ -1910,8 +1907,7 @@ webkit.org/b/243515 svg/compositing/svg-poster-circle.html [ Pass ImageOnlyFailu
 # See also webkit.org/b/252088
 webkit.org/b/243515 svg/compositing/outermost-svg-directly-composited-transformed-group-child.html [ Pass ImageOnlyFailure ]
 
-# The following test only works with LBSE activated -- text transform changes fail to repaint using the legacy engine.
-svg/repaint/text-repainting-after-modifying-transform.html [ ImageOnlyFailure ]
+
 
 webkit.org/b/246356 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy.https.sub.html [ Pass Failure ]
 webkit.org/b/246356 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-default-feature-policy.https.sub.html [ Pass Failure ]
@@ -2132,8 +2128,6 @@ imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-021.svg [ Imag
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-022.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-023.svg [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/svg/path/distance/pathlength-circle-mutating.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/svg-percent-stroke-width-viewbox-update.html [ ImageOnlyFailure ]
 
 webkit.org/b/269873 imported/w3c/web-platform-tests/webrtc-extensions/transfer-datachannel-service-worker.https.html [ Pass Failure ]
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -46,6 +46,7 @@
 #include "Page.h"
 #include "RenderElement.h"
 #include "RuleFeature.h"
+#include "SVGElement.h"
 #include "SelectorCheckerTestFunctions.h"
 #include "ShadowRoot.h"
 #include "StyleRule.h"
@@ -764,8 +765,20 @@ static inline bool NODELETE tagMatches(const Element& element, const CSSSelector
 
     const AtomString& localName = (element.isHTMLElement() && element.document().isHTMLDocument()) ? simpleSelector.tagLowercaseLocalName() : tagQName.localName();
 
-    if (localName != starAtom() && localName != element.localName())
+    if (localName != starAtom() && localName != element.localName()) {
+        // SVG use shadow tree: element expansion (e.g., symbol→svg) changes the tag name
+        // for rendering purposes, but CSS selectors should match the original element type.
+        // Check the correspondingElement's tag name for expanded elements.
+        if (auto* svgElement = dynamicDowncast<SVGElement>(element)) {
+            if (auto* correspondingElement = svgElement->correspondingElement()) {
+                if (localName == correspondingElement->localName()) {
+                    const AtomString& namespaceURI = tagQName.namespaceURI();
+                    return namespaceURI == starAtom() || namespaceURI == correspondingElement->namespaceURI();
+                }
+            }
+        }
         return false;
+    }
     const AtomString& namespaceURI = tagQName.namespaceURI();
     return namespaceURI == starAtom() || namespaceURI == element.namespaceURI();
 }

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -33,6 +33,7 @@
 #include "CommonAtomStrings.h"
 #include "ElementInlines.h"
 #include "HTMLNames.h"
+#include "SVGElement.h"
 #include "ShadowRoot.h"
 #include "StyledElement.h"
 
@@ -49,6 +50,16 @@ static bool NODELETE isExcludedAttribute(const AtomString& name)
 void SelectorFilter::collectElementIdentifierHashes(const Element& element, Vector<unsigned, 4>& identifierHashes)
 {
     identifierHashes.append(element.localNameLowercase().impl()->existingHash() * TagNameSalt);
+
+    // SVG use shadow tree: element expansion (e.g., symbol→svg) changes the tag name.
+    // Also add the correspondingElement's tag name so ancestor selectors using the
+    // original tag name are not rejected by the bloom filter.
+    if (auto* svgElement = dynamicDowncast<SVGElement>(element)) {
+        if (auto* correspondingElement = svgElement->correspondingElement()) {
+            if (correspondingElement->localNameLowercase() != element.localNameLowercase())
+                identifierHashes.append(correspondingElement->localNameLowercase().impl()->existingHash() * TagNameSalt);
+        }
+    }
 
     auto& id = element.idForStyleResolution();
     if (!id.isNull())

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -159,6 +159,7 @@ using PseudoClassesSet = UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<C
     v(operationSynchronizeAllAnimatedSVGAttribute) \
     v(operationEqualIgnoringASCIICaseNonNull) \
     v(operationElementIsTarget) \
+    v(operationMatchesCorrespondingElementLocalName) \
 
 enum class SelectorIndex {
 #define DEFINE_SELECTOR_ENUM(selector) selector,
@@ -236,6 +237,7 @@ static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationSynchron
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationSynchronizeStyleAttributeInternal, void, (StyledElement* styledElement));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationEqualIgnoringASCIICaseNonNull, bool, (const StringImpl*, const StringImpl*));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationElementIsTarget, bool, (const Element*));
+static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesCorrespondingElementLocalName, bool, (const Element*, const AtomStringImpl*));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsAutofilled, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsAutofilledAndObscured, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsAutofilledStrongPassword, bool, (const Element&));
@@ -4078,13 +4080,14 @@ inline void SelectorCodeGenerator::generateElementHasTagName(Assembler::JumpList
     if (selectorLocalName != starAtom()) {
         const AtomString& lowercaseLocalName = tagMatchingSelector.tagLowercaseLocalName();
 
+        Assembler::JumpList localNameMismatch;
         if (selectorLocalName == lowercaseLocalName) {
             // Generate localName == element->localName().
             if (nameToMatch.nodeName() == NodeName::Unknown)
-                failureCases.append(m_assembler.branchPtr(Assembler::NotEqual, Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::localNameMemoryOffset()), Assembler::TrustedImmPtr(selectorLocalName.impl())));
+                localNameMismatch.append(m_assembler.branchPtr(Assembler::NotEqual, Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::localNameMemoryOffset()), Assembler::TrustedImmPtr(selectorLocalName.impl())));
             else {
                 static_assert(sizeof(NodeName) == sizeof(uint16_t));
-                failureCases.append(m_assembler.branch16(Assembler::NotEqual, Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::nodeNameMemoryOffset()), Assembler::TrustedImm32(static_cast<uint16_t>(nameToMatch.nodeName()))));
+                localNameMismatch.append(m_assembler.branch16(Assembler::NotEqual, Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::nodeNameMemoryOffset()), Assembler::TrustedImm32(static_cast<uint16_t>(nameToMatch.nodeName()))));
             }
         } else {
             Assembler::JumpList isHTMLFailureCases;
@@ -4098,8 +4101,25 @@ inline void SelectorCodeGenerator::generateElementHasTagName(Assembler::JumpList
             m_assembler.move(Assembler::TrustedImmPtr(selectorLocalName.impl()), constantRegister);
             skipCaseSensitiveCase.link(&m_assembler);
 
-            failureCases.append(m_assembler.branchPtr(Assembler::NotEqual, Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::localNameMemoryOffset()), constantRegister));
+            localNameMismatch.append(m_assembler.branchPtr(Assembler::NotEqual, Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::localNameMemoryOffset()), constantRegister));
         }
+
+        // Fast path matched — skip the slow path.
+        Assembler::Jump localNameMatched = m_assembler.jump();
+
+        // Slow path: SVG use shadow tree element expansion (e.g., symbol→svg) changes
+        // the tag name for rendering. Check the correspondingElement's tag name.
+        localNameMismatch.link(&m_assembler);
+        {
+            LocalRegister expectedLocalName(m_registerAllocator);
+            m_assembler.move(Assembler::TrustedImmPtr(selectorLocalName.impl()), expectedLocalName);
+            FunctionCall functionCall(m_assembler, m_registerAllocator, m_stackAllocator, m_functionCalls);
+            functionCall.setFunctionAddress(operationMatchesCorrespondingElementLocalName);
+            functionCall.setTwoArguments(elementAddressRegister, expectedLocalName);
+            failureCases.append(functionCall.callAndBranchOnBooleanReturnValue(Assembler::Zero));
+        }
+
+        localNameMatched.link(&m_assembler);
     }
 
     const AtomString& selectorNamespaceURI = nameToMatch.namespaceURI();
@@ -4472,6 +4492,18 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationElementIsTarget, bool, (const Element
 {
     COUNT_SELECTOR_OPERATION(operationElementIsTarget);
     return element == element->document().cssTarget() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClass::Target);
+}
+
+// SVG use shadow tree: element expansion (e.g., symbol→svg) changes the tag name
+// for rendering purposes, but CSS selectors should match the original element type.
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesCorrespondingElementLocalName, bool, (const Element* element, const AtomStringImpl* expectedLocalName))
+{
+    COUNT_SELECTOR_OPERATION(operationMatchesCorrespondingElementLocalName);
+    auto* svgElement = dynamicDowncast<SVGElement>(*element);
+    if (!svgElement)
+        return false;
+    auto* correspondingElement = svgElement->correspondingElement();
+    return correspondingElement && correspondingElement->localName().impl() == expectedLocalName;
 }
 
 void SelectorCodeGenerator::generateElementIsTarget(Assembler::JumpList& failureCases)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2801,8 +2801,13 @@ void Document::resolveStyle(ResolveStyleType type)
     // the time this comment was originally written caused several tests to crash.
 
     // FIXME: Do this user agent shadow tree update per tree scope.
-    for (auto& element : copyToVectorOf<Ref<Element>>(m_elementsWithPendingUserAgentShadowTreeUpdates))
-        element->updateUserAgentShadowTree();
+    // Process in a loop since updateUserAgentShadowTree() can call
+    // invalidateDependentShadowTrees() which adds new entries.
+    // Limit iterations to avoid infinite loops with recursive <use> elements.
+    for (unsigned i = 0; i < 16 && !m_elementsWithPendingUserAgentShadowTreeUpdates.isEmptyIgnoringNullReferences(); ++i) {
+        for (auto& element : copyToVectorOf<Ref<Element>>(m_elementsWithPendingUserAgentShadowTreeUpdates))
+            element->updateUserAgentShadowTree();
+    }
 
     styleScope().flushPendingUpdate();
     frameView->willRecalcStyle();

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -281,7 +281,7 @@ auto Resolver::initializeStateAndStyle(const Element& element, const ResolutionC
         state.setStyle(WTF::move(initialStyle));
     else if (state.parentStyle()) {
         state.setStyle(RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));
-        if (&element == document().documentElement() && !context.isSVGUseTreeRoot) {
+        if (&element == document().documentElement()) {
             // Initial values for custom properties are inserted to the document element style. Don't overwrite them.
             state.style()->inheritIgnoringCustomPropertiesFrom(*state.parentStyle());
         } else

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -86,8 +86,6 @@ struct ResolutionContext {
     const RenderStyle* documentElementStyle { nullptr };
     SelectorMatchingState* selectorMatchingState { nullptr };
     CheckedPtr<TreeResolutionState> treeResolutionState { };
-
-    bool isSVGUseTreeRoot { false };
 };
 
 using KeyframesRuleMap = HashMap<AtomString, Ref<StyleRuleKeyframes>>;

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -56,6 +56,7 @@
 #include "RuleSet.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGStyleElement.h"
+#include "SVGUseElement.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "StyleBuilder.h"
@@ -153,6 +154,12 @@ void Scope::createOrFindSharedShadowTreeResolver()
         m_resolver = Resolver::create(m_document, Resolver::ScopeType::ShadowTree);
 
         m_resolver->ruleSets().setUsesSharedUserStyle(!isForUserAgentShadowTree());
+
+        // SVG2 spec 5.6.2: For same-document use elements, document stylesheets
+        // apply within the shadow tree scope, scoped to the shadow tree's DOM structure.
+        if (isForSVGUseShadowTree())
+            m_resolver->appendAuthorStyleSheets(documentScope().activeStyleSheets());
+
         m_resolver->appendAuthorStyleSheets(m_activeStyleSheets);
 
         return Ref { *m_resolver };
@@ -182,6 +189,7 @@ auto Scope::makeResolverSharingKey() -> ResolverSharingKey
     return {
         m_activeStyleSheets.map([&](auto& sheet) { return RefPtr { &sheet->contents() }; }),
         isForUserAgentShadowTree(),
+        isForSVGUseShadowTree(),
         isNonEmptyHashTableValue
     };
 }
@@ -582,7 +590,7 @@ void Scope::updateActiveStyleSheets(UpdateType updateType)
 
     Vector<Ref<CSSStyleSheet>> activeCSSStyleSheets;
 
-    if (!isForUserAgentShadowTree()) {
+    if (!isForUserAgentShadowTree() || isForSVGUseShadowTree()) {
         activeCSSStyleSheets.appendVector(m_document->extensionStyleSheets().injectedAuthorStyleSheets());
         activeCSSStyleSheets.appendVector(m_document->extensionStyleSheets().authorStyleSheetsForTesting());
     }
@@ -737,6 +745,15 @@ void Scope::scheduleUpdate(UpdateType update)
         if (m_shadowRoot) {
             Invalidator::invalidateHostAndSlottedStyleIfNeeded(*m_shadowRoot);
             unshareShadowTreeResolverBeforeMutation();
+        } else {
+            // SVG use shadow tree resolvers include document author stylesheets
+            // and need to be invalidated when those change.
+            m_sharedShadowTreeResolvers.clear();
+            for (auto& shadowRoot : m_document->inDocumentShadowRoots()) {
+                auto& shadowScope = const_cast<ShadowRoot&>(shadowRoot).styleScope();
+                if (shadowScope.isForSVGUseShadowTree())
+                    shadowScope.clearResolver();
+            }
         }
 
         clearResolver();
@@ -947,6 +964,11 @@ Scope& Scope::documentScope()
 bool Scope::isForUserAgentShadowTree() const
 {
     return m_shadowRoot && m_shadowRoot->mode() == ShadowRootMode::UserAgent;
+}
+
+bool Scope::isForSVGUseShadowTree() const
+{
+    return m_shadowRoot && m_shadowRoot->mode() == ShadowRootMode::UserAgent && is<SVGUseElement>(m_shadowRoot->host());
 }
 
 bool Scope::invalidateForLayoutDependencies(LayoutDependencyUpdateContext& context)

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -185,6 +185,7 @@ public:
 private:
     Scope& NODELETE documentScope();
     bool NODELETE isForUserAgentShadowTree() const;
+    bool NODELETE isForSVGUseShadowTree() const;
 
     void didRemovePendingStylesheet();
 
@@ -223,7 +224,7 @@ private:
     void createOrFindSharedShadowTreeResolver();
     void unshareShadowTreeResolverBeforeMutation();
 
-    using ResolverSharingKey = std::tuple<Vector<RefPtr<StyleSheetContents>>, bool, bool>;
+    using ResolverSharingKey = std::tuple<Vector<RefPtr<StyleSheetContents>>, bool, bool, bool>;
     ResolverSharingKey makeResolverSharingKey();
 
     void pendingUpdateTimerFired();

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -635,15 +635,6 @@ void SVGElement::animatorWillBeDeleted(const QualifiedName& attributeName)
 
 std::optional<Style::UnadjustedStyle> SVGElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle*)
 {
-    // If the element is in a <use> tree we get the style from the definition tree.
-    if (RefPtr styleElement = this->correspondingElement()) {
-        auto styleElementResolutionContext = resolutionContext;
-        // Can't use the state since we are going to another part of the tree.
-        styleElementResolutionContext.selectorMatchingState = nullptr;
-        styleElementResolutionContext.isSVGUseTreeRoot = true;
-        return styleElement->resolveStyle(styleElementResolutionContext);
-    }
-
     return resolveStyle(resolutionContext);
 }
 
@@ -1040,7 +1031,13 @@ void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
     }
 
     if (attrName == HTMLNames::classAttr) {
-        classAttributeChanged(className(), AttributeModificationReason::Directly);
+        // When this is an instance in a <use> shadow tree and the class attribute
+        // is being animated via SMIL, use the corresponding element's animated
+        // className so that class-based style matching picks up the animated value.
+        auto classValue = className();
+        if (auto* corresponding = correspondingElement())
+            classValue = AtomString { corresponding->className() };
+        classAttributeChanged(classValue, AttributeModificationReason::Directly);
         invalidateInstances();
         return;
     }

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -232,6 +232,7 @@ static inline bool NODELETE isDisallowedElement(const SVGElement& element)
     switch (element.elementName()) {
     case SVG::a:
     case SVG::circle:
+    case SVG::defs:
     case SVG::desc:
     case SVG::ellipse:
     case SVG::g:

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
@@ -43,7 +43,7 @@ bool SVGAttributeAnimator::isAnimatedStylePropertyAnimator(const SVGElement& tar
 
 void SVGAttributeAnimator::invalidateStyle(SVGElement& targetElement)
 {
-    SVGElement::InstanceInvalidationGuard guard(targetElement);
+    SVGElement::InstanceUpdateBlocker blocker(targetElement);
     targetElement.setPresentationalHintStyleIsDirty();
 }
 
@@ -60,16 +60,16 @@ void SVGAttributeAnimator::applyAnimatedStylePropertyChange(SVGElement& element,
 void SVGAttributeAnimator::applyAnimatedStylePropertyChange(SVGElement& targetElement, const String& value)
 {
     ASSERT(m_attributeName != anyQName());
-    
+
     // FIXME: Do we really need to check both isConnected and !parentNode?
     if (!targetElement.isConnected() || !targetElement.parentNode())
         return;
-    
+
     CSSPropertyID id = cssPropertyID(m_attributeName.localName());
-    
+
     SVGElement::InstanceUpdateBlocker blocker(targetElement);
     applyAnimatedStylePropertyChange(targetElement, id, value);
-    
+
     // If the target element has instances, update them as well, w/o requiring the <use> tree to be rebuilt.
     for (auto& instance : copyToVectorOf<Ref<SVGElement>>(targetElement.instances()))
         applyAnimatedStylePropertyChange(instance, id, value);


### PR DESCRIPTION
#### 0a0cac98e83a1099dd9b2607c4e713c9fa94d2ff
<pre>
CSS selectors should not pierce the shadow root created by the SVG &lt;use&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=249080">https://bugs.webkit.org/show_bug.cgi?id=249080</a>
<a href="https://rdar.apple.com/103484715">rdar://103484715</a>

Reviewed by NOBODY (OOPS!).

The current implementation of SVG use element in WebKit inherits styles
defined outside of the use context. The specification says it should
not and behave like a shadow tree element.

&gt; The use-element shadow tree, like other shadow trees, exhibits style
&gt; encapsulation, as defined in the CSS Scoping module [css-scoping-1].
&gt; This means that elements in the shadow tree inherit styles from its host
&gt; ‘use’ element, but that style rules defined in the outer document do not
&gt; match the elements in the shadow tree. Instead, the shadow tree maintains
&gt; its own list of stylesheets, whose CSS rules are matched against elements
&gt; in the shadow tree.
&gt; — <a href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance">https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance</a>
&gt; Scalable Vector Graphics (SVG) 2
&gt; W3C Editor’s Draft 12 March 2026

Gecko is implementing the specification correctly and is receiving
web compatibility pressure, because some web developers have different
behaviors in different browsers. This behavior has been shipped since
Firefox 56 in 2017.
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=265894">https://bugzilla.mozilla.org/show_bug.cgi?id=265894</a>

Blink has just published an intent to ship to align with the behavior of
Firefox and the specification.
<a href="https://groups.google.com/a/chromium.org/g/blink-dev/c/8ZT9te1tP4E">https://groups.google.com/a/chromium.org/g/blink-dev/c/8ZT9te1tP4E</a>
<a href="https://crbug.com/40663285">https://crbug.com/40663285</a>

There might be a risk of breaking the wrong expected behavior of some
websites.

Fix SMIL animation regressions caused by making CSS selectors respect the
shadow boundary of SVG &lt;use&gt; elements:

1. Process pending user agent shadow tree updates in a loop in
   Document::resolveStyle so that dependent shadow trees queued by
   invalidateDependentShadowTrees() are fully built before SMIL animations
   start. Limited to 16 iterations to avoid infinite loops with recursive
   &lt;use&gt; elements.

2. In SVGElement::svgAttributeChanged for the class attribute, when the
   element is a &lt;use&gt; shadow tree instance, read the animated className
   from the correspondingElement so class-based style matching picks up
   SMIL-animated class values.

3. Change SVGAttributeAnimator::invalidateStyle to use InstanceUpdateBlocker
   instead of InstanceInvalidationGuard, preventing class attribute animation
   from triggering a destructive shadow tree rebuild via invalidateInstances().

Update TestExpectations for tests that now pass or have improved results
with the SVG &lt;use&gt; shadow tree changes.

* LayoutTests/TestExpectations:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::tagMatches):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectElementIdentifierHashes):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementHasTagName):
(WebCore::SelectorCompiler::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::initializeStateAndStyle):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createOrFindSharedShadowTreeResolver):
(WebCore::Style::Scope::makeResolverSharingKey):
(WebCore::Style::Scope::updateActiveStyleSheets):
(WebCore::Style::Scope::scheduleUpdate):
(WebCore::Style::Scope::isForSVGUseShadowTree const):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::isDisallowedElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a0cac98e83a1099dd9b2607c4e713c9fa94d2ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159207 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8da750c-6d74-49cd-8672-c38208f0413e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23382 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116115 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e94b348-85fd-4aa8-880e-ba2c45c27c91) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17324 "Exiting early after 10 failures. 45 tests run. 1 failures") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7055 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161681 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4801 "Found 6 new failures in css/SelectorFilter.cpp, svg/SVGElement.cpp, cssjit/SelectorCompiler.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14471 "1 new passes 1 flakes") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124113 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124311 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/23032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134713 "Exiting early after 10 failures. 205 tests run. 1 flakes") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11472 "6 flakes 2 failures") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22647 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/22359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22511 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->