### PR TITLE
Refactor text extraction filtering logic to be more extensible

### DIFF
--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -58,22 +58,22 @@ using TextExtractionFilterCallback = Function<Ref<TextExtractionFilterPromise>(c
 
 struct TextExtractionOptions {
     TextExtractionOptions(TextExtractionOptions&& other)
-        : filterCallback(WTFMove(other.filterCallback))
+        : filterCallbacks(WTFMove(other.filterCallbacks))
         , nativeMenuItems(WTFMove(other.nativeMenuItems))
         , replacementStrings(WTFMove(other.replacementStrings))
         , flags(other.flags)
     {
     }
 
-    TextExtractionOptions(TextExtractionFilterCallback&& filter, Vector<String>&& items, HashMap<String, String>&& replacementStrings, TextExtractionOptionFlags flags)
-        : filterCallback(WTFMove(filter))
+    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, TextExtractionOptionFlags flags)
+        : filterCallbacks(WTFMove(filters))
         , nativeMenuItems(WTFMove(items))
         , replacementStrings(WTFMove(replacementStrings))
         , flags(flags)
     {
     }
 
-    TextExtractionFilterCallback filterCallback;
+    Vector<TextExtractionFilterCallback> filterCallbacks;
     Vector<String> nativeMenuItems;
     HashMap<String, String> replacementStrings;
     TextExtractionOptionFlags flags;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -32,6 +32,13 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 @class WKWebView;
 @class _WKJSHandle;
 
+typedef NS_OPTIONS(NSUInteger, _WKTextExtractionFilterOptions) {
+    _WKTextExtractionFilterNone = 0,
+    _WKTextExtractionFilterTextRecognition = 1 << 0,
+    _WKTextExtractionFilterClassifier = 1 << 1,
+    _WKTextExtractionFilterAll = _WKTextExtractionFilterTextRecognition | _WKTextExtractionFilterClassifier,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
 
@@ -105,6 +112,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  The default value is `nil`.
  */
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *replacementStrings;
+
+/*!
+ Filters to apply when extracting text.
+ Defaults to `_WKTextExtractionFilterAll`.
+ */
+@property (nonatomic) _WKTextExtractionFilterOptions filterOptions;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -53,7 +53,7 @@
     if (!(self = [super init]))
         return nil;
 
-    _shouldFilterText = YES;
+    _filterOptions = _WKTextExtractionFilterAll;
     _includeURLs = !onlyVisibleText;
     _includeRects = !onlyVisibleText;
     _includeNodeIdentifiers = !onlyVisibleText;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -47,11 +47,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL skipNearlyTransparentContent;
 
 /*!
- Defaults to `YES`.
- */
-@property (nonatomic) BOOL shouldFilterText;
-
-/*!
  Iterates over all custom node attributes added via -addClientAttribute:value:forNode:.
  */
 - (void)forEachClientNodeAttribute:(void(^)(NSString *attribute, NSString *value, _WKJSHandle *))block;

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -114,7 +114,7 @@ extension WKWebView {
             configuration.includeNodeIdentifiers = false
             configuration.includeEventListeners = false
             configuration.includeAccessibilityAttributes = false
-            configuration.shouldFilterText = false
+            configuration.filterOptions = []
             if let result = await _requestTextExtraction(configuration) {
                 collector.collect(createIntelligenceElement(item: result.rootItem))
             }


### PR DESCRIPTION
#### fb1eae0edd1479f4642007ffaa4005d476dfe234
<pre>
Refactor text extraction filtering logic to be more extensible
<a href="https://bugs.webkit.org/show_bug.cgi?id=302301">https://bugs.webkit.org/show_bug.cgi?id=302301</a>
<a href="https://rdar.apple.com/164442518">rdar://164442518</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Currently, the `TextExtractionOptions` passed into `convertToText` (i.e. converting extraction items
into text) only allow for a single text filtering callback which returns a `NativePromise` (which
is resolved once all relevant text filtering steps have been performed). However, this makes it
somewhat tricky to implement more sophisticated logic around conditionally enabling filtering steps
at both build-time and runtime:

1.  The `TextExtractionFilter` classifier is behind a compile-time flag, as well as a runtime flag.
    It&apos;s now also configurable by the WebKit client, via the new option flag.
2.  The text recognition filter is behind the same compile-time and runtime flags. It&apos;s also
    configurable by the client, independently of (1).
3.  The maximum word limit is configurable by the WebKit client.

To make this filtering callback mechanism more extensible, we convert the callback into a vector of
callbacks that represent a filtering pipeline, where any of the above steps (1-3) can be added as
needed (and any future steps can just be appended to the list as needed).

See below for more details.

Test: TextExtractionTests.FilterOptions

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::filter const):
(WebKit::TextExtractionAggregator::filterRecursive const):

Turn the `filterCallback` into a `Vector` of `filterCallbacks`; the callbacks are invoked in order,
and each callback&apos;s output is fed into the next callback as input (unless the promise rejects, in
which case we stop early).

* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _debugTextWithConfiguration:completionHandler:]):
(joinAndTruncateLinesToWordLimit): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:

Add a new enum options property, which allows clients to opt in or out of the classifier and/or OCR
filter during extraction.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration _initForOnlyVisibleText:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, FilterOptions)):

Canonical link: <a href="https://commits.webkit.org/302850@main">https://commits.webkit.org/302850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83b1807bd43e23764e5920322158c49a9e9346e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ccb11e77-c45e-4ec7-9096-8ca144aef8ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99388 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba8b21e1-a099-4608-9464-02e548ba1276) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80086 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/10d095cc-2649-429f-b597-abbd4d4079e5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81127 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140347 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107903 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27438 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31596 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55476 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2507 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->