### PR TITLE
Address more Safer CPP warnings in WTF/

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -58,7 +58,6 @@ ftl/FTLOSRExitHandle.cpp
 ftl/FTLOperations.cpp
 ftl/FTLPatchpointExceptionHandle.cpp
 heap/ConservativeRoots.cpp
-heap/HeapHelperPool.cpp
 heap/JITStubRoutineSet.cpp
 inspector/AsyncStackTrace.cpp
 inspector/JSJavaScriptCallFrame.cpp

--- a/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,2 +1,1 @@
 wtf/ThreadSpecific.h
-wtf/text/SymbolRegistry.cpp

--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,7 +1,5 @@
 wtf/HashTable.h
 wtf/JSONValues.h
-wtf/ParallelHelperPool.cpp
 wtf/RecursiveLockAdapter.h
 wtf/RedBlackTree.h
 wtf/Vector.h
-wtf/WorkerPool.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,4 +1,1 @@
 wtf/JSONValues.cpp
-wtf/ParallelHelperPool.cpp
-wtf/WorkerPool.cpp
-wtf/text/cf/StringCF.cpp

--- a/Source/WTF/wtf/WorkerPool.h
+++ b/Source/WTF/wtf/WorkerPool.h
@@ -26,15 +26,19 @@
 #pragma once
 
 #include <wtf/AutomaticThread.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
 
-class WorkerPool : public ThreadSafeRefCounted<WorkerPool> {
+class WorkerPool final : public ThreadSafeRefCounted<WorkerPool>, public CanMakeThreadSafeCheckedPtr<WorkerPool> {
+    WTF_MAKE_TZONE_ALLOCATED(WorkerPool);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerPool);
 public:
     WTF_EXPORT_PRIVATE void postTask(Function<void()>&&);
 

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -218,6 +218,10 @@ ValueCheck<const SymbolImpl*> {
 
 } // namespace WTF
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WTF::SymbolImpl)
+    static bool isType(const WTF::StringImpl& impl) { return impl.isSymbol(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
 using WTF::SymbolImpl;
 using WTF::PrivateSymbolImpl;
 using WTF::RegisteredSymbolImpl;

--- a/Source/WTF/wtf/text/SymbolRegistry.cpp
+++ b/Source/WTF/wtf/text/SymbolRegistry.cpp
@@ -38,19 +38,15 @@ SymbolRegistry::SymbolRegistry(Type type)
 
 SymbolRegistry::~SymbolRegistry()
 {
-    for (auto& key : m_table) {
-        ASSERT(key->isSymbol());
-        static_cast<SymbolImpl*>(key.get())->asRegisteredSymbolImpl()->clearSymbolRegistry();
-    }
+    for (auto& key : m_table)
+        downcast<SymbolImpl>(key.get())->asRegisteredSymbolImpl()->clearSymbolRegistry();
 }
 
 Ref<RegisteredSymbolImpl> SymbolRegistry::symbolForKey(const String& rep)
 {
     auto addResult = m_table.add(rep.impl());
-    if (!addResult.isNewEntry) {
-        ASSERT(addResult.iterator->get()->isSymbol());
-        return *static_cast<SymbolImpl*>(addResult.iterator->get())->asRegisteredSymbolImpl();
-    }
+    if (!addResult.isNewEntry)
+        return *downcast<SymbolImpl>(addResult.iterator->get())->asRegisteredSymbolImpl();
 
     RefPtr<RegisteredSymbolImpl> symbol;
     if (m_symbolType == Type::PrivateSymbol)

--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -57,10 +57,9 @@ String::String(CFStringRef str)
 
 RetainPtr<CFStringRef> String::createCFString() const
 {
-    if (!m_impl)
-        return CFSTR("");
-
-    return m_impl->createCFString();
+    if (RefPtr impl = m_impl)
+        return impl->createCFString();
+    return CFSTR("");
 }
 
 RetainPtr<CFStringRef> makeCFArrayElement(const String& vectorElement)


### PR DESCRIPTION
#### 8caaae923aa6461b5b66715f7281fd7e1babc7e1
<pre>
Address more Safer CPP warnings in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=302303">https://bugs.webkit.org/show_bug.cgi?id=302303</a>

Reviewed by Darin Adler.

This tested as performance neutral on the benchmarks we track.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/JavaScriptCore/heap/HeapHelperPool.cpp:
(JSC::heapHelperPool):
* Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WTF/wtf/ParallelHelperPool.cpp:
(WTF::ParallelHelperPool::create):
* Source/WTF/wtf/ParallelHelperPool.h:
(WTF::ParallelHelperPool::numberOfThreads const): Deleted.
* Source/WTF/wtf/WorkerPool.cpp:
* Source/WTF/wtf/WorkerPool.h:
(WTF::WorkerPool::create): Deleted.
(WTF::WorkerPool::name const): Deleted.
* Source/WTF/wtf/text/SymbolImpl.h:
(isType):
* Source/WTF/wtf/text/SymbolRegistry.cpp:
(WTF::SymbolRegistry::~SymbolRegistry):
(WTF::SymbolRegistry::symbolForKey):
* Source/WTF/wtf/text/cf/StringCF.cpp:
(WTF::String::createCFString const):

Canonical link: <a href="https://commits.webkit.org/302894@main">https://commits.webkit.org/302894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e53bc4d06bb156e6e580a310555ff3cbc929d37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138008 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3ffb3957-e139-475d-8f45-31cdb8070a71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2753 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eac6ba83-2cca-4bd7-9bec-3b4e657f1b1d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133537 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80197 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff6a1682-f08d-4c52-8982-5322305982c7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35068 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81267 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122593 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140488 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129043 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2407 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2043 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31710 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66110 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162058 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40411 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->