### PR TITLE
Fix the ENABLE_MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING build after 302823@main

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -119,8 +119,6 @@ private:
     void didReceiveScrollEvent(const WebWheelEvent&);
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
-    void pushLogEntry(uint32_t generatedPhase, uint32_t eventPhase);
-
     WebCore::FloatSize m_lastActivePhaseDelta;
 
     struct LogEntry {
@@ -129,11 +127,17 @@ private:
         float totalGeneratedOffset { 0 };
         float totalEventOffset { 0 };
 
-        uint32_t generatedPhase { 0 };
-        uint32_t eventPhase { 0 };
+        struct Phases {
+            WebWheelEvent::Phase event { WebWheelEvent::Phase::None };
+            WebWheelEvent::Phase momentum { WebWheelEvent::Phase::None };
+        };
+        Phases generatedPhases;
+        Phases eventPhases;
     };
     LogEntry m_currentLogState;
     Vector<LogEntry> m_log;
+
+    void pushLogEntry(LogEntry::Phases /*generatedPhases*/, LogEntry::Phases /*eventPhases*/);
 #endif
 
     struct Delta {


### PR DESCRIPTION
#### 0df3d2738b500259a6cc5b9d645a955aa9923f5e
<pre>
Fix the ENABLE_MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING build after 302823@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=302305">https://bugs.webkit.org/show_bug.cgi?id=302305</a>
<a href="https://rdar.apple.com/164445802">rdar://164445802</a>

Reviewed by Tim Horton.

Critically, WebWheelEvent::Phase is now a scoped enum.

Previously, for ease of logging, the wheel event phase and the momentum
phase were packed into a single integral value. We could still do this,
but I find reading the values separately easier, so we plumb both phase
values throughout the MomentumEventDispatcher logging code, finally
logging them next to each other.

No change in functionality, so no new tests.

* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::handleWheelEvent):
(WebKit::MomentumEventDispatcher::dispatchSyntheticMomentumEvent):
(WebKit::MomentumEventDispatcher::equalizeTailGaps):
(WebKit::MomentumEventDispatcher::pushLogEntry):
(WebKit::MomentumEventDispatcher::flushLog):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/302829@main">https://commits.webkit.org/302829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d68ea3cbf2035bbc40790d427f489f298ee14f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137784 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/975f7b27-b2b0-4a81-8179-ed5b0ca74667) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cf6bdd90-b38a-46ba-890b-d4b99947e3ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133313 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80020 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8b1ac398-2957-453c-9e78-25a591034e3f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81043 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140261 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2427 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2235 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107838 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107739 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1898 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31533 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55384 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65885 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->