### PR TITLE
Address Safer CPP warnings in TextBreakIterator.cpp

### DIFF
--- a/Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,10 +1,7 @@
 usr/local/include/wtf/text/SymbolImpl.h
-usr/local/include/wtf/text/TextBreakIterator.h
-usr/local/include/wtf/text/icu/TextBreakIteratorICU.h
 usr/local/include/wtf/unicode/Collator.h
 wtf/ParkingLot.h
 wtf/PrintStream.h
 wtf/RetainPtr.h
 wtf/URLParser.cpp
 wtf/text/StringView.cpp
-wtf/text/TextBreakIterator.cpp

--- a/Source/WTF/icu/unicode/ustring.h
+++ b/Source/WTF/icu/unicode/ustring.h
@@ -18,6 +18,8 @@
 #ifndef USTRING_H
 #define USTRING_H
 
+DECLARE_SYSTEM_HEADER
+
 #include "unicode/utypes.h"
 #include "unicode/putil.h"
 #include "unicode/uiter.h"

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -26,7 +26,6 @@ Modules/mediastream/RTCPeerConnection.h
 Modules/notifications/NotificationController.h
 Modules/webdatabase/DatabaseManager.h
 Modules/webdatabase/DatabaseThread.h
-[ Mac ] accessibility/AXTextMarker.cpp
 accessibility/AccessibilityObject.cpp
 bindings/js/GarbageCollectionController.cpp
 bindings/js/JSLocationCustom.cpp
@@ -42,14 +41,11 @@ css/StyleSheetContents.h
 css/values/primitives/CSSPrimitiveData.h
 dom/CustomElementReactionQueue.h
 dom/Element.h
-dom/FragmentDirectiveRangeFinder.cpp
 dom/Node.h
 editing/Editor.h
 editing/TextIterator.cpp
-editing/VisibleUnits.cpp
 html/HTMLMediaElement.cpp
 html/canvas/PlaceholderRenderingContext.cpp
-html/parser/HTMLConstructionSite.cpp
 html/shadow/DateTimeEditElement.h
 html/track/TrackBase.h
 inspector/InspectorController.h
@@ -63,7 +59,6 @@ inspector/agents/InspectorPageAgent.h
 layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/formattingContexts/inline/InlineLine.h
-layout/formattingContexts/inline/text/TextUtil.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.h
 layout/layouttree/LayoutElementBox.h
 page/DOMWindow.cpp
@@ -82,18 +77,15 @@ platform/Scrollbar.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 platform/graphics/ImageBufferContextSwitcher.h
-platform/graphics/StringTruncator.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
 [ iOS ] platform/ios/DeviceMotionClientIOS.h
 [ iOS ] platform/ios/LegacyTileCache.h
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
 [ iOS ] platform/text/TextBoundaries.cpp
-rendering/BreakablePositions.h
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderTableCellInlines.h
-rendering/RenderText.cpp
 rendering/RenderTextLineBoxes.h
 rendering/TableLayout.h
 rendering/style/StyleCachedImage.cpp


### PR DESCRIPTION
#### 7f23bc05e28fb8a932f995b9be550ceeee2f6245
<pre>
Address Safer CPP warnings in TextBreakIterator.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=302309">https://bugs.webkit.org/show_bug.cgi?id=302309</a>

Reviewed by Darin Adler.

Address safer cpp warnings about `UBreakIterator` being forward-declared.

* Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WTF/icu/unicode/ustring.h:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/302872@main">https://commits.webkit.org/302872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acb21944a6da3f9a09bee8130f7f7874bb0dde6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93f63b77-83e8-4b7f-844c-afe873f98670) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99372 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cef509a3-6e23-48b2-a8ff-d15ac961dfa7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80070 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/67a6e656-3292-4e08-914f-31ae14d9f0db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34927 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81109 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122435 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140328 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128885 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107888 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107790 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31582 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55452 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65951 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161900 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2381 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40371 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->