### PR TITLE
[JSC][Wasm][Debugger] Rename debugger variables for clarity: tmp -> oneTime, instance -> module

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
@@ -50,7 +50,7 @@ void BreakpointManager::setBreakpoint(VirtualAddress address, Breakpoint&& break
     breakpoint.patchBreakpoint();
     dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] setBreakpoint ", breakpoint, " at moduleAddress:", address);
     if (breakpoint.isOneTimeBreakpoint())
-        m_tmpBreakpoints.add(address);
+        m_oneTimeBreakpoints.add(address);
     m_breakpoints.set(address, WTFMove(breakpoint));
 }
 
@@ -72,12 +72,12 @@ bool BreakpointManager::removeBreakpoint(VirtualAddress address)
     return true;
 }
 
-void BreakpointManager::clearAllTmpBreakpoints()
+void BreakpointManager::clearAllOneTimeBreakpoints()
 {
-    for (VirtualAddress address : m_tmpBreakpoints)
+    for (VirtualAddress address : m_oneTimeBreakpoints)
         removeBreakpoint(address);
-    m_tmpBreakpoints.clear();
-    dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Cleared all tmp breakpoints");
+    m_oneTimeBreakpoints.clear();
+    dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Cleared all one-time breakpoints");
 }
 
 void BreakpointManager::clearAllBreakpoints()
@@ -85,7 +85,7 @@ void BreakpointManager::clearAllBreakpoints()
     for (auto& [_, breakpoint] : m_breakpoints)
         breakpoint.restorePatch();
     m_breakpoints.clear();
-    RELEASE_ASSERT(m_tmpBreakpoints.isEmpty());
+    RELEASE_ASSERT(m_oneTimeBreakpoints.isEmpty());
 }
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h
@@ -58,12 +58,12 @@ public:
     JS_EXPORT_PRIVATE Breakpoint* findBreakpoint(VirtualAddress);
     JS_EXPORT_PRIVATE void setBreakpoint(VirtualAddress, Breakpoint&&);
     JS_EXPORT_PRIVATE bool removeBreakpoint(VirtualAddress);
-    JS_EXPORT_PRIVATE void clearAllTmpBreakpoints();
+    JS_EXPORT_PRIVATE void clearAllOneTimeBreakpoints();
     JS_EXPORT_PRIVATE void clearAllBreakpoints();
 
 private:
     UncheckedKeyHashMap<VirtualAddress, Breakpoint> m_breakpoints;
-    UncheckedKeyHashSet<VirtualAddress> m_tmpBreakpoints;
+    UncheckedKeyHashSet<VirtualAddress> m_oneTimeBreakpoints;
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -185,7 +185,7 @@ private:
     std::unique_ptr<MemoryHandler> m_memoryHandler;
     std::unique_ptr<ExecutionHandler> m_executionHandler;
 
-    std::unique_ptr<ModuleManager> m_instanceManager;
+    std::unique_ptr<ModuleManager> m_moduleManager;
     std::unique_ptr<BreakpointManager> m_breakpointManager;
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -183,7 +183,7 @@ private:
     void handleClientDisconnectionLocked() WTF_REQUIRES_LOCK(m_lock);
 
     DebugServer& m_debugServer;
-    ModuleManager& m_instanceManager;
+    ModuleManager& m_moduleManager;
     BreakpointManager& m_breakpointManager;
 
     Lock m_lock;

--- a/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
@@ -97,7 +97,7 @@ bool MemoryHandler::readModuleData(VirtualAddress address, size_t length, String
     uint32_t id = address.id();
     uint32_t offset = address.offset();
 
-    RefPtr module = m_debugServer.m_instanceManager->module(id);
+    RefPtr module = m_debugServer.m_moduleManager->module(id);
     if (!module)
         return false;
 
@@ -124,7 +124,7 @@ bool MemoryHandler::readMemoryData(VirtualAddress address, size_t length, String
     uint32_t instanceId = address.id();
     uint32_t offset = address.offset();
 
-    JSWebAssemblyInstance* jsInstance = m_debugServer.m_instanceManager->jsInstance(instanceId);
+    JSWebAssemblyInstance* jsInstance = m_debugServer.m_moduleManager->jsInstance(instanceId);
     if (!jsInstance) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] - instance not found for ID: ", instanceId);
         return false;
@@ -186,7 +186,7 @@ void MemoryHandler::handleMemoryRegionInfo(StringView packet)
 
 void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t instanceId, uint32_t offset)
 {
-    JSWebAssemblyInstance* instance = m_debugServer.m_instanceManager->jsInstance(instanceId);
+    JSWebAssemblyInstance* instance = m_debugServer.m_moduleManager->jsInstance(instanceId);
     if (instance) {
         size_t memorySize = instance->memory()->memory().size();
         if (offset < memorySize) {
@@ -198,7 +198,7 @@ void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t 
         }
     }
 
-    uint32_t idUpperBoundary = m_debugServer.m_instanceManager->nextInstanceId();
+    uint32_t idUpperBoundary = m_debugServer.m_moduleManager->nextInstanceId();
     uint32_t nextValidID = instanceId;
     do {
         if (++nextValidID >= idUpperBoundary) {
@@ -207,7 +207,7 @@ void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t 
             sendUnmappedRegionReply(address, unmappedSize);
             return;
         }
-    } while (!m_debugServer.m_instanceManager->jsInstance(nextValidID));
+    } while (!m_debugServer.m_moduleManager->jsInstance(nextValidID));
 
     // Address is beyond this module - return unmapped region to next module
     VirtualAddress nextMemoryAddress = VirtualAddress::createMemory(nextValidID);
@@ -217,7 +217,7 @@ void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t 
 
 void MemoryHandler::handleWasmModuleRegionInfo(VirtualAddress address, uint32_t moduleId, uint32_t offset)
 {
-    JSWebAssemblyInstance* instance = m_debugServer.m_instanceManager->jsInstance(moduleId);
+    JSWebAssemblyInstance* instance = m_debugServer.m_moduleManager->jsInstance(moduleId);
     if (instance) {
         JSWebAssemblyModule* jsModule = instance->jsModule();
         const auto& source = jsModule->moduleInformation().debugInfo->source;
@@ -229,7 +229,7 @@ void MemoryHandler::handleWasmModuleRegionInfo(VirtualAddress address, uint32_t 
         }
     }
 
-    uint32_t idUpperBoundary = m_debugServer.m_instanceManager->nextInstanceId();
+    uint32_t idUpperBoundary = m_debugServer.m_moduleManager->nextInstanceId();
     uint32_t nextValidID = moduleId;
     do {
         if (++nextValidID >= idUpperBoundary) {
@@ -238,7 +238,7 @@ void MemoryHandler::handleWasmModuleRegionInfo(VirtualAddress address, uint32_t 
             sendUnmappedRegionReply(address, unmappedSize);
             return;
         }
-    } while (!m_debugServer.m_instanceManager->jsInstance(nextValidID));
+    } while (!m_debugServer.m_moduleManager->jsInstance(nextValidID));
 
     // Address is beyond this module - return unmapped region to next module
     VirtualAddress nextModuleAddress = VirtualAddress::createModule(nextValidID);

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -183,7 +183,7 @@ bool QueryHandler::parseLibrariesReadPacket(StringView packet, size_t& offset, s
 
 bool QueryHandler::handleChunkedLibrariesResponse(size_t offset, size_t maxSize, String& response)
 {
-    String xmlData = m_debugServer.m_instanceManager->generateLibrariesXML();
+    String xmlData = m_debugServer.m_moduleManager->generateLibrariesXML();
 
     // Handle chunked response according to GDB Remote Protocol
     // 'm' prefix = more data follows


### PR DESCRIPTION
#### f33b9fcbc7d0829e8bfb9ed3cc71840acc5397ca
<pre>
[JSC][Wasm][Debugger] Rename debugger variables for clarity: tmp -&gt; oneTime, instance -&gt; module
<a href="https://rdar.apple.com/164454352">rdar://164454352</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302310">https://bugs.webkit.org/show_bug.cgi?id=302310</a>

Reviewed by Yusuke Suzuki.

Refactor WASM debugger code to improve naming clarity:
- Rename m_tmpBreakpoints to m_oneTimeBreakpoints and clearAllTmpBreakpoints()
to clearAllOneTimeBreakpoints() in BreakpointManager to better describe their
purpose as temporary, single-use breakpoints used for stepping operations
- Rename m_instanceManager to m_moduleManager in DebugServer and dependent
classes to more accurately reflect that this manager handles both modules
and instances, not just instances

No functional changes, just improved code readability.

Canonical link: <a href="https://commits.webkit.org/302831@main">https://commits.webkit.org/302831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8538252284423ad2c6a39bf06bf8c4501db7f53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137818 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4820a78b-9017-4fb7-9aea-e4566d763c60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94067282-63d3-4608-9cee-752644f3434e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133347 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80045 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/782e0863-1d77-4be6-b8cf-1c2c2ebd2139) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/34902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122403 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/35407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140295 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128853 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2461 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/113114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/107762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20318 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2531 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/65919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161867 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40363 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->