### PR TITLE
REGRESSION(302392@main, amazon): PLT6 ~10%

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -288,8 +288,6 @@ bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector&);
 enum class ComplexSelectorsEqualMode : bool { Full, IgnoreNonElementBackedPseudoElements };
 bool complexSelectorsEqual(const CSSSelector&, const CSSSelector&, ComplexSelectorsEqualMode = ComplexSelectorsEqualMode::Full);
 
-void addComplexSelector(Hasher&, const CSSSelector&, ComplexSelectorsEqualMode = ComplexSelectorsEqualMode::Full);
-
 inline bool operator==(const PossiblyQuotedIdentifier& a, const AtomString& b) { return a.identifier == b; }
 
 inline const QualifiedName& CSSSelector::attribute() const

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -268,11 +268,4 @@ bool CSSSelectorList::operator==(const CSSSelectorList& other) const
     return true;
 }
 
-void add(Hasher& hasher, const CSSSelectorList& list)
-{
-    for (auto& selector : list)
-        addComplexSelector(hasher, selector);
-}
-
-
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -122,6 +122,4 @@ private:
     UniqueArray<CSSSelector> m_selectorArray;
 };
 
-void add(Hasher&, const CSSSelectorList&);
-
 } // namespace WebCore

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -24,7 +24,6 @@
 #include "CSSSelectorList.h"
 #include "CommonAtomStrings.h"
 #include <wtf/Forward.h>
-#include <wtf/GenericHashKey.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/text/AtomString.h>
@@ -106,30 +105,11 @@ using PseudoClassInvalidationKey = std::tuple<unsigned, uint8_t, AtomString>;
 
 using RuleFeatureVector = Vector<RuleFeature>;
 
-template<typename RuleFeatureType>
-struct RuleFeatureDeduplicationKey {
-    const Vector<RuleFeatureType>* vector;
-    RuleFeatureType feature;
-
-    unsigned hash() const;
-    bool operator==(const RuleFeatureDeduplicationKey&) const;
-};
-
-template<typename FeatureType>
-using RuleFeatureDeduplicationSetForFeatureType = HashSet<GenericHashKey<RuleFeatureDeduplicationKey<FeatureType>>>;
-using RuleFeatureDeduplicationSet = RuleFeatureDeduplicationSetForFeatureType<RuleFeature>;
-using RuleFeatureWithInvalidationSelectorDeduplicationSet = RuleFeatureDeduplicationSetForFeatureType<RuleFeatureWithInvalidationSelector>;
-
 struct RuleFeatureSet {
     void add(const RuleFeatureSet&);
     void clear();
     void shrinkToFit();
-
-    struct CollectionContext {
-        RuleFeatureDeduplicationSet deduplicationSet;
-        RuleFeatureWithInvalidationSelectorDeduplicationSet withInvalidationSelectorDeduplicationSet;
-    };
-    void collectFeatures(CollectionContext&, const RuleData&, const Vector<Ref<const StyleRuleScope>>& scopeRules = { });
+    void collectFeatures(const RuleData&, const Vector<Ref<const StyleRuleScope>>& scopeRules = { });
     void registerContentAttribute(const AtomString&);
 
     bool usesHasPseudoClass() const;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -136,11 +136,10 @@ static bool shouldHaveBucketForAttributeName(const CSSSelector& attributeSelecto
 void RuleSet::addRule(const StyleRule& rule, unsigned selectorIndex, unsigned selectorListIndex)
 {
     RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, { });
-    // This path is used when building invalidation RuleSets, no need to collect features (nullptr CollectionContext).
-    addRule(WTFMove(ruleData), 0, 0, 0, nullptr);
+    addRule(WTFMove(ruleData), 0, 0, 0);
 }
 
-void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerIdentifier, ContainerQueryIdentifier containerQueryIdentifier, ScopeRuleIdentifier scopeRuleIdentifier, RuleFeatureSet::CollectionContext* featureCollectionContext)
+void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerIdentifier, ContainerQueryIdentifier containerQueryIdentifier, ScopeRuleIdentifier scopeRuleIdentifier)
 {
     ASSERT(ruleData.position() == m_ruleCount);
 
@@ -171,8 +170,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     };
     ruleData.setLinkMatchType(computeLinkMatchType());
 
-    if (featureCollectionContext)
-        m_features.collectFeatures(*featureCollectionContext, ruleData, scopeRules);
+    m_features.collectFeatures(ruleData, scopeRules);
 
     unsigned classBucketSize = 0;
     const CSSSelector* idSelector = nullptr;

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -146,7 +146,7 @@ private:
     using ContainerQueryIdentifier = unsigned;
     using ScopeRuleIdentifier = unsigned;
 
-    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier, RuleFeatureSet::CollectionContext*);
+    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier);
 
     struct ResolverMutatingRule {
         Ref<StyleRuleBase> rule;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -304,7 +304,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
         RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_usedRuleTypes);
         m_mediaQueryCollector.addRuleIfNeeded(ruleData);
-        m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier, &m_featureCollectionContext);
+        m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier);
         ++selectorListIndex;
     }
 }

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -96,8 +96,6 @@ private:
 
     Vector<RuleSet::ResolverMutatingRule> m_collectedResolverMutatingRules;
     bool requiresStaticMediaQueryEvaluation { false };
-
-    RuleFeatureSet::CollectionContext m_featureCollectionContext;
 };
 
 }


### PR DESCRIPTION
#### 1dd42f3eab3131e48343c425a3a81644cc639f64
<pre>
REGRESSION(302392@main, amazon): PLT6 ~10%
<a href="https://bugs.webkit.org/show_bug.cgi?id=302317">https://bugs.webkit.org/show_bug.cgi?id=302317</a>
<a href="https://rdar.apple.com/164252021">rdar://164252021</a>

Unreviewed revert.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::complexSelectorsEqual):
(WebCore::shouldSkipForEqualMode): Deleted.
(WebCore::addSimpleSelector): Deleted.
(WebCore::addComplexSelector): Deleted.
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::add): Deleted.
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::addIgnoringPseudoElement): Deleted.
(WebCore::Style::RuleFeatureDeduplicationKey&lt;RuleFeatureType&gt;::hash const): Deleted.
(WebCore::Style::= const): Deleted.
* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/302835@main">https://commits.webkit.org/302835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8cf3d66898f80504001e2abfd84f6e35dcd6319

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137840 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/24bb69bb-c158-4b78-8705-3f7edf0f9c3d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0e448d52-b6bf-4ff4-84dd-83840d0636b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133369 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80062 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68f6a0e5-f3ab-4416-a884-2332f0860c40) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81099 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140317 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2483 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107781 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27423 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31570 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2553 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/65941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->