### PR TITLE
[blocks-in-inline] Include blocks in getBoundingClientRect for inline box

### DIFF
--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -89,6 +89,7 @@ public:
     std::optional<size_t> firstBoxIndexForLayoutBox(const Layout::Box&) const;
 
     template<typename Function> void traverseNonRootInlineBoxes(const Layout::Box&, Function&&);
+    template<typename Function> void traverseDescendantBlockLevelBoxes(const Layout::Box&, Function&&);
 
     const RenderBlockFlow& formattingContextRoot() const;
 
@@ -136,6 +137,21 @@ template<typename Function> void InlineContent::traverseNonRootInlineBoxes(const
 {
     for (auto index : nonRootInlineBoxIndexesForLayoutBox(layoutBox))
         function(displayContent().boxes[index]);
+}
+
+template<typename Function> void InlineContent::traverseDescendantBlockLevelBoxes(const Layout::Box& ancestor, Function&& function)
+{
+    if (!m_hasBlockLevelBoxes)
+        return;
+
+    for (auto& box : m_displayContent.boxes) {
+        if (!box.isBlockLevelBox())
+            continue;
+        CheckedRef layoutBox = box.layoutBox();
+        if (!layoutBox->isDescendantOfWithinFormattingContext(ancestor))
+            continue;
+        function(box);
+    }
 }
 
 }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1079,7 +1079,9 @@ LayoutRect LineLayout::inkOverflowBoundingBoxRectFor(const RenderInline& renderI
     m_inlineContent->traverseNonRootInlineBoxes(layoutBox, [&](auto& inlineBox) {
         result.unite(Layout::toLayoutRect(inlineBox.inkOverflow()));
     });
-
+    m_inlineContent->traverseDescendantBlockLevelBoxes(layoutBox, [&](auto& inlineBox) {
+        result.unite(Layout::toLayoutRect(inlineBox.inkOverflow()));
+    });
     return result;
 }
 
@@ -1094,7 +1096,11 @@ Vector<FloatRect> LineLayout::collectInlineBoxRects(const RenderInline& renderIn
     m_inlineContent->traverseNonRootInlineBoxes(layoutBox, [&](auto& inlineBox) {
         result.append(inlineBox.visualRectIgnoringBlockDirection());
     });
-
+    m_inlineContent->traverseDescendantBlockLevelBoxes(layoutBox, [&](auto& inlineBox) {
+        auto rect = inlineBox.visualRectIgnoringBlockDirection();
+        if (!rect.isEmpty())
+            result.append(rect);
+    });
     return result;
 }
 

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -405,12 +405,20 @@ const Box* Box::previousOutOfFlowSibling() const
     return previousSibling;
 }
 
-bool Box::isDescendantOf(const ElementBox& ancestor) const
+bool Box::isDescendantOf(const Box& box) const
 {
-    if (ancestor.isInitialContainingBlock())
-        return true;
-    for (auto& containingBlock : containingBlockChain(*this)) {
-        if (&containingBlock == &ancestor)
+
+    for (auto* ancestor = &parent(); !ancestor->isInitialContainingBlock(); ancestor = &ancestor->parent()) {
+        if (ancestor == &box)
+            return true;
+    }
+    return false;
+}
+
+bool Box::isDescendantOfWithinFormattingContext(const Box& box) const
+{
+    for (auto* ancestor = &parent(); !ancestor->establishesFormattingContext(); ancestor = &ancestor->parent()) {
+        if (ancestor == &box)
             return true;
     }
     return false;

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -166,7 +166,8 @@ public:
     const Box* previousInFlowSibling() const;
     const Box* previousInFlowOrFloatingSibling() const;
     const Box* previousOutOfFlowSibling() const;
-    bool isDescendantOf(const ElementBox&) const;
+    bool isDescendantOf(const Box&) const;
+    bool isDescendantOfWithinFormattingContext(const Box&) const;
     bool isInFormattingContextEstablishedBy(const ElementBox& formattingContextRoot) const;
 
     // FIXME: This is currently needed for style updates.


### PR DESCRIPTION
#### 543b61df8c722a93b3510b5d4bd4c8566e0addf5
<pre>
[blocks-in-inline] Include blocks in getBoundingClientRect for inline box
<a href="https://bugs.webkit.org/show_bug.cgi?id=302323">https://bugs.webkit.org/show_bug.cgi?id=302323</a>
<a href="https://rdar.apple.com/164470525">rdar://164470525</a>

Reviewed by Alan Baradlay.

This is the expected behavior tested by for example css/CSS2/normal-flow/block-in-inline-client-rects-001.html

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
(WebCore::LayoutIntegration::InlineContent::traverseDescendantBlockLevelBoxes):

Add a helper.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::inkOverflowBoundingBoxRectFor const):
(WebCore::LayoutIntegration::LineLayout::collectInlineBoxRects const):

Include the contained blocks along with the inline boxes.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::isDescendantOf const):

Fix this to do what it says. The only client doesn&apos;t mind.

(WebCore::Layout::Box::isDescendantOfWithinFormattingContext const):

Add a version that bails out faster.

* Source/WebCore/layout/layouttree/LayoutBox.h:

Canonical link: <a href="https://commits.webkit.org/302904@main">https://commits.webkit.org/302904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c6614c3ce01484abce4164c02f7d14c22c957ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138036 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41683da3-6175-41da-bdbb-58c81daa1357) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99509 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6a224f4c-380f-4256-95d3-a3ad56432042) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133563 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80216 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/200538c4-6213-4c32-9cfa-a42f1e323f79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35091 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81293 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140515 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108013 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27465 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31728 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55661 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2747 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66136 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2566 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2673 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->