### PR TITLE
Implement EnhancedSecurity HTTP and heuristics tracking.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2726,6 +2726,21 @@ EncryptedMediaAPIEnabled:
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
+EnhancedSecurityHeuristicsEnabled:
+  type: bool
+  status: testable
+  category: security
+  defaultsOverridable: true
+  humanReadableName: "Enable EnhancedSecurity Heuristics"
+  humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 EnterKeyHintEnabled:
   type: bool
   status: internal

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1163,6 +1163,26 @@ void NetworkProcess::clearUserInteraction(PAL::SessionID sessionID, RegistrableD
     }
 }
 
+void NetworkProcess::hasLocalStorageOrCookies(PAL::SessionID sessionID, const RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler)
+{
+    CheckedPtr session = networkSession(sessionID);
+    CheckedPtr networkStorageSession = storageSession(sessionID);
+
+    if (!session || !networkStorageSession)
+        return completionHandler(false);
+
+    networkStorageSession->hasCookies(domain, [session, domain, completionHandler = WTFMove(completionHandler)](bool hasCookies) mutable {
+        if (hasCookies)
+            return completionHandler(true);
+
+        session->storageManager().fetchData({ WebsiteDataType::LocalStorage }, NetworkStorageManager::ShouldComputeSize::No, [domain, completionHandler = WTFMove(completionHandler)](auto entries) mutable {
+            completionHandler(std::ranges::any_of(entries, [&domain](auto& entry) {
+                return domain.matches(entry.origin);
+            }));
+        });
+    });
+}
+
 void NetworkProcess::hasLocalStorage(PAL::SessionID sessionID, const RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
     CheckedPtr session = networkSession(sessionID);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -267,6 +267,7 @@ public:
     void setPruneEntriesDownTo(PAL::SessionID, uint64_t pruneTargetCount, CompletionHandler<void()>&&);
     void hadUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void(bool)>&&);
     void isRelationshipOnlyInDatabaseOnce(PAL::SessionID, RegistrableDomain&& subDomain, RegistrableDomain&& topDomain, CompletionHandler<void(bool)>&&);
+    void hasLocalStorageOrCookies(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void hasLocalStorage(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void getAllStorageAccessEntries(PAL::SessionID, CompletionHandler<void(Vector<String> domains)>&&);
     void logFrameNavigation(PAL::SessionID, NavigatedToDomain&&, TopFrameDomain&&, NavigatedFromDomain&&, bool isRedirect, bool isMainFrame, Seconds delayAfterMainFrameDocumentLoad, bool wasPotentiallyInitiatedByUser);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -113,6 +113,8 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     HadUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> (bool hadUserInteraction)
     IsRelationshipOnlyInDatabaseOnce(PAL::SessionID sessionID, WebCore::RegistrableDomain subDomain, WebCore::RegistrableDomain topDomain) -> (bool hadUserInteraction)
     HasLocalStorage(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> (bool hadUserInteraction)
+    HasLocalStorageOrCookies(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> (bool hadUserInteraction)
+
     GetAllStorageAccessEntries(PAL::SessionID sessionID) -> (Vector<String> domains)
     IsRegisteredAsRedirectingTo(PAL::SessionID sessionID, WebCore::RegistrableDomain redirectedFromDomain, WebCore::RegistrableDomain redirectedToDomain) -> (bool isRedirectingTo)
     IsRegisteredAsSubFrameUnder(PAL::SessionID sessionID, WebCore::RegistrableDomain subFrameDomain, WebCore::RegistrableDomain topFrameDomain) -> (bool isSubframeUnder)

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -101,6 +101,7 @@ extern "C" {
     M(DiskPersistency) \
     M(DragAndDrop) \
     M(EME) \
+    M(EnhancedSecurity) \
     M(Extensions) \
     M(FrameTree) \
     M(Fullscreen) \

--- a/Source/WebKit/Shared/EnhancedSecurity.h
+++ b/Source/WebKit/Shared/EnhancedSecurity.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/RegistrableDomain.h>
+
+namespace WebKit {
+
+enum class EnhancedSecurity : uint8_t { Disabled, EnabledInsecure, EnabledPolicy };
+enum class EnhancedSecurityReason : uint8_t { None, InsecureProvisional, InsecureLoad, Policy };
+
+using EnhancedSecuritySites = HashMap<WebCore::RegistrableDomain, EnhancedSecurityReason>;
+
+ALWAYS_INLINE bool enhancedSecurityEnabledForState(EnhancedSecurity state)
+{
+    return state != EnhancedSecurity::Disabled;
+}
+
+ALWAYS_INLINE bool enhancedSecurityStatesAreConsistent(EnhancedSecurity state, EnhancedSecurity other)
+{
+    return enhancedSecurityEnabledForState(state) == enhancedSecurityEnabledForState(other);
+}
+
+};

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include "EnhancedSecurity.h"
 #include "SessionState.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebsiteDataStore.h"
@@ -102,6 +103,9 @@ public:
 
     String loggingString();
 
+    void setEnhancedSecurity(EnhancedSecurity state) { m_enhancedSecurity = state; }
+    EnhancedSecurity enhancedSecurity() const { return m_enhancedSecurity; }
+
 private:
     WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, BrowsingContextGroup*);
 
@@ -124,6 +128,7 @@ private:
     RefPtr<ViewSnapshot> m_snapshot;
 #endif
     bool m_isRemoteFrameNavigation { false };
+    EnhancedSecurity m_enhancedSecurity { EnhancedSecurity::Disabled };
 } SWIFT_SHARED_REFERENCE(refBackForwardListItem, derefBackForwardListItem);
 
 typedef Vector<Ref<WebBackForwardListItem>> BackForwardListItemVector;

--- a/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
@@ -83,6 +83,8 @@ WebsiteDataProcessType WebsiteData::ownerProcess(WebsiteDataType dataType)
     case WebsiteDataType::ScreenTime:
         return WebsiteDataProcessType::UI;
 #endif
+    case WebsiteDataType::EnhancedSecuritySites:
+        return WebsiteDataProcessType::UI;
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
@@ -55,6 +55,7 @@ enum class WebsiteDataType : uint32_t {
 #if ENABLE(SCREEN_TIME)
     ScreenTime = 1 << 21,
 #endif
+    EnhancedSecuritySites = 1 << 22,
 };
 
 inline ASCIILiteral toString(WebsiteDataType type)
@@ -106,6 +107,8 @@ inline ASCIILiteral toString(WebsiteDataType type)
     case WebsiteDataType::ScreenTime:
         return "ScreenTime"_s;
 #endif
+    case WebsiteDataType::EnhancedSecuritySites:
+        return "EnhancedSecuritySites"_s;
     default:
         break;
     }
@@ -140,10 +143,11 @@ template<> struct EnumTraitsForPersistence<WebKit::WebsiteDataType> {
         WebKit::WebsiteDataType::AlternativeServices,
 #endif
         WebKit::WebsiteDataType::FileSystem,
-        WebKit::WebsiteDataType::BackgroundFetchStorage
+        WebKit::WebsiteDataType::BackgroundFetchStorage,
 #if ENABLE(SCREEN_TIME)
-        , WebKit::WebsiteDataType::ScreenTime
+        WebKit::WebsiteDataType::ScreenTime,
 #endif
+        WebKit::WebsiteDataType::EnhancedSecuritySites
     >;
 };
 

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
@@ -48,4 +48,5 @@ headers: "WebsiteDataType.h"
 #if ENABLE(SCREEN_TIME)
     ScreenTime,
 #endif
+    EnhancedSecuritySites,
 };

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -409,6 +409,7 @@ UIProcess/DeviceIdHashSaltStorage.cpp
 UIProcess/DisplayLink.cpp
 UIProcess/DisplayLinkProcessProxyClient.cpp
 UIProcess/DrawingAreaProxy.cpp
+UIProcess/EnhancedSecurityTracking.cpp
 UIProcess/FindStringCallbackAggregator.cpp
 UIProcess/FindTextMatchesCallbackAggregator.cpp
 UIProcess/FrameLoadState.cpp
@@ -668,6 +669,8 @@ UIProcess/WebAuthentication/Authenticator.cpp
 UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
 UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
 
+UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
+UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/WebsiteData/WebsiteDataRecord.cpp
 UIProcess/WebsiteData/WebsiteDataStore.cpp

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -115,6 +115,7 @@ void Navigation::setCurrentRequest(ResourceRequest&& request, std::optional<Proc
 {
     m_currentRequest = WTFMove(request);
     m_currentRequestProcessIdentifier = processIdentifier;
+    m_siteHasStorage = false;
 }
 
 void Navigation::appendRedirectionURL(const WTF::URL& url)
@@ -207,5 +208,12 @@ WTF::String Navigation::loggingString() const
 }
 
 #endif
+
+
+void Navigation::setSiteHasStorage(const WTF::URL& url, bool siteHasStorage)
+{
+    ASSERT(url == m_currentRequest.url());
+    m_siteHasStorage = siteHasStorage;
+}
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -199,6 +199,9 @@ public:
 
     void setPendingSharedProcess(WebKit::FrameProcess&);
 
+    void setSiteHasStorage(const WTF::URL&, bool);
+    bool currentRequestSiteHasStorage() const { return m_siteHasStorage; }
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -229,6 +232,7 @@ private:
     bool m_requestIsFromClientInput : 1 { false };
     bool m_isFromLoadData : 1 { false };
     bool m_safeBrowsingCheckTimedOut : 1 { false };
+    bool m_siteHasStorage : 1 { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> m_originatorAdvancedPrivacyProtections;
     MonotonicTime m_requestStart { MonotonicTime::now() };

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -113,8 +113,9 @@ public:
     WebCore::AllowsContentJavaScript allowsContentJavaScript() const { return m_data.allowsContentJavaScript; }
     void setAllowsContentJavaScript(WebCore::AllowsContentJavaScript allows) { m_data.allowsContentJavaScript = allows; }
 
-    bool enhancedSecurityEnabled() const { return m_enhancedSecurityEnabled; }
-    void setEnhancedSecurityEnabled(bool enabled) { m_enhancedSecurityEnabled = enabled; }
+    bool enhancedSecurityEnabled() const { return m_enhancedSecurityEnabled.value_or(false); }
+    void setEnhancedSecurityEnabled(std::optional<bool> enabled) { m_enhancedSecurityEnabled = enabled; }
+    bool isEnhancedSecurityExplicitlySet() const { return !!m_enhancedSecurityEnabled; }
 
     bool lockdownModeEnabled() const;
     void setLockdownModeEnabled(std::optional<bool> enabled) { m_lockdownModeEnabled = enabled; }
@@ -173,7 +174,7 @@ private:
     RefPtr<WebKit::WebsiteDataStore> m_websiteDataStore;
     RefPtr<WebKit::WebUserContentControllerProxy> m_userContentController;
     std::optional<bool> m_lockdownModeEnabled;
-    bool m_enhancedSecurityEnabled { false };
+    std::optional<bool> m_enhancedSecurityEnabled;
 #if PLATFORM(COCOA)
     const std::unique_ptr<WebKit::LockdownModeObserver> m_lockdownModeObserver;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -57,6 +57,7 @@ NSString * const _WKWebsiteDataTypeAdClickAttributions = @"_WKWebsiteDataTypeAdC
 NSString * const _WKWebsiteDataTypePrivateClickMeasurements = @"_WKWebsiteDataTypePrivateClickMeasurements";
 NSString * const _WKWebsiteDataTypeAlternativeServices = @"_WKWebsiteDataTypeAlternativeServices";
 NSString * const _WKWebsiteDataTypeFileSystem = WKWebsiteDataTypeFileSystem;
+NSString* const _WKWebsiteDataTypeEnhancedSecuritySites = @"_WKWebsiteDataTypeEnhancedSecuritySites";
 
 @implementation WKWebsiteDataRecord
 
@@ -116,6 +117,8 @@ static NSString *dataTypesToString(NSSet *dataTypes)
     if ([dataTypes containsObject:WKWebsiteDataTypeScreenTime])
         [array addObject:@"Screen Time"];
 #endif
+    if ([dataTypes containsObject:_WKWebsiteDataTypeEnhancedSecuritySites])
+        [array addObject:@"Enhanced Security Sites"];
 
     return [array componentsJoinedByString:@", "];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
@@ -82,6 +82,8 @@ static inline std::optional<WebsiteDataType> toWebsiteDataType(NSString *website
     if ([websiteDataType isEqualToString:WKWebsiteDataTypeScreenTime])
         return WebsiteDataType::ScreenTime;
 #endif
+    if ([websiteDataType isEqualToString:_WKWebsiteDataTypeEnhancedSecuritySites])
+        return WebsiteDataType::EnhancedSecuritySites;
     return std::nullopt;
 }
 
@@ -143,6 +145,8 @@ static inline RetainPtr<NSSet> toWKWebsiteDataTypes(OptionSet<WebKit::WebsiteDat
     if (websiteDataTypes.contains(WebsiteDataType::ScreenTime))
         [wkWebsiteDataTypes addObject:WKWebsiteDataTypeScreenTime];
 #endif
+    if (websiteDataTypes.contains(WebsiteDataType::EnhancedSecuritySites))
+        [wkWebsiteDataTypes addObject:_WKWebsiteDataTypeEnhancedSecuritySites];
 
     return wkWebsiteDataTypes;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
@@ -39,6 +39,7 @@ WK_EXTERN NSString * const _WKWebsiteDataTypeAdClickAttributions WK_API_AVAILABL
 WK_EXTERN NSString * const _WKWebsiteDataTypePrivateClickMeasurements WK_API_AVAILABLE(macos(12.0), ios(15.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeAlternativeServices WK_API_AVAILABLE(macos(11.0), ios(14.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeFileSystem WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebsiteDataTypeFileSystem", macos(13.0, 14.0), ios(16.0, 17.0));
+WK_EXTERN NSString * const _WKWebsiteDataTypeEnhancedSecuritySites WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @interface WKWebsiteDataRecord (WKPrivate)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -739,7 +739,8 @@ struct WKWebsiteData {
             _WKWebsiteDataTypeCredentials,
             _WKWebsiteDataTypeAdClickAttributions,
             _WKWebsiteDataTypePrivateClickMeasurements,
-            _WKWebsiteDataTypeAlternativeServices
+            _WKWebsiteDataTypeAlternativeServices,
+            _WKWebsiteDataTypeEnhancedSecuritySites
         ];
 
         return [retainPtr([self allWebsiteDataTypes]) setByAddingObjectsFromArray:privateTypes];

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -28,6 +28,7 @@
 
 #include "APIPageConfiguration.h"
 #include "APIWebsitePolicies.h"
+#include "EnhancedSecurity.h"
 #include "FrameProcess.h"
 #include "PageLoadState.h"
 #include "ProvisionalPageProxy.h"
@@ -46,7 +47,7 @@ BrowsingContextGroup::BrowsingContextGroup() = default;
 BrowsingContextGroup::~BrowsingContextGroup() = default;
 
 void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataStore, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const WebCore::Site& site, const WebCore::Site& mainFrameSite,
-    WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, API::PageConfiguration& pageConfiguration, IsMainFrame isMainFrame, CompletionHandler<void(FrameProcess*)>&& completionHandler)
+    WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, API::PageConfiguration& pageConfiguration, IsMainFrame isMainFrame, CompletionHandler<void(FrameProcess*)>&& completionHandler)
 {
     if (!preferences.siteIsolationEnabled() || !preferences.siteIsolationSharedProcessEnabled())
         return completionHandler(nullptr);

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EnhancedSecurity.h"
 #include "WebProcessProxy.h"
 #include <WebCore/Site.h>
 #include <wtf/CompletionHandler.h>
@@ -59,7 +60,7 @@ public:
     static Ref<BrowsingContextGroup> create() { return adoptRef(*new BrowsingContextGroup()); }
     ~BrowsingContextGroup();
 
-    void sharedProcessForSite(WebsiteDataStore&, API::WebsitePolicies*, const WebPreferences&, const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, API::PageConfiguration&, IsMainFrame, CompletionHandler<void(FrameProcess*)>&&);
+    void sharedProcessForSite(WebsiteDataStore&, API::WebsitePolicies*, const WebPreferences&, const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, API::PageConfiguration&, IsMainFrame, CompletionHandler<void(FrameProcess*)>&&);
     Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, InjectBrowsingContextIntoProcess = InjectBrowsingContextIntoProcess::Yes);
     FrameProcess* processForSite(const WebCore::Site&);
     void addFrameProcess(FrameProcess&);

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "config.h"
+#include "EnhancedSecurityTracking.h"
+
+#include <WebCore/IPAddressSpace.h>
+#include <wtf/Condition.h>
+#include <wtf/Lock.h>
+
+namespace WebKit {
+
+using namespace WebCore;
+
+static EnhancedSecuritySites& enabledSitesMap()
+{
+    ASSERT(isMainRunLoop());
+    static NeverDestroyed<EnhancedSecuritySites> staticEnabledSites;
+    return staticEnabledSites;
+}
+
+static bool didSitePreviouslyUseEnhancedSecurity(API::Navigation& navigation)
+{
+    return enabledSitesMap().contains(RegistrableDomain { navigation.currentRequest().url() });
+}
+
+void EnhancedSecurityTracking::initializeWithWebsiteDataStore(Ref<WebsiteDataStore> websiteDataStore)
+{
+    websiteDataStore->fetchEnhancedSecurityOnlyDomains([this](HashSet<RegistrableDomain>&& domains) {
+        updateEnhancedSecurityDomains(WTFMove(domains));
+    });
+}
+
+void EnhancedSecurityTracking::updateEnhancedSecurityDomains(HashSet<RegistrableDomain>&& domains)
+{
+    for (auto domain : domains)
+        enabledSitesMap().add(domain, EnhancedSecurityReason::InsecureLoad);
+}
+
+void EnhancedSecurityTracking::transfer(EnhancedSecurityTracking& other)
+{
+    m_activeState = other.m_activeState;
+    m_activeReason = other.m_activeReason;
+    m_initialProtectedDomain = other.m_initialProtectedDomain;
+}
+
+EnhancedSecurity EnhancedSecurityTracking::enhancedSecurityState() const
+{
+    if (m_activeState != ActivationState::Active)
+        return EnhancedSecurity::Disabled;
+
+    switch (enhancedSecurityReason()) {
+    case EnhancedSecurityReason::None:
+        ASSERT_NOT_REACHED();
+        return EnhancedSecurity::Disabled;
+
+    case EnhancedSecurityReason::InsecureProvisional:
+    case EnhancedSecurityReason::InsecureLoad:
+        return EnhancedSecurity::EnabledInsecure;
+
+    case EnhancedSecurityReason::Policy:
+        return EnhancedSecurity::EnabledPolicy;
+    }
+
+    ASSERT_NOT_REACHED();
+    return EnhancedSecurity::Disabled;
+}
+
+void EnhancedSecurityTracking::reset()
+{
+    m_activeState = ActivationState::None;
+    m_activeReason = EnhancedSecurityReason::None;
+}
+
+void EnhancedSecurityTracking::makeDormant()
+{
+    m_activeState = ActivationState::Dormant;
+}
+
+void EnhancedSecurityTracking::makeActive()
+{
+    m_activeState = ActivationState::Active;
+}
+
+static EnhancedSecurityReason reasonForEnhancedSecurity(EnhancedSecurity state)
+{
+    switch (state) {
+    case EnhancedSecurity::Disabled:
+        return EnhancedSecurityReason::None;
+
+    case EnhancedSecurity::EnabledInsecure:
+        return EnhancedSecurityReason::InsecureLoad;
+
+    case EnhancedSecurity::EnabledPolicy:
+        return EnhancedSecurityReason::Policy;
+    }
+
+    ASSERT_NOT_REACHED();
+}
+
+void EnhancedSecurityTracking::enableFor(EnhancedSecurityReason reason, API::Navigation& navigation)
+{
+    m_activeState = ActivationState::Active;
+    m_activeReason = reason;
+    m_initialProtectedDomain = RegistrableDomain(navigation.currentRequest().url());
+
+    enabledSitesMap().add(m_initialProtectedDomain, m_activeReason);
+}
+
+void EnhancedSecurityTracking::trackChangingSiteNavigation(API::Navigation& navigation)
+{
+    if (enhancedSecurityReason() == EnhancedSecurityReason::InsecureProvisional) {
+        m_activeReason = EnhancedSecurityReason::InsecureLoad;
+
+        if (enabledSitesMap().contains(m_initialProtectedDomain)) {
+            if (enabledSitesMap().get(m_initialProtectedDomain) == EnhancedSecurityReason::InsecureProvisional)
+                enabledSitesMap().set(m_initialProtectedDomain, EnhancedSecurityReason::InsecureLoad);
+        }
+    }
+}
+
+void EnhancedSecurityTracking::trackSameSiteNavigation(API::Navigation& navigation)
+{
+    bool isHttps = navigation.currentRequest().url().protocolIs("https"_s);
+
+    if (enhancedSecurityReason() == EnhancedSecurityReason::InsecureProvisional && isHttps) {
+        reset();
+
+        auto domain = RegistrableDomain { navigation.currentRequest().url() };
+        if (enabledSitesMap().contains(domain)) {
+            if (enabledSitesMap().get(domain) == EnhancedSecurityReason::InsecureProvisional)
+                enabledSitesMap().remove(domain);
+        }
+    }
+}
+
+bool EnhancedSecurityTracking::enableIfRequired(API::Navigation& navigation)
+{
+    auto currentRequestURL = navigation.currentRequest().url();
+
+    if (currentRequestURL.protocolIs("http"_s) && !WebCore::isLocalIPAddressSpace(currentRequestURL)) {
+        enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
+        return true;
+    }
+
+    return false;
+}
+
+void EnhancedSecurityTracking::handleBackForwardNavigation(API::Navigation& navigation)
+{
+    EnhancedSecurity priorState = navigation.targetItem() ? navigation.targetItem()->enhancedSecurity() : EnhancedSecurity::Disabled;
+
+    if (priorState == EnhancedSecurity::Disabled) {
+        if (m_activeState != ActivationState::None)
+            makeDormant();
+    } else
+        enableFor(reasonForEnhancedSecurity(priorState), navigation);
+}
+
+void EnhancedSecurityTracking::trackNavigation(API::Navigation& navigation)
+{
+    auto lastNavigationAction = navigation.lastNavigationAction();
+
+    bool isBackForward = lastNavigationAction && lastNavigationAction->navigationType == NavigationType::BackForward;
+    bool isReload = lastNavigationAction && lastNavigationAction->navigationType == NavigationType::Reload;
+    bool isInitialUIDriven = navigation.isRequestFromClientOrUserInput() && !navigation.currentRequestIsRedirect();
+
+    if (isBackForward) {
+        handleBackForwardNavigation(navigation);
+        return;
+    }
+
+    if (m_activeState != ActivationState::None && isInitialUIDriven && !isReload)
+        reset();
+
+    if (m_activeState != ActivationState::Active && enableIfRequired(navigation))
+        return;
+
+    if (m_activeState == ActivationState::Active
+        && m_activeReason == EnhancedSecurityReason::InsecureProvisional) {
+        if (!m_initialProtectedDomain.matches(navigation.currentRequest().url()))
+            trackChangingSiteNavigation(navigation);
+        else
+            trackSameSiteNavigation(navigation);
+    }
+
+    if (m_activeState == ActivationState::None)
+        return;
+
+    if (didSitePreviouslyUseEnhancedSecurity(navigation)) {
+        if (m_activeState == ActivationState::Dormant)
+            makeActive();
+
+        ASSERT(m_activeState == ActivationState::Active);
+        return;
+    }
+
+    bool siteHasStorage = navigation.currentRequestSiteHasStorage();
+
+    if (m_activeState == ActivationState::Dormant && !siteHasStorage)
+        makeActive();
+
+    if (m_activeState == ActivationState::Active) {
+        if (siteHasStorage)
+            makeDormant();
+        else
+            enabledSitesMap().add(RegistrableDomain { navigation.currentRequest().url() }, m_activeReason);
+    }
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+
+#include "APINavigation.h"
+#include "EnhancedSecurity.h"
+
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/Seconds.h>
+
+namespace WebKit {
+
+class EnhancedSecurityTracking final {
+public:
+    void initializeWithWebsiteDataStore(Ref<WebsiteDataStore>);
+
+    void trackNavigation(API::Navigation&);
+
+    bool enhancedSecurityEnabled() const { return enhancedSecurityEnabledForState(enhancedSecurityState()); }
+    EnhancedSecurity enhancedSecurityState() const;
+    EnhancedSecurityReason enhancedSecurityReason() const { return m_activeReason; }
+
+    void transfer(EnhancedSecurityTracking& other);
+
+    void updateEnhancedSecurityDomains(HashSet<WebCore::RegistrableDomain>&&);
+
+private:
+    enum class ActivationState : uint8_t { None, Dormant, Active };
+
+    void reset();
+    void makeDormant();
+    void makeActive();
+
+    void handleBackForwardNavigation(API::Navigation&);
+
+    void enableFor(EnhancedSecurityReason, API::Navigation&);
+    bool enableIfRequired(API::Navigation&);
+
+    void trackSameSiteNavigation(API::Navigation&);
+    void trackChangingSiteNavigation(API::Navigation&);
+
+    ActivationState m_activeState;
+    EnhancedSecurityReason m_activeReason;
+
+    WebCore::RegistrableDomain m_initialProtectedDomain;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 
 #include "RemoteMediaSessionClientProxy.h"
+#include "RemoteMediaSessionManagerMessages.h"
 #include "RemoteMediaSessionManagerProxyMessages.h"
 #include "RemoteMediaSessionProxy.h"
 #include "RemoteMediaSessionState.h"

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
@@ -28,6 +28,8 @@
 #include "UIProcess/Media/RemoteMediaSessionManagerProxy.h"
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 
+#include "RemoteMediaSessionClientProxy.h"
+#include "RemoteMediaSessionManagerProxy.h"
 #include "RemoteMediaSessionState.h"
 #include <WebCore/PlatformMediaSession.h>
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -882,6 +882,16 @@ void NetworkProcessProxy::clearUserInteraction(PAL::SessionID sessionID, const R
     sendWithAsyncReply(Messages::NetworkProcess::ClearUserInteraction(sessionID, resourceDomain), WTFMove(completionHandler));
 }
 
+void NetworkProcessProxy::hasLocalStorageOrCookies(PAL::SessionID sessionID, const RegistrableDomain& resourceDomain, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (!canSendMessage()) {
+        completionHandler(false);
+        return;
+    }
+
+    sendWithAsyncReply(Messages::NetworkProcess::HasLocalStorageOrCookies(sessionID, resourceDomain), WTFMove(completionHandler));
+}
+
 void NetworkProcessProxy::hasLocalStorage(PAL::SessionID sessionID, const RegistrableDomain& resourceDomain, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!canSendMessage()) {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -160,6 +160,7 @@ public:
     void updatePrevalentDomainsToBlockCookiesFor(PAL::SessionID, const Vector<RegistrableDomain>&, CompletionHandler<void()>&&);
     void hasHadUserInteraction(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void isRelationshipOnlyInDatabaseOnce(PAL::SessionID, const RegistrableDomain& subDomain, const RegistrableDomain& topDomain, CompletionHandler<void(bool)>&&);
+    void hasLocalStorageOrCookies(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void hasLocalStorage(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void isGrandfathered(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void isPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -29,6 +29,7 @@
 #include "APIPageConfiguration.h"
 #include "BrowsingContextGroup.h"
 #include "DrawingAreaProxy.h"
+#include "EnhancedSecurity.h"
 #include "HandleMessage.h"
 #include "Logging.h"
 #include "MessageSenderInlines.h"
@@ -60,7 +61,7 @@ static WeakHashSet<SuspendedPageProxy>& allSuspendedPages()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
 
-RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
+RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
     for (Ref suspendedPage : allSuspendedPages()) {
         Ref process = suspendedPage->process();

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Connection.h"
+#include "EnhancedSecurity.h"
 #include "ProcessThrottler.h"
 #include "WebBackForwardListItem.h"
 #include "WebPageProxyMessageReceiverRegistration.h"
@@ -65,7 +66,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, const API::PageConfiguration&);
+    static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
 
     WebPageProxy* page() const;
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -684,6 +684,7 @@ void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, R
         Ref item = WebBackForwardListItem::create(completeFrameStateForNavigation(WTFMove(navigatedFrameState)), webPageProxy->identifier(), navigatedFrameID, webPageProxy->protectedBrowsingContextGroup().ptr());
         item->setResourceDirectoryURL(webPageProxy->currentResourceDirectoryURL());
         item->setIsRemoteFrameNavigation(isRemoteFrameNavigation);
+        item->setEnhancedSecurity(process->enhancedSecurity());
         if (loadedWebArchive == LoadedWebArchive::Yes)
             item->setDataStoreForWebArchive(process->websiteDataStore());
         addItem(WTFMove(item));

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
@@ -43,15 +43,16 @@ enum class ProcessSwapRequestedByClient : bool { No, Yes };
 enum class ShouldExpectSafeBrowsingResult : bool { No, Yes };
 enum class ShouldExpectAppBoundDomainResult : bool { No, Yes };
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool { No, Yes };
+enum class ShouldWaitForSiteHasStorageCheck : bool { No, Yes };
 enum class WasNavigationIntercepted : bool { No, Yes };
 
 class WebFramePolicyListenerProxy : public API::ObjectImpl<API::Object::Type::FramePolicyListener>, public CanMakeWeakPtr<WebFramePolicyListenerProxy> {
 public:
 
     using Reply = CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>;
-    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData)
+    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck)
     {
-        return adoptRef(*new WebFramePolicyListenerProxy(WTFMove(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData));
+        return adoptRef(*new WebFramePolicyListenerProxy(WTFMove(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck));
     }
     ~WebFramePolicyListenerProxy();
 
@@ -63,13 +64,15 @@ public:
     void didReceiveAppBoundDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveManagedDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveInitialLinkDecorationFilteringData();
+    void didReceiveSiteHasStorageResults();
 
 private:
-    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData);
+    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck);
 
     std::optional<std::pair<RefPtr<API::WebsitePolicies>, ProcessSwapRequestedByClient>> m_policyResult;
     std::optional<RefPtr<BrowsingWarning>> m_safeBrowsingWarning;
     std::optional<std::optional<NavigatingToAppBoundDomain>> m_isNavigatingToAppBoundDomain;
+    bool m_doneWaitingForSiteHasStorage { false };
     bool m_doneWaitingForLinkDecorationFilteringData { false };
     Reply m_reply;
 };

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -363,7 +363,7 @@ void WebFrameProxy::didChangeTitle(String&& title)
     m_title = WTFMove(title);
 }
 
-WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData)
+WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck)
 {
     if (RefPtr previousListener = m_activeListener)
         previousListener->ignore();
@@ -373,7 +373,7 @@ WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionH
 
         completionHandler(action, policies, processSwapRequestedByClient, isNavigatingToAppBoundDomain, wasNavigationIntercepted);
         m_activeListener = nullptr;
-    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData);
+    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck);
     return *m_activeListener;
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -105,6 +105,7 @@ enum class NavigatingToAppBoundDomain : bool;
 enum class ShouldExpectSafeBrowsingResult : bool;
 enum class ShouldExpectAppBoundDomainResult : bool;
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool;
+enum class ShouldWaitForSiteHasStorageCheck : bool;
 enum class ProcessSwapRequestedByClient : bool;
 enum class WasNavigationIntercepted : bool;
 
@@ -183,7 +184,7 @@ public:
     void didSameDocumentNavigation(URL&&); // eg. anchor navigation, session state change.
     void didChangeTitle(String&&);
 
-    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData);
+    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck);
 
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler contentFilterUnblockHandler) { m_contentFilterUnblockHandler = WTFMove(contentFilterUnblockHandler); }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -79,6 +79,7 @@
 #include "DrawingAreaMessages.h"
 #include "DrawingAreaProxy.h"
 #include "DrawingAreaProxyMessages.h"
+#include "EnhancedSecurity.h"
 #include "EventDispatcherMessages.h"
 #include "FindStringCallbackAggregator.h"
 #include "FindTextMatchesCallbackAggregator.h"
@@ -972,6 +973,8 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #endif
     if (protectedPreferences()->siteIsolationEnabled())
         IPC::Connection::setShouldCrashOnMessageCheckFailure(true);
+
+    internals().enhancedSecurityTracker.initializeWithWebsiteDataStore(protectedWebsiteDataStore());
 }
 
 WebPageProxy::~WebPageProxy()
@@ -1368,7 +1371,7 @@ void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
         m_legacyMainFrameProcess = relatedPage->ensureRunningProcess();
         WEBPAGEPROXY_RELEASE_LOG(Loading, "launchProcess: Using process (process=%p, PID=%i) from related page", m_legacyMainFrameProcess.ptr(), m_legacyMainFrameProcess->processID());
     } else
-        m_legacyMainFrameProcess = processPool->processForSite(protectedWebsiteDataStore(), WebProcessPool::IsSharedProcess::No, site, site, { }, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled, (shouldEnableEnhancedSecurity() || protectedPreferences()->forceEnhancedSecurity()) ? WebProcessProxy::EnhancedSecurity::Enabled : WebProcessProxy::EnhancedSecurity::Disabled, m_configuration, WebCore::ProcessSwapDisposition::None);
+        m_legacyMainFrameProcess = processPool->processForSite(protectedWebsiteDataStore(), WebProcessPool::IsSharedProcess::No, site, site, { }, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled, enhancedSecurityEnabled(), m_configuration, WebCore::ProcessSwapDisposition::None);
 
     m_shouldReloadDueToCrashWhenVisible = false;
     m_isLockdownModeExplicitlySet = m_configuration->isLockdownModeExplicitlySet();
@@ -5089,7 +5092,12 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
 
     m_isLockdownModeExplicitlySet = (websitePolicies && websitePolicies->isLockdownModeExplicitlySet()) || m_configuration->isLockdownModeExplicitlySet();
     auto lockdownMode = (websitePolicies ? websitePolicies->lockdownModeEnabled() : shouldEnableLockdownMode()) ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled;
-    auto enhancedSecurity = ((websitePolicies && websitePolicies->enhancedSecurityEnabled()) || protectedPreferences()->forceEnhancedSecurity()) ? WebProcessProxy::EnhancedSecurity::Enabled : WebProcessProxy::EnhancedSecurity::Disabled;
+
+    if (frame.isMainFrame() && protectedPreferences()->enhancedSecurityHeuristicsEnabled())
+        internals().enhancedSecurityTracker.trackNavigation(navigation);
+
+    auto enhancedSecurity = enhancedSecurityEnabled(websitePolicies);
+    protectedWebsiteDataStore()->trackEnhancedSecurityForDomain(RegistrableDomain { navigation.currentRequest().url() }, enhancedSecurity);
 
     Ref browsingContextGroup = m_browsingContextGroup;
     bool usesSameWebsiteDataStore = websiteDataStore.ptr() == &this->websiteDataStore();
@@ -5213,6 +5221,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
 
     Site site { navigation.currentRequest().url() };
     Site mainFrameSite = frame.isMainFrame() ? site : Site { URL(protectedPageLoadState()->activeURL()) };
+
     browsingContextGroup->sharedProcessForSite(websiteDataStore, policies.get(), preferences, site, mainFrameSite, lockdownMode, enhancedSecurity, Ref { m_configuration }, frame.isMainFrame() ? IsMainFrame::Yes : IsMainFrame::No, [
         this,
         protectedThis = Ref { *this },
@@ -8353,6 +8362,10 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     if (!protectedPreferences()->safeBrowsingEnabled())
         shouldExpectSafeBrowsingResult = ShouldExpectSafeBrowsingResult::No;
 
+    ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck = ShouldWaitForSiteHasStorageCheck::Yes;
+    if (!frame.isMainFrame() || !protectedPreferences()->enhancedSecurityHeuristicsEnabled())
+        shouldWaitForSiteHasStorageCheck = ShouldWaitForSiteHasStorageCheck::No;
+
     ShouldExpectAppBoundDomainResult shouldExpectAppBoundDomainResult = ShouldExpectAppBoundDomainResult::No;
 #if ENABLE(APP_BOUND_DOMAINS)
     shouldExpectAppBoundDomainResult = ShouldExpectAppBoundDomainResult::Yes;
@@ -8479,11 +8492,13 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
         completionHandlerWrapper(policyAction);
 
-    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData);
+    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck);
     if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
         beginSafeBrowsingCheck(request.url(), *navigation, frame.isMainFrame());
     if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::Yes)
         waitForInitialLinkDecorationFilteringData(listener);
+    if (shouldWaitForSiteHasStorageCheck == ShouldWaitForSiteHasStorageCheck::Yes)
+        beginSiteHasStorageCheck(request.url(), *navigation, listener);
 #if ENABLE(APP_BOUND_DOMAINS)
     bool shouldSendSecurityOriginData = !frame.isMainFrame() && shouldTreatURLProtocolAsAppBound(request.url(), websiteDataStore().configuration().enableInAppBrowserPrivacyForTesting());
     auto host = shouldSendSecurityOriginData ? frameInfo.securityOrigin.host() : request.url().host();
@@ -8648,7 +8663,7 @@ void WebPageProxy::decidePolicyForNewWindowAction(IPC::Connection& connection, N
         RELEASE_ASSERT(processSwapRequestedByClient == ProcessSwapRequestedByClient::No);
 
         receivedPolicyDecision(policyAction, nullptr, std::nullopt, WTFMove(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTFMove(completionHandler));
-    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No);
+    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No);
 
     if (m_policyClient)
         m_policyClient->decidePolicyForNewWindowAction(*this, *frame, navigationAction.get(), request, frameName, WTFMove(listener));
@@ -8783,7 +8798,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         }
 #endif
         completionHandlerWrapper(policyAction);
-    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No);
+    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No);
     if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
         Seconds timeout = (MonotonicTime::now() - requestStart) * 1.5 + 0.25_s;
         RunLoop::mainSingleton().dispatchAfter(timeout, [listener, navigation] mutable {
@@ -9051,6 +9066,8 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
             reply(std::nullopt, std::nullopt);
             return;
         }
+
+        newPage->internals().enhancedSecurityTracker.transfer(internals().enhancedSecurityTracker);
 
         if (RefPtr pageClient = this->pageClient())
             pageClient->dismissAnyOpenPicker();
@@ -16215,9 +16232,18 @@ bool WebPageProxy::shouldEnableLockdownMode() const
     return m_configuration->lockdownModeEnabled();
 }
 
-bool WebPageProxy::shouldEnableEnhancedSecurity() const
+EnhancedSecurity WebPageProxy::enhancedSecurityEnabled(const RefPtr<API::WebsitePolicies> websitePolicies) const
 {
-    return m_configuration->enhancedSecurityEnabled();
+    if (protectedPreferences()->forceEnhancedSecurity())
+        return EnhancedSecurity::EnabledPolicy;
+
+    if (websitePolicies && websitePolicies->isEnhancedSecurityExplicitlySet()) {
+        if (websitePolicies->enhancedSecurityEnabled())
+            return EnhancedSecurity::EnabledPolicy;
+    } else if (m_configuration->enhancedSecurityEnabled())
+        return EnhancedSecurity::EnabledPolicy;
+
+    return internals().enhancedSecurityTracker.enhancedSecurityState();
 }
 
 #if PLATFORM(COCOA)
@@ -16406,6 +16432,14 @@ void WebPageProxy::waitForInitialLinkDecorationFilteringData(WebFramePolicyListe
 #else
     listener.didReceiveInitialLinkDecorationFilteringData();
 #endif
+}
+
+void WebPageProxy::beginSiteHasStorageCheck(const URL& url, API::Navigation& navigation, WebFramePolicyListenerProxy& listener)
+{
+    protectedWebsiteDataStore()->hasLocalStorageOrCookies(url, [weakThis = WeakPtr { *this }, navigation = Ref { navigation }, url = url.isolatedCopy(), listener = Ref { listener }] (bool siteHasStorage) mutable {
+        navigation->setSiteHasStorage(url, siteHasStorage);
+        listener->didReceiveSiteHasStorageResults();
+    });
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -619,6 +619,7 @@ struct RendererBufferFormat;
 enum class ColorControlSupportsAlpha : bool;
 enum class ContentAsStringIncludesChildFrames : bool;
 enum class DragControllerAction : uint8_t;
+enum class EnhancedSecurity : uint8_t;
 enum class FindDecorationStyle : uint8_t;
 enum class FindOptions : uint16_t;
 enum class ForceSoftwareCapturingViewportSnapshot : bool;
@@ -729,7 +730,7 @@ public:
     bool isLockdownModeExplicitlySet() const { return m_isLockdownModeExplicitlySet; }
     bool shouldEnableLockdownMode() const;
 
-    bool shouldEnableEnhancedSecurity() const;
+    EnhancedSecurity enhancedSecurityEnabled(const RefPtr<API::WebsitePolicies> = nullptr) const;
 
     bool hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfiguration&) const;
     bool hasSameGPUAndNetworkProcessPreferencesAs(const WebPageProxy&) const;
@@ -3510,6 +3511,8 @@ private:
 
     void setCustomUserAgentInternal();
     HashSet<Ref<WebProcessProxy>> webContentProcessesWithFrame();
+
+    void beginSiteHasStorageCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
 
     const UniqueRef<Internals> m_internals;
     Identifier m_identifier;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -27,6 +27,7 @@
 
 #include "ContextMenuContextData.h"
 #include "EditorState.h"
+#include "EnhancedSecurityTracking.h"
 #include "GeolocationPermissionRequestManagerProxy.h"
 #include "HiddenPageThrottlingAutoIncreasesCounter.h"
 #include "LayerTreeContext.h"
@@ -442,6 +443,8 @@ public:
 #endif
 
     std::optional<TextManipulationParameters> textManipulationParameters;
+
+    EnhancedSecurityTracking enhancedSecurityTracker;
 
     explicit Internals(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -27,6 +27,7 @@
 #include "WebProcessCache.h"
 
 #include "APIPageConfiguration.h"
+#include "EnhancedSecurity.h"
 #include "LegacyGlobalSettings.h"
 #include "Logging.h"
 #include "ProcessThrottler.h"
@@ -218,7 +219,7 @@ void WebProcessCache::evictAtRandomIfNeeded()
     }
 }
 
-RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::Site& site, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
+RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::Site& site, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
     auto it = m_processesPerSite.find(site);
     if (it == m_processesPerSite.end()) {
@@ -261,7 +262,7 @@ RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::Site& site, 
     return process;
 }
 
-RefPtr<WebProcessProxy> WebProcessCache::takeSharedProcess(const WebCore::Site& mainFrameSite, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
+RefPtr<WebProcessProxy> WebProcessCache::takeSharedProcess(const WebCore::Site& mainFrameSite, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
     auto it = m_sharedProcessesPerSite.find(mainFrameSite);
     if (it == m_sharedProcessesPerSite.end()) {

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "EnhancedSecurity.h"
 #include "WebProcessProxy.h"
 #include <WebCore/Site.h>
 #include <pal/SessionID.h>
@@ -49,8 +50,8 @@ public:
     explicit WebProcessCache(WebProcessPool&);
 
     bool addProcessIfPossible(Ref<WebProcessProxy>&&);
-    RefPtr<WebProcessProxy> takeProcess(const WebCore::Site&, WebsiteDataStore&, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, const API::PageConfiguration&);
-    RefPtr<WebProcessProxy> takeSharedProcess(const WebCore::Site& mainFrameSite, WebsiteDataStore&, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, const API::PageConfiguration&);
+    RefPtr<WebProcessProxy> takeProcess(const WebCore::Site&, WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
+    RefPtr<WebProcessProxy> takeSharedProcess(const WebCore::Site& mainFrameSite, WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
 
     void updateCapacity(WebProcessPool&);
     unsigned capacity() const { return m_capacity; }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -43,6 +43,7 @@
 #include "BrowsingContextGroup.h"
 #include "DownloadProxy.h"
 #include "DownloadProxyMessages.h"
+#include "EnhancedSecurity.h"
 #include "FrameProcess.h"
 #include "GPUProcessConnectionParameters.h"
 #include "GamepadData.h"
@@ -706,7 +707,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
 
     RefPtr requestingProcess = requestingProcessIdentifier ? WebProcessProxy::processForIdentifier(*requestingProcessIdentifier) : nullptr;
     auto lockdownMode = requestingProcess ? requestingProcess->lockdownMode() : (lockdownModeEnabledBySystem() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled);
-    auto enhancedSecurity = requestingProcess ? requestingProcess->enhancedSecurity() : WebProcessProxy::EnhancedSecurity::Disabled;
+    auto enhancedSecurity = requestingProcess ? requestingProcess->enhancedSecurity() : EnhancedSecurity::Disabled;
     Ref processPool = requestingProcess ? requestingProcess->processPool() : processPools()[0].get();
 
     RefPtr<WebProcessProxy> remoteWorkerProcessProxy;
@@ -839,7 +840,7 @@ void WebProcessPool::resolvePathsForSandboxExtensions()
     platformResolvePathsForSandboxExtensions();
 }
 
-Ref<WebProcessProxy> WebProcessPool::createNewWebProcess(WebsiteDataStore* websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, WebProcessProxy::IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode)
+Ref<WebProcessProxy> WebProcessPool::createNewWebProcess(WebsiteDataStore* websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, WebProcessProxy::IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode)
 {
     auto processProxy = WebProcessProxy::create(*this, websiteDataStore, lockdownMode, enhancedSecurity, isPrewarmed, crossOriginMode);
     initializeNewWebProcess(processProxy, websiteDataStore, isPrewarmed);
@@ -848,7 +849,7 @@ Ref<WebProcessProxy> WebProcessPool::createNewWebProcess(WebsiteDataStore* websi
     return processProxy;
 }
 
-RefPtr<WebProcessProxy> WebProcessPool::tryTakePrewarmedProcess(WebsiteDataStore& websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
+RefPtr<WebProcessProxy> WebProcessPool::tryTakePrewarmedProcess(WebsiteDataStore& websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
     RefPtr<WebProcessProxy> prewarmedProcess;
 
@@ -1124,7 +1125,7 @@ void WebProcessPool::prewarmProcess()
     WEBPROCESSPOOL_RELEASE_LOG(PerformanceLogging, "prewarmProcess: Prewarming a WebProcess for performance");
 
     auto lockdownMode = lockdownModeEnabledBySystem() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled;
-    auto enhancedSecurity = WebProcessProxy::EnhancedSecurity::Disabled;
+    auto enhancedSecurity = EnhancedSecurity::Disabled;
     createNewWebProcess(nullptr, lockdownMode, enhancedSecurity, WebProcessProxy::IsPrewarmed::Yes);
 }
 
@@ -1262,7 +1263,7 @@ void WebProcessPool::disconnectProcess(WebProcessProxy& process)
 #endif
 }
 
-Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDataStore, IsSharedProcess isSharedProcess, const std::optional<Site>& site, const std::optional<Site>& mainFrameSite, const HashSet<RegistrableDomain>& isolatedDomains, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration, ProcessSwapDisposition processSwapDisposition)
+Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDataStore, IsSharedProcess isSharedProcess, const std::optional<Site>& site, const std::optional<Site>& mainFrameSite, const HashSet<RegistrableDomain>& isolatedDomains, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration, ProcessSwapDisposition processSwapDisposition)
 {
     if (isSharedProcess == IsSharedProcess::Yes) {
         ASSERT(mainFrameSite);
@@ -1334,8 +1335,7 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
 
     RefPtr<WebProcessProxy> process;
     auto lockdownMode = pageConfiguration->lockdownModeEnabled() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled;
-    auto enhancedSecurity = (pageConfiguration->protectedPreferences()->forceEnhancedSecurity() || pageConfiguration->enhancedSecurityEnabled()) ? WebProcessProxy::EnhancedSecurity::Enabled : WebProcessProxy::EnhancedSecurity::Disabled;
-
+    auto enhancedSecurity = (pageConfiguration->protectedPreferences()->forceEnhancedSecurity() || pageConfiguration->enhancedSecurityEnabled()) ? EnhancedSecurity::EnabledPolicy : EnhancedSecurity::Disabled;
     RefPtr relatedPage = pageConfiguration->relatedPage();
 
     if (auto& openerInfo = pageConfiguration->openerInfo(); openerInfo && Ref { pageConfiguration->preferences() }->siteIsolationEnabled())
@@ -2141,7 +2141,7 @@ unsigned WebProcessPool::prewarmedProcessCountLimit() const
     return m_hasUsedSiteIsolation ? 2 : 1;
 }
 
-void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& frame, const API::Navigation& navigation, const URL& sourceURL, BrowsingContextGroup& browsingContextGroup, IsSharedProcess isSharedProcess, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler)
+void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& frame, const API::Navigation& navigation, const URL& sourceURL, BrowsingContextGroup& browsingContextGroup, IsSharedProcess isSharedProcess, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler)
 {
     Site site { navigation.currentRequest().url() };
 
@@ -2159,7 +2159,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
         RefPtr<WebProcessProxy> process;
         if (RefPtr frameProcess = browsingContextGroup.processForSite(site))
             process = &frameProcess->process();
-        if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache()) {
+        if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity)) {
             dataStore->protectedNetworkProcess()->addAllowedFirstPartyForCookies(*process, mainFrameSite.domain(), LoadedWebArchive::No, [completionHandler = WTFMove(completionHandler), process] () mutable {
                 completionHandler(process.releaseNonNull(), nullptr, "Found process for the same site"_s);
             });
@@ -2198,7 +2198,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
 }
 
 void WebProcessPool::prepareProcessForNavigation(Ref<WebProcessProxy>&& process, WebPageProxy& page, SuspendedPageProxy* suspendedPage, ASCIILiteral reason, IsSharedProcess isSharedProcess, const Site& site, const Site& mainFrameSite,
-    const API::Navigation& navigation, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, Ref<WebsiteDataStore>&& dataStore, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler, unsigned previousAttemptsCount)
+    const API::Navigation& navigation, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, Ref<WebsiteDataStore>&& dataStore, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler, unsigned previousAttemptsCount)
 {
     static constexpr unsigned maximumNumberOfAttempts = 3;
     auto preventProcessShutdownScope = process->shutdownPreventingScope();
@@ -2226,7 +2226,7 @@ void WebProcessPool::prepareProcessForNavigation(Ref<WebProcessProxy>&& process,
     });
 }
 
-std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebProcessPool::processForNavigationInternal(WebPageProxy& page, const API::Navigation& navigation, Ref<WebProcessProxy>&& sourceProcess, const URL& pageSourceURL, IsSharedProcess isSharedProcess, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::EnhancedSecurity enhancedSecurity, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore)
+std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebProcessPool::processForNavigationInternal(WebPageProxy& page, const API::Navigation& navigation, Ref<WebProcessProxy>&& sourceProcess, const URL& pageSourceURL, IsSharedProcess isSharedProcess, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore)
 {
     auto& targetURL = navigation.currentRequest().url();
     auto targetSite = Site { targetURL };
@@ -2246,7 +2246,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
     if (sourceProcess->lockdownMode() != lockdownMode)
         return { createNewProcess(), nullptr, "Process swap due to Lockdown mode change"_s };
 
-    if (sourceProcess->enhancedSecurity() != enhancedSecurity)
+    if (!enhancedSecurityStatesAreConsistent(sourceProcess->enhancedSecurity(), enhancedSecurity))
         return { createNewProcess(), nullptr, "Process swap due to EnhancedSecurity change"_s };
 
     if (processSwapRequestedByClient == ProcessSwapRequestedByClient::Yes)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -28,6 +28,7 @@
 #include "APIDictionary.h"
 #include "APIObject.h"
 #include "APIProcessPoolConfiguration.h"
+#include "EnhancedSecurity.h"
 #include "GPUProcessProxy.h"
 #include "HiddenPageThrottlingAutoIncreasesCounter.h"
 #include "MessageReceiver.h"
@@ -346,7 +347,7 @@ public:
 
     enum class IsSharedProcess : bool { No, Yes };
     Ref<WebProcessProxy> processForSite(WebsiteDataStore&, IsSharedProcess, const std::optional<WebCore::Site>&, const std::optional<WebCore::Site>& mainFrameSite, const HashSet<WebCore::RegistrableDomain>& isolatedDomains,
-        WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, const API::PageConfiguration&, WebCore::ProcessSwapDisposition); // Will return an existing one if limit is met or due to caching.
+        WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&, WebCore::ProcessSwapDisposition); // Will return an existing one if limit is met or due to caching.
 
     void prewarmProcess();
 
@@ -504,7 +505,7 @@ public:
     bool hasBackgroundWebProcessesWithModels() const;
 #endif
 
-    void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, BrowsingContextGroup&, IsSharedProcess, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, LoadedWebArchive, const FrameInfoData&, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&);
+    void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, BrowsingContextGroup&, IsSharedProcess, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, const FrameInfoData&, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&);
 
     void didReachGoodTimeToPrewarm();
 
@@ -580,7 +581,7 @@ public:
     static void platformInitializeNetworkProcess(NetworkProcessCreationParameters&);
     static Vector<String> urlSchemesWithCustomProtocolHandlers();
 
-    Ref<WebProcessProxy> createNewWebProcess(WebsiteDataStore*, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared);
+    Ref<WebProcessProxy> createNewWebProcess(WebsiteDataStore*, WebProcessProxy::LockdownMode, EnhancedSecurity, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared);
 
     bool hasAudibleMediaActivity() const { return !!m_audibleMediaActivity; }
 #if PLATFORM(IOS_FAMILY)
@@ -655,10 +656,10 @@ private:
     void platformInitializeWebProcess(const WebProcessProxy&, WebProcessCreationParameters&);
     void platformInvalidateContext();
 
-    std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> processForNavigationInternal(WebPageProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, IsSharedProcess, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, const FrameInfoData&, Ref<WebsiteDataStore>&&);
-    void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, IsSharedProcess, const WebCore::Site&, const WebCore::Site& mainFrameSite, const API::Navigation&, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, LoadedWebArchive, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
+    std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> processForNavigationInternal(WebPageProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, IsSharedProcess, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, EnhancedSecurity, const FrameInfoData&, Ref<WebsiteDataStore>&&);
+    void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, IsSharedProcess, const WebCore::Site&, const WebCore::Site& mainFrameSite, const API::Navigation&, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
 
-    RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, WebProcessProxy::EnhancedSecurity, const API::PageConfiguration&);
+    RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
     unsigned prewarmedProcessCountLimit() const;
 
     void initializeNewWebProcess(WebProcessProxy&, WebsiteDataStore*, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -28,6 +28,7 @@
 #include "APIUserInitiatedAction.h"
 #include "AuxiliaryProcessProxy.h"
 #include "BackgroundProcessResponsivenessTimer.h"
+#include "EnhancedSecurity.h"
 #include "GPUProcessConnectionIdentifier.h"
 #include "MessageReceiverMap.h"
 #include "NetworkProcessProxy.h"
@@ -189,7 +190,6 @@ public:
 
     enum class ShouldLaunchProcess : bool { No, Yes };
     enum class LockdownMode : bool { Disabled, Enabled };
-    enum class EnhancedSecurity : bool { Disabled, Enabled };
 
     static Ref<WebProcessProxy> create(WebProcessPool&, WebsiteDataStore*, LockdownMode, EnhancedSecurity, IsPrewarmed, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared, ShouldLaunchProcess = ShouldLaunchProcess::Yes);
     static Ref<WebProcessProxy> createForRemoteWorkers(RemoteWorkerType, WebProcessPool&, WebCore::Site&&, WebsiteDataStore&, LockdownMode, EnhancedSecurity);
@@ -622,7 +622,7 @@ private:
     bool isJITEnabled() const final;
     bool shouldEnableSharedArrayBuffer() const final { return m_crossOriginMode == WebCore::CrossOriginMode::Isolated; }
     bool shouldEnableLockdownMode() const final { return m_lockdownMode == LockdownMode::Enabled; }
-    bool shouldEnableEnhancedSecurity() const final { return m_enhancedSecurity == EnhancedSecurity::Enabled; }
+    bool shouldEnableEnhancedSecurity() const final { return enhancedSecurityEnabledForState(m_enhancedSecurity); }
     bool shouldDisableJITCage() const final;
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     RefPtr<XPCEventHandler> xpcEventHandler() const final;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -555,6 +555,14 @@ String WebsiteDataStore::defaultResourceMonitorThrottlerDirectory(const String& 
 }
 #endif
 
+String WebsiteDataStore::defaultEnhancedSecurityDirectory(const String& baseDirectory)
+{
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "EnhancedSecurity"_s);
+
+    return websiteDataDirectoryFileSystemRepresentation("EnhancedSecurity"_s, { }, ShouldCreateDirectory::No);
+}
+
 String WebsiteDataStore::tempDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory shouldCreateDirectory)
 {
     static NeverDestroyed<RetainPtr<NSURL>> tempURL = [] {
@@ -1075,6 +1083,61 @@ HashSet<WebCore::RegistrableDomain> WebsiteDataStore::platformAdditionalDomainsW
     }
 
     return result;
+}
+
+EnhancedSecuritySitesHolder& WebsiteDataStore::enhancedSecuritySitesHolder()
+{
+    ASSERT(isPersistent());
+
+    if (!m_enhancedSecuritySites)
+        lazyInitialize(m_enhancedSecuritySites, EnhancedSecuritySitesHolder::create(resolvedDirectories().enhancedSecurityDirectory));
+
+    return *m_enhancedSecuritySites;
+}
+
+void WebsiteDataStore::trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&& domain, EnhancedSecurity reason)
+{
+    if (!isPersistent())
+        return;
+
+    enhancedSecuritySitesHolder().trackEnhancedSecurityForDomain(WTFMove(domain), reason);
+}
+
+void WebsiteDataStore::fetchEnhancedSecurityOnlyDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    if (!isPersistent())
+        return completionHandler({ });
+
+    enhancedSecuritySitesHolder().fetchEnhancedSecurityOnlyDomains(WTFMove(completionHandler));
+}
+
+void WebsiteDataStore::fetchAllEnhancedSecuritySites(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    if (!isPersistent())
+        return completionHandler({ });
+
+    enhancedSecuritySitesHolder().fetchAllEnhancedSecuritySites(WTFMove(completionHandler));
+}
+
+void WebsiteDataStore::removeEnhancedSecuritySites(const Vector<WebCore::SecurityOriginData>& origins, CompletionHandler<void()>&& completionHandler)
+{
+    if (!isPersistent())
+        return completionHandler();
+
+    Vector<WebCore::RegistrableDomain> sites;
+
+    for (auto& origin : origins)
+        sites.append(WebCore::RegistrableDomain(origin));
+
+    enhancedSecuritySitesHolder().deleteSites(sites, WTFMove(completionHandler));
+}
+
+void WebsiteDataStore::removeAllEnhancedSecuritySites(CompletionHandler<void()>&& completionHandler)
+{
+    if (!isPersistent())
+        return completionHandler();
+
+    enhancedSecuritySitesHolder().deleteAllSites(WTFMove(completionHandler));
 }
 
 }

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EnhancedSecuritySitesHolder.h"
+
+#include "EnhancedSecuritySitesPersistence.h"
+#include <WebCore/SQLiteDatabase.h>
+#include <wtf/CrossThreadCopier.h>
+#include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Seconds.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebKit {
+
+Ref<WorkQueue> EnhancedSecuritySitesHolder::sharedWorkQueueSingleton()
+{
+    static NeverDestroyed<Ref<WorkQueue>> workQueue = WorkQueue::create("EnhancedSecuritySitesHolder Work Queue"_s);
+    return workQueue.get();
+}
+
+Ref<EnhancedSecuritySitesHolder> EnhancedSecuritySitesHolder::create(const String& databaseDirectoryPath)
+{
+    return adoptRef(*new EnhancedSecuritySitesHolder(databaseDirectoryPath));
+}
+
+EnhancedSecuritySitesHolder::EnhancedSecuritySitesHolder(const String& databaseDirectoryPath)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, path = crossThreadCopy(databaseDirectoryPath)] mutable {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence = makeUnique<EnhancedSecuritySitesPersistence>(WTFMove(path));
+    });
+}
+
+EnhancedSecuritySitesHolder::~EnhancedSecuritySitesHolder()
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton()->dispatch([container = WTFMove(m_enhancedSecurityPersistence)] { });
+}
+
+void EnhancedSecuritySitesHolder::fetchEnhancedSecurityOnlyDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)] mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            callOnMainRunLoop([completionHandler = WTFMove(completionHandler)] mutable {
+                completionHandler({ });
+            });
+            return;
+        }
+
+        auto enhancedSecuritySites = protectedThis->m_enhancedSecurityPersistence->fetchEnhancedSecurityOnlyDomains();
+
+        callOnMainRunLoop([enhancedSecuritySites = crossThreadCopy(enhancedSecuritySites), completionHandler = WTFMove(completionHandler)] mutable {
+            completionHandler(WTFMove(enhancedSecuritySites));
+        });
+    });
+}
+
+void EnhancedSecuritySitesHolder::fetchAllEnhancedSecuritySites(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)] mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            callOnMainRunLoop([completionHandler = WTFMove(completionHandler)] mutable {
+                completionHandler({ });
+            });
+            return;
+        }
+
+        auto enhancedSecuritySites = protectedThis->m_enhancedSecurityPersistence->fetchAllEnhancedSecuritySites();
+
+        callOnMainRunLoop([enhancedSecuritySites = crossThreadCopy(enhancedSecuritySites), completionHandler = WTFMove(completionHandler)] mutable {
+            completionHandler(WTFMove(enhancedSecuritySites));
+        });
+    });
+}
+
+void EnhancedSecuritySitesHolder::trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&& domain, EnhancedSecurity reason)
+{
+    ASSERT(isMainRunLoop());
+
+    if (domain.isEmpty())
+        return;
+
+    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, domain = crossThreadCopy(WTFMove(domain)), reason]() mutable {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence->trackEnhancedSecurityForDomain(WTFMove(domain), reason);
+    });
+}
+
+void EnhancedSecuritySitesHolder::deleteSites(const Vector<WebCore::RegistrableDomain>& sites, CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    if (sites.isEmpty())
+        return completionHandler();
+
+    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, sites = crossThreadCopy(sites), completionHandler = WTFMove(completionHandler)]() mutable {
+        auto wrappedCompletionHandler = [completionHandler = WTFMove(completionHandler)]() mutable {
+            callOnMainRunLoop(WTFMove(completionHandler));
+        };
+
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence->deleteSites(sites, WTFMove(wrappedCompletionHandler));
+        else
+            callOnMainRunLoop(WTFMove(completionHandler));
+    });
+}
+
+void EnhancedSecuritySitesHolder::deleteAllSites(CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)] mutable {
+        auto wrappedCompletionHandler = [completionHandler = WTFMove(completionHandler)]() mutable {
+            callOnMainRunLoop(WTFMove(completionHandler));
+        };
+
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence->deleteAllSites(WTFMove(wrappedCompletionHandler));
+        else
+            callOnMainRunLoop(WTFMove(completionHandler));
+    });
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.h
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "EnhancedSecurity.h"
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/ContinuousApproximateTime.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WorkQueue.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class EnhancedSecuritySitesPersistence;
+
+class EnhancedSecuritySitesHolder final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<EnhancedSecuritySitesHolder, WTF::DestructionThread::Main> {
+public:
+    static Ref<EnhancedSecuritySitesHolder> create(const String& databaseDirectoryPath);
+
+    ~EnhancedSecuritySitesHolder();
+
+    void fetchEnhancedSecurityOnlyDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
+    void fetchAllEnhancedSecuritySites(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
+
+    void trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&&, EnhancedSecurity);
+
+    void deleteSites(const Vector<WebCore::RegistrableDomain>&, CompletionHandler<void()>&&);
+    void deleteAllSites(CompletionHandler<void()>&&);
+
+private:
+    // Shared WorkQueue is used to prevent race condition when delete and create Persistence for same database file.
+    static Ref<WorkQueue> sharedWorkQueueSingleton();
+
+    EnhancedSecuritySitesHolder(const String& databasePath);
+
+    std::unique_ptr<EnhancedSecuritySitesPersistence> m_enhancedSecurityPersistence;
+};
+
+}

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EnhancedSecuritySitesPersistence.h"
+
+#include "Logging.h"
+#include <WebCore/RegistrableDomain.h>
+#include <WebCore/SQLiteStatement.h>
+#include <wtf/FileSystem.h>
+#include <wtf/MainThread.h>
+#include <wtf/Seconds.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/MakeString.h>
+
+#define ENHANCEDSECURITY_RELEASE_LOG(fmt, ...) RELEASE_LOG(EnhancedSecurity, "EnhancedSecuritySitesPersistence::" fmt, ##__VA_ARGS__)
+
+namespace WebKit {
+
+EnhancedSecuritySitesPersistence::EnhancedSecuritySitesPersistence(const String& databaseDirectoryPath)
+{
+    ASSERT(!isMainRunLoop());
+    openDatabase(databaseDirectoryPath);
+}
+
+EnhancedSecuritySitesPersistence::~EnhancedSecuritySitesPersistence()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (m_sqliteDB)
+        closeDatabase();
+}
+
+static constexpr auto sitesTableName = "sites"_s;
+static constexpr auto siteIndexName = "idx_sites_site"_s;
+static constexpr auto enhancedSecurityStateIndexName = "idx_sites_enhanced_security_state"_s;
+
+static constexpr auto createSitesTableSQL = "CREATE TABLE sites (site TEXT PRIMARY KEY NOT NULL, enhanced_security_state INT NOT NULL)"_s;
+static constexpr auto createEnhancedSecurityStateIndexSQL = "CREATE INDEX idx_sites_enhanced_security_state ON sites(enhanced_security_state)"_s;
+
+static constexpr auto selectAllSitesSQL = "SELECT site FROM sites"_s;
+
+static_assert(!static_cast<int>(EnhancedSecurity::Disabled), "EnhancedSecurity::Disabled is not 0 as expected");
+static constexpr auto selectEnhancedSecurityOnlySitesSQL = "SELECT site FROM sites WHERE enhanced_security_state != 0"_s;
+
+static constexpr auto selectSpecificSiteSQL = "SELECT enhanced_security_state FROM sites WHERE site = ?"_s;
+static constexpr auto deleteAllSitesSQL = "DELETE FROM sites"_s;
+static constexpr auto deleteSiteSQL = "DELETE FROM sites WHERE site = ?"_s;
+static constexpr auto insertSiteSQL = "INSERT OR REPLACE INTO sites (site, enhanced_security_state) VALUES (?, ?)"_s;
+
+void EnhancedSecuritySitesPersistence::reportSQLError(ASCIILiteral method, ASCIILiteral action)
+{
+    RELEASE_LOG_ERROR(EnhancedSecurity, "EnhancedSecuritySitesPersistence::%" PUBLIC_LOG_STRING ": Failed to %" PUBLIC_LOG_STRING " (%d) - %" PUBLIC_LOG_STRING, method.characters(), action.characters(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
+}
+
+static String databasePath(const String& directoryPath)
+{
+    ASSERT(!directoryPath.isEmpty());
+    return FileSystem::pathByAppendingComponent(directoryPath, "EnhancedSecuritySites.db"_s);
+}
+
+CheckedPtr<WebCore::SQLiteDatabase> EnhancedSecuritySitesPersistence::checkedDatabase() const
+{
+    return m_sqliteDB.get();
+}
+
+WebCore::SQLiteStatementAutoResetScope EnhancedSecuritySitesPersistence::cachedStatement(StatementType type)
+{
+    ASSERT(m_sqliteDB);
+
+    switch (type) {
+    case StatementType::SelectSite:
+        return WebCore::SQLiteStatementAutoResetScope { m_selectSpecificSiteSQLStatement.get() };
+    case StatementType::InsertSite:
+        return WebCore::SQLiteStatementAutoResetScope { m_insertSiteSQLStatement.get() };
+    case StatementType::DeleteSite:
+        return WebCore::SQLiteStatementAutoResetScope { m_deleteSQLStatement.get() };
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+bool EnhancedSecuritySitesPersistence::openDatabase(const String& directoryPath)
+{
+    ASSERT(!isMainRunLoop());
+    ASSERT(!directoryPath.isEmpty());
+
+    FileSystem::makeAllDirectories(directoryPath);
+
+    m_sqliteDB = makeUnique<WebCore::SQLiteDatabase>();
+    // This database is accessed from serial queue EnhancedSecuritySitesHolder::sharedWorkQueueSingleton().
+    checkedDatabase()->disableThreadingChecks();
+
+    auto reportErrorAndCloseDatabase = [&](ASCIILiteral action) {
+        reportSQLError("openDatabase"_s, action);
+        closeDatabase();
+        return false;
+    };
+
+    const auto path = databasePath(directoryPath);
+
+    if (!checkedDatabase()->open(path, WebCore::SQLiteDatabase::OpenMode::ReadWriteCreate, WebCore::SQLiteDatabase::OpenOptions::CanSuspendWhileLocked))
+        return reportErrorAndCloseDatabase("open database"_s);
+
+    if (!checkedDatabase()->tableExists(sitesTableName)) {
+        if (!checkedDatabase()->executeCommand(createSitesTableSQL))
+            return reportErrorAndCloseDatabase("create `sites` table"_s);
+
+        ENHANCEDSECURITY_RELEASE_LOG("openDatabase: Table %" PUBLIC_LOG_STRING " created", sitesTableName.characters());
+    }
+
+    if (!checkedDatabase()->indexExists(enhancedSecurityStateIndexName)) {
+        if (!checkedDatabase()->executeCommand(createEnhancedSecurityStateIndexSQL))
+            return reportErrorAndCloseDatabase("create `enhanced_security_state` index on `sites` table"_s);
+
+        ENHANCEDSECURITY_RELEASE_LOG("openDatabase: Index %" PUBLIC_LOG_STRING " created", enhancedSecurityStateIndexName.characters());
+    }
+
+    m_insertSiteSQLStatement = checkedDatabase()->prepareStatement(insertSiteSQL);
+    if (!m_insertSiteSQLStatement)
+        return reportErrorAndCloseDatabase("prepare insert statement"_s);
+
+    m_selectSpecificSiteSQLStatement = checkedDatabase()->prepareStatement(selectSpecificSiteSQL);
+    if (!m_selectSpecificSiteSQLStatement)
+        return reportErrorAndCloseDatabase("prepare select specific site statement"_s);
+
+    m_deleteSQLStatement = checkedDatabase()->prepareStatement(deleteSiteSQL);
+    if (!m_deleteSQLStatement)
+        return reportErrorAndCloseDatabase("prepare delete statement"_s);
+
+    checkedDatabase()->turnOnIncrementalAutoVacuum();
+
+    return true;
+}
+
+void EnhancedSecuritySitesPersistence::deleteSite(const WebCore::RegistrableDomain& site)
+{
+    if (!isDatabaseOpen())
+        return;
+
+    CheckedPtr deleteStatement = cachedStatement(StatementType::DeleteSite).get();
+
+    if (!deleteStatement
+        || deleteStatement->bindText(1, site.string()) != SQLITE_OK
+        || !deleteStatement->executeCommand())
+        reportSQLError("deleteSite"_s, "failed to delete site"_s);
+}
+
+void EnhancedSecuritySitesPersistence::deleteSites(const Vector<WebCore::RegistrableDomain>& sites, CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen())
+        return completionHandler();
+
+    for (auto& site : sites)
+        deleteSite(site);
+
+    completionHandler();
+}
+
+void EnhancedSecuritySitesPersistence::deleteAllSites(CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen())
+        return completionHandler();
+
+    auto deleteStatement = checkedDatabase()->prepareStatement(deleteAllSitesSQL);
+    if (!deleteStatement || !deleteStatement->executeCommand())
+        return reportSQLError("deleteAllSites"_s, "delete all sites"_s);
+
+    completionHandler();
+}
+
+HashSet<WebCore::RegistrableDomain> EnhancedSecuritySitesPersistence::fetchEnhancedSecurityOnlyDomains()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen())
+        return { };
+
+    auto selectStatement = checkedDatabase()->prepareStatement(selectEnhancedSecurityOnlySitesSQL);
+    if (!selectStatement) {
+        reportSQLError("fetchEnhancedSecurityOnlyDomains"_s, "fetch enhanced security only sites"_s);
+        return { };
+    }
+
+    HashSet<WebCore::RegistrableDomain> sites;
+    while (selectStatement->step() == SQLITE_ROW) {
+        auto site = selectStatement->columnText(0);
+        sites.add(WebCore::RegistrableDomain::fromRawString(String { site }));
+    }
+
+    return sites;
+}
+
+HashSet<WebCore::RegistrableDomain> EnhancedSecuritySitesPersistence::fetchAllEnhancedSecuritySites()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen())
+        return { };
+
+    auto selectStatement = checkedDatabase()->prepareStatement(selectAllSitesSQL);
+    if (!selectStatement) {
+        reportSQLError("fetchAllEnhancedSecuritySites"_s, "fetch all sites"_s);
+        return { };
+    }
+
+    HashSet<WebCore::RegistrableDomain> sites;
+    while (selectStatement->step() == SQLITE_ROW) {
+        auto site = selectStatement->columnText(0);
+        sites.add(WebCore::RegistrableDomain::fromRawString(String { site }));
+    }
+
+    return sites;
+}
+
+void EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&& site, EnhancedSecurity reason)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen())
+        return;
+
+    CheckedPtr selectSiteStatement = cachedStatement(StatementType::SelectSite).get();
+
+    if (!selectSiteStatement
+        || selectSiteStatement->bindText(1, site.string()) != SQLITE_OK)
+        reportSQLError("trackEnhancedSecurityForDomain"_s, "Failed to query specific site"_s);
+
+    if (selectSiteStatement->step() == SQLITE_ROW) {
+        if (static_cast<EnhancedSecurity>(selectSiteStatement->columnInt(0)) == EnhancedSecurity::Disabled)
+            return;
+    }
+
+    CheckedPtr insertSiteStatement = cachedStatement(StatementType::InsertSite).get();
+
+    int enhancedSecurityReason = static_cast<int>(reason);
+    if (!insertSiteStatement
+        || insertSiteStatement->bindText(1, site.string()) != SQLITE_OK
+        || insertSiteStatement->bindInt(2, enhancedSecurityReason) != SQLITE_OK
+        || !insertSiteStatement->executeCommand())
+        reportSQLError("trackEnhancedSecurityForDomain"_s, "Failed to insert or replace site"_s);
+}
+
+void EnhancedSecuritySitesPersistence::closeDatabase()
+{
+    ASSERT(!isMainRunLoop());
+
+    m_insertSiteSQLStatement = nullptr;
+    m_selectSpecificSiteSQLStatement = nullptr;
+    m_deleteSQLStatement = nullptr;
+
+    if (isDatabaseOpen()) {
+        ENHANCEDSECURITY_RELEASE_LOG("closeDatabase: Closing database");
+        checkedDatabase()->close();
+    }
+
+    m_sqliteDB = nullptr;
+}
+
+} // namespace WebKit
+
+#undef ENHANCEDSECURITY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "EnhancedSecurity.h"
+#include <WebCore/SQLiteDatabase.h>
+#include <WebCore/SQLiteStatementAutoResetScope.h>
+#include <wtf/ContinuousApproximateTime.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class EnhancedSecuritySitesPersistence final {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(EnhancedSecuritySitesPersistence);
+public:
+    EnhancedSecuritySitesPersistence(const String&);
+    ~EnhancedSecuritySitesPersistence();
+
+    bool openDatabase(const String& directoryPath);
+    bool isDatabaseOpen() const { return m_sqliteDB && m_sqliteDB->isOpen(); }
+
+    void deleteSites(const Vector<WebCore::RegistrableDomain>&, CompletionHandler<void()>&&);
+    void deleteAllSites(CompletionHandler<void()>&&);
+
+    HashSet<WebCore::RegistrableDomain> fetchEnhancedSecurityOnlyDomains();
+    HashSet<WebCore::RegistrableDomain> fetchAllEnhancedSecuritySites();
+
+    void trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&&, EnhancedSecurity);
+
+private:
+    CheckedPtr<WebCore::SQLiteDatabase> checkedDatabase() const;
+
+    enum class StatementType : uint8_t {
+        SelectSite,
+        InsertSite,
+        DeleteSite
+    };
+    WebCore::SQLiteStatementAutoResetScope cachedStatement(StatementType);
+
+    void deleteSite(const WebCore::RegistrableDomain&);
+
+    void closeDatabase();
+    void reportSQLError(ASCIILiteral method, ASCIILiteral action);
+
+    std::unique_ptr<WebCore::SQLiteDatabase> m_sqliteDB;
+    std::unique_ptr<WebCore::SQLiteStatement> m_selectSpecificSiteSQLStatement;
+    std::unique_ptr<WebCore::SQLiteStatement> m_insertSiteSQLStatement;
+    std::unique_ptr<WebCore::SQLiteStatement> m_deleteSQLStatement;
+};
+
+}

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -480,6 +480,9 @@ static void resolveDirectories(WebsiteDataStoreConfiguration::Directories& direc
     if (!directories.resourceMonitorThrottlerDirectory.isEmpty())
         directories.resourceMonitorThrottlerDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.resourceMonitorThrottlerDirectory);
 #endif
+
+    if (!directories.enhancedSecurityDirectory.isEmpty())
+        directories.enhancedSecurityDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.enhancedSecurityDirectory);
 }
 
 const WebsiteDataStoreConfiguration::Directories& WebsiteDataStore::resolvedDirectories() const
@@ -821,6 +824,16 @@ private:
         });
     }
 #endif
+
+    if (dataTypes.contains(WebsiteDataType::EnhancedSecuritySites)) {
+        fetchAllEnhancedSecuritySites([callbackAggregator] (HashSet<WebCore::RegistrableDomain>&& enhancedSecuritySites) {
+            WebsiteData websiteData;
+            websiteData.entries = WTF::map(enhancedSecuritySites, [](auto& entry) {
+                return WebsiteData::Entry { WebCore::SecurityOriginData { "https"_s, entry.string(), std::nullopt }, WebsiteDataType::EnhancedSecuritySites, 0 };
+            });
+            callbackAggregator->addWebsiteData(WTFMove(websiteData));
+        });
+    }
 }
 
 void WebsiteDataStore::fetchDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, OptionSet<WebsiteDataFetchOption> fetchOptions, Vector<WebCore::RegistrableDomain>&& domains, CompletionHandler<void(Vector<WebsiteDataRecord>&&, HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
@@ -976,6 +989,9 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime
     if (dataTypes.contains(WebsiteDataType::ScreenTime) && isPersistent())
         ScreenTimeWebsiteDataSupport::removeScreenTimeDataWithInterval(modifiedSince, configuration());
 #endif
+
+    if (dataTypes.contains(WebsiteDataType::EnhancedSecuritySites) && isPersistent())
+        removeAllEnhancedSecuritySites([callbackAggregator] { });
 }
 
 void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Vector<WebsiteDataRecord>& dataRecords, Function<void()>&& completionHandler)
@@ -1081,6 +1097,8 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Ve
         ScreenTimeWebsiteDataSupport::removeScreenTimeData(websitesToRemove, configuration());
     }
 #endif
+    if (dataTypes.contains(WebsiteDataType::EnhancedSecuritySites) && isPersistent())
+        removeEnhancedSecuritySites(origins, [callbackAggregator] { });
 }
 
 DeviceIdHashSaltStorage& WebsiteDataStore::ensureDeviceIdHashSaltStorage()
@@ -1618,6 +1636,11 @@ void WebsiteDataStore::resetCrossSiteLoadsWithLinkDecorationForTesting(Completio
 void WebsiteDataStore::deleteCookiesForTesting(const URL& url, bool includeHttpOnlyCookies, CompletionHandler<void()>&& completionHandler)
 {
     protectedNetworkProcess()->deleteCookiesForTesting(m_sessionID, WebCore::RegistrableDomain { url }, includeHttpOnlyCookies, WTFMove(completionHandler));
+}
+
+void WebsiteDataStore::hasLocalStorageOrCookies(const URL& url, CompletionHandler<void(bool)>&& completionHandler) const
+{
+    protectedNetworkProcess()->hasLocalStorageOrCookies(m_sessionID, WebCore::RegistrableDomain { url }, WTFMove(completionHandler));
 }
 
 void WebsiteDataStore::hasLocalStorageForTesting(const URL& url, CompletionHandler<void(bool)>&& completionHandler) const
@@ -2953,5 +2976,33 @@ void WebsiteDataStore::isStorageSuspendedForTesting(CompletionHandler<void(bool)
 {
     protectedNetworkProcess()->isStorageSuspendedForTesting(m_sessionID, WTFMove(completionHandler));
 }
+
+#if !PLATFORM(COCOA)
+
+void WebsiteDataStore::removeEnhancedSecuritySites(const Vector<WebCore::SecurityOriginData>&, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
+}
+
+void WebsiteDataStore::removeAllEnhancedSecuritySites(CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
+}
+
+void WebsiteDataStore::fetchEnhancedSecurityOnlyDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+void WebsiteDataStore::fetchAllEnhancedSecuritySites(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+void WebsiteDataStore::trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&& domain, EnhancedSecurity reason)
+{
+}
+
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EnhancedSecurity.h"
 #include "FrameInfoData.h"
 #include "NetworkSessionCreationParameters.h"
 #include "WebDeviceOrientationAndMotionAccessController.h"
@@ -43,6 +44,7 @@
 #include <pal/SessionID.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
+#include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
@@ -56,6 +58,7 @@
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
+#include "EnhancedSecuritySitesHolder.h"
 #include <pal/spi/cf/CFNetworkSPI.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
@@ -269,6 +272,7 @@ public:
     void setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&&);
     void resetCrossSiteLoadsWithLinkDecorationForTesting(CompletionHandler<void()>&&);
     void deleteCookiesForTesting(const URL&, bool includeHttpOnlyCookies, CompletionHandler<void()>&&);
+    void hasLocalStorageOrCookies(const URL&, CompletionHandler<void(bool)>&&) const;
     void hasLocalStorageForTesting(const URL&, CompletionHandler<void(bool)>&&) const;
     void hasIsolatedSessionForTesting(const URL&, CompletionHandler<void(bool)>&&) const;
     void setResourceLoadStatisticsShouldDowngradeReferrerForTesting(bool, CompletionHandler<void()>&&);
@@ -378,6 +382,7 @@ public:
     static String defaultWebsiteDataStoreDirectory(const WTF::UUID& identifier);
     static String defaultCookieStorageFile(const String& baseDataDirectory = nullString());
     static String defaultSearchFieldHistoryDirectory(const String& baseDataDirectory = nullString());
+    static String defaultEnhancedSecurityDirectory(const String& baseDataDirectory = nullString());
 #endif
     static String defaultServiceWorkerRegistrationDirectory(const String& baseDataDirectory = nullString());
     static String defaultLocalStorageDirectory(const String& baseDataDirectory = nullString());
@@ -525,6 +530,9 @@ public:
     void clearStorageAccessForTesting(CompletionHandler<void()>&&);
     void isStorageSuspendedForTesting(CompletionHandler<void(bool)>&&) const;
 
+    void trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&&, EnhancedSecurity);
+    void fetchEnhancedSecurityOnlyDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
+
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)
@@ -586,6 +594,14 @@ private:
     void removeDataInNetworkProcess(WebsiteDataStore::ProcessAccessType, OptionSet<WebsiteDataType>, WallTime, CompletionHandler<void()>&&);
 
     HashSet<WebCore::RegistrableDomain> platformAdditionalDomainsWithUserInteraction() const;
+
+#if PLATFORM(COCOA)
+    EnhancedSecuritySitesHolder& enhancedSecuritySitesHolder();
+#endif
+
+    void removeEnhancedSecuritySites(const Vector<WebCore::SecurityOriginData>&, CompletionHandler<void()>&&);
+    void removeAllEnhancedSecuritySites(CompletionHandler<void()>&&);
+    void fetchAllEnhancedSecuritySites(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
 
     const PAL::SessionID m_sessionID;
 
@@ -671,6 +687,10 @@ private:
 #endif
 
     HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypesForTesting;
+
+#if PLATFORM(COCOA)
+    const RefPtr<EnhancedSecuritySitesHolder> m_enhancedSecuritySites;
+#endif
 
 #if HAVE(NW_PROXY_CONFIG)
     std::optional<Vector<std::pair<Vector<uint8_t>, std::optional<WTF::UUID>>>> m_proxyConfigData;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -118,6 +118,7 @@ void WebsiteDataStoreConfiguration::initializePaths()
 #if PLATFORM(COCOA)
     setCookieStorageFile(WebsiteDataStore::defaultCookieStorageFile(m_baseDataDirectory));
     setSearchFieldHistoryDirectory(WebsiteDataStore::defaultSearchFieldHistoryDirectory(m_baseDataDirectory));
+    setEnhancedSecurityDirectory(WebsiteDataStore::defaultEnhancedSecurityDirectory(m_baseDataDirectory));
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -216,6 +217,7 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
 #if ENABLE(CONTENT_EXTENSIONS)
         crossThreadCopy(resourceMonitorThrottlerDirectory),
 #endif
+        crossThreadCopy(enhancedSecurityDirectory),
     };
 }
 
@@ -247,6 +249,7 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
 #if ENABLE(CONTENT_EXTENSIONS)
         crossThreadCopy(WTFMove(resourceMonitorThrottlerDirectory)),
 #endif
+        crossThreadCopy(WTFMove(enhancedSecurityDirectory)),
     };
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -261,6 +261,9 @@ public:
     void setAdditionalDomainsWithUserInteractionForTesting(String&& domains) { m_additionalDomainsWithUserInteractionForTesting = WTFMove(domains); }
     const String& additionalDomainsWithUserInteractionForTesting() const { return m_additionalDomainsWithUserInteractionForTesting; }
 
+    const String& enhancedSecurityDirectory() const { return m_directories.enhancedSecurityDirectory; }
+    void setEnhancedSecurityDirectory(String&& directory) { m_directories.enhancedSecurityDirectory = WTFMove(directory); }
+
     struct Directories {
         String alternativeServicesDirectory;
         String cacheStorageDirectory;
@@ -287,6 +290,7 @@ public:
 #if ENABLE(CONTENT_EXTENSIONS)
         String resourceMonitorThrottlerDirectory;
 #endif
+        String enhancedSecurityDirectory;
         Directories isolatedCopy() const&;
         Directories isolatedCopy() &&;
     };

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.h
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.h
@@ -33,6 +33,7 @@
 #import <wtf/CheckedPtr.h>
 #import <wtf/NakedPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
 class WebPageProxy;

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -42,6 +42,7 @@
 #import <wtf/Deque.h>
 #import <wtf/NakedPtr.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 // FIXME: Implement scrollFindMatchToVisible.

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -35,6 +35,7 @@
 #include "WKLayoutMode.h"
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/FocusDirection.h>
+#include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/KeypressCommand.h>
 #include <WebCore/PlatformPlaybackSessionInterface.h>
 #include <WebCore/ScrollTypes.h>

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7302,7 +7302,7 @@ void WebViewImpl::unregisterViewAboveScrollPocket(NSView *containerView)
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 #if ENABLE(VIDEO)
-void WebViewImpl::showCaptionDisplaySettings(HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
+void WebViewImpl::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     RetainPtr controller = adoptNS([[WKCaptionStyleMenuController alloc] init]);
     NSMenu *menu = [controller captionStyleMenu];

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1342,8 +1342,12 @@
 		561A54532B61E49E00073A72 /* CoreIPCSecCertificate.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */; };
 		561A54612B6438C000073A72 /* CoreIPCSecKeychainItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */; };
 		562674F52B69B4C8008BB425 /* CoreIPCSecTrust.h in Headers */ = {isa = PBXBuildFile; fileRef = 562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */; };
+		562844102ED9E5DD0080DD29 /* EnhancedSecuritySitesHolder.h in Headers */ = {isa = PBXBuildFile; fileRef = 5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */; };
+		562844112ED9E5E30080DD29 /* EnhancedSecuritySitesPersistence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */; };
 		564599972B71C3B700BC59E6 /* CoreIPCPresentationIntent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */; };
 		564599992B71C3D100BC59E6 /* CoreIPCPresentationIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = 564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */; };
+		56487A242E951686009CB259 /* EnhancedSecurity.h in Headers */ = {isa = PBXBuildFile; fileRef = 56487A232E951667009CB259 /* EnhancedSecurity.h */; };
+		56487A8D2EAFACEB009CB259 /* EnhancedSecurityTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = 56487A8B2EAFAC48009CB259 /* EnhancedSecurityTracking.h */; };
 		570AB8F320AE3BD700B8BE87 /* SecKeyProxyStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 570AB8F220AE3BD700B8BE87 /* SecKeyProxyStore.h */; };
 		570DAAAE23026F5C00E8FC04 /* NfcService.h in Headers */ = {isa = PBXBuildFile; fileRef = 570DAAAC23026F5C00E8FC04 /* NfcService.h */; };
 		570DAAC22303730300E8FC04 /* NfcConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 570DAAC02303730300E8FC04 /* NfcConnection.h */; };
@@ -6213,9 +6217,16 @@
 		561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecKeychainItem.h; sourceTree = "<group>"; };
 		562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecTrust.h; sourceTree = "<group>"; };
 		562674F42B69B4C8008BB425 /* CoreIPCSecTrust.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCSecTrust.serialization.in; sourceTree = "<group>"; };
+		5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecuritySitesPersistence.h; sourceTree = "<group>"; };
+		5628440D2ED9E5250080DD29 /* EnhancedSecuritySitesPersistence.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EnhancedSecuritySitesPersistence.cpp; sourceTree = "<group>"; };
+		5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecuritySitesHolder.h; sourceTree = "<group>"; };
+		5628440F2ED9E5580080DD29 /* EnhancedSecuritySitesHolder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnhancedSecuritySitesHolder.cpp; sourceTree = "<group>"; };
 		564599932B71BBA000BC59E6 /* CoreIPCPresentationIntent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPresentationIntent.serialization.in; sourceTree = "<group>"; };
 		564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPresentationIntent.h; sourceTree = "<group>"; };
 		564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPresentationIntent.mm; sourceTree = "<group>"; };
+		56487A232E951667009CB259 /* EnhancedSecurity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecurity.h; sourceTree = "<group>"; };
+		56487A8B2EAFAC48009CB259 /* EnhancedSecurityTracking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecurityTracking.h; sourceTree = "<group>"; };
+		56487A8C2EAFAC48009CB259 /* EnhancedSecurityTracking.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnhancedSecurityTracking.cpp; sourceTree = "<group>"; };
 		570AB8F220AE3BD700B8BE87 /* SecKeyProxyStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SecKeyProxyStore.h; sourceTree = "<group>"; };
 		570AB90020B2517400B8BE87 /* AuthenticationChallengeProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuthenticationChallengeProxyCocoa.mm; sourceTree = "<group>"; };
 		570AB90320B2541C00B8BE87 /* SecKeyProxyStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SecKeyProxyStore.mm; sourceTree = "<group>"; };
@@ -9845,6 +9856,10 @@
 			isa = PBXGroup;
 			children = (
 				1A4832C01A965A33008B4DFE /* Cocoa */,
+				5628440F2ED9E5580080DD29 /* EnhancedSecuritySitesHolder.cpp */,
+				5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */,
+				5628440D2ED9E5250080DD29 /* EnhancedSecuritySitesPersistence.cpp */,
+				5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */,
 				46B0524522668D2400265B97 /* WebDeviceOrientationAndMotionAccessController.cpp */,
 				46B0524422668D2300265B97 /* WebDeviceOrientationAndMotionAccessController.h */,
 				1A4832D81A9D1FD2008B4DFE /* WebsiteDataRecord.cpp */,
@@ -9987,6 +10002,7 @@
 				8CFECE931490F140002AAA32 /* EditorState.cpp */,
 				1AA41AB412C02EC4002BE67B /* EditorState.h */,
 				5C6CED8E2900598000B5D522 /* EditorState.serialization.in */,
+				56487A232E951667009CB259 /* EnhancedSecurity.h */,
 				93B42F2E29834A4200DF1D45 /* FileSystemSyncAccessHandleInfo.h */,
 				86BAAFD829A3D4040013F9A9 /* FileSystemSyncAccessHandleInfo.serialization.in */,
 				C59C4A5718B81174007BDCB6 /* FocusedElementInformation.h */,
@@ -15269,6 +15285,8 @@
 				1A6422FC12DD08FE00CAAE2C /* DrawingAreaProxy.messages.in */,
 				CDCDC99B248FE8DA00A69522 /* EndowmentStateTracker.h */,
 				CDCDC99C248FE8DA00A69522 /* EndowmentStateTracker.mm */,
+				56487A8C2EAFAC48009CB259 /* EnhancedSecurityTracking.cpp */,
+				56487A8B2EAFAC48009CB259 /* EnhancedSecurityTracking.h */,
 				0250C24E2B5DCAFB00D05C0B /* FindStringCallbackAggregator.cpp */,
 				0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */,
 				D6C27CBB2EC2759A00AA941F /* FindTextMatchesCallbackAggregator.cpp */,
@@ -17768,6 +17786,10 @@
 				DD4DB787280F945E001700D4 /* ElementDisplayed.js in Headers */,
 				BC032DA810F437D10058C15A /* Encoder.h in Headers */,
 				CDCDC99D248FE8DA00A69522 /* EndowmentStateTracker.h in Headers */,
+				56487A242E951686009CB259 /* EnhancedSecurity.h in Headers */,
+				562844102ED9E5DD0080DD29 /* EnhancedSecuritySitesHolder.h in Headers */,
+				562844112ED9E5E30080DD29 /* EnhancedSecuritySitesPersistence.h in Headers */,
+				56487A8D2EAFACEB009CB259 /* EnhancedSecurityTracking.h in Headers */,
 				DD4DB788280F9471001700D4 /* EnterFullscreen.js in Headers */,
 				51B15A8513843A3900321AD8 /* EnvironmentUtilities.h in Headers */,
 				1AA575FB1496B52600A4EE06 /* EventDispatcher.h in Headers */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -118,6 +118,7 @@ Tests/WebKitCocoa/EditorStateTests.mm @nonARC
 Tests/WebKitCocoa/ElementTargetingTests.mm @nonARC
 Tests/WebKitCocoa/ElementTextPreview.mm @nonARC
 Tests/WebKitCocoa/EnhancedSecurity.mm @nonARC
+Tests/WebKitCocoa/EnhancedSecurityPolicies.mm @nonARC
 Tests/WebKitCocoa/EventAttribution.mm @nonARC
 Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm @nonARC
 Tests/WebKitCocoa/ExitPiPOnSuspendVideoElement.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3091,6 +3091,7 @@
 		55A817FD218101DF0004A39A /* 400x400-green.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "400x400-green.png"; sourceTree = "<group>"; };
 		55A817FE218101DF0004A39A /* 100x100-red.tga */ = {isa = PBXFileReference; lastKnownFileType = file; path = "100x100-red.tga"; sourceTree = "<group>"; };
 		55F9D2E42205031800A9AB38 /* AdditionalSupportedImageTypes.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = AdditionalSupportedImageTypes.mm; sourceTree = "<group>"; };
+		562C00702E86DDC2009D428B /* EnhancedSecurityPolicies.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EnhancedSecurityPolicies.mm; sourceTree = "<group>"; };
 		56EEE4772D8D6B85003D4FB1 /* coreipc.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = coreipc.js; sourceTree = "<group>"; };
 		56EEE4822D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "RemoteObjectRegistry-BadReplyBlock.html"; sourceTree = "<group>"; };
 		56EEE48E2D8DB402003D4FB1 /* coreipc-helpers.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "coreipc-helpers.js"; sourceTree = "<group>"; };
@@ -4858,6 +4859,7 @@
 				F4DADCF62BABA65B008B398F /* ElementTargetingTests.mm */,
 				E502E42E2D39B79500C3D56D /* ElementTextPreview.mm */,
 				869429BF2E53635100E0DA9D /* EnhancedSecurity.mm */,
+				562C00702E86DDC2009D428B /* EnhancedSecurityPolicies.mm */,
 				6B25A75125DC8D4E0070744F /* EventAttribution.mm */,
 				CDA29B2820FD2A9900F15CED /* ExitFullscreenOnEnterPiP.mm */,
 				1D12BEBF245BEF85004C0B7A /* ExitPiPOnSuspendVideoElement.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -1,0 +1,1064 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebCore/SQLiteDatabase.h>
+#import <WebCore/SQLiteStatement.h>
+#import <WebKit/WKFoundation.h>
+#import <WebKit/WKFrameInfoPrivate.h>
+#import <WebKit/WKHTTPCookieStorePrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/WKWebpagePreferencesPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/WebKit.h>
+#import <WebKit/_WKFeature.h>
+#import <WebKit/_WKFrameTreeNode.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <wtf/Assertions.h>
+#import <wtf/Function.h>
+#import <wtf/RetainPtr.h>
+
+using namespace TestWebKitAPI;
+
+#if !PLATFORM(IOS)
+
+@interface TestUIDelegate (EnhancedSecurityExtras)
+- (NSArray *)waitForAlertWithEnhancedSecurity;
+@end
+
+@implementation TestUIDelegate (EnhancedSecurityExtras)
+
+- (NSArray *)waitForAlertWithEnhancedSecurity
+{
+    EXPECT_FALSE(self.runJavaScriptAlertPanelWithMessage);
+
+    __block bool finished = false;
+    __block RetainPtr<NSString> alertMessage;
+    __block RetainPtr<NSString> childFrameVariant;
+
+    self.runJavaScriptAlertPanelWithMessage = ^(WKWebView *webView, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
+        alertMessage = message;
+
+        // FIXME: rdar://164477631 (Fix Enhanced Security tests to work on non Apple Internal builds)
+#if USE(APPLE_INTERNAL_SDK)
+        childFrameVariant = [webView _webContentProcessVariantForFrame:frameInfo._handle];
+#else
+        childFrameVariant = @"unknown";
+#endif
+
+        finished = true;
+        completionHandler();
+    };
+
+    TestWebKitAPI::Util::run(&finished);
+
+    self.runJavaScriptAlertPanelWithMessage = nil;
+
+    BOOL enhancedSecurityEnabled = [childFrameVariant isEqualToString:@"security"];
+
+    NSArray *result = @[alertMessage.autorelease(), [NSNumber numberWithBool:enhancedSecurityEnabled]];
+    return result;
+}
+
+@end
+
+@interface WKWebView (EnhancedSecurityExtras)
+- (NSArray *)_test_waitForAlertWithEnhancedSecurity;
+@end
+
+@implementation WKWebView (EnhancedSecurityExtras)
+
+- (NSArray *)_test_waitForAlertWithEnhancedSecurity
+{
+    EXPECT_FALSE(self.UIDelegate);
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    self.UIDelegate = uiDelegate.get();
+    NSArray *result = [uiDelegate waitForAlertWithEnhancedSecurity];
+    self.UIDelegate = nil;
+    return result;
+}
+
+@end
+
+static void testAlertWithEnhancedSecurity(RetainPtr<TestUIDelegate> uiDelegate, String message, BOOL enhancedSecurityEnabled)
+{
+    NSArray *result = [uiDelegate waitForAlertWithEnhancedSecurity];
+
+    EXPECT_WK_STREQ(result[0], message);
+
+    // FIXME: rdar://164477631 (Fix Enhanced Security tests to work on non Apple Internal builds)
+#if USE(APPLE_INTERNAL_SDK)
+    EXPECT_EQ([result[1] boolValue], enhancedSecurityEnabled);
+#endif
+}
+
+static RetainPtr<TestWKWebView> enhancedSecurityTestConfiguration(
+    const TestWebKitAPI::HTTPServer* plaintextServer,
+    const TestWebKitAPI::HTTPServer* secureServer = nullptr,
+    bool useSiteIsolation = false,
+    bool useNonPersistentStore = true)
+{
+    auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+
+    [configuration preferences].javaScriptCanOpenWindowsAutomatically = YES;
+
+    auto preferences = [configuration preferences];
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ((useSiteIsolation && [feature.key isEqualToString:@"SiteIsolationEnabled"])
+            || [feature.key isEqualToString:@"EnhancedSecurityHeuristicsEnabled"]) {
+            [preferences _setEnabled:YES forFeature:feature];
+        }
+    }
+
+    auto storeConfiguration = useNonPersistentStore
+        ? adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration])
+        : adoptNS([_WKWebsiteDataStoreConfiguration new]);
+
+    if (plaintextServer)
+        [storeConfiguration setHTTPProxy:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", plaintextServer->port()]]];
+
+    if (secureServer)
+        [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", secureServer->port()]]];
+
+    [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:configuration]);
+
+    if (secureServer) {
+        auto navigationDelegate = [TestNavigationDelegate new];
+        [navigationDelegate allowAnyTLSCertificate];
+        [webView setNavigationDelegate: navigationDelegate];
+    }
+
+    return webView;
+}
+
+enum class ExpectedEnhancedSecurity : bool { Disabled = false, Enabled = true };
+
+static void runActionAndCheckEnhancedSecurityAlerts(
+    RetainPtr<TestWKWebView> webView,
+    Function<void()>&& performAction,
+    std::initializer_list<std::pair<String, ExpectedEnhancedSecurity>> alerts)
+{
+    RELEASE_ASSERT(!webView.get().UIDelegate);
+
+    __block auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+
+    __block auto navigationDelegate = [webView navigationDelegate];
+    __block RetainPtr<TestWKWebView> createdWebView;
+
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        createdWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        createdWebView.get().UIDelegate = uiDelegate.get();
+        createdWebView.get().navigationDelegate = navigationDelegate;
+        return createdWebView.get();
+    };
+
+    performAction();
+
+    for (auto& pair : alerts)
+        testAlertWithEnhancedSecurity(uiDelegate, pair.first, static_cast<bool>(pair.second));
+
+    [webView setUIDelegate:nil];
+}
+
+static void loadRequestAndCheckEnhancedSecurityAlerts(
+    RetainPtr<TestWKWebView> webView,
+    NSString *url,
+    std::initializer_list<std::pair<String, ExpectedEnhancedSecurity>> alerts)
+{
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView, url] {
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    }, alerts);
+}
+
+#define TEST_WITHOUT_SITE_ISOLATION(test_name) \
+TEST(EnhancedSecurityPolicies, test_name) \
+{ \
+    run##test_name(false); \
+} \
+
+#define TEST_WITH_SITE_ISOLATION(test_name) \
+TEST(EnhancedSecurityPolicies, test_name##WithSiteIsolation) \
+{ \
+    run##test_name(true); \
+}
+
+#define TEST_WITH_AND_WITHOUT_SITE_ISOLATION(test_name) \
+TEST_WITHOUT_SITE_ISOLATION(test_name) \
+\
+TEST_WITH_SITE_ISOLATION(test_name)
+
+// MARK: - Basic HTTP Detection Tests
+
+static void runHttpLoad(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-page')</script>"_s } },
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-page"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpLoad)
+
+static void runHttpsLoad(bool useSiteIsolation)
+{
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-page')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsLoad)
+
+static void runSameSiteHttpsUpgrade(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://example.co.uk/"_s, { 302, { { "Location"_s, "https://example.co.uk/"_s } }, emptyString() } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-page')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://example.co.uk/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(SameSiteHttpsUpgrade)
+
+// MARK: - Frame Tests
+
+static void runHttpEmbeddingHttpIframe(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<iframe src='http://insecure.different.internal/'></iframe>"_s } },
+        { "http://insecure.different.internal/"_s, { "<script>alert('redirected-page')</script>"_s } }
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "redirected-page"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpEmbeddingHttpIframe)
+
+static void runHttpEmbedHttpsIframe(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<iframe src='https://secure.example.internal/'></iframe>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('embed-iframe')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "embed-iframe"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpEmbedHttpsIframe)
+
+// MARK: - Redirection Tests
+
+static void runCrossSiteHttpRedirect(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://first.example.internal/"_s, { 302, { { "Location"_s, "http://second.different.internal/"_s } }, emptyString() } },
+        { "http://second.different.internal/"_s, { "<script>alert('redirected-site')</script>"_s } },
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://first.example.internal/", {
+        { "redirected-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(CrossSiteHttpRedirect)
+
+static void runCrossSiteHttpToHttpsRedirect(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { 302, { { "Location"_s, "https://secure.different.internal/"_s } }, emptyString() } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('redirected-site')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "redirected-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(CrossSiteHttpToHttpsRedirect)
+
+// MARK: - Window Tests
+
+static void runHttpOpeningHttpsWindow(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.open('https://secure.different.internal/'); }</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('opened-window')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "opened-window"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpOpeningHttpsWindow)
+
+static void runHttpOpeningHttpsTargetSelf(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.open('https://secure.different.internal/', '_self', 'noopener'); }</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('opened-window')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "opened-window"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpOpeningHttpsTargetSelf)
+
+static void runHttpOpeningHttpsNoOpener(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.open('https://secure.different.internal/', '_blank', 'noopener'); }</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('opened-window')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "opened-window"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpOpeningHttpsNoOpener)
+
+static void runHttpLocationRedirectsHttps(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.location = 'https://secure.different.internal/'; }</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('location-redirected-site')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "location-redirected-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpLocationRedirectsHttps)
+
+// MARK: - User / Client Input Tests
+
+static void runHttpThenUserNavigateToHttps(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-first-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-second-site');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-first-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/", {
+        { "secure-second-site"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenUserNavigateToHttps)
+
+static void runHttpThenClickLinkToHttps(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-first-site');</script><a id='testLink' href='https://secure.different.internal/'>Link</a>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-second-site')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-first-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView clickOnElementID:@"testLink"];
+    }, {
+        { "secure-second-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenClickLinkToHttps)
+
+static void runHttpsToHttpsThenBack(bool useSiteIsolation)
+{
+    HTTPServer secureServer({
+        { "/first"_s, { "<script>window.addEventListener('pageshow', function() { alert('first-page'); });</script>"_s } },
+        { "/second"_s, { "<script>alert('second-page')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/first", {
+        { "first-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/second", {
+        { "second-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        auto* backForwardList = [webView backForwardList];
+
+        EXPECT_TRUE(!!backForwardList.backItem);
+        EXPECT_EQ(1U, backForwardList.backList.count);
+
+        [webView goBack];
+    }, {
+        { "first-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsToHttpsThenBack)
+
+static void runHttpNavigateToHttpsThenBack(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.addEventListener('pageshow', function() { alert('insecure-first-site'); });</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-page');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-first-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        auto* backForwardList = [webView backForwardList];
+
+        EXPECT_TRUE(!!backForwardList.backItem);
+        EXPECT_EQ(1U, backForwardList.backList.count);
+
+        [webView goBack];
+    }, {
+        { "insecure-first-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpNavigateToHttpsThenBack)
+
+static void runMultiHopThenBack(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-first-site');  window.location.href = 'https://secure.example.internal/tainted'; </script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/tainted"_s, { "<script>window.addEventListener('pageshow', function() { alert('tainted-https-site'); });</script>"_s } },
+        { "/secure"_s, { "<script>alert('secure-page');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-first-site"_s, ExpectedEnhancedSecurity::Enabled },
+        { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/secure", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        auto* backForwardList = [webView backForwardList];
+
+        EXPECT_TRUE(!!backForwardList.backItem);
+        EXPECT_EQ(1U, backForwardList.backList.count);
+
+        [webView goBack];
+    }, {
+        { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+
+// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
+TEST_WITHOUT_SITE_ISOLATION(MultiHopThenBack)
+
+static void runMultiHopThenBackJavascript(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-first-site');  window.location.href = 'https://secure.example.internal/tainted'; </script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/tainted"_s, { "<script>window.addEventListener('pageshow', function() { alert('tainted-https-site'); });</script>"_s } },
+        { "/secure"_s, { "<script>alert('secure-page');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-first-site"_s, ExpectedEnhancedSecurity::Enabled },
+        { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/secure", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"history.back()" completionHandler:nil];
+    }, {
+        { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+
+// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
+TEST_WITHOUT_SITE_ISOLATION(MultiHopThenBackJavascript)
+
+static void runMultiHopThenBackToSecure(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>window.addEventListener('pageshow', function() { alert('secure-page'); });</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        auto* backForwardList = [webView backForwardList];
+
+        EXPECT_TRUE(!!backForwardList.backItem);
+        EXPECT_EQ(2U, backForwardList.backList.count);
+
+        [webView goBack];
+    }, {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(MultiHopThenBackToSecure)
+
+static void runMultiHopThenBackToSecureJavascript(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>window.addEventListener('pageshow', function() { alert('secure-page'); });</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        auto* backForwardList = [webView backForwardList];
+
+        EXPECT_TRUE(!!backForwardList.backItem);
+        EXPECT_EQ(2U, backForwardList.backList.count);
+
+        [webView evaluateJavaScript:@"history.back()" completionHandler:nil];
+    }, {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(MultiHopThenBackToSecureJavascript)
+
+static void runHttpThenNavigateToHttpsSiteWithCookies(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-site-with-cookies');</script>"_s } },
+        { "/set-cookie"_s, { "<script>document.cookie = 'CookieName=CookieValue; Path=/'; alert('cookie-set');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/set-cookie", {
+        { "cookie-set"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-with-cookies"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithCookies)
+
+static void runHttpThenNavigateToHttpsSiteWithLocalStorage(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-site-with-storage');</script>"_s } },
+        { "/set-storage"_s, { "<script>localStorage.setItem('KeyName', 'KeyValue'); alert('storage-set');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/set-storage", {
+        { "storage-set"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-with-storage"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithLocalStorage)
+
+static void runHttpThenHttpsThenNavigateToHttpsSiteWithCookies(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert(document.cookie ? 'secure-site-with-cookies' : 'secure-site-without-cookies');</script>"_s } },
+        { "/set-cookie"_s, { "<script>document.cookie = 'CookieName=CookieValue; Path=/'; alert('cookie-set');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.different.internal/set-cookie", {
+        { "cookie-set"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-without-cookies"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.different.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-with-cookies"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenHttpsThenNavigateToHttpsSiteWithCookies)
+
+static void runHttpThenNavigateToHttpsSiteWithCookiesThenHttps(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert(document.cookie ? 'secure-site-with-cookies' : 'secure-site-without-cookies');</script>"_s } },
+        { "/set-cookie"_s, { "<script>document.cookie = 'CookieName=CookieValue; Path=/'; alert('cookie-set');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.different.internal/set-cookie", {
+        { "cookie-set"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.different.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-with-cookies"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-without-cookies"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithCookiesThenHttps)
+
+static void runHttpThenNavigateToHttpsSetCookiesThenNavigateToHttpsAgain(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert(document.cookie ? 'secure-site-with-cookies' : 'secure-site-without-cookies');</script>"_s } },
+        { "/set-cookie"_s, { "<script>document.cookie = 'CookieName=CookieValue; Path=/'; alert('cookie-set');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/set-cookie'" completionHandler:nil];
+    }, {
+        { "cookie-set"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-with-cookies"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSetCookiesThenNavigateToHttpsAgain)
+
+static void runWindowOpenThenNavigateToMeaningfulSite(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert(document.cookie ? 'secure-site-with-cookies' : 'secure-site-without-cookies');</script>"_s } },
+        { "/set-cookie"_s, { "<script>document.cookie = 'CookieName=CookieValue; Path=/'; alert('cookie-set');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/set-cookie'" completionHandler:nil];
+    }, {
+        { "cookie-set"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.open('https://secure.example.internal/', '_blank', 'noopener');" completionHandler:nil];
+    }, {
+        { "secure-site-with-cookies"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(WindowOpenThenNavigateToMeaningfulSite)
+
+static void runReloadEnhancedSecurityRemains(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>window.onload = function() { alert('secure-site'); }</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView reload];
+    }, {
+        { "secure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(ReloadEnhancedSecurityRemains)
+
+static void runJavascriptRefreshEnhancedSecurityRemains(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>window.onload = function() { alert('secure-site'); }</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://secure.example.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.reload();" completionHandler:nil];
+    }, {
+        { "secure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(JavascriptRefreshEnhancedSecurityRemains)
+
+static void runHttpThenNavigateToHttpsSiteWithCookiesViaAPI(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-site-with-cookies');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    RetainPtr<NSHTTPCookie> sessionCookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieName: @"CookieName",
+        NSHTTPCookieValue: @"CookieValue",
+        NSHTTPCookieDomain: @"different.internal",
+    }];
+    [[webView configuration].websiteDataStore.httpCookieStore setCookie:sessionCookie.get() completionHandler:^{ }];
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://different.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-with-cookies"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithCookiesViaAPI)
+
+// Intentionally flipped to match EnhancedSecurity::Disabled, EnhancedSecurity::EnabledInsecure
+enum class SeenOutsideEnhancedSecurity : bool { Seen, NotSeen };
+
+static NSURL *enhancedSecuritySitesPath()
+{
+    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    NSURL *rootStorage = [dataStoreConfiguration.get().generalStorageDirectory URLByDeletingLastPathComponent];
+    NSURL *enhancedSecurityDirectory = [rootStorage URLByAppendingPathComponent:@"EnhancedSecurity"];
+    NSURL *enhancedSecurityFile = [enhancedSecurityDirectory URLByAppendingPathComponent:@"EnhancedSecuritySites.db"];
+    return enhancedSecurityFile;
+}
+
+static RetainPtr<NSString> emptyEnhancedSecuritySitesPath()
+{
+    NSFileManager *defaultFileManager = NSFileManager.defaultManager;
+
+    NSURL *enhancedSecurityFile = enhancedSecuritySitesPath();
+    NSURL *enhancedSecurityDirectory = [enhancedSecurityFile URLByDeletingLastPathComponent];
+
+    [defaultFileManager removeItemAtPath:enhancedSecurityDirectory.path error:nil];
+    EXPECT_FALSE([defaultFileManager fileExistsAtPath:enhancedSecurityFile.path]);
+    [defaultFileManager createDirectoryAtURL:enhancedSecurityDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+
+    return enhancedSecurityFile.path;
+}
+
+static void createEnhancedSecuritySitesTable(WebCore::SQLiteDatabase& database)
+{
+    constexpr auto createEnhancedSecuritySitesTable = "CREATE TABLE sites ("
+        "site TEXT PRIMARY KEY, enhanced_security_state INT NOT NULL)"_s;
+
+    EXPECT_TRUE(database.executeCommand(createEnhancedSecuritySitesTable));
+}
+
+static void addEnhancedSecuritySite(WebCore::SQLiteDatabase& database, String site, SeenOutsideEnhancedSecurity seenOutsideEnhancedSecurity)
+{
+    constexpr auto query = "INSERT INTO sites (site, enhanced_security_state) VALUES (?, ?)"_s;
+    auto statement = database.prepareStatement(query);
+    EXPECT_TRUE(!!statement);
+
+    EXPECT_EQ(statement->bindText(1, site), SQLITE_OK);
+    EXPECT_EQ(statement->bindInt(2, seenOutsideEnhancedSecurity == SeenOutsideEnhancedSecurity::Seen ? 0 : 1), SQLITE_OK);
+    EXPECT_EQ(statement->step(), SQLITE_DONE);
+    EXPECT_EQ(statement->reset(), SQLITE_OK);
+}
+
+static void setUpEnhancedSecuritySeenValues(std::initializer_list<std::pair<String, SeenOutsideEnhancedSecurity>> priorValues)
+{
+    auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(database->open(emptyEnhancedSecuritySitesPath().get()));
+
+    createEnhancedSecuritySitesTable(database.get());
+
+    RetainPtr<NSMutableDictionary> itemsDictionary = adoptNS([[NSMutableDictionary alloc] initWithCapacity:priorValues.size()]);
+    for (auto& pair : priorValues)
+        addEnhancedSecuritySite(database.get(), pair.first, pair.second);
+
+    database->close();
+}
+
+static void cleanUpEnhancedSecuritySites()
+{
+    NSFileManager *defaultFileManager = NSFileManager.defaultManager;
+    NSString* enhancedSecurityFile = enhancedSecuritySitesPath().path;
+
+    [defaultFileManager removeItemAtPath:enhancedSecurityFile error:nil];
+    while ([defaultFileManager fileExistsAtPath:enhancedSecurityFile])
+        usleep(10000);
+}
+
+static void runHttpThenNavigateToHttpsSiteWithCookiesViaAndExpectations(bool useSiteIsolation, SeenOutsideEnhancedSecurity seenOutsideEnhancedSecurity, ExpectedEnhancedSecurity finalExpectedEnhancedSecurity)
+{
+    setUpEnhancedSecuritySeenValues({
+        { "different.internal"_s, seenOutsideEnhancedSecurity }
+    });
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-site');</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-site-with-cookies');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation, /* useNonPersistentStore */ false);
+
+    RetainPtr<NSHTTPCookie> sessionCookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieName: @"CookieName",
+        NSHTTPCookieValue: @"CookieValue",
+        NSHTTPCookieDomain: @"different.internal",
+    }];
+    [[webView configuration].websiteDataStore.httpCookieStore setCookie:sessionCookie.get() completionHandler:^{ }];
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView]() {
+        [webView evaluateJavaScript:@"window.location.href = 'https://different.internal/'" completionHandler:nil];
+    }, {
+        { "secure-site-with-cookies"_s, finalExpectedEnhancedSecurity }
+    });
+
+    cleanUpEnhancedSecuritySites();
+}
+
+static void runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndNotSeenOutsideEnhancedSecurity(bool useSiteIsolation)
+{
+    runHttpThenNavigateToHttpsSiteWithCookiesViaAndExpectations(useSiteIsolation, SeenOutsideEnhancedSecurity::NotSeen, ExpectedEnhancedSecurity::Enabled);
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithCookiesViaAPIAndNotSeenOutsideEnhancedSecurity)
+
+static void runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhancedSecurity(bool useSiteIsolation)
+{
+    runHttpThenNavigateToHttpsSiteWithCookiesViaAndExpectations(useSiteIsolation, SeenOutsideEnhancedSecurity::Seen, ExpectedEnhancedSecurity::Disabled);
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhancedSecurity)
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.mm
@@ -25,6 +25,8 @@
 
 #import "config.h"
 #import "FindInPageUtilities.h"
+#import "Utilities.h"
+#import <WebKit/WKWebViewPrivate.h>
 
 #if HAVE(UIFINDINTERACTION)
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -98,6 +98,7 @@ const TestFeatures& TestOptions::defaults()
             { "DeveloperExtrasEnabled", true },
             { "DirectoryUploadEnabled", true },
             { "EncryptedMediaAPIEnabled", true },
+            { "EnhancedSecurityHeuristicsEnabled", false },
             { "EnumeratedARIAAttributeReflectionEnabled", false },
             { "EventHandlerDrivenSmoothKeyboardScrollingEnabled", eventHandlerDrivenSmoothKeyboardScrollingEnabledValue },
             { "ExposeSpeakersEnabled", true },


### PR DESCRIPTION
#### 93ffc509729c05e6a7c9920d1fe59d90fa092458
<pre>
Implement EnhancedSecurity HTTP and heuristics tracking.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302003">https://bugs.webkit.org/show_bug.cgi?id=302003</a>
<a href="https://rdar.apple.com/159219681">rdar://159219681</a>

Reviewed by NOBODY (OOPS!).

This change enables usage of EnhancedSecurity when various conditions occur.

In particular, if an insecure HTTP request is made for the main frame, which
is not later upgraded to a HTTPS site, we will enable EnhancedSecurity.

Various heuristics then apply to determine whether we will retain this
EnhancedSecurity state for subsequent navigations, which this change implements.

When a UI initiated navigation occurs we will disable EnhancedSecurity, dropping
back to a regular tab state.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::hasLocalStorageOrCookies):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Platform/Logging.h:
* Source/WebKit/Shared/EnhancedSecurity.h: Added.
(WebKit::enhancedSecurityEnabledForState):
(WebKit::enhancedSecurityStatesAreConsistent):
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::setEnhancedSecurity):
(WebKit::WebBackForwardListItem::enhancedSecurity const):
* Source/WebKit/Shared/WebsiteData/WebsiteData.cpp:
(WebKit::WebsiteData::ownerProcess):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.h:
(WebKit::toString):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setCurrentRequest):
(API::Navigation::setSiteHasStorage):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::currentRequestSiteHasStorage const):
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(dataTypesToString):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h:
(WebKit::toWebsiteDataType):
(WebKit::toWKWebsiteDataTypes):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate]):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp: Added.
(WebKit::enabledSitesMap):
(WebKit::didSitePreviouslyUseEnhancedSecurity):
(WebKit::EnhancedSecurityTracking::initializeWithWebsiteDataStore):
(WebKit::EnhancedSecurityTracking::updateEnhancedSecurityDomains):
(WebKit::EnhancedSecurityTracking::transfer):
(WebKit::EnhancedSecurityTracking::enhancedSecurityState const):
(WebKit::EnhancedSecurityTracking::reset):
(WebKit::EnhancedSecurityTracking::makeDormant):
(WebKit::EnhancedSecurityTracking::makeActive):
(WebKit::reasonForEnhancedSecurity):
(WebKit::EnhancedSecurityTracking::enableFor):
(WebKit::EnhancedSecurityTracking::trackChangingSiteNavigation):
(WebKit::EnhancedSecurityTracking::trackSameSiteNavigation):
(WebKit::EnhancedSecurityTracking::enableIfRequired):
(WebKit::EnhancedSecurityTracking::handleBackForwardNavigation):
(WebKit::EnhancedSecurityTracking::trackNavigation):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.h: Added.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::hasLocalStorageOrCookies):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardAddItemShared):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp:
(WebKit::WebFramePolicyListenerProxy::WebFramePolicyListenerProxy):
(WebKit::WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult):
(WebKit::WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData):
(WebKit::WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults):
(WebKit::WebFramePolicyListenerProxy::use):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h:
(WebKit::WebFramePolicyListenerProxy::create):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setUpPolicyListenerProxy):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::enhancedSecurityEnabled const):
(WebKit::WebPageProxy::beginSiteHasStorageCheck):
(WebKit::WebPageProxy::shouldEnableEnhancedSecurity const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::takeProcess):
(WebKit::WebProcessCache::takeSharedProcess):
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::createNewWebProcess):
(WebKit::WebProcessPool::tryTakePrewarmedProcess):
(WebKit::WebProcessPool::prewarmProcess):
(WebKit::WebProcessPool::processForSite):
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::prepareProcessForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultEnhancedSecurityDirectory):
(WebKit::WebsiteDataStore::enhancedSecuritySitesHolder):
(WebKit::WebsiteDataStore::trackEnhancedSecurityForDomain):
(WebKit::WebsiteDataStore::fetchEnhancedSecurityOnlyDomains):
(WebKit::WebsiteDataStore::fetchAllEnhancedSecuritySites):
(WebKit::WebsiteDataStore::removeEnhancedSecuritySites):
(WebKit::WebsiteDataStore::removeAllEnhancedSecuritySites):
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp: Added.
(WebKit::EnhancedSecuritySitesHolder::sharedWorkQueueSingleton):
(WebKit::EnhancedSecuritySitesHolder::create):
(WebKit::EnhancedSecuritySitesHolder::EnhancedSecuritySitesHolder):
(WebKit::EnhancedSecuritySitesHolder::~EnhancedSecuritySitesHolder):
(WebKit::EnhancedSecuritySitesHolder::fetchEnhancedSecurityOnlyDomains):
(WebKit::EnhancedSecuritySitesHolder::fetchAllEnhancedSecuritySites):
(WebKit::EnhancedSecuritySitesHolder::trackEnhancedSecurityForDomain):
(WebKit::EnhancedSecuritySitesHolder::deleteSites):
(WebKit::EnhancedSecuritySitesHolder::deleteAllSites):
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.h: Added.
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp: Added.
(WebKit::EnhancedSecuritySitesPersistence::EnhancedSecuritySitesPersistence):
(WebKit::EnhancedSecuritySitesPersistence::~EnhancedSecuritySitesPersistence):
(WebKit::EnhancedSecuritySitesPersistence::reportSQLError):
(WebKit::databasePath):
(WebKit::EnhancedSecuritySitesPersistence::checkedDatabase const):
(WebKit::EnhancedSecuritySitesPersistence::cachedStatement):
(WebKit::EnhancedSecuritySitesPersistence::openDatabase):
(WebKit::EnhancedSecuritySitesPersistence::deleteSite):
(WebKit::EnhancedSecuritySitesPersistence::deleteSites):
(WebKit::EnhancedSecuritySitesPersistence::deleteAllSites):
(WebKit::EnhancedSecuritySitesPersistence::fetchEnhancedSecurityOnlyDomains):
(WebKit::EnhancedSecuritySitesPersistence::fetchAllEnhancedSecuritySites):
(WebKit::EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain):
(WebKit::EnhancedSecuritySitesPersistence::closeDatabase):
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h: Added.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::resolveDirectories):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::hasLocalStorageOrCookies const):
(WebKit::WebsiteDataStore::removeEnhancedSecuritySites):
(WebKit::WebsiteDataStore::removeAllEnhancedSecuritySites):
(WebKit::WebsiteDataStore::fetchEnhancedSecurityOnlyDomains):
(WebKit::WebsiteDataStore::fetchAllEnhancedSecuritySites):
(WebKit::WebsiteDataStore::trackEnhancedSecurityForDomain):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::initializePaths):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy const):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::enhancedSecurityDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setEnhancedSecurityDirectory):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.h:
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::showCaptionDisplaySettings):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm: Added.
(-[TestUIDelegate waitForAlertWithEnhancedSecurity]):
(-[WKWebView _test_waitForAlertWithEnhancedSecurity]):
(testAlertWithEnhancedSecurity):
(enhancedSecurityTestConfiguration):
(runActionAndCheckEnhancedSecurityAlerts):
(loadRequestAndCheckEnhancedSecurityAlerts):
(runHttpLoad):
(runHttpsLoad):
(runSameSiteHttpsUpgrade):
(runHttpEmbeddingHttpIframe):
(runHttpEmbedHttpsIframe):
(runCrossSiteHttpRedirect):
(runCrossSiteHttpToHttpsRedirect):
(runHttpOpeningHttpsWindow):
(runHttpOpeningHttpsTargetSelf):
(runHttpOpeningHttpsNoOpener):
(runHttpLocationRedirectsHttps):
(runHttpThenUserNavigateToHttps):
(runHttpThenClickLinkToHttps):
(runHttpsToHttpsThenBack):
(runHttpNavigateToHttpsThenBack):
(runMultiHopThenBack):
(runMultiHopThenBackJavascript):
(runMultiHopThenBackToSecure):
(runMultiHopThenBackToSecureJavascript):
(runHttpThenNavigateToHttpsSiteWithCookies):
(runHttpThenNavigateToHttpsSiteWithLocalStorage):
(runHttpThenHttpsThenNavigateToHttpsSiteWithCookies):
(runHttpThenNavigateToHttpsSiteWithCookiesThenHttps):
(runHttpThenNavigateToHttpsSetCookiesThenNavigateToHttpsAgain):
(runWindowOpenThenNavigateToMeaningfulSite):
(runReloadEnhancedSecurityRemains):
(runJavascriptRefreshEnhancedSecurityRemains):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAPI):
(enhancedSecuritySitesPath):
(emptyEnhancedSecuritySitesPath):
(createEnhancedSecuritySitesTable):
(addEnhancedSecuritySite):
(setUpEnhancedSecuritySeenValues):
(cleanUpEnhancedSecuritySites):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAndExpectations):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndNotSeenOutsideEnhancedSecurity):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhancedSecurity):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.mm:
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea4c174682b21a738dc9e29112659e7e121eba17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85569 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102132 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69524 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82931 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4506 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2109 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125590 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143721 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132029 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5689 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110512 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110694 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4366 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115950 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59439 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5744 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34262 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164994 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69196 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43116 "Found 4 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/regexp-zero-length-alternatives.js.layout-no-llint, microbenchmarks/regexp-prototype-search-complex-pattern.js.no-cjit-collect-continuously, stress/simple-regexp-test-folding-fail.js.dfg-eager, wasm.yaml/wasm/function-tests/memory-alignment.js.wasm-eager (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5833 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->