### PR TITLE
Use correct format specifiers in UIGamepadProvider logging

### DIFF
--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -105,7 +105,8 @@ void UIGamepadProvider::scheduleGamepadStateSync()
 void UIGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, EventMakesGamepadsVisible eventVisibility)
 {
     RELEASE_ASSERT(isMainRunLoop());
-    RELEASE_LOG(Gamepad, "UIGamepadProvider::platformGamepadConnected - Gamepad index %i attached (visibility: %i, currently m_gamepads.size: %i)\n", gamepad.index(), (int)eventVisibility, (int)m_gamepads.size());
+    RELEASE_LOG(Gamepad, "UIGamepadProvider::platformGamepadConnected - Gamepad index %u attached (visibility: %s, currently m_gamepads.size: %zu)\n",
+        gamepad.index(), eventVisibility == EventMakesGamepadsVisible::Yes ? "yes" : "no", m_gamepads.size());
 
     if (m_gamepads.size() <= gamepad.index())
         m_gamepads.grow(gamepad.index() + 1);
@@ -122,7 +123,7 @@ void UIGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Event
 void UIGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
 {
     RELEASE_ASSERT(isMainRunLoop());
-    RELEASE_LOG(Gamepad, "UIGamepadProvider::platformGamepadConnected - Detaching gamepad index %i (Current m_gamepads size: %i)\n", gamepad.index(), (int)m_gamepads.size());
+    RELEASE_LOG(Gamepad, "UIGamepadProvider::platformGamepadConnected - Detaching gamepad index %u (Current m_gamepads size: %zu)\n", gamepad.index(), m_gamepads.size());
 
     ASSERT(gamepad.index() < m_gamepads.size());
     ASSERT(m_gamepads[gamepad.index()]);
@@ -132,7 +133,7 @@ void UIGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
         auto reason = makeString("Unknown platform gamepad disconnect: Index "_s, gamepad.index(), " with "_s, m_gamepads.size(), " known gamepads"_s);
         os_fault_with_payload(OS_REASON_WEBKIT, 0, nullptr, 0, reason.utf8().data(), 0);
 #else
-        RELEASE_LOG_ERROR(Gamepad, "Unknown platform gamepad disconnect: Index %zu with %zu known gamepads", gamepad.index(), m_gamepads.size());
+        RELEASE_LOG_ERROR(Gamepad, "Unknown platform gamepad disconnect: Index %u with %zu known gamepads", gamepad.index(), m_gamepads.size());
 #endif
         return;
     }
@@ -231,7 +232,7 @@ void UIGamepadProvider::stopMonitoringGamepads()
     if (!m_isMonitoringGamepads)
         return;
 
-    RELEASE_LOG(Gamepad, "UIGamepadProvider::stopMonitoringGamepads - Clearing m_gamepads vector of size %i", (int)m_gamepads.size());
+    RELEASE_LOG(Gamepad, "UIGamepadProvider::stopMonitoringGamepads - Clearing m_gamepads vector of size %zu", m_gamepads.size());
 
     m_isMonitoringGamepads = false;
 


### PR DESCRIPTION
#### 0a6a3aa627d3e82fc2489a3985a89ae913b3e346
<pre>
Use correct format specifiers in UIGamepadProvider logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=302329">https://bugs.webkit.org/show_bug.cgi?id=302329</a>

Reviewed by Michael Catanzaro.

Use the correct format (%u) for the gamepad index, for the size (%zu) of
the array, and explicitly convert an enum value to string for logging.

* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::platformGamepadConnected):
(WebKit::UIGamepadProvider::platformGamepadDisconnected):
(WebKit::UIGamepadProvider::stopMonitoringGamepads):

Canonical link: <a href="https://commits.webkit.org/302869@main">https://commits.webkit.org/302869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d3772d0aaaef7b48c06b608f7cf823e165888fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137924 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2669 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133453 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116865 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80126 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81183 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2567 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31648 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55545 "Hash 0d3772d0 for PR 53742 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2637 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66025 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->