### PR TITLE
[WPT][WebXR Hit Test] the promise test in webxr/hit-test/ar_hittest_subscription_states_regular.https.html doesn't work as expected

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Hit test subscription succeeds if the feature was requested - webgl
 PASS Hit test subscription succeeds if the feature was requested - webgl2
-PASS Hit test subscription fails if the feature was not requested - webgl
-PASS Hit test subscription fails if the feature was not requested - webgl2
+FAIL Hit test subscription fails if the feature was not requested - webgl assert_true: `requestHitTestSource` succeeded when it was expected to fail expected true got false
+FAIL Hit test subscription fails if the feature was not requested - webgl2 assert_true: `requestHitTestSource` succeeded when it was expected to fail expected true got false
 PASS Hit test subscription fails if the feature was requested but the session already ended - webgl
 PASS Hit test subscription fails if the feature was requested but the session already ended - webgl2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https.html
@@ -20,8 +20,8 @@ const fakeDeviceInitParams = {
 // |endSession| - true if the test case should call session.end() prior to requesting hit test
 // |expectedError| - expected error name that should be returned in case shouldSucceed is false
 const testFunctionGeneratorRegular = function(shouldSucceed, endSession, expectedError) {
-  const testFunction = function(session, fakeDeviceController, t) {
-    session.requestReferenceSpace('viewer').then((viewerRefSpace) => {
+  const testFunction = async function(session, fakeDeviceController, t) {
+      const viewerRefSpace = await session.requestReferenceSpace('viewer');
 
       const hitTestOptionsInit = {
         space: viewerRefSpace,
@@ -32,20 +32,20 @@ const testFunctionGeneratorRegular = function(shouldSucceed, endSession, expecte
         session.end();
       }
 
-      return session.requestHitTestSource(hitTestOptionsInit).then((hitTestSource) => {
-        t.step(() => {
-          assert_true(shouldSucceed,
-            "`requestHitTestSource` succeeded when it was expected to fail");
-        });
-      }).catch((error) => {
-        t.step(() => {
-          assert_false(shouldSucceed,
-            "`requestHitTestSource` failed when it was expected to succeed, error: " + error);
-          assert_equals(error.name, expectedError,
-            "`requestHitTestSource` failed with unexpected error name");
-        });
-      });
-    });
+      try {
+          const hitTestSource = await session.requestHitTestSource(hitTestOptionsInit);
+          t.step(() => {
+              assert_true(shouldSucceed,
+                  "`requestHitTestSource` succeeded when it was expected to fail");
+          });
+      } catch(error) {
+          t.step(() => {
+              assert_false(shouldSucceed,
+                  "`requestHitTestSource` failed when it was expected to succeed, error: " + error);
+              assert_equals(error.name, expectedError,
+                  "`requestHitTestSource` failed with unexpected error name");
+          });
+      };
   };
 
   return testFunction;


### PR DESCRIPTION
#### 104bb9f0be1fa1dd2b22950acc3e50c06ead5783
<pre>
[WPT][WebXR Hit Test] the promise test in webxr/hit-test/ar_hittest_subscription_states_regular.https.html doesn&apos;t work as expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=302330">https://bugs.webkit.org/show_bug.cgi?id=302330</a>

Reviewed by Dan Glastonbury.

In this test case, both requestReferenceSpace and requestHitTestSource return a
promise. These promises should be chained properly by using `then` like the
following code.

    session.requestReferenceSpace(...).then(refSpace =&gt; {
        ...
        return session.requestHitTestSource(...);
    }).then(hitTestSource =&gt; {
        ...
    })

However, the second promise was not chained, but using the second `then` inside
the first `then`.

    session.requestReferenceSpace(...).then(refSpace =&gt; {
        ...
        return session.requestHitTestSource(...).then(hitTestSource =&gt; {
            ...
        });
    })

This code doesn&apos;t wait the second promise to be settled.

Rather than using promises chaining, this change rewrote the test using
async&amp;await. This change should be exported to the upstream WPT.

After this change, this test starts to fail as expected due to a existing bug
&lt;<a href="https://webkit.org/b/302322">https://webkit.org/b/302322</a>&gt;.

* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https.html:

Canonical link: <a href="https://commits.webkit.org/302876@main">https://commits.webkit.org/302876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa769d98a87f2464bd88bcfa9fb7754c3ce66ca3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82073 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99399 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133416 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80099 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81146 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140366 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107821 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55508 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20329 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2600 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2419 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->