### PR TITLE
[JSC][32-bit] Optimize 64-bit operations in ARMv7 backend

### DIFF
--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -697,6 +697,8 @@ private:
         OP_ROR_reg_T2   = 0xFA60,
         OP_RBIT         = 0xFA90,
         OP_CLZ          = 0xFAB0,
+        OP_MUL_T2       = 0xFB00,
+        OP_MLA_T1       = 0xFB00,
         OP_SMULL_T1     = 0xFB80,
         OP_UMULL_T1     = 0xFBA0,
 #if HAVE(ARM_IDIV_INSTRUCTIONS)
@@ -1741,6 +1743,23 @@ public:
         ASSERT(!BadReg(rm));
         ASSERT(rdLo != rdHi);
         m_formatter.twoWordOp12Reg4FourFours(OP_UMULL_T1, rn, FourFours(rdLo, rdHi, 0, rm));
+    }
+
+    ALWAYS_INLINE void mul(RegisterID rd, RegisterID rn, RegisterID rm)
+    {
+        ASSERT(!BadReg(rd));
+        ASSERT(!BadReg(rn));
+        ASSERT(!BadReg(rm));
+        m_formatter.twoWordOp12Reg4FourFours(OP_MUL_T2, rn, FourFours(0xF, rd, 0, rm));
+    }
+
+    ALWAYS_INLINE void mla(RegisterID rd, RegisterID rn, RegisterID rm, RegisterID ra)
+    {
+        ASSERT(!BadReg(rd));
+        ASSERT(!BadReg(rn));
+        ASSERT(!BadReg(rm));
+        ASSERT(!BadReg(ra));
+        m_formatter.twoWordOp12Reg4FourFours(OP_MLA_T1, rn, FourFours(ra, rd, 0, rm));
     }
 
     // rt == ARMRegisters::pc only allowed if last instruction in IT (if then) block.

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2220,8 +2220,6 @@ private:
     enum class RotI64HelperOp { Left, Right };
     void rotI64Helper(RotI64HelperOp op, Location lhsLocation, Location rhsLocation, Location resultLocation);
 
-    void compareI64Helper(RelationalCondition condition, Location lhsLocation, Location rhsLocation, Location resultLocation);
-
     bool canTierUpToOMG() const;
 
     void emitIncrementCallProfileCount(unsigned callProfileIndex);


### PR DESCRIPTION
#### 73b3a4e9ff46a2be947f0377ccd0919d7efca6c8
<pre>
[JSC][32-bit] Optimize 64-bit operations in ARMv7 backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=302334">https://bugs.webkit.org/show_bug.cgi?id=302334</a>

Reviewed by Yusuke Suzuki.

Add dedicated backend functions for 64-bit operations with register
aliasing handling and reduced scratch register usage.

Changes:

* Added MUL and MLA instructions to ARMv7Assembler
* Added backend functions: and64, xor64, mul64, compare64, countLeadingZeros64, countTrailingZeros64
* Optimized add64/sub64 to avoid scratch register when possible
* All functions check for register overlap and only use scratch when necessary
* compare64 optimizes Equal/NotEqual to use single conditional move

* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::mul):
(JSC::ARMv7Assembler::mla):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::add64):
(JSC::MacroAssemblerARMv7::and64):
(JSC::MacroAssemblerARMv7::mul64):
(JSC::MacroAssemblerARMv7::countLeadingZeros64):
(JSC::MacroAssemblerARMv7::countTrailingZeros64):
(JSC::MacroAssemblerARMv7::compare64):
(JSC::MacroAssemblerARMv7::sub64):
(JSC::MacroAssemblerARMv7::xor64):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64And):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Xor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Clz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Ctz):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCompareI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::compareI64Helper): Deleted.

Canonical link: <a href="https://commits.webkit.org/302910@main">https://commits.webkit.org/302910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b49b1e349c1de2086b616a7f3253d2d9265b826d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82069 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99400 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67261 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81148 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122474 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140368 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128924 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107915 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107822 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27468 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31614 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55510 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2602 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65990 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161939 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2421 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40379 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2623 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->