### PR TITLE
Clean up OrderedHashTable Resizing

### DIFF
--- a/JSTests/stress/map-rehash-oom.js
+++ b/JSTests/stress/map-rehash-oom.js
@@ -1,0 +1,27 @@
+function testMap() {
+    const oomString = '\u1234'.padEnd(0x7fffffff, 'a');
+    const map = new Map();
+
+    map.set(1, null);
+    map.set(2, null);
+    map.set(3, null);
+    map.set(4, null);
+
+    map.delete(1);
+    map.delete(2);
+    map.delete(3);
+    map.delete(4);
+
+    try {
+        map.set(oomString, null);
+    } catch (e) {
+        if (!(e instanceof RangeError))
+            throw e;
+    }
+
+    if (map.size !== 0)
+        throw new Error("wrong size");
+}
+
+// This should run in a loop but it takes forever so just run it once.
+testMap();

--- a/JSTests/stress/set-rehash-oom.js
+++ b/JSTests/stress/set-rehash-oom.js
@@ -1,0 +1,27 @@
+function testSet() {
+    const oomString = '\u1234'.padEnd(0x7fffffff, 'a');
+    const set = new Set();
+
+    set.add(1);
+    set.add(2);
+    set.add(3);
+    set.add(4);
+
+    set.delete(1);
+    set.delete(2);
+    set.delete(3);
+    set.delete(4);
+
+    try {
+        set.add(oomString, null);
+    } catch (e) {
+        if (!(e instanceof RangeError))
+            throw e;
+    }
+
+    if (set.size !== 0)
+        throw new Error("wrong size");
+}
+
+// This should run in a loop but it takes forever so just run it once.
+testSet();

--- a/LayoutTests/http/tests/security/offscreen-canvas-remote-read-remote-image-expected.txt
+++ b/LayoutTests/http/tests/security/offscreen-canvas-remote-read-remote-image-expected.txt
@@ -1,0 +1,11 @@
+Test that offscreen canvas does not allow leaking cross-site image.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Calling toDataURL() on an untainted canvas was allowed.
+PASS Calling toDataURL() on remote image was not allowed - Threw error: (SecurityError: The operation is insecure.).
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/offscreen-canvas-remote-read-remote-image.html
+++ b/LayoutTests/http/tests/security/offscreen-canvas-remote-read-remote-image.html
@@ -1,0 +1,47 @@
+<script src="/js-test-resources/js-test.js"></script>
+<body>
+    <canvas width="200" height="200"></canvas>
+    <script>
+        function testToDataURL(canvas, state, shouldSucceed)
+        {
+            state = "Calling toDataURL() on " + state;
+            try {
+                var dataURL = canvas.toDataURL();
+                debug((shouldSucceed ? "PASS " : "FAIL ") + state + " was allowed.");
+            } catch (e) {
+                debug((shouldSucceed ? "FAIL " : "PASS ") + state + " was not allowed - Threw error: (" + e + ").");
+            }
+        }
+
+        (async () => {
+            description("Test that offscreen canvas does not allow leaking cross-site image.");
+
+            window.jsTestIsAsync = true;
+
+            const image = new Image;
+            image.src = "http://localhost:8000/security/resources/abe.png";
+            await image.decode();
+
+            const canvas = document.querySelector('canvas');
+
+            testToDataURL(canvas, "an untainted canvas", true);
+
+            const offscreenCanvas = canvas.transferControlToOffscreen();
+            const offscreenContext = offscreenCanvas.getContext('bitmaprenderer');
+            const imageBitmapLeak = await createImageBitmap(image);
+
+            offscreenContext.transferFromImageBitmap(imageBitmapLeak);
+
+            await new Promise((resolve) => {
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        resolve();
+                    });
+                });
+            });
+
+            testToDataURL(canvas, "remote image", false);
+            finishJSTest();
+        })();
+    </script>
+</body>

--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/options-range-error-expected.txt
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/options-range-error-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test with -1
+PASS Test with Number.MAX_SAFE_INTEGER
+

--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/options-range-error.html
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/options-range-error.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<title>Make sure we don't crash if the AudioWorklet gets constructed with parameters out of range.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+var context;
+promise_setup(async (t) => {
+  const processorCode = `class P extends AudioWorkletProcessor { process() { return true; } } registerProcessor('p', P);`;
+  context = new AudioContext();
+  const blob = new Blob([processorCode], { type: 'application/javascript' });
+  await context.audioWorklet.addModule(URL.createObjectURL(blob));
+});
+
+promise_test(async (t) => {
+  const options = {
+    numberOfInputs: -1,
+    numberOfOutputs: -1,
+    processorOptions: { win: window }
+  };
+
+  assert_throws_js(RangeError, () => { new AudioWorkletNode(context, 'p', options) });
+}, 'Test with -1');
+
+promise_test(async (t) => {
+  const options = {
+    numberOfInputs: Number.MAX_SAFE_INTEGER,
+    numberOfOutputs: Number.MAX_SAFE_INTEGER,
+    processorOptions: { win: window }
+  };
+
+  assert_throws_js(RangeError, () => { new AudioWorkletNode(context, 'p', options) });
+}, 'Test with Number.MAX_SAFE_INTEGER');
+</script>

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -313,23 +313,9 @@ public:
         return copyImpl<>(globalObject, base, capacity(base));
     }
 
-    enum class UpdateOwnerStorage : uint8_t {
-        Yes,
-        No
-    };
-    template<UpdateOwnerStorage update>
-    ALWAYS_INLINE static Storage* rehash(JSGlobalObject* globalObject, HashTable* owner, Storage& base, TableSize newCapacity)
+    ALWAYS_INLINE static Storage* rehash(JSGlobalObject* globalObject, Storage& base, TableSize newCapacity)
     {
-        VM& vm = getVM(globalObject);
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        Storage* copy = copyImpl<UpdateDeletedEntries::Yes>(globalObject, base, newCapacity);
-        RETURN_IF_EXCEPTION(scope, nullptr);
-
-        setNextTable(vm, base, copy);
-        if constexpr (update == UpdateOwnerStorage::Yes)
-            owner->m_storage.set(vm, owner, copy);
-        return copy;
+        return copyImpl<UpdateDeletedEntries::Yes>(globalObject, base, newCapacity);
     }
 
     ALWAYS_INLINE static void clear(JSGlobalObject* globalObject, HashTable* owner, Storage& base)
@@ -386,7 +372,7 @@ public:
         return { normalizedKey, hash, bucketIndex, InvalidTableIndex, nullptr };
     }
 
-    ALWAYS_INLINE static Storage* expandIfNeeded(JSGlobalObject* globalObject, HashTable* owner, Storage& base)
+    ALWAYS_INLINE static Storage* expandIfNeeded(JSGlobalObject* globalObject, Storage& base)
     {
         ASSERT(!isObsolete(base));
         TableSize capacity = Helper::capacity(base);
@@ -394,20 +380,22 @@ public:
         TableSize usedCapacity = Helper::aliveEntryCount(base) + deletedEntryCount;
 
         bool isSmallCapacity = capacity < LargeCapacity;
-        TableSize expandFactor = isSmallCapacity ? 2 : 1;
-
         if (isSmallCapacity) {
-            if (usedCapacity < (capacity >> 1))
-                return &base;
+            if (usedCapacity < (capacity / 2))
+                return nullptr;
         } else {
-            if (usedCapacity < ((capacity >> 2) * 3))
-                return &base;
+            if (usedCapacity < ((capacity / 4) * 3))
+                return nullptr;
         }
 
-        TableSize newCapacity = Checked<TableSize>(capacity) << expandFactor;
-        if (deletedEntryCount >= (capacity >> 1))
-            newCapacity = capacity; // No need to expanded. Just clear the deleted entries.
-        return rehash<UpdateOwnerStorage::No>(globalObject, owner, base, newCapacity);
+        TableSize expansionFactor = isSmallCapacity ? 4 : 2;
+        TableSize newCapacity = Checked<TableSize>(capacity) * expansionFactor;
+        if (deletedEntryCount >= (capacity  / 2)) {
+            // No need to expand. Just clear the deleted entries.
+            // FIXME: Can we do this in place?
+            newCapacity = capacity;
+        }
+        return rehash(globalObject, base, newCapacity);
     }
     template<typename FindKeyFunctor>
     ALWAYS_INLINE static void addImpl(JSGlobalObject* globalObject, HashTable* owner, Storage& base, JSValue key, JSValue value, const FindKeyFunctor& findKeyFunctor)
@@ -433,11 +421,7 @@ public:
         VM& vm = getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
         ASSERT(!isObsolete(base));
-
         ASSERT(!isValidTableIndex(result.entryKeyIndex));
-
-        Storage* candidate = expandIfNeeded(globalObject, owner, base);
-        RETURN_IF_EXCEPTION(scope, void());
 
         bool firstAliveEntry = result.normalizedKey.isEmpty();
         if (firstAliveEntry) [[unlikely]] {
@@ -446,23 +430,31 @@ public:
             RETURN_IF_EXCEPTION(scope, void());
         }
 
-        Storage& candidateRef = *candidate;
-        TableSize capacity = Helper::capacity(candidateRef);
-        Entry newEntry = usedCapacity(candidateRef);
-        TableIndex newEntryKeyIndex = entryDataStartIndex(dataTableStartIndex(capacity), newEntry);
-        incrementAliveEntryCount(candidateRef);
+        Storage* newBuffer = expandIfNeeded(globalObject, base);
+        RETURN_IF_EXCEPTION(scope, void());
 
-        bool rehashed = &base != candidate;
+        bool rehashed = newBuffer;
+        Storage& storage = newBuffer ? *newBuffer : base;
+
+        TableSize capacity = Helper::capacity(storage);
+        Entry newEntry = usedCapacity(storage);
+        TableIndex newEntryKeyIndex = entryDataStartIndex(dataTableStartIndex(capacity), newEntry);
+        incrementAliveEntryCount(storage);
+
         if (rehashed || firstAliveEntry) [[unlikely]]
             result.bucketIndex = bucketIndex(capacity, result.hash);
 
-        addToChain(candidateRef, result.bucketIndex, newEntryKeyIndex);
-        setKeyOrValueData(vm, candidateRef, newEntryKeyIndex, result.normalizedKey);
+        addToChain(storage, result.bucketIndex, newEntryKeyIndex);
+        setKeyOrValueData(vm, storage, newEntryKeyIndex, result.normalizedKey);
         if constexpr (Traits::hasValueData)
-            setKeyOrValueData(vm, candidateRef, newEntryKeyIndex + 1, value);
+            setKeyOrValueData(vm, storage, newEntryKeyIndex + 1, value);
 
-        if (rehashed) [[unlikely]]
-            owner->m_storage.set(vm, owner, candidate);
+        if (rehashed) [[unlikely]] {
+            // Only commit the new buffer once everything is set up. This way if things change and we end up throwing an exception in the middle we're not left in an inconsistent state.
+            ASSERT(&storage == newBuffer);
+            setNextTable(vm, base, newBuffer);
+            owner->m_storage.set(vm, owner, newBuffer);
+        }
     }
     ALWAYS_INLINE static void add(JSGlobalObject* globalObject, HashTable* owner, Storage& storage, JSValue key, JSValue value)
     {
@@ -480,6 +472,8 @@ public:
 
     ALWAYS_INLINE static void shrinkIfNeeded(JSGlobalObject* globalObject, HashTable* owner, Storage& base)
     {
+        VM& vm = globalObject->vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
         ASSERT(!isObsolete(base));
         TableSize capacity = Helper::capacity(base);
         TableSize aliveEntryCount = Helper::aliveEntryCount(base);
@@ -487,7 +481,12 @@ public:
             return;
         if (capacity == InitialCapacity)
             return;
-        rehash<UpdateOwnerStorage::Yes>(globalObject, owner, base, capacity >> 1);
+
+        Storage* newBuffer = rehash(globalObject, base, capacity / 2);
+        RETURN_IF_EXCEPTION(scope, void());
+
+        setNextTable(vm, base, newBuffer);
+        owner->m_storage.set(vm, owner, newBuffer);
     }
     template<typename FindKeyFunctor>
     ALWAYS_INLINE static bool removeImpl(JSGlobalObject* globalObject, HashTable* owner, Storage& storage, const FindKeyFunctor& findKeyFunctor)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -66,6 +66,12 @@ ExceptionOr<Ref<AudioWorkletNode>> AudioWorkletNode::create(JSC::JSGlobalObject&
     if (!options.numberOfInputs && !options.numberOfOutputs)
         return Exception { ExceptionCode::NotSupportedError, "Number of inputs and outputs cannot both be 0"_s };
 
+    if (options.numberOfInputs > UINT16_MAX)
+        return Exception { ExceptionCode::RangeError, "Number of inputs is out of range"_s };
+
+    if (options.numberOfOutputs > UINT16_MAX)
+        return Exception { ExceptionCode::RangeError, "Number of outputs is out of range"_s };
+
     if (options.outputChannelCount) {
         if (options.numberOfOutputs != options.outputChannelCount->size())
             return Exception { ExceptionCode::IndexSizeError, "Length of specified outputChannelCount does not match the given number of outputs"_s };

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -421,8 +421,8 @@ void OffscreenCanvas::commitToPlaceholderCanvas()
     RefPtr imageBuffer = m_context->surfaceBufferToImageBuffer(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
     if (!imageBuffer)
         return;
-    m_placeholderSource->setPlaceholderBuffer(*imageBuffer, m_context->isOpaque());
-    }
+    m_placeholderSource->setPlaceholderBuffer(*imageBuffer, m_context->canvasBase().originClean(), m_context->isOpaque());
+}
 
 void OffscreenCanvas::scheduleCommitToPlaceholderCanvas()
 {

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -45,7 +45,7 @@ public:
     virtual ~PlaceholderRenderingContextSource() = default;
 
     // Called by the offscreen context to submit the frame.
-    void setPlaceholderBuffer(ImageBuffer&, bool opaque);
+    void setPlaceholderBuffer(ImageBuffer&, bool originClean, bool opaque);
 
     // Called by the placeholder context to attach to compositor layer.
     void setContentsToLayer(GraphicsLayer&, ImageBuffer*, bool opaque);
@@ -69,7 +69,7 @@ public:
     HTMLCanvasElement& canvas() const;
     Ref<HTMLCanvasElement> protectedCanvas() const { return canvas(); }
     IntSize size() const;
-    void setPlaceholderBuffer(Ref<ImageBuffer>&&, bool opaque);
+    void setPlaceholderBuffer(Ref<ImageBuffer>&&, bool originClean, bool opaque);
 
     PlaceholderRenderingContextSource& source() const { return m_source; }
 


### PR DESCRIPTION
#### 8107fd50709174433bcaab8eab18333abb53d981
<pre>
Clean up OrderedHashTable Resizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=297708">https://bugs.webkit.org/show_bug.cgi?id=297708</a>
<a href="https://rdar.apple.com/158014775">rdar://158014775</a>

Reviewed by Yusuke Suzuki.

When inserting into an OrderedHashTable, if the buffer is resized then subsequently an
exception is thrown. The original buffer will be left in a inconsistent state. This patch
takes two approaches to this problem:

1) Compute the hash key before resizing. This isn&apos;t observable semantically since resizing
can only OOM and that is free to happen anywhere.

2) Only commit the new buffer once everything is set up. This way if we change our design
in the future and throw somewhere in the middle we&apos;ll just roll back to the previous state.

Lastly, convert some shifts into multiplications/divisions by the appropriate power of two.
Clang will convert the muls/divs into the corresponding shifts so we should focus on
readability.

Originally-landed-as: 297297.293@safari-7622-branch (5b49a0d04fbe). <a href="https://rdar.apple.com/164280528">rdar://164280528</a>
Canonical link: <a href="https://commits.webkit.org/302959@main">https://commits.webkit.org/302959@main</a>
</pre>
----------------------------------------------------------------------
#### 569f9f07502847a509d1592019b451ab0b15cfd8
<pre>
Offscreen canvas allows leaking cross-origin image
<a href="https://bugs.webkit.org/show_bug.cgi?id=297566">https://bugs.webkit.org/show_bug.cgi?id=297566</a>
<a href="https://rdar.apple.com/157055145">rdar://157055145</a>

Reviewed by Kimmo Kinnunen.

If a cross-origin image is drawn to an ImageBitmap and it is transferred to an
OffscreenCanvas, the context of the output canvas should be tainted.

* LayoutTests/http/tests/security/offscreen-canvas-remote-read-remote-image-expected.txt: Added.
* LayoutTests/http/tests/security/offscreen-canvas-remote-read-remote-image.html: Added.
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::commitToPlaceholderCanvas):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContextSource::setPlaceholderBuffer):
(WebCore::PlaceholderRenderingContext::setPlaceholderBuffer):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:

Originally-landed-as: 297297.288@safari-7622-branch (bdeaba2e1881). <a href="https://rdar.apple.com/164280686">rdar://164280686</a>
Canonical link: <a href="https://commits.webkit.org/302958@main">https://commits.webkit.org/302958@main</a>
</pre>
----------------------------------------------------------------------
#### 8df060354aae3827a95a06b196c8c8ce8a536cde
<pre>
Avoid careating AudioWorkletNode with out-of-range parameters
<a href="https://rdar.apple.com/156322582">rdar://156322582</a>

Reviewed by Ryosuke Niwa.

Existing implementation allows clients to create AudioWorkletNode with numberOfInputs and numberOfOutputs up to
UINT32_MAX, and this could lead to web content process crash when AudioWorkletNode tries to constuct Vectors with big
size. To avoid that, now we set the maximum allowed numbers to be UINT16_MAX (to match Firefox&apos;s behavior), and throw
RangeError if parameter is out of range.

* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/options-range-error-expected.txt: Added.
* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/options-range-error.html: Added.
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::create):

Originally-landed-as: 297297.215@safari-7622-branch (d4b50b1f7725). <a href="https://rdar.apple.com/164281024">rdar://164281024</a>
Canonical link: <a href="https://commits.webkit.org/302957@main">https://commits.webkit.org/302957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/026095a3d73e07a7632ed7c7379b1b040ea7e836

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82334 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c35686b-e9fc-415b-93ac-94d83e42398b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99575 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad1a998e-f3a8-4d1e-a144-b71d4bb6f3c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80283 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a275a3fd-5605-4e30-8602-47d6bef07333) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35164 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81378 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122704 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140602 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129154 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108080 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55759 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2832 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66221 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162169 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2652 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40444 "Found 18 new JSC stress test failures: stress/map-rehash-oom.js.bytecode-cache, stress/map-rehash-oom.js.default, stress/map-rehash-oom.js.dfg-eager, stress/map-rehash-oom.js.dfg-eager-no-cjit-validate, stress/map-rehash-oom.js.eager-jettison-no-cjit, stress/map-rehash-oom.js.mini-mode, stress/map-rehash-oom.js.no-cjit-collect-continuously, stress/map-rehash-oom.js.no-cjit-validate-phases, stress/map-rehash-oom.js.no-llint, stress/set-rehash-oom.js.bytecode-cache ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2853 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2758 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->