### PR TITLE
[bmalloc] Make SystemHeap enabled but unused by default

### DIFF
--- a/Source/bmalloc/bmalloc/Allocator.cpp
+++ b/Source/bmalloc/bmalloc/Allocator.cpp
@@ -42,7 +42,7 @@ Allocator::Allocator(Heap& heap, Deallocator& deallocator)
     : m_heap(heap)
     , m_deallocator(deallocator)
 {
-    BASSERT(!Environment::get()->isSystemHeapEnabled());
+    BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
     for (size_t sizeClass = 0; sizeClass < sizeClassCount; ++sizeClass)
         m_bumpAllocators[sizeClass].init(objectSize(sizeClass));
 }

--- a/Source/bmalloc/bmalloc/Deallocator.cpp
+++ b/Source/bmalloc/bmalloc/Deallocator.cpp
@@ -45,7 +45,7 @@ namespace bmalloc {
 Deallocator::Deallocator(Heap& heap)
     : m_heap(heap)
 {
-    BASSERT(!Environment::get()->isSystemHeapEnabled());
+    BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
 }
 
 Deallocator::~Deallocator()

--- a/Source/bmalloc/bmalloc/Environment.h
+++ b/Source/bmalloc/bmalloc/Environment.h
@@ -35,11 +35,14 @@ public:
     BEXPORT Environment(const LockHolder&);
     
     bool isSystemHeapEnabled() { return m_isSystemHeapEnabled; }
+    bool shouldBmallocAllocateThroughSystemHeap() { return m_shouldBmallocAllocateThroughSystemHeap; }
 
 private:
     bool computeIsSystemHeapEnabled();
+    bool computeShouldBmallocAllocateThroughSystemHeap();
 
     bool m_isSystemHeapEnabled;
+    bool m_shouldBmallocAllocateThroughSystemHeap;
 };
 BALLOW_DEPRECATED_DECLARATIONS_BEGIN
 DECLARE_STATIC_PER_PROCESS_STORAGE(Environment);

--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -274,7 +274,7 @@ bool shouldBeEnabled()
             RELEASE_BASSERT(!g_gigacageConfig.shouldBeEnabledHasBeenCalled);
             g_gigacageConfig.shouldBeEnabledHasBeenCalled = true;
 
-            bool systemHeapEnabled = Environment::get()->isSystemHeapEnabled();
+            bool systemHeapEnabled = Environment::get()->shouldBmallocAllocateThroughSystemHeap();
             if (systemHeapEnabled)
                 return;
 

--- a/Source/bmalloc/bmalloc/Heap.cpp
+++ b/Source/bmalloc/bmalloc/Heap.cpp
@@ -53,7 +53,7 @@ namespace bmalloc {
 Heap::Heap(HeapKind kind, LockHolder&)
     : m_kind { kind }, m_constants { *HeapConstants::get() }
 {
-    BASSERT(!Environment::get()->isSystemHeapEnabled());
+    BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
 
     Gigacage::ensureGigacage();
 #if GIGACAGE_ENABLED

--- a/Source/bmalloc/bmalloc/IsoMallocFallback.cpp
+++ b/Source/bmalloc/bmalloc/IsoMallocFallback.cpp
@@ -56,7 +56,7 @@ void determineMallocFallbackState()
             if (mallocFallbackState != MallocFallbackState::Undecided)
                 return;
 
-            if (Environment::get()->isSystemHeapEnabled()) {
+            if (Environment::get()->shouldBmallocAllocateThroughSystemHeap()) {
                 mallocFallbackState = MallocFallbackState::FallBackToMalloc;
                 return;
             }

--- a/Source/bmalloc/bmalloc/IsoTLS.cpp
+++ b/Source/bmalloc/bmalloc/IsoTLS.cpp
@@ -56,7 +56,7 @@ void IsoTLS::scavenge()
 
 IsoTLS::IsoTLS()
 {
-    BASSERT(!Environment::get()->isSystemHeapEnabled());
+    BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
 }
 
 IsoTLS* IsoTLS::ensureEntries(unsigned offset)

--- a/Source/bmalloc/bmalloc/IsoTLSInlines.h
+++ b/Source/bmalloc/bmalloc/IsoTLSInlines.h
@@ -102,7 +102,7 @@ BNO_INLINE void* IsoTLS::allocateSlow(api::IsoHeapBase<Type>& handle, bool abort
         return fallbackResult.ptr;
     
     // If system heap is enabled, IsoMallocFallback::mallocFallbackState becomes MallocFallbackState::FallBackToMalloc.
-    BASSERT(!Environment::get()->isSystemHeapEnabled());
+    BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
     
     IsoTLS* tls = ensureHeapAndEntries(handle);
     
@@ -141,7 +141,7 @@ BNO_INLINE void IsoTLS::deallocateSlow(api::IsoHeapBase<Type>& handle, void* p)
         return;
     
     // If system heap is enabled, IsoMallocFallback::mallocFallbackState becomes MallocFallbackState::FallBackToMalloc.
-    BASSERT(!Environment::get()->isSystemHeapEnabled());
+    BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
     
     RELEASE_BASSERT(handle.isInitialized());
     

--- a/Source/bmalloc/bmalloc/Scavenger.cpp
+++ b/Source/bmalloc/bmalloc/Scavenger.cpp
@@ -76,7 +76,7 @@ DEFINE_STATIC_PER_PROCESS_STORAGE(Scavenger);
 
 Scavenger::Scavenger(const LockHolder&)
 {
-    BASSERT(!Environment::get()->isSystemHeapEnabled());
+    BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
 
 #if BOS(DARWIN)
     auto queue = dispatch_queue_create("WebKit Malloc Memory Pressure Handler", DISPATCH_QUEUE_SERIAL);
@@ -275,7 +275,7 @@ size_t Scavenger::freeableMemory()
 
 size_t Scavenger::footprint()
 {
-    RELEASE_BASSERT(!Environment::get()->isSystemHeapEnabled());
+    RELEASE_BASSERT(!Environment::get()->shouldBmallocAllocateThroughSystemHeap());
 
     size_t result = 0;
     for (unsigned i = numHeaps; i--;) {

--- a/Source/bmalloc/bmalloc/SystemHeap.cpp
+++ b/Source/bmalloc/bmalloc/SystemHeap.cpp
@@ -270,6 +270,24 @@ bool pas_system_heap_is_enabled(pas_heap_config_kind kind)
     }
 }
 
+bool pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind kind)
+{
+    SystemHeap* heap;
+    switch (kind) {
+    case pas_heap_config_kind_bmalloc:
+        heap = SystemHeap::tryGet();
+        if (!heap)
+            return false;
+        return heap->shouldSupplantBmalloc();
+    case pas_heap_config_kind_jit:
+    case pas_heap_config_kind_pas_utility:
+        return false;
+    default:
+        BCRASH();
+        return false;
+    }
+}
+
 void* pas_system_heap_malloc(size_t size)
 {
     auto systemHeap = SystemHeap::getExisting();
@@ -326,6 +344,12 @@ void pas_system_heap_free(void* ptr)
 #else // BUSE(LIBPAS) -> so !BUSE(LIBPAS)
 
 bool pas_system_heap_is_enabled(pas_heap_config_kind kind)
+{
+    BUNUSED_PARAM(kind);
+    return false;
+}
+
+bool pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind kind)
 {
     BUNUSED_PARAM(kind);
     return false;

--- a/Source/bmalloc/bmalloc/SystemHeap.h
+++ b/Source/bmalloc/bmalloc/SystemHeap.h
@@ -61,7 +61,10 @@ public:
     void scavenge();
     void dump();
 
+    bool shouldSupplantBmalloc() { return Environment::get()->shouldBmallocAllocateThroughSystemHeap(); };
+
     static SystemHeap* tryGet();
+    static SystemHeap* tryGetIfShouldSupplantBmalloc();
     static SystemHeap* getExisting();
 
 #if BENABLE(MALLOC_HEAP_BREAKDOWN) || BOS(DARWIN)
@@ -98,6 +101,16 @@ BINLINE SystemHeap* SystemHeap::tryGet()
     if (result)
         return result;
     return tryGetSlow();
+}
+
+BINLINE SystemHeap* SystemHeap::tryGetIfShouldSupplantBmalloc()
+{
+    SystemHeap* result = systemHeapCache;
+    if (result == systemHeapDisabled())
+        return nullptr;
+    if (!result)
+        result = tryGetSlow();
+    return result->shouldSupplantBmalloc() ? result : nullptr;
 }
 
 BINLINE SystemHeap* SystemHeap::getExisting()

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -123,7 +123,7 @@ void determineTZoneMallocFallback()
     if (tzoneMallocFallback != TZoneMallocFallback::Undecided)
         return;
 
-    if (Environment::get()->isSystemHeapEnabled()) {
+    if (Environment::get()->shouldBmallocAllocateThroughSystemHeap()) {
         tzoneMallocFallback = TZoneMallocFallback::ForceDebugMalloc;
         return;
     }

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -268,7 +268,7 @@ BEXPORT void forceEnablePGM(uint16_t guardMallocRate);
 #if BENABLE(MALLOC_SIZE)
 inline size_t mallocSize(const void* object)
 {
-    if (auto* systemHeap = SystemHeap::tryGet())
+    if (auto* systemHeap = SystemHeap::tryGetIfShouldSupplantBmalloc())
         return systemHeap->mallocSize(object);
     return bmalloc_get_allocation_size(const_cast<void*>(object));
 }
@@ -277,7 +277,7 @@ inline size_t mallocSize(const void* object)
 #if BENABLE(MALLOC_GOOD_SIZE)
 inline size_t mallocGoodSize(size_t size)
 {
-    if (auto* systemHeap = SystemHeap::tryGet())
+    if (auto* systemHeap = SystemHeap::tryGetIfShouldSupplantBmalloc())
         return systemHeap->mallocGoodSize(size);
     return size;
 }

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.c
@@ -55,7 +55,7 @@ void bmalloc_heap_config_activate(void)
                                              &bmalloc_heap_config);
 
 #if PAS_OS(DARWIN)
-    if (register_with_libmalloc && !pas_system_heap_is_enabled(pas_heap_config_kind_bmalloc))
+    if (register_with_libmalloc && !pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind_bmalloc))
         pas_root_ensure_for_libmalloc_enumeration();
 #endif
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
@@ -128,7 +128,7 @@ bool pas_try_deallocate_slow_no_cache(void* ptr,
 
     if (verbose)
         pas_log("Trying to deallocate %p.\n", ptr);
-    if (PAS_UNLIKELY(pas_system_heap_is_enabled(config_ptr->kind))) {
+    if (PAS_UNLIKELY(pas_system_heap_should_supplant_bmalloc(config_ptr->kind))) {
         if (verbose)
             pas_log("Deallocating %p with system heap.\n", ptr);
         PAS_ASSERT(deallocation_mode == pas_deallocate_mode);

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -105,7 +105,7 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate_not_small_exclusive_segregated(
         }
     }
 
-    if (pas_system_heap_is_enabled(config.kind)) {
+    if (pas_system_heap_should_supplant_bmalloc(config.kind)) {
         pas_system_heap_free((void*)begin);
         return true;
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -1586,7 +1586,7 @@ pas_local_allocator_try_allocate_small_segregated_slow_impl(
     pas_heap_config config,
     pas_allocator_counts* counts)
 {
-    PAS_ASSERT(!pas_system_heap_is_enabled(config.kind));
+    PAS_ASSERT(!pas_system_heap_should_supplant_bmalloc(config.kind));
     
     pas_local_allocator_commit_if_necessary(allocator, config);
     
@@ -1718,7 +1718,7 @@ pas_local_allocator_try_allocate_slow_impl(pas_local_allocator* allocator,
                 pas_local_allocator_config_kind_get_string(allocator->config_kind));
     }
     
-    PAS_ASSERT(!pas_system_heap_is_enabled(config.kind));
+    PAS_ASSERT(!pas_system_heap_should_supplant_bmalloc(config.kind));
     
     pas_local_allocator_commit_if_necessary(allocator, config);
     
@@ -1860,7 +1860,7 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
             pas_allocation_result_create_success_with_zero_mode(result.begin, result.zero_mode));
     }
 
-    if (PAS_UNLIKELY(pas_system_heap_is_enabled(config.kind)))
+    if (PAS_UNLIKELY(pas_system_heap_should_supplant_bmalloc(config.kind)))
         return pas_system_heap_allocate(size, alignment, allocation_mode);
     
     if (config.small_segregated_config.base.is_enabled &&

--- a/Source/bmalloc/libpas/src/libpas/pas_system_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_system_heap.h
@@ -48,6 +48,7 @@ PAS_BEGIN_EXTERN_C;
 
 /* The implementations are provided by bmalloc. */
 BEXPORT extern bool pas_system_heap_is_enabled(pas_heap_config_kind);
+BEXPORT extern bool pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind);
 BEXPORT extern void* pas_system_heap_malloc(size_t);
 BEXPORT extern void* pas_system_heap_memalign(size_t alignment, size_t);
 BEXPORT extern void* pas_system_heap_realloc(void* ptr, size_t);
@@ -58,7 +59,13 @@ BEXPORT extern void pas_system_heap_free(void* ptr);
 
 #else /* PAS_BMALLOC -> so !PAS_BMALLOC */
 
-static inline bool pas_system_heap_is_enabled(pas_heap_config_kind kind)
+static inline bool pas_system_heap_is_enabled(pas_heap_config_kind)
+{
+    PAS_UNUSED_PARAM(kind);
+    return false;
+}
+
+static inline bool pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind kind)
 {
     PAS_UNUSED_PARAM(kind);
     return false;

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -501,7 +501,7 @@ pas_thread_local_cache_get_local_allocator_if_can_set_cache_for_possibly_uniniti
     unsigned allocator_index,
     const pas_heap_config* heap_config)
 {
-    if (!pas_thread_local_cache_can_set() || pas_system_heap_is_enabled(heap_config->kind))
+    if (!pas_thread_local_cache_can_set() || pas_system_heap_should_supplant_bmalloc(heap_config->kind))
         return pas_local_allocator_result_create_failure();
 
     return pas_thread_local_cache_get_local_allocator_for_possibly_uninitialized_index(

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -168,7 +168,7 @@ pas_try_allocate_common_impl_slow(
     type = heap_ref->type;
     alignment = PAS_MAX(alignment, config.get_type_alignment(type));
     
-    if (PAS_UNLIKELY(pas_system_heap_is_enabled(config.kind))) {
+    if (PAS_UNLIKELY(pas_system_heap_should_supplant_bmalloc(config.kind))) {
         if (verbose)
             pas_log("System heap enabled, asking system heap.\n");
         result = pas_system_heap_allocate(size, alignment, allocation_mode);

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
@@ -112,7 +112,7 @@ pas_try_allocate_intrinsic_impl_casual_case(
     if (!pas_is_power_of_2(alignment))
         return pas_allocation_result_create_failure();
 
-    if (PAS_UNLIKELY(pas_system_heap_is_enabled(config.kind)))
+    if (PAS_UNLIKELY(pas_system_heap_should_supplant_bmalloc(config.kind)))
         return pas_system_heap_allocate(size, alignment, allocation_mode);
 
     if (verbose)

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -326,7 +326,7 @@ pas_try_reallocate(void* old_ptr,
         if (!begin)
             return allocate_callback(heap, new_size, allocation_mode, allocate_callback_arg);
 
-        if (PAS_UNLIKELY(pas_system_heap_is_enabled(config.kind))) {
+        if (PAS_UNLIKELY(pas_system_heap_should_supplant_bmalloc(config.kind))) {
             void* raw_result;
             
             PAS_ASSERT(free_mode == pas_reallocate_free_if_successful);


### PR DESCRIPTION
#### 0cdb20ed4dec7b1f38dbc0ef0e02530068746f07
<pre>
[bmalloc] Make SystemHeap enabled but unused by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=302340">https://bugs.webkit.org/show_bug.cgi?id=302340</a>
<a href="https://rdar.apple.com/164497152">rdar://164497152</a>

Reviewed by Keith Miller.

Previously, libpas would delegate all allocations from the
bmalloc heap to the bmalloc SystemHeap whenever the SystemHeap was
enabled. In preparation for guard-objects, we will want to be able to
use the SystemHeap for a subset of allocations without turning it on for
the rest. This requires us to separate the notion of &apos;enablement&apos; from
that of &apos;using it to replace libpas for bmalloc allocations&apos;, which is
what this patch does.

Currently, the SystemHeap is always enabled, but is only used in the
same conditions that would have previously enabled it.
One new envvar has been added to configure this:
setting `WebKitSystemHeapOverrideEnablement=0` will disable the
SystemHeap entirely.

Canonical link: <a href="https://commits.webkit.org/303149@main">https://commits.webkit.org/303149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08cbabfd0e096d8bcc75898c031b90b2c26444c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131474 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138981 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/edb4ff01-3b6c-4133-978d-3748f835948d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/663d7223-6184-4048-a6a8-2d919e893c03) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134420 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81185 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de65bae8-4cdd-4bf1-9e7d-32e408ef0414) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82173 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123499 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141627 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129928 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3550 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36325 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2695 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56738 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3611 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32423 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162945 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3436 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3637 "Hash 08cbabfd for PR 53756 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->