### PR TITLE
Remove FileSystemEnabled guard on endpoints

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -30,9 +30,9 @@
     SharedPreferencesNeedsConnection
 ]
  messages -> NetworkStorageManager {
-    [EnabledBy=FileSystemEnabled] Persisted(struct WebCore::ClientOrigin origin) -> (bool persisted)
-    [EnabledBy=FileSystemEnabled] Persist(struct WebCore::ClientOrigin origin) -> (bool persisted)
-    [EnabledBy=FileSystemEnabled] Estimate(struct WebCore::ClientOrigin origin) -> (struct std::optional<WebCore::StorageEstimate> result);
+    Persisted(struct WebCore::ClientOrigin origin) -> (bool persisted)
+    Persist(struct WebCore::ClientOrigin origin) -> (bool persisted)
+    Estimate(struct WebCore::ClientOrigin origin) -> (struct std::optional<WebCore::StorageEstimate> result);
     [EnabledBy=FileSystemEnabled] FileSystemGetDirectory(struct WebCore::ClientOrigin origin) -> (Expected<std::optional<WebCore::FileSystemHandleIdentifier>, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] CloseHandle(WebCore::FileSystemHandleIdentifier identifier)
     [EnabledBy=FileSystemEnabled] IsSameEntry(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (bool result)


### PR DESCRIPTION
#### 2aba09142e50e2c26dde28a14d0ee747ec05df75
<pre>
Remove FileSystemEnabled guard on endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=298049">https://bugs.webkit.org/show_bug.cgi?id=298049</a>
<a href="https://rdar.apple.com/159340350">rdar://159340350</a>

Reviewed by Sihui Liu.

Remove incorrect flags added to NetworkStorageManager messages.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:

Originally-landed-as: 297297.333@safari-7622-branch (8d500b316ffc). <a href="https://rdar.apple.com/164279488">rdar://164279488</a>
Canonical link: <a href="https://commits.webkit.org/303191@main">https://commits.webkit.org/303191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49de8a9adbbf7daba3a77fd9344d0921823f1fac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83228 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9611c667-832f-4314-8c77-c04e8de82064) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67929 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ecc8bfb0-d26d-425e-8915-5cf47db9e6b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80573 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6db1154-6a0a-4125-a3e1-1d6a8a259d4c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81781 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111273 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141028 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3163 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108385 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3211 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2824 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108339 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2387 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56221 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20453 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3230 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32107 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66626 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3251 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->