### PR TITLE
ASAN_TRAP | WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForGridItem

### DIFF
--- a/LayoutTests/fast/css/content-visibility-container-with-oof-child-crash-expected.txt
+++ b/LayoutTests/fast/css/content-visibility-container-with-oof-child-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/css/content-visibility-container-with-oof-child-crash.html
+++ b/LayoutTests/fast/css/content-visibility-container-with-oof-child-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<div style="content-visibility: hidden">
+  <svg style="position: absolute" stroke="currentColor">
+    <polyline id="polyline" />
+  </svg>
+</div>
+<script>
+  testRunner?.dumpAsText();
+  document.body.scrollHeight;
+  polyline.isPointInStroke(undefined);
+  document.body.innerHTML = "PASS if no crash";
+</script>

--- a/LayoutTests/fast/css/content-visibility-with-multi-column-and-view-transition-crash-expected.txt
+++ b/LayoutTests/fast/css/content-visibility-with-multi-column-and-view-transition-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/content-visibility-with-multi-column-and-view-transition-crash.html
+++ b/LayoutTests/fast/css/content-visibility-with-multi-column-and-view-transition-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+#outer { content-visibility: hidden; }
+#outer, #inner { -webkit-column-width: 0px; }
+#inner { z-index: 1; }
+</style>
+<script>
+  window.testRunner?.dumpAsText();
+  window.testRunner?.waitUntilDone();
+  document.startViewTransition();
+  onload = _ => {
+    setTimeout(function() { document.body.innerHTML = "PASS if no crash."; window.testRunner?.notifyDone(); }, 0);
+  }
+</script>
+<div id="outer">
+  <div style="-webkit-column-width: 0px">
+    <div id="inner">foo</div>
+  </div>
+</div>

--- a/LayoutTests/fast/css/immutable-properties-crash-expected.txt
+++ b/LayoutTests/fast/css/immutable-properties-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/immutable-properties-crash.html
+++ b/LayoutTests/fast/css/immutable-properties-crash.html
@@ -1,0 +1,5 @@
+<script>
+    window.testRunner?.dumpAsText();
+</script>
+<span style="column-rule: 1px solid; outline-style: auto; shape-margin: 1em; max-width: 1cm">
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/grid/nested-grid-and-subgrid-crash-expected.txt
+++ b/LayoutTests/fast/grid/nested-grid-and-subgrid-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/grid/nested-grid-and-subgrid-crash.html
+++ b/LayoutTests/fast/grid/nested-grid-and-subgrid-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+  #outergrid, #grid, #subgrid { display: grid;}
+  #subgrid { grid-template-columns: subgrid;}
+  #griditem { writing-mode: vertical-lr; }
+</style>
+<div id="outergrid">
+  <div id="grid">
+    <div id="subgrid">
+      <div id="griditem"></div>
+    </div>
+  </div>
+</div>
+<div>PASS if no crash.</div>
+<script>
+  window.testRunner?.dumpAsText();
+</script>

--- a/LayoutTests/svg/animations/key-times-zero-path-crash-expected.html
+++ b/LayoutTests/svg/animations/key-times-zero-path-crash-expected.html
@@ -1,0 +1,10 @@
+<body>
+<svg id="svg">
+  <path d="M0 0 q1 26 0 0" />
+</svg>
+<svg>
+  <use href="#svg" >
+    <animateMotion keyTimes="0;0" dur="1s" keyPoints="1;0" path="M 0,1 1,0" />
+  </use>
+</svg>
+</body>

--- a/LayoutTests/svg/animations/key-times-zero-path-crash.html
+++ b/LayoutTests/svg/animations/key-times-zero-path-crash.html
@@ -1,0 +1,16 @@
+<script>
+testRunner?.waitUntilDone();
+function runTest() {
+  requestAnimationFrame(() => { requestAnimationFrame(() => { requestAnimationFrame(() => { testRunner?.notifyDone(); }) }) });
+}
+</script>
+<body onload=runTest()>
+<svg id="svg">
+  <path d="M0 0 q1 26 0 0" />
+</svg>
+<svg>
+  <use href="#svg" >
+   <animateMotion keyTimes="0;0" dur="1s" keyPoints="1;0" path="M 0,1 1,0" />
+  </use>
+</svg>
+</body>

--- a/Source/WTF/wtf/text/StringHash.h
+++ b/Source/WTF/wtf/text/StringHash.h
@@ -212,7 +212,7 @@ namespace WTF {
         static unsigned avoidDeletedValue(unsigned hash)
         {
             ASSERT(hash);
-            unsigned newHash = hash | (!(hash + 1) << 31);
+            unsigned newHash = hash ^ (!(hash + 1) << 31);
             ASSERT(newHash);
             ASSERT(newHash != 0xFFFFFFFF);
             return newHash;

--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -88,7 +88,7 @@ Ref<ImmutableStyleProperties> ImmutableStyleProperties::createDeduplicating(std:
     if (!hash)
         return create(properties, mode);
 
-    auto result = deduplicationMap().ensure(hash, [&] {
+    auto result = deduplicationMap().ensure(AlreadyHashed::avoidDeletedValue(hash), [&] {
         return create(properties, mode);
     });
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -862,15 +862,15 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForGridItem(c
     // height, which may depend on the row track's size. It's possible that the row tracks sizing
     // logic has not been performed yet, so we will need to do an estimation.
     if (direction == Style::GridTrackSizingDirection::Rows && (m_sizingState == SizingState::ColumnSizingFirstIteration || m_sizingState == SizingState::ColumnSizingSecondIteration) && !m_renderGrid->areMasonryColumns()) {
-        ASSERT(GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, gridItem));
         if (m_sizingState == SizingState::ColumnSizingFirstIteration) {
             auto spannedRowsSize = estimatedGridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Rows);
-
-            if (auto availableLogicalHeight = m_renderGrid->availableLogicalHeightForContentBox(); availableLogicalHeight && hasAllLengthRowSizes())  {
-                auto contentDistributionForRows = m_renderGrid->computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection::Rows,
-                    *availableLogicalHeight - *spannedRowsSize, m_renderGrid->numTracks(Style::GridTrackSizingDirection::Rows));
-                auto rowSpanForGridItem = m_renderGrid->gridSpanForGridItem(gridItem, Style::GridTrackSizingDirection::Rows);
-                return *spannedRowsSize + contentDistributionForRows.distributionOffset * (rowSpanForGridItem.integerSpan() - 1);
+            if (spannedRowsSize) {
+                if (auto availableLogicalHeight = m_renderGrid->availableLogicalHeightForContentBox(); availableLogicalHeight && hasAllLengthRowSizes())  {
+                    auto contentDistributionForRows = m_renderGrid->computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection::Rows,
+                        *availableLogicalHeight - *spannedRowsSize, m_renderGrid->numTracks(Style::GridTrackSizingDirection::Rows));
+                    auto rowSpanForGridItem = m_renderGrid->gridSpanForGridItem(gridItem, Style::GridTrackSizingDirection::Rows);
+                    return *spannedRowsSize + contentDistributionForRows.distributionOffset * (rowSpanForGridItem.integerSpan() - 1);
+                }
             }
             return spannedRowsSize;
         }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -693,6 +693,8 @@ bool RenderBlock::canPerformSimplifiedLayout() const
         return false;
     if (layoutContext().isSkippedContentRootForLayout(*this) && (outOfFlowChildNeedsLayout() || canContainFixedPositionObjects()))
         return false;
+    if (isSkippedContentRoot(*this) && firstChild() && firstChild()->wasSkippedDuringLastLayoutDueToContentVisibility())
+        return false;
     return outOfFlowChildNeedsLayout() || needsSimplifiedNormalFlowLayout();
 }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -792,7 +792,7 @@ void RenderBlockFlow::layoutInFlowChildren(RelayoutChildren relayoutChildren, La
     }
 
     // FIXME: We should bail out sooner when subtree layout entry point is _inside_ a skipped subtree.
-    if (layoutContext().isSkippedContentRootForLayout(*this) || layoutContext().isSkippedContentForLayout(*this)) {
+    if ((layoutContext().isSkippedContentRootForLayout(*this) || layoutContext().isSkippedContentForLayout(*this)) && !(isRenderMultiColumnFlow() || multiColumnFlow())) {
         clearNeedsLayoutForSkippedContent();
         return;
     }
@@ -869,7 +869,7 @@ void RenderBlockFlow::layoutBlockChildren(RelayoutChildren relayoutChildren, Lay
         if (child.isExcludedFromNormalLayout())
             continue; // Skip this child, since it will be positioned by the specialized subclass (fieldsets and ruby runs).
 
-        if (layoutContext().isSkippedContentForLayout(child)) {
+        if (layoutContext().isSkippedContentForLayout(child) && !(isRenderMultiColumnFlow() || multiColumnFlow())) {
             ASSERT(child.isColumnSpanner());
 
             child.clearNeedsLayout();

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -78,6 +78,11 @@ static Vector<float> parseKeyTimes(StringView value, bool verifyOrder)
         result.append(time);
     }
 
+    if (verifyOrder && !result.isEmpty() && !result.last()) {
+        ASSERT(!std::accumulate(result.begin(), result.end(), 0));
+        return { };
+    }
+
     return result;
 }
 


### PR DESCRIPTION
#### 629f07bc714c01131375a94f8ab602042d05e1fb
<pre>
ASAN_TRAP | WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForGridItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=295928">https://bugs.webkit.org/show_bug.cgi?id=295928</a>
<a href="https://rdar.apple.com/155792516">rdar://155792516</a>

Reviewed by Alan Baradlay.

After <a href="https://commits.webkit.org/296300@main">https://commits.webkit.org/296300@main</a>, it&apos;s possible that
`GridTrackSizingAlgorithm::gridAreaBreadthForGridItem()` dereferences
`spannedRowsSize`, causing a release crash if the value returned by
`GridTrackSizingAlgorithm::estimatedGridAreaBreadthForGridItem()` is a
`nullopt`, as it is the case in the new test added by this patch.

Checking carefully, such a nullopt can only be returned for indefinite
grid area with an a grid item parallel to the `m_renderGrid`. In
<a href="https://commits.webkit.org/206127@main">https://commits.webkit.org/206127@main</a>, a debug assert was added to
guarantee grid item is actually orthogonal, which is probably why the
code is written in a way that assumes the return value is not a nullopt.
However, this assert fails for the simple configuration below. Indeed,
`minContentContributionForGridItem` is called with m_renderGrid being
(the div of) id=grid and arguments (the div of) id=griditem. Because
of id=griditem&apos;s `writing-mode`, this in turn calls the method
`updateOverridingContainingBlockContentSizeForGridItem` with
parameters id=griditem and `GridTrackSizingDirection::Rows`. Because of
id=subgrid&apos;s `grid-template-columns`, the same method is called
recursively with arguments id=subgrid and
`GridTrackSizingDirection::Rows`. Finally, `gridAreaBreadthForGridItem`
is called with parallel m_renderGrid(id=grid) and gridItem(id=subgrid).

```
&lt;div id=&quot;grid&quot; style=&quot;display: grid&quot;&gt;
  &lt;div id=&quot;subgrid&quot; style=&quot;grid-template-columns: subgrid;&quot;&gt;
    &lt;div id=&quot;griditem&quot; style=&quot;writing-mode: vertical-lr&quot;&gt;&lt;/div&gt;
  &lt;/div&gt;
&lt;/div&gt;

ASSERTION FAILED: GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, gridItem)
WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForGridItem(WebCore::RenderBox const&amp;, WebCore::Style::GridTrackSizingDirection) const
WebCore::GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForGridItem(WebCore::RenderBox&amp;, WebCore::Style::GridTrackSizingDirection, std::optional&lt;WebCore::LayoutUnit&gt;) const
WebCore::GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForGridItem(WebCore::RenderBox&amp;, WebCore::Style::GridTrackSizingDirection, std::optional&lt;WebCore::LayoutUnit&gt;) const
WebCore::GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem(WebCore::RenderBox&amp;, WebCore::GridLayoutState&amp;) const
```

It&apos;s very likely that some wrong assumptions were made when subgrid
were introduced, `updateOverridingContainingBlockContentSizeForGridItem`
should probably now perform something more clever in order to handle the
case when `gridItem` can change its direction in the recursive call. But
in order to minimize behavior changes, this patch just makes
gridAreaBreadthForGridItem return a nullopt in the case where current
code tries to derefence a nullopt rowSpanForGridItem. The obsolete debug
ASSERT is removed.

* LayoutTests/fast/grid/nested-grid-and-subgrid-crash-expected.txt: Added.
* LayoutTests/fast/grid/nested-grid-and-subgrid-crash.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForGridItem const): Remove obsolete ASSERT and return nullopt if spannedRowsSize is nullopt.

Originally-landed-as: 297297.6@webkit-2025.7-embargoed (22c1764572c2). <a href="https://rdar.apple.com/164278536">rdar://164278536</a>
Canonical link: <a href="https://commits.webkit.org/302889@main">https://commits.webkit.org/302889@main</a>
</pre>
----------------------------------------------------------------------
#### 4808d9db86eb0492a3502b204a9bdd268c389f5d
<pre>
Bug 295932 ASAN_SEGV | WebCore::RenderFragmentedFlow::boxIsFragmented; WebCore::rendererIsFragmented; WebCore::forEachRendererInPaintOrder
<a href="https://bugs.webkit.org/show_bug.cgi?id=295932">https://bugs.webkit.org/show_bug.cgi?id=295932</a>
<a href="https://rdar.apple.com/155792317">rdar://155792317</a>

Reviewed by Alan Baradlay.

View transition algorithms test whether a renderer is frsgmented or not, however when content-visibility: hidden
causes a subtree to be hidden the fragmentation information is not always fully computed. To fix this avoid
early returns due to content-visibility: hidden when fragmented flows are involved.

* LayoutTests/fast/css/content-visibility-with-multi-column-and-view-transition-crash-expected.txt: Added.
* LayoutTests/fast/css/content-visibility-with-multi-column-and-view-transition-crash.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutInFlowChildren):
(WebCore::RenderBlockFlow::layoutBlockChildren):

Originally-landed-as: 297297.5@webkit-2025.7-embargoed (fad8efb954b8). <a href="https://rdar.apple.com/164278651">rdar://164278651</a>
Canonical link: <a href="https://commits.webkit.org/302888@main">https://commits.webkit.org/302888@main</a>
</pre>
----------------------------------------------------------------------
#### 2cc9274ac081db225b92d52ccd0fedab3b1056b6
<pre>
ASAN_ILL | WTF::Markable::operator*; WebCore::LegacyRenderSVGRoot::repaintRectInLocalCoordinates; WebCore::LegacyRenderSVGRoot::localClippedOverflowRect
<a href="https://bugs.webkit.org/show_bug.cgi?id=295930">https://bugs.webkit.org/show_bug.cgi?id=295930</a>
<a href="https://rdar.apple.com/155792445">rdar://155792445</a>

Reviewed by Said Abou-Hallawa.

Ending the keyTimes list with 0 should be treated as an invalid animation for animateMotion. While this
does not seem specified, it is what Chrome does.

* LayoutTests/svg/animations/key-times-zero-path-crash-expected.html: Added.
* LayoutTests/svg/animations/key-times-zero-path-crash.html:
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::parseKeyTimes):

Originally-landed-as: 297297.4@webkit-2025.7-embargoed (278e39816d42). <a href="https://rdar.apple.com/164278816">rdar://164278816</a>
Canonical link: <a href="https://commits.webkit.org/302887@main">https://commits.webkit.org/302887@main</a>
</pre>
----------------------------------------------------------------------
#### 7d181b38a42c5e4af12be76f3b10775ffa196c21
<pre>
ASAN_ILL | WebCore::ImmutableStyleProperties::createDeduplicating; WebCore::createStyleProperties; WebCore::CSSParser::parseInlineStyleDeclaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=295927">https://bugs.webkit.org/show_bug.cgi?id=295927</a>
<a href="https://rdar.apple.com/155792201">rdar://155792201</a>

Reviewed by Simon Fraser.

AlreadyHashed::avoidDeletedValue() always returns the passed hash, as
the or-bitwise operator doesn&apos;t really do anything. If the expected
behavior of this method is to avoid the special 0xFFFFFFFF value,
then I strongly suspect that what was intended was to use a xor-bitwise
operation; this will indeed flip the topmost bit if the hash is
0xFFFFFFFF but leave it unchanged for any other value (except 0,
of course).

ImmutableStyleProperties should use this method when adding elements
to its hash map, to make sure that it doesn&apos;t accidentally try to
insert a value whose hash key is 0xFFFFFFFF. Otherwise it will
hit an assertion.

* LayoutTests/fast/css/immutable-properties-crash-expected.txt: Added.
* LayoutTests/fast/css/immutable-properties-crash.html: Added.
* Source/WTF/wtf/text/StringHash.h:
(WTF::AlreadyHashed::avoidDeletedValue):
* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::ImmutableStyleProperties::createDeduplicating):

Originally-landed-as: 297297.3@webkit-2025.7-embargoed (c54787bc3732). <a href="https://rdar.apple.com/164279182">rdar://164279182</a>
Canonical link: <a href="https://commits.webkit.org/302886@main">https://commits.webkit.org/302886@main</a>
</pre>
----------------------------------------------------------------------
#### b1f0317c51e1489cc8b1e8f37bbbd18c7875010b
<pre>
ASAN_SEGV | WebCore::Path::strokeContains; WebCore::LegacyRenderSVGPath::shapeDependentStrokeContains; WebCore::SVGGeometryElement::isPointInStroke
<a href="https://bugs.webkit.org/show_bug.cgi?id=295244">https://bugs.webkit.org/show_bug.cgi?id=295244</a>
<a href="https://rdar.apple.com/154646149">rdar://154646149</a>

Reviewed by Alan Baradlay.

Prevent simplified layout on a c-v root with a previously skipped subtree, since that means any out of flow
children in the subtree have not been processed yet, and only the normal layout path handles them correctly.

* LayoutTests/fast/css/content-visibility-container-with-oof-child-crash-expected.txt: Added.
* LayoutTests/fast/css/content-visibility-container-with-oof-child-crash.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::canPerformSimplifiedLayout const):

Originally-landed-as: 297297.2@webkit-2025.7-embargoed (2f7305a50eb3). <a href="https://rdar.apple.com/164279372">rdar://164279372</a>
Canonical link: <a href="https://commits.webkit.org/302885@main">https://commits.webkit.org/302885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1011882dd17f37b3d153860aff91e6b6610543a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82104 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/efe40b14-ad7b-4e26-aa47-219132048bc0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99439 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4caaff55-a834-4476-aae4-f527e3b74756) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80139 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a36ba3a9-c78e-49bb-a4da-1a4e37324a3b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81179 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122505 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140399 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128955 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107951 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1991 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55541 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66021 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161970 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2452 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40389 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2654 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2559 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->