### PR TITLE
Registered properties and revert-layer may dereference disengaged std::optional

### DIFF
--- a/LayoutTests/fast/css/custom-properties/registered-custom-property-revert-layer-crash-expected.txt
+++ b/LayoutTests/fast/css/custom-properties/registered-custom-property-revert-layer-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/custom-properties/registered-custom-property-revert-layer-crash.html
+++ b/LayoutTests/fast/css/custom-properties/registered-custom-property-revert-layer-crash.html
@@ -1,0 +1,13 @@
+<script>
+window.testRunner?.dumpAsText();
+</script>
+<div>This test passes if it doesn't crash.</div>
+<style>
+@property --v0 {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 10px;
+}
+@layer { div { --v0: foo } }
+div { --v0: revert-layer; }
+</style>

--- a/LayoutTests/webanimations/null-timeline-crash-expected.txt
+++ b/LayoutTests/webanimations/null-timeline-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/null-timeline-crash.html
+++ b/LayoutTests/webanimations/null-timeline-crash.html
@@ -1,0 +1,17 @@
+<body>
+PASS if this does not crash.
+<script>
+
+window.testRunner?.dumpAsText();
+
+const doc = new DOMParser().parseFromString("", "text/html");
+const root = doc.documentElement;
+
+const keyframes = { "divisor": [0, -1] };
+root.animate(keyframes, 1).timeline = null;
+root.animate(keyframes, 1);
+
+window.GCController?.collect();
+
+</script>
+</body>

--- a/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp
@@ -35,7 +35,7 @@ namespace JSC { namespace B3 {
 
 WasmBoundsCheckValue::~WasmBoundsCheckValue() = default;
 
-WasmBoundsCheckValue::WasmBoundsCheckValue(Origin origin, GPRReg pinnedSize, Value* ptr, unsigned offset)
+WasmBoundsCheckValue::WasmBoundsCheckValue(Origin origin, GPRReg pinnedSize, Value* ptr, uint64_t offset)
     : Value(CheckedOpcode, WasmBoundsCheck, One, origin, ptr)
     , m_offset(offset)
     , m_boundsType(Type::Pinned)
@@ -43,7 +43,7 @@ WasmBoundsCheckValue::WasmBoundsCheckValue(Origin origin, GPRReg pinnedSize, Val
     m_bounds.pinnedSize = pinnedSize;
 }
 
-WasmBoundsCheckValue::WasmBoundsCheckValue(Origin origin, Value* ptr, unsigned offset, size_t maximum)
+WasmBoundsCheckValue::WasmBoundsCheckValue(Origin origin, Value* ptr, uint64_t offset, size_t maximum)
     : Value(CheckedOpcode, WasmBoundsCheck, One, origin, ptr)
     , m_offset(offset)
     , m_boundsType(Type::Maximum)

--- a/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.h
@@ -50,7 +50,7 @@ public:
         size_t maximum;
     };
 
-    unsigned offset() const { return m_offset; }
+    uint64_t offset() const { return m_offset; }
     Type boundsType() const { return m_boundsType; }
     Bounds bounds() const { return m_bounds; }
 
@@ -63,13 +63,13 @@ private:
     friend class Procedure;
     friend class Value;
 
-    static Opcode opcodeFromConstructor(Origin, GPRReg, Value*, unsigned) { return WasmBoundsCheck; }
-    JS_EXPORT_PRIVATE WasmBoundsCheckValue(Origin, GPRReg pinnedGPR, Value* ptr, unsigned offset);
+    static Opcode opcodeFromConstructor(Origin, GPRReg, Value*, uint64_t) { return WasmBoundsCheck; }
+    JS_EXPORT_PRIVATE WasmBoundsCheckValue(Origin, GPRReg pinnedGPR, Value* ptr, uint64_t offset);
 
-    static Opcode opcodeFromConstructor(Origin, Value*, unsigned, size_t) { return WasmBoundsCheck; }
-    JS_EXPORT_PRIVATE WasmBoundsCheckValue(Origin, Value* ptr, unsigned offset, size_t maximum);
+    static Opcode opcodeFromConstructor(Origin, Value*, uint64_t, size_t) { return WasmBoundsCheck; }
+    JS_EXPORT_PRIVATE WasmBoundsCheckValue(Origin, Value* ptr, uint64_t offset, size_t maximum);
 
-    unsigned m_offset;
+    uint64_t m_offset;
     Type m_boundsType;
     Bounds m_bounds;
 

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -114,6 +114,10 @@ public:
 private:
     bool foldConstants(BasicBlock* block)
     {
+        // CFAUnreachable, skip
+        if (!block->cfaHasVisited)
+            return false;
+
         bool changed = false;
         m_state.beginBasicBlock(block);
         for (unsigned indexInBlock = 0; indexInBlock < block->size(); ++indexInBlock) {

--- a/Source/WebCore/animation/ElementAnimationRareData.cpp
+++ b/Source/WebCore/animation/ElementAnimationRareData.cpp
@@ -42,6 +42,7 @@ ElementAnimationRareData::ElementAnimationRareData()
 
 ElementAnimationRareData::~ElementAnimationRareData()
 {
+    ASSERT(!m_keyframeEffectStack || !m_keyframeEffectStack->hasEffects());
 }
 
 KeyframeEffectStack& ElementAnimationRareData::ensureKeyframeEffectStack()

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -99,6 +99,18 @@ using namespace JSC;
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(KeyframeEffect);
 
+KeyframeEffect::~KeyframeEffect()
+{
+    if (m_inTargetEffectStack) {
+        if (auto target = targetStyleable()) {
+            if (auto* keyframeEffectStack = target->keyframeEffectStack())
+                keyframeEffectStack->removeEffect(*this);
+        }
+    }
+
+    ASSERT(!m_inTargetEffectStack);
+}
+
 KeyframeEffect::ParsedKeyframe::ParsedKeyframe()
     : style(MutableStyleProperties::create())
 {

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -202,6 +202,7 @@ public:
 
 private:
     KeyframeEffect(Element*, const std::optional<Style::PseudoElementIdentifier>&);
+    ~KeyframeEffect();
 
     enum class AcceleratedAction : uint8_t { Play, Pause, UpdateProperties, TransformChange, Stop };
     enum class AcceleratedProperties : uint8_t { None, Some, All };

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -325,6 +325,9 @@ bool Builder::applyRollbackCascadeCustomProperty(const PropertyCascade& rollback
 
         SetForScope levelScope(m_state->m_currentProperty, &rollbackProperty);
         auto resolvedValue = resolveCustomPropertyValue(customPropertyValue);
+        if (!resolvedValue)
+            resolvedValue = CustomProperty::createForGuaranteedInvalid(name);
+
         applyCustomProperty(name, WTFMove(*resolvedValue));
     }
     return true;


### PR DESCRIPTION
#### a179b3a3ac1bac852fae28f1d2d28e1c88d611de
<pre>
Registered properties and revert-layer may dereference disengaged std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=298314">https://bugs.webkit.org/show_bug.cgi?id=298314</a>
<a href="https://rdar.apple.com/157023648">rdar://157023648</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/custom-properties/registered-custom-property-revert-layer-crash-expected.txt: Added.
* LayoutTests/fast/css/custom-properties/registered-custom-property-revert-layer-crash.html: Added.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyRollbackCascadeCustomProperty):

With registered properties custom property resolution may fail. Return guaranteed-invalid value in this case.

Originally-landed-as: 297297.373@safari-7622-branch (3800cebd8f22). <a href="https://rdar.apple.com/164277929">rdar://164277929</a>
Canonical link: <a href="https://commits.webkit.org/302884@main">https://commits.webkit.org/302884@main</a>
</pre>
----------------------------------------------------------------------
#### a339ef586913358995ac59b24dfb947ba7029e6a
<pre>
ASAN_ILL | WebCore::KeyframeEffectStack::allowsAcceleration; WebCore::KeyframeEffectStack::removeEffect; WebCore::KeyframeEffect::updateEffectStackMembership
<a href="https://bugs.webkit.org/show_bug.cgi?id=298317">https://bugs.webkit.org/show_bug.cgi?id=298317</a>
<a href="https://rdar.apple.com/157023038">rdar://157023038</a>

Reviewed by Cameron McCormack.

When a document is torn down, we call into `AnimationTimelinesController::detachFromDocument()` which
will call `AnimationTimeline::detachFromDocument()` for each known timeline and then `WebAnimation::remove()`
for each animation associated with that timeline. This will eventually disassociate animation effects
from the `KeyframeEffectStack` of their target, ensuring there are no null references in the stack&apos;s
list of effects.

However, with the advent of scroll-driven animations, an animation&apos;s timeline may be set to null, which
will not perform such a disassociation since that animation may remain &quot;relevant&quot; [0]. However, since
the cleanup described above occurs for animations associated with a timeline, such timeline-less
animations will not be processed and thus it&apos;s possible that an effect is destroyed but a (weak)
reference remains in the effect stack.

To address this issue, we add logic in the `KeyframeEffect` destructor to remove itself from any associated
effect stack, and add an assertion that it is indeed no longer in that stack. Additionally, we now check
in the `ElementAnimationRareData` destructor that it no longer has an effect stack or that the stack is empty.

[0] <a href="https://drafts.csswg.org/web-animations-1/#relevant-animations-section">https://drafts.csswg.org/web-animations-1/#relevant-animations-section</a>

* LayoutTests/webanimations/null-timeline-crash-expected.txt: Added.
* LayoutTests/webanimations/null-timeline-crash.html: Added.
* Source/WebCore/animation/ElementAnimationRareData.cpp:
(WebCore::ElementAnimationRareData::~ElementAnimationRareData):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::~KeyframeEffect):
* Source/WebCore/animation/KeyframeEffect.h:

Originally-landed-as: 297297.371@safari-7622-branch (02618abc17c4). <a href="https://rdar.apple.com/164278044">rdar://164278044</a>
Canonical link: <a href="https://commits.webkit.org/302883@main">https://commits.webkit.org/302883@main</a>
</pre>
----------------------------------------------------------------------
#### 78b31d59089f6578e9bac67c8101220b6b19bcdb
<pre>
DFG Constant Folding should ignore results of blocks which CFA has marked unreachable
<a href="https://bugs.webkit.org/show_bug.cgi?id=298126">https://bugs.webkit.org/show_bug.cgi?id=298126</a>
<a href="https://rdar.apple.com/158662405">rdar://158662405</a>

Reviewed by Yusuke Suzuki.

DFG&apos;s constant folding pass included value result information from blocks which were found to be unreachable
through control flow analysis. This could lead to weaker type guarantees during further analysis.

* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Originally-landed-as: 297297.362@safari-7622-branch (cb6fcc0b908c). <a href="https://rdar.apple.com/164278150">rdar://164278150</a>
Canonical link: <a href="https://commits.webkit.org/302882@main">https://commits.webkit.org/302882@main</a>
</pre>
----------------------------------------------------------------------
#### 1e419fbe0c7af1486200ee8d2feaefc13ebd53bb
<pre>
OMG Wasm memory access should emit a full 64-bit immediate
<a href="https://bugs.webkit.org/show_bug.cgi?id=298129">https://bugs.webkit.org/show_bug.cgi?id=298129</a>
<a href="https://rdar.apple.com/159439036">rdar://159439036</a>

Reviewed by Yusuke Suzuki.

Previously, OMG computed memory indices using a 32-bit integer, which could overflow
at higher offsets. We switch this over to a 64-bit integer, allowing us to avoid any
overflow conditions.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitCheckAndPreparePointer):

Originally-landed-as: 297297.360@safari-7622-branch (f5ded472170d). <a href="https://rdar.apple.com/164278368">rdar://164278368</a>
Canonical link: <a href="https://commits.webkit.org/302881@main">https://commits.webkit.org/302881@main</a>
</pre>
----------------------------------------------------------------------
#### 152a5a7fcd1057411f5f1d8f9ca7f99271c3905e
<pre>
[Cocoa] Fix thread safety issues with the Web Share API
<a href="https://bugs.webkit.org/show_bug.cgi?id=298063">https://bugs.webkit.org/show_bug.cgi?id=298063</a>
<a href="https://rdar.apple.com/159066364">rdar://159066364</a>

Reviewed by Abrar Rahman Protyasha and Ryosuke Niwa.

Ensure use of `UIActivityItemProvider` and `NSPreviewRepresentingActivityItem`
happens only on the main thread. These APIs are not thread-safe.

* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(appendFilesAsShareableURLs):

Make a slight behavior change to avoid `nil`-ing out the entire share
data array if an item for a file could not be successfully created. In this
scenario, the title/text/URL can still be shared.

Originally-landed-as: 297297.358@safari-7622-branch (60e047dee492). <a href="https://rdar.apple.com/164278361">rdar://164278361</a>
Canonical link: <a href="https://commits.webkit.org/302880@main">https://commits.webkit.org/302880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a24704412c44867abbbfae7b77049b6cdd0c235

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82112 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/203e427b-f310-4f92-b874-10d4e201e044) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99431 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07953a55-1994-4f32-b6e3-df19fd1fa777) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc7d9c15-d1c4-4d78-95ec-759344ecb034) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34997 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81185 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122511 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140405 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128961 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107943 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107855 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27456 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31650 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55547 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66027 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161976 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2458 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40390 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2565 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->