### PR TITLE
Reland "[GTK][WPE] ThreadedCompositor: Switch didRenderFrameTimer to use a RunLoopObserver"

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Igalia S.L.
+ * Copyright (C) 2014, 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,9 +70,12 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost)
     , m_sceneState(&m_layerTreeHost->sceneState())
     , m_flipY(m_surface->shouldPaintMirrored())
     , m_compositingRunLoop(makeUnique<CompositingRunLoop>([this] { renderLayerTree(); }))
-    , m_didRenderFrameTimer(RunLoop::mainSingleton(), "ThreadedCompositor::DidRenderFrameTimer"_s, this, &ThreadedCompositor::didRenderFrameTimerFired)
 {
     ASSERT(RunLoop::isMain());
+
+    m_didCompositeRunLoopObserver = makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::GraphicsCommit, [this] {
+        this->didCompositeRunLoopObserverFired();
+    });
 
     initializeFPSCounter();
 #if ENABLE(DAMAGE_TRACKING)
@@ -83,10 +86,6 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost)
     updateSceneAttributes(webPage.size(), webPage.deviceScaleFactor());
 
     m_surface->didCreateCompositingRunLoop(m_compositingRunLoop->runLoop());
-
-#if USE(GLIB_EVENT_LOOP)
-    m_didRenderFrameTimer.setPriority(RunLoopSourcePriority::RunLoopTimer - 1);
-#endif
 
     m_compositingRunLoop->performTaskSync([this, protectedThis = Ref { *this }] {
         // GLNativeWindowType depends on the EGL implementation: reinterpret_cast works
@@ -116,7 +115,7 @@ void ThreadedCompositor::invalidate()
 {
     ASSERT(RunLoop::isMain());
     m_compositingRunLoop->stopUpdates();
-    m_didRenderFrameTimer.stop();
+    m_didCompositeRunLoopObserver->invalidate();
     m_compositingRunLoop->performTaskSync([this, protectedThis = Ref { *this }] {
         if (!m_context || !m_context->makeContextCurrent())
             return;
@@ -323,11 +322,11 @@ void ThreadedCompositor::renderLayerTree()
 
     uint32_t compositionRequestID = m_compositionRequestID.load();
     m_compositionResponseID = compositionRequestID;
-    if (!m_didRenderFrameTimer.isActive())
-        m_didRenderFrameTimer.startOneShot(0_s);
 #if !HAVE(OS_SIGNPOST) && !USE(SYSPROF_CAPTURE)
     UNUSED_VARIABLE(compositionRequestID);
 #endif
+
+    m_didCompositeRunLoopObserver->schedule(&RunLoop::mainSingleton());
 
     WTFEmitSignpost(this, DidRenderFrame, "compositionResponseID %i", compositionRequestID);
 
@@ -371,8 +370,9 @@ void ThreadedCompositor::frameComplete()
     m_compositingRunLoop->updateCompleted(stateLocker);
 }
 
-void ThreadedCompositor::didRenderFrameTimerFired()
+void ThreadedCompositor::didCompositeRunLoopObserverFired()
 {
+    m_didCompositeRunLoopObserver->invalidate();
     if (m_layerTreeHost)
         m_layerTreeHost->didComposite(m_compositionResponseID);
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Igalia S.L.
+ * Copyright (C) 2014, 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include <WebCore/DisplayUpdate.h>
 #include <WebCore/GLContext.h>
 #include <WebCore/IntSize.h>
+#include <WebCore/RunLoopObserver.h>
 #include <WebCore/TextureMapperDamageVisualizer.h>
 #include <atomic>
 #include <optional>
@@ -100,7 +101,7 @@ private:
     void paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::IntSize&);
     void frameComplete();
 
-    void didRenderFrameTimerFired();
+    void didCompositeRunLoopObserverFired();
 
     void updateSceneAttributes(const WebCore::IntSize&, float deviceScaleFactor);
 
@@ -144,7 +145,7 @@ private:
 
     std::atomic<uint32_t> m_compositionRequestID { 0 };
     std::atomic<uint32_t> m_compositionResponseID { 0 };
-    RunLoop::Timer m_didRenderFrameTimer;
+    std::unique_ptr<WebCore::RunLoopObserver> m_didCompositeRunLoopObserver;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### c7854cde7b15902e95be53a13585c872d277aa42
<pre>
Reland &quot;[GTK][WPE] ThreadedCompositor: Switch didRenderFrameTimer to use a RunLoopObserver&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=302348">https://bugs.webkit.org/show_bug.cgi?id=302348</a>

Reviewed by Carlos Garcia Campos.

We reverted 302433@main in 302809@main to cure the random timeouts observed
on the build bots. The underlying issue was identified, thus we can reland
the patch with a fix included avoiding the timeouts.

Invalidate the didCompositeRunLoopObserver _before_ notifying LayerTreeHost
about the finished composition - this was the culprit leading to a race
condition, where we could miss re-scheduling a RLO, when needed.

Covered by existing tests.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_compositingRunLoop):
(WebKit::ThreadedCompositor::invalidate):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::didCompositeRunLoopObserverFired):
(WebKit::m_didRenderFrameTimer): Deleted.
(WebKit::ThreadedCompositor::didRenderFrameTimerFired): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/302899@main">https://commits.webkit.org/302899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06613dd0e0118ef82d725480309264de7f9de37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82123 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99435 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2042 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1965 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81194 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110528 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140414 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107860 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1997 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55556 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66037 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->