### PR TITLE
[MSE] Make MediaSourcePrivate::hasAudio/hasVideo thread-safe

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -600,6 +600,14 @@ void SourceBufferPrivate::addTrackBuffer(TrackID trackId, RefPtr<MediaDescriptio
     trackBuffer->setLogger(protectedLogger(), logIdentifier());
 #endif
     m_trackBufferMap.try_emplace(trackId, WTFMove(trackBuffer));
+    if (RefPtr mediaSource = m_mediaSource.get()) {
+        MediaSourcePrivate::TracksType tracksType;
+        if (m_hasAudio)
+            tracksType |= TrackInfoTrackType::Audio;
+        if (m_hasVideo)
+            tracksType |= TrackInfoTrackType::Video;
+        mediaSource->tracksTypeChanged(*this, tracksType);
+    }
 }
 
 void SourceBufferPrivate::updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIdPairs)

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -133,8 +133,6 @@ public:
     WEBCORE_EXPORT Vector<PlatformTimeRanges> trackBuffersRanges() const;
 
     // Methods used by MediaSourcePrivate
-    bool hasAudio() const { return m_hasAudio; }
-    bool hasVideo() const { return m_hasVideo; }
     bool hasReceivedFirstInitializationSegment() const { return m_receivedFirstInitializationSegment; }
 
     virtual MediaTime timestampOffset() const { return m_timestampOffset; }


### PR DESCRIPTION
#### f686ca89c6e15f061c8669b19fc7344eb5612adb
<pre>
[MSE] Make MediaSourcePrivate::hasAudio/hasVideo thread-safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=302250">https://bugs.webkit.org/show_bug.cgi?id=302250</a>
<a href="https://rdar.apple.com/164393150">rdar://164393150</a>

Reviewed by Youenn Fablet.

MediaSourcePrivate::hasAudio/hasVideo are called from the MediaPlayerPrivate
from the main thread. Those methods need to be thread-safe as MediaSourcePrivate
may be running on a different workqueue.
We can let the SourceBufferPrivate tells the MediaSourcePrivate at the time
the information is received rather than have MediaSourcePrivate call
into SourceBufferPrivate instead.

No change in observable heaviour.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::removeSourceBuffer):
(WebCore::MediaSourcePrivate::hasAudio const):
(WebCore::MediaSourcePrivate::hasVideo const):
(WebCore::MediaSourcePrivate::tracksTypeChanged):
(WebCore::MediaSourcePrivate::updateTracksType):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::addTrackBuffer):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::hasAudio const): Deleted.
(WebCore::SourceBufferPrivate::hasVideo const): Deleted.

Canonical link: <a href="https://commits.webkit.org/302975@main">https://commits.webkit.org/302975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/786081ea3852fb117029a58d066add5a28bf3794

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130806 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138232 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0052b806-b303-404d-9bfa-6faaa66a79f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2972 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d875fd1c-712d-4f98-8e11-947e555c2065) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133752 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1bd5b6ec-6851-4696-87e0-35b450f2646f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81484 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140708 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108094 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27500 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/2198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55875 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2941 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66333 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2870 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->