### PR TITLE
Unreviewed, reverting 302849@main (55c7cd08092a)

### DIFF
--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -120,7 +120,7 @@ SWIFT_VERSION = $(SWIFT_VERSION$(WK_XCODE_16));
 SWIFT_VERSION_XCODE_BEFORE_16 = 5.0;
 SWIFT_VERSION_XCODE_SINCE_16 = 6.0;
 
-OTHER_SWIFT_FLAGS = $(inherited) -Xfrontend -experimental-spi-only-imports $(OTHER_SWIFT_FLAGS$(WK_XCODE_16)) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/platform-enabled-swift-args.$(arch).resp @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/swift-tba-availability-macros.resp;
+OTHER_SWIFT_FLAGS = $(inherited) -no-warnings-as-errors -Xfrontend -experimental-spi-only-imports $(OTHER_SWIFT_FLAGS$(WK_XCODE_16)) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/platform-enabled-swift-args.$(arch).resp @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/swift-tba-availability-macros.resp;
 OTHER_SWIFT_FLAGS_XCODE_BEFORE_16 = -Xfrontend -enable-experimental-concurrency -Xfrontend -enable-upcoming-feature -Xfrontend IsolatedDefaultValues;
 
 WK_ENABLE_SWIFTUI = YES;

--- a/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
@@ -38,8 +38,7 @@ final class WKURLSchemeHandlerAdapter: NSObject, WKURLSchemeHandler {
     func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
         let task = Task {
             do {
-                // Safety: this is actually safe; false positive is rdar://154775389
-                for try await unsafe result in wrapped.reply(for: urlSchemeTask.request) {
+                for try await result in wrapped.reply(for: urlSchemeTask.request) {
                     try Task.checkCancellation()
 
                     switch result {

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -87,12 +87,8 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
         let interaction = NSTextFinder()
         interaction.isIncrementalSearchingEnabled = true
         interaction.incrementalSearchingShouldDimContentView = false
-        // Safety: both the folloowing two properties are
-        // @property (assign) which means non-owning.
-        // We therefore have to guarantee that webView and self
-        // outlive the interaction. rdar://163268246 is working on this.
-        unsafe interaction.client = webView
-        unsafe interaction.findBarContainer = self
+        interaction.client = webView
+        interaction.findBarContainer = self
         #else
         guard let interaction = webView?.findInteraction else {
             return nil
@@ -191,8 +187,7 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
                 return
             }
 
-            // Safety: rdar://163268246 working on proving safety here.
-            unsafe webView.window?.makeFirstResponder(webView)
+            webView.window?.makeFirstResponder(webView)
         }
     }
     #endif
@@ -271,8 +266,7 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
 
             webView.delegate = self
             #if os(macOS)
-            // Safety: rdar://163268246 working on proving safety here.
-            unsafe findInteraction?.wrapped.client = webView
+            findInteraction?.wrapped.client = webView
             #endif
         }
     }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -292,10 +292,7 @@ struct EquatableScrollBounceBehavior: Equatable {
     let behavior: ScrollBounceBehavior
 
     static func == (lhs: EquatableScrollBounceBehavior, rhs: EquatableScrollBounceBehavior) -> Bool {
-        // Safety: ScrollBounceBehavior is opaque, but stores data, so is guaranteed
-        // to be at least 1 byte long. We will compare just that first byte.
-        // This is a temporary workaround for rdar://145030632.
-        unsafe unsafeBitCast(lhs.behavior, to: Int8.self) == unsafeBitCast(rhs.behavior, to: Int8.self)
+        unsafeBitCast(lhs.behavior, to: Int8.self) == unsafeBitCast(rhs.behavior, to: Int8.self)
     }
 }
 


### PR DESCRIPTION
#### 79be752a83814d7a0a734f62960c78c85f9941a7
<pre>
Unreviewed, reverting 302849@main (55c7cd08092a)
<a href="https://bugs.webkit.org/show_bug.cgi?id=302353">https://bugs.webkit.org/show_bug.cgi?id=302353</a>
<a href="https://rdar.apple.com/164509985">rdar://164509985</a>

302849@main broke internal builds.

Reverted change:

    Enforce strict memory safety across WebKit
    <a href="https://bugs.webkit.org/show_bug.cgi?id=300439">https://bugs.webkit.org/show_bug.cgi?id=300439</a>
    <a href="https://rdar.apple.com/162275605">rdar://162275605</a>
    302849@main (55c7cd08092a)

Canonical link: <a href="https://commits.webkit.org/302867@main">https://commits.webkit.org/302867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1c2842fdab3fd5ad00938e836d2ee5edf9c19d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130530 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/2801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137948 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/2813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2693 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133477 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/2813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/80146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/2813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/2813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/35520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140427 "Failed to checkout and rebase branch from PR 53769") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/140427 "Failed to checkout and rebase branch from PR 53769") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/113228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/140427 "Failed to checkout and rebase branch from PR 53769") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20327 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/2661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66050 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->