### PR TITLE
Retain the TypeDefinition underlying the Wasm::Type in Wasm::Global and Wasm::Table

### DIFF
--- a/LayoutTests/fast/speechsynthesis/lockdown-mode/speech-synthesis-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/lockdown-mode/speech-synthesis-expected.txt
@@ -1,0 +1,10 @@
+This test ensures SpeechSynthesis is not available in LDM.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.speechSynthesis is undefined.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/speechsynthesis/lockdown-mode/speech-synthesis.html
+++ b/LayoutTests/fast/speechsynthesis/lockdown-mode/speech-synthesis.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This test ensures SpeechSynthesis is not available in LDM.");
+
+shouldBeUndefined("window.speechSynthesis");
+finishJSTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3482,6 +3482,9 @@ webkit.org/b/98925 fast/viewport/viewport-legacy-xhtmlmp.html [ Skip ]
 # Expects a particular fixed size ofr layer tiles.
 fast/images/low-memory-decode.html [ Skip ]
 
+# Lockdown Mode does not apply
+fast/speechsynthesis/lockdown-mode [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of UNSUPPORTED tests.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3279,6 +3279,7 @@ media/video-setSinkId-default.html [ Skip ]
 
 # Lockdown Mode does not apply
 dom/xsl/lockdown-mode [ Skip ]
+fast/speechsynthesis/lockdown-mode [ Skip ]
 http/tests/lockdown-mode [ Skip ]
 js/dom/lockdown-mode [ Skip ]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4547,6 +4547,7 @@ imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.ht
 
 # Lockdown Mode does not apply
 dom/xsl/lockdown-mode [ Skip ]
+fast/speechsynthesis/lockdown-mode [ Skip ]
 http/tests/lockdown-mode [ Skip ]
 js/dom/lockdown-mode [ Skip ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -446,6 +446,7 @@ webkit.org/b/264660 imported/w3c/web-platform-tests/html/semantics/disabled-elem
 
 # Lockdown Mode does not apply
 dom/xsl/lockdown-mode [ Skip ]
+fast/speechsynthesis/lockdown-mode [ Skip ]
 http/tests/lockdown-mode [ Skip ]
 js/dom/lockdown-mode [ Skip ]
 

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -97,6 +97,7 @@ public:
 private:
     Global(Wasm::Type type, Wasm::Mutability mutability, uint64_t initialValue)
         : m_type(type)
+        , m_typeDefinition(TypeInformation::getRef(type.index))
         , m_mutability(mutability)
     {
         ASSERT(m_type != Types::V128);
@@ -105,6 +106,7 @@ private:
 
     Global(Wasm::Type type, Wasm::Mutability mutability, v128_t initialValue)
         : m_type(type)
+        , m_typeDefinition(TypeInformation::getRef(type.index))
         , m_mutability(mutability)
     {
         ASSERT(m_type == Types::V128);
@@ -112,6 +114,8 @@ private:
     }
 
     Wasm::Type m_type;
+    // If m_type came from a TypeDefinition, the following retains the definition to prevent a dangling m_type.
+    RefPtr<const Wasm::TypeDefinition> m_typeDefinition;
     Wasm::Mutability m_mutability;
     JSWebAssemblyGlobal* m_owner { nullptr };
     Value m_value;

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -86,6 +86,7 @@ Table::Table(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType, T
     : m_maximum(maximum)
     , m_type(type)
     , m_wasmType(wasmType)
+    , m_wasmTypeDefinition(TypeInformation::getRef(wasmType.index))
     , m_isFixedSized(maximum && maximum.value() == initial)
     , m_owner(nullptr)
 {

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -104,6 +104,8 @@ protected:
     NO_UNIQUE_ADDRESS const std::optional<uint32_t> m_maximum;
     const TableElementType m_type;
     Type m_wasmType;
+    // If m_wasmType came from a TypeDefinition, the following retains the definition to prevent a dangling m_wasmType.
+    RefPtr<const TypeDefinition> m_wasmTypeDefinition;
     bool m_isFixedSized { false };
     JSWebAssemblyTable* m_owner;
 };

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -958,6 +958,8 @@ public:
 
     static const TypeDefinition& get(TypeIndex);
     static TypeIndex get(const TypeDefinition&);
+    // Unlike with `get`, the index passed to `getRef` may be a type or invalid, in which case a nullptr is returned.
+    static RefPtr<const TypeDefinition> getRef(TypeIndex);
 
     inline static const FunctionSignature& getFunctionSignature(TypeIndex);
     inline static std::optional<const FunctionSignature*> tryGetFunctionSignature(TypeIndex);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
@@ -83,6 +83,13 @@ inline TypeIndex TypeInformation::get(const TypeDefinition& type)
     return type.index();
 }
 
+inline RefPtr<const TypeDefinition> TypeInformation::getRef(TypeIndex typeIndex)
+{
+    if (typeIndexIsType(typeIndex) || typeIndex == TypeDefinition::invalidIndex)
+        return nullptr;
+    return TypeInformation::get(typeIndex);
+}
+
 } } // namespace JSC::Wasm
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -86,6 +86,7 @@ void MemoryBackingStoreTransaction::removeNewIndex(MemoryIndex& index)
 
     ASSERT(isVersionChange());
 
+    m_originalIndexNames.remove(&index);
     m_versionChangeAddedIndexes.remove(&index);
     m_indexes.remove(&index);
 }

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -99,7 +99,7 @@ private:
     HashMap<String, RefPtr<MemoryObjectStore>> m_deletedObjectStores;
     HashSet<RefPtr<MemoryIndex>> m_deletedIndexes;
     HashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
-    HashMap<MemoryIndex*, String> m_originalIndexNames;
+    HashMap<RefPtr<MemoryIndex>, String> m_originalIndexNames;
 
     HashMap<IDBResourceIdentifier, WeakPtr<MemoryCursor>> m_cursors;
 };

--- a/Source/WebCore/Modules/speech/DOMWindow+SpeechSynthesis.idl
+++ b/Source/WebCore/Modules/speech/DOMWindow+SpeechSynthesis.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     ImplementedBy=LocalDOMWindowSpeechSynthesis
 ] partial interface DOMWindow {

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -726,6 +726,7 @@ namespace WebCore {
     macro(showModalDialog) \
     macro(signal) \
     macro(signalAbort) \
+    macro(speechSynthesis) \
     macro(SpeechSynthesis) \
     macro(SpeechSynthesisErrorEvent) \
     macro(SpeechSynthesisEvent) \

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -117,10 +117,9 @@ private:
     {
     }
     static Lock syncMessageStateMapLock;
-    // FIXME: Don't use raw pointers.
-    static HashMap<SerialFunctionDispatcher*, SyncMessageState*>& syncMessageStateMap() WTF_REQUIRES_LOCK(syncMessageStateMapLock)
+    static HashMap<RefPtr<SerialFunctionDispatcher>, SyncMessageState*>& syncMessageStateMap() WTF_REQUIRES_LOCK(syncMessageStateMapLock)
     {
-        static NeverDestroyed<HashMap<SerialFunctionDispatcher*, SyncMessageState*>> map;
+        static NeverDestroyed<HashMap<RefPtr<SerialFunctionDispatcher>, SyncMessageState*>> map;
         return map;
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -226,6 +226,10 @@ private:
 
     RetainPtr<WKLayerHostView> createLayerHostViewWithID(PlaybackSessionContextIdentifier, const WebCore::HostingContext&, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
 
+#if USE(EXTENSIONKIT)
+    void setVisibilityPropagationViewForLayerHostView(UIView *, WKLayerHostView *);
+#endif
+
     // Messages from VideoPresentationManager
     void setupFullscreenWithID(PlaybackSessionContextIdentifier, const WebCore::HostingContext&, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingScaleFactor, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     void setInlineRect(PlaybackSessionContextIdentifier, const WebCore::FloatRect& inlineRect, bool visible);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -436,6 +436,7 @@ public:
 #endif
 #if USE(EXTENSIONKIT)
     virtual UIView *createVisibilityPropagationView() { return nullptr; }
+    virtual void removeVisibilityPropagationView(UIView *) { }
 #endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -95,6 +95,7 @@ private:
 #endif // ENABLE(MODEL_PROCESS)
 #if USE(EXTENSIONKIT)
     UIView *createVisibilityPropagationView() override;
+    void removeVisibilityPropagationView(UIView *) override;
 #endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -266,6 +266,11 @@ UIView *PageClientImpl::createVisibilityPropagationView()
 {
     return [contentView() _createVisibilityPropagationView];
 }
+
+void PageClientImpl::removeVisibilityPropagationView(UIView *view)
+{
+    [contentView() _removeVisibilityPropagationView:view];
+}
 #endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -118,6 +118,7 @@ enum class ViewStabilityFlag : uint8_t;
 #endif // ENABLE(MODEL_PROCESS)
 #if USE(EXTENSIONKIT)
 - (UIView *)_createVisibilityPropagationView;
+- (void)_removeVisibilityPropagationView:(UIView *)view;
 #endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -224,7 +224,7 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 #if USE(EXTENSIONKIT)
     RetainPtr<UIView> _visibilityPropagationViewForWebProcess;
     RetainPtr<UIView> _visibilityPropagationViewForGPUProcess;
-    RetainPtr<NSHashTable<WKVisibilityPropagationView *>> _visibilityPropagationViews;
+    RetainPtr<NSMutableSet<WKVisibilityPropagationView *>> _visibilityPropagationViews;
 #else
 #if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
     RetainPtr<_UINonHostingVisibilityPropagationView> _visibilityPropagationViewForWebProcess;
@@ -975,7 +975,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 - (WKVisibilityPropagationView *)_createVisibilityPropagationView
 {
     if (!_visibilityPropagationViews)
-        _visibilityPropagationViews = [NSHashTable weakObjectsHashTable];
+        _visibilityPropagationViews = adoptNS([[NSMutableSet alloc] init]);
 
     RetainPtr visibilityPropagationView = adoptNS([[WKVisibilityPropagationView alloc] init]);
     [_visibilityPropagationViews addObject:visibilityPropagationView.get()];
@@ -989,6 +989,12 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 #endif
 
     return visibilityPropagationView.autorelease();
+}
+
+- (void)_removeVisibilityPropagationView:(UIView *)view
+{
+    if (RetainPtr visibilityPropagationView = dynamic_objc_cast<WKVisibilityPropagationView>(view))
+        [_visibilityPropagationViews removeObject:visibilityPropagationView.get()];
 }
 #endif // USE(EXTENSIONKIT)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)


### PR DESCRIPTION
#### ef9304e0e82bf30459af19381a690f0601b5687d
<pre>
Retain the TypeDefinition underlying the Wasm::Type in Wasm::Global and Wasm::Table
<a href="https://bugs.webkit.org/show_bug.cgi?id=297958">https://bugs.webkit.org/show_bug.cgi?id=297958</a>
<a href="https://rdar.apple.com/159278266">rdar://159278266</a>

Reviewed by Yusuke Suzuki.

Wasm::Global and Wasm::Table both have a field containing a Wasm::Type describing the
value of the global or the contents of the table. Wasm::Type has a field `index` of type
`TypeIndex`. Formally, `TypeIndex` is an alias for `uintptr_t`. However, the field may
actually be a pointer to the `TypeDefinition` instance corresponding to the type.

Because TypeDefinitions are refcounted but Wasm::Type contains a raw unmanaged pointer, it
is possible for a pointer in Wasm::Type to outlive the TypeDefinition it points to. This
can happen with Wasm Globals and Tables because an exported global or a table (if it&apos;s
empty) may outlive their associated Wasm instance when they are retained by JavaScript
code. In that situation TypeDefinitions referenced by the instance may be
garbage-collected while pointers to them from the globals or tables still exist. After
that, an attempt to set the value of the global or a table entry will dereference the
dangling pointer as the value is validated against the type of the global or the table.

This patch adds an explicit counted TypeDefinition reference to Wasm::Global
and Wasm::Table to ensure the TypeDefinition lives long enough.

Ideally, we might want to redesign Wasm::Type to have it carry a proper counted reference
to its TypeDefinition instead of a disguised raw pointer. But that is a larger
undertaking, while in the meantime this patch fixes the known vulnerability.

Originally-landed-as: 297297.393@safari-7622-branch (b3e1519a9399). <a href="https://rdar.apple.com/164277125">rdar://164277125</a>
Canonical link: <a href="https://commits.webkit.org/302928@main">https://commits.webkit.org/302928@main</a>
</pre>
----------------------------------------------------------------------
#### e9b2e94578123a7cb9130a7be0143ce1f0a12eac
<pre>
Stop using raw pointer in syncMessageStateMap()
<a href="https://bugs.webkit.org/show_bug.cgi?id=298489">https://bugs.webkit.org/show_bug.cgi?id=298489</a>
<a href="https://rdar.apple.com/156584462">rdar://156584462</a>

Reviewed by Chris Dumez.

Connection::SyncMessageStateRelease::operator() only removes entry from syncMessageStateMap() if instance&apos;s dispatcher
is not null (i.e. dispatcher has not been destroyed). This means if dispatcher is destroyed, the map would keep a
dangling pointer that is not to be removed.

* Source/WebKit/Platform/IPC/Connection.cpp:

Originally-landed-as: 297297.390@safari-7622-branch (cef844c4512c). <a href="https://rdar.apple.com/164277284">rdar://164277284</a>
Canonical link: <a href="https://commits.webkit.org/302927@main">https://commits.webkit.org/302927@main</a>
</pre>
----------------------------------------------------------------------
#### 38178546e86677235938cda80ddc90711d567422
<pre>
Fix use-after-free in MemoryBackingStoreTransaction::abort
<a href="https://rdar.apple.com/159649671">rdar://159649671</a>

Reviewed by Per Arne Vollan and Rupin Mittal.

MemoryIndex can be destroyed after the last reference is removed in MemoryBackingStoreTransaction::removeNewIndex(), but
MemoryBackingStoreTransaction::m_originalIndexNames might still keep the raw pointer to the MemoryIndex, and when
transaction is aborted later, MemoryBackingStoreTransaction::abort would access the pointer. To fix this, ensure
the MemoryIndex is removed from m_originalIndexNames in removeNewIndex(). Also, to avoid this use-after-free issue,
make m_originalIndexNames store RefPtr instead of raw pointer.

* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::removeNewIndex):
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:

Originally-landed-as: 297297.386@safari-7622-branch (70a1e97f4ce6). <a href="https://rdar.apple.com/164277522">rdar://164277522</a>
Canonical link: <a href="https://commits.webkit.org/302926@main">https://commits.webkit.org/302926@main</a>
</pre>
----------------------------------------------------------------------
#### efe12c3441641637f8a4bdddcef7138b3b1df195
<pre>
UAF may occur in `-[WKContentView .cxx_destruct]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298293">https://bugs.webkit.org/show_bug.cgi?id=298293</a>
<a href="https://rdar.apple.com/151523238">rdar://151523238</a>

Reviewed by Abrar Rahman Protyasha.

UAFs have been observed when loading a weak reference from the (weak)
`NSHashTable` containing `WKVisibilityPropagationView`s.

The root cause of the issue is still unclear, since the references should have
been zeroed out. Mitigate the issue by using an `NSMutableSet` that strongly
references the `WKVisibilityPropagationView`s. This is safe to do since it does
not introduce a reference cycle. The only downside is additional manual
bookkeeping when the views are removed.

* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setVisibilityPropagationViewForLayerHostView):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::removeVisibilityPropagationView):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::removeVisibilityPropagationView):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _createVisibilityPropagationView]):
(-[WKContentView _removeVisibilityPropagationView:]):

Originally-landed-as: 297297.376@safari-7622-branch (d159f371e83b). <a href="https://rdar.apple.com/164277707">rdar://164277707</a>
Canonical link: <a href="https://commits.webkit.org/302925@main">https://commits.webkit.org/302925@main</a>
</pre>
----------------------------------------------------------------------
#### 5d87b66c79d041c09293189d38e0ed2d5f094779
<pre>
Prevent speechSynthesis from being accessible in LDM.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298382">https://bugs.webkit.org/show_bug.cgi?id=298382</a>
<a href="https://rdar.apple.com/159462101">rdar://159462101</a>

Reviewed by Alex Christensen.

We were missing an EnabledBySetting=SpeechSynthesisAPIEnabled guard on the
DOMWindow+SpeechSynthesis.idl file. This results in window.speechSynthesis
still remaining accessible to sites, even when the setting is disabled. This
then results in process termination when the IPC message is attempted and the
privileged process marks the IPC message as invalid.

This adds the guard, and a new test to ensure this is sufficiently disabled
when in Lockdown Mode.

* LayoutTests/fast/speechsynthesis/lockdown-mode/speech-synthesis-expected.txt: Added.
* LayoutTests/fast/speechsynthesis/lockdown-mode/speech-synthesis.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/Modules/speech/DOMWindow+SpeechSynthesis.idl:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Originally-landed-as: 297297.375@safari-7622-branch (7d5ef34062b7). <a href="https://rdar.apple.com/164277664">rdar://164277664</a>
Canonical link: <a href="https://commits.webkit.org/302924@main">https://commits.webkit.org/302924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72139c0ff620e15e8a3187919dc76519e160d29c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82142 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d28e26dc-7dee-42ca-ae2a-5a03818911a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99452 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6e6b602d-6ee0-4f6d-af9d-41c60a2a0e1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2054 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116888 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6690f523-0cf2-4547-920d-2cb1ac97a020) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35020 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81211 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122537 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110541 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140431 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128987 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107966 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113233 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107884 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31671 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55573 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20344 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66054 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162002 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2484 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40392 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2591 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->