### PR TITLE
[AutoFill Debugging] Make several minor adjustments to the text extraction output format

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -11,7 +11,7 @@ root
         section,aria-label='Interactive Elements'
             button,uid=…,events=[click],aria-label='Test button','Click Me',[…]
             '        \nThis button does nothing\n\n        ',[…]
-            textFormControl,'text',uid=…,placeholder='Enter text here','Enter text here',[…]
+            input,'text',uid=…,placeholder='Enter text here'
             uid=…,role='button',events=[click,keyboard],'Clickable Div',[…]
         section,aria-label='Content with Roles'
             article,role='article','            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.\n\n\n        ',[…]
@@ -27,6 +27,8 @@ root
                 button,uid=…,events=[click],'Update Status',[…]
             aria-label='Figure 1'
                 canvas,uid=…,[…]
+            link,uid=…,url='https://webkit.org/'
+            textarea,uid=…,'This is a text box',[…]
     role='contentinfo'
         '    \nFooter content with ',[…]
         role='img',aria-label='copyright symbol','©',[…]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -78,6 +78,8 @@ canvas {
         <div class="canvas-container" aria-label="Figure 1">
             <canvas width="400" height="400"></canvas>
         </div>
+        <a href="https://webkit.org">webkit.org</a>
+        <textarea rows="15" cols="40">This is a text box</textarea>
     </section>
 </main>
 <footer role="contentinfo">

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
@@ -1,4 +1,4 @@
 root
-	textFormControl,'email',placeholder='Enter your email'
-	textFormControl,'password',placeholder='Enter your password',secure
-	textFormControl,'number',placeholder='Security code','123456'
+	input,'email',placeholder='Enter your email'
+	input,'password',placeholder='Enter your password',secure
+	input,'number',placeholder='Security code','123456'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -10,7 +10,7 @@ root
     section
         button,'Click Me'
         '        \nThis button does nothing\n\n        '
-        textFormControl,'text',placeholder='Enter text here','Enter text here'
+        input,'text',placeholder='Enter text here'
         '        \nClickable Div\n\n    '
     section
         article,'            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content…\n\n\n        '

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -634,6 +634,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
                 WTFMove(result),
                 WTFMove(bounds),
                 { },
+                node.nodeName(),
                 WTFMove(nodeIdentifier),
                 eventListeners,
                 WTFMove(ariaAttributes),
@@ -651,6 +652,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
             item = {
                 TextItemData { { }, { }, emptyString(), { } },
                 WTFMove(bounds),
+                { },
                 { },
                 { },
                 eventListeners,
@@ -757,7 +759,7 @@ static Node* nodeFromJSHandle(JSHandleIdentifier identifier)
 
 Item extractItem(Request&& request, Page& page)
 {
-    Item root { ContainerType::Root, { }, { }, { }, { }, { }, { }, { } };
+    Item root { ContainerType::Root, { }, { }, { }, { }, { }, { }, { }, { } };
     RefPtr mainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
     if (!mainFrame) {
         // FIXME: Propagate text extraction to RemoteFrames.

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -151,11 +151,19 @@ struct Item {
     ItemData data;
     FloatRect rectInRootView;
     Vector<Item> children;
+    String nodeName;
     std::optional<NodeIdentifier> nodeIdentifier;
     OptionSet<EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;
     HashMap<String, String> clientAttributes;
+
+    template<typename T> std::optional<T> dataAs() const
+    {
+        if (std::holds_alternative<T>(data))
+            return std::get<T>(data);
+        return std::nullopt;
+    }
 };
 
 } // namespace TextExtraction

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6833,6 +6833,7 @@ header: <WebCore/TextExtractionTypes.h>
     Variant<WebCore::TextExtraction::ContainerType, WebCore::TextExtraction::TextItemData, WebCore::TextExtraction::ScrollableItemData, WebCore::TextExtraction::ImageItemData, WebCore::TextExtraction::SelectData, WebCore::TextExtraction::ContentEditableData, WebCore::TextExtraction::TextFormControlData, WebCore::TextExtraction::LinkItemData> data;
     WebCore::FloatRect rectInRootView;
     Vector<WebCore::TextExtraction::Item> children;
+    String nodeName;
     std::optional<WebCore::NodeIdentifier> nodeIdentifier;
     OptionSet<WebCore::TextExtraction::EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;


### PR DESCRIPTION
#### df7894a3240074f70d8e3b1ce1b4ea4886c72052
<pre>
[AutoFill Debugging] Make several minor adjustments to the text extraction output format
<a href="https://bugs.webkit.org/show_bug.cgi?id=302352">https://bugs.webkit.org/show_bug.cgi?id=302352</a>
<a href="https://rdar.apple.com/164509017">rdar://164509017</a>

Reviewed by Abrar Rahman Protyasha.

Make several adjustments to text extraction output formatting, and rebaseline / augment tests as
needed. See below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
(WebCore::TextExtraction::Item::dataAs const):

Add a helper method to grab the item&apos;s data variant as the given template type (or `nullopt` if the
type does not match).

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForItem):
(WebKit::childTextNodeIsRedundant):

Avoid exposing a child text node in the extraction output, in the case where the content of the
child text node is already reflected in one of the attributes on the element (e.g. in the case where
you have `&lt;input aria-label=&quot;foo&quot;&gt;foo&lt;/input&gt;` or `&lt;a href=&quot;<a href="http://example.com&quot">http://example.com&quot</a>;&gt;example.com&lt;/a&gt;`, we
condense that into `input,aria-label=&apos;foo&apos;` and `link,url=&apos;<a href="http://example.com&apos">http://example.com&apos</a>;`, respectively).

(WebKit::addTextRepresentationRecursive):

Instead of exposing a top-level `textFormControl` item type, just use the tag name (`input` or
`textarea`) which more clearly represents the type of the element.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/302898@main">https://commits.webkit.org/302898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f71daf490c000a4a9767846da6849bbea0865755

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138011 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2756 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133540 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80200 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81270 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140491 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2654 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27462 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2049 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2724 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66113 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->