### PR TITLE
[iOS] Third-party video apps lack standardized caption customization for FCC compliance

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1785,7 +1785,7 @@ CanvasUsesAcceleratedDrawing:
 
 CaptionDisplaySettingsEnabled:
   type: bool
-  status: unstable
+  status: internal
   category: media
   humanReadableName: "Caption Display Settings API"
   humanReadableDescription: "Enable Caption Display Settings API"

--- a/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
@@ -408,8 +408,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) __kindof AVPictureInPictureContentViewController *activeContentViewController API_AVAILABLE(ios(16.0),tvos(16.0)) API_UNAVAILABLE(macos, watchos);
 @end
 
-NS_ASSUME_NONNULL_END
 
+NS_ASSUME_NONNULL_END
 #endif // PLATFORM(IOS_FAMILY)
 
 #endif // USE(APPLE_INTERNAL_SDK)
@@ -626,3 +626,54 @@ NS_ASSUME_NONNULL_END
 #endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // HAVE(AVKIT_CONTENT_SOURCE)
+
+#if USE(APPLE_INTERNAL_SDK)
+
+#if !__has_include(<AVKit/AVLegibleMediaOptionsMenuController.h>)
+
+typedef NS_ENUM(NSInteger, AVLegibleMediaOptionsMenuType) {
+    AVLegibleMediaOptionsMenuTypeDefault,
+    AVLegibleMediaOptionsMenuTypeCaptionAppearance
+} SPI_AVAILABLE(ios(26.4), macos(26.4)) API_UNAVAILABLE(tvos, visionos, watchos);
+
+typedef NS_ENUM(NSInteger, AVLegibleMediaOptionEnablementState) {
+    AVLegibleMediaOptionEnablementStateOff,
+    AVLegibleMediaOptionEnablementStateOn
+} SPI_AVAILABLE(ios(26.4), macos(26.4)) API_UNAVAILABLE(tvos, visionos, watchos);
+
+typedef NS_ENUM(NSInteger, AVLegibleMediaOptionsPresentationState) {
+    AVLegibleMediaOptionsPresentationStateDismissed,
+    AVLegibleMediaOptionsPresentationStatePresented
+} SPI_AVAILABLE(macos(26.4)) API_UNAVAILABLE(ios, tvos, visionos, watchos);
+
+@protocol AVLegibleMediaOptionsMenuControllerDelegate;
+
+SPI_AVAILABLE(ios(26.4), macos(26.4)) API_UNAVAILABLE(tvos, visionos, watchos)
+@interface AVLegibleMediaOptionsMenuController : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithPlayer:(nullable AVPlayer *)player NS_DESIGNATED_INITIALIZER;
+
+#if TARGET_OS_OSX && !TARGET_OS_MACCATALYST
+- (void)presentMenuOfType:(AVLegibleMediaOptionsMenuType)type fromButton:(NSButton *)button presentationStateHandler:(nullable void (^)(AVLegibleMediaOptionsPresentationState state))handler;
+#else
+- (nullable UIMenu *)buildMenuOfType:(AVLegibleMediaOptionsMenuType)type;
+#endif
+
+@property (nonatomic, weak) id<AVLegibleMediaOptionsMenuControllerDelegate> delegate;
+@property (nonatomic, readonly) AVLegibleMediaOptionEnablementState currentEnablementState;
+
+@end
+
+SPI_AVAILABLE(ios(26.4), macos(26.4)) API_UNAVAILABLE(tvos, visionos, watchos)
+@protocol AVLegibleMediaOptionsMenuControllerDelegate <NSObject>
+@optional
+
+- (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didUpdateEnablementState:(AVLegibleMediaOptionEnablementState)enablementState;
+- (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didRequestCaptionPreviewForProfileID:(NSString *)profileID;
+- (void)legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:(AVLegibleMediaOptionsMenuController *)menuController;
+
+@end
+
+#endif
+#endif

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -230,3 +230,14 @@ selectors = [
     { name = "_verticalScrollIndicatorColor", class = "UIScrollView" },
 ]
 requires = ["HAVE_UIKIT_SCROLLBAR_COLOR_SPI"]
+
+[[temporary-usage]]
+request = "rdar://164431329"
+cleanup = "rdar://164667890"
+classes = [
+    "AVLegibleMediaOptionsMenuController",
+]
+selectors = [
+    { name = "buildMenuOfType:", class = "AVLegibleMediaOptionsMenuController" },
+]
+requires = ["HAVE_AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER"]

--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
@@ -25,38 +25,33 @@
 
 #pragma once
 
-#import <WebKit/WKFoundation.h>
+#import "_WKCaptionStyleMenuController.h"
 
-#if TARGET_OS_OSX
-@class NSMenu;
-typedef NSMenu PlatformMenu;
-#else
+#import <wtf/RetainPtr.h>
+#import <wtf/Vector.h>
+#import <wtf/text/WTFString.h>
+
+#if !TARGET_OS_OSX && !TARGET_OS_WATCH
 @class UIContextMenuInteraction;
-@class UIMenu;
-typedef UIMenu PlatformMenu;
+@class UIAction;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol WKCaptionStyleMenuControllerDelegate <NSObject>
-- (void)captionStyleMenuWillOpen:(PlatformMenu *)menu;
-- (void)captionStyleMenuDidClose:(PlatformMenu *)menu;
-@end
-
-WK_EXTERN
-@interface WKCaptionStyleMenuController : NSObject
-
-#if TARGET_OS_IPHONE
-+ (instancetype)menuController;
-#endif
-
-@property (weak, nonatomic) id<WKCaptionStyleMenuControllerDelegate> delegate;
-@property (readonly, nonatomic) PlatformMenu *captionStyleMenu;
+@interface WKCaptionStyleMenuController ()
+{
+    WTF::RetainPtr<PlatformMenu> _menu;
 #if !TARGET_OS_OSX && !TARGET_OS_WATCH
-@property (readonly, nullable, nonatomic) UIContextMenuInteraction *contextMenuInteraction;
+    WTF::RetainPtr<UIContextMenuInteraction> _interaction;
+#endif
+}
+
+@property (nonatomic, copy, nullable) NSString *savedActiveProfileID;
+@property (nonatomic, strong) PlatformMenu *menu;
+#if !TARGET_OS_OSX && !TARGET_OS_WATCH
+@property (nonatomic, strong) UIContextMenuInteraction *interaction;
 #endif
 
-- (BOOL)isAncestorOf:(PlatformMenu*)menu;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -893,7 +893,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
-    _captionStyleMenuController = adoptNS([[WKCaptionStyleMenuController alloc] init]);
+    _captionStyleMenuController = adoptNS([WKCaptionStyleMenuController menuController]);
     [_captionStyleMenuController setDelegate:self];
 
     NSArray<UIMenuElement *> *menuItems = [self _uiMenuElementsForMediaControlContextMenuItems:WTFMove(itemsToPresent)];

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.h
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.h
@@ -25,38 +25,12 @@
 
 #pragma once
 
-#import <WebKit/WKFoundation.h>
+#import "_WKCaptionStyleMenuController.h"
 
-#if TARGET_OS_OSX
-@class NSMenu;
-typedef NSMenu PlatformMenu;
-#else
-@class UIContextMenuInteraction;
-@class UIMenu;
-typedef UIMenu PlatformMenu;
-#endif
+#if HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
 
-NS_ASSUME_NONNULL_BEGIN
+@interface _WKCaptionStyleMenuControllerAVKit : WKCaptionStyleMenuController
 
-@protocol WKCaptionStyleMenuControllerDelegate <NSObject>
-- (void)captionStyleMenuWillOpen:(PlatformMenu *)menu;
-- (void)captionStyleMenuDidClose:(PlatformMenu *)menu;
 @end
 
-WK_EXTERN
-@interface WKCaptionStyleMenuController : NSObject
-
-#if TARGET_OS_IPHONE
-+ (instancetype)menuController;
 #endif
-
-@property (weak, nonatomic) id<WKCaptionStyleMenuControllerDelegate> delegate;
-@property (readonly, nonatomic) PlatformMenu *captionStyleMenu;
-#if !TARGET_OS_OSX && !TARGET_OS_WATCH
-@property (readonly, nullable, nonatomic) UIContextMenuInteraction *contextMenuInteraction;
-#endif
-
-- (BOOL)isAncestorOf:(PlatformMenu*)menu;
-@end
-
-NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "_WKCaptionStyleMenuControllerAVKit.h"
+
+#if HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
+
+#import "_WKCaptionStyleMenuControllerInternal.h"
+
+#if __has_include(<AVKit/AVLegibleMediaOptionsMenuController.h>)
+#import <AVKit/AVLegibleMediaOptionsMenuController.h>
+#endif
+
+#import <UIKit/UIKit.h>
+#import <WebCore/CaptionUserPreferencesMediaAF.h>
+#import <pal/spi/cocoa/AVKitSPI.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
+#import <wtf/text/WTFString.h>
+
+#import <pal/cf/CoreMediaSoftLink.h>
+
+SOFTLINK_AVKIT_FRAMEWORK()
+SOFT_LINK_CLASS_OPTIONAL(AVKit, AVLegibleMediaOptionsMenuController)
+
+using namespace WebCore;
+using namespace WTF;
+
+@interface _WKCaptionStyleMenuControllerAVKit () <AVLegibleMediaOptionsMenuControllerDelegate> {
+    RetainPtr<AVLegibleMediaOptionsMenuController> _menuController;
+}
+@end
+
+@implementation _WKCaptionStyleMenuControllerAVKit
+
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+
+    if (!AVKitLibrary())
+        return nil;
+
+    _menuController = [allocAVLegibleMediaOptionsMenuControllerInstance() initWithPlayer:nil];
+    [_menuController setDelegate:self];
+    [self rebuildMenu];
+
+    return self;
+}
+
+- (void)rebuildMenu
+{
+    self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
+}
+
+- (BOOL)isAncestorOf:(PlatformMenu*)menu
+{
+    if (!self.menu)
+        return NO;
+    return [menu isEqual:self.menu];
+}
+
+#pragma mark - AVLegibleMediaOptionsMenuControllerDelegate
+
+- (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didRequestCaptionPreviewForProfileID:(NSString *)profileID
+{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
+        [self findAndDismissContextMenus];
+    });
+}
+
+- (void)findAndDismissContextMenus
+{
+    UIApplication *app = [UIApplication sharedApplication];
+
+    for (UIScene *scene in app.connectedScenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]]) {
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            for (UIWindow *window in windowScene.windows)
+                [self searchForContextMenuInteractionsInView:window];
+        }
+    }
+}
+
+- (void)searchForContextMenuInteractionsInView:(UIView *)view
+{
+    for (id<UIInteraction> interaction in view.interactions) {
+        if ([interaction isKindOfClass:[UIContextMenuInteraction class]]) {
+            RetainPtr<UIContextMenuInteraction> contextInteraction = interaction;
+            [contextInteraction dismissMenu];
+            break;
+        }
+    }
+
+    for (UIView *subview in view.subviews)
+        [self searchForContextMenuInteractionsInView:subview];
+}
+
+@end
+
+#endif
+

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1823,6 +1823,8 @@
 		961A72D02E17270900DD2AF9 /* WebExtensionBookmarksParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 96CC7DBF2E15EC2800233E69 /* WebExtensionBookmarksParameters.h */; };
 		96418A5E2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */; };
 		96EE6CE82DFA4980000F90BD /* WebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */; };
+		97AD28742ECE625300039097 /* _WKCaptionStyleMenuControllerAVKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 97F26D492EC67188006096CD /* _WKCaptionStyleMenuControllerAVKit.mm */; };
+		97C476282ECD33A6004D1492 /* _WKCaptionStyleMenuControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C476272ECD338A004D1492 /* _WKCaptionStyleMenuControllerInternal.h */; };
 		99036AE223A949CF0000B06A /* _WKInspectorDebuggableInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE123A949CE0000B06A /* _WKInspectorDebuggableInfoInternal.h */; };
 		99036AE523A958750000B06A /* APIDebuggableInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE323A958740000B06A /* APIDebuggableInfo.h */; };
 		99036AE923A970870000B06A /* DebuggableInfoData.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE723A970870000B06A /* DebuggableInfoData.h */; };
@@ -2545,10 +2547,10 @@
 		F4E090952D889D6A00322226 /* WKIdentityDocumentPresentmentDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E090942D889CB800322226 /* WKIdentityDocumentPresentmentDelegate.h */; };
 		F4E090992D88AAC300322226 /* WKIdentityDocumentPresentmentRawRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E090962D88A66F00322226 /* WKIdentityDocumentPresentmentRawRequest.h */; };
 		F4E28A362C923814008120DD /* ScriptTrackingPrivacyFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E28A352C923814008120DD /* ScriptTrackingPrivacyFilter.h */; };
-		F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */; };
-		F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */; };
 		F4E2A3832EB5416C00D7A783 /* CoreIPCDDScannerResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E2A3822EB5415B00D7A783 /* CoreIPCDDScannerResult.mm */; };
 		F4E2A3842EB5417300D7A783 /* CoreIPCDDScannerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E2A3812EB5415B00D7A783 /* CoreIPCDDScannerResult.h */; };
+		F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */; };
+		F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */; };
 		F4E44EB72DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
@@ -7314,6 +7316,9 @@
 		96D1B84C2E01F06300D2D42E /* WebExtensionAPIBookmarksCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIBookmarksCocoa.mm; sourceTree = "<group>"; };
 		96E05A002DF7B58700285827 /* WebExtensionAPIBookmarks.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIBookmarks.idl; sourceTree = "<group>"; };
 		96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIBookmarks.h; sourceTree = "<group>"; };
+		97C476272ECD338A004D1492 /* _WKCaptionStyleMenuControllerInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKCaptionStyleMenuControllerInternal.h; sourceTree = "<group>"; };
+		97F26D492EC67188006096CD /* _WKCaptionStyleMenuControllerAVKit.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKCaptionStyleMenuControllerAVKit.mm; sourceTree = "<group>"; };
+		97F26D4A2EC67246006096CD /* _WKCaptionStyleMenuControllerAVKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKCaptionStyleMenuControllerAVKit.h; sourceTree = "<group>"; };
 		99036AE123A949CE0000B06A /* _WKInspectorDebuggableInfoInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorDebuggableInfoInternal.h; sourceTree = "<group>"; };
 		99036AE323A958740000B06A /* APIDebuggableInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIDebuggableInfo.h; sourceTree = "<group>"; };
 		99036AE423A958740000B06A /* APIDebuggableInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIDebuggableInfo.cpp; sourceTree = "<group>"; };
@@ -8728,11 +8733,11 @@
 		F4E28A352C923814008120DD /* ScriptTrackingPrivacyFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScriptTrackingPrivacyFilter.h; sourceTree = "<group>"; };
 		F4E28A372C923C71008120DD /* ScriptTrackingPrivacyFilter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScriptTrackingPrivacyFilter.cpp; sourceTree = "<group>"; };
 		F4E28A382C923C71008120DD /* ScriptTrackingPrivacyFilter.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScriptTrackingPrivacyFilter.serialization.in; sourceTree = "<group>"; };
+		F4E2A3812EB5415B00D7A783 /* CoreIPCDDScannerResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDScannerResult.h; sourceTree = "<group>"; };
+		F4E2A3822EB5415B00D7A783 /* CoreIPCDDScannerResult.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDScannerResult.mm; sourceTree = "<group>"; };
 		F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDSecureActionContext.h; sourceTree = "<group>"; };
 		F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDSecureActionContext.mm; sourceTree = "<group>"; };
 		F4E2A38D2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCDDSecureActionContext.serialization.in; sourceTree = "<group>"; };
-		F4E2A3812EB5415B00D7A783 /* CoreIPCDDScannerResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDScannerResult.h; sourceTree = "<group>"; };
-		F4E2A3822EB5415B00D7A783 /* CoreIPCDDScannerResult.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDScannerResult.mm; sourceTree = "<group>"; };
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift"; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
@@ -10405,6 +10410,7 @@
 				57FD316B22B3367E008D0E8B /* SOAuthorization */,
 				0753694A2DC589F4006446F8 /* TextExtraction */,
 				CD89ACBA2EA696A300C76423 /* _WKCaptionStyleMenuController.h */,
+				97C476272ECD338A004D1492 /* _WKCaptionStyleMenuControllerInternal.h */,
 				5CA26D80217ABBB600F97A35 /* _WKWarningView.h */,
 				5CA26D7F217ABBB600F97A35 /* _WKWarningView.mm */,
 				EB517B7A2D7BC03B0019E451 /* AboutSchemeHandlerCocoa.mm */,
@@ -12128,6 +12134,8 @@
 			children = (
 				C54256AE18BEC16100DE4179 /* forms */,
 				CDC2831A201BD75600E6E745 /* fullscreen */,
+				97F26D4A2EC67246006096CD /* _WKCaptionStyleMenuControllerAVKit.h */,
+				97F26D492EC67188006096CD /* _WKCaptionStyleMenuControllerAVKit.mm */,
 				CDFF2D082EAB3CAA00899478 /* _WKCaptionStyleMenuControllerIOS.mm */,
 				F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */,
 				F41795A52AC619A2007F5F12 /* CompactContextMenuPresenter.mm */,
@@ -12889,7 +12897,6 @@
 				5181988E2B7585E30084E292 /* CoreIPCDateComponents.h */,
 				5181988F2B7585E30084E292 /* CoreIPCDateComponents.mm */,
 				5181988D2B7585E30084E292 /* CoreIPCDateComponents.serialization.in */,
-				51AD56892B1C3BA1001A0ECB /* CoreIPCDDActionContext.serialization.in */,
 				F4E2A3812EB5415B00D7A783 /* CoreIPCDDScannerResult.h */,
 				F4E2A3822EB5415B00D7A783 /* CoreIPCDDScannerResult.mm */,
 				51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */,
@@ -17307,6 +17314,7 @@
 				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
 				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
 				CD89ACBD2EA696A300C76423 /* _WKCaptionStyleMenuController.h in Headers */,
+				97C476282ECD33A6004D1492 /* _WKCaptionStyleMenuControllerInternal.h in Headers */,
 				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
 				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
 				9B4CE9512CD99B7C00351173 /* _WKContentWorldConfiguration.h in Headers */,
@@ -19616,6 +19624,9 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				KnownAssetTags = (
+					New,
+				);
 				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1140;
 				TargetAttributes = {
@@ -21299,6 +21310,7 @@
 				5790A6852567A21E0077C5A7 /* _WKAuthenticatorAttestationResponse.mm in Sources */,
 				5790A6812567A1AC0077C5A7 /* _WKAuthenticatorResponse.mm in Sources */,
 				5790A66725679CEA0077C5A7 /* _WKAuthenticatorSelectionCriteria.mm in Sources */,
+				97AD28742ECE625300039097 /* _WKCaptionStyleMenuControllerAVKit.mm in Sources */,
 				CDFF2D092EAB3CAA00899478 /* _WKCaptionStyleMenuControllerIOS.mm in Sources */,
 				CD89ACBC2EA696A300C76423 /* _WKCaptionStyleMenuControllerMac.mm in Sources */,
 				5CBD595C2280EDF4002B22AA /* _WKCustomHeaderFields.mm in Sources */,


### PR DESCRIPTION
#### f27610320c33bed78f1a2a19e2e8a3652c039e66
<pre>
[iOS] Third-party video apps lack standardized caption customization for FCC compliance
<a href="https://bugs.webkit.org/show_bug.cgi?id=302359">https://bugs.webkit.org/show_bug.cgi?id=302359</a>
<a href="https://rdar.apple.com/164670301">rdar://164670301</a>

Reviewed by Jer Noble.

Replace existing media controls captions styles menu for iOS with the new AVKit SPI to meet FCC
compliance. Add SPI declaration to AVKitSPI.h and soft-link it in WKCaptionStyleMenuControllerIOS

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h:
* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h: Copied from Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h.
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant showMediaControlsContextMenu:items:frameInfo:identifier:completionHandler:]):
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.h: Copied from Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h.
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm: Added.
(-[_WKCaptionStyleMenuControllerAVKit init]):
(-[_WKCaptionStyleMenuControllerAVKit rebuildMenu]):
(-[_WKCaptionStyleMenuControllerAVKit isAncestorOf:]):
(-[_WKCaptionStyleMenuControllerAVKit legibleMenuController:didRequestCaptionPreviewForProfileID:]):
(-[_WKCaptionStyleMenuControllerAVKit findAndDismissContextMenus]):
(-[_WKCaptionStyleMenuControllerAVKit searchForContextMenuInteractionsInView:]):
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm:
(+[WKCaptionStyleMenuController menuController]):
(-[WKCaptionStyleMenuController init]):
(-[WKCaptionStyleMenuController rebuildMenu]):
(-[WKCaptionStyleMenuController menu]):
(-[WKCaptionStyleMenuController setMenu:]):
(-[WKCaptionStyleMenuController interaction]):
(-[WKCaptionStyleMenuController setInteraction:]):
(-[WKCaptionStyleMenuController profileActionSelected:]):
(-[WKCaptionStyleMenuController notifyMenuWillOpen]):
(-[WKCaptionStyleMenuController notifyMenuDidClose]):
(-[WKCaptionStyleMenuController contextMenuInteraction:configurationForMenuAtLocation:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(-[TestContextMenuDelegate contextMenuInteraction:configurationForMenuAtLocation:]):
(-[TestAVKitDelegate legibleMenuController:didRequestCaptionPreviewForProfileID:]):
(TestWebKitAPI::CaptionPreferenceTests::ensureController):
(TestWebKitAPI::CaptionPreferenceTests::runAndWaitForCaptionPreviewRequested):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, AVKitMenuControllerIntegration)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, ProfileIDSavingAndRestoration)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, ContextMenuDismissalSearch)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, MenuRebuildingWithAVKit)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, MenuAncestryCheck)):

Canonical link: <a href="https://commits.webkit.org/303293@main">https://commits.webkit.org/303293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fa46780023630ecb52ccbe4f05046ea290ecb27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139440 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e12e9cfd-b62a-44d5-b729-64245cce6519) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81632 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ae5f77e-5709-45bd-96d4-2a7c1c7a87dc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82660 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123991 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142085 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130435 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36855 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4171 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3100 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114432 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57311 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4143 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32830 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163402 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3975 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67590 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42481 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4103 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->