### PR TITLE
MediaSourcePrivate should be the reference when calculating the MediaPlayer's readyState

### DIFF
--- a/LayoutTests/media/media-source/media-detachablemse-append.html
+++ b/LayoutTests/media/media-source/media-detachablemse-append.html
@@ -45,8 +45,7 @@
         testExpected('video.audioTracks.length >= 1', true);
 
         run('source.endOfStream()');
-        waitFor(source, 'sourceended');
-        await loadedDataPromise;
+        await Promise.all([ loadedDataPromise, waitFor(source, 'sourceended') ]);
 
         run('readyState = video.readyState');
 

--- a/LayoutTests/media/media-source/media-source-video-renders.html
+++ b/LayoutTests/media/media-source/media-source-video-renders.html
@@ -29,7 +29,7 @@
                 once(video, 'seeked');
 
                 video.currentTime = 0;
-                once(video, 'seeked');
+                await once(video, 'seeked');
 
                 if (window.testRunner)
                     testRunner.notifyDone();

--- a/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort-expected.txt
+++ b/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort-expected.txt
@@ -10,7 +10,6 @@ EVENT(update)
 EXPECTED (video.readyState == '1') OK
 Append a media segment.
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
-EVENT(update)
 EVENT(loadeddata)
 EVENT(canplay)
 EXPECTED (video.readyState == '3') OK

--- a/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html
+++ b/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html
@@ -43,7 +43,7 @@
             await Promise.all([
                 waitFor(video, 'loadeddata'),
                 waitFor(video, 'canplay'),
-                waitFor(sourceBuffer, 'update'),
+                waitFor(sourceBuffer, 'update', true),
             ]);
             testExpected('video.readyState', video.HAVE_FUTURE_DATA);
             testExpected('sourceBuffer.buffered.length', 1);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -63,6 +63,7 @@ public:
 
 #if ENABLE(MEDIA_SOURCE)
     virtual void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) = 0;
+    virtual void readyStateFromMediaSourceChanged() { }
 #endif
 #if ENABLE(MEDIA_STREAM)
     virtual void load(MediaStreamPrivate&) = 0;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -236,6 +236,23 @@ bool MediaSourcePrivate::hasBufferedData() const
     return m_buffered.length();
 }
 
+MediaPlayer::ReadyState MediaSourcePrivate::mediaPlayerReadyState() const
+{
+    return m_mediaPlayerReadyState;
+}
+
+void MediaSourcePrivate::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
+{
+    m_mediaPlayerReadyState = readyState;
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (RefPtr player = protectedThis->player())
+            player->readyStateFromMediaSourceChanged();
+    });
+}
+
 PlatformTimeRanges MediaSourcePrivate::seekable() const
 {
     MediaTime duration;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -88,8 +88,8 @@ public:
     virtual void bufferedChanged(const PlatformTimeRanges&); // Base class method must be called in overrides. Must be thread-safe.
     void trackBufferedChanged(SourceBufferPrivate&, Vector<PlatformTimeRanges>&&);
 
-    virtual MediaPlayer::ReadyState mediaPlayerReadyState() const = 0;
-    virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState) = 0;
+    MediaPlayer::ReadyState mediaPlayerReadyState() const;
+    virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState);
     virtual void markEndOfStream(EndOfStreamStatus) { m_isEnded = true; }
     virtual void unmarkEndOfStream() { m_isEnded = false; }
     bool isEnded() const { return m_isEnded; }
@@ -137,6 +137,8 @@ protected:
     Vector<SourceBufferPrivate*> m_activeSourceBuffers;
     std::atomic<bool> m_isEnded { false }; // Set on MediaSource's dispatcher.
     std::atomic<MediaSourceReadyState> m_readyState; // Set on MediaSource's dispatcher.
+    std::atomic<WebCore::MediaPlayer::ReadyState> m_mediaPlayerReadyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
+
     const Ref<WorkQueue> m_dispatcher; // SerialFunctionDispatcher the SourceBufferPrivate/MediaSourcePrivate is running on.
 
 private:

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -1012,7 +1012,7 @@ void AudioVideoRendererAVFObjC::maybeCompleteSeek()
         ALWAYS_LOG(LOGIDENTIFIER, "Not resuming playback, shouldBePlaying:false");
 
     if (auto promise = std::exchange(m_seekPromise, std::nullopt))
-        promise->resolve();
+        promise->resolve(m_lastSeekTime);
     ALWAYS_LOG(LOGIDENTIFIER, "seek completed");
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -304,6 +304,9 @@ private:
 
     void isInFullscreenOrPictureInPictureChanged(bool) final;
 
+    void readyStateFromMediaSourceChanged() final;
+    void updateStateFromReadyState();
+
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const final { return true; }
 #endif
@@ -345,7 +348,7 @@ private:
     ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;
 #endif
     MediaPlayer::NetworkState m_networkState WTF_GUARDED_BY_CAPABILITY(mainThread);
-    MediaPlayer::ReadyState m_readyState WTF_GUARDED_BY_CAPABILITY(mainThread);
+    MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     bool m_readyStateIsWaitingForAvailableFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     MediaTime m_duration WTF_GUARDED_BY_CAPABILITY(mainThread) { MediaTime::invalidTime() };
     MediaTime m_lastSeekTime WTF_GUARDED_BY_CAPABILITY(mainThread);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -74,11 +74,6 @@ public:
     void durationChanged(const MediaTime&) final;
     void markEndOfStream(EndOfStreamStatus) final;
 
-    MediaPlayer::ReadyState mediaPlayerReadyState() const final;
-    void setMediaPlayerReadyState(MediaPlayer::ReadyState) final;
-
-    bool hasSelectedVideo() const;
-
     FloatSize naturalSize() const;
 
     void hasSelectedVideoChanged(SourceBufferPrivateAVFObjC&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -77,6 +77,7 @@ MediaSourcePrivateAVFObjC::~MediaSourcePrivateAVFObjC()
 
 void MediaSourcePrivateAVFObjC::setPlayer(MediaPlayerPrivateInterface* player)
 {
+    ASSERT(player);
     m_player = downcast<MediaPlayerPrivateMediaSourceAVFObjC>(player);
     for (RefPtr sourceBuffer : m_sourceBuffers)
         downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->setAudioVideoRenderer(m_player->audioVideoRenderer());
@@ -145,26 +146,6 @@ void MediaSourcePrivateAVFObjC::markEndOfStream(EndOfStreamStatus status)
     if (auto player = platformPlayer(); status == EndOfStreamStatus::NoError && player)
         player->setNetworkState(MediaPlayer::NetworkState::Loaded);
     MediaSourcePrivate::markEndOfStream(status);
-}
-
-MediaPlayer::ReadyState MediaSourcePrivateAVFObjC::mediaPlayerReadyState() const
-{
-    if (auto player = this->player())
-        return player->readyState();
-    return MediaPlayer::ReadyState::HaveNothing;
-}
-
-void MediaSourcePrivateAVFObjC::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
-{
-    if (auto player = platformPlayer())
-        player->setReadyState(readyState);
-}
-
-bool MediaSourcePrivateAVFObjC::hasSelectedVideo() const
-{
-    return std::ranges::any_of(m_activeSourceBuffers, [](auto* sourceBuffer) {
-        return downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->hasSelectedVideo();
-    });
 }
 
 FloatSize MediaSourcePrivateAVFObjC::naturalSize() const

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -78,7 +78,7 @@ public:
     bool supportsProgressMonitoring() const override { return false; }
 
     void setNetworkState(MediaPlayer::NetworkState);
-    void setReadyState(MediaPlayer::ReadyState);
+    void readyStateFromMediaSourceChanged() final;
 
     void setInitialVideoSize(const FloatSize&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -174,18 +174,6 @@ void MediaSourcePrivateGStreamer::unmarkEndOfStream()
     MediaSourcePrivate::unmarkEndOfStream();
 }
 
-MediaPlayer::ReadyState MediaSourcePrivateGStreamer::mediaPlayerReadyState() const
-{
-    RefPtr player = platformPlayer();
-    return player ? player->readyState() : MediaPlayer::ReadyState::HaveNothing;
-}
-
-void MediaSourcePrivateGStreamer::setMediaPlayerReadyState(MediaPlayer::ReadyState state)
-{
-    if (RefPtr player = platformPlayer())
-        player->setReadyState(state);
-}
-
 void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
 {
     RefPtr player = platformPlayer();

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -67,9 +67,6 @@ public:
     void markEndOfStream(EndOfStreamStatus) override;
     void unmarkEndOfStream() override;
 
-    MediaPlayer::ReadyState mediaPlayerReadyState() const override;
-    void setMediaPlayerReadyState(MediaPlayer::ReadyState) override;
-
     void notifyActiveSourceBuffersChanged() final;
 
     void startPlaybackIfHasAllTracks();

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -177,7 +177,15 @@ MediaPlayer::NetworkState MockMediaPlayerMediaSource::networkState() const
 
 MediaPlayer::ReadyState MockMediaPlayerMediaSource::readyState() const
 {
-    return m_readyState;
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate ? mediaSourcePrivate->mediaPlayerReadyState() : MediaPlayer::ReadyState::HaveNothing;
+}
+
+void MockMediaPlayerMediaSource::readyStateFromMediaSourceChanged()
+{
+    assertIsMainThread();
+    if (RefPtr player = m_player.get())
+        player->readyStateChanged();
 }
 
 MediaTime MockMediaPlayerMediaSource::maxTimeSeekable() const
@@ -285,16 +293,6 @@ void MockMediaPlayerMediaSource::updateDuration(const MediaTime& duration)
     m_duration = duration;
     if (auto player = m_player.get())
         player->durationChanged();
-}
-
-void MockMediaPlayerMediaSource::setReadyState(MediaPlayer::ReadyState readyState)
-{
-    if (readyState == m_readyState)
-        return;
-
-    m_readyState = readyState;
-    if (auto player = m_player.get())
-        player->readyStateChanged();
 }
 
 void MockMediaPlayerMediaSource::setNetworkState(MediaPlayer::NetworkState networkState)

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -65,7 +65,7 @@ public:
     void updateDuration(const MediaTime&);
 
     MediaPlayer::ReadyState readyState() const override;
-    void setReadyState(MediaPlayer::ReadyState);
+    void readyStateFromMediaSourceChanged() final;
     void setNetworkState(MediaPlayer::NetworkState);
 
 #if !RELEASE_LOG_DISABLED
@@ -107,7 +107,6 @@ private:
     MediaTime m_currentTime;
     MediaTime m_duration;
     std::optional<SeekTarget> m_lastSeekTarget;
-    MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
     bool m_playing { false };
 };

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -97,19 +97,6 @@ void MockMediaSourcePrivate::markEndOfStream(EndOfStreamStatus status)
     MediaSourcePrivate::markEndOfStream(status);
 }
 
-MediaPlayer::ReadyState MockMediaSourcePrivate::mediaPlayerReadyState() const
-{
-    if (m_player)
-        return m_player->readyState();
-    return MediaPlayer::ReadyState::HaveNothing;
-}
-
-void MockMediaSourcePrivate::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
-{
-    if (m_player)
-        m_player->setReadyState(readyState);
-}
-
 void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
 {
     if (m_player)

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -75,9 +75,6 @@ private:
     void durationChanged(const MediaTime&) override;
     void markEndOfStream(EndOfStreamStatus) override;
 
-    MediaPlayer::ReadyState mediaPlayerReadyState() const override;
-    void setMediaPlayerReadyState(MediaPlayer::ReadyState) override;
-
     void notifyActiveSourceBuffersChanged() final;
 
     friend class MockSourceBufferPrivate;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -268,7 +268,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
         if (!createExtension()) {
             WTFLogAlways("Unable to create sandbox extension handle for GPUProcess url.\n");
             m_cachedState.networkState = MediaPlayer::NetworkState::FormatError;
-            if (auto player = m_player.get())
+            if (RefPtr player = m_player.get())
                 player->networkStateChanged();
             return;
         }
@@ -470,7 +470,7 @@ MediaPlayer::MovieLoadType MediaPlayerPrivateRemote::movieLoadType() const
 void MediaPlayerPrivateRemote::networkStateChanged(RemoteMediaPlayerState&& state)
 {
     updateCachedState(WTFMove(state));
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->networkStateChanged();
 }
 
@@ -483,7 +483,7 @@ void MediaPlayerPrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
             return;
         if (readyState > MediaPlayer::ReadyState::HaveCurrentData && m_readyState == MediaPlayer::ReadyState::HaveCurrentData)
             ALWAYS_LOG(LOGIDENTIFIER, "stall detected");
-        if (auto player = m_player.get())
+        if (RefPtr player = m_player.get())
             player->readyStateChanged();
     });
 }
@@ -502,14 +502,14 @@ void MediaPlayerPrivateRemote::readyStateChanged(RemoteMediaPlayerState&& state,
 void MediaPlayerPrivateRemote::volumeChanged(double volume)
 {
     m_volume = volume;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->volumeChanged(volume);
 }
 
 void MediaPlayerPrivateRemote::muteChanged(bool muted)
 {
     m_muted = muted;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->muteChanged(muted);
 }
 
@@ -518,7 +518,7 @@ void MediaPlayerPrivateRemote::seeked(MediaTimeUpdateData&& timeData)
     ALWAYS_LOG(LOGIDENTIFIER, "currentTime:", timeData.currentTime, " timeIsProgressing:", timeData.timeIsProgressing);
     m_seeking = false;
     m_currentTimeEstimator.setTime(timeData);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->seeked(timeData.currentTime);
 }
 
@@ -527,14 +527,14 @@ void MediaPlayerPrivateRemote::timeChanged(RemoteMediaPlayerState&& state, Media
     ALWAYS_LOG(LOGIDENTIFIER, "currentTime:", timeData.currentTime, " timeIsProgressing:", timeData.timeIsProgressing);
     updateCachedState(WTFMove(state));
     m_currentTimeEstimator.setTime(timeData);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->timeChanged();
 }
 
 void MediaPlayerPrivateRemote::durationChanged(RemoteMediaPlayerState&& state)
 {
     updateCachedState(WTFMove(state));
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->durationChanged();
 }
 
@@ -552,7 +552,7 @@ void MediaPlayerPrivateRemote::rateChanged(double rate, MediaTimeUpdateData&& ti
     // Force to use the cached time so that the next call to currentTime() will return the cached time.
     // Time will progress following the next call to currentTimeChanged.
     m_currentTimeEstimator.forceUseOfCachedTimeUntilNextSetTime();
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->rateChanged();
 }
 
@@ -561,28 +561,28 @@ void MediaPlayerPrivateRemote::playbackStateChanged(bool paused, MediaTimeUpdate
     INFO_LOG(LOGIDENTIFIER, "currentTime:", timeData.currentTime, " timeIsProgressing:", timeData.timeIsProgressing);
     m_cachedState.paused = paused;
     m_currentTimeEstimator.setTime(timeData);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->playbackStateChanged();
 }
 
 void MediaPlayerPrivateRemote::engineFailedToLoad(int64_t platformErrorCode)
 {
     m_platformErrorCode = platformErrorCode;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->remoteEngineFailedToLoad();
 }
 
 void MediaPlayerPrivateRemote::characteristicChanged(RemoteMediaPlayerState&& state)
 {
     updateCachedState(WTFMove(state));
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->characteristicChanged();
 }
 
 void MediaPlayerPrivateRemote::sizeChanged(WebCore::FloatSize naturalSize)
 {
     m_cachedState.naturalSize = naturalSize;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->sizeChanged();
 }
 
@@ -601,7 +601,7 @@ void MediaPlayerPrivateRemote::currentTimeChanged(MediaTimeUpdateData&& timeData
 
     if (reverseJump
         || (timeData.timeIsProgressing != oldTimeIsProgressing && timeData.currentTime != oldCachedTime && !m_cachedState.paused)) {
-        if (auto player = m_player.get())
+        if (RefPtr player = m_player.get())
             player->timeChanged();
     }
 }
@@ -609,14 +609,14 @@ void MediaPlayerPrivateRemote::currentTimeChanged(MediaTimeUpdateData&& timeData
 void MediaPlayerPrivateRemote::firstVideoFrameAvailable()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->firstVideoFrameAvailable();
 }
 
 void MediaPlayerPrivateRemote::renderingModeChanged()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->renderingModeChanged();
 }
 
@@ -647,7 +647,7 @@ bool MediaPlayerPrivateRemote::supportsAcceleratedRendering() const
 
 void MediaPlayerPrivateRemote::acceleratedRenderingStateChanged()
 {
-    if (auto player = m_player.get()) {
+    if (RefPtr player = m_player.get()) {
         protectedConnection()->send(Messages::RemoteMediaPlayerProxy::AcceleratedRenderingStateChanged(player->renderingCanBeAccelerated()), m_id);
     }
 }
@@ -765,7 +765,7 @@ void MediaPlayerPrivateRemote::addRemoteAudioTrack(AudioTrackPrivateRemoteConfig
         return;
 #endif
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->addAudioTrack(addResult.first->second);
 }
 
@@ -777,7 +777,7 @@ void MediaPlayerPrivateRemote::removeRemoteAudioTrack(TrackID trackID)
     ASSERT(m_audioTracks.contains(trackID));
 
     if (auto it = m_audioTracks.find(trackID); it != m_audioTracks.end()) {
-        if (auto player = m_player.get())
+        if (RefPtr player = m_player.get())
             player->removeAudioTrack(it->second);
         m_audioTracks.erase(trackID);
     }
@@ -815,7 +815,7 @@ void MediaPlayerPrivateRemote::addRemoteTextTrack(TextTrackPrivateRemoteConfigur
         return;
 #endif
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->addTextTrack(addResult.first->second);
 }
 
@@ -827,7 +827,7 @@ void MediaPlayerPrivateRemote::removeRemoteTextTrack(TrackID trackID)
     ASSERT(m_textTracks.contains(trackID));
 
     if (auto it = m_textTracks.find(trackID); it != m_textTracks.end()) {
-        if (auto player = m_player.get())
+        if (RefPtr player = m_player.get())
             player->removeTextTrack(it->second);
         m_textTracks.erase(trackID);
     }
@@ -979,7 +979,7 @@ void MediaPlayerPrivateRemote::addRemoteVideoTrack(VideoTrackPrivateRemoteConfig
         return;
 #endif
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->addVideoTrack(addResult.first->second);
 }
 
@@ -991,7 +991,7 @@ void MediaPlayerPrivateRemote::removeRemoteVideoTrack(TrackID trackID)
     ASSERT(m_videoTracks.contains(trackID));
 
     if (auto it = m_videoTracks.find(trackID); it != m_videoTracks.end()) {
-        if (auto player = m_player.get())
+        if (RefPtr player = m_player.get())
             player->removeVideoTrack(it->second);
         m_videoTracks.erase(trackID);
     }
@@ -1320,7 +1320,7 @@ void MediaPlayerPrivateRemote::setWirelessVideoPlaybackDisabled(bool disabled)
 void MediaPlayerPrivateRemote::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackTargetWireless)
 {
     m_isCurrentPlaybackTargetWireless = isCurrentPlaybackTargetWireless;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->currentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless);
 }
 
@@ -1439,7 +1439,7 @@ void MediaPlayerPrivateRemote::keyAdded()
 
 void MediaPlayerPrivateRemote::mediaPlayerKeyNeeded(std::span<const uint8_t> message)
 {
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->keyNeeded(SharedBuffer::create(message));
 }
 #endif
@@ -1466,14 +1466,14 @@ void MediaPlayerPrivateRemote::attemptToDecryptWithInstance(CDMInstance& instanc
 void MediaPlayerPrivateRemote::waitingForKeyChanged(bool waitingForKey)
 {
     m_waitingForKey = waitingForKey;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->waitingForKeyChanged();
 }
 
 void MediaPlayerPrivateRemote::initializationDataEncountered(const String& initDataType, std::span<const uint8_t> initData)
 {
     auto initDataBuffer = ArrayBuffer::create(initData);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->initializationDataEncountered(initDataType, WTFMove(initDataBuffer));
 }
 
@@ -1523,7 +1523,7 @@ size_t MediaPlayerPrivateRemote::extraMemoryCost() const
 
 void MediaPlayerPrivateRemote::reportGPUMemoryFootprint(uint64_t footPrint)
 {
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->reportGPUMemoryFootprint(footPrint);
 }
 
@@ -1691,20 +1691,20 @@ void MediaPlayerPrivateRemote::removeResource(RemoteMediaResourceIdentifier remo
 
 void MediaPlayerPrivateRemote::resourceNotSupported()
 {
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->resourceNotSupported();
 }
 
 void MediaPlayerPrivateRemote::activeSourceBuffersChanged()
 {
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->activeSourceBuffersChanged();
 }
 
 #if PLATFORM(IOS_FAMILY)
 void MediaPlayerPrivateRemote::getRawCookies(const URL& url, WebCore::MediaPlayerClient::GetRawCookiesCallback&& completionHandler) const
 {
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->getRawCookies(url, WTFMove(completionHandler));
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -213,11 +213,6 @@ void MediaSourcePrivateRemote::unmarkEndOfStream()
     });
 }
 
-MediaPlayer::ReadyState MediaSourcePrivateRemote::mediaPlayerReadyState() const
-{
-    return m_mediaPlayerReadyState;
-}
-
 void MediaSourcePrivateRemote::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
     // Call from MediaSource's dispatcher.

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -71,7 +71,6 @@ public:
     void durationChanged(const MediaTime&) final;
     void markEndOfStream(EndOfStreamStatus) final;
     void unmarkEndOfStream() final;
-    WebCore::MediaPlayer::ReadyState mediaPlayerReadyState() const final;
     void setMediaPlayerReadyState(WebCore::MediaPlayer::ReadyState) final;
     void setPlayer(WebCore::MediaPlayerPrivateInterface*) final;
     void shutdown() final;
@@ -116,7 +115,6 @@ private:
     const CheckedRef<RemoteMediaPlayerMIMETypeCache> m_mimeTypeCache;
     ThreadSafeWeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
     std::atomic<bool> m_shutdown { false };
-    std::atomic<WebCore::MediaPlayer::ReadyState> m_mediaPlayerReadyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateRemote"_s; }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h
@@ -34,7 +34,7 @@
 namespace WebKit {
 
 struct RemoteMediaPlayerConfiguration {
-    String engineDescription;
+    String engineDescription { "RemoteMediaPlayer_uninitialized"_s };
     bool supportsScanning { false };
     bool supportsFullscreen { false };
     bool supportsPictureInPicture { false };


### PR DESCRIPTION
#### ae8698d30174d73c3c7da72a642fc42b74ad46ae
<pre>
MediaSourcePrivate should be the reference when calculating the MediaPlayer&apos;s readyState
<a href="https://bugs.webkit.org/show_bug.cgi?id=302242">https://bugs.webkit.org/show_bug.cgi?id=302242</a>
<a href="https://rdar.apple.com/164381937">rdar://164381937</a>

Reviewed by Andy Estes.

The HTMLMediaElement&apos;s readyState is controlled via the MediaSource&apos;s monitor source buffer algorithm.
We have four participants at play:
HTMLMediaElement (main thread)
MediaPlayerPrivate (main thread)
MediaSource (worker)
MediaSourcePrivate (dedicated workqueue once webkit.org/b/302054 is completed).

The MediaSource used to call MediaSourcePrivate::setMediaPlayerReadyState
which would in turn call into MediaPlayerPrivate::setReadyState.
This required the MediaPlayerPrivate to provide thread-safe access to readyState().
A MediaPlayerPrivate is a main-thread only object and shouldn&apos;t know about any others.
So we make the MediaSourcePrivate the reference point for the readyState value
so that the MediaSourcePrivate can act as the multi-thread bridge between
MediaSource and MediaSourcePrivate.

No changes in existing behaviour; covered by existing tests.

* LayoutTests/media/media-source/media-detachablemse-append.html: Intermittent failures was revealed, we didn&apos;t wait for the `sourceended`
event, resulting in different results from time to time. Wait for the event to be fired being continuing
* LayoutTests/media/media-source/media-source-video-renders.html: Wait for seek event to be fired, otherwise there&apos;s no guarantee the expected frame is showing.
as the operation is asynchronous. Do not log it.
* LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort-expected.txt:
* LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html: `updateend` can be fired after `loadeddata` event is fired
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::readyStateFromMediaSourceChanged):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::mediaPlayerReadyState const):
(WebCore::MediaSourcePrivate::setMediaPlayerReadyState):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::maybeCompleteSeek): Fly-by fix: the seek promise wasn&apos;t resolved with the currentTime, causing the readyState
to incorrectly changed to HAVE_METADATA instead of HAVE_CURRENT_DATA. This issue was exposed due to the change of operation orders in this commit.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::readyState const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::readyStateFromMediaSourceChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldBePlaying const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setReadyState):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::setPlayer):
(WebCore::MediaSourcePrivateAVFObjC::mediaPlayerReadyState const): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::setMediaPlayerReadyState): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::hasSelectedVideo const): Deleted. Fly-by Removed unused method.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::readyStateFromMediaSourceChanged):
(WebCore::MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer):
(WebCore::MediaPlayerPrivateGStreamerMSE::setReadyState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::mediaPlayerReadyState const): Deleted.
(WebCore::MediaSourcePrivateGStreamer::setMediaPlayerReadyState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::readyState const):
(WebCore::MockMediaPlayerMediaSource::readyStateFromMediaSourceChanged):
(WebCore::MockMediaPlayerMediaSource::setReadyState): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::mediaPlayerReadyState const): Deleted.
(WebCore::MockMediaSourcePrivate::setMediaPlayerReadyState): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp: Replace all instances of `if (auto player = m_player.get())` with `if (RefPtr player = m_player.get())`
(WebKit::MediaPlayerPrivateRemote::load):
(WebKit::MediaPlayerPrivateRemote::networkStateChanged):
(WebKit::MediaPlayerPrivateRemote::setReadyState):
(WebKit::MediaPlayerPrivateRemote::volumeChanged):
(WebKit::MediaPlayerPrivateRemote::muteChanged):
(WebKit::MediaPlayerPrivateRemote::seeked):
(WebKit::MediaPlayerPrivateRemote::timeChanged):
(WebKit::MediaPlayerPrivateRemote::durationChanged):
(WebKit::MediaPlayerPrivateRemote::rateChanged):
(WebKit::MediaPlayerPrivateRemote::playbackStateChanged):
(WebKit::MediaPlayerPrivateRemote::engineFailedToLoad):
(WebKit::MediaPlayerPrivateRemote::characteristicChanged):
(WebKit::MediaPlayerPrivateRemote::sizeChanged):
(WebKit::MediaPlayerPrivateRemote::currentTimeChanged):
(WebKit::MediaPlayerPrivateRemote::firstVideoFrameAvailable):
(WebKit::MediaPlayerPrivateRemote::renderingModeChanged):
(WebKit::MediaPlayerPrivateRemote::acceleratedRenderingStateChanged):
(WebKit::MediaPlayerPrivateRemote::addRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::removeRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::removeRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::removeRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::currentPlaybackTargetIsWirelessChanged):
(WebKit::MediaPlayerPrivateRemote::mediaPlayerKeyNeeded):
(WebKit::MediaPlayerPrivateRemote::waitingForKeyChanged):
(WebKit::MediaPlayerPrivateRemote::initializationDataEncountered):
(WebKit::MediaPlayerPrivateRemote::reportGPUMemoryFootprint):
(WebKit::MediaPlayerPrivateRemote::resourceNotSupported):
(WebKit::MediaPlayerPrivateRemote::activeSourceBuffersChanged):
(WebKit::MediaPlayerPrivateRemote::getRawCookies const):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::mediaPlayerReadyState const): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h: Initialize the default identifier with a nullString
as it could cause crash in logging should we attempt to log a media operation before the RemoteMediaPlayerProxy has returned
with a new value.

Canonical link: <a href="https://commits.webkit.org/303379@main">https://commits.webkit.org/303379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d65bfc305e8414755e219e1d62bbc4864a8cf27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132226 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139741 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a18924b-f0eb-42a4-bf9f-1d7fe64a3d9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4480 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0670c6c7-d96d-4958-8b8f-c597071aaa4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135172 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81864 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/62a348f6-e618-45b3-b317-a4894c2f06a2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82961 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142388 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4388 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37130 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109629 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27766 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114703 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4442 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/4274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67888 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->