### PR TITLE
REGRESSION (301964@main): When creating a list on sharepoint.microsoft.com, panel turns blank until mouse click

### DIFF
--- a/LayoutTests/fast/repaint/iframe-from-display-none-repaint-expected.html
+++ b/LayoutTests/fast/repaint/iframe-from-display-none-repaint-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            width: 400px;
+            height: 300px;
+            border: none;
+        }
+    </style>
+</head>
+<body>
+
+<iframe scrolling="no" srcdoc="
+<style>
+    body {
+        width: 400px;
+        height: 300px;
+        background-color: green;
+    }
+</style>
+<body>
+</body>
+"></iframe>
+
+</body>
+</html>

--- a/LayoutTests/fast/repaint/iframe-from-display-none-repaint.html
+++ b/LayoutTests/fast/repaint/iframe-from-display-none-repaint.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            width: 400px;
+            height: 300px;
+            border: none;
+            display: none;
+        }
+        
+        body.changed iframe {
+            display: block;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+
+        window.addEventListener('load', async () => {
+            
+            await UIHelper.renderingUpdate();
+            document.body.classList.add('changed');
+
+            await UIHelper.renderingUpdate();
+            const iframe = document.getElementsByTagName('iframe')[0];
+            iframe.contentDocument.body.classList.add('changed');
+
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+
+            window.testRunner?.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+
+<iframe scrolling="no" srcdoc="
+<style>
+    body {
+        width: 400px;
+        height: 300px;
+        background-color: red;
+    }
+    
+    body.changed {
+        background-color: green;
+    }
+</style>
+<body>
+</body>
+"></iframe>
+
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2970,7 +2970,7 @@ intersection-observer/root-element-deleted.html [ Skip ]
 webkit.org/b/270310 [ Sonoma+ ] imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/removed-element-is-removed-from-top-layer.html [ ImageOnlyFailure ]
 webkit.org/b/270310 [ Sonoma+ ] imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-stacking-correct-order-remove-readd.html [ ImageOnlyFailure ]
 
-# webkit.org/b/270207 REGRESSION (Sonoma23B74 --> Sonoma23D56 ): [ macOS wk1 ] Multiple tests are failing with image diff (0.01%) in fast/ and composting/ tests
+# webkit.org/b/270207 REGRESSION (Sonoma23B74 --> Sonoma23D56 ): [ macOS wk1 ] Multiple tests are failing with image diff (0.01%) in fast/ and compositing/ tests
 [ Sonoma+ ] compositing/clipping/border-radius-with-composited-descendant.html [ ImageOnlyFailure ]
 [ Sonoma+ ] compositing/clipping/border-radius-with-composited-descendant-nested.html [ ImageOnlyFailure ]
 [ Sonoma+ ] fast/images/exif-orientation-composited.html [ ImageOnlyFailure ]
@@ -3057,6 +3057,9 @@ webkit.org/b/276145 http/tests/security/block-popup-to-all-zero-address.html [ S
 http/tests/xmlhttprequest/cross-origin-authorization.html [ Failure ]
 
 compositing/repaint/scroller-repaints-once.html [ Failure ]
+
+# No support for # testRunner.dontForceRepaint in WK1.
+fast/repaint/iframe-from-display-none-repaint.html [ Skip ]
 
 fast/scrolling/scroll-corner-update-on-direction-change.html [ Skip ]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -461,6 +461,7 @@ http/tests/referrer-policy/unsafe-url/cross-origin-http-http.html [ Skip ]
 compositing/repaint/copy-forward-dirty-region-purged-backbuffer.html [ Skip ]
 compositing/repaint/copy-forward-dirty-region-purged.html [ Skip ]
 compositing/repaint/copy-forward-dirty-region.html [ Skip ]
+fast/repaint/iframe-from-display-none-repaint.html [ Skip ]
 
 # testRunner.pathToLocalResource
 fast/loader/local-CSS-from-local.html [ Failure ]

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -584,8 +584,10 @@ void RenderView::flushAccumulatedRepaintRegion() const
     CheckedPtr<RenderBox> iframeOwnerRenderer;
     if (RefPtr ownerElement = protectedDocument()->ownerElement()) {
         iframeOwnerRenderer = ownerElement->renderBox();
-        if (!iframeOwnerRenderer)
+        if (!iframeOwnerRenderer) {
+            m_accumulatedRepaintRegion = nullptr;
             return;
+        }
 
         auto viewRect = this->viewRect();
         auto rectOffsetLayoutSize = toLayoutSize(-viewRect.location() + iframeOwnerRenderer->contentBoxRect().location());


### PR DESCRIPTION
#### 318c5002fea31eb0c3b099949039ce78c0285805
<pre>
REGRESSION (301964@main): When creating a list on sharepoint.microsoft.com, panel turns blank until mouse click
<a href="https://bugs.webkit.org/show_bug.cgi?id=302362">https://bugs.webkit.org/show_bug.cgi?id=302362</a>
<a href="https://rdar.apple.com/164258690">rdar://164258690</a>

Reviewed by Alan Baradlay.

We can get stuck in `m_accumulatedRepaintRegion` mode when hitting the `if (!iframeOwnerRenderer)`
clause in `RenderView::flushAccumulatedRepaintRegion()`, which breaks all future repaints in the
iframe. This happens when the iframe starts as `display:none`, for example.

Fix by ensuring that when we early return here, we also clear `m_accumulatedRepaintRegion`.

Test: fast/repaint/iframe-from-display-none-repaint.html
* LayoutTests/fast/repaint/iframe-from-display-none-repaint-expected.html: Added.
* LayoutTests/fast/repaint/iframe-from-display-none-repaint.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::flushAccumulatedRepaintRegion const):

Canonical link: <a href="https://commits.webkit.org/302912@main">https://commits.webkit.org/302912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/702f14a7289b2f0bbc0262a9ae27cc0f40cb5d79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82173 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/95336cdd-af5f-47b8-a7e9-d1100a017b52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99467 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/77b163f7-494a-4c68-bd7b-98c83ba6c520) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80172 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/65a668e9-d31c-4c69-9406-4b5587530835) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35040 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81236 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110555 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107976 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27470 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55598 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2690 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66079 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2509 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2711 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->