### PR TITLE
GuardMalloc crash in MediaStreamAudioSource::consumeAudio(...)

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h
@@ -39,10 +39,10 @@ public:
 
 protected:
     bool m_needAutomaticPull { false }; // When setting to true, AudioBasicInspectorNode will be pulled automatically by AudioContext before the end of each render quantum.
+    void checkNumberOfChannelsForInput(AudioNodeInput*) override;
 
 private:
     void pullInputs(size_t framesToProcess) override;
-    void checkNumberOfChannelsForInput(AudioNodeInput*) override;
 
     void updatePullStatus() override;
 };

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp
@@ -73,6 +73,13 @@ void MediaStreamAudioDestinationNode::process(size_t numberOfFrames)
     m_source->consumeAudio(input(0)->bus(), numberOfFrames);
 }
 
+void MediaStreamAudioDestinationNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
+{
+    ASSERT(context().isAudioThread() && context().isGraphOwner());
+    m_source->setNumberOfChannels(input->numberOfChannels());
+    AudioBasicInspectorNode::checkNumberOfChannelsForInput(input);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO) && ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.h
@@ -55,6 +55,7 @@ private:
     double tailTime() const final { return 0; }
     double latencyTime() const final { return 0; }
     bool requiresTailProcessing() const final { return false; }
+    void checkNumberOfChannelsForInput(AudioNodeInput*) override;
 
     // As an audio source, we will never propagate silence.
     bool propagatesSilence() const final { return false; }

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.cpp
@@ -61,6 +61,15 @@ const RealtimeMediaSourceSettings& MediaStreamAudioSource::settings()
     return m_currentSettings;
 }
 
+#if !PLATFORM(COCOA)
+void MediaStreamAudioSource::setNumberOfChannels(unsigned)
+{
+    // FIXME: implement this.
+    // https://bugs.webkit.org/show_bug.cgi?id=122430
+    notImplemented();
+}
+#endif
+
 #if !PLATFORM(COCOA) && !USE(GSTREAMER)
 void MediaStreamAudioSource::consumeAudio(AudioBus&, size_t)
 {

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
@@ -56,6 +56,7 @@ public:
     void setDeviceId(const String& deviceId) { m_deviceId = deviceId; }
 
     void consumeAudio(AudioBus&, size_t numberOfFrames);
+    void setNumberOfChannels(unsigned);
 
 private:
     explicit MediaStreamAudioSource(float sampleRate);

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "AudioBus.h"
+#include "AudioUtilities.h"
 #include "CAAudioStreamDescription.h"
 #include "Logging.h"
 #include "WebAudioBufferList.h"
@@ -56,41 +57,61 @@ static inline CAAudioStreamDescription streamDescription(size_t sampleRate, size
 
 static inline void copyChannelData(AudioChannel& channel, AudioBuffer& buffer, size_t numberOfFrames, bool isMuted)
 {
-    buffer.mDataByteSize = numberOfFrames * sizeof(float);
+    RELEASE_ASSERT(buffer.mDataByteSize <= numberOfFrames * sizeof(float), "copyChannelData() given an AudioBuffer with insufficient size");
     buffer.mNumberChannels = 1;
     if (isMuted) {
         zeroSpan(mutableSpan<uint8_t>(buffer));
         return;
     }
-    memcpySpan(mutableSpan<uint8_t>(buffer), asByteSpan(channel.span()).first(buffer.mDataByteSize));
+
+    auto destination = mutableSpan<uint8_t>(buffer);
+    auto source = asByteSpan(channel.span());
+    ASSERT(destination.size() >= source.size(), "copyChannelData() given a larger source than destination");
+
+    memcpySpan(destination, source.first(buffer.mDataByteSize));
+    if (destination.size() > source.size())
+        zeroSpan(destination.last(destination.size() - source.size()));
+}
+
+void MediaStreamAudioSource::setNumberOfChannels(unsigned numberOfChannels)
+{
+    if (numberOfChannels != 1 && numberOfChannels != 2) {
+        RELEASE_LOG_ERROR(Media, "MediaStreamAudioSource::setNumberOfChannels(%p) trying to configure source with %u channels", this, numberOfChannels);
+        m_audioBuffer = nullptr;
+        return;
+    }
+
+    if (auto* audioBuffer = downcast<WebAudioBufferList>(m_audioBuffer.get()); audioBuffer && audioBuffer->channelCount() == numberOfChannels)
+        return;
+
+    auto description = streamDescription(m_currentSettings.sampleRate(), numberOfChannels);
+    auto numberOfFrames = AudioUtilities::renderQuantumSize;
+
+    // Heap allocations are forbidden on the audio thread for performance reasons so we need to
+    // explicitly allow the following allocation(s).
+    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
+    m_audioBuffer = makeUnique<WebAudioBufferList>(description, numberOfFrames);
 }
 
 void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
 {
-    if (bus.numberOfChannels() != 1 && bus.numberOfChannels() != 2) {
-        RELEASE_LOG_ERROR(Media, "MediaStreamAudioSource::consumeAudio(%p) trying to consume bus with %u channels", this, bus.numberOfChannels());
-        return;
-    }
-
     CMTime startTime = PAL::CMTimeMake(m_numberOfFrames, m_currentSettings.sampleRate());
     auto mediaTime = PAL::toMediaTime(startTime);
     m_numberOfFrames += numberOfFrames;
 
     auto* audioBuffer = m_audioBuffer ? &downcast<WebAudioBufferList>(*m_audioBuffer) : nullptr;
 
-    auto description = streamDescription(m_currentSettings.sampleRate(), bus.numberOfChannels());
-    if (!audioBuffer || audioBuffer->channelCount() != bus.numberOfChannels()) {
-        // Heap allocations are forbidden on the audio thread for performance reasons so we need to
-        // explicitly allow the following allocation(s).
-        DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
-        m_audioBuffer = makeUnique<WebAudioBufferList>(description, numberOfFrames);
-        audioBuffer = &downcast<WebAudioBufferList>(*m_audioBuffer);
-    } else
-        audioBuffer->setSampleCount(numberOfFrames);
+    if (!audioBuffer || audioBuffer->bufferCount() != bus.numberOfChannels()) {
+        ASSERT_NOT_REACHED("MediaStreamAudioSource::consumeAudio without being initialized with a valid number of channels");
+        return;
+    }
+
+    audioBuffer->setSampleCount(numberOfFrames);
 
     for (size_t cptr = 0; cptr < bus.numberOfChannels(); ++cptr)
         copyChannelData(*bus.channel(cptr), *audioBuffer->buffer(cptr), numberOfFrames, muted());
 
+    auto description = streamDescription(m_currentSettings.sampleRate(), bus.numberOfChannels());
     audioSamplesAvailable(mediaTime, *m_audioBuffer, description, numberOfFrames);
 }
 


### PR DESCRIPTION
#### 7c6d29846903b70418c711864f663874b8bcec3b
<pre>
GuardMalloc crash in MediaStreamAudioSource::consumeAudio(...)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298971">https://bugs.webkit.org/show_bug.cgi?id=298971</a>
<a href="https://rdar.apple.com/150526896">rdar://150526896</a>

Reviewed by Eric Carlson.

MediaStreamAudioSource::consumeAudio() will re-create its WebAudioBufferList when it detects
that the buffer list&apos;s channelCount() does not match the incoming AudioBus&apos;s numberOfChannels().
However, this is a logic error; WebAudioBufferList::channelCount() returns the number of
interleaved channels within each of the list&apos;s buffers, not the number of buffers within the list.

Fix this logic error, and also move the creation/re-creation of the WebAudioBufferList outside
of consumeAudio(), and into a new method that is called when the nodes are reconfigured, and a
lock is taken on the render thread. Also, add a number of ASSERT checks that validate assumptions
we make about the memory layout of the WebAudioBufferList we are given.

* Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp:
(WebCore::MediaStreamAudioDestinationNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSource.cpp:
(WebCore::MediaStreamAudioSource::setNumberOfChannels):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp:
(WebCore::copyChannelData):
(WebCore::MediaStreamAudioSource::setNumberOfChannels):
(WebCore::MediaStreamAudioSource::consumeAudio):

Originally-landed-as: 297297.425@safari-7622-branch (26ee022968ca). <a href="https://rdar.apple.com/164214101">rdar://164214101</a>
Canonical link: <a href="https://commits.webkit.org/304256@main">https://commits.webkit.org/304256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36305130ad703fdc7ade496d16d1b04a3391ca90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86844 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49170317-e40d-454d-82b7-e72f3ba5bba7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103158 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/66f0641d-c12f-4b34-b74b-3257b5905473) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121010 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84010 "Found 1 new API test failure: WPE/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/243ba92b-2071-44df-863f-c3ff637affe9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3132 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3104 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145207 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111536 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111896 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5355 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117291 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61031 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20829 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7140 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35464 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6913 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7147 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->