### PR TITLE
Fix crashing with UAF while setting IBL's memory attribution

### DIFF
--- a/JSTests/stress/dfg-proto-fold-invalidate.js
+++ b/JSTests/stress/dfg-proto-fold-invalidate.js
@@ -1,0 +1,58 @@
+//@ runDefault
+function opt(object, arr, exitEarly) {
+    if (exitEarly) {
+        return;
+    }
+
+    object.tag;
+
+    arr[1] = 1.1;
+    object.toString;
+    arr[0] = 2.3023e-320;
+}
+
+function main() {
+    [1.1, 2.2][0] = {};
+
+    const proto = {};
+    const object = Object.create(proto);
+
+    object.tag = 1;
+
+    const arr = [1.1, 2.2];
+
+    for (let i = 0; i < 50; i++) {
+        opt(object, arr, /* exitEarly */ false);
+    }
+
+    proto.toString = 1;
+
+    for (let i = 0; i < 1000; i++) {
+        opt(object, arr, /* exitEarly */ true);
+    }
+
+    setTimeout(() => {
+        let convert = false;
+        proto.__defineGetter__('toString', () => {
+            if (convert) {
+                arr[0] = {};
+            }
+        });
+
+        try {
+            proto + '';
+        } catch {
+
+        }
+
+        setTimeout(() => {
+            convert = true;
+            opt(object, arr, /* exitEarly */ false);
+
+            print(arr);
+        }, 1000);
+    }, 500);
+}
+
+main();
+

--- a/JSTests/stress/dfg-proto-fold-invalidate2.js
+++ b/JSTests/stress/dfg-proto-fold-invalidate2.js
@@ -1,0 +1,83 @@
+//@ runDefault
+function opt(objectA, exitEarly) {
+    if (exitEarly) {
+        return;
+    }
+
+    objectA.tag;
+
+    const arr = objectA.callee;
+
+    arr[0] = 2.3023e-320;
+}
+
+function watchCalleeProperty(objectA) {
+    return objectA.callee;
+}
+
+async function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createObjectX(objectD) {
+    const x = new Function();
+    Reflect.setPrototypeOf(x, objectD);
+
+    return x;
+}
+
+function createClonedArguments() {
+    return createClonedArguments.arguments;
+}
+
+async function main() {
+    createClonedArguments[0] = {};
+
+    const objectE = {};
+    const objectD = Object.create(objectE);
+    const objectC = Object.create(objectD);
+    const objectB = Object.create(objectC);
+    const objectA = Object.create(objectB);
+
+    const objectX = createClonedArguments();
+    Object.setPrototypeOf(objectX, objectD);
+
+    objectA.tag = 1;
+
+    objectE.callee = {
+        0: 1.1
+    };
+
+    for (let i = 0; i < 50; i++) {
+        opt(objectA, /* exitEarly */ false);
+    }
+
+    for (let i = 0; i < 1000; i++) {
+        watchCalleeProperty(objectE);
+    }
+
+    await sleep(1000);
+    Reflect.setPrototypeOf(objectD, null);
+
+    for (let i = 0; i < 1000; i++) {
+        opt(objectA, /* exitEarly */ true);
+    }
+
+    await sleep(500);
+
+    // Before: A -> B -> C -> D -> E
+    // After:  A -> B -> X -> D -> E
+    Reflect.setPrototypeOf(objectD, objectE);
+    Reflect.setPrototypeOf(objectB, objectX);
+
+    await sleep(1000);
+
+    opt(objectA, /* exitEarly */ false);
+
+    print(createClonedArguments[0]);
+}
+
+main().catch(e => {
+    print(e);
+});
+

--- a/JSTests/stress/loop-unrolling-multi-get-and-put-by-offset.js
+++ b/JSTests/stress/loop-unrolling-multi-get-and-put-by-offset.js
@@ -1,0 +1,18 @@
+//@ runDefault("--forceEagerCompilation=true")
+function foo() {
+  const v0 = [];
+  let v1 = 0;
+
+  do {
+      for (let v5 = v1; v5 < 7; v5++) {
+          v0.c **= v5;
+      }
+      v1++;
+  } while (v1 < 9);
+
+  return v0;
+}
+
+for(let i = 0; i < 32; i++) {
+    foo(); 
+}

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -173,7 +173,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(Call, Common) \
     CLONE_STATUS(CallCustomAccessorGetter, Common) \
     CLONE_STATUS(CallDirectEval, Common) \
-    CLONE_STATUS(CallVarargs, Common) \
+    CLONE_STATUS(CallVarargs, Special) \
     CLONE_STATUS(Check, Common) \
     CLONE_STATUS(CheckArray, Common) \
     CLONE_STATUS(CheckBadValue, Common) \
@@ -194,7 +194,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(CompareStrictEq, Common) \
     CLONE_STATUS(ConstantStoragePointer, Common) \
     CLONE_STATUS(Construct, Common) \
-    CLONE_STATUS(ConstructVarargs, Common) \
+    CLONE_STATUS(ConstructVarargs, Special) \
     CLONE_STATUS(CreateActivation, Common) \
     CLONE_STATUS(CreateDirectArguments, Common) \
     CLONE_STATUS(CreateRest, Common) \
@@ -271,7 +271,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(JSConstant, Common) \
     CLONE_STATUS(Jump, Common) \
     CLONE_STATUS(LoadMapValue, Common) \
-    CLONE_STATUS(LoadVarargs, Common) \
+    CLONE_STATUS(LoadVarargs, Special) \
     CLONE_STATUS(LogicalNot, Common) \
     CLONE_STATUS(LoopHint, Common) \
     CLONE_STATUS(MakeAtomString, Common) \
@@ -284,8 +284,8 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(MapSet, Common) \
     CLONE_STATUS(MatchStructure, Common) \
     CLONE_STATUS(MovHint, Common) \
-    CLONE_STATUS(MultiGetByOffset, Common) \
-    CLONE_STATUS(MultiPutByOffset, Common) \
+    CLONE_STATUS(MultiGetByOffset, Special) \
+    CLONE_STATUS(MultiPutByOffset, Special) \
     CLONE_STATUS(NewArray, Common) \
     CLONE_STATUS(NewArrayBuffer, Common) \
     CLONE_STATUS(NewArrayWithButterfly, Common) \
@@ -346,9 +346,9 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringSubstring, Common) \
     CLONE_STATUS(StrCat, Common) \
     CLONE_STATUS(Switch, Special) \
-    CLONE_STATUS(TailCallForwardVarargsInlinedCaller, Common) \
+    CLONE_STATUS(TailCallForwardVarargsInlinedCaller, Special) \
     CLONE_STATUS(TailCallInlinedCaller, Common) \
-    CLONE_STATUS(TailCallVarargsInlinedCaller, Common) \
+    CLONE_STATUS(TailCallVarargsInlinedCaller, Special) \
     CLONE_STATUS(ToLength, Common) \
     CLONE_STATUS(ToLowerCase, Common) \
     CLONE_STATUS(ToPrimitive, Common) \
@@ -370,7 +370,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(ValueRep, Common) \
     CLONE_STATUS(ValueSub, Common) \
     CLONE_STATUS(ValueToInt32, Common) \
-    CLONE_STATUS(VarargsLength, Common) \
+    CLONE_STATUS(VarargsLength, Special) \
     CLONE_STATUS(ZombieHint, Common)
 
 } } // namespace JSC::DFG

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_bitstream.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_bitstream.c
@@ -56,6 +56,7 @@ static const struct vp9_token inter_mode_encodings[INTER_MODES] = {
 
 static void write_intra_mode(vpx_writer *w, PREDICTION_MODE mode,
                              const vpx_prob *probs) {
+  assert(!is_inter_mode(mode));
   vp9_write_token(w, vp9_intra_mode_tree, probs, &intra_mode_encodings[mode]);
 }
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encodeframe.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encodeframe.c
@@ -1301,8 +1301,13 @@ static int choose_partitioning(VP9_COMP *cpi, const TileInfo *const tile,
       is_key_frame = 1;
   }
 
-  // Always use 4x4 partition for key frame.
-  const int use_4x4_partition = frame_is_intra_only(cm);
+  // Allow for sub8x8 (4x4) partition on key frames, but only for hybrid mode
+  // (i.e., sf->nonrd_keyframe = 0), where for small blocks rd intra pickmode
+  // (vp9_rd_pick_intra_mode_sb) is used. The nonrd intra pickmode
+  // (vp9_pick_intra_mode) does not currently support sub8x8 blocks. This causes
+  // the issue: 44166813. Assert is added in vp9_pick_intra_mode to check this.
+  const int use_4x4_partition =
+      frame_is_intra_only(cm) && !cpi->sf.nonrd_keyframe;
   const int low_res = (cm->width <= 352 && cm->height <= 288);
   int variance4x4downsample[16];
   int segment_id;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
@@ -1179,6 +1179,7 @@ void vp9_pick_intra_mode(VP9_COMP *cpi, MACROBLOCK *x, RD_COST *rd_cost,
   const PREDICTION_MODE A = vp9_above_block_mode(mic, above_mi, 0);
   const PREDICTION_MODE L = vp9_left_block_mode(mic, left_mi, 0);
   bmode_costs = cpi->y_mode_costs[A][L];
+  assert(bsize >= BLOCK_8X8);
 
   (void)ctx;
   vp9_rd_cost_reset(&best_rdc);

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -905,19 +905,19 @@ void ModelProcessModelPlayerProxy::animateModelToFitPortal(CompletionHandler<voi
 #if HAVE(MODEL_MEMORY_ATTRIBUTION)
 static void setIBLAssetOwnership(const String& attributionTaskID, REAssetRef iblAsset)
 {
-    const char* attributionIDString = attributionTaskID.utf8().data();
+    auto attributionIDString = attributionTaskID.utf8();
 
     if (REPtr<REAssetRef> skyboxTexture = REIBLAssetGetSkyboxTexture(iblAsset)) {
-        RELEASE_LOG_DEBUG(ModelElement, "Attributing skyboxTexture to task ID: %s", attributionIDString);
-        REAssetSetMemoryAttributionTarget(skyboxTexture.get(), attributionIDString);
+        RELEASE_LOG_DEBUG(ModelElement, "Attributing skyboxTexture to task ID: %s", attributionIDString.data());
+        REAssetSetMemoryAttributionTarget(skyboxTexture.get(), attributionIDString.data());
     }
     if (REPtr<REAssetRef> diffuseTexture = REIBLAssetGetDiffuseTexture(iblAsset)) {
-        RELEASE_LOG_DEBUG(ModelElement, "Attributing diffuseTexture to task ID: %s", attributionIDString);
-        REAssetSetMemoryAttributionTarget(diffuseTexture.get(), attributionIDString);
+        RELEASE_LOG_DEBUG(ModelElement, "Attributing diffuseTexture to task ID: %s", attributionIDString.data());
+        REAssetSetMemoryAttributionTarget(diffuseTexture.get(), attributionIDString.data());
     }
     if (REPtr<REAssetRef> specularTexture = REIBLAssetGetSpecularTexture(iblAsset)) {
-        RELEASE_LOG_DEBUG(ModelElement, "Attributing specularTexture to task ID: %s", attributionIDString);
-        REAssetSetMemoryAttributionTarget(specularTexture.get(), attributionIDString);
+        RELEASE_LOG_DEBUG(ModelElement, "Attributing specularTexture to task ID: %s", attributionIDString.data());
+        REAssetSetMemoryAttributionTarget(specularTexture.get(), attributionIDString.data());
     }
 }
 #endif


### PR DESCRIPTION
#### a8249e0ac40ba0fb33295f124f97d8604af864dc
<pre>
Fix crashing with UAF while setting IBL&apos;s memory attribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=299304">https://bugs.webkit.org/show_bug.cgi?id=299304</a>
<a href="https://rdar.apple.com/160676142">rdar://160676142</a>

Reviewed by Ada Chan and Mike Wyrzykowski.

The change guaranties that attributionIDString outlives all
REAssetSetMemoryAttributionTarget calls.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::setIBLAssetOwnership):

Originally-landed-as: 297297.457@safari-7622-branch (966231bb9c2e). <a href="https://rdar.apple.com/164213100">rdar://164213100</a>
Canonical link: <a href="https://commits.webkit.org/302919@main">https://commits.webkit.org/302919@main</a>
</pre>
----------------------------------------------------------------------
#### 413ed42394edad7c9ad55be6a842654448478525
<pre>
[JSC] DFG compiler-side concurrent prototype access folding needs to validate ObjectConditionSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=299307">https://bugs.webkit.org/show_bug.cgi?id=299307</a>
<a href="https://rdar.apple.com/154481123">rdar://154481123</a>

Reviewed by Yijia Huang.

DFG does concurrent prototype access folding. Before calling generateConditionsForPrototypePropertyHitConcurrently,
DFG does its own lookup to avoid installing watchpoints for
non-beneficial cases (generateConditionsForPrototypePropertyHitConcurrently is just creating ObjectConditionSet,
so in the most of cases, it succeeds regardless). But this lookup and generateConditionsForPrototypePropertyHitConcurrently
are different, so we should validate the output generateConditionsForPrototypePropertyHitConcurrently after calling it,
since generateConditionsForPrototypePropertyHitConcurrently may return
some weird ObjectConditionSet because of concurrent mutator. If ObjectConditionSet is weried, installing this means we will
ensure that condition, but that does not mean that it can be usable for
prototype folding. So we should check whether the resulted
ObjectConditionSet is meeting the criteria we would like to guarantee
for prototype folding.

In this case, it is not necessary to strictly align ObjectConditionSet
to what we saw in the first lookup. What we must ensure is the output is
meeting some critical criteria. If they are met, then it is fine.
This patch adds these checks after ObjectConditionSet is created.

* JSTests/stress/dfg-proto-fold-invalidate.js: Added.
(opt):
(main):
* JSTests/stress/dfg-proto-fold-invalidate2.js: Added.
(opt):
(watchCalleeProperty):
(async sleep):
(createClonedArguments):
(async main):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFor):

Originally-landed-as: 297297.455@safari-7622-branch (fb078f3ea09e). <a href="https://rdar.apple.com/164213241">rdar://164213241</a>
Canonical link: <a href="https://commits.webkit.org/302918@main">https://commits.webkit.org/302918@main</a>
</pre>
----------------------------------------------------------------------
#### 644a1faac1c53d8918c77d284c667c1ecb4e2b5e
<pre>
Potential &apos;overflow&apos; issue commited to upstream libwebrtc
<a href="https://rdar.apple.com/159773684">rdar://159773684</a>

Reviewed by Jean-Yves Avenard.

Cherry-picking of <a href="https://github.com/webmproject/libvpx/commit/ba9dad15b83f791773452bc4889102cbdda50605">https://github.com/webmproject/libvpx/commit/ba9dad15b83f791773452bc4889102cbdda50605</a>

* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_bitstream.c:
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encodeframe.c:
(choose_partitioning):
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c:
(vp9_pick_intra_mode):

Originally-landed-as: 297297.446@safari-7622-branch (010e247adf52). <a href="https://rdar.apple.com/164213400">rdar://164213400</a>
Canonical link: <a href="https://commits.webkit.org/302917@main">https://commits.webkit.org/302917@main</a>
</pre>
----------------------------------------------------------------------
#### 4ec6fc4dac06f56cabb9e18445aaa48a68a6a9b5
<pre>
Network process crash due to environment variable race in libsystem_coreservices.dylib: _dirhelper_update_tmpdir
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=299218">https://bugs.webkit.org/show_bug.cgi?id=299218</a>&gt;
&lt;<a href="https://rdar.apple.com/160718740">rdar://160718740</a>&gt;

Reviewed by Per Arne Vollan and Darin Adler.

* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::initializeSQLiteIfNecessary):
- Ensure that sqlite3_initialize() is called from the main thread to
  avoid race conditions.

Originally-landed-as: 297297.445@safari-7622-branch (9acf4b8eff51). <a href="https://rdar.apple.com/164213590">rdar://164213590</a>
Canonical link: <a href="https://commits.webkit.org/302916@main">https://commits.webkit.org/302916@main</a>
</pre>
----------------------------------------------------------------------
#### fcd2a8fc20dda5aaffe1890887462daa3048c950
<pre>
[JSC] Fix DFG node cloning to properly copy mutable data structures
<a href="https://rdar.apple.com/160593174">rdar://160593174</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298851">https://bugs.webkit.org/show_bug.cgi?id=298851</a>

Reviewed by Yusuke Suzuki.

The DFG clone helper was incorrectly sharing mutable data structures between
original and cloned nodes during loop unrolling optimizations. This caused
inconsistent state when subsequent optimization phases modified the shared data.
This patch ensures that nodes with mutable data structures are properly cloned with
independent copies of their associated data.

Originally-landed-as: 297297.428@safari-7622-branch (0369cf4f5755). <a href="https://rdar.apple.com/164213886">rdar://164213886</a>
Canonical link: <a href="https://commits.webkit.org/302915@main">https://commits.webkit.org/302915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/296799a98e0d91d2371c23373d4a736c88d1d202

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82184 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7df23fa7-2395-4428-913c-9994a58344e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99472 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c23c99aa-4b62-4c0d-9acc-5a59198a133a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80178 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a3a5cb4-c1e5-492b-958f-52c8731e33dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81246 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122572 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140466 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129022 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107983 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113260 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107907 "Found 3 new API test failures: WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/initialization, WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/clear, WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/ephemeral (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31692 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55608 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66089 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162037 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2519 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40405 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2721 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->