### PR TITLE
Add TextStream operator for WebWheelEvent

### DIFF
--- a/Source/WebKit/Shared/WebWheelEvent.cpp
+++ b/Source/WebKit/Shared/WebWheelEvent.cpp
@@ -25,7 +25,7 @@
 
 #include "config.h"
 #include "WebWheelEvent.h"
-
+#include <wtf/text/TextStream.h>
 
 namespace WebKit {
 
@@ -81,6 +81,67 @@ WebWheelEvent::WebWheelEvent(WebEvent&& event, const IntPoint& position, const I
 bool WebWheelEvent::isWheelEventType(WebEventType type)
 {
     return type == WebEventType::Wheel;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, WebWheelEvent::Granularity granularity)
+{
+    using enum WebWheelEvent::Granularity;
+    switch (granularity) {
+    case ScrollByPageWheelEvent: ts << "scrollByPageWheelEvent"; break;
+    case ScrollByPixelWheelEvent: ts << "scrollByPixelWheelEvent"; break;
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, WebWheelEvent::Phase phase)
+{
+    using enum WebWheelEvent::Phase;
+    switch (phase) {
+    case None: ts << "none"; break;
+    case Began: ts << "began"; break;
+    case Stationary: ts << "stationary"; break;
+    case Changed: ts << "changed"; break;
+    case Ended: ts << "ended"; break;
+    case Cancelled: ts << "cancelled"; break;
+    case MayBegin: ts << "mayBegin"; break;
+    case WillBegin: ts << "willBegin"; break;
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, WebWheelEvent::MomentumEndType endType)
+{
+    using enum WebWheelEvent::MomentumEndType;
+    switch (endType) {
+    case Unknown: ts << "unknown"; break;
+    case Interrupted: ts << "interrupted"; break;
+    case Natural: ts << "natural"; break;
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const WebWheelEvent& event)
+{
+    TextStream::GroupScope group(ts);
+    ts.dumpProperty("position"_s, event.position());
+    ts.dumpProperty("globalPosition"_s, event.globalPosition());
+    ts.dumpProperty("delta"_s, event.delta());
+    ts.dumpProperty("wheelTicks"_s, event.wheelTicks());
+    ts.dumpProperty("granularity"_s, event.granularity());
+    ts.dumpProperty("directionInvertedFromDevice"_s, event.directionInvertedFromDevice());
+    ts.dumpProperty("phase"_s, event.phase());
+    ts.dumpProperty("momentumPhase"_s, event.momentumPhase());
+    ts.dumpProperty("momentumEndType"_s, event.momentumEndType());
+#if PLATFORM(COCOA) || PLATFORM(GTK) || USE(LIBWPE)
+    ts.dumpProperty("hasPreciseScrollingDeltas"_s, event.hasPreciseScrollingDeltas());
+#endif
+#if PLATFORM(COCOA)
+    ts.dumpProperty("ioHIDEventTimestamp"_s, event.ioHIDEventTimestamp().secondsSinceEpoch().value());
+    ts.dumpProperty("rawPlatformDelta"_s, event.rawPlatformDelta());
+    ts.dumpProperty("scrollCount"_s, event.scrollCount());
+    ts.dumpProperty("unacceleratedScrollingDelta"_s, event.unacceleratedScrollingDelta());
+#endif
+    return ts;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -30,6 +30,10 @@
 #include <WebCore/FloatSize.h>
 #include <WebCore/IntPoint.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebKit {
 
 class WebWheelEvent : public WebEvent {
@@ -108,6 +112,11 @@ private:
     WebCore::FloatSize m_unacceleratedScrollingDelta;
 #endif
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, WebWheelEvent::Granularity);
+WTF::TextStream& operator<<(WTF::TextStream&, WebWheelEvent::Phase);
+WTF::TextStream& operator<<(WTF::TextStream&, WebWheelEvent::MomentumEndType);
+WTF::TextStream& operator<<(WTF::TextStream&, const WebWheelEvent&);
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 52862fdd520e3bbefbf4efe90badb1cf0db0bf30
<pre>
Add TextStream operator for WebWheelEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=302373">https://bugs.webkit.org/show_bug.cgi?id=302373</a>
<a href="https://rdar.apple.com/164527271">rdar://164527271</a>

Reviewed by Wenson Hsieh.

Several scrolling methods pass around WebWheelEvent instances, and this
helps avoid boilerplate when locally debugging in said paths.

* Source/WebKit/Shared/WebWheelEvent.cpp:
(WebKit::operator&lt;&lt;):
* Source/WebKit/Shared/WebWheelEvent.h:

Canonical link: <a href="https://commits.webkit.org/302893@main">https://commits.webkit.org/302893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b271411d40a573a7474734236557f8abd7b8ede7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138002 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54b45559-349d-40d1-bb8d-b24ac91455fc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2747 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c4eb3d73-135f-4e3c-9b6a-4a31ee3b7fe6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133531 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80189 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5cab88b-a8d1-4423-8111-191a82494c91) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81261 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140481 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2645 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107920 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2038 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55623 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20333 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66104 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->