### PR TITLE
Stop using raw AutomaticThread pointers in Vector

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -36,7 +36,6 @@ inspector/agents/InspectorDebuggerAgent.h
 interpreter/StackVisitor.h
 jit/JIT.h
 jit/JITCode.h
-jit/JITPlan.h
 jit/JITWorklistThread.h
 jit/OperationResult.h
 jsc.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -22,9 +22,7 @@ heap/JITStubRoutineSet.h
 inspector/InspectorAgentBase.h
 inspector/JSJavaScriptCallFrame.h
 jit/JIT.h
-jit/JITPlan.h
 jit/JITSafepoint.h
-jit/JITWorklistThread.cpp
 jit/OperationResult.h
 parser/Parser.h
 parser/SourceProvider.h

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -69,7 +69,6 @@ interpreter/Interpreter.cpp
 interpreter/StackVisitor.cpp
 jit/JITOpcodes.cpp
 jit/JITOperations.cpp
-jit/JITSafepoint.cpp
 jit/JITWorklist.cpp
 jsc.cpp
 llint/LLIntEntrypoint.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -95,6 +95,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SimpleStats.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 
 #if USE(BMALLOC_MEMORY_FOOTPRINT_API)
@@ -270,6 +271,8 @@ private:
 } // anonymous namespace
 
 class Heap::HeapThread final : public AutomaticThread {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(HeapThread);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HeapThread);
 public:
     HeapThread(const AbstractLocker& locker, JSC::Heap& heap)
         : AutomaticThread(locker, heap.m_threadLock, heap.m_threadCondition.copyRef())
@@ -460,7 +463,7 @@ Heap::Heap(VM& vm, HeapType heapType)
     m_maxEdenSizeWhenCritical = memoryAboveCriticalThreshold / 4;
 
     Locker locker { *m_threadLock };
-    m_thread = adoptRef(new HeapThread(locker, *this));
+    lazyInitialize(m_thread, adoptRef(*new HeapThread(locker, *this)));
 }
 
 #undef INIT_SERVER_ISO_SUBSPACE

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -983,7 +983,7 @@ private:
     uint64_t m_gcVersion { 0 };
     Box<Lock> m_threadLock;
     const Ref<AutomaticThreadCondition> m_threadCondition; // The mutator must not wait on this. It would cause a deadlock.
-    RefPtr<AutomaticThread> m_thread;
+    const RefPtr<AutomaticThread> m_thread;
 
     RefPtr<Thread> m_collectContinuouslyThread { nullptr };
     

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -52,7 +52,7 @@ public:
 
     VM* vm() const { return m_vm; }
     CodeBlock* codeBlock() const { return m_codeBlock; }
-    JITWorklistThread* thread() const { return m_thread; }
+    JITWorklistThread* thread() const { return m_thread.get(); }
 
     JITCompilationMode mode() const { return m_mode; }
 
@@ -138,7 +138,7 @@ protected:
     MonotonicTime m_timeBeforeFTL;
     VM* m_vm;
     CodeBlock* m_codeBlock;
-    JITWorklistThread* m_thread { nullptr };
+    CheckedPtr<JITWorklistThread> m_thread;
     Vector<RefPtr<SharedTask<void()>>> m_mainThreadFinalizationTasks;
     CString m_signpostMessage; // Non-null iff Options::useCompilerSignpost()
 };

--- a/Source/JavaScriptCore/jit/JITSafepoint.cpp
+++ b/Source/JavaScriptCore/jit/JITSafepoint.cpp
@@ -60,7 +60,7 @@ Safepoint::Safepoint(JITPlan& plan, Result& result)
 Safepoint::~Safepoint()
 {
     RELEASE_ASSERT(m_didCallBegin);
-    if (JITWorklistThread* thread = m_plan.thread()) {
+    if (RefPtr thread = m_plan.thread()) {
         RELEASE_ASSERT(thread->m_safepoint == this);
         thread->m_rightToRun.lock();
         thread->m_safepoint = nullptr;
@@ -78,7 +78,7 @@ void Safepoint::begin(bool keepDependenciesLive) WTF_IGNORES_THREAD_SAFETY_ANALY
     RELEASE_ASSERT(!m_didCallBegin);
     m_didCallBegin = true;
     m_keepDependenciesLive = keepDependenciesLive;
-    if (JITWorklistThread* data = m_plan.thread()) {
+    if (RefPtr data = m_plan.thread()) {
         RELEASE_ASSERT(!data->m_safepoint);
         data->m_safepoint = this;
         data->m_rightToRun.unlockFairly();

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -59,7 +59,7 @@ JITWorklist::JITWorklist()
 
     Locker locker { *m_lock };
     for (unsigned i = 0; i < Options::maxNumberOfWorklistThreads(); ++i)
-        m_threads.append(*new JITWorklistThread(locker, *this));
+        m_threads.append(adoptRef(*new JITWorklistThread(locker, *this)));
 }
 
 JITWorklist::~JITWorklist()

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -36,6 +36,9 @@ class JITWorklist;
 class Safepoint;
 
 class JITWorklistThread final : public AutomaticThread {
+    WTF_MAKE_TZONE_ALLOCATED(JITWorklistThread);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(JITWorklistThread);
+
     class WorkScope;
 
     friend class Safepoint;

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -51,6 +51,8 @@ void Worklist::dump(PrintStream& out) const
 // many threads. In order to stop a thread from wasting time we remove any plan that is
 // is currently in a single threaded state from the work queue so other plans can run.
 class Worklist::Thread final : public AutomaticThread {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Thread);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Thread);
 public:
     using Base = AutomaticThread;
     static Ref<Thread> create(const AbstractLocker& locker, Worklist& work)
@@ -233,7 +235,7 @@ Worklist::~Worklist()
         m_planEnqueued->notifyAll(locker);
     }
     for (unsigned i = 0; i < m_threads.size(); ++i)
-        m_threads[i]->join();
+        Ref { m_threads[i] }->join();
 }
 
 static Worklist* globalWorklist;

--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,4 +1,3 @@
 wtf/HashTable.h
 wtf/JSONValues.h
 wtf/RecursiveLockAdapter.h
-wtf/Vector.h

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-wtf/AutomaticThread.cpp
 [ iOS ] wtf/MainThread.cpp
 wtf/text/StringImpl.cpp
 wtf/text/SymbolImpl.cpp

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include <wtf/Box.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 #include <wtf/Vector.h>
@@ -94,10 +96,12 @@ private:
     bool contains(const AbstractLocker&, AutomaticThread*);
     
     Condition m_condition;
-    Vector<AutomaticThread*> m_threads;
+    Vector<CheckedPtr<AutomaticThread>> m_threads;
 };
 
-class WTF_EXPORT_PRIVATE AutomaticThread : public ThreadSafeRefCounted<AutomaticThread> {
+class WTF_EXPORT_PRIVATE AutomaticThread : public ThreadSafeRefCounted<AutomaticThread>, public CanMakeThreadSafeCheckedPtr<AutomaticThread> {
+    WTF_MAKE_TZONE_ALLOCATED(AutomaticThread);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AutomaticThread);
 public:
     // Note that if you drop all of your references to an AutomaticThread then as soon as there is a
     // timeout during which it doesn't get woken up, it will simply die on its own. This is a

--- a/Source/WTF/wtf/ParallelHelperPool.cpp
+++ b/Source/WTF/wtf/ParallelHelperPool.cpp
@@ -177,6 +177,8 @@ void ParallelHelperPool::doSomeHelping()
 }
 
 class ParallelHelperPool::Thread final : public AutomaticThread {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Thread);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Thread);
 public:
     Thread(const AbstractLocker& locker, ParallelHelperPool& pool)
         : AutomaticThread(locker, pool.m_lock, pool.m_workAvailableCondition.copyRef())

--- a/Source/WTF/wtf/WorkerPool.cpp
+++ b/Source/WTF/wtf/WorkerPool.cpp
@@ -33,6 +33,8 @@ namespace WTF {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerPool);
 
 class WorkerPool::Worker final : public AutomaticThread {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Worker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Worker);
 public:
     friend class WorkerPool;
 


### PR DESCRIPTION
#### 5d6036bf8f1240b2c2545e0a86e0af52913416f1
<pre>
Stop using raw AutomaticThread pointers in Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=302384">https://bugs.webkit.org/show_bug.cgi?id=302384</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/jit/JITPlan.h:
(JSC::JITPlan::thread const):
* Source/JavaScriptCore/jit/JITSafepoint.cpp:
(JSC::Safepoint::~Safepoint):
* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::JITWorklist):
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
* Source/JavaScriptCore/jit/JITWorklistThread.h:
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
(JSC::Wasm::Worklist::~Worklist):
* Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WTF/wtf/AutomaticThread.cpp:
(WTF::AutomaticThreadCondition::notifyOne):
(WTF::AutomaticThreadCondition::notifyAll):
(WTF::AutomaticThreadCondition::remove):
(WTF::AutomaticThreadCondition::contains):
* Source/WTF/wtf/AutomaticThread.h:
* Source/WTF/wtf/ParallelHelperPool.cpp:
* Source/WTF/wtf/WorkerPool.cpp:

Canonical link: <a href="https://commits.webkit.org/303023@main">https://commits.webkit.org/303023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3528b7a1b75f1e0be8527b05dc2538b40c20d90e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130921 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41880 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3087 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/138363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133867 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/117222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/122938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/35856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129374 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2690 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/140855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/3034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/113553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27537 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66451 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162391 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/40557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->