### PR TITLE
Simply canAllocateBits calculation

### DIFF
--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -296,7 +296,7 @@ void BlockDirectory::endMarking()
     
     // Sweeper is suspended so we don't need the lock here.
     emptyBits() = liveBits() & ~markingNotEmptyBits();
-    canAllocateBits() = (liveBits() & markingNotEmptyBits() & ~markingRetiredBits()) | emptyBits();
+    canAllocateBits() = liveBits() & ~markingRetiredBits();
 
     switch (m_attributes.destruction) {
     case NeedsDestruction: {

--- a/Source/JavaScriptCore/heap/BlockDirectoryBits.h
+++ b/Source/JavaScriptCore/heap/BlockDirectoryBits.h
@@ -38,7 +38,7 @@ namespace JSC {
     macro(live, Live) /* The set of block indices that have actual blocks. */\
     macro(empty, Empty) /* The set of all blocks that have no live objects and are not free listed. */ \
     macro(allocated, Allocated) /* The set of all blocks that are full of live objects. */\
-    macro(canAllocate, CanAllocate) /* The set of all blocks are live, not allocated yet, and not retired (i.e. are more than minMarkedBlockUtilization full). */ \
+    macro(canAllocate, CanAllocate) /* The set of all blocks are live and not retired (i.e. are more than minMarkedBlockUtilization full). Note: This also implies they wouldn't be allocated. */ \
     macro(destructible, Destructible) /* The set of all blocks that may have destructors to run. */\
     macro(eden, Eden) /* The set of all blocks that have new objects since the last GC. */\
     macro(unswept, Unswept) /* The set of all blocks that could be swept by the incremental sweeper. */\


### PR DESCRIPTION
#### d8d673dc763b84231451285bbcd325fd489456b1
<pre>
Simply canAllocateBits calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=302385">https://bugs.webkit.org/show_bug.cgi?id=302385</a>
<a href="https://rdar.apple.com/164539045">rdar://164539045</a>

Reviewed by Keith Miller.

These 2 expressions are equivalent, so we should use the latter:
(liveBits() &amp; markingNotEmptyBits() &amp; ~markingRetiredBits()) | emptyBits();
liveBits() &amp; ~markingRetiredBits();

* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::endMarking):
* Source/JavaScriptCore/heap/BlockDirectoryBits.h:

Canonical link: <a href="https://commits.webkit.org/302920@main">https://commits.webkit.org/302920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5da7220853f9994b6d01d0af3ba63fc093d06e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82230 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99506 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80213 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35086 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81288 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122614 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140510 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129064 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108009 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55650 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66131 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162079 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2561 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40421 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2763 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->