### PR TITLE
Implement navigation rate limiting

### DIFF
--- a/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded-expected.txt
@@ -1,0 +1,17 @@
+Tests that navigation.navigate() is rate-limited after exceeding the configured window threshold
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Successful navigations: 200
+Failed navigations: 10
+QuotaExceededError count: 10
+PASS successfulNavigations >= 195 && successfulNavigations <= 200 is true
+PASS failedNavigations >= 5 && failedNavigations <= 15 is true
+PASS quotaExceededErrors is failedNavigations
+PASS lastError.name is 'QuotaExceededError'
+PASS lastError.message is 'Navigation rate limit exceeded'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded.html
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded.html
@@ -1,0 +1,66 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() is rate-limited after exceeding the configured window threshold");
+
+// Rate limit details (see Source/WebCore/page/Navigation.h RateLimiter):
+// - maxNavigationsPerWindow = 200
+// - windowDuration = 10 seconds
+// This test verifies the limit is enforced by attempting 210 rapid navigations.
+
+jsTestIsAsync = true;
+
+const EXPECTED_LIMIT = 200; // RateLimiter::maxNavigationsPerWindow
+const TEST_ATTEMPTS = EXPECTED_LIMIT + 10;
+
+var successfulNavigations = 0;
+var failedNavigations = 0;
+var quotaExceededErrors = 0;
+var lastError = null;
+
+window.onload = async () => {
+
+    // Try to navigate more than the limit
+    for (let i = 0; i < TEST_ATTEMPTS; i++) {
+        try {
+            const result = navigation.navigate(`#url${i}`);
+            await result.committed;
+            successfulNavigations++;
+        } catch (error) {
+            failedNavigations++;
+            if (error.name === "QuotaExceededError")
+                quotaExceededErrors++;
+        }
+    }
+
+    debug(`Successful navigations: ${successfulNavigations}`);
+    debug(`Failed navigations: ${failedNavigations}`);
+    debug(`QuotaExceededError count: ${quotaExceededErrors}`);
+
+    // Verify that approximately EXPECTED_LIMIT succeeded (allow small margin for timing)
+    shouldBeTrue(`successfulNavigations >= ${EXPECTED_LIMIT - 5} && successfulNavigations <= ${EXPECTED_LIMIT}`);
+
+    // Verify that remaining failed
+    const expectedFailures = TEST_ATTEMPTS - EXPECTED_LIMIT;
+    shouldBeTrue(`failedNavigations >= ${expectedFailures - 5} && failedNavigations <= ${expectedFailures + 5}`);
+
+    // Verify all failures were QuotaExceededError
+    shouldBe("quotaExceededErrors", "failedNavigations");
+
+    // Verify error message
+    try {
+        // Try one more navigation to get the error
+        for (let i = 0; i < 5; i++) {
+            await navigation.navigate(`#extra${i}`).committed;
+        }
+    } catch (error) {
+        lastError = error;
+    }
+
+    shouldBe("lastError.name", "'QuotaExceededError'");
+    shouldBe("lastError.message", "'Navigation rate limit exceeded'");
+
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset-expected.txt
@@ -1,0 +1,19 @@
+Tests that the navigation rate limit resets after the time window expires
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Configured rate limiter: 5 navigations per 0.5s
+Phase 1: Hitting the rate limit...
+First phase - Successful: 5, Failed: 3
+PASS firstPhaseSuccess <= 5 is true
+PASS firstPhaseFailures >= 3 is true
+PASS blockedBeforeWait is true
+Phase 2: Waiting 600ms for window to reset...
+Phase 3: Attempting navigation after window reset...
+PASS successAfterReset is true
+PASS postResetNavigations is 3
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset.html
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that the navigation rate limit resets after the time window expires");
+
+// Using test parameters for faster execution:
+// - maxNavigations = 5 (instead of 200)
+// - windowDuration = 0.5 seconds (instead of 10 seconds)
+
+jsTestIsAsync = true;
+
+const TEST_LIMIT = 5;
+const TEST_WINDOW_DURATION_S = 0.5;
+const WAIT_BUFFER_MS = 100; // Small buffer to ensure window has reset
+
+var firstPhaseSuccess = 0;
+var firstPhaseFailures = 0;
+var blockedBeforeWait = false;
+var successAfterReset = false;
+var postResetNavigations = 0;
+
+window.onload = async () => {
+
+    // Configure rate limiter for testing
+    if (window.internals) {
+        internals.setNavigationRateLimiterParameters(window, TEST_LIMIT, TEST_WINDOW_DURATION_S);
+        debug(`Configured rate limiter: ${TEST_LIMIT} navigations per ${TEST_WINDOW_DURATION_S}s`);
+    } else {
+        testFailed("window.internals not available - test cannot run");
+        finishJSTest();
+        return;
+    }
+
+    // Phase 1: Hit the rate limit
+    debug("Phase 1: Hitting the rate limit...");
+
+    for (let i = 0; i < TEST_LIMIT + 3; i++) {
+        try {
+            const result = navigation.navigate(`#phase1-${i}`);
+            await result.committed;
+            firstPhaseSuccess++;
+        } catch (error) {
+            if (error.name === "QuotaExceededError")
+                firstPhaseFailures++;
+        }
+    }
+
+    debug(`First phase - Successful: ${firstPhaseSuccess}, Failed: ${firstPhaseFailures}`);
+    shouldBeTrue(`firstPhaseSuccess <= ${TEST_LIMIT}`);
+    shouldBeTrue("firstPhaseFailures >= 3");
+
+    // Verify we're now blocked
+    try {
+        await navigation.navigate("#blocked-test").committed;
+    } catch (error) {
+        if (error.name === "QuotaExceededError")
+            blockedBeforeWait = true;
+    }
+    shouldBeTrue("blockedBeforeWait");
+
+    // Phase 2: Wait for window to reset
+    const waitTimeMs = (TEST_WINDOW_DURATION_S * 1000) + WAIT_BUFFER_MS;
+    debug(`Phase 2: Waiting ${waitTimeMs}ms for window to reset...`);
+    await new Promise(resolve => setTimeout(resolve, waitTimeMs));
+
+    // Phase 3: Verify navigations are allowed again
+    debug("Phase 3: Attempting navigation after window reset...");
+    try {
+        const result = navigation.navigate("#after-reset");
+        await result.committed;
+        successAfterReset = true;
+    } catch (error) {
+        testFailed(`Navigation after reset failed with: ${error.name}: ${error.message}`);
+    }
+
+    shouldBeTrue("successAfterReset");
+
+    // Verify we can do multiple navigations again
+    for (let i = 0; i < 3; i++) {
+        try {
+            await navigation.navigate(`#post-reset-${i}`).committed;
+            postResetNavigations++;
+        } catch (error) {
+            testFailed(`Post-reset navigation ${i} failed: ${error.name}`);
+        }
+    }
+
+    shouldBe("postResetNavigations", "3");
+
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -349,7 +349,7 @@ public:
 #endif
 
     // Navigation API
-    Navigation& navigation();
+    WEBCORE_EXPORT Navigation& navigation();
     Ref<Navigation> protectedNavigation();
 
     void willDetachDocumentFromFrame();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -172,6 +172,7 @@
 #include "MockLibWebRTCPeerConnection.h"
 #include "MockPageOverlay.h"
 #include "MockPageOverlayClient.h"
+#include "Navigation.h"
 #include "NavigatorBeacon.h"
 #include "NavigatorMediaDevices.h"
 #include "NetworkLoadInformation.h"
@@ -7293,6 +7294,18 @@ bool Internals::hasSandboxUnixSyscallAccess(const String& process, unsigned sysc
 String Internals::windowLocationHost(DOMWindow& window)
 {
     return window.location().host();
+}
+
+void Internals::setNavigationRateLimiterParameters(DOMWindow& window, unsigned maxNavigations, double windowDurationSeconds)
+{
+    if (RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(window))
+        localWindow->navigation().rateLimiterForTesting().setParametersForTesting(maxNavigations, Seconds(windowDurationSeconds));
+}
+
+void Internals::resetNavigationRateLimiter(DOMWindow& window)
+{
+    if (RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(window))
+        localWindow->navigation().rateLimiterForTesting().resetForTesting();
 }
 
 ExceptionOr<String> Internals::systemColorForCSSValue(const String& cssValue, bool useDarkModeAppearance, bool useElevatedUserInterfaceLevel)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1465,6 +1465,10 @@ public:
 
     String windowLocationHost(DOMWindow&);
 
+    // Navigation API rate limiter testing
+    void setNavigationRateLimiterParameters(DOMWindow&, unsigned maxNavigations, double windowDurationSeconds);
+    void resetNavigationRateLimiter(DOMWindow&);
+
     ExceptionOr<String> systemColorForCSSValue(const String& cssValue, bool useDarkModeAppearance, bool useElevatedUserInterfaceLevel);
 
     bool systemHasBattery() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1478,4 +1478,8 @@ enum ContentsFormat {
     [Conditional=MODEL_ELEMENT] undefined disableModelLoadDelaysForTesting();
     [Conditional=MODEL_ELEMENT] DOMString modelElementState(HTMLModelElement element);
     [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);
+
+    // Navigation API rate limiter testing
+    undefined setNavigationRateLimiterParameters(DOMWindow window, unsigned long maxNavigations, double windowDurationSeconds);
+    undefined resetNavigationRateLimiter(DOMWindow window);
 };


### PR DESCRIPTION
#### 923205935b5be77b722f998a306732eacd648754
<pre>
Implement navigation rate limiting
<a href="https://bugs.webkit.org/show_bug.cgi?id=302355">https://bugs.webkit.org/show_bug.cgi?id=302355</a>
<a href="https://rdar.apple.com/164510890">rdar://164510890</a>

Reviewed by Basuke Suzuki.

Add a sliding window rate limiter (200 navigations per 10 second window) to the Navigation API
to prevent malicious or buggy scripts from flooding the system with navigation requests. This
matches Chromium&apos;s implementation and prevents IPC flooding, resource exhaustion, and other
issues caused by excessive navigation attempts. The limiter is enforced at innerDispatchNavigateEvent()
to cover all navigation methods (navigate, reload, back, forward, traverseTo).

Tests: navigation-api/navigation-api-rate-limit-exceeded.html
       navigation-api/navigation-api-rate-limit-window-reset.html

* LayoutTests/navigation-api/navigation-api-rate-limit-exceeded-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-exceeded.html: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-window-reset-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-window-reset.html: Added.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::RateLimiter::navigationAllowed):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setNavigationRateLimiterParameters):
(WebCore::Internals::resetNavigationRateLimiter):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/302943@main">https://commits.webkit.org/302943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38fbf77d16764ffe66e05d28bea7809355a72be3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130678 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/3047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82307 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e80b8c82-7886-4408-95dc-dbe803369911) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99560 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/50466ad3-eb55-4e0b-bba5-be907096d936) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b98a148e-4330-4083-a851-8771cadfc0bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35145 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81355 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140579 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2110 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55734 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2809 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66198 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2629 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2735 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->