### PR TITLE
[WebAuthn] CTAP excludeCredentials not sent when size=1

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -140,6 +140,21 @@
     }, "PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator. 2");
 
     promise_test(function(t) {
+        const excludedCredential = Base64URL.parse("dGVzdGNyZWRlbnRpYWwx"); // "testcredential1"
+
+        const config = {
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "malicious-payload",
+                payloadBase64: [testCtapErrCredentialExcludedOnlyResponseBase64],
+                validateExpectedCommands: true,
+                expectedCommandsBase64: [
+                    "AaUBWCAa2kobC+fJlf+RMJIo/kN+6IXwkpjr76haP2Ha5BcxtQKiYmlkaWxvY2FsaG9zdGRuYW1la2V4YW1wbGUuY29tA6NiaWRGMTIzNDU2ZG5hbWVuSm9obiBBcHBsZXNlZWRrZGlzcGxheU5hbWVkSm9obgSBomNhbGcmZHR5cGVqcHVibGljLWtleQWBomJpZE90ZXN0Y3JlZGVudGlhbDFkdHlwZWpwdWJsaWMta2V5"
+                ]
+            }
+        };
+
         const options = {
             publicKey: {
                 rp: {
@@ -151,12 +166,13 @@
                     displayName: "John",
                 },
                 challenge: asciiToUint8Array("123456"),
-                pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                excludeCredentials: [{ type: "public-key", id: excludedCredential }]
             }
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCtapErrCredentialExcludedOnlyResponseBase64] } });
+            internals.setMockWebAuthenticationConfiguration(config);
         return promiseRejects(t, "InvalidStateError", navigator.credentials.create(options), "At least one credential matches an entry of the excludeCredentials list in the authenticator.");
     }, "PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.");
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -192,11 +192,12 @@ void CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials(bool
 {
     Vector<uint8_t> cborCmd;
     auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
-    Vector<PublicKeyCredentialDescriptor> overrideExcludeCredentials;
+    std::optional<Vector<PublicKeyCredentialDescriptor>> overrideExcludeCredentials;
     if (includeCurrentBatch) {
         ASSERT(m_currentBatch < m_batches.size());
         overrideExcludeCredentials = m_batches[m_currentBatch];
-    }
+    } else if (!m_batches.isEmpty())
+        overrideExcludeCredentials = Vector<PublicKeyCredentialDescriptor> { };
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     auto residentKeyAvailability = m_info.options().residentKeyAvailability();
     if (options.authenticatorSelection && options.authenticatorSelection->userVerification() == UserVerificationRequirement::Required && !isUVSetup()) {


### PR DESCRIPTION
#### f65970cb73c0cbbd8ef19f9c9412d0f47e6e0df3
<pre>
[WebAuthn] CTAP excludeCredentials not sent when size=1
<a href="https://rdar.apple.com/164546088">rdar://164546088</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302389">https://bugs.webkit.org/show_bug.cgi?id=302389</a>

Reviewed by Brent Fulgham.

We do not send the excludeCredentials list when size=1. This patch fixes that.

Modified existing test to validate we send the correct command.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):

Canonical link: <a href="https://commits.webkit.org/303120@main">https://commits.webkit.org/303120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b76001f2ad4b768cbfc2c398e618cece696bce75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82242 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bcc39d9e-e6c3-4f90-8994-560ce75f7eb2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99514 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67378 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a0148e0-a514-4a9d-8f14-a19c8444f5c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80221 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76a38b11-5c14-4f54-9a7e-a8b5d61f143b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2028 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81298 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140520 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108016 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107948 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27596 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2069 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55663 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2752 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31732 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2571 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66141 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 49633 issues") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->