### PR TITLE
[WebXR] hit test subscription should fail if the feature was not requested

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Hit test subscription succeeds if the feature was requested - webgl
 PASS Hit test subscription succeeds if the feature was requested - webgl2
-FAIL Hit test subscription fails if the feature was not requested - webgl assert_true: `requestHitTestSource` succeeded when it was expected to fail expected true got false
-FAIL Hit test subscription fails if the feature was not requested - webgl2 assert_true: `requestHitTestSource` succeeded when it was expected to fail expected true got false
+PASS Hit test subscription fails if the feature was not requested - webgl
+PASS Hit test subscription fails if the feature was not requested - webgl2
 PASS Hit test subscription fails if the feature was requested but the session already ended - webgl
 PASS Hit test subscription fails if the feature was requested but the session already ended - webgl2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_transient.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_transient.https-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Transient hit test subscription succeeds if the feature was requested - webgl
 PASS Transient hit test subscription succeeds if the feature was requested - webgl2
-FAIL Transient hit test subscription fails if the feature was not requested - webgl assert_true: `requestHitTestSourceForTransientInput` succeeded when it was expected to fail expected true got false
-FAIL Transient hit test subscription fails if the feature was not requested - webgl2 assert_true: `requestHitTestSourceForTransientInput` succeeded when it was expected to fail expected true got false
+PASS Transient hit test subscription fails if the feature was not requested - webgl
+PASS Transient hit test subscription fails if the feature was not requested - webgl2
 PASS Transient test subscription fails if the feature was requested but the session already ended - webgl
 PASS Transient test subscription fails if the feature was requested but the session already ended - webgl2
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -754,7 +754,10 @@ bool WebXRSession::isHandTrackingEnabled() const
 // https://immersive-web.github.io/hit-test/#dom-xrsession-requesthittestsource
 void WebXRSession::requestHitTestSource(const XRHitTestOptionsInit& init, RequestHitTestSourcePromise&& promise)
 {
-    // 3. If session’s ended value is true, throw an InvalidStateError and abort these steps.
+    if (!m_requestedFeatures.contains(PlatformXR::SessionFeature::HitTest)) {
+        promise.reject(Exception { ExceptionCode::NotSupportedError });
+        return;
+    }
     if (m_ended) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "The session was already ended"_s });
         return;
@@ -787,6 +790,10 @@ void WebXRSession::requestHitTestSource(const XRHitTestOptionsInit& init, Reques
 // https://immersive-web.github.io/hit-test/#dom-xrsession-requesthittestsourcefortransientinput
 void WebXRSession::requestHitTestSourceForTransientInput(const XRTransientInputHitTestOptionsInit& init, RequestHitTestSourceForTransientInputPromise&& promise)
 {
+    if (!m_requestedFeatures.contains(PlatformXR::SessionFeature::HitTest)) {
+        promise.reject(Exception { ExceptionCode::NotSupportedError });
+        return;
+    }
     if (m_ended) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "The session was already ended"_s });
         return;


### PR DESCRIPTION
#### 7540c603a777f4b0470ae0d60a7f1f848de9c1d8
<pre>
[WebXR] hit test subscription should fail if the feature was not requested
<a href="https://bugs.webkit.org/show_bug.cgi?id=302322">https://bugs.webkit.org/show_bug.cgi?id=302322</a>

Reviewed by Adrian Perez de Castro and Sergio Villar Senin.

requestHitTestSource and requestHitTestSourceForTransientInput of XRSession
interface have to check the hit-test feature was requested.
&lt;<a href="https://immersive-web.github.io/hit-test/#dom-xrsession-requesthittestsource">https://immersive-web.github.io/hit-test/#dom-xrsession-requesthittestsource</a>&gt;

Tests: imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https.html
       imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_transient.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_regular.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_states_transient.https-expected.txt:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::requestHitTestSource):
(WebCore::WebXRSession::requestHitTestSourceForTransientInput):

Canonical link: <a href="https://commits.webkit.org/302971@main">https://commits.webkit.org/302971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1863a9bf8387ed97ca79184e79288491eaaa68b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99515 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35097 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81299 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140521 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108019 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113307 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107951 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55665 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20361 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66142 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->