### PR TITLE
[GLIB] Skip run loop observer notifications earlier for activities with no observers registered

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -207,6 +207,7 @@ set(WTF_PUBLIC_HEADERS
     ObjCRuntimeExtras.h
     ObjectIdentifier.h
     Observer.h
+    OptionCountedSet.h
     OptionSet.h
     OptionalOrReference.h
     OptionSetHash.h

--- a/Source/WTF/wtf/OptionCountedSet.h
+++ b/Source/WTF/wtf/OptionCountedSet.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/OptionSet.h>
+#include <wtf/Vector.h>
+
+namespace WTF {
+
+template<typename E> class OptionCountedSet {
+    static_assert(std::is_enum<E>::value, "T is not an enum type");
+public:
+    constexpr bool isEmpty() const { return m_optionSet.isEmpty(); }
+
+    constexpr bool contains(E option) const { return m_optionSet.contains(option); }
+
+    constexpr void add(E option)
+    {
+        auto i = index(option);
+        const auto currentSize = m_counts.size();
+        const auto newSize = i + 1;
+        if (currentSize < newSize)
+            m_counts.insertFill(currentSize, 0, newSize - currentSize);
+
+        m_counts[i] += 1;
+        if (m_counts[i] == 1)
+            m_optionSet.add(option);
+    }
+
+    constexpr void remove(E option)
+    {
+        if (!m_optionSet.contains(option))
+            return;
+
+        auto i = index(option);
+        ASSERT(i < m_counts.size());
+        ASSERT(m_counts[i] > 0);
+        m_counts[i] -= 1;
+        if (!m_counts[i])
+            m_optionSet.remove(option);
+    }
+
+    constexpr void add(OptionSet<E> optionSet)
+    {
+        for (auto option : optionSet)
+            add(option);
+    }
+
+    constexpr void remove(OptionSet<E> optionSet)
+    {
+        for (auto option : optionSet)
+            remove(option);
+    }
+
+private:
+    static constexpr size_t index(E option)
+    {
+        auto value = static_cast<std::underlying_type_t<E>>(option);
+        return value ? std::countr_zero(value) : 0;
+    }
+
+    OptionSet<E> m_optionSet;
+    Vector<unsigned, 8> m_counts;
+};
+
+} // namespace WTF
+
+using WTF::OptionCountedSet;

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -51,6 +51,7 @@
 #endif
 
 #if USE(GLIB_EVENT_LOOP)
+#include <wtf/OptionCountedSet.h>
 #include <wtf/glib/GRefPtr.h>
 #endif
 
@@ -341,6 +342,7 @@ private:
     using ActivityObservers = Vector<Ref<ActivityObserver>, 4>;
     Lock m_activityObserversLock;
     ActivityObservers m_activityObservers WTF_GUARDED_BY_LOCK(m_activityObserversLock);
+    OptionCountedSet<Activity> m_activities WTF_GUARDED_BY_LOCK(m_activityObserversLock);
 
     static constexpr size_t s_pollFDsCapacity = 64;
     Vector<GPollFD, s_pollFDsCapacity> m_pollFDs;

--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -175,6 +175,7 @@ void RunLoop::observeActivity(const Ref<ActivityObserver>& observer)
         Locker locker { m_activityObserversLock };
         ASSERT(!m_activityObservers.contains(observer));
         m_activityObservers.append(observer);
+        m_activities.add(observer->activities());
 
         if (m_activityObservers.size() > 1) {
             // We use bubble sort here because the input is always sorted already. See BubbleSort.h.
@@ -192,6 +193,7 @@ void RunLoop::unobserveActivity(const Ref<ActivityObserver>& observer)
     Locker locker { m_activityObserversLock };
     ASSERT(m_activityObservers.contains(observer));
     m_activityObservers.removeFirst(observer);
+    m_activities.remove(observer->activities());
 }
 
 void RunLoop::notifyActivity(Activity activity)
@@ -201,6 +203,9 @@ void RunLoop::notifyActivity(Activity activity)
     {
         Locker locker { m_activityObserversLock };
         if (m_activityObservers.isEmpty())
+            return;
+
+        if (!m_activities.contains(activity))
             return;
 
         for (Ref observer : m_activityObservers) {

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -82,6 +82,7 @@ set(TestWTF_SOURCES
     Tests/WTF/NakedPtr.cpp
     Tests/WTF/NativePromise.cpp
     Tests/WTF/NeverDestroyed.cpp
+    Tests/WTF/OptionCountedSet.cpp
     Tests/WTF/OptionSet.cpp
     Tests/WTF/Packed.cpp
     Tests/WTF/PackedRef.cpp

--- a/Tools/TestWebKitAPI/Tests/WTF/OptionCountedSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OptionCountedSet.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <wtf/OptionCountedSet.h>
+
+namespace TestWebKitAPI {
+
+enum class ExampleFlags : uint32_t {
+    A = 1 << 0,
+    B = 1 << 1,
+    C = 1 << 2,
+};
+
+TEST(WTF_OptionCountedSet, EmptySet)
+{
+    OptionCountedSet<ExampleFlags> set;
+    EXPECT_TRUE(set.isEmpty());
+    EXPECT_FALSE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    set.add({ ExampleFlags::C, ExampleFlags::B });
+    EXPECT_FALSE(set.isEmpty());
+    EXPECT_FALSE(set.contains(ExampleFlags::A));
+    EXPECT_TRUE(set.contains(ExampleFlags::B));
+    EXPECT_TRUE(set.contains(ExampleFlags::C));
+}
+
+TEST(WTF_OptionCountedSet, AddAndRemove)
+{
+    OptionCountedSet<ExampleFlags> set;
+    set.add(ExampleFlags::A);
+    EXPECT_TRUE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_FALSE(set.contains(ExampleFlags::C));
+
+    // Adding the same flag increments the counter.
+    set.add(ExampleFlags::A);
+    EXPECT_TRUE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_FALSE(set.contains(ExampleFlags::C));
+
+    // Removing the flag added twice decrements the counter.
+    set.remove(ExampleFlags::A);
+    EXPECT_TRUE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_FALSE(set.contains(ExampleFlags::C));
+
+    // Removing again makes the flag not present anymore.
+    set.remove(ExampleFlags::A);
+    EXPECT_FALSE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_FALSE(set.contains(ExampleFlags::C));
+
+    // Remove again does nothing.
+    set.remove(ExampleFlags::A);
+    EXPECT_FALSE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_FALSE(set.contains(ExampleFlags::C));
+
+    // Add multiple flags.
+    set.add({ ExampleFlags::B, ExampleFlags::C });
+    EXPECT_FALSE(set.contains(ExampleFlags::A));
+    EXPECT_TRUE(set.contains(ExampleFlags::B));
+    EXPECT_TRUE(set.contains(ExampleFlags::C));
+    set.add({ ExampleFlags::A, ExampleFlags::C });
+    EXPECT_TRUE(set.contains(ExampleFlags::A));
+    EXPECT_TRUE(set.contains(ExampleFlags::B));
+    EXPECT_TRUE(set.contains(ExampleFlags::C));
+
+    // Remove multiple flags.
+    set.remove({ ExampleFlags::B, ExampleFlags::C });
+    EXPECT_TRUE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_TRUE(set.contains(ExampleFlags::C));
+    set.remove({ ExampleFlags::A, ExampleFlags::C });
+    EXPECT_FALSE(set.contains(ExampleFlags::A));
+    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    EXPECT_FALSE(set.contains(ExampleFlags::C));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 098750050ead7a58b0424eb9113fa554be8bafb7
<pre>
[GLIB] Skip run loop observer notifications earlier for activities with no observers registered
<a href="https://bugs.webkit.org/show_bug.cgi?id=302392">https://bugs.webkit.org/show_bug.cgi?id=302392</a>

Reviewed by Nikolas Zimmermann.

We currently don&apos;t use Activity::AfterWaiting but on every run loop
iteration we iterate the observers again after waiting for sources to
check if there&apos;s any to notify. We could keep a count of observers
registered for every activity and early return from
RunLoop::notifyActivity when the given activity doesn&apos;t have observers
registered. This patch adds a new class OptionCountedSet with the
minimum API to help with this.

Tests: Tools/TestWebKitAPI/Tests/WTF/OptionCountedSet.cpp
Canonical link: <a href="https://commits.webkit.org/303110@main">https://commits.webkit.org/303110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2acb23c0d29aad895704e0d13dd4ae067e36f747

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130630 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67384 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2034 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81307 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122633 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140529 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129083 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2691 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107961 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2077 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113314 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55674 "Hash 2acb23c0 for PR 53803 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20418 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2761 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31741 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162098 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66150 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40426 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->