### PR TITLE
Make SourceBufferPrivate's eviction calculation and query of buffer size thread-safe

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -725,7 +725,7 @@ void SourceBuffer::sourceBufferPrivateAppendComplete(MediaPromise::Result&& resu
     source->monitorSourceBuffers();
     m_private->reenqueueMediaIfNeeded(source->currentTime());
 
-    ALWAYS_LOG(LOGIDENTIFIER, "buffered = ", m_buffered->ranges(), ", totalBufferSize: ", m_private->totalTrackBufferSizeInBytes());
+    ALWAYS_LOG(LOGIDENTIFIER, "buffered = ", m_buffered->ranges(), ", totalBufferSize: ", m_private->contentSize());
 }
 
 void SourceBuffer::sourceBufferPrivateDidReceiveRenderingError(int64_t error)
@@ -1446,7 +1446,7 @@ void SourceBuffer::setShouldGenerateTimestamps(bool flag)
 
 Ref<MediaPromise> SourceBuffer::sourceBufferPrivateBufferedChanged(Vector<PlatformTimeRanges>&& trackBuffers)
 {
-    reportExtraMemoryAllocated(m_private->totalTrackBufferSizeInBytes());
+    reportExtraMemoryAllocated(m_private->contentSize());
     m_trackBuffers = WTFMove(trackBuffers);
 
     updateBuffered();

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -122,18 +122,14 @@ private:
     void resetTimestampOffsetInTrackBuffers() final;
     void startChangingType() final;
     void setTimestampOffset(const MediaTime&) final;
-    MediaTime timestampOffset() const final;
     void setAppendWindowStart(const MediaTime&) final;
     void setAppendWindowEnd(const MediaTime&) final;
     Ref<GenericPromise> setMaximumBufferSize(size_t) final;
-    bool isBufferFullFor(uint64_t requiredSize) const final;
-    bool canAppend(uint64_t requiredSize) const final;
 
     Ref<ComputeSeekPromise> computeSeekTime(const WebCore::SeekTarget&) final;
     void seekToTime(const MediaTime&) final;
 
     void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&) final;
-    uint64_t totalTrackBufferSizeInBytes() const final;
 
     void memoryPressure(const MediaTime& currentTime) final;
 
@@ -163,14 +159,10 @@ private:
     const Ref<MessageReceiver> m_receiver;
     const RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
 
-    std::atomic<uint64_t> m_totalTrackBufferSizeInBytes = { 0 };
-
     bool isGPURunning() const { return !m_removed; }
     std::atomic<bool> m_removed { false };
 
-    mutable Lock m_lock;
     // We mirror some members from the base class, as we require them to be atomic.
-    MediaTime m_timestampOffset WTF_GUARDED_BY_LOCK(m_lock);
     std::atomic<bool> m_isActive { false };
 
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### 291e800aa6fc9d7fda5dc59c670d6430f48e085e
<pre>
Make SourceBufferPrivate&apos;s eviction calculation and query of buffer size thread-safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=302396">https://bugs.webkit.org/show_bug.cgi?id=302396</a>
<a href="https://rdar.apple.com/164553410">rdar://164553410</a>

Reviewed by Jer Noble.

The SourceBufferPrivateRemote mirrorred some of the base-class members but had
those atomics. We move it to the base class.
We also make the querying of the SourceBufferPrivate&apos;s eviction data thread-safe
and its calculation (via lock).

We also remove from SourceBufferPrivateRemote the thread-safe implementation
of timeStampOffset/setTimestampOffset in favour of the base class. This
allows to reduce differences between SourceBufferPrivateRemote and the
generic SourceBufferPrivate

No change in existing behaviours.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete):
(WebCore::SourceBuffer::sourceBufferPrivateBufferedChanged):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):
(WebCore::SourceBufferPrivate::setMaximumBufferSize):
(WebCore::SourceBufferPrivate::computeEvictionData):
(WebCore::SourceBufferPrivate::hasTooManySamples const):
(WebCore::SourceBufferPrivate::asyncEvictCodedFrames):
(WebCore::SourceBufferPrivate::evictCodedFrames):
(WebCore::SourceBufferPrivate::evictCodedFramesInternal):
(WebCore::SourceBufferPrivate::isBufferFullFor const):
(WebCore::SourceBufferPrivate::canAppend const):
(WebCore::SourceBufferPrivate::evictionData const):
(WebCore::SourceBufferPrivate::contentSize const):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::evictionData const): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::setMaximumBufferSize):
(WebKit::SourceBufferPrivateRemote::totalTrackBufferSizeInBytes const): Deleted.
(WebKit::SourceBufferPrivateRemote::isBufferFullFor const): Deleted.
(WebKit::SourceBufferPrivateRemote::canAppend const): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/303151@main">https://commits.webkit.org/303151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8d4ff99d4f5b6bdab9b5365f5adf669bcc429bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82438 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/42fd7c51-9a3b-4249-bdd4-24c822d75e5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99649 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67490 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e63a362b-08cc-4e27-95b0-1ea11ae50ad6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80350 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8974b822-977b-4ccc-91a3-918291ecd43a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2143 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81467 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140691 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108153 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108081 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2179 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55858 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2924 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31869 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2745 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2852 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->