### PR TITLE
HeapSnapshotBuilder should support printing directly to a PrintStream

### DIFF
--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
@@ -110,7 +110,7 @@ class JS_EXPORT_PRIVATE HeapSnapshotBuilder final : public HeapAnalyzer {
 public:
     enum SnapshotType { InspectorSnapshot, GCDebuggingSnapshot };
 
-    HeapSnapshotBuilder(HeapProfiler&, SnapshotType = SnapshotType::InspectorSnapshot, OverflowPolicy = OverflowPolicy::CrashOnOverflow);
+    HeapSnapshotBuilder(HeapProfiler&, SnapshotType = SnapshotType::InspectorSnapshot);
     ~HeapSnapshotBuilder() final;
 
     static void resetNextAvailableObjectIdentifier();
@@ -132,6 +132,7 @@ public:
     void setLabelForCell(JSCell*, const String&) final;
 
     String json();
+    void dumpToStream(PrintStream&);
 
     bool hasOverflowed() const { return m_hasOverflowed; }
 
@@ -141,9 +142,9 @@ public:
     public:
         virtual ~Client() = default;
 
-        virtual bool heapSnapshotBuilderIgnoreNode(HeapSnapshotBuilder&, JSCell*) { return false; }
-        virtual String heapSnapshotBuilderOverrideClassName(HeapSnapshotBuilder&, JSCell*, const String& currentClassName) { return currentClassName; }
-        virtual bool heapSnapshotBuilderIsElement(HeapSnapshotBuilder&, JSCell*) { return false; }
+        virtual bool heapSnapshotBuilderIgnoreNode(const HeapSnapshotBuilder&, JSCell*) { return false; }
+        virtual String heapSnapshotBuilderOverrideClassName(const HeapSnapshotBuilder&, JSCell*, const String& currentClassName) { return currentClassName; }
+        virtual bool heapSnapshotBuilderIsElement(const HeapSnapshotBuilder&, JSCell*) { return false; }
     };
     void setClient(Client* client) { m_client = client; }
 
@@ -165,7 +166,6 @@ private:
     HeapProfiler& m_profiler;
     CheckedPtr<Client> m_client;
 
-    OverflowPolicy m_overflowPolicy;
     bool m_hasOverflowed { false };
 
     // SlotVisitors run in parallel.

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -295,7 +295,7 @@ void InspectorHeapAgent::didGarbageCollect(CollectionScope scope)
     m_gcStartTime = Seconds::nan();
 }
 
-bool InspectorHeapAgent::heapSnapshotBuilderIgnoreNode(HeapSnapshotBuilder&, JSC::JSCell* cell)
+bool InspectorHeapAgent::heapSnapshotBuilderIgnoreNode(const HeapSnapshotBuilder&, JSC::JSCell* cell)
 {
     if (const Structure* structure = cell->structure()) {
         if (JSGlobalObject* globalObject = structure->globalObject()) {

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -70,7 +70,7 @@ public:
     void didGarbageCollect(JSC::CollectionScope) final;
 
     // JSC::HeapSnapshotBuilder::Client
-    bool heapSnapshotBuilderIgnoreNode(JSC::HeapSnapshotBuilder&, JSC::JSCell*) final;
+    bool heapSnapshotBuilderIgnoreNode(const JSC::HeapSnapshotBuilder&, JSC::JSCell*) final;
 
 protected:
     void clearHeapSnapshots();

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3182,7 +3182,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSGlobalObject* globalOb
     DeferTermination deferScope(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::InspectorSnapshot, OverflowPolicy::RecordOverflow);
+    HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::InspectorSnapshot);
     snapshotBuilder.buildSnapshot();
 
     String jsonString = snapshotBuilder.json();
@@ -3204,7 +3204,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshotForGCDebugging, (JSGlobalOb
     {
         DeferGCForAWhile deferGC(vm); // Prevent concurrent GC from interfering with the full GC that the snapshot does.
 
-        HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::GCDebuggingSnapshot, OverflowPolicy::RecordOverflow);
+        HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::GCDebuggingSnapshot);
         snapshotBuilder.buildSnapshot();
 
         jsonString = snapshotBuilder.json();

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -151,6 +151,11 @@ void printInternal(PrintStream& out, unsigned value)
     out.printf("%u", value);
 }
 
+void printInternal(PrintStream& out, char value)
+{
+    out.printf("%c", value);
+}
+
 void printInternal(PrintStream& out, signed char value)
 {
     out.printf("%d", static_cast<int>(value));

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -120,9 +120,12 @@ inline void printInternal(PrintStream& out, char* value) { printInternal(out, st
 inline void printInternal(PrintStream& out, CString& value) { printInternal(out, static_cast<const CString&>(value)); }
 inline void printInternal(PrintStream& out, String& value) { printInternal(out, static_cast<const String&>(value)); }
 inline void printInternal(PrintStream& out, StringImpl* value) { printInternal(out, static_cast<const StringImpl*>(value)); }
+
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, bool);
-WTF_EXPORT_PRIVATE void printInternal(PrintStream&, signed char); // NOTE: this prints as a number, not as a character; use CharacterDump if you want the character
-WTF_EXPORT_PRIVATE void printInternal(PrintStream&, unsigned char); // NOTE: see above.
+// These three overloads rely on the fact that in C++ `char`, `signed char` (e.g. int8_t) and `unsigned char` (e.g. uint8_t) are different types. So character literals will end up here rather than in one of the below overloads.
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, char);
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, signed char);
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, unsigned char);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, char16_t);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, char32_t);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, short);

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
@@ -62,7 +62,7 @@ Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::disable()
     return WebHeapAgent::disable();
 }
 
-String PageHeapAgent::heapSnapshotBuilderOverrideClassName(JSC::HeapSnapshotBuilder& builder, JSC::JSCell* cell, const String& currentClassName)
+String PageHeapAgent::heapSnapshotBuilderOverrideClassName(const JSC::HeapSnapshotBuilder& builder, JSC::JSCell* cell, const String& currentClassName)
 {
     if (currentClassName == "HTMLElement"_s) {
         if (auto* jsElement = jsDynamicCast<JSElement*>(cell)) {
@@ -86,7 +86,7 @@ String PageHeapAgent::heapSnapshotBuilderOverrideClassName(JSC::HeapSnapshotBuil
     return JSC::HeapSnapshotBuilder::Client::heapSnapshotBuilderOverrideClassName(builder, cell, currentClassName);
 }
 
-bool PageHeapAgent::heapSnapshotBuilderIsElement(JSC::HeapSnapshotBuilder&, JSC::JSCell* cell)
+bool PageHeapAgent::heapSnapshotBuilderIsElement(const JSC::HeapSnapshotBuilder&, JSC::JSCell* cell)
 {
     return jsDynamicCast<JSNode*>(cell);
 }

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.h
@@ -46,8 +46,8 @@ public:
     Inspector::Protocol::ErrorStringOr<void> disable() override;
 
     // JSC::HeapSnapshotBuilder::Client
-    String heapSnapshotBuilderOverrideClassName(JSC::HeapSnapshotBuilder&, JSC::JSCell*, const String& currentClassName) override;
-    bool heapSnapshotBuilderIsElement(JSC::HeapSnapshotBuilder&, JSC::JSCell*) override;
+    String heapSnapshotBuilderOverrideClassName(const JSC::HeapSnapshotBuilder&, JSC::JSCell*, const String& currentClassName) override;
+    bool heapSnapshotBuilderIsElement(const JSC::HeapSnapshotBuilder&, JSC::JSCell*) override;
 
     // InspectorInstrumentation
     void mainFrameNavigated();


### PR DESCRIPTION
#### 1e0aabf642efe4174336677ba0807da3bc224983
<pre>
HeapSnapshotBuilder should support printing directly to a PrintStream
<a href="https://bugs.webkit.org/show_bug.cgi?id=302397">https://bugs.webkit.org/show_bug.cgi?id=302397</a>
<a href="https://rdar.apple.com/164555302">rdar://164555302</a>

Reviewed by Mark Lam.

Adds support for writing directly to a file descriptor (or I guess os_log
but good luck) via PrintStream. This is helpful when trying to understand
the heap near a jetsam limit on iOS.

Also, fixes a longstanding issue where character literals would print
as a integral rather than ASCII. Since `char`, `signed char`, and
`unsigned char` are all different types in C++, I think adding an
extra overload for `char` should &quot;just work&quot; as it&apos;s poor style to use
something other than `int8_t`/`uint8_t` for one byte integral values
in WebKit at this point.

Canonical link: <a href="https://commits.webkit.org/303047@main">https://commits.webkit.org/303047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/233e95aaf7734c6c266b6269371a3f52f343dbfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130962 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82631 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29a93ae4-e735-4942-8e0e-3a5dcfc09f44) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99765 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c868fec8-18ae-4c6d-ab04-6f62ba862e31) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80469 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8b0db5b2-84fd-4682-9cd9-9c30563cdbd1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2263 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35382 "Found 1 new test failure: webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81649 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122979 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140896 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129415 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108284 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108240 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56066 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3097 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66492 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162432 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2918 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/40572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3027 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->