### PR TITLE
Prefer libpas to allocate memory for pixel buffer.

### DIFF
--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -39,6 +39,7 @@
 #include <Accelerate/Accelerate.h>
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -57,6 +58,30 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include "CoreVideoSoftLink.h"
 
 namespace WebCore {
+
+class FastBuffer final: public RefCounted<FastBuffer> {
+    WTF_MAKE_NONCOPYABLE(FastBuffer);
+public:
+
+    std::span<uint8_t> mutableSpan() { return m_span.mutableSpan(); }
+
+    static RefPtr<FastBuffer> tryCreateUninitialized(size_t sizeInBytes)
+    {
+        auto span = MallocSpan<uint8_t, FastMalloc>::tryMalloc(sizeInBytes);
+        if (!span)
+            return nullptr;
+
+        return adoptRef(*new FastBuffer(WTF::move(span)));
+    }
+
+protected:
+    explicit FastBuffer(MallocSpan<uint8_t, FastMalloc> &&span)
+        : m_span(WTF::move(span))
+    {
+    }
+
+    MallocSpan<uint8_t, FastMalloc> m_span;
+};
 
 RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
 {
@@ -104,6 +129,33 @@ static vImage_Buffer makeVImageBuffer8888(CVPixelBufferRef buffer)
         CVPixelBufferGetBytesPerRow(buffer));
 }
 
+static RetainPtr<CVPixelBufferRef> makeCVPixelBuffer8888(size_t width, size_t height, OSType pixelFormatType)
+{
+    RELEASE_ASSERT(pixelFormatType == kCVPixelFormatType_32ARGB || pixelFormatType == kCVPixelFormatType_32BGRA);
+
+    auto buffer = FastBuffer::tryCreateUninitialized(width * height * 4);
+    if (!buffer)
+        return nullptr;
+
+    auto releaseBuffer = [] (void* context, const void*) {
+        static_cast<FastBuffer*>(context)->deref();
+    };
+
+    CVPixelBufferRef pixelBufferRaw = nullptr;
+    const auto status = CVPixelBufferCreateWithBytes(kCFAllocatorDefault, width, height, pixelFormatType, buffer->mutableSpan().data(), width * 4, releaseBuffer, buffer.get(), nullptr, &pixelBufferRaw);
+
+    auto pixelBuffer = adoptCF(pixelBufferRaw);
+    if (!pixelBuffer)
+        return nullptr;
+
+    // The CVPixelBuffer now owns the buffer and will call `deref()` on it when it gets destroyed.
+    buffer->ref();
+
+    ASSERT_UNUSED(status, status == noErr);
+
+    return pixelBuffer;
+}
+
 RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t width, size_t height, const ComputedPlaneLayout& planeY, const ComputedPlaneLayout& planeUV, PlatformVideoColorSpace&& colorSpace)
 {
     CVPixelBufferRef rawPixelBuffer = nullptr;
@@ -141,14 +193,9 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
 
 RefPtr<VideoFrame> VideoFrame::createRGBA(std::span<const uint8_t> span, size_t width, size_t height, const ComputedPlaneLayout& plane, PlatformVideoColorSpace&& colorSpace)
 {
-    CVPixelBufferRef rawPixelBuffer = nullptr;
+    RetainPtr pixelBuffer = makeCVPixelBuffer8888(width, height, kCVPixelFormatType_32ARGB);
 
-    auto status = CVPixelBufferCreate(kCFAllocatorDefault, width, height, kCVPixelFormatType_32ARGB, nullptr, &rawPixelBuffer);
-    if (status != noErr || !rawPixelBuffer)
-        return nullptr;
-    RetainPtr pixelBuffer = adoptCF(rawPixelBuffer);
-
-    status = CVPixelBufferLockBaseAddress(pixelBuffer.get(), 0);
+    auto status = CVPixelBufferLockBaseAddress(pixelBuffer.get(), 0);
     if (status != noErr)
         return nullptr;
 
@@ -169,14 +216,9 @@ RefPtr<VideoFrame> VideoFrame::createRGBA(std::span<const uint8_t> span, size_t 
 
 RefPtr<VideoFrame> VideoFrame::createBGRA(std::span<const uint8_t> span, size_t width, size_t height, const ComputedPlaneLayout& plane, PlatformVideoColorSpace&& colorSpace)
 {
-    CVPixelBufferRef rawPixelBuffer = nullptr;
+    RetainPtr pixelBuffer = makeCVPixelBuffer8888(width, height, kCVPixelFormatType_32BGRA);
 
-    auto status = CVPixelBufferCreate(kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, nullptr, &rawPixelBuffer);
-    if (status != noErr || !rawPixelBuffer)
-        return nullptr;
-    RetainPtr pixelBuffer = adoptCF(rawPixelBuffer);
-
-    status = CVPixelBufferLockBaseAddress(pixelBuffer.get(), 0);
+    auto status = CVPixelBufferLockBaseAddress(pixelBuffer.get(), 0);
     if (status != noErr)
         return nullptr;
 


### PR DESCRIPTION
#### e93f55ab2d3cf5c13154b97f0e43a60711202168
<pre>
Prefer libpas to allocate memory for pixel buffer.
https://bugs.webkit.org/show_bug.cgi?id=303007
Reviewed by NOBODY (OOPS!).

The modern system malloc relies on secure allocator (xzm malloc).
But it has huge performance implication for the scenario of pixel buffer
creation from array of pixels.

No new tests (OOPS!).

* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::createRGBA):
(WebCore::VideoFrame::createBGRA):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e461987c66516453e30fa7c3468f0841b4e04173

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106615 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83837 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17652 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129358 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164375 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7511 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126455 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126613 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137169 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82404 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13948 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89641 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->