### PR TITLE
[JSC][32-bit] Improve BBQ's load/store operations for ARMv7

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -1556,6 +1556,12 @@ public:
         store16(dataTempRegister, address);
     }
 
+    void store16(TrustedImm32 imm, Address address)
+    {
+        move(imm, dataTempRegister);
+        store16(dataTempRegister, address);
+    }
+
     void storeRel16(RegisterID src, Address address)
     {
         storeFence();
@@ -1576,6 +1582,14 @@ public:
 
     void storePair32(TrustedImm32 imm1, TrustedImm32 imm2, Address address)
     {
+        if (imm1.m_value == imm2.m_value) {
+            RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+            move(imm1, scratch);
+            store32(scratch, address);
+            store32(scratch, address.withOffset(4));
+            return;
+        }
+
         int32_t absOffset = address.offset;
         if (absOffset < 0)
             absOffset = -absOffset;


### PR DESCRIPTION
#### 08ba4dce0a3020c30c39f035fa1abdd8e0f5af18
<pre>
[JSC][32-bit] Improve BBQ&apos;s load/store operations for ARMv7
<a href="https://bugs.webkit.org/show_bug.cgi?id=302403">https://bugs.webkit.org/show_bug.cgi?id=302403</a>

Reviewed by Yusuke Suzuki.

This PR includes seveal changes to improve the codegen of store/load:
* Optimized storePair to use a single move when constants are equal
* Eliminated register materialization for constant integer store
* Constant pointer folding when they are statically known

One example where these work together is I64Store, before:

    [   0x22d] I64Store
              0xf1a22bcc: ldrd r1, r2, [r10, #0x34]
              0xf1a22bd0: movw r0, #0x5d18
              0xf1a22bd4: mov r5, r0
              0xf1a22bd6: adds r5, r5, #7
              0xf1a22bd8: bhs.w #0xf1a22c44
              0xf1a22bdc: cmp r5, r2
              0xf1a22bde: bhs.w #0xf1a22c44
              0xf1a22be2: mov r5, r0
              0xf1a22be4: add r5, r1
              0xf1a22be6: movs r4, #0
              0xf1a22be8: movs r3, #0
              0xf1a22bea: str r3, [r5]
              0xf1a22bec: str r4, [r5, #4]

after:

    [   0x22d] I64Store
              0xf1b22c50: ldrd r1, r2, [r10, #0x34]
              0xf1b22c54: movw r5, #0x5d1f
              0xf1b22c58: cmp r5, r2
              0xf1b22c5a: bhs.w #0xf1b22cc0
              0xf1b22c5e: movw r12, #0x5d18
              0xf1b22c62: add.w r5, r1, r12
              0xf1b22c66: mov.w r12, #0
              0xf1b22c6a: str.w r12, [r5]
              0xf1b22c6e: str.w r12, [r5, #4]

On JetStream3&apos;s tfjs-wasm.js, we reduce the code size by -9,5KiB:

Base total code size: 433254 bytes (424KiB)
New total code size: 423578 bytes (414KiB)

Difference (new - base): -9676 bytes (-9,5KiB)
Percentage change: -2.23%

* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::store16):
(JSC::MacroAssemblerARMv7::storePair32):
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPrepareAndMaterializePointerApply):

Canonical link: <a href="https://commits.webkit.org/302984@main">https://commits.webkit.org/302984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e8e11ecdf6c5a195cf7d9381d7b1d835fd47f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82282 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67403 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35126 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81333 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122659 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140557 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129109 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108046 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27509 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55706 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66176 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162124 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2607 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40432 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->