### PR TITLE
[JSC] Improve BBQ's rotate and shift implementations

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1408,6 +1408,25 @@ public:
         m_assembler.ror<32>(dest, src, shiftAmmount);
     }
 
+    void rotateLeft32(RegisterID src, TrustedImm32 imm, RegisterID dest)
+    {
+        if (!imm.m_value) [[unlikely]]
+            return move(src, dest);
+        rotateRight32(src, TrustedImm32(-(imm.m_value & 31)), dest);
+    }
+
+    void rotateLeft32(TrustedImm32 imm, RegisterID srcDst)
+    {
+        rotateLeft32(srcDst, imm, srcDst);
+    }
+
+    void rotateLeft32(RegisterID src, RegisterID shiftAmount, RegisterID dest)
+    {
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        neg32(shiftAmount, scratch);
+        rotateRight32(src, scratch, dest);
+    }
+
     void rotateRight64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
         if (!imm.m_value) [[unlikely]]
@@ -1423,6 +1442,25 @@ public:
     void rotateRight64(RegisterID src, RegisterID shiftAmmount, RegisterID dest)
     {
         m_assembler.ror<64>(dest, src, shiftAmmount);
+    }
+
+    void rotateLeft64(RegisterID src, TrustedImm32 imm, RegisterID dest)
+    {
+        if (!imm.m_value) [[unlikely]]
+            return move(src, dest);
+        rotateRight64(src, TrustedImm32(-(imm.m_value & 63)), dest);
+    }
+
+    void rotateLeft64(TrustedImm32 imm, RegisterID srcDst)
+    {
+        rotateLeft64(srcDst, imm, srcDst);
+    }
+
+    void rotateLeft64(RegisterID src, RegisterID shiftAmount, RegisterID dest)
+    {
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        neg64(shiftAmount, scratch);
+        rotateRight64(src, scratch, dest);
     }
 
     void rshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -406,6 +406,343 @@ public:
         }
     }
 
+    void rotateLeft64(RegisterID srcHi, RegisterID srcLo, RegisterID shiftAmount, RegisterID destHi, RegisterID destLo, RegisterID scratch0, RegisterID scratch1)
+    {
+        // Test/swap bit 5
+        // leftShift = amount & 31
+        // rightShift = 32 - leftShift
+        // resultLo = (srcLo << leftShift) | (srcHi >> rightShift)
+        // resultHi = (srcHi << leftShift) | (srcLo >> rightShift)
+
+        // Test if bit 5 is set
+        m_assembler.tst(shiftAmount, ARMThumbImmediate::makeEncodedImm(32));
+        m_assembler.mov(scratch0, srcLo);
+        m_assembler.mov(scratch1, srcHi);
+
+        // If bit 5 is set, swap them
+        m_assembler.it(ARMv7Assembler::ConditionNE, true);
+        m_assembler.mov(scratch0, srcHi);
+        m_assembler.mov(scratch1, srcLo);
+
+        // leftShift = shiftAmount & 31
+        RegisterID dataTemp = getCachedDataTempRegisterIDAndInvalidate();
+        m_assembler.ARM_and(dataTemp, shiftAmount, ARMThumbImmediate::makeEncodedImm(31));
+
+        // rightShift = 32 - leftShift
+        sub32(TrustedImm32(32), dataTemp, destLo);
+
+        m_assembler.lsl(destHi, scratch0, dataTemp); // A = scratch0 << leftShift
+        m_assembler.lsl(dataTemp, scratch1, dataTemp); // C = scratch1 << leftShift
+        m_assembler.lsr(scratch1, scratch1, destLo); // B = scratch1 >> rightShift
+        m_assembler.lsr(scratch0, scratch0, destLo); // D = scratch0 >> rightShift
+
+        m_assembler.orr(destLo, destHi, scratch1); // resultLo = A | B
+        m_assembler.orr(destHi, dataTemp, scratch0); // resultHi = C | D
+    }
+
+    void rotateLeft64(RegisterID srcHi, RegisterID srcLo, TrustedImm32 shiftAmount, RegisterID destHi, RegisterID destLo, RegisterID scratch0, RegisterID scratch1)
+    {
+        ASSERT(shiftAmount.m_value > 0 && shiftAmount.m_value <= 63);
+
+        // Special case: rotation by 32 is just a swap
+        if (shiftAmount.m_value == 32) {
+            m_assembler.mov(destLo, srcHi);
+            m_assembler.mov(destHi, srcLo);
+            return;
+        }
+
+        int32_t leftShift = shiftAmount.m_value & 31;
+        int32_t rightShift = 32 - leftShift;
+
+        bool needSwap = shiftAmount.m_value & 32;
+        if (needSwap) {
+            m_assembler.mov(scratch0, srcHi);
+            m_assembler.mov(scratch1, srcLo);
+        } else {
+            m_assembler.mov(scratch0, srcLo);
+            m_assembler.mov(scratch1, srcHi);
+        }
+
+        RegisterID dataTemp = getCachedDataTempRegisterIDAndInvalidate();
+
+        m_assembler.lsl(destHi, scratch0, leftShift); // A = scratch0 << leftShift
+        m_assembler.lsl(dataTemp, scratch1, leftShift); // C = scratch1 << leftShift
+        m_assembler.lsr(scratch1, scratch1, rightShift); // B = scratch1 >> rightShift
+        m_assembler.lsr(scratch0, scratch0, rightShift); // D = scratch0 >> rightShift
+
+        m_assembler.orr(destLo, destHi, scratch1); // resultLo = A | B
+        m_assembler.orr(destHi, dataTemp, scratch0); // resultHi = C | D
+    }
+
+    void rotateRight64(RegisterID srcHi, RegisterID srcLo, RegisterID shiftAmount, RegisterID destHi, RegisterID destLo, RegisterID scratch0, RegisterID scratch1)
+    {
+        // Test/swap bit 5
+        // rightShift = amount & 31
+        // leftShift = 32 - rightShift
+        // resultLo = (srcLo >> rightShift) | (srcHi << leftShift)
+        // resultHi = (srcHi >> rightShift) | (srcLo << leftShift)
+
+        // Test if bit 5 is set
+        m_assembler.tst(shiftAmount, ARMThumbImmediate::makeEncodedImm(32));
+        m_assembler.mov(scratch0, srcLo);
+        m_assembler.mov(scratch1, srcHi);
+
+        // If bit 5 is set, swap them
+        m_assembler.it(ARMv7Assembler::ConditionNE, true);
+        m_assembler.mov(scratch0, srcHi);
+        m_assembler.mov(scratch1, srcLo);
+
+        // rightShift = shiftAmount & 31
+        RegisterID dataTemp = getCachedDataTempRegisterIDAndInvalidate();
+        m_assembler.ARM_and(dataTemp, shiftAmount, ARMThumbImmediate::makeEncodedImm(31));
+
+        // leftShift = 32 - rightShift
+        sub32(TrustedImm32(32), dataTemp, destLo);
+
+        m_assembler.lsr(destHi, scratch0, dataTemp); // A = scratch0 >> rightShift
+        m_assembler.lsr(dataTemp, scratch1, dataTemp); // C = scratch1 >> rightShift
+        m_assembler.lsl(scratch1, scratch1, destLo); // B = scratch1 << leftShift
+        m_assembler.lsl(scratch0, scratch0, destLo); // D = scratch0 << leftShift
+
+        m_assembler.orr(destLo, destHi, scratch1); // resultLo = A | B
+        m_assembler.orr(destHi, dataTemp, scratch0); // resultHi = C | D
+    }
+
+    void rotateRight64(RegisterID srcHi, RegisterID srcLo, TrustedImm32 shiftAmount, RegisterID destHi, RegisterID destLo, RegisterID scratch0, RegisterID scratch1)
+    {
+        ASSERT(shiftAmount.m_value > 0 && shiftAmount.m_value <= 63);
+
+        // Special case: rotation by 32 is just a swap
+        if (shiftAmount.m_value == 32) {
+            m_assembler.mov(destLo, srcHi);
+            m_assembler.mov(destHi, srcLo);
+            return;
+        }
+
+        int32_t rightShift = shiftAmount.m_value & 31;
+        int32_t leftShift = 32 - rightShift;
+
+        bool needSwap = shiftAmount.m_value & 32;
+        if (needSwap) {
+            m_assembler.mov(scratch0, srcHi);
+            m_assembler.mov(scratch1, srcLo);
+        } else {
+            m_assembler.mov(scratch0, srcLo);
+            m_assembler.mov(scratch1, srcHi);
+        }
+
+        RegisterID dataTemp = getCachedDataTempRegisterIDAndInvalidate();
+
+        m_assembler.lsr(destHi, scratch0, rightShift); // A = scratch0 >> rightShift
+        m_assembler.lsr(dataTemp, scratch1, rightShift); // C = scratch1 >> rightShift
+        m_assembler.lsl(scratch1, scratch1, leftShift); // B = scratch1 << leftShift
+        m_assembler.lsl(scratch0, scratch0, leftShift); // D = scratch0 << leftShift
+
+        m_assembler.orr(destLo, destHi, scratch1); // resultLo = A | B
+        m_assembler.orr(destHi, dataTemp, scratch0); // resultHi = C | D
+    }
+
+    void lshift64(RegisterID srcHi, RegisterID srcLo, RegisterID shiftAmount, RegisterID destHi, RegisterID destLo, RegisterID scratch0, RegisterID scratch1)
+    {
+        // shift = amount & 63
+        // resultHi = (srcHi << shift) | (srcLo >> (32 - shift)) | (srcLo << (shift - 32))
+        // resultLo = srcLo << shift
+
+        RegisterID dataTemp = getCachedDataTempRegisterIDAndInvalidate();
+
+        // shift = shiftAmount & 63
+        m_assembler.ARM_and(dataTemp, shiftAmount, ARMThumbImmediate::makeEncodedImm(63));
+
+        // 32 - shift
+        sub32(TrustedImm32(32), dataTemp, scratch0);
+
+        // resultHi = (srcHi << shift) | (srcLo >> (32 - shift))
+        m_assembler.lsl(destHi, srcHi, dataTemp);
+        m_assembler.lsr(scratch1, srcLo, scratch0);
+        m_assembler.orr(destHi, destHi, scratch1);
+
+        // shift - 32
+        m_assembler.sub(scratch0, dataTemp, ARMThumbImmediate::makeEncodedImm(32));
+
+        // resultHi |= (srcLo << (shift - 32))
+        m_assembler.lsl(scratch1, srcLo, scratch0);
+        m_assembler.orr(destHi, destHi, scratch1);
+
+        // resultLo = srcLo << shift
+        m_assembler.lsl(destLo, srcLo, dataTemp);
+    }
+
+    void lshift64(RegisterID srcHi, RegisterID srcLo, TrustedImm32 shiftAmount, RegisterID destHi, RegisterID destLo)
+    {
+        ASSERT(shiftAmount.m_value >= 0 && shiftAmount.m_value <= 63);
+
+        int32_t shift = shiftAmount.m_value;
+        if (!shift) {
+            m_assembler.mov(destLo, srcLo);
+            m_assembler.mov(destHi, srcHi);
+            return;
+        }
+
+        if (shift < 32) {
+            // resultHi = (srcHi << shift) | (srcLo >> (32 - shift))
+            // resultLo = srcLo << shift
+            RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+            m_assembler.lsl(destHi, srcHi, shift);
+            m_assembler.lsr(scratch, srcLo, 32 - shift);
+            m_assembler.orr(destHi, destHi, scratch);
+            m_assembler.lsl(destLo, srcLo, shift);
+            return;
+        }
+
+        if (shift == 32) {
+            // resultHi = srcLo
+            // resultLo = 0
+            m_assembler.mov(destHi, srcLo);
+            m_assembler.mov(destLo, ARMThumbImmediate::makeEncodedImm(0));
+            return;
+        }
+
+        // resultHi = srcLo << (shift - 32)
+        // resultLo = 0
+        m_assembler.lsl(destHi, srcLo, shift - 32);
+        m_assembler.mov(destLo, ARMThumbImmediate::makeEncodedImm(0));
+    }
+
+    void urshift64(RegisterID srcHi, RegisterID srcLo, RegisterID shiftAmount, RegisterID destHi, RegisterID destLo, RegisterID scratch0, RegisterID scratch1)
+    {
+        // shift = amount & 63
+        // resultLo = (srcLo >> shift) | (srcHi << (32 - shift)) | (srcHi >> (shift - 32))
+        // resultHi = srcHi >> shift
+
+        RegisterID dataTemp = getCachedDataTempRegisterIDAndInvalidate();
+
+        // shift = shiftAmount & 63
+        m_assembler.ARM_and(dataTemp, shiftAmount, ARMThumbImmediate::makeEncodedImm(63));
+
+        // 32 - shift
+        sub32(TrustedImm32(32), dataTemp, scratch0);
+
+        // resultLo = (srcLo >> shift) | (srcHi << (32 - shift))
+        m_assembler.lsr(destLo, srcLo, dataTemp);
+        m_assembler.lsl(scratch1, srcHi, scratch0);
+        m_assembler.orr(destLo, destLo, scratch1);
+
+        // shift - 32
+        m_assembler.sub(scratch0, dataTemp, ARMThumbImmediate::makeEncodedImm(32));
+
+        // resultLo |= (srcHi >> (shift - 32))
+        m_assembler.lsr(scratch1, srcHi, scratch0);
+        m_assembler.orr(destLo, destLo, scratch1);
+
+        // resultHi = srcHi >> shift
+        m_assembler.lsr(destHi, srcHi, dataTemp);
+    }
+
+    void urshift64(RegisterID srcHi, RegisterID srcLo, TrustedImm32 shiftAmount, RegisterID destHi, RegisterID destLo)
+    {
+        ASSERT(shiftAmount.m_value >= 0 && shiftAmount.m_value <= 63);
+
+        int32_t shift = shiftAmount.m_value;
+        if (!shift) {
+            m_assembler.mov(destLo, srcLo);
+            m_assembler.mov(destHi, srcHi);
+            return;
+        }
+
+        if (shift < 32) {
+            // resultLo = (srcLo >> shift) | (srcHi << (32 - shift))
+            // resultHi = srcHi >> shift
+            RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+            m_assembler.lsr(destLo, srcLo, shift);
+            m_assembler.lsl(scratch, srcHi, 32 - shift);
+            m_assembler.orr(destLo, destLo, scratch);
+            m_assembler.lsr(destHi, srcHi, shift);
+            return;
+        }
+
+        if (shift == 32) {
+            // resultLo = srcHi
+            // resultHi = 0
+            m_assembler.mov(destLo, srcHi);
+            m_assembler.mov(destHi, ARMThumbImmediate::makeEncodedImm(0));
+            return;
+        }
+
+        // resultLo = srcHi >> (shift - 32)
+        // resultHi = 0
+        m_assembler.lsr(destLo, srcHi, shift - 32);
+        m_assembler.mov(destHi, ARMThumbImmediate::makeEncodedImm(0));
+    }
+
+    void rshift64(RegisterID srcHi, RegisterID srcLo, RegisterID shiftAmount, RegisterID destHi, RegisterID destLo, RegisterID scratch0, RegisterID scratch1)
+    {
+        // shift = amount & 63
+        // resultLo = (srcLo >> shift) | (srcHi << (32 - shift)) | (srcHi >> (shift - 32))
+        // resultHi = srcHi >> shift (arithmetic)
+
+        RegisterID dataTemp = getCachedDataTempRegisterIDAndInvalidate();
+
+        // shift = shiftAmount & 63
+        m_assembler.ARM_and(dataTemp, shiftAmount, ARMThumbImmediate::makeEncodedImm(63));
+
+        // 32 - shift
+        sub32(TrustedImm32(32), dataTemp, scratch0);
+
+        // resultLo = (srcLo >> shift) | (srcHi << (32 - shift))
+        m_assembler.lsr(destLo, srcLo, dataTemp);
+        m_assembler.lsl(scratch1, srcHi, scratch0);
+        m_assembler.orr(destLo, destLo, scratch1);
+
+        // shift - 32
+        m_assembler.sub(scratch0, dataTemp, ARMThumbImmediate::makeEncodedImm(32));
+
+        // (srcHi >> (shift - 32)) for the shift >= 32 case
+        m_assembler.asr(scratch1, srcHi, scratch0);
+
+        // if (shift >= 32) use scratch1, else keep destLo
+        m_assembler.orr(scratch1, destLo, scratch1);
+        moveConditionally32(RelationalCondition::AboveOrEqual, dataTemp, TrustedImm32(32), scratch1, destLo, destLo);
+
+        // resultHi = srcHi >> shift (arithmetic)
+        m_assembler.asr(destHi, srcHi, dataTemp);
+    }
+
+    void rshift64(RegisterID srcHi, RegisterID srcLo, TrustedImm32 shiftAmount, RegisterID destHi, RegisterID destLo)
+    {
+        ASSERT(shiftAmount.m_value >= 0 && shiftAmount.m_value <= 63);
+
+        int32_t shift = shiftAmount.m_value;
+        if (!shift) {
+            m_assembler.mov(destLo, srcLo);
+            m_assembler.mov(destHi, srcHi);
+            return;
+        }
+
+        if (shift < 32) {
+            // resultLo = (srcLo >> shift) | (srcHi << (32 - shift))
+            // resultHi = srcHi >> shift (arithmetic)
+            RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+            m_assembler.lsr(destLo, srcLo, shift);
+            m_assembler.lsl(scratch, srcHi, 32 - shift);
+            m_assembler.orr(destLo, destLo, scratch);
+            m_assembler.asr(destHi, srcHi, shift);
+            return;
+        }
+
+        if (shift == 32) {
+            // resultLo = srcHi
+            // resultHi = srcHi >> 31 (sign extend)
+            m_assembler.mov(destLo, srcHi);
+            m_assembler.asr(destHi, srcHi, 31);
+            return;
+        }
+
+        // resultLo = srcHi >> (shift - 32) (arithmetic)
+        // resultHi = srcHi >> 31 (sign extend)
+        m_assembler.asr(destLo, srcHi, shift - 32);
+        m_assembler.asr(destHi, srcHi, 31);
+    }
+
     void and16(Address src, RegisterID dest)
     {
         load16(src, dataTempRegister);
@@ -577,11 +914,6 @@ public:
             done.link(this);
             move(scratch, dest);
         }
-    }
-
-    void lshiftUnchecked(RegisterID src, RegisterID shiftAmount, RegisterID dest)
-    {
-        m_assembler.lsl(dest, src, shiftAmount);
     }
 
     void lshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)
@@ -803,11 +1135,6 @@ public:
         m_assembler.ror(dest, src, scratch);
     }
 
-    void rshiftUnchecked(RegisterID src, RegisterID shiftAmount, RegisterID dest)
-    {
-        m_assembler.asr(dest, src, shiftAmount);
-    }
-
     void rshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)
     {
         RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
@@ -843,11 +1170,6 @@ public:
         m_assembler.ARM_and(dest, shiftAmount, ARMThumbImmediate::makeEncodedImm(0x1f));
         move(imm, getCachedDataTempRegisterIDAndInvalidate());
         m_assembler.asr(dest, dataTempRegister, dest);
-    }
-
-    void urshiftUnchecked(RegisterID src, RegisterID shiftAmount, RegisterID dest)
-    {
-        m_assembler.lsr(dest, src, shiftAmount);
     }
 
     void urshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -2467,7 +2467,6 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Rotl(Value lhs, Value rhs, Value&
     EMIT_BINARY(
         "I32Rotl", TypeKind::I32,
         BLOCK(Value::fromI32(B3::rotateLeft(lhs.asI32(), rhs.asI32()))),
-#if CPU(X86_64)
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.rotateLeft32(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
@@ -2481,23 +2480,6 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Rotl(Value lhs, Value rhs, Value&
                 m_jit.rotateLeft32(resultLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
             }
         )
-#else
-        BLOCK(
-            moveShiftAmountIfNecessary(rhsLocation);
-            m_jit.neg32(rhsLocation.asGPR(), wasmScratchGPR);
-            m_jit.rotateRight32(lhsLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
-        ),
-        BLOCK(
-            if (rhs.isConst())
-                m_jit.rotateRight32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(-rhs.asI32())), resultLocation.asGPR());
-            else {
-                moveShiftAmountIfNecessary(rhsLocation);
-                m_jit.neg32(rhsLocation.asGPR(), wasmScratchGPR);
-                emitMoveConst(lhs, resultLocation);
-                m_jit.rotateRight32(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
-            }
-        )
-#endif
     );
 }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2217,9 +2217,6 @@ private:
 
     constexpr static int tempSlotSize = 16; // Size of the stack slot for a stack temporary. Currently the size of the largest possible temporary (a v128).
 
-    enum class RotI64HelperOp { Left, Right };
-    void rotI64Helper(RotI64HelperOp op, Location lhsLocation, Location rhsLocation, Location resultLocation);
-
     bool canTierUpToOMG() const;
 
     void emitIncrementCallProfileCount(unsigned callProfileIndex);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -2154,200 +2154,207 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Or(Value lhs, Value rhs, Value& r
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
 {
-    auto emitI64Shl = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
-        ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
-
-        auto shiftReg = rhsLocation.asGPRlo();
-        auto resultLo = resultLocation.asGPRlo();
-        auto resultHi = resultLocation.asGPRhi();
-        auto lhsLo    = lhsLocation.asGPRlo();
-        auto lhsHi    = lhsLocation.asGPRhi();
-
-        auto shift = scratches.gpr(0);
-        auto tmp = scratches.gpr(1);
-
-        m_jit.and32(TrustedImm32(63), shiftReg, shift);
-
-        m_jit.sub32(shift, TrustedImm32(32), tmp);
-        m_jit.lshiftUnchecked(lhsHi, shift, resultHi);
-        m_jit.lshiftUnchecked(lhsLo, tmp, tmp);
-        m_jit.or32(resultHi, tmp, resultHi);
-
-        m_jit.sub32(TrustedImm32(32), shift, tmp);
-        m_jit.urshiftUnchecked(lhsLo, tmp, tmp);
-        m_jit.or32(resultHi, tmp, resultHi);
-        m_jit.lshiftUnchecked(lhsLo, shift, resultLo);
-    };
-
     EMIT_BINARY(
         "I64Shl", TypeKind::I64,
         BLOCK(Value::fromI64(lhs.asI64() << rhs.asI64())),
         BLOCK(
-            emitI64Shl(lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.lshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         ),
         BLOCK(
+            if (rhs.isConst()) {
+                int32_t amount = rhs.asI32() & 63;
+                if (!amount) {
+                    m_jit.move(lhsLocation.asGPRlo(), resultLocation.asGPRlo());
+                    m_jit.move(lhsLocation.asGPRhi(), resultLocation.asGPRhi());
+                    return;
+                }
+
+                m_jit.lshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), TrustedImm32(amount), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+                return;
+            }
+
+            int64_t value = lhs.asI64();
+            if (!value) {
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRhi());
+                return;
+            }
+
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
-            emitI64Shl(lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.lshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         )
     );
 }
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
 {
-    auto emitI64ShrS = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
-        ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
-
-        auto shiftReg = rhsLocation.asGPRlo();
-        auto resultLo = resultLocation.asGPRlo();
-        auto resultHi = resultLocation.asGPRhi();
-        auto lhsLo    = lhsLocation.asGPRlo();
-        auto lhsHi    = lhsLocation.asGPRhi();
-
-        auto shift = scratches.gpr(0);
-        auto tmp = scratches.gpr(1);
-
-        m_jit.and32(TrustedImm32(63), shiftReg, shift);
-
-        m_jit.urshiftUnchecked(lhsLo, shift, resultLo);
-
-        m_jit.sub32(TrustedImm32(32), shift, tmp);
-        m_jit.lshiftUnchecked(lhsHi, tmp, tmp);
-        m_jit.or32(tmp, resultLo);
-
-        m_jit.sub32(shift, TrustedImm32(32), tmp);
-        m_jit.rshiftUnchecked(lhsHi, tmp, tmp);
-        m_jit.or32(resultLo, tmp, tmp);
-        m_jit.moveConditionally32(RelationalCondition::AboveOrEqual, shift, TrustedImm32(32), tmp, resultLo, resultLo);
-
-        m_jit.rshiftUnchecked(lhsHi, shift, resultHi);
-    };
-
     EMIT_BINARY(
         "I64ShrS", TypeKind::I64,
         BLOCK(Value::fromI64(lhs.asI64() >> rhs.asI64())),
         BLOCK(
-            emitI64ShrS(lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.rshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         ),
         BLOCK(
+            if (rhs.isConst()) {
+                int32_t amount = rhs.asI32() & 63;
+                if (!amount) {
+                    m_jit.move(lhsLocation.asGPRlo(), resultLocation.asGPRlo());
+                    m_jit.move(lhsLocation.asGPRhi(), resultLocation.asGPRhi());
+                    return;
+                }
+
+                m_jit.rshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), TrustedImm32(amount), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+                return;
+            }
+
+            int64_t value = lhs.asI64();
+            if (!value) {
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRhi());
+                return;
+            }
+
+            if (value == -1) {
+                m_jit.move(TrustedImm32(-1), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(-1), resultLocation.asGPRhi());
+                return;
+            }
+
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
-            emitI64ShrS(lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.rshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         )
     );
 }
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
 {
-    auto emitI64ShrU = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
-        ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
-
-        auto shiftReg = rhsLocation.asGPRlo();
-        auto resultLo = resultLocation.asGPRlo();
-        auto resultHi = resultLocation.asGPRhi();
-        auto lhsLo    = lhsLocation.asGPRlo();
-        auto lhsHi    = lhsLocation.asGPRhi();
-
-        auto shift = scratches.gpr(0);
-        auto tmp = scratches.gpr(1);
-
-        m_jit.and32(TrustedImm32(63), shiftReg, shift);
-
-        m_jit.urshiftUnchecked(lhsLo, shift, resultLo);
-
-        m_jit.sub32(TrustedImm32(32), shift, tmp);
-        m_jit.lshiftUnchecked(lhsHi, tmp, tmp);
-        m_jit.or32(tmp, resultLo);
-
-        m_jit.sub32(shift, TrustedImm32(32), tmp);
-        m_jit.urshiftUnchecked(lhsHi, tmp, tmp);
-        m_jit.or32(tmp, resultLo);
-
-        m_jit.urshiftUnchecked(lhsHi, shift, resultHi);
-    };
-
     EMIT_BINARY(
         "I64ShrU", TypeKind::I64,
         BLOCK(Value::fromI64(static_cast<uint64_t>(lhs.asI64()) >> static_cast<uint64_t>(rhs.asI64()))),
         BLOCK(
-            emitI64ShrU(lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.urshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         ),
         BLOCK(
+            if (rhs.isConst()) {
+                int32_t amount = rhs.asI32() & 63;
+                if (!amount) {
+                    m_jit.move(lhsLocation.asGPRlo(), resultLocation.asGPRlo());
+                    m_jit.move(lhsLocation.asGPRhi(), resultLocation.asGPRhi());
+                    return;
+                }
+
+                m_jit.urshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), TrustedImm32(amount), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+                return;
+            }
+
+            int64_t value = lhs.asI64();
+            if (!value) {
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRhi());
+                return;
+            }
+
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
-            emitI64ShrU(lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.urshift64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         )
     );
 }
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
 {
-    PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I64Rotl", TypeKind::I64,
         BLOCK(Value::fromI64(B3::rotateLeft(lhs.asI64(), rhs.asI64()))),
         BLOCK(
-            rotI64Helper(RotI64HelperOp::Left, lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.rotateLeft64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         ),
         BLOCK(
+            if (rhs.isConst()) {
+                int32_t amount = rhs.asI32() & 63;
+                if (!amount) {
+                    m_jit.move(lhsLocation.asGPRlo(), resultLocation.asGPRlo());
+                    m_jit.move(lhsLocation.asGPRhi(), resultLocation.asGPRhi());
+                    return;
+                }
+
+                ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+                m_jit.rotateLeft64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), TrustedImm32(amount), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
+                return;
+            }
+
+            int64_t value = lhs.asI64();
+            if (!value) {
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRhi());
+                return;
+            }
+
+            if (value == -1) {
+                m_jit.move(TrustedImm32(-1), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(-1), resultLocation.asGPRhi());
+                return;
+            }
+
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
-            rotI64Helper(RotI64HelperOp::Left, lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.rotateLeft64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         )
     );
 }
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
 {
-    PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I64Rotr", TypeKind::I64,
         BLOCK(Value::fromI64(B3::rotateRight(lhs.asI64(), rhs.asI64()))),
         BLOCK(
-            rotI64Helper(RotI64HelperOp::Right, lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.rotateRight64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         ),
         BLOCK(
+            if (rhs.isConst()) {
+                int32_t amount = rhs.asI32() & 63;
+                if (!amount) {
+                    m_jit.move(lhsLocation.asGPRlo(), resultLocation.asGPRlo());
+                    m_jit.move(lhsLocation.asGPRhi(), resultLocation.asGPRhi());
+                    return;
+                }
+
+                ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+                m_jit.rotateRight64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), TrustedImm32(amount), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
+                return;
+            }
+
+            int64_t value = lhs.asI64();
+            if (!value) {
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(0), resultLocation.asGPRhi());
+                return;
+            }
+
+            if (value == -1) {
+                m_jit.move(TrustedImm32(-1), resultLocation.asGPRlo());
+                m_jit.move(TrustedImm32(-1), resultLocation.asGPRhi());
+                return;
+            }
+
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
-            rotI64Helper(RotI64HelperOp::Right, lhsLocation, rhsLocation, resultLocation);
+            ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+            m_jit.rotateRight64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo(), scratches.gpr(0), scratches.gpr(1));
         )
     );
-}
-
-void BBQJIT::rotI64Helper(RotI64HelperOp op, Location lhsLocation, Location rhsLocation, Location resultLocation)
-{
-    // NB: this only works as long as result is allocated in lhsLocation!
-    auto carry = rhsLocation.asGPRhi();
-    auto shift = rhsLocation.asGPRlo();
-    ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
-    auto tmpHi = scratches.gpr(0);
-    auto tmpLo = scratches.gpr(1);
-    m_jit.move(lhsLocation.asGPRhi(), resultLocation.asGPRhi());
-    m_jit.move(lhsLocation.asGPRlo(), resultLocation.asGPRlo());
-    m_jit.and32(TrustedImm32(63), shift, shift);
-    auto rotate = m_jit.branch32(RelationalCondition::LessThan, shift, TrustedImm32(32));
-    // swap
-    m_jit.swap(resultLocation.asGPRhi(), resultLocation.asGPRlo());
-    rotate.link(&m_jit);
-    m_jit.and32(TrustedImm32(31), shift, shift);
-    auto zero = m_jit.branch32(RelationalCondition::Equal, shift, TrustedImm32(0));
-    // rotate
-    m_jit.move(TrustedImm32(32), carry);
-    m_jit.sub32(carry, shift, carry);
-    if (op == RotI64HelperOp::Left) {
-        m_jit.urshift32(resultLocation.asGPRhi(), carry, tmpLo);
-        m_jit.urshift32(resultLocation.asGPRlo(), carry, tmpHi);
-        m_jit.lshift32(resultLocation.asGPRhi(), shift, resultLocation.asGPRhi());
-        m_jit.lshift32(resultLocation.asGPRlo(), shift, resultLocation.asGPRlo());
-    } else if (op == RotI64HelperOp::Right) {
-        m_jit.lshift32(resultLocation.asGPRhi(), carry, tmpLo);
-        m_jit.lshift32(resultLocation.asGPRlo(), carry, tmpHi);
-        m_jit.urshift32(resultLocation.asGPRhi(), shift, resultLocation.asGPRhi());
-        m_jit.urshift32(resultLocation.asGPRlo(), shift, resultLocation.asGPRlo());
-    }
-    m_jit.or32(tmpHi, resultLocation.asGPRhi());
-    m_jit.or32(tmpLo, resultLocation.asGPRlo());
-    zero.link(&m_jit);
 }
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Clz(Value operand, Value& result)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2575,7 +2575,6 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotl(Value lhs, Value rhs, Value&
     EMIT_BINARY(
         "I64Rotl", TypeKind::I64,
         BLOCK(Value::fromI64(B3::rotateLeft(lhs.asI64(), rhs.asI64()))),
-#if CPU(X86_64)
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.rotateLeft64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
@@ -2589,23 +2588,6 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotl(Value lhs, Value rhs, Value&
                 m_jit.rotateLeft64(resultLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
             }
         )
-#else
-        BLOCK(
-            moveShiftAmountIfNecessary(rhsLocation);
-            m_jit.neg64(rhsLocation.asGPR(), wasmScratchGPR);
-            m_jit.rotateRight64(lhsLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
-        ),
-        BLOCK(
-            if (rhs.isConst())
-                m_jit.rotateRight64(lhsLocation.asGPR(), TrustedImm32(-rhs.asI64()), resultLocation.asGPR());
-            else {
-                moveShiftAmountIfNecessary(rhsLocation);
-                m_jit.neg64(rhsLocation.asGPR(), wasmScratchGPR);
-                emitMoveConst(lhs, resultLocation);
-                m_jit.rotateRight64(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
-            }
-        )
-#endif
     );
 }
 


### PR DESCRIPTION
#### b5819712d9f5b5ef54b649b04d5ad1aebb4aed01
<pre>
[JSC] Improve BBQ&apos;s rotate and shift implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=302406">https://bugs.webkit.org/show_bug.cgi?id=302406</a>

Reviewed by Yusuke Suzuki.

This PR is mostly focused on improving the rotate and shift implementations for
ARMv7, but also includes small thcanges to 64-bit arm which I&apos;ll describe
below.

For 32-bit:
- Implemented rotateLeft64, rotateRight64, lshift64, urshift64, rshift64:
  similar to some fp functions (e.g., truncateDoubleToUint64) we need to pass 2
  scratches to implement the algorithms. One benefit of moving the shift
  operations to the backend is that we have an extra scratch (r12), so things are
  slightly easier to implement.
- Removed lshiftUnchecked(), rshiftUnchecked(), urshiftUnchecked() since we can
  access the instructions directly.
- Implemented several optimizations for shift and rotate: we see a .5%
  reduction in code size in JetStream3&apos;s tfjs-wasm.js.
- The rotate algorithm should now be safe to run when registers overlap, which
  was causing a crash in JetStream3&apos;s tfjs-wasm.js.

For 64-bit arm:
- Implemented rotateLeft32 and rotateLeft64: this allows us to unify both
  x86_64 and ARM64 code paths.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::rotateLeft32):
(JSC::MacroAssemblerARM64::rotateLeft64):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::rotateLeft64):
(JSC::MacroAssemblerARMv7::rotateRight64):
(JSC::MacroAssemblerARMv7::lshift64):
(JSC::MacroAssemblerARMv7::urshift64):
(JSC::MacroAssemblerARMv7::rshift64):
(JSC::MacroAssemblerARMv7::lshiftUnchecked): Deleted.
(JSC::MacroAssemblerARMv7::rshiftUnchecked): Deleted.
(JSC::MacroAssemblerARMv7::urshiftUnchecked): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Rotl):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Shl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotr):
(JSC::Wasm::BBQJITImpl::BBQJIT::rotI64Helper): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotl):

Canonical link: <a href="https://commits.webkit.org/303502@main">https://commits.webkit.org/303502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2280930fff24fc63b45c574ce89dd996cbf3eed2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82520 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99707 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67516 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80401 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2201 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81544 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122877 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140767 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129314 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2928 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108222 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108142 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2244 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113508 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55962 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2996 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31935 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162331 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66388 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40494 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->