### PR TITLE
[SaferCPP] Eliminate raw pointer hash table for Thread

### DIFF
--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,4 +1,3 @@
-wtf/HashTable.h
 wtf/JSONValues.h
 wtf/RecursiveLockAdapter.h
 wtf/RedBlackTree.h

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -303,7 +303,7 @@ static int schedPolicy(Thread::QOS qos, Thread::SchedulingPolicy schedulingPolic
 }
 #endif
 
-bool Thread::establishHandle(NewThreadContext* context, std::optional<size_t> stackSize, QOS qos, SchedulingPolicy schedulingPolicy)
+bool Thread::establishHandle(NewThreadContext& context, std::optional<size_t> stackSize, QOS qos, SchedulingPolicy schedulingPolicy)
 {
     pthread_t threadHandle;
     pthread_attr_t attr;
@@ -316,10 +316,10 @@ bool Thread::establishHandle(NewThreadContext* context, std::optional<size_t> st
 #endif
     if (stackSize)
         pthread_attr_setstacksize(&attr, stackSize.value());
-    int error = pthread_create(&threadHandle, &attr, wtfThreadEntryPoint, context);
+    int error = pthread_create(&threadHandle, &attr, wtfThreadEntryPoint, &context);
     pthread_attr_destroy(&attr);
     if (error) {
-        LOG_ERROR("Failed to create pthread at entry point %p with context %p", wtfThreadEntryPoint, context);
+        LOG_ERROR("Failed to create pthread at entry point %p with context %p", wtfThreadEntryPoint, &context);
         return false;
     }
 
@@ -437,7 +437,7 @@ Thread& Thread::initializeCurrentTLS()
 {
     // Not a WTF-created thread, Thread is not established yet.
     WTF::initialize();
-    Ref<Thread> thread = adoptRef(*new Thread());
+    Ref thread = adoptRef(*new Thread(SchedulingPolicy::Other));
     thread->establishPlatformSpecificHandle(pthread_self());
     thread->initializeInThread();
     initializeCurrentThreadEvenIfNonWTFCreated();

--- a/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
@@ -168,9 +168,8 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
 
     HashSet<mach_port_t> knownWebKitThreads;
     {
-        Locker locker { Thread::allThreadsLock() };
-        for (auto* thread : Thread::allThreads()) {
-            mach_port_t machThread = thread->machThread();
+        for (auto& thread : Thread::allThreads()) {
+            mach_port_t machThread = thread.machThread();
             if (MACH_PORT_VALID(machThread))
                 knownWebKitThreads.add(machThread);
         }

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -251,9 +251,8 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
 
     HashSet<pid_t> knownWebKitThreads;
     {
-        Locker locker { Thread::allThreadsLock() };
-        for (auto* thread : Thread::allThreads()) {
-            if (auto id = thread->id())
+        for (auto& thread : Thread::allThreads()) {
+            if (auto id = thread.id())
                 knownWebKitThreads.add(id);
         }
     }

--- a/Source/WebCore/platform/audio/RealtimeAudioThread.cpp
+++ b/Source/WebCore/platform/audio/RealtimeAudioThread.cpp
@@ -40,10 +40,9 @@ Ref<Thread> createMaybeRealtimeAudioThread(ASCIILiteral threadName, Function<voi
     // FIXME: Coalesce these threads to allow a single realtime thread to service every audio instance.
 
     bool shouldCreateRealtimeThread = [] {
-        Locker threadLocker { Thread::allThreadsLock() };
         uint8_t numberOfRealtimeThreads = 0;
-        for (RefPtr thread : Thread::allThreads()) {
-            if (thread && thread->isRealtime())
+        for (Ref thread : Thread::allThreads()) {
+            if (thread->isRealtime())
                 ++numberOfRealtimeThreads;
         }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -471,9 +471,8 @@ public:
         }
         while (true) {
             sleep(0.1_s);
-            Locker lock { Thread::allThreadsLock() };
             for (auto& thread : threadsToWait) {
-                if (Thread::allThreads().contains(thread.ptr()))
+                if (Thread::allThreads().contains(thread.get()))
                     continue;
             }
             break;

--- a/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
@@ -273,10 +273,8 @@ TEST(WTF_RunLoop, Create)
         });
         semaphore.wait();
     }
-    {
-        Locker threadsLock { Thread::allThreadsLock() };
-        EXPECT_TRUE(Thread::allThreads().contains(runLoopThread));
-    }
+
+    EXPECT_TRUE(Thread::allThreads().contains(*runLoopThread));
 
     runLoop->dispatch([] {
         RunLoop::currentSingleton().stop();
@@ -285,10 +283,7 @@ TEST(WTF_RunLoop, Create)
     Util::runFor(.2_s);
 
     // Expect that RunLoop Thread does not leak.
-    {
-        Locker threadsLock { Thread::allThreadsLock() };
-        EXPECT_FALSE(Thread::allThreads().contains(runLoopThread));
-    }
+    EXPECT_FALSE(Thread::allThreads().contains(*runLoopThread));
 }
 
 // FIXME(https://bugs.webkit.org/show_bug.cgi?id=246569): glib and Windows runloop does not match Cocoa.


### PR DESCRIPTION
#### 26ebb2b1983fed45ad687a87c8d0863f47f6537d
<pre>
[SaferCPP] Eliminate raw pointer hash table for Thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=302414">https://bugs.webkit.org/show_bug.cgi?id=302414</a>
<a href="https://rdar.apple.com/164575958">rdar://164575958</a>

Reviewed by Brady Eidson and Chris Dumez.

Adopted ThreadSafeWeakHashSet instead. It&apos;s pretty neat!

Now we end up locking less than we used to, and that revealed a race
condition between thread startup and shutdown in workers/bomb.html.

Fixed the race condition by ensuring that all Thread initialization happens
before launching the new thread or while holding the NewThreadContext lock
(either on the caller thread or on the callee thread, depending on build config).

Canonical link: <a href="https://commits.webkit.org/303075@main">https://commits.webkit.org/303075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d572f5d1888a8c64e1e403334f5f96fdc1cd3264

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82916 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/40845ec5-2445-4450-81c3-cca094491977) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7c31ca6-ac53-41c7-a2ee-80eba3ecf211) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134152 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80665 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cdcdf00c-155c-4f9b-ba44-cf5c96f75673) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2448 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81898 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123228 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141148 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129660 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3281 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108486 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108429 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2464 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56361 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20414 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3343 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32209 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162677 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66750 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/40876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->