### PR TITLE
ASAN_ILL | LayoutIntegration::LineLayout::paint; WebCore::RenderBlock::paintObject; WebCore::RenderBlock::paint

### DIFF
--- a/LayoutTests/fast/html/crash-marquee-fullscreen-expected.txt
+++ b/LayoutTests/fast/html/crash-marquee-fullscreen-expected.txt
@@ -1,0 +1,2 @@
+  This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/html/crash-marquee-fullscreen.html
+++ b/LayoutTests/fast/html/crash-marquee-fullscreen.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script>
+ function run(){
+     marqueeElement.stop();
+     (async () => {
+         internals.withUserGesture(() => {
+             toFS.addEventListener("fullscreenchange", (event) => { testRunner.notifyDone(); });
+             toFS.requestFullscreen();
+         });
+         await (()=>{
+             return window.caches?.has("");
+         })();
+         divElement2.replaceWith(divElement);
+     })();
+ }
+ if (window.testRunner) {
+     testRunner.dumpAsText();
+     testRunner.waitUntilDone();
+ }
+</script>
+<body onload="run()">
+    <marquee id="marqueeElement"></marquee>
+    <input>
+    <div id="divElement"></div>
+    This test passes if it doesn't crash.
+    <div>
+        <div id="toFS"></div>
+    </div>
+    <div id="divElement2"></div>
+</body>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -339,7 +339,10 @@ StyleDifference RenderElement::adjustStyleDifference(StyleDifference diff, Optio
         else
             diff = std::max(diff, StyleDifference::RecompositeLayer);
     }
-    
+
+    if (isHTMLMarquee())
+        diff = std::max(diff, StyleDifference::Layout);
+
     // The answer to requiresLayer() for plugins, iframes, and canvas can change without the actual
     // style changing, since it depends on whether we decide to composite these elements. When the
     // layer status of one of these elements changes, we need to force a layout.


### PR DESCRIPTION
#### b011d3f4dbd8cda10ed26259f9946617943fe5e4
<pre>
ASAN_ILL | LayoutIntegration::LineLayout::paint; WebCore::RenderBlock::paintObject; WebCore::RenderBlock::paint
<a href="https://bugs.webkit.org/show_bug.cgi?id=296869">https://bugs.webkit.org/show_bug.cgi?id=296869</a>
<a href="https://rdar.apple.com/157022958">rdar://157022958</a>

Reviewed by Alan Baradlay.

This crash is caused by how RenderMarquee (which is not an actual render)
handles internally its state. When the marquee is in a seemingly active
state but it has been stopped, RenderMarquee will mark its renderer
as needing layout. However, when the marquee is part of inline content,
this information is not available when the style difference is adjusted --
so it can easily be skipped for layout, creating an inconsistent state
and trigger an assertion after layout has finished and it is detected
that there is still a renderer that is dirty.

Address this by checking in RenderElement::adjustStyleDifference() whether
the renderer is used for a Marquee, in which case we make the difference
include layout as well as any other needed change.

The conditions for this to happen seem to be that the marquee is stopped
early on, nearby elements have to be reparented so as to trigger a rebuild of the
render tree, and the marquee block renderer ends up as part of inline content.
In the test case added, the asynchronous fullscreen call forces a relayout
after the conditions are met, so we end up with a dirty render tree after
layout. It seems to be very time-sensitive, hence the test is not so elegant,
but it&apos;s as good as it gets considering it&apos;s a reduction from a fuzzing test case.

* LayoutTests/fast/html/crash-marquee-fullscreen-expected.txt: Added.
* LayoutTests/fast/html/crash-marquee-fullscreen.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::adjustStyleDifference const):

Originally-landed-as: 297297.7@webkit-2025.7-embargoed (6a0447375f9d). <a href="https://rdar.apple.com/164212697">rdar://164212697</a>
Canonical link: <a href="https://commits.webkit.org/302947@main">https://commits.webkit.org/302947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceff8e50a3dd12080a63c1fe1a591955a1b90005

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82311 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9cfe821-534a-4b70-81b4-20ff1eabde14) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99562 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8d21b1f-cf2d-4916-a129-6462c9fbc66e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80270 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35148 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81359 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140583 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108068 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108001 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55739 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66202 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2633 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->