### PR TITLE
[JSC] Wasm: Fix OMG exceptions with nested catch

### DIFF
--- a/JSTests/wasm/stress/catch-nested-expr-stack-and-locals.js
+++ b/JSTests/wasm/stress/catch-nested-expr-stack-and-locals.js
@@ -1,0 +1,169 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let watExpressionStackBug = `
+(module
+    (import "env" "thrower" (func $thrower))
+    (import "env" "val1" (global $val1 i32))
+    (import "env" "val2" (global $val2 f64))
+    (import "env" "val3" (global $val3 i32))
+    (import "env" "tag" (tag $exc))
+
+    (func (export "test") (result i32)
+        (local $outerlocal i32)
+        (local $innerlocal i32)
+
+        global.get $val3  ;; 50
+        local.set $outerlocal
+
+        try $outer
+            call $thrower
+        catch $exc
+            global.get $val1  ;; 100 (i32)
+            global.get $val2  ;; 200.0 (f64)
+
+            ;; Enter inner try with those values on the stack
+            try $inner
+                i32.const 25
+                local.set $innerlocal
+                call $thrower
+            catch $exc
+                ;; Inner catch completes - values 100 (i32), 200.0 (f64) should still be on stack
+                ;; And innerlocal should still be 25
+            end
+
+            ;; Convert f64 to i32 and add: i32.trunc_f64_s(200.0) + 100 = 200 + 100 = 300
+            i32.trunc_f64_s
+            i32.add
+
+            ;; Add the local values: 300 + 50 + 25 = 375
+            local.get $outerlocal
+            i32.add
+            local.get $innerlocal
+            i32.add
+            return
+        end
+
+        ;; Should not reach here
+        i32.const 999
+    )
+)
+`;
+
+let watExpressionStackBugWithOSR = `
+(module
+    (import "env" "thrower" (func $thrower))
+    (import "env" "val1" (global $val1 i32))
+    (import "env" "val2" (global $val2 f64))
+    (import "env" "val3" (global $val3 i32))
+    (import "env" "tag" (tag $exc))
+
+    (func (export "test") (param $loopCount i32) (result i32)
+        (local $outerlocal i32)
+        (local $innerlocal i32)
+        (local $counter i32)
+
+        global.get $val3  ;; 50
+        local.set $outerlocal
+
+        try $outer
+            call $thrower
+        catch $exc
+            global.get $val1  ;; 100 (i32)
+            global.get $val2  ;; 200.0 (f64)
+
+            try $inner
+                i32.const 25
+                local.set $innerlocal
+                call $thrower
+            catch $exc
+                ;; Inner catch - do a hot loop to trigger OSR tier-up
+                ;; This tests that expression stack and locals are preserved across OSR
+                i32.const 0
+                local.set $counter
+
+                (block $break
+                    (loop $continue
+                        ;; Increment counter
+                        local.get $counter
+                        i32.const 1
+                        i32.add
+                        local.set $counter
+
+                        local.get $counter
+                        local.get $loopCount
+                        i32.lt_u
+                        br_if $continue
+                    )
+                )
+                ;; After OSR, values 100 (i32), 200.0 (f64) should still be on stack
+                ;; And innerlocal should still be 25
+            end
+
+            ;; Convert f64 to i32 and add: i32.trunc_f64_s(200.0) + 100 = 200 + 100 = 300
+            i32.trunc_f64_s
+            i32.add
+
+            ;; Add the local values: 300 + 50 + 25 = 375
+            local.get $outerlocal
+            i32.add
+            local.get $innerlocal
+            i32.add
+            return
+        end
+
+        ;; Should not reach here
+        i32.const 999
+    )
+)
+`;
+
+async function testExpressionStack() {
+    const tag = new WebAssembly.Tag({ parameters: [] });
+
+    const importObject = {
+        env: {
+            tag: tag,
+            thrower: () => { throw new WebAssembly.Exception(tag, []); },
+            val1: new WebAssembly.Global({ value: 'i32', mutable: false }, 100),
+            val2: new WebAssembly.Global({ value: 'f64', mutable: false }, 200.0),
+            val3: new WebAssembly.Global({ value: 'i32', mutable: false }, 50)
+        }
+    };
+
+    const instance = await instantiate(watExpressionStackBug, importObject, { exceptions: true });
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        let result = instance.exports.test();
+        // Expected: i32.trunc_f64_s(200.0) + 100 + 50 + 25 = 200 + 100 + 50 + 25 = 375
+        assert.eq(result, 375);
+    }
+}
+
+async function testExpressionStackWithOSR() {
+    const tag = new WebAssembly.Tag({ parameters: [] });
+
+    const importObject = {
+        env: {
+            tag: tag,
+            thrower: () => { throw new WebAssembly.Exception(tag, []); },
+            val1: new WebAssembly.Global({ value: 'i32', mutable: false }, 100),
+            val2: new WebAssembly.Global({ value: 'f64', mutable: false }, 200.0),
+            val3: new WebAssembly.Global({ value: 'i32', mutable: false }, 50)
+        }
+    };
+
+    const instance = await instantiate(watExpressionStackBugWithOSR, importObject, { exceptions: true });
+
+    // Use a large loop count to ensure OSR tier-up happens
+    const loopCount = 10000;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        let result = instance.exports.test(loopCount);
+        // Expected: i32.trunc_f64_s(200.0) + 100 + 50 + 25 = 200 + 100 + 50 + 25 = 375
+        assert.eq(result, 375);
+    }
+}
+
+assert.asyncTest(testExpressionStack());
+assert.asyncTest(testExpressionStackWithOSR());

--- a/JSTests/wasm/stress/catch-nested-rethrow.js
+++ b/JSTests/wasm/stress/catch-nested-rethrow.js
@@ -1,0 +1,104 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (tag $exc (param i32))
+
+    (func (export "test")
+
+        try $outer
+            i32.const 777
+            throw $exc
+        catch $exc
+            ;; Now do inner try-catch
+            try $inner
+                i32.const 888
+                throw $exc
+            catch $exc
+                ;; Rethrow the outer exception (depth 1)
+                rethrow 1
+            end
+            unreachable
+        end
+        unreachable
+    )
+)
+`;
+
+let watWithOSR = `
+(module
+    (tag $exc (param i32))
+
+    (func (export "test") (param $loopCount i32)
+        (local $counter i32)
+
+        try $outer
+            i32.const 777
+            throw $exc
+        catch $exc
+            ;; Now do inner try-catch
+            try $inner
+                i32.const 888
+                throw $exc
+            catch $exc
+                ;; Do a hot loop to trigger OSR tier-up before rethrowing
+                i32.const 0
+                local.set $counter
+
+                (block $break
+                    (loop $continue
+                        ;; Increment counter
+                        local.get $counter
+                        i32.const 1
+                        i32.add
+                        local.set $counter
+
+                        local.get $counter
+                        local.get $loopCount
+                        i32.lt_u
+                        br_if $continue
+                    )
+                )
+
+                ;; After the hot loop, rethrow the outer exception (depth 1)
+                rethrow 1
+            end
+            unreachable
+        end
+        unreachable
+    )
+)
+`;
+
+async function testBasic() {
+    const instance = await instantiate(wat, {}, { exceptions: true });
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        try {
+            instance.exports.test();
+            assert.fail("Expected WebAssembly.Exception to be thrown");
+        } catch (e) {
+            assert.instanceof(e, WebAssembly.Exception, "Should throw WebAssembly.Exception");
+        }
+    }
+}
+
+async function testWithOSR() {
+    const instance = await instantiate(watWithOSR, {}, { exceptions: true });
+
+    // Use a large loop count to ensure OSR tier-up happens
+    const loopCount = 10000;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        try {
+            instance.exports.test(loopCount);
+            assert.fail("Expected WebAssembly.Exception to be thrown");
+        } catch (e) {
+            assert.instanceof(e, WebAssembly.Exception, "Should throw WebAssembly.Exception");
+        }
+    }
+}
+
+await assert.asyncTest(testBasic());
+await assert.asyncTest(testWithOSR());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3442,6 +3442,7 @@ B3::ValueRep BBQJIT::toB3Rep(Location location)
     return B3::ValueRep();
 }
 
+// This needs to be kept in sync with WasmIPIntSlowPaths.cpp buildEntryBufferForLoopOSR and OMGIRGenerator::addLoop.
 StackMap BBQJIT::makeStackMap(const ControlData& data, Stack& enclosingStack)
 {
     unsigned numElements = m_locals.size() + data.enclosedHeight() + data.argumentLocations().size();

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -210,6 +210,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
     WASM_RETURN_TWO(nullptr, nullptr);
 }
 
+// This needs to be kept in sync with BBQJIT::makeStackMap.
 template<SavedFPWidth savedFPWidth>
 static ALWAYS_INLINE uint64_t* buildEntryBufferForLoopOSR(Wasm::IPIntCallee* ipintCallee, Wasm::BBQCallee* bbqCallee, JSWebAssemblyInstance* instance, const Wasm::IPIntTierUpCounter::OSREntryData& osrEntryData, IPIntLocal* pl)
 {


### PR DESCRIPTION
#### 9b2df38070c9fd95acffa874a0d7f4a5656586fd
<pre>
[JSC] Wasm: Fix OMG exceptions with nested catch
<a href="https://bugs.webkit.org/show_bug.cgi?id=300395">https://bugs.webkit.org/show_bug.cgi?id=300395</a>
<a href="https://rdar.apple.com/162211758">rdar://162211758</a>

Reviewed by Yusuke Suzuki.

OMGIRGenerator::emitCatchImpl consumes the scratch buffer produced by
the stack map generated by OMGIRGenerator::preparePatchpointForExceptions
which has the catch exception after the expressions of a Catch block.
However, when Options::useWasmIPInt()==true, connectControlAtEntrypoint()
does not load the exception value.

Added new tests to verify nested catch rethrow exception and
expression slots (and locals) are restored correctly when entering an
inner catch handler, as well verify that this state remains correct
for the OSR loop case.

* JSTests/wasm/stress/catch-nested-expr-stack-and-locals.js: Added.
(async testExpressionStack):
(async testExpressionStackWithOSR):
* JSTests/wasm/stress/catch-nested-rethrow.js: Added.
(async testBasic):
(async testWithOSR):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::connectControlAtEntrypoint):
(JSC::Wasm::OMGIRGenerator::addLoop):
(JSC::Wasm::OMGIRGenerator::emitCatchImpl):
(JSC::Wasm::OMGIRGenerator::emitCatchTableImpl):

Originally-landed-as: 297297.521@safari-7622-branch (6f9b4a803bef). <a href="https://rdar.apple.com/164211289">rdar://164211289</a>
Canonical link: <a href="https://commits.webkit.org/302967@main">https://commits.webkit.org/302967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85239e99d654a52b8097e2d9a7815564bec33fbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82313 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b413f4c-5ea5-45b8-995b-f430ae94bb97) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99565 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fda6efb0-543e-4f62-9ed3-cb369b92a37f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80273 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35150 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81361 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140585 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129137 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108070 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108003 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55742 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20359 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66204 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162152 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2635 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40441 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2741 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->