### PR TITLE
[JSC] Skip loop unrolling when tail has non-branch terminal

### DIFF
--- a/JSTests/stress/loop-unrolling-with-a-switch-tail-terminal.js
+++ b/JSTests/stress/loop-unrolling-with-a-switch-tail-terminal.js
@@ -1,0 +1,18 @@
+const a = new Float32Array(1);
+const b = [2];
+function test() {
+    function foo() { }
+    for (let i = 0; i < 100; i++) {
+        switch (foo) {
+            default:
+                for (const j of a) { }
+            case 0:
+            case 1:
+            case 1:
+        }
+    }
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    test();
+}

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -353,6 +353,11 @@ public:
             return false;
         }
 
+        if (!tail->terminal()->isBranch()) {
+            dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *header, " since the tail ", *tail, " has a non-branch terminal");
+            return false;
+        }
+
         for (BasicBlock* successor : tail->successors()) {
             if (data.loop->contains(successor))
                 continue;


### PR DESCRIPTION
#### eafee057d4d16608181f6a7c8223b850e217e5e5
<pre>
[JSC] Skip loop unrolling when tail has non-branch terminal
<a href="https://bugs.webkit.org/show_bug.cgi?id=297153">https://bugs.webkit.org/show_bug.cgi?id=297153</a>
<a href="https://rdar.apple.com/157755838">rdar://157755838</a>

Reviewed by Yusuke Suzuki.

The loop unrolling phase assumed tail blocks always have Branch terminals,
but could encounter Switch terminals. Add an early check in locateTail() to
skip loops with non-Branch terminals, as the current implementation only
supports Branch-based loop structures.

Originally-landed-as: 297297.245@safari-7622-branch (dc6269bc685f). <a href="https://rdar.apple.com/164280938">rdar://164280938</a>
Canonical link: <a href="https://commits.webkit.org/302968@main">https://commits.webkit.org/302968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bc7bce873af664adc598e4e67a96cacb4669320

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82316 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c70ea1b-3705-44d5-9870-d0d8cee7306d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99566 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e1589709-04fe-47fe-a7c5-c4d9b5267193) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80274 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae92ea7d-189d-4f24-93a1-f3f2c63b7f4f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81363 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122689 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110657 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35655 "Found 1 new test failure: media/media-source/media-source-interruption-with-resume-allowing-play.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140587 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129139 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108071 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108004 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55744 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20357 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66206 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162154 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2637 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40442 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->