### PR TITLE
REGRESSION(302776@main): Made inspector/timeline/timeline-event-TimerInstall.html flakey

### DIFF
--- a/LayoutTests/inspector/timeline/recording-start-stop-timestamps.html
+++ b/LayoutTests/inspector/timeline/recording-start-stop-timestamps.html
@@ -14,7 +14,7 @@ function test()
     }
 
     WI.timelineManager.addEventListener(WI.TimelineManager.Event.CapturingStateChanged, (event) => {
-        if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Active) {
+        if (event.data.capturingState === WI.TimelineManager.CapturingState.Active) {
             InspectorTest.assert(typeof event.data.startTime === "number");
             InspectorTest.assert(event.data.startTime > 0);
 
@@ -31,7 +31,7 @@ function test()
             return;
         }
 
-        if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Inactive) {
+        if (event.data.capturingState === WI.TimelineManager.CapturingState.Inactive) {
             InspectorTest.assert(typeof event.data.endTime === "number");
             InspectorTest.assert(event.data.endTime > 0);
 

--- a/LayoutTests/inspector/timeline/resources/timeline-event-utilities.js
+++ b/LayoutTests/inspector/timeline/resources/timeline-event-utilities.js
@@ -10,7 +10,7 @@ TestPage.registerInitializer(() => {
 
         let promise = new Promise((resolve, reject) => {
             let listener = WI.timelineManager.addEventListener(WI.TimelineManager.Event.CapturingStateChanged, (event) => {
-                if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Active) {
+                if (event.data.capturingState === WI.TimelineManager.CapturingState.Active) {
                     let recording = WI.timelineManager.activeRecording;
                     let timeline = recording.timelines.get(timelineType ?? WI.TimelineRecord.Type.Script);
 
@@ -30,7 +30,7 @@ TestPage.registerInitializer(() => {
                     return;
                 }
 
-                if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Inactive) {
+                if (event.data.capturingState === WI.TimelineManager.CapturingState.Inactive) {
                     WI.timelineManager.removeEventListener(WI.TimelineManager.Event.CapturingStateChanged, listener);
                     InspectorTest.assert(savePageDataPromise, "savePageData should have been called in the page before capturing was stopped.");
                     savePageDataPromise.then(resolve);
@@ -51,7 +51,7 @@ TestPage.registerInitializer(() => {
 
         let promise = new Promise((resolve, reject) => {
             let listener = WI.timelineManager.addEventListener(WI.TimelineManager.Event.CapturingStateChanged, (event) => {
-                if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Active) {
+                if (event.data.capturingState === WI.TimelineManager.CapturingState.Active) {
                     let recording = WI.timelineManager.activeRecording;
 
                     let markerAddedListener = recording.addEventListener(WI.TimelineRecording.Event.MarkerAdded, (markerAddedEvent) => {
@@ -70,7 +70,7 @@ TestPage.registerInitializer(() => {
                     return;
                 }
 
-                if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Inactive) {
+                if (event.data.capturingState === WI.TimelineManager.CapturingState.Inactive) {
                     WI.timelineManager.removeEventListener(WI.TimelineManager.Event.CapturingStateChanged, listener);
                     InspectorTest.assert(savePageDataPromise, "savePageData should have been called in the page before capturing was stopped.");
                     savePageDataPromise.then(resolve);

--- a/LayoutTests/inspector/timeline/timeline-recording.html
+++ b/LayoutTests/inspector/timeline/timeline-recording.html
@@ -16,7 +16,7 @@ function test()
             async function awaitCapturingState(capturingState) {
                 return new Promise((resolve, reject) => {
                     let listener = WI.timelineManager.addEventListener(WI.TimelineManager.Event.CapturingStateChanged, (event) => {
-                        if (WI.timelineManager.capturingState !== capturingState)
+                        if (event.data.capturingState !== capturingState)
                             return;
 
                         WI.timelineManager.removeEventListener(WI.TimelineManager.Event.CapturingStateChanged, listener);

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -1625,7 +1625,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
     _handleTimelineCapturingStateChanged(event)
     {
-        switch (WI.timelineManager.capturingState) {
+        switch (event.data.capturingState) {
         case WI.TimelineManager.CapturingState.Starting:
             this._startDisablingBreakpointsTemporarily();
             if (this.paused)

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -2703,7 +2703,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
     {
         this._updateTemporarilyDisabledBreakpointsButtons();
 
-        switch (WI.timelineManager.capturingState) {
+        switch (event.data.capturingState) {
         case WI.TimelineManager.CapturingState.Starting:
             if (!this._timelineRecordingWarningElement) {
                 let stopRecordingButton = document.createElement("button");

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
@@ -1022,7 +1022,7 @@ WI.TimelineOverview = class TimelineOverview extends WI.View
 
     _handleTimelineCapturingStateChanged(event)
     {
-        switch (WI.timelineManager.capturingState) {
+        switch (event.data.capturingState) {
         case WI.TimelineManager.CapturingState.Active:
             this._editInstrumentsButton.enabled = false;
             this._stopEditingInstruments();

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js
@@ -339,7 +339,7 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
 
         this._timelineOverview.viewMode = newViewMode;
         this._updateTimelineOverviewHeight();
-        this._updateProgressView();
+        this._updateProgressView(WI.timelineManager.capturingState);
         this._updateFilterBar();
 
         if (timelineView) {
@@ -548,14 +548,14 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
 
     _handleTimelineCapturingStateChanged(event)
     {
-        let {startTime, endTime} = event.data;
+        let {capturingState} = event.data;
 
-        this._updateProgressView();
+        this._updateProgressView(capturingState);
 
-        switch (WI.timelineManager.capturingState) {
+        switch (capturingState) {
         case WI.TimelineManager.CapturingState.Active:
             if (!this._updating)
-                this._startUpdatingCurrentTime(startTime);
+                this._startUpdatingCurrentTime(event.data.startTime);
 
             this._clearTimelineNavigationItem.enabled = !this._recording.readonly;
             this._exportButtonNavigationItem.enabled = false;
@@ -981,10 +981,9 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
         this._filterBarNavigationItem.filterBar.clear();
     }
 
-    _updateProgressView()
+    _updateProgressView(capturingState)
     {
-        let isCapturing = WI.timelineManager.isCapturing();
-        this._progressView.visible = isCapturing && this.currentTimelineView && !this.currentTimelineView.showsLiveRecordingData;
+        this._progressView.visible = capturingState !== WI.TimelineManager.CapturingState.Inactive && this.currentTimelineView && !this.currentTimelineView.showsLiveRecordingData;
     }
 
     _updateFilterBar()

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingProgressView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingProgressView.js
@@ -64,16 +64,16 @@ WI.TimelineRecordingProgressView = class TimelineRecordingProgressView extends W
         this.element.classList.toggle("hidden", !this._visible);
 
         if (this._visible)
-            this._updateState();
+            this._updateState(WI.timelineManager.capturingState);
     }
 
     // Private
 
-    _updateState() {
+    _updateState(capturingState) {
         if (!this._visible)
             return;
 
-        switch (WI.timelineManager.capturingState) {
+        switch (capturingState) {
         case WI.TimelineManager.CapturingState.Starting:
         case WI.TimelineManager.CapturingState.Active:
             this._statusElement.textContent = WI.UIString("Recording Timeline Data", "Recording Timeline Data @ Timeline Recording Progress", "Message for progress of a timeline recording.");
@@ -92,7 +92,7 @@ WI.TimelineRecordingProgressView = class TimelineRecordingProgressView extends W
 
     _handleTimelineCapturingStateChanged(event)
     {
-        this._updateState();
+        this._updateState(event.data.capturingState);
     }
 
 };

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
@@ -490,9 +490,9 @@ WI.TimelineTabContentView = class TimelineTabContentView extends WI.ContentBrows
         this._continueButton.hidden = false;
     }
 
-    _updateNavigationBarButtons()
+    _updateNavigationBarButtons(capturingState)
     {
-        if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Stopping)
+        if (capturingState === WI.TimelineManager.CapturingState.Stopping)
             this._showRecordStoppingSpinner();
         else if (!WI.modifierKeys.altKey || !WI.timelineManager.willAutoStop())
             this._showRecordButton();
@@ -502,16 +502,17 @@ WI.TimelineTabContentView = class TimelineTabContentView extends WI.ContentBrows
 
     _handleTimelineCapturingStateChanged(event)
     {
-        let enabled = WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Active || WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Inactive;
-        let stopping = WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Stopping;
+        let {capturingState} = event.data;
+        let enabled = capturingState === WI.TimelineManager.CapturingState.Active || capturingState === WI.TimelineManager.CapturingState.Inactive;
+        let stopping = capturingState === WI.TimelineManager.CapturingState.Stopping;
 
         this._toggleRecordingShortcut.disabled = !enabled || stopping;
         this._toggleNewRecordingShortcut.disabled = !enabled || stopping;
 
-        this._recordButton.toggled = WI.timelineManager.isCapturing();
+        this._recordButton.toggled = capturingState !== WI.TimelineManager.CapturingState.Inactive;
         this._recordButton.enabled = enabled;
 
-        this._updateNavigationBarButtons();
+        this._updateNavigationBarButtons(capturingState);
     }
 
     _inspectorVisibilityChanged(event)
@@ -521,7 +522,7 @@ WI.TimelineTabContentView = class TimelineTabContentView extends WI.ContentBrows
 
     _globalModifierKeysDidChange(event)
     {
-        this._updateNavigationBarButtons();
+        this._updateNavigationBarButtons(WI.timelineManager.capturingState);
     }
 
     _toggleRecordingOnSpacebar(event)
@@ -577,7 +578,7 @@ WI.TimelineTabContentView = class TimelineTabContentView extends WI.ContentBrows
 
         WI.timelineManager.relaxAutoStop();
 
-        this._updateNavigationBarButtons();
+        this._updateNavigationBarButtons(WI.timelineManager.capturingState);
     }
 
     _recordingsTreeSelectionDidChange(event)


### PR DESCRIPTION
#### daecaef2cb817911209fd87b2250903593139b7e
<pre>
REGRESSION(302776@main): Made inspector/timeline/timeline-event-TimerInstall.html flakey
<a href="https://bugs.webkit.org/show_bug.cgi?id=302413">https://bugs.webkit.org/show_bug.cgi?id=302413</a>
&lt;<a href="https://rdar.apple.com/problem/164574854">rdar://problem/164574854</a>&gt;

Reviewed by BJ Burg.

Previously, there was a counter variable used to ensure that the frontend only reported that the recording was stopped once all instruments had stopped.

This didn&apos;t work when recording over a cross-origin navigation as the backend is disconnected before any messages can be sent (i.e. the frontend is told that there&apos;s a new WebProcess instead of that each instrument has stopped recording).

Ultimately, the primary purpose of that count in the frontend was to prevent the developer from starting a new recording before a previous recording had finished (assuming it existed).

The nature of WebKit&apos;s IPC means that the frontend can leverage the fact that messages are guaranteed to be delivered in the order that they&apos;re sent, so it frequently will dispatch multiple commands/events without waiting for the previous to finish.

Similarly, the frontend can wait to dispatch `WI.TimelineManager.Event.CapturingStateChanged` until any pending events from the backend have been handled.

* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype.startCapturing):
(WI.TimelineManager.prototype.stopCapturing):
(WI.TimelineManager.prototype.capturingStarted):
(WI.TimelineManager.prototype.capturingStopped):
(WI.TimelineManager.prototype._updateCapturingState): Deleted.
Include additional information about the `WI.TimelineManager.CapturingState` since `WI.TimelineManager.Event.CapturingStateChanged` is now delayed until after pending dispatches, some of which may affect the `WI.timelineManager.capturingState`.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype._handleTimelineCapturingStateChanged):
* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel.prototype._handleTimelineCapturingStateChanged):
* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js:
(WI.TimelineOverview.prototype._handleTimelineCapturingStateChanged):
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js:
(WI.TimelineRecordingContentView.prototype._currentContentViewDidChange):
(WI.TimelineRecordingContentView.prototype._handleTimelineCapturingStateChanged):
(WI.TimelineRecordingContentView.prototype._updateProgressView):
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordingProgressView.js:
(WI.TimelineRecordingProgressView.prototype.set visible):
(WI.TimelineRecordingProgressView.prototype._updateState):
(WI.TimelineRecordingProgressView.prototype._handleTimelineCapturingStateChanged):
* Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js:
(WI.TimelineTabContentView.prototype._updateNavigationBarButtons):
(WI.TimelineTabContentView.prototype._handleTimelineCapturingStateChanged):
(WI.TimelineTabContentView.prototype._globalModifierKeysDidChange):
(WI.TimelineTabContentView.prototype._continueButtonClicked):
Use the `WI.TimelineManager.CapturingState` included in `WI.TimelineManager.Event.CapturingStateChanged` instead of `WI.timelineManager.capturingState`.

* LayoutTests/inspector/timeline/resources/timeline-event-utilities.js:
(InspectorTest.TimelineEvent.captureTimelineWithScript):
(InspectorTest.TimelineEvent.captureTimelineWithMarker):
* LayoutTests/inspector/timeline/recording-start-stop-timestamps.html:
* LayoutTests/inspector/timeline/timeline-recording.html:

Canonical link: <a href="https://commits.webkit.org/303033@main">https://commits.webkit.org/303033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fc801339a98e6ba0a73f9e23375e5a6372e0254

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99569 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67429 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108074 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108008 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55753 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66215 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->