### PR TITLE
Inspector agents should use CheckedRef for InspectorEnvironment references.

### DIFF
--- a/Source/JavaScriptCore/API/APIUtils.h
+++ b/Source/JavaScriptCore/API/APIUtils.h
@@ -46,7 +46,7 @@ inline ExceptionStatus handleExceptionIfNeeded(JSC::CatchScope& scope, JSContext
             *returnedExceptionRef = toRef(globalObject, exception->value());
         scope.clearException();
 #if ENABLE(REMOTE_INSPECTOR)
-        globalObject->inspectorController().reportAPIException(globalObject, exception);
+        globalObject->checkedInspectorController()->reportAPIException(globalObject, exception);
 #endif
         return ExceptionStatus::DidThrow;
     }
@@ -60,7 +60,7 @@ inline void setException(JSContextRef ctx, JSValueRef* returnedExceptionRef, JSC
         *returnedExceptionRef = toRef(globalObject, exception);
 #if ENABLE(REMOTE_INSPECTOR)
     JSC::VM& vm = getVM(globalObject);
-    globalObject->inspectorController().reportAPIException(globalObject, JSC::Exception::create(vm, exception));
+    globalObject->checkedInspectorController()->reportAPIException(globalObject, JSC::Exception::create(vm, exception));
 #endif
 }
 

--- a/Source/JavaScriptCore/API/JSBase.cpp
+++ b/Source/JavaScriptCore/API/JSBase.cpp
@@ -61,7 +61,7 @@ JSValueRef JSEvaluateScriptInternal(const JSLockHolder&, JSContextRef ctx, JSObj
         // Debugger path is currently ignored by inspector.
         // NOTE: If we don't have a debugger, this SourceCode will be forever lost to the inspector.
         // We could stash it in the inspector in case an inspector is ever opened.
-        globalObject->inspectorController().reportAPIException(globalObject, evaluationException);
+        globalObject->checkedInspectorController()->reportAPIException(globalObject, evaluationException);
 #endif
         return nullptr;
     }
@@ -114,7 +114,7 @@ bool JSCheckScriptSyntax(JSContextRef ctx, JSStringRef script, JSStringRef sourc
             *exception = toRef(globalObject, syntaxException);
 #if ENABLE(REMOTE_INSPECTOR)
         Exception* exception = Exception::create(vm, syntaxException);
-        globalObject->inspectorController().reportAPIException(globalObject, exception);
+        globalObject->checkedInspectorController()->reportAPIException(globalObject, exception);
 #endif
         return false;
     }

--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -882,7 +882,7 @@ static void reportExceptionToInspector(JSGlobalContextRef context, JSC::JSValue 
     JSC::JSGlobalObject* globalObject = toJS(context);
     JSC::VM& vm = globalObject->vm();
     JSC::Exception* exception = JSC::Exception::create(vm, exceptionValue);
-    globalObject->inspectorController().reportAPIException(globalObject, exception);
+    globalObject->checkedInspectorController()->reportAPIException(globalObject, exception);
 }
 #endif
 

--- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
@@ -59,7 +59,7 @@ InjectedScript::~InjectedScript() = default;
 
 void InjectedScript::execute(Protocol::ErrorString& errorString, const String& functionString, ExecuteOptions&& options, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "execute"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "execute"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(functionString);
     function.appendArgument(options.objectGroup);
     function.appendArgument(options.includeCommandLineAPI);
@@ -72,7 +72,7 @@ void InjectedScript::execute(Protocol::ErrorString& errorString, const String& f
 
 void InjectedScript::evaluate(Protocol::ErrorString& errorString, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluate"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluate"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(expression);
     function.appendArgument(objectGroup);
     function.appendArgument(includeCommandLineAPI);
@@ -84,7 +84,7 @@ void InjectedScript::evaluate(Protocol::ErrorString& errorString, const String& 
 
 void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByValue, bool generatePreview, bool saveResult, AsyncCallCallback&& callback)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "awaitPromise"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "awaitPromise"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(promiseObjectId);
     function.appendArgument(returnByValue);
     function.appendArgument(generatePreview);
@@ -94,7 +94,7 @@ void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByVa
 
 void InjectedScript::callFunctionOn(const String& objectId, const String& expression, const String& arguments, bool returnByValue, bool generatePreview, bool awaitPromise, AsyncCallCallback&& callback)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "callFunctionOn"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "callFunctionOn"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(expression);
     function.appendArgument(arguments);
@@ -106,7 +106,7 @@ void InjectedScript::callFunctionOn(const String& objectId, const String& expres
 
 void InjectedScript::evaluateOnCallFrame(Protocol::ErrorString& errorString, JSC::JSValue callFrames, const String& callFrameId, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluateOnCallFrame"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluateOnCallFrame"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(callFrames);
     function.appendArgument(callFrameId);
     function.appendArgument(expression);
@@ -120,7 +120,7 @@ void InjectedScript::evaluateOnCallFrame(Protocol::ErrorString& errorString, JSC
 
 void InjectedScript::getFunctionDetails(Protocol::ErrorString& errorString, const String& functionId, RefPtr<Protocol::Debugger::FunctionDetails>& result)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getFunctionDetails"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getFunctionDetails"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(functionId);
 
     RefPtr<JSON::Value> resultValue = makeCall(function);
@@ -136,7 +136,7 @@ void InjectedScript::getFunctionDetails(Protocol::ErrorString& errorString, cons
 
 void InjectedScript::functionDetails(Protocol::ErrorString& errorString, JSC::JSValue value, RefPtr<Protocol::Debugger::FunctionDetails>& result)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "functionDetails"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "functionDetails"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(value);
 
     RefPtr<JSON::Value> resultValue = makeCall(function);
@@ -152,7 +152,7 @@ void InjectedScript::functionDetails(Protocol::ErrorString& errorString, JSC::JS
 
 void InjectedScript::getPreview(Protocol::ErrorString& errorString, const String& objectId, RefPtr<Protocol::Runtime::ObjectPreview>& result)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getPreview"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getPreview"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
 
     RefPtr<JSON::Value> resultValue = makeCall(function);
@@ -171,7 +171,7 @@ void InjectedScript::getProperties(Protocol::ErrorString& errorString, const Str
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
 
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getProperties"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getProperties"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(ownProperties);
     function.appendArgument(fetchStart);
@@ -192,7 +192,7 @@ void InjectedScript::getDisplayableProperties(Protocol::ErrorString& errorString
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
 
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getDisplayableProperties"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getDisplayableProperties"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(fetchStart);
     function.appendArgument(fetchCount);
@@ -209,7 +209,7 @@ void InjectedScript::getDisplayableProperties(Protocol::ErrorString& errorString
 
 void InjectedScript::getInternalProperties(Protocol::ErrorString& errorString, const String& objectId, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::InternalPropertyDescriptor>>& properties)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getInternalProperties"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getInternalProperties"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(generatePreview);
 
@@ -229,7 +229,7 @@ void InjectedScript::getCollectionEntries(Protocol::ErrorString& errorString, co
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
 
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getCollectionEntries"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getCollectionEntries"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(objectGroup);
     function.appendArgument(fetchStart);
@@ -246,7 +246,7 @@ void InjectedScript::getCollectionEntries(Protocol::ErrorString& errorString, co
 
 void InjectedScript::saveResult(Protocol::ErrorString& errorString, const String& callArgumentJSON, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "saveResult"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "saveResult"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(callArgumentJSON);
 
     RefPtr<JSON::Value> result = makeCall(function);
@@ -261,7 +261,7 @@ void InjectedScript::saveResult(Protocol::ErrorString& errorString, const String
 Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> InjectedScript::wrapCallFrames(JSC::JSValue callFrames) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "wrapCallFrames"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "wrapCallFrames"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(callFrames);
 
     auto callResult = callFunctionWithEvalEnabled(function);
@@ -279,7 +279,7 @@ Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> InjectedScript::wrapCallFrames
 RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapObject(JSC::JSValue value, const String& groupName, bool generatePreview) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapObject"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapObject"_s, checkedInspectorEnvironment()->functionCallHandler());
     wrapFunction.appendArgument(value);
     wrapFunction.appendArgument(groupName);
     wrapFunction.appendArgument(hasAccessToInspectedScriptState());
@@ -303,7 +303,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapObject(JSC::JSValue 
 RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapJSONString(const String& json, const String& groupName, bool generatePreview) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapJSONString"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapJSONString"_s, checkedInspectorEnvironment()->functionCallHandler());
     wrapFunction.appendArgument(json);
     wrapFunction.appendArgument(groupName);
     wrapFunction.appendArgument(generatePreview);
@@ -329,7 +329,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapJSONString(const Str
 RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapTable(JSC::JSValue table, JSC::JSValue columns) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapTable"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapTable"_s, checkedInspectorEnvironment()->functionCallHandler());
     wrapFunction.appendArgument(hasAccessToInspectedScriptState());
     wrapFunction.appendArgument(table);
     if (!columns)
@@ -355,7 +355,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapTable(JSC::JSValue t
 RefPtr<Protocol::Runtime::ObjectPreview> InjectedScript::previewValue(JSC::JSValue value) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "previewValue"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "previewValue"_s, checkedInspectorEnvironment()->functionCallHandler());
     wrapFunction.appendArgument(value);
 
     auto callResult = callFunctionWithEvalEnabled(wrapFunction);
@@ -376,7 +376,7 @@ RefPtr<Protocol::Runtime::ObjectPreview> InjectedScript::previewValue(JSC::JSVal
 void InjectedScript::setEventValue(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setEventValue"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setEventValue"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(value);
     makeCall(function);
 }
@@ -384,14 +384,14 @@ void InjectedScript::setEventValue(JSC::JSValue value)
 void InjectedScript::clearEventValue()
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearEventValue"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearEventValue"_s, checkedInspectorEnvironment()->functionCallHandler());
     makeCall(function);
 }
 
 void InjectedScript::setExceptionValue(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setExceptionValue"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setExceptionValue"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(value);
     makeCall(function);
 }
@@ -399,14 +399,14 @@ void InjectedScript::setExceptionValue(JSC::JSValue value)
 void InjectedScript::clearExceptionValue()
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearExceptionValue"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearExceptionValue"_s, checkedInspectorEnvironment()->functionCallHandler());
     makeCall(function);
 }
 
 JSC::JSValue InjectedScript::findObjectById(const String& objectId) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "findObjectById"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "findObjectById"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
 
     auto callResult = callFunctionWithEvalEnabled(function);
@@ -419,14 +419,14 @@ JSC::JSValue InjectedScript::findObjectById(const String& objectId) const
 void InjectedScript::inspectObject(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "inspectObject"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "inspectObject"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(value);
     makeCall(function);
 }
 
 void InjectedScript::releaseObject(const String& objectId)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "releaseObject"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "releaseObject"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
     makeCall(function);
 }
@@ -434,7 +434,7 @@ void InjectedScript::releaseObject(const String& objectId)
 void InjectedScript::releaseObjectGroup(const String& objectGroup)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall releaseFunction(globalObject(), injectedScriptObject(), "releaseObjectGroup"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall releaseFunction(globalObject(), injectedScriptObject(), "releaseObjectGroup"_s, checkedInspectorEnvironment()->functionCallHandler());
     releaseFunction.appendArgument(objectGroup);
 
     auto callResult = callFunctionWithEvalEnabled(releaseFunction);
@@ -444,7 +444,7 @@ void InjectedScript::releaseObjectGroup(const String& objectGroup)
 JSC::JSObject* InjectedScript::createCommandLineAPIObject(JSC::JSValue callFrame) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "createCommandLineAPIObject"_s, inspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "createCommandLineAPIObject"_s, checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(callFrame);
 
     auto callResult = callFunctionWithEvalEnabled(function);

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -126,7 +126,9 @@ InjectedScriptBase::~InjectedScriptBase() = default;
 
 bool InjectedScriptBase::hasAccessToInspectedScriptState() const
 {
-    return m_environment && m_environment->canAccessInspectedScriptState(m_globalObject);
+    if (CheckedPtr environment = m_environment)
+        return environment->canAccessInspectedScriptState(m_globalObject);
+    return false;
 }
 
 JSC::JSObject* InjectedScriptBase::injectedScriptObject() const

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.h
@@ -66,7 +66,8 @@ protected:
     InjectedScriptBase(const String& name);
     InjectedScriptBase(const String& name, JSC::JSGlobalObject*, JSC::JSObject*, InspectorEnvironment*);
 
-    InspectorEnvironment* inspectorEnvironment() const { return m_environment; }
+    InspectorEnvironment& inspectorEnvironment() const { return *m_environment; }
+    CheckedRef<InspectorEnvironment> checkedInspectorEnvironment() const { return inspectorEnvironment(); }
 
     bool hasAccessToInspectedScriptState() const;
 
@@ -83,7 +84,7 @@ private:
     String m_name;
     JSC::JSGlobalObject* m_globalObject { nullptr };
     JSC::Strong<JSC::JSObject> m_injectedScriptObject;
-    InspectorEnvironment* m_environment { nullptr };
+    CheckedPtr<InspectorEnvironment> m_environment { nullptr };
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -173,7 +173,7 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
             return it1->value;
     }
 
-    if (!m_environment.canAccessInspectedScriptState(globalObject))
+    if (!checkedInspectorEnvironment()->canAccessInspectedScriptState(globalObject))
         return InjectedScript();
 
     int id = injectedScriptIdFor(globalObject);
@@ -197,7 +197,7 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    InjectedScript result(globalObject, createResult.value(), &m_environment);
+    InjectedScript result(globalObject, createResult.value(), m_environment.ptr());
     m_idToInjectedScript.set(id, result);
     didCreateInjectedScript(result);
     return result;

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.h
@@ -60,6 +60,7 @@ public:
 
     InjectedScriptHost& injectedScriptHost();
     InspectorEnvironment& inspectorEnvironment() const { return m_environment; }
+    CheckedRef<InspectorEnvironment> checkedInspectorEnvironment() const { return m_environment; }
 
     JS_EXPORT_PRIVATE InjectedScript injectedScriptFor(JSC::JSGlobalObject*);
     JS_EXPORT_PRIVATE InjectedScript injectedScriptForId(int);
@@ -78,7 +79,7 @@ protected:
 private:
     Expected<JSC::JSObject*, NakedPtr<JSC::Exception>> createInjectedScript(JSC::JSGlobalObject*, int id);
 
-    InspectorEnvironment& m_environment;
+    CheckedRef<InspectorEnvironment> m_environment;
     const Ref<InjectedScriptHost> m_injectedScriptHost;
     int m_nextInjectedScriptId;
 };

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -59,7 +59,7 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
 
     // FIXME: Make the InjectedScript a module itself.
     JSC::JSLockHolder locker(injectedScript.globalObject());
-    ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "hasInjectedModule"_s, injectedScriptManager->inspectorEnvironment().functionCallHandler());
+    ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "hasInjectedModule"_s, injectedScriptManager->checkedInspectorEnvironment()->functionCallHandler());
     function.appendArgument(name());
     auto hasInjectedModuleResult = injectedScript.callFunctionWithEvalEnabled(function);
     ASSERT(hasInjectedModuleResult);
@@ -78,7 +78,7 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
         RELEASE_ASSERT_NOT_REACHED();
     }
     if (!hasInjectedModuleResult.value().isBoolean() || !hasInjectedModuleResult.value().asBoolean()) {
-        ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "injectModule"_s, injectedScriptManager->inspectorEnvironment().functionCallHandler());
+        ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "injectModule"_s, injectedScriptManager->checkedInspectorEnvironment()->functionCallHandler());
         function.appendArgument(name());
         function.appendArgument(JSC::JSValue(injectModuleFunction(injectedScript.globalObject())));
         function.appendArgument(host(injectedScriptManager, injectedScript.globalObject()));

--- a/Source/JavaScriptCore/inspector/InspectorAgentBase.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentBase.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/InspectorEnvironment.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
@@ -39,10 +40,9 @@ namespace Inspector {
 
 class BackendDispatcher;
 class InjectedScriptManager;
-class InspectorEnvironment;
 
 struct AgentContext {
-    InspectorEnvironment& environment;
+    CheckedRef<InspectorEnvironment> environment;
     InjectedScriptManager& injectedScriptManager;
     CheckedRef<FrontendRouter> frontendRouter;
     BackendDispatcher& backendDispatcher;

--- a/Source/JavaScriptCore/inspector/InspectorEnvironment.h
+++ b/Source/JavaScriptCore/inspector/InspectorEnvironment.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/CallData.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 
 namespace WTF {
 class Stopwatch;
@@ -43,7 +44,7 @@ namespace Inspector {
 typedef JSC::JSValue (*InspectorFunctionCallHandler)(JSC::JSGlobalObject* globalObject, JSC::JSValue functionObject, const JSC::CallData& callData, JSC::JSValue thisValue, const JSC::ArgList& args, NakedPtr<JSC::Exception>& returnedException);
 typedef JSC::JSValue (*InspectorEvaluateHandler)(JSC::JSGlobalObject*, const JSC::SourceCode&, JSC::JSValue thisValue, NakedPtr<JSC::Exception>& returnedException);
 
-class InspectorEnvironment {
+class InspectorEnvironment : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~InspectorEnvironment() { }
     virtual bool developerExtrasEnabled() const = 0;

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
@@ -29,6 +29,7 @@
 #include "InspectorEnvironment.h"
 #include "InspectorFrontendRouter.h"
 #include "Strong.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -61,15 +62,24 @@ struct JSAgentContext;
 
 class JSGlobalObjectInspectorController final
     : public InspectorEnvironment
+    , public CanMakeCheckedPtr<JSGlobalObjectInspectorController>
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
     , public AugmentableInspectorController
 #endif
 {
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectInspectorController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(JSGlobalObjectInspectorController);
 public:
     JSGlobalObjectInspectorController(JSC::JSGlobalObject&);
     ~JSGlobalObjectInspectorController() final;
+
+    // AbstractCanMakeCheckedPtr overrides
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
     void connectFrontend(FrontendChannel&, bool isAutomaticInspection, bool immediatelyPause);
     void disconnectFrontend(FrontendChannel&);

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
@@ -84,7 +84,7 @@ Protocol::ErrorStringOr<void> InspectorAgent::disable()
 
 Protocol::ErrorStringOr<void> InspectorAgent::initialized()
 {
-    m_environment.frontendInitialized();
+    CheckedRef { m_environment }->frontendInitialized();
 
     return { };
 }

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
@@ -63,7 +63,7 @@ public:
     void evaluateForTestInFrontend(const String& script);
 
 private:
-    InspectorEnvironment& m_environment;
+    CheckedRef<InspectorEnvironment> m_environment;
     const UniqueRef<InspectorFrontendDispatcher> m_frontendDispatcher;
     const Ref<InspectorBackendDispatcher> m_backendDispatcher;
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
@@ -46,7 +46,7 @@ InspectorAuditAgent::InspectorAuditAgent(AgentContext& context)
     : InspectorAgentBase("Audit"_s)
     , m_backendDispatcher(AuditBackendDispatcher::create(context.backendDispatcher, this))
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_debugger(*context.environment.debugger())
+    , m_debugger(*CheckedRef { context.environment }->debugger())
 {
 }
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -80,10 +80,12 @@ protected:
 private:
     std::optional<JSC::HeapSnapshotNode> nodeForHeapObjectIdentifier(Protocol::ErrorString&, unsigned heapObjectIdentifier);
 
+    CheckedRef<InspectorEnvironment> checkedEnvironment() const { return m_environment; }
+
     InjectedScriptManager& m_injectedScriptManager;
     const UniqueRef<HeapFrontendDispatcher> m_frontendDispatcher;
     const Ref<HeapBackendDispatcher> m_backendDispatcher;
-    InspectorEnvironment& m_environment;
+    CheckedRef<InspectorEnvironment> m_environment;
 
     bool m_enabled { false };
     bool m_tracking { false };

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -56,8 +56,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorRuntimeAgent);
 InspectorRuntimeAgent::InspectorRuntimeAgent(AgentContext& context)
     : InspectorAgentBase("Runtime"_s)
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_debugger(*context.environment.debugger())
-    , m_vm(context.environment.vm())
+    , m_debugger(*CheckedRef { context.environment }->debugger())
+    , m_vm(CheckedRef { context.environment }->vm())
 {
 }
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
@@ -63,9 +63,11 @@ private:
     void trackingComplete();
     void stopSamplingWhenDisconnecting();
 
+    CheckedRef<InspectorEnvironment> checkedEnvironment() const { return m_environment; }
+
     const UniqueRef<ScriptProfilerFrontendDispatcher> m_frontendDispatcher;
     const Ref<ScriptProfilerBackendDispatcher> m_backendDispatcher;
-    InspectorEnvironment& m_environment;
+    CheckedRef<InspectorEnvironment> m_environment;
     bool m_tracking { false };
 #if ENABLE(SAMPLING_PROFILER)
     bool m_enabledSamplingProfiler { false };

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -932,7 +932,7 @@ JSGlobalObject::~JSGlobalObject()
 {
     clearWeakTickets();
 #if ENABLE(REMOTE_INSPECTOR)
-    m_inspectorController->globalObjectDestroyed();
+    checkedInspectorController()->globalObjectDestroyed();
     m_inspectorDebuggable->globalObjectDestroyed();
 #endif
 
@@ -1054,7 +1054,7 @@ void JSGlobalObject::init(VM& vm)
     m_inspectorController = makeUnique<Inspector::JSGlobalObjectInspectorController>(*this);
     m_inspectorDebuggable = JSGlobalObjectDebuggable::create(*this);
     m_inspectorDebuggable->init();
-    m_consoleClient = m_inspectorController->consoleClient();
+    m_consoleClient = checkedInspectorController()->consoleClient();
 #endif
 
     m_functionPrototype.set(vm, this, FunctionPrototype::create(vm, FunctionPrototype::createStructure(vm, this, jsNull()))); // The real prototype will be set once ObjectPrototype is created.
@@ -3761,6 +3761,16 @@ void JSGlobalObject::cachedFunctionExecutableForFunctionConstructor(FunctionExec
 Ref<JSGlobalObjectDebuggable> JSGlobalObject::protectedInspectorDebuggable()
 {
     return inspectorDebuggable();
+}
+
+Inspector::JSGlobalObjectInspectorController& JSGlobalObject::inspectorController() const
+{
+    return *m_inspectorController.get();
+}
+
+CheckedRef<Inspector::JSGlobalObjectInspectorController> JSGlobalObject::checkedInspectorController() const
+{
+    return *m_inspectorController;
 }
 #endif
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1006,7 +1006,8 @@ public:
 
 #if ENABLE(REMOTE_INSPECTOR)
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.
-    Inspector::JSGlobalObjectInspectorController& inspectorController() const { return *m_inspectorController.get(); }
+    Inspector::JSGlobalObjectInspectorController& inspectorController() const;
+    CheckedRef<Inspector::JSGlobalObjectInspectorController> checkedInspectorController() const;
     JSGlobalObjectDebuggable& inspectorDebuggable() { return *m_inspectorDebuggable; }
     Ref<JSGlobalObjectDebuggable> protectedInspectorDebuggable();
 #endif

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
@@ -66,7 +66,7 @@ void JSGlobalObjectDebuggable::connect(FrontendChannel& frontendChannel, bool au
         return;
 
     JSLockHolder locker(&m_globalObject->vm());
-    m_globalObject->inspectorController().connectFrontend(frontendChannel, automaticInspection, immediatelyPause);
+    m_globalObject->checkedInspectorController()->connectFrontend(frontendChannel, automaticInspection, immediatelyPause);
 }
 
 void JSGlobalObjectDebuggable::disconnect(FrontendChannel& frontendChannel)
@@ -76,7 +76,7 @@ void JSGlobalObjectDebuggable::disconnect(FrontendChannel& frontendChannel)
 
     JSLockHolder locker(&m_globalObject->vm());
 
-    m_globalObject->inspectorController().disconnectFrontend(frontendChannel);
+    m_globalObject->checkedInspectorController()->disconnectFrontend(frontendChannel);
 }
 
 void JSGlobalObjectDebuggable::dispatchMessageFromRemote(String&& message)
@@ -86,7 +86,7 @@ void JSGlobalObjectDebuggable::dispatchMessageFromRemote(String&& message)
 
     JSLockHolder locker(&m_globalObject->vm());
 
-    m_globalObject->inspectorController().dispatchMessageFromFrontend(WTFMove(message));
+    m_globalObject->checkedInspectorController()->dispatchMessageFromFrontend(WTFMove(message));
 }
 
 void JSGlobalObjectDebuggable::pauseWaitingForAutomaticInspection()

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/InspectorAgentRegistry.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <WebCore/InspectorOverlay.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -55,12 +56,20 @@ class LocalFrame;
 class WebInjectedScriptManager;
 struct FrameAgentContext;
 
-class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<FrameInspectorController> {
+class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<FrameInspectorController>, public CanMakeCheckedPtr<FrameInspectorController> {
     WTF_MAKE_NONCOPYABLE(FrameInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(FrameInspectorController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameInspectorController);
 public:
     FrameInspectorController(LocalFrame&);
     ~FrameInspectorController() override;
+
+    // AbstractCanMakeCheckedPtr overrides
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
     WEBCORE_EXPORT void ref() const;
     WEBCORE_EXPORT void deref() const;

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -34,6 +34,7 @@
 #include <JavaScriptCore/InspectorAgentRegistry.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <WebCore/InspectorOverlay.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -64,12 +65,20 @@ class PageDebugger;
 class WebInjectedScriptManager;
 struct PageAgentContext;
 
-class InspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<InspectorController> {
+class InspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<InspectorController>, public CanMakeCheckedPtr<InspectorController> {
     WTF_MAKE_NONCOPYABLE(InspectorController);
     WTF_MAKE_TZONE_ALLOCATED(InspectorController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorController);
 public:
     InspectorController(Page&, std::unique_ptr<InspectorBackendClient>&&);
     ~InspectorController() override;
+
+    // AbstractCanMakeCheckedPtr overrides
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
     WEBCORE_EXPORT void ref() const;
     WEBCORE_EXPORT void deref() const;

--- a/Source/WebCore/inspector/InspectorWebAgentBase.h
+++ b/Source/WebCore/inspector/InspectorWebAgentBase.h
@@ -82,12 +82,15 @@ protected:
     InspectorAgentBase(const String& name, WebAgentContext& context)
         : Inspector::InspectorAgentBase(name)
         , m_instrumentingAgents(context.instrumentingAgents)
-        , m_environment(context.environment)
+        , m_environment(context.environment.get())
     {
     }
 
+    CheckedRef<Inspector::InspectorEnvironment> checkedEnvironment() const { return m_environment; }
+
+
     WeakRef<InstrumentingAgents> m_instrumentingAgents;
-    Inspector::InspectorEnvironment& m_environment;
+    CheckedRef<Inspector::InspectorEnvironment> m_environment;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -161,7 +161,7 @@ FOR_EACH_INSPECTOR_AGENT(DECLARE_GETTER_SETTER_FOR_INSPECTOR_AGENT)
 private:
     InstrumentingAgents(Inspector::InspectorEnvironment&, InstrumentingAgents* fallbackAgents);
 
-    Inspector::InspectorEnvironment& m_environment;
+    CheckedRef<Inspector::InspectorEnvironment> m_environment;
     const WeakPtr<InstrumentingAgents> m_fallbackAgents;
 
 #define DECLARE_MEMBER_VARIABLE_FOR_INSPECTOR_AGENT(Class, Name, Getter, Setter) \

--- a/Source/WebCore/inspector/WorkerInspectorController.h
+++ b/Source/WebCore/inspector/WorkerInspectorController.h
@@ -29,6 +29,7 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include <JavaScriptCore/InspectorAgentRegistry.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Stopwatch.h>
@@ -46,12 +47,20 @@ class WebInjectedScriptManager;
 class WorkerDebugger;
 struct WorkerAgentContext;
 
-class WorkerInspectorController final : public Inspector::InspectorEnvironment {
+class WorkerInspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<WorkerInspectorController> {
     WTF_MAKE_NONCOPYABLE(WorkerInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(WorkerInspectorController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerInspectorController);
 public:
     explicit WorkerInspectorController(WorkerOrWorkletGlobalScope&);
     ~WorkerInspectorController() override;
+
+    // AbstractCanMakeCheckedPtr overrides
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
     void workerTerminating();
 

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -400,7 +400,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking(
 
     ASSERT(m_trackedStyleOriginatedAnimationData.isEmpty());
 
-    m_frontendDispatcher->trackingStart(m_environment.executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingStart(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -415,7 +415,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::stopTracking()
 
     m_trackedStyleOriginatedAnimationData.clear();
 
-    m_frontendDispatcher->trackingComplete(m_environment.executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingComplete(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -490,7 +490,7 @@ void InspectorAnimationAgent::willApplyKeyframeEffect(const Styleable& target, K
             ASSERT_NOT_REACHED();
     }
 
-    m_frontendDispatcher->trackingUpdate(m_environment.executionStopwatch().elapsedTime().seconds(), WTFMove(event));
+    m_frontendDispatcher->trackingUpdate(checkedEnvironment()->executionStopwatch().elapsedTime().seconds(), WTFMove(event));
 }
 
 void InspectorAnimationAgent::didChangeWebAnimationName(WebAnimation& animation)
@@ -681,7 +681,7 @@ void InspectorAnimationAgent::stopTrackingStyleOriginatedAnimation(StyleOriginat
             .setTrackingAnimationId(data->trackingAnimationId)
             .setAnimationState(Inspector::Protocol::Animation::AnimationState::Canceled)
             .release();
-        m_frontendDispatcher->trackingUpdate(m_environment.executionStopwatch().elapsedTime().seconds(), WTFMove(event));
+        m_frontendDispatcher->trackingUpdate(checkedEnvironment()->executionStopwatch().elapsedTime().seconds(), WTFMove(event));
     }
 }
 

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
@@ -72,7 +72,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::startTrackin
 
     m_tracking = true;
 
-    m_frontendDispatcher->trackingStart(m_environment.executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingStart(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -86,7 +86,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::stopTracking
 
     m_tracking = false;
 
-    m_frontendDispatcher->trackingComplete(m_environment.executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingComplete(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -114,7 +114,7 @@ static Ref<Inspector::Protocol::CPUProfiler::ThreadInfo> buildThreadInfo(const T
 void InspectorCPUProfilerAgent::collectSample(const ResourceUsageData& data)
 {
     auto event = Inspector::Protocol::CPUProfiler::Event::create()
-        .setTimestamp(m_environment.executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
+        .setTimestamp(checkedEnvironment()->executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
         .setUsage(data.cpuExcludingDebuggerThreads)
         .release();
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -285,7 +285,7 @@ public:
             data->setBoolean("enabled"_s, !!node->document().fullscreen().fullscreenElement());
 #endif // ENABLE(FULLSCREEN_API)
 
-        auto timestamp = m_domAgent->m_environment.executionStopwatch().elapsedTime().seconds();
+        auto timestamp = m_domAgent->m_environment->executionStopwatch().elapsedTime().seconds();
         m_domAgent->m_frontendDispatcher->didFireEvent(nodeId, event.type(), timestamp, data->size() ? WTFMove(data) : nullptr);
     }
 
@@ -3067,7 +3067,7 @@ void InspectorDOMAgent::mediaMetricsTimerFired()
             iterator->value.isPowerEfficient = isPowerEfficient;
 
             if (auto nodeId = pushNodePathToFrontend(mediaElement.ptr())) {
-                auto timestamp = m_environment.executionStopwatch().elapsedTime().seconds();
+                auto timestamp = m_environment->executionStopwatch().elapsedTime().seconds();
                 m_frontendDispatcher->powerEfficientPlaybackStateChanged(nodeId, timestamp, iterator->value.isPowerEfficient);
             }
         }

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
@@ -99,7 +99,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::startTracking()
 
     m_tracking = true;
 
-    m_frontendDispatcher->trackingStart(m_environment.executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingStart(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -113,7 +113,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::stopTracking()
 
     m_tracking = false;
 
-    m_frontendDispatcher->trackingComplete(m_environment.executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingComplete(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -121,7 +121,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::stopTracking()
 void InspectorMemoryAgent::didHandleMemoryPressure(Critical critical)
 {
     MemoryFrontendDispatcher::Severity severity = critical == Critical::Yes ? MemoryFrontendDispatcher::Severity::Critical : MemoryFrontendDispatcher::Severity::NonCritical;
-    m_frontendDispatcher->memoryPressure(m_environment.executionStopwatch().elapsedTime().seconds(), Inspector::Protocol::Helpers::getEnumConstantValue(severity));
+    m_frontendDispatcher->memoryPressure(checkedEnvironment()->executionStopwatch().elapsedTime().seconds(), Inspector::Protocol::Helpers::getEnumConstantValue(severity));
 }
 
 void InspectorMemoryAgent::collectSample(const ResourceUsageData& data)
@@ -165,7 +165,7 @@ void InspectorMemoryAgent::collectSample(const ResourceUsageData& data)
     categories->addItem(WTFMove(otherCategory));
 
     auto event = Inspector::Protocol::Memory::Event::create()
-        .setTimestamp(m_environment.executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
+        .setTimestamp(checkedEnvironment()->executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
         .setCategories(WTFMove(categories))
         .release();
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -154,7 +154,7 @@ static Ref<Inspector::Protocol::Network::Headers> buildObjectForHeaders(const HT
 Ref<Inspector::Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildObjectForTiming(const NetworkLoadMetrics& timing, ResourceLoader& resourceLoader)
 {
     auto elapsedTimeSince = [&] (const MonotonicTime& time) {
-        return m_environment.executionStopwatch().elapsedTimeSince(time).seconds();
+        return m_environment->executionStopwatch().elapsedTimeSince(time).seconds();
     };
     auto millisecondsSinceFetchStart = [&] (const MonotonicTime& time) {
         if (!time)
@@ -390,7 +390,7 @@ Ref<Inspector::Protocol::Network::CachedResource> InspectorNetworkAgent::buildOb
 
 double InspectorNetworkAgent::timestamp()
 {
-    return m_environment.executionStopwatch().elapsedTime().seconds();
+    return m_environment->executionStopwatch().elapsedTime().seconds();
 }
 
 void InspectorNetworkAgent::willSendRequest(ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, Inspector::ResourceType type, ResourceLoader* resourceLoader)
@@ -580,7 +580,7 @@ void InspectorNetworkAgent::didFinishLoading(ResourceLoaderIdentifier identifier
 
     double elapsedFinishTime;
     if (networkLoadMetrics.responseEnd)
-        elapsedFinishTime = m_environment.executionStopwatch().elapsedTimeSince(networkLoadMetrics.responseEnd).seconds();
+        elapsedFinishTime = m_environment->executionStopwatch().elapsedTimeSince(networkLoadMetrics.responseEnd).seconds();
     else
         elapsedFinishTime = timestamp();
 

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -133,7 +133,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
 
     agents->setEnabledPageAgent(this);
 
-    auto& stopwatch = m_environment.executionStopwatch();
+    auto& stopwatch = m_environment->executionStopwatch();
     stopwatch.reset();
     stopwatch.start();
 
@@ -178,7 +178,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
 
 double InspectorPageAgent::timestamp()
 {
-    return m_environment.executionStopwatch().elapsedTime().seconds();
+    return m_environment->executionStopwatch().elapsedTime().seconds();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optional<bool>&& ignoreCache, std::optional<bool>&& revalidateAllResources)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -178,7 +178,7 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
 
     Ref { m_instrumentingAgents.get() }->setTrackingTimelineAgent(this);
 
-    m_environment.debugger()->addObserver(*this);
+    checkedEnvironment()->debugger()->addObserver(*this);
 
     m_frontendDispatcher->recordingStarted(timestamp());
 }
@@ -187,7 +187,7 @@ void InspectorTimelineAgent::internalStop()
 {
     Ref { m_instrumentingAgents.get() }->setTrackingTimelineAgent(nullptr);
 
-    m_environment.debugger()->removeObserver(*this, true);
+    checkedEnvironment()->debugger()->removeObserver(*this, true);
 
     // Complete all pending records to prevent discarding events that are currently in progress.
     while (!m_recordStack.isEmpty())
@@ -205,12 +205,12 @@ void InspectorTimelineAgent::autoCaptureStarted() const
 
 double InspectorTimelineAgent::timestamp()
 {
-    return m_environment.executionStopwatch().elapsedTime().seconds();
+    return checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
 }
 
 std::optional<double> InspectorTimelineAgent::timestampFromMonotonicTime(MonotonicTime time)
 {
-    auto stopwatchTime = m_environment.executionStopwatch().fromMonotonicTime(time);
+    auto stopwatchTime = checkedEnvironment()->executionStopwatch().fromMonotonicTime(time);
     if (!stopwatchTime)
         return std::nullopt;
     return stopwatchTime->seconds();

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -116,7 +116,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
         CheckedPtr checkedThis = weakThis.get();
         if (!checkedThis)
             return;
-        if (!checkedThis->tracking() || checkedThis->m_environment.debugger()->isPaused())
+        if (!checkedThis->tracking() || checkedThis->checkedEnvironment()->debugger()->isPaused())
             return;
         if (!checkedThis->m_runLoopNestingLevel) {
             checkedThis->pushCurrentRecord(JSON::Object::create(), TimelineRecordType::RenderingFrame, false);
@@ -136,7 +136,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
         CheckedPtr checkedThis = weakThis.get();
         if (!checkedThis)
             return;
-        if (!checkedThis->tracking() || checkedThis->m_environment.debugger()->isPaused())
+        if (!checkedThis->tracking() || checkedThis->checkedEnvironment()->debugger()->isPaused())
             return;
 
         switch (event) {
@@ -299,7 +299,7 @@ void PageTimelineAgent::mainFrameNavigated()
 void PageTimelineAgent::didCompleteRenderingFrame()
 {
 #if PLATFORM(COCOA)
-    if (!tracking() || m_environment.debugger()->isPaused())
+    if (!tracking() || checkedEnvironment()->debugger()->isPaused())
         return;
 
     ASSERT(m_runLoopNestingLevel > 0);

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -11,6 +11,11 @@ WebCoreSupport/SocketStreamHandleImpl.cpp
 WebCoreSupport/SocketStreamHandleImplCFNet.cpp
 WebCoreSupport/WebResourceLoadScheduler.cpp
 WebCoreSupport/WebSocketChannel.cpp
+[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebGeolocation.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
 mac/DOM/DOM.mm
 mac/DOM/DOMAbstractView.mm
 mac/DOM/DOMAttr.mm
@@ -112,12 +117,14 @@ mac/DOM/DOMTimeRanges.mm
 mac/DOM/DOMTokenList.mm
 mac/DOM/DOMTreeWalker.mm
 mac/DOM/DOMUIEvent.mm
+[ iOS ] mac/DOM/DOMUIKitExtensions.mm
 mac/DOM/DOMXPath.mm
 mac/DOM/DOMXPathExpression.mm
 mac/DOM/DOMXPathResult.mm
 mac/DOM/WebDOMOperations.mm
 mac/History/WebBackForwardList.mm
 mac/History/WebHistoryItem.mm
+[ iOS ] mac/Misc/WebCache.mm
 mac/Misc/WebCoreStatistics.mm
 mac/Misc/WebElementDictionary.mm
 [ Mac ] mac/Misc/WebNSPasteboardExtras.mm
@@ -138,7 +145,6 @@ mac/WebCoreSupport/WebNotificationClient.mm
 mac/WebCoreSupport/WebOpenPanelResultListener.mm
 mac/WebCoreSupport/WebSecurityOrigin.mm
 mac/WebCoreSupport/WebValidationMessageClient.mm
-mac/WebInspector/WebNodeHighlightView.mm
 mac/WebView/WebArchive.mm
 mac/WebView/WebDataSource.mm
 mac/WebView/WebFrame.mm
@@ -154,10 +160,3 @@ mac/WebView/WebScriptWorld.mm
 mac/WebView/WebTextIterator.mm
 [ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
-[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
-[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
-[ iOS ] ios/WebCoreSupport/WebGeolocation.mm
-[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
-[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
-[ iOS ] mac/DOM/DOMUIKitExtensions.mm
-[ iOS ] mac/Misc/WebCache.mm

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
@@ -99,7 +99,8 @@ using namespace WebCore;
         ASSERT([[NSGraphicsContext currentContext] isFlipped]);
 
         GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext]);
-        [_webNodeHighlight inspectorController]->drawHighlight(context);
+        if (CheckedPtr controller = [_webNodeHighlight inspectorController].get())
+            controller->drawHighlight(context);
         [NSGraphicsContext restoreGraphicsState];
     }
 }


### PR DESCRIPTION
#### 3db54ba8bc59c2b0226d5400edb63a60a2b86a4e
<pre>
Inspector agents should use CheckedRef for InspectorEnvironment references.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302416">https://bugs.webkit.org/show_bug.cgi?id=302416</a>
<a href="https://rdar.apple.com/164582768">rdar://164582768</a>

Reviewed by BJ Burg and Devin Rousso.

Inspector agents hold references to their InspectorEnvironment through the AgentContext
structure. This changes the raw reference to CheckedRef to provide runtime lifetime
checking.

This ensures that if there&apos;s a bug causing an agent to outlive its environment, we get
an immediate, actionable crash rather than undefined behavior.

No new tests.

* Source/JavaScriptCore/API/APIUtils.h:
(handleExceptionIfNeeded):
(setException):
* Source/JavaScriptCore/API/JSBase.cpp:
(JSEvaluateScriptInternal):
(JSCheckScriptSyntax):
* Source/JavaScriptCore/API/JSValue.mm:
(reportExceptionToInspector):
* Source/JavaScriptCore/inspector/InjectedScript.cpp:
(Inspector::InjectedScript::execute):
(Inspector::InjectedScript::evaluate):
(Inspector::InjectedScript::awaitPromise):
(Inspector::InjectedScript::callFunctionOn):
(Inspector::InjectedScript::evaluateOnCallFrame):
(Inspector::InjectedScript::getFunctionDetails):
(Inspector::InjectedScript::functionDetails):
(Inspector::InjectedScript::getPreview):
(Inspector::InjectedScript::getProperties):
(Inspector::InjectedScript::getDisplayableProperties):
(Inspector::InjectedScript::getInternalProperties):
(Inspector::InjectedScript::getCollectionEntries):
(Inspector::InjectedScript::saveResult):
(Inspector::InjectedScript::wrapCallFrames const):
(Inspector::InjectedScript::wrapObject const):
(Inspector::InjectedScript::wrapJSONString const):
(Inspector::InjectedScript::wrapTable const):
(Inspector::InjectedScript::previewValue const):
(Inspector::InjectedScript::setEventValue):
(Inspector::InjectedScript::clearEventValue):
(Inspector::InjectedScript::setExceptionValue):
(Inspector::InjectedScript::clearExceptionValue):
(Inspector::InjectedScript::findObjectById const):
(Inspector::InjectedScript::inspectObject):
(Inspector::InjectedScript::releaseObject):
(Inspector::InjectedScript::releaseObjectGroup):
(Inspector::InjectedScript::createCommandLineAPIObject const):
* Source/JavaScriptCore/inspector/InjectedScriptBase.cpp:
(Inspector::InjectedScriptBase::hasAccessToInspectedScriptState const):
* Source/JavaScriptCore/inspector/InjectedScriptBase.h:
(Inspector::InjectedScriptBase::inspectorEnvironment const):
(Inspector::InjectedScriptBase::checkedInspectorEnvironment const):
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::injectedScriptFor):
* Source/JavaScriptCore/inspector/InjectedScriptManager.h:
(Inspector::InjectedScriptManager::checkedInspectorEnvironment const):
* Source/JavaScriptCore/inspector/InjectedScriptModule.cpp:
(Inspector::InjectedScriptModule::ensureInjected):
* Source/JavaScriptCore/inspector/InspectorAgentBase.h:
* Source/JavaScriptCore/inspector/InspectorEnvironment.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h:
* Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp:
(Inspector::InspectorAgent::initialized):
* Source/JavaScriptCore/inspector/agents/InspectorAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp:
(Inspector::InspectorAuditAgent::InspectorAuditAgent):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::InspectorDebuggerAgent):
(Inspector::InspectorDebuggerAgent::didPause):
(Inspector::InspectorDebuggerAgent::breakpointActionProbe):
(Inspector::InspectorDebuggerAgent::didContinue):
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
(Inspector::InspectorHeapAgent::enable):
(Inspector::InspectorHeapAgent::disable):
(Inspector::InspectorHeapAgent::gc):
(Inspector::InspectorHeapAgent::snapshot):
(Inspector::InspectorHeapAgent::nodeForHeapObjectIdentifier):
(Inspector::InspectorHeapAgent::getPreview):
(Inspector::InspectorHeapAgent::getRemoteObject):
(Inspector::InspectorHeapAgent::willGarbageCollect):
(Inspector::InspectorHeapAgent::didGarbageCollect):
(Inspector::InspectorHeapAgent::heapSnapshotBuilderIgnoreNode):
(Inspector::InspectorHeapAgent::clearHeapSnapshots):
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp:
(Inspector::InspectorRuntimeAgent::InspectorRuntimeAgent):
(Inspector::m_vm):
* Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp:
(Inspector::InspectorScriptProfilerAgent::willDestroyFrontendAndBackend):
(Inspector::InspectorScriptProfilerAgent::startTracking):
(Inspector::InspectorScriptProfilerAgent::stopTracking):
(Inspector::InspectorScriptProfilerAgent::willEvaluateScript):
(Inspector::InspectorScriptProfilerAgent::didEvaluateScript):
(Inspector::InspectorScriptProfilerAgent::trackingComplete):
(Inspector::InspectorScriptProfilerAgent::stopSamplingWhenDisconnecting):
* Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::~JSGlobalObject):
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::inspectorController const):
(JSC::JSGlobalObject::checkedInspectorController const):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::inspectorController const): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp:
(JSC::JSGlobalObjectDebuggable::connect):
(JSC::JSGlobalObjectDebuggable::disconnect):
(JSC::JSGlobalObjectDebuggable::dispatchMessageFromRemote):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/InspectorController.h:
* Source/WebCore/inspector/InspectorWebAgentBase.h:
(WebCore::InspectorAgentBase::InspectorAgentBase):
(WebCore::InspectorAgentBase::checkedEnvironment const):
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/WorkerInspectorController.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::startTracking):
(WebCore::InspectorAnimationAgent::stopTracking):
(WebCore::InspectorAnimationAgent::willApplyKeyframeEffect):
(WebCore::InspectorAnimationAgent::stopTrackingStyleOriginatedAnimation):
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp:
(WebCore::InspectorCPUProfilerAgent::startTracking):
(WebCore::InspectorCPUProfilerAgent::stopTracking):
(WebCore::InspectorCPUProfilerAgent::collectSample):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::mediaMetricsTimerFired):
* Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp:
(WebCore::InspectorMemoryAgent::startTracking):
(WebCore::InspectorMemoryAgent::stopTracking):
(WebCore::InspectorMemoryAgent::didHandleMemoryPressure):
(WebCore::InspectorMemoryAgent::collectSample):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::buildObjectForTiming):
(WebCore::InspectorNetworkAgent::timestamp):
(WebCore::InspectorNetworkAgent::didFinishLoading):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::enable):
(WebCore::InspectorPageAgent::timestamp):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::internalStart):
(WebCore::InspectorTimelineAgent::internalStop):
(WebCore::InspectorTimelineAgent::timestamp):
(WebCore::InspectorTimelineAgent::timestampFromMonotonicTime):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::internalStart):
(WebCore::PageTimelineAgent::didCompleteRenderingFrame):
* Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm:
(-[WebNodeHighlightView drawRect:]):

Canonical link: <a href="https://commits.webkit.org/303022@main">https://commits.webkit.org/303022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/659db35866db1e01d2f9c248ac1e1d98b8f43e11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130889 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138317 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cbfc485b-8a8c-4d3c-be74-8eb78071b2bc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99733 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f4e00d0-139b-4f53-96fb-24193ddc5f79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133835 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80421 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1dc6be25-8c35-4378-b426-7a75778c2272) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2223 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81576 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122906 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110812 "Passed tests") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140797 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129342 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2956 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2669 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130318 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3002 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108163 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27536 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55993 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66422 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162359 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2845 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40500 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3045 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2954 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->