### PR TITLE
Improve CISupport testing

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -335,6 +335,7 @@ class ServicesFactory(Factory):
         self.addStep(RunBuildbotCheckConfigForBuildWebKit())
         self.addStep(RunEWSUnitTests())
         self.addStep(RunBuildbotCheckConfigForEWS())
+        self.addStep(RunSharedUnitTests())
         self.addStep(RunResultsdbpyTests())
 
 

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -811,6 +811,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'buildbot-check-config-for-build-webkit',
             'ews-unit-tests',
             'buildbot-check-config-for-ews',
+            'shared-unit-tests',
             'resultsdbpy-unit-tests'
         ],
         'Commit-Queue': [

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3084,7 +3084,7 @@ class ReRunWebKitPerlTests(RunWebKitPerlTests):
 class RunBuildWebKitOrgUnitTests(shell.ShellCommand):
     name = 'build-webkit-org-unit-tests'
     description = ['build-webkit-unit-tests running']
-    command = ['python3', 'runUnittests.py', 'build-webkit-org', '--autoinstall']
+    command = ['python3', './run-tests', 'build-webkit-org']
 
     def __init__(self, **kwargs):
         super().__init__(workdir='build/Tools/CISupport', timeout=2 * 60, logEnviron=False, **kwargs)
@@ -3098,7 +3098,7 @@ class RunBuildWebKitOrgUnitTests(shell.ShellCommand):
 class RunEWSUnitTests(shell.ShellCommand):
     name = 'ews-unit-tests'
     description = ['ews-unit-tests running']
-    command = ['python3', 'runUnittests.py', 'ews-build', '--autoinstall']
+    command = ['python3', './run-tests', 'ews-build']
 
     def __init__(self, **kwargs):
         super().__init__(workdir='build/Tools/CISupport', timeout=2 * 60, logEnviron=False, **kwargs)
@@ -3107,6 +3107,20 @@ class RunEWSUnitTests(shell.ShellCommand):
         if self.results == SUCCESS:
             return {'step': 'Passed EWS unit tests'}
         return {'step': 'Failed EWS unit tests'}
+
+
+class RunSharedUnitTests(shell.ShellCommand):
+    name = 'shared-unit-tests'
+    description = ['shared-unit-tests running']
+    command = ['python3', './run-tests', 'Shared']
+
+    def __init__(self, **kwargs):
+        super().__init__(workdir='build/Tools/CISupport', timeout=2 * 60, logEnviron=False, **kwargs)
+
+    def getResultSummary(self):
+        if self.results == SUCCESS:
+            return {'step': 'Passed Shared unit tests'}
+        return {'step': 'Failed Shared unit tests'}
 
 
 class RunBuildbotCheckConfig(shell.ShellCommand):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -795,7 +795,7 @@ class TestRunEWSUnitTests(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         log_environ=False,
-                        command=['python3', 'runUnittests.py', 'ews-build', '--autoinstall'],
+                        command=['python3', './run-tests', 'ews-build'],
                         )
             .exit(0),
         )
@@ -808,7 +808,7 @@ class TestRunEWSUnitTests(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         log_environ=False,
-                        command=['python3', 'runUnittests.py', 'ews-build', '--autoinstall'],
+                        command=['python3', './run-tests', 'ews-build'],
                         )
             .log('stdio', stdout='Unhandled Error. Traceback (most recent call last): Keys in cmd missing from expectation: [logfiles.json]')
             .exit(2),
@@ -867,7 +867,7 @@ class TestRunBuildWebKitOrgUnitTests(BuildStepMixinAdditions, unittest.TestCase)
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         log_environ=False,
-                        command=['python3', 'runUnittests.py', 'build-webkit-org', '--autoinstall'],
+                        command=['python3', './run-tests', 'build-webkit-org'],
                         )
             .exit(0),
         )
@@ -880,12 +880,48 @@ class TestRunBuildWebKitOrgUnitTests(BuildStepMixinAdditions, unittest.TestCase)
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         log_environ=False,
-                        command=['python3', 'runUnittests.py', 'build-webkit-org', '--autoinstall'],
+                        command=['python3', './run-tests', 'build-webkit-org'],
                         )
             .log('stdio', stdout='Unhandled Error. Traceback (most recent call last): Keys in cmd missing from expectation: [logfiles.json]')
             .exit(2),
         )
         self.expect_outcome(result=FAILURE, state_string='Failed build.webkit.org unit tests')
+        return self.run_step()
+
+
+class TestRunSharedUnitTests(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def test_success(self):
+        self.setup_step(RunSharedUnitTests())
+        self.expectRemoteCommands(
+            ExpectShell(workdir='build/Tools/CISupport',
+                        timeout=120,
+                        log_environ=False,
+                        command=['python3', './run-tests', 'Shared'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed Shared unit tests')
+        return self.run_step()
+
+    def test_failure(self):
+        self.setup_step(RunSharedUnitTests())
+        self.expectRemoteCommands(
+            ExpectShell(workdir='build/Tools/CISupport',
+                        timeout=120,
+                        log_environ=False,
+                        command=['python3', './run-tests', 'Shared'],
+                        )
+            .log('stdio', stdout='Unhandled Error. Traceback (most recent call last): Keys in cmd missing from expectation: [logfiles.json]')
+            .exit(2),
+        )
+        self.expect_outcome(result=FAILURE, state_string='Failed Shared unit tests')
         return self.run_step()
 
 

--- a/Tools/CISupport/run-tests
+++ b/Tools/CISupport/run-tests
@@ -25,31 +25,27 @@
 import logging
 import os
 import sys
+import warnings
 
 scripts = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'Scripts')
 sys.path.insert(0, scripts)
 
-import webkitpy
+# This is needed to set up all the autoinstall logic.
+import webkitpy  # noqa: F401
 
-from webkitcorepy import log, testing, OutputCapture, StringIO
-from webkitpy.autoinstalled import buildbot
-
+from webkitcorepy import StringIO, log, testing
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)
+    warnings.filterwarnings(
+        'ignore',
+        message='^You do not have a working installation of the service_identity module',
+    )
 
-    # Disable logging while loading buildbot to surpress service_identity error
-    try:
-        sys.stderr = StringIO()
-        from webkitpy.autoinstalled import buildbot
-    finally:
-        sys.stderr = sys.__stderr__
+    # We import this here after we've set the above warnings filter.
+    from webkitpy.autoinstalled import buildbot  # noqa: F401
 
-    # This is work-around for https://bugs.webkit.org/show_bug.cgi?id=222361
-    from buildbot.process.buildstep import BuildStep
-    BuildStep.warn_deprecated_if_oldstyle_subclass = lambda self, name: None
-
-    # Disable logging while loading libraries to surpress load_password error
+    # Disable output to stdout while loading libraries to suppress load_password error
     try:
         sys.stdout = StringIO()
         runner = testing.PythonTestRunner(

--- a/Tools/CISupport/runUnittests.py
+++ b/Tools/CISupport/runUnittests.py
@@ -1,59 +1,75 @@
 #!/usr/bin/python3
 
+# Copyright (C) 2018-2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import argparse
 import os
+import shlex
 import sys
-import unittest
-
-"""
-This is the equivalent of running:
-    python -m unittest discover --start-directory {test_discovery_path} --pattern {UNIT_TEST_PATTERN}
-"""
-
-UNIT_TEST_PATTERN = '*_unittest.py'
-
-
-def run_unittests(test_discovery_path):
-    test_suite = unittest.defaultTestLoader.discover(
-        test_discovery_path, pattern=UNIT_TEST_PATTERN,
-        top_level_dir=os.path.dirname(os.path.abspath(__file__)),
-    )
-    results = unittest.TextTestRunner(buffer=True).run(test_suite)
-    if results.failures or results.errors:
-        raise RuntimeError('Test failures or errors were generated during this test run.')
-    return 0
+from pathlib import Path
 
 
 def main():
+    print('runUnittests.py is deprecated!', file=sys.stderr)
+
     parser = argparse.ArgumentParser(
         description='Run Python unit tests for our various build masters',
     )
     parser.add_argument(
-        'path', nargs=1,
+        'path',
         help='Relative path of directory to run Python unit tests in',
+        nargs=1,
+        type=Path,
     )
     parser.add_argument(
         '--autoinstall',
         help='Opt in to using autoinstall for buildbot packages',
         action='store_true',
-        dest='autoinstall',
-        default=False,
     )
 
     args = parser.parse_args()
-    if not args.path:
-        args.path = [os.path.dirname(__file__)]
+    self_path = Path(__file__).parent.resolve(strict=True)
 
-    path = os.path.abspath(args.path[0])
-    assert os.path.isdir(path), '{} is not a directory. Please specify a valid directory'.format(path)
+    run_tests_args = []
+    for path in args.path:
+        if not path.is_dir():
+            print(f'{path} is not a directory. Please specify a valid directory')
+            sys.exit(1)
 
-    scripts = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'Scripts')
-    if args.autoinstall and os.path.isdir(os.path.join(scripts, 'webkitpy')):
-        sys.path.insert(0, scripts)
-        import webkitpy
-        from webkitpy.autoinstalled import buildbot
+        run_tests_args.append(
+            '.'.join(path.resolve(strict=True).relative_to(self_path).parts)
+        )
 
-    return run_unittests(path)
+    extra_env = {}
+    if not args.autoinstall:
+        extra_env['DISABLE_WEBKITCOREPY_AUTOINSTALLER'] = '1'
+
+    new_args = [sys.executable, str(self_path / 'run-tests'), *run_tests_args]
+
+    repro_args = [*(f'{k}={v}' for k, v in extra_env.items()), *(new_args)]
+
+    print(f'Run instead: {shlex.join(repro_args)}\n\n', file=sys.stderr)
+    os.execve(sys.executable, new_args, os.environ | extra_env)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### eafd98a20440c864b45f056a5eb71d6c77ef0d15
<pre>
Improve CISupport testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=302418">https://bugs.webkit.org/show_bug.cgi?id=302418</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-build/factories.py:
(ServicesFactory.__init__): Add RunSharedUnitTests.
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps): Add RunSharedUnitTests.
* Tools/CISupport/ews-build/steps.py:
(RunBuildWebKitOrgUnitTests): Move to run-tests.
(RunEWSUnitTests): Move to run-tests.
(RunSharedUnitTests): Added.
* Tools/CISupport/ews-build/steps_unittest.py: Update for above.
* Tools/CISupport/run-tests: Tidy up output handling.
* Tools/CISupport/runUnittests.py:
(main): Make this just call run-tests.

Canonical link: <a href="https://commits.webkit.org/306347@main">https://commits.webkit.org/306347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d71869253756054df85dccc87aa1a64f7be9848e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94108 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108268 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78467 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89178 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10482 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8071 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151976 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13082 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116432 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/140435 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116776 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12826 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122881 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68255 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21768 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13125 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12864 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13063 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->