### PR TITLE
Modify task_pool to allow for repeated tasks that run alongside regular tasks.

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py
@@ -60,6 +60,18 @@ def exception(value):
     raise RuntimeError(value)
 
 
+def simple_repeat_task():
+    """A simple repeat task that just returns a constant value."""
+    return 'repeat_task_executed'
+
+
+def printing_repeat_task(marker):
+    """A repeat task that prints a marker for counting."""
+    print('REPEAT_MARKER_{}'.format(marker))
+    time.sleep(0.01)
+    return marker
+
+
 class TaskPoolUnittest(unittest.TestCase):
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
 
@@ -297,3 +309,96 @@ class TaskPoolUnittest(unittest.TestCase):
                         pool.wait()
 
             self.assertEqual(len(captured.stdout.getvalue().splitlines()), 26)
+
+        def test_repeat_task_with_groups(self):
+            """Test that repeat tasks run continuously in groups while regular tasks execute."""
+
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=4, force_fork=True, mutually_exclusive_groups=['repeat_group']) as pool:
+                    pool.do(printing_repeat_task, 'TEST', repeat=True, group='repeat_group')
+
+                    # Add slow tasks to keep the pool busy and allow repeat task to run multiple times
+                    for i in range(6):
+                        pool.do(wait, 0.1)
+
+                    pool.wait()
+
+            # Verify repeat task executed multiple times by checking stdout
+            stdout_output = captured.stdout.getvalue()
+            repeat_count = stdout_output.count('REPEAT_MARKER_TEST')
+            self.assertGreater(repeat_count, 1, "Repeat task should execute multiple times (got {})".format(repeat_count))
+
+        def test_repeat_task_multiple_groups(self):
+            """Test that multiple repeat tasks in different groups run simultaneously."""
+
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=4, force_fork=True, mutually_exclusive_groups=['group1', 'group2']) as pool:
+                    # Add repeat tasks with markers to different groups
+                    pool.do(printing_repeat_task, 'GROUP1', repeat=True, group='group1')
+                    pool.do(printing_repeat_task, 'GROUP2', repeat=True, group='group2')
+
+                    # Add slow tasks to give repeat tasks time to run
+                    for i in range(20):
+                        pool.do(wait, 0.1)
+                    pool.wait()
+
+                    # Verify both repeat tasks executed multiple times
+                    stdout_output = captured.stdout.getvalue()
+                    group1_count = stdout_output.count('REPEAT_MARKER_GROUP1')
+                    group2_count = stdout_output.count('REPEAT_MARKER_GROUP2')
+
+                    self.assertGreater(group1_count, 1, "Repeat task in group1 should execute multiple times (got {})".format(group1_count))
+                    self.assertGreater(group2_count, 1, "Repeat task in group2 should execute multiple times (got {})".format(group2_count))
+
+        def test_repeat_task_with_regular_grouped_tasks(self):
+            """Test repeat tasks alongside regular grouped tasks."""
+
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=4, force_fork=True, mutually_exclusive_groups=['repeat_group', 'regular_group']) as pool:
+                    # Add repeat task to repeat_group
+                    pool.do(printing_repeat_task, 'REGULAR', repeat=True, group='repeat_group')
+
+                    # Add slow tasks to keep the pool busy and allow repeat task to run multiple times
+                    for i in range(6):
+                        pool.do(wait, 0.1)
+
+                    # Add regular tasks to regular_group
+                    for i in range(10):
+                        pool.do(action, 'grouped{}'.format(i), include_worker=True, group='regular_group')
+
+                    # Add regular tasks to main queue
+                    for i in range(10):
+                        pool.do(action, 'regular{}'.format(i))
+                    pool.wait()
+
+            stdout_lines = captured.stdout.getvalue().splitlines()
+            for i in range(10):
+                # Grouped tasks include worker name
+                self.assertTrue(any('action(grouped{})'.format(i) in line for line in stdout_lines), 'action(grouped{}) not found in output'.format(i))
+                self.assertIn('action(regular{})'.format(i), stdout_lines)
+
+            # Verify repeat task executed multiple times
+            stdout_output = captured.stdout.getvalue()
+            repeat_count = stdout_output.count('REPEAT_MARKER_REGULAR')
+            self.assertGreater(repeat_count, 1, "Repeat task should execute multiple times (got {})".format(repeat_count))
+
+        def test_repeat_task_pool_state_tracking_forked(self):
+            """Test that TaskPool correctly tracks repeat task state in forked mode."""
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=4, force_fork=True, mutually_exclusive_groups=['test_group']) as pool:
+                    # Check initial state
+                    self.assertEqual(pool.repeat_pending_count, 0)
+                    self.assertFalse(pool._has_repeat_tasks)
+
+                    # Add regular task
+                    pool.do(simple_repeat_task)
+                    self.assertEqual(pool.repeat_pending_count, 0)
+                    self.assertFalse(pool._has_repeat_tasks)
+
+                    # Add repeat task to a group - this should update the tracking
+                    pool.do(simple_repeat_task, repeat=True, group='test_group')
+                    self.assertEqual(pool.repeat_pending_count, 1)
+                    self.assertTrue(pool._has_repeat_tasks)
+
+                    # Call wait() to properly clean up
+                    pool.wait()


### PR DESCRIPTION
#### cafffd84ce641f66540dacabbfd898cc19e7e3ca
<pre>
Modify task_pool to allow for repeated tasks that run alongside regular tasks.
<a href="https://rdar.apple.com/164584838">rdar://164584838</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302420">https://bugs.webkit.org/show_bug.cgi?id=302420</a>

Reviewed by Jonathan Bedard.

repeated tasks must be added to the taskpool instead of requeued,if they were requeued they would not repeat on a specific worker.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
(_Message.__call__):
(_Task.__init__):
(_Result.__init__):
(_Result.__call__):
(_StopRepeat):
(_StopRepeat.__init__):
(_StopRepeat.__call__):
(_Process):
(_Process.main):
(TaskPool):
(TaskPool.do):
(TaskPool.wait):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py:
(simple_repeat_task):
(printing_repeat_task):
(TaskPoolUnittest.test_mutually_exclusive_group_hang):
(TaskPoolUnittest):
(TaskPoolUnittest.test_repeat_task_with_groups):
(TaskPoolUnittest.test_repeat_task_multiple_groups):
(TaskPoolUnittest.test_repeat_task_with_regular_grouped_tasks):
(TaskPoolUnittest.test_repeat_task_pool_state_tracking_forked):

Canonical link: <a href="https://commits.webkit.org/304186@main">https://commits.webkit.org/304186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c585de3c9a3d3dd6adfc7b5942e27e4dd23d1806

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134861 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142373 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4977bc0e-56bd-4a5c-bff2-6da8828edddd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7904 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/7136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cbbc325d-da58-41f3-a3ee-7c7029ddec4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137807 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83887 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d1138937-6168-470e-9f3c-555df7c3c3e2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/134209 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2966 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145071 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6964 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/134288 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/7023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/7136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111770 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28347 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/7011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->