### PR TITLE
[AutoFill Debugging] Add support for superscript and subscript elements

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -27,8 +27,13 @@ root
                 button,uid=…,events=[click],'Update Status',[…]
             aria-label='Figure 1'
                 canvas,uid=…,[…]
-            link,uid=…,url='https://webkit.org/'
             textarea,uid=…,'This is a text box',[…]
+            '        Price: $11',[…]
+            superscript,'99',[…]
+            '        Link to ',[…]
+            subscript
+                'WebKit home page:',[…]
+                link,uid=…,url='https://webkit.org/'
     role='contentinfo'
         '    \nFooter content with ',[…]
         role='img',aria-label='copyright symbol','©',[…]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -78,8 +78,9 @@ canvas {
         <div class="canvas-container" aria-label="Figure 1">
             <canvas width="400" height="400"></canvas>
         </div>
-        <a href="https://webkit.org">webkit.org</a>
         <textarea rows="15" cols="40">This is a text box</textarea>
+        Price: $11<sup>99</sup>
+        Link to <sub>WebKit home page:<a href="https://webkit.org">webkit.org</a></sub>
     </section>
 </main>
 <footer role="contentinfo">

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -482,6 +482,12 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
     if (element->hasTagName(HTMLNames::navTag))
         return { ItemData { ContainerType::Nav } };
 
+    if (element->hasTagName(HTMLNames::supTag))
+        return { ItemData { ContainerType::Superscript } };
+
+    if (element->hasTagName(HTMLNames::subTag))
+        return { ItemData { ContainerType::Subscript } };
+
     if (CheckedPtr renderElement = dynamicDowncast<RenderBox>(*renderer); renderElement && renderElement->style().hasViewportConstrainedPosition())
         return { ItemData { ContainerType::ViewportConstrained } };
 
@@ -509,6 +515,8 @@ static inline bool shouldIncludeNodeIdentifier(OptionSet<EventListenerCategory> 
             case ContainerType::BlockQuote:
             case ContainerType::Section:
             case ContainerType::Nav:
+            case ContainerType::Subscript:
+            case ContainerType::Superscript:
             case ContainerType::Generic:
                 return eventListeners || AccessibilityObject::isARIAControl(role);
             case ContainerType::Button:

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -142,6 +142,8 @@ enum class ContainerType : uint8_t {
     Nav,
     Button,
     Canvas,
+    Subscript,
+    Superscript,
     Generic,
 };
 

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -363,6 +363,12 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
             case TextExtraction::ContainerType::Canvas:
                 containerString = "canvas"_s;
                 break;
+            case TextExtraction::ContainerType::Subscript:
+                containerString = "subscript"_s;
+                break;
+            case TextExtraction::ContainerType::Superscript:
+                containerString = "superscript"_s;
+                break;
             case TextExtraction::ContainerType::Generic:
                 break;
             }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6816,6 +6816,8 @@ header: <WebCore/TextExtractionTypes.h>
     Nav,
     Button,
     Canvas,
+    Subscript,
+    Superscript,
     Generic
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -83,6 +83,8 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
     WKTextExtractionContainerNav,
     WKTextExtractionContainerButton,
     WKTextExtractionContainerCanvas,
+    WKTextExtractionContainerSubscript,
+    WKTextExtractionContainerSuperscript,
     WKTextExtractionContainerGeneric
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
@@ -62,6 +62,10 @@ inline static WKTextExtractionContainer containerType(TextExtraction::ContainerT
         return WKTextExtractionContainerButton;
     case TextExtraction::ContainerType::Canvas:
         return WKTextExtractionContainerCanvas;
+    case TextExtraction::ContainerType::Subscript:
+        return WKTextExtractionContainerSubscript;
+    case TextExtraction::ContainerType::Superscript:
+        return WKTextExtractionContainerSuperscript;
     case TextExtraction::ContainerType::Generic:
         return WKTextExtractionContainerGeneric;
     }

--- a/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
+++ b/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
@@ -62,6 +62,10 @@ ASCIILiteral description(WKTextExtractionContainer container)
         return "BUTTON"_s;
     case WKTextExtractionContainerCanvas:
         return "CANVAS"_s;
+    case WKTextExtractionContainerSubscript:
+        return "SUBSCRIPT"_s;
+    case WKTextExtractionContainerSuperscript:
+        return "SUPERSCRIPT"_s;
     case WKTextExtractionContainerGeneric:
         return "GENERIC"_s;
     }


### PR DESCRIPTION
#### 89c358fcab84650649e799788df5209013cfe935
<pre>
[AutoFill Debugging] Add support for superscript and subscript elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=302422">https://bugs.webkit.org/show_bug.cgi?id=302422</a>
<a href="https://rdar.apple.com/164584999">rdar://164584999</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

Add support for `sub` and `sup` during text extraction, as separate container types. This appears
in debug text extraction output like so (both the single-line and multi-line cases):

```
&apos;Hello world $11&apos;
superscript,&apos;99&apos;
&apos;Link to &apos;
subscript
    &apos;WebKit home page:&apos;
    link,url=&apos;<a href="https://webkit.org/&apos">https://webkit.org/&apos</a>;
```

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:

Augment an existing test to cover these new container types.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::containerType):
* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm:
(WTR::description):

Canonical link: <a href="https://commits.webkit.org/302944@main">https://commits.webkit.org/302944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/690bf792565f90a2a09593363c15c5284c1fa7ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130707 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/3024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138131 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/71555847-9779-44d2-a517-9c8ff60415b1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132578 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/2994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2871 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a4776dd2-a25b-4354-91fd-c17fb939b1bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/2994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80286 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f1805cc-a47a-4e72-a2b5-e2444a15dabf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/2994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35167 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81384 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/2994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140608 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2497 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108017 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27484 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2136 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31801 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55765 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66227 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2764 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->