### PR TITLE
Drag image contains content from neighboring elements when css transform is involved

### DIFF
--- a/LayoutTests/fast/snapshot/scaled-down-drag-expected.html
+++ b/LayoutTests/fast/snapshot/scaled-down-drag-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box1 {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+#box2 {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 240px;
+    height: 240px;
+    transform-origin: top left;
+    transform: scale(0.333);
+    background-color: green;
+    font-size: 3em;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box1" draggable="true">
+        <div id="box2">
+            Should be included
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/scaled-down-drag.html
+++ b/LayoutTests/fast/snapshot/scaled-down-drag.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-18; totalPixels=0-1000" />
+<style>
+#box1 {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+#box2 {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 240px;
+    height: 240px;
+    transform-origin: top left;
+    transform: scale(0.333);
+    background-color: green;
+    font-size: 3em;
+    color: black;
+}
+#box3 {
+    position: absolute;
+    top: 110px;
+    left: 110px;
+    width: 100px;
+    height: 100px;
+    background-color: red;
+    color: black;
+}
+</style>
+<script type="text/javascript" src="../../resources/snapshot-helper.js"></script>
+</head>
+<body>
+    <div id="box1" draggable="true">
+        <div id="box2">
+            Should be included
+        </div>
+    </div>
+    <div id="box3">
+        Should not be included
+    </div>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+async function main() {
+    if (!window.internals) {
+        console.log('FAIL: window.internals is not available');
+        return;
+    }
+    
+    const box = document.getElementById('box1');
+    const canvas = await SnapshotHelper.takeSnapshot(box);
+    canvas.style.position = "absolute";
+    canvas.style.top = "10px";
+    canvas.style.left = "10px";
+    box.remove();
+    document.getElementById("box3").remove();
+    document.body.appendChild(canvas);
+
+    if (window.testRunner) {
+        testRunner.notifyDone();
+    }
+}
+
+window.addEventListener('load', main, false);
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3766,7 +3766,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             CheckedPtr subtreeRootLayer = paintingInfo.subtreePaintRoot->enclosingLayer();
             bool isLayerInSubtree = (this == subtreeRootLayer) || isDescendantOf(*subtreeRootLayer);
 
-            if (isLayerInSubtree && (paintingInfo.subtreePaintRoot != &renderer() && shouldExcludeBasedOnContainingBlock()))
+            if (!isLayerInSubtree || (paintingInfo.subtreePaintRoot != &renderer() && shouldExcludeBasedOnContainingBlock()))
                 shouldPaintContent = false;
         } else if (renderer().isAbsolutelyPositioned() && paintingInfo.subtreePaintRoot != &renderer() && shouldExcludeBasedOnContainingBlock()) {
             shouldPaintContent = false;


### PR DESCRIPTION
#### e6308f70605c1eb4c2e652472d899ba416c0f76a
<pre>
Drag image contains content from neighboring elements when css transform is involved

<a href="https://bugs.webkit.org/show_bug.cgi?id=302344">https://bugs.webkit.org/show_bug.cgi?id=302344</a>

Reviewed by Simon Fraser.

Skips painting content of elements that are not descendants of the dragged
element.  Specifically, sets shouldPaintContent to false when isLayerInSubtree
is false.

This builds on related fixes in a3e5281 and 1d76f58 from a few months ago.
I think the latter commit unintentionally mixed up the logic when it reworked
the former.

Test: fast/snapshot/scaled-down-drag.html

* LayoutTests/fast/snapshot/scaled-down-drag-expected.html: Added.
* LayoutTests/fast/snapshot/scaled-down-drag.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):

Canonical link: <a href="https://commits.webkit.org/303407@main">https://commits.webkit.org/303407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55a2892ce72b3bc360b6ceee3dd97a5a88fc1fde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100970 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81761 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3114 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/996 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82821 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111888 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142248 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4249 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37009 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109342 "Found 1 new test failure: fast/mediastream/mediastreamtrack-configurationchange.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4330 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3698 "Found 3 new test failures: fast/images/individual-animation-toggle.html http/tests/webgpu/webgpu/api/operation/labels.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109516 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3229 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114585 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57493 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4303 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32979 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4134 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67749 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->