### PR TITLE
Provide a fallback scrolling acceleration curve if curve data is otherwise unavailable

### DIFF
--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.cpp
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.cpp
@@ -33,11 +33,6 @@
 
 namespace WebKit {
 
-ScrollingAccelerationCurve::ScrollingAccelerationCurve(float gainLinear, float gainParabolic, float gainCubic, float gainQuartic, float tangentSpeedLinear, float tangentSpeedParabolicRoot, float resolution, float frameRate)
-    : m_parameters { gainLinear, gainParabolic, gainCubic, gainQuartic, tangentSpeedLinear, tangentSpeedParabolicRoot, resolution, frameRate }
-{
-}
-
 ScrollingAccelerationCurve ScrollingAccelerationCurve::interpolate(const ScrollingAccelerationCurve& from, const ScrollingAccelerationCurve& to, float amount)
 {
     auto interpolate = [&] (float a, float b) -> float {

--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.h
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.h
@@ -41,7 +41,7 @@ class NativeWebWheelEvent;
 
 class ScrollingAccelerationCurve {
 public:
-    ScrollingAccelerationCurve(float gainLinear, float gainParabolic, float gainCubic, float gainQuartic, float tangentSpeedLinear, float tangentSpeedParabolicRoot, float resolution, float frameRate);
+    constexpr ScrollingAccelerationCurve(float gainLinear, float gainParabolic, float gainCubic, float gainQuartic, float tangentSpeedLinear, float tangentSpeedParabolicRoot, float resolution, float frameRate);
 
     static std::optional<ScrollingAccelerationCurve> fromNativeWheelEvent(const NativeWebWheelEvent&);
 
@@ -63,7 +63,9 @@ public:
         // Does not check m_intermediates.
         return a.m_parameters == b.m_parameters;
     }
-    
+
+    static constexpr std::optional<ScrollingAccelerationCurve> fallbackCurve();
+
 private:
     friend TextStream& operator<<(TextStream&, const ScrollingAccelerationCurve&);
 
@@ -98,6 +100,29 @@ private:
     };
 
     std::optional<ComputedIntermediateValues> m_intermediates;
+};
+
+constexpr ScrollingAccelerationCurve::ScrollingAccelerationCurve(float gainLinear, float gainParabolic, float gainCubic, float gainQuartic, float tangentSpeedLinear, float tangentSpeedParabolicRoot, float resolution, float frameRate)
+    : m_parameters { gainLinear, gainParabolic, gainCubic, gainQuartic, tangentSpeedLinear, tangentSpeedParabolicRoot, resolution, frameRate }
+{
+}
+
+constexpr std::optional<ScrollingAccelerationCurve> ScrollingAccelerationCurve::fallbackCurve()
+{
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER) && PLATFORM(MAC)
+    return ScrollingAccelerationCurve {
+        0.924995422,
+        0.75,
+        0,
+        0,
+        6.29999542,
+        12,
+        400,
+        60,
+    };
+#else
+    return std::nullopt;
+#endif
 };
 
 TextStream& operator<<(TextStream&, const ScrollingAccelerationCurve&);

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -383,9 +383,9 @@ void EventDispatcher::pageScreenDidChange(PageIdentifier pageID, PlatformDisplay
 }
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-void EventDispatcher::setScrollingAccelerationCurve(PageIdentifier pageID, std::optional<ScrollingAccelerationCurve> curve)
+void EventDispatcher::setScrollingAccelerationCurve(PageIdentifier pageID, std::optional<ScrollingAccelerationCurve>&& curve)
 {
-    m_momentumEventDispatcher->setScrollingAccelerationCurve(pageID, curve);
+    m_momentumEventDispatcher->setScrollingAccelerationCurve(pageID, WTFMove(curve));
 }
 
 void EventDispatcher::handleSyntheticWheelEvent(WebCore::PageIdentifier pageIdentifier, const WebWheelEvent& event, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -123,7 +123,7 @@ private:
     // Message handlers
     void wheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>);
+    void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>&&);
 #endif
 #if ENABLE(IOS_TOUCH_EVENTS)
     void touchEvent(WebCore::PageIdentifier, WebCore::FrameIdentifier, const WebTouchEvent&, CompletionHandler<void(bool, std::optional<RemoteWebTouchEvent>)>&&);

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -251,16 +251,16 @@ void MomentumEventDispatcher::didEndMomentumPhase()
     tracePoint(SyntheticMomentumEnd);
 }
 
-void MomentumEventDispatcher::setScrollingAccelerationCurve(WebCore::PageIdentifier pageIdentifier, std::optional<ScrollingAccelerationCurve> curve)
+void MomentumEventDispatcher::setScrollingAccelerationCurve(WebCore::PageIdentifier pageIdentifier, std::optional<ScrollingAccelerationCurve>&& curve)
 {
-    Locker locker { m_accelerationCurvesLock };
-    m_accelerationCurves.set(pageIdentifier, curve);
-
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     WTF::TextStream stream(WTF::TextStream::LineMode::SingleLine);
     stream << curve;
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher set curve %" PUBLIC_LOG_STRING, stream.release().utf8().data());
 #endif
+
+    Locker locker { m_accelerationCurvesLock };
+    m_accelerationCurves.set(pageIdentifier, WTFMove(curve));
 }
 
 std::optional<ScrollingAccelerationCurve> MomentumEventDispatcher::scrollingAccelerationCurveForPage(WebCore::PageIdentifier pageIdentifier) const

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -77,7 +77,7 @@ public:
 
     bool handleWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
 
-    void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>);
+    void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>&&);
 
     void displayDidRefresh(WebCore::PlatformDisplayID);
 


### PR DESCRIPTION
#### 59e1c6227cec2f038d36d6420c893fc17398beb2
<pre>
Provide a fallback scrolling acceleration curve if curve data is otherwise unavailable
<a href="https://bugs.webkit.org/show_bug.cgi?id=302436">https://bugs.webkit.org/show_bug.cgi?id=302436</a>
<a href="https://rdar.apple.com/164600621">rdar://164600621</a>

Reviewed by Simon Fraser.

There are some situations where curve data may be unavailable from a
WebWheelEvent instance, for example when WKTR synthesizes a wheel event
stream. In situations like this, we would like to have momentum event
generation for (fake, or otherwise) wheel events.

To facilitate this change, we introduce a hardcoded fallback scrolling
acceleration curve. We also introduce a constexpr constructor for
ScrollingAccelerationCurve.

No change in functionality, so no new tests.

* Source/WebKit/Shared/ScrollingAccelerationCurve.cpp:
(WebKit::ScrollingAccelerationCurve::ScrollingAccelerationCurve): Deleted.

Move the constructor to ScrollingAccelerationCurve.h since it is now
constexpr.

* Source/WebKit/Shared/ScrollingAccelerationCurve.h:
(WebKit::ScrollingAccelerationCurve::ScrollingAccelerationCurve):
(WebKit::ScrollingAccelerationCurve::fallbackCurve):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::cacheWheelEventScrollingAccelerationCurve):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::setScrollingAccelerationCurve):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::setScrollingAccelerationCurve):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:

Drive-by fix: Pass ScrollingAccelerationCurve as r-value references
instead of creating copies at call boundaries.

Canonical link: <a href="https://commits.webkit.org/302978@main">https://commits.webkit.org/302978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/379662b95e811010e1f58033f0618755b645c29e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138216 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2956 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cce13b5b-2db1-44a9-ae7a-e7161fcb940c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133736 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80349 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea393540-2bef-4b67-a9c4-0b2990123d22) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81468 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140692 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108156 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108083 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55859 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20364 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66317 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2746 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->