### PR TITLE
[Site Isolation] [macOS] UI Process may crash during gesture event handling for cross-origin frames.

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -105,6 +105,7 @@ extern "C" {
     M(FrameTree) \
     M(Fullscreen) \
     M(Gamepad) \
+    M(GestureHandling) \
     M(IPC) \
     M(IPCMessages) \
     M(ITPDebug) \

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -35,7 +35,7 @@ class WebKit::WebEvent {
     WTF::UUID authorizationToken();
 };
 
-enum class WebKit::WebEventType : uint8_t {
+enum class WebKit::WebEventType : uint32_t {
     MouseDown,
     MouseUp,
     MouseMove,

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -46,7 +46,7 @@ namespace WebKit {
 class WebMouseEvent;
 class WebWheelEvent;
 class WebKeyboardEvent;
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 enum class WebMouseEventButton : int8_t;
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/Shared/WebEventType.h
+++ b/Source/WebKit/Shared/WebEventType.h
@@ -27,36 +27,36 @@
 
 namespace WebKit {
 
-enum class WebEventType : uint8_t {
+enum class WebEventType : uint32_t {
     // WebMouseEvent
-    MouseDown,
-    MouseUp,
-    MouseMove,
-    MouseForceChanged,
-    MouseForceDown,
-    MouseForceUp,
+    MouseDown           = 1 << 0,
+    MouseUp             = 1 << 1,
+    MouseMove           = 1 << 2,
+    MouseForceChanged   = 1 << 3,
+    MouseForceDown      = 1 << 4,
+    MouseForceUp        = 1 << 5,
 
     // WebWheelEvent
-    Wheel,
+    Wheel               = 1 << 6,
 
     // WebKeyboardEvent
-    KeyDown,
-    KeyUp,
-    RawKeyDown,
-    Char,
+    KeyDown             = 1 << 7,
+    KeyUp               = 1 << 8,
+    RawKeyDown          = 1 << 9,
+    Char                = 1 << 10,
 
 #if ENABLE(TOUCH_EVENTS)
     // WebTouchEvent
-    TouchStart,
-    TouchMove,
-    TouchEnd,
-    TouchCancel,
+    TouchStart          = 1 << 11,
+    TouchMove           = 1 << 12,
+    TouchEnd            = 1 << 13,
+    TouchCancel         = 1 << 14,
 #endif
 
 #if ENABLE(MAC_GESTURE_EVENTS)
-    GestureStart,
-    GestureChange,
-    GestureEnd,
+    GestureStart        = 1 << 15,
+    GestureChange       = 1 << 16,
+    GestureEnd          = 1 << 17
 #endif
 };
 

--- a/Source/WebKit/Shared/mac/WebGestureEvent.h
+++ b/Source/WebKit/Shared/mac/WebGestureEvent.h
@@ -56,7 +56,7 @@ public:
 
     float gestureScale() const { return m_gestureScale; }
     float gestureRotation() const { return m_gestureRotation; }
-    
+
 private:
     bool isGestureEventType(WebEventType) const;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -645,7 +645,7 @@ enum class UndoOrRedo : bool;
 enum class WasNavigationIntercepted : bool;
 enum class WebContentMode : uint8_t;
 enum class WebEventModifier : uint8_t;
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 enum class WindowKind : uint8_t;
 
 template<typename> class MonotonicObjectIdentifier;
@@ -1410,6 +1410,7 @@ public:
 #if ENABLE(MAC_GESTURE_EVENTS)
     void sendGestureEvent(WebCore::FrameIdentifier, const NativeWebGestureEvent&);
     void handleGestureEvent(const NativeWebGestureEvent&);
+    void processNextQueuedGestureEvent();
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -3164,6 +3165,9 @@ private:
 
     void mouseEventHandlingCompleted(std::optional<WebEventType>, bool handled, std::optional<WebCore::RemoteUserInputEventData>);
     void keyEventHandlingCompleted(std::optional<WebEventType>, bool handled);
+#if ENABLE(MAC_GESTURE_EVENTS)
+    void gestureEventHandlingCompleted(std::optional<WebEventType>, bool handled, std::optional<WebCore::RemoteUserInputEventData>);
+#endif
     void didReceiveEvent(IPC::Connection*, WebEventType, bool handled, std::optional<WebCore::RemoteUserInputEventData>&&);
     void didReceiveEventIPC(IPC::Connection&, WebEventType, bool handled, std::optional<WebCore::RemoteUserInputEventData>&&);
     void didUpdateRenderingAfterCommittingLoad();
@@ -3966,6 +3970,9 @@ private:
     size_t m_suspendMediaPlaybackCounter { 0 };
 
     size_t m_deferredMouseEvents { 0 };
+#if ENABLE(MAC_GESTURE_EVENTS)
+    size_t m_deferredGestureEvents { 0 };
+#endif
 
     bool m_lastNavigationWasAppInitiated { true };
     bool m_isRunningModalJavaScriptDialog { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -36,7 +36,7 @@ messages -> WebPageProxy {
     RunJavaScriptPrompt(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, String message, String defaultValue) -> (String result) Synchronous
     MouseDidMoveOverElement(struct WebKit::WebHitTestResultData hitTestResultData, OptionSet<WebKit::WebEventModifier> modifiers)
 
-    DidReceiveEventIPC(enum:uint8_t WebKit::WebEventType eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
+    DidReceiveEventIPC(enum:uint32_t WebKit::WebEventType eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
     SetCursor(WebCore::Cursor cursor)
     SetCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
     SetFocus(bool focused)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -357,6 +357,7 @@ public:
 
 #if ENABLE(MAC_GESTURE_EVENTS)
     Deque<NativeWebGestureEvent> gestureEventQueue;
+    unsigned droppedGestureEventCount { 0 };
 #endif
 
 #if ENABLE(META_VIEWPORT)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -82,7 +82,7 @@ struct DocumentEditingContext;
 struct PDFContextMenu;
 struct PDFContextMenuItem;
 
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 enum class WebMouseEventButton : int8_t;
 enum class WebEventModifier : uint8_t;
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -30,7 +30,7 @@ messages -> EventDispatcher {
     TouchEvent(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, WebKit::WebTouchEvent event) -> (bool handled, struct std::optional<WebKit::RemoteWebTouchEvent> transformedEvent) MainThreadCallback
 #endif
 #if ENABLE(MAC_GESTURE_EVENTS)
-    GestureEvent(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event) -> (enum:uint8_t std::optional<WebKit::WebEventType> eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) MainThreadCallback
+    GestureEvent(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event) -> (enum:uint32_t std::optional<WebKit::WebEventType> eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) MainThreadCallback
 #endif
 #if HAVE(DISPLAY_LINK)
     DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update, bool sendToMainThread)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -479,7 +479,7 @@ enum class TextInteractionSource : uint8_t;
 enum class TextRecognitionUpdateResult : uint8_t;
 enum class VisitedLinkTableIdentifierType;
 enum class WebEventModifier : uint8_t;
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 
 struct ContentWorldData;
 struct ContentWorldIdentifierType;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -168,7 +168,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     DidBeginTouchPoint(WebCore::FloatPoint locationInRootView)
 #endif
 #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
-    TouchEvent(WebKit::WebTouchEvent event) -> (enum:uint8_t std::optional<WebKit::WebEventType> eventType, bool handled)
+    TouchEvent(WebKit::WebTouchEvent event) -> (enum:uint32_t std::optional<WebKit::WebEventType> eventType, bool handled)
 #endif
 
     CancelPointer(WebCore::PointerID pointerId, WebCore::IntPoint documentPoint)


### PR DESCRIPTION
#### 32f678793901fdabc6ea217e9631434c1f8af1c4
<pre>
[Site Isolation] [macOS] UI Process may crash during gesture event handling for cross-origin frames.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302439">https://bugs.webkit.org/show_bug.cgi?id=302439</a>
<a href="https://rdar.apple.com/164432967">rdar://164432967</a>

Reviewed by Wenson Hsieh.

Previously, a race condition could cause the UI process to crash when processing gesture
events due to a mismatch between the type passed to `WebPageProxy::didReceiveEvent` and
the event type of the first event in the gesture event queue. Resolve this issue by
waiting for the web process to handle each gesture event before sending the next one,
just like we do for mouse events.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.h:
* Source/WebKit/Shared/WebEventType.h:
* Source/WebKit/Shared/mac/WebGestureEvent.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::removeOldRedundantEvent):
(WebKit::WebPageProxy::handleMouseEvent):
(WebKit::WebPageProxy::processNextQueuedGestureEvent):
(WebKit::WebPageProxy::handleGestureEvent):
(WebKit::WebPageProxy::gestureEventHandlingCompleted):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/303122@main">https://commits.webkit.org/303122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27163e5114ae527074f0307fe3d6bbab4ea948fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83116 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e018a2b-c46e-49ff-8e60-3423cee02b35) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67843 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81132 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/153205b4-7b6b-432b-805a-3564194d3fa3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2592 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/325 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82055 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111199 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141512 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108688 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27598 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2603 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56604 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32337 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3519 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->