### PR TITLE
[ews-build.webkit.org] Handle undefined architecture

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -685,7 +685,7 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
             self.setProperty('configuration', self.configuration, 'config.json')
         if self.architecture:
             self.setProperty('architecture', self.architecture, 'config.json')
-        self.setProperty('archForUpload', '-'.join(self.getProperty('architecture').split(' ')))
+        self.setProperty('archForUpload', '-'.join(self.getProperty('architecture', '').split(' ')))
         if self.buildOnly:
             self.setProperty('buildOnly', self.buildOnly, 'config.json')
         if self.triggers and not self.getProperty('triggers'):


### PR DESCRIPTION
#### f36eed3278d55a13424d840294c9254b6fb8c395
<pre>
[ews-build.webkit.org] Handle undefined architecture
<a href="https://bugs.webkit.org/show_bug.cgi?id=302444">https://bugs.webkit.org/show_bug.cgi?id=302444</a>
<a href="https://rdar.apple.com/164611042">rdar://164611042</a>

Unreviewed infrastructure fix.

* Tools/CISupport/ews-build/steps.py:
(ConfigureBuild.run):

Canonical link: <a href="https://commits.webkit.org/302963@main">https://commits.webkit.org/302963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daa9d810fb55face4b158fa7354a03f1679bae12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [💥 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130781 "An unexpected error occured. Recent messages:") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/3105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41740 "Build is in progress. Recent messages:") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138206 "Failed to checkout and rebase branch from PR 53857") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [💥 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132651 "An unexpected error occured. Recent messages:") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/2948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/138206 "Failed to checkout and rebase branch from PR 53857") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [💥 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133727 "An unexpected error occured. Recent messages:") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/41740 "Build is in progress. Recent messages:") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/138206 "Failed to checkout and rebase branch from PR 53857") | | ⏳ 🛠 vision-apple 
| [💥 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/130130 "An unexpected error occured. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/41740 "Build is in progress. Recent messages:") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81459 "Failed to checkout and rebase branch from PR 53857") | | 
| [💥 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122792 "An unexpected error occured. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/41740 "Build is in progress. Recent messages:") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140683 "Failed to checkout and rebase branch from PR 53857") | | 
| [💥 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129234 "An unexpected error occured. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/2948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/140683 "Failed to checkout and rebase branch from PR 53857") | | 
| [💥 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130210 "An unexpected error occured. Recent messages:") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/41740 "Build is in progress. Recent messages:") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/140683 "Failed to checkout and rebase branch from PR 53857") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/41740 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20352 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2914 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2841 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->