### PR TITLE
Address Safer CPP warnings in RedBlackTree.h

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -779,7 +779,7 @@ public:
                 visitRight = true;
         });
 
-        for (Islands* islands : toRemove)
+        SUPPRESS_UNCHECKED_LOCAL for (Islands* islands : toRemove)
             freeIslands(locker, islands);
 
         if (ASSERT_ENABLED) {
@@ -834,16 +834,16 @@ private:
 
     void* islandForJumpLocation(const Locker<Lock>& locker, uintptr_t jumpLocation, uintptr_t target, bool concurrently, bool useMemcpy)
     {
-        Islands* islands = m_islandsForJumpSourceLocation.findExact(std::bit_cast<void*>(jumpLocation));
+        CheckedPtr islands = m_islandsForJumpSourceLocation.findExact(std::bit_cast<void*>(jumpLocation));
         if (islands) {
             // FIXME: We could create some method of reusing already allocated islands here, but it's
             // unlikely to matter in practice.
             if (!concurrently)
-                freeJumpIslands(locker, islands);
+                freeJumpIslands(locker, islands.get());
         } else {
             islands = new Islands;
             islands->jumpSourceLocation = CodeLocationLabel<ExecutableMemoryPtrTag>(tagCodePtr<ExecutableMemoryPtrTag>(std::bit_cast<void*>(jumpLocation)));
-            m_islandsForJumpSourceLocation.insert(islands);
+            m_islandsForJumpSourceLocation.insert(islands.get());
         }
 
         RegionAllocator* allocator = findRegion(jumpLocation > target ? jumpLocation - m_regionSize : jumpLocation);
@@ -1099,8 +1099,9 @@ private:
     }
 
 #if ENABLE(JUMP_ISLANDS)
-    class Islands : public RedBlackTree<Islands, void*>::Node {
+    class Islands final : public RedBlackTree<Islands, void*>::Node {
         WTF_MAKE_TZONE_ALLOCATED(Islands);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Islands);
     public:
         void* key() { return jumpSourceLocation.dataLocation(); }
         CodeLocationLabel<ExecutableMemoryPtrTag> jumpSourceLocation;

--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,5 +1,4 @@
 wtf/HashTable.h
 wtf/JSONValues.h
 wtf/RecursiveLockAdapter.h
-wtf/RedBlackTree.h
 wtf/Vector.h

--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -36,6 +36,7 @@
 #include <wtf/PageBlock.h>
 #include <wtf/RedBlackTree.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 
@@ -139,7 +140,9 @@ private:
     
     friend class MetaAllocatorHandle;
     
-    class FreeSpaceNode : public RedBlackTree<FreeSpaceNode, size_t>::Node {
+    class FreeSpaceNode final : public RedBlackTree<FreeSpaceNode, size_t>::Node {
+        WTF_MAKE_TZONE_ALLOCATED(FreeSpaceNode);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FreeSpaceNode);
     public:
         size_t sizeInBytes()
         {
@@ -187,8 +190,8 @@ private:
     unsigned m_logPageSize;
     
     Tree m_freeSpaceSizeMap;
-    UncheckedKeyHashMap<FreeSpacePtr, FreeSpaceNode*> m_freeSpaceStartAddressMap;
-    UncheckedKeyHashMap<FreeSpacePtr, FreeSpaceNode*> m_freeSpaceEndAddressMap;
+    UncheckedKeyHashMap<FreeSpacePtr, CheckedPtr<FreeSpaceNode>> m_freeSpaceStartAddressMap;
+    UncheckedKeyHashMap<FreeSpacePtr, CheckedPtr<FreeSpaceNode>> m_freeSpaceEndAddressMap;
     UncheckedKeyHashMap<uintptr_t, size_t> m_pageOccupancyMap;
     
     size_t m_bytesAllocated;

--- a/Source/WTF/wtf/MetaAllocatorHandle.h
+++ b/Source/WTF/wtf/MetaAllocatorHandle.h
@@ -39,9 +39,9 @@ class MetaAllocator;
 class PrintStream;
 
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetaAllocatorHandle);
-class MetaAllocatorHandle : public ThreadSafeRefCounted<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::Node {
+class MetaAllocatorHandle final : public ThreadSafeRefCounted<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::Node {
     WTF_DEPRECATED_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(MetaAllocatorHandle, MetaAllocatorHandle);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MetaAllocatorHandle);
 public:
     using MemoryPtr = CodePtr<HandleMemoryPtrTag>;
 

--- a/Source/WTF/wtf/RedBlackTree.h
+++ b/Source/WTF/wtf/RedBlackTree.h
@@ -29,8 +29,10 @@
 #pragma once
 
 #include <wtf/Assertions.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WTF {
 
@@ -54,16 +56,17 @@ private:
     };
     
 public:
-    class Node {
+    class Node : public CanMakeCheckedPtr<Node> {
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(Node);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Node);
         friend class RedBlackTree;
-        
     public:
         const NodeType* successor() const
         {
-            const Node* x = this;
+            CheckedPtr x = this;
             if (x->right())
                 return treeMinimum(x->right());
-            const NodeType* y = x->parent();
+            auto* y = x->parent();
             unsigned depth = 0;
             while (y && x == y->right()) {
                 RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -75,10 +78,10 @@ public:
         
         const NodeType* predecessor() const
         {
-            const Node* x = this;
+            CheckedPtr x = this;
             if (x->left())
                 return treeMaximum(x->left());
-            const NodeType* y = x->parent();
+            auto* y = x->parent();
             unsigned depth = 0;
             while (y && x == y->left()) {
                 RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -120,7 +123,7 @@ public:
         
         NodeType* left() const
         {
-            return m_left;
+            return m_left.get();
         }
         
         void setLeft(NodeType* node)
@@ -130,7 +133,7 @@ public:
         
         NodeType* right() const
         {
-            return m_right;
+            return m_right.get();
         }
         
         void setRight(NodeType* node)
@@ -153,15 +156,12 @@ public:
                 m_parentAndRed &= ~static_cast<uintptr_t>(1);
         }
         
-        NodeType* m_left;
-        NodeType* m_right;
+        CheckedPtr<NodeType> m_left;
+        CheckedPtr<NodeType> m_right;
         uintptr_t m_parentAndRed;
     };
 
-    RedBlackTree()
-        : m_root(nullptr)
-    {
-    }
+    RedBlackTree() = default;
     
     void insert(NodeType* x)
     {
@@ -292,7 +292,7 @@ public:
     NodeType* findExact(const KeyType& key) const
     {
         unsigned depth = 0;
-        for (NodeType* current = m_root; current;) {
+        for (NodeType* current = m_root.get(); current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (current->key() == key)
                 return current;
@@ -308,7 +308,7 @@ public:
     {
         NodeType* best = nullptr;
         unsigned depth = 0;
-        for (NodeType* current = m_root; current;) {
+        for (NodeType* current = m_root.get(); current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (current->key() == key)
                 return current;
@@ -326,7 +326,7 @@ public:
     {
         NodeType* best = nullptr;
         unsigned depth = 0;
-        for (NodeType* current = m_root; current;) {
+        for (NodeType* current = m_root.get(); current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (current->key() == key)
                 return current;
@@ -346,19 +346,19 @@ public:
         if (!m_root)
             return;
 
-        Vector<NodeType*, 16> toIterate;
+        Vector<CheckedPtr<NodeType>, 16> toIterate;
         unsigned size = 0;
         toIterate.append(m_root);
         while (toIterate.size()) {
             RELEASE_ASSERT(++size < std::numeric_limits<unsigned>::max());
-            NodeType& current = *toIterate.takeLast();
+            CheckedPtr current = toIterate.takeLast();
             bool iterateLeft = false;
             bool iterateRight = false;
-            function(current, iterateLeft, iterateRight);
-            if (iterateLeft && current.left())
-                toIterate.append(current.left());
-            if (iterateRight && current.right())
-                toIterate.append(current.right());
+            function(*current, iterateLeft, iterateRight);
+            if (iterateLeft && current->left())
+                toIterate.append(current->left());
+            if (iterateRight && current->right())
+                toIterate.append(current->right());
         }
     }
     
@@ -366,14 +366,14 @@ public:
     {
         if (!m_root)
             return nullptr;
-        return treeMinimum(m_root);
+        return treeMinimum(m_root.get());
     }
     
     NodeType* last() const
     {
         if (!m_root)
             return 0;
-        return treeMaximum(m_root);
+        return treeMaximum(m_root.get());
     }
     
     // This is an O(n) operation.
@@ -442,7 +442,7 @@ private:
         ASSERT(z->color() == Red);
         
         NodeType* y = nullptr;
-        NodeType* x = m_root;
+        NodeType* x = m_root.get();
         unsigned depth = 0;
         while (x) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -569,7 +569,7 @@ private:
                     if (w->right())
                         w->right()->setColor(Black);
                     leftRotate(xParent);
-                    x = m_root;
+                    x = m_root.get();
                     xParent = x->parent();
                 }
             } else {
@@ -609,7 +609,7 @@ private:
                     if (w->left())
                         w->left()->setColor(Black);
                     rightRotate(xParent);
-                    x = m_root;
+                    x = m_root.get();
                     xParent = x->parent();
                 }
             }
@@ -618,7 +618,7 @@ private:
             x->setColor(Black);
     }
 
-    NodeType* m_root;
+    CheckedPtr<NodeType> m_root;
 };
 
 }

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -35,10 +35,10 @@ namespace WTF {
 
 static constexpr bool report = false;
 
-class RunLoop::TimerBase::ScheduledTask : public ThreadSafeRefCounted<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::Node {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(RunLoop);
+class RunLoop::TimerBase::ScheduledTask final : public ThreadSafeRefCounted<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::Node {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ScheduledTask);
     WTF_MAKE_NONCOPYABLE(ScheduledTask);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScheduledTask);
 public:
     static Ref<ScheduledTask> create(RunLoop::TimerBase& timer)
     {

--- a/Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp
@@ -29,13 +29,16 @@
 #include "config.h"
 #include <wtf/HashSet.h>
 #include <wtf/RedBlackTree.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace TestWebKitAPI {
 
 using namespace WTF;
 
-class TestNode : public RedBlackTree<TestNode, char>::Node {
+class TestNode final : public RedBlackTree<TestNode, char>::Node {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(TestNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TestNode);
 public:
     TestNode(char key, unsigned value)
         : m_key(key)
@@ -320,14 +323,16 @@ TEST_F(RedBlackTreeTest, BiggerBestFitSearch)
     testDriver("+d+d+d+d+d+d+d+d+d+d+f+f+f+f+f+f+f+h+h+i+j+k+l+m+o+p+q+r+z@a@b@c@d@e@f@g@h@i@j@k@l@m@n@o@p@q@r@s@t@u@v@w@x@y@z");
 }
 
+class IterateTestNode final : public RedBlackTree<IterateTestNode, unsigned>::Node {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(IterateTestNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IterateTestNode);
+public:
+    unsigned key() { return value; }
+    unsigned value;
+};
+
 TEST_F(RedBlackTreeTest, Iterate)
 {
-    class Node : public RedBlackTree<Node, unsigned>::Node {
-    public:
-        unsigned value;
-        unsigned key() { return value; }
-    };
-
     HashSet<unsigned> items;
     items.add(2);
     items.add(42);
@@ -339,16 +344,16 @@ TEST_F(RedBlackTreeTest, Iterate)
     items.add(250);
     items.add(300);
 
-    RedBlackTree<Node, unsigned> tree;
+    RedBlackTree<IterateTestNode, unsigned> tree;
     for (unsigned value : items) {
-        Node* node = new Node;
+        IterateTestNode* node = new IterateTestNode;
         node->value = value;
         tree.insert(node);
     }
 
     {
         HashSet<unsigned> testItems;
-        tree.iterate([&] (Node& node, bool& iterateLeft, bool& iterateRight) {
+        tree.iterate([&] (IterateTestNode& node, bool& iterateLeft, bool& iterateRight) {
             testItems.add(node.value);
             iterateLeft = true;
             iterateRight = true;
@@ -359,7 +364,7 @@ TEST_F(RedBlackTreeTest, Iterate)
 
     {
         HashSet<unsigned> lessThanOrEqual73;
-        tree.iterate([&] (Node& node, bool& iterateLeft, bool& iterateRight) {
+        tree.iterate([&] (IterateTestNode& node, bool& iterateLeft, bool& iterateRight) {
             if (node.value < 73) {
                 iterateRight = true;
                 iterateLeft = true;
@@ -380,7 +385,7 @@ TEST_F(RedBlackTreeTest, Iterate)
 
     {
         HashSet<unsigned> greaterThan55;
-        tree.iterate([&] (Node& node, bool& iterateLeft, bool& iterateRight) {
+        tree.iterate([&] (IterateTestNode& node, bool& iterateLeft, bool& iterateRight) {
             if (node.value <= 55)
                 iterateRight = true;
             else {


### PR DESCRIPTION
#### bc25de03bf712a68cf9dc55cce475c85f2e5ff37
<pre>
Address Safer CPP warnings in RedBlackTree.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302453">https://bugs.webkit.org/show_bug.cgi?id=302453</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WTF/wtf/MetaAllocator.cpp:
(WTF::MetaAllocator::~MetaAllocator):
(WTF::MetaAllocator::findAndRemoveFreeSpace):
(WTF::MetaAllocator::debugFreeSpaceSize):
(WTF::MetaAllocator::addFreeSpace):
* Source/WTF/wtf/MetaAllocator.h:
(WTF::MetaAllocator::FreeSpaceNode::sizeInBytes): Deleted.
(WTF::MetaAllocator::FreeSpaceNode::key): Deleted.
* Source/WTF/wtf/MetaAllocatorHandle.h:
(WTF::MetaAllocatorHandle::start const): Deleted.
(WTF::MetaAllocatorHandle::end const): Deleted.
(WTF::MetaAllocatorHandle::startAsInteger const): Deleted.
(WTF::MetaAllocatorHandle::endAsInteger const): Deleted.
(WTF::MetaAllocatorHandle::sizeInBytes const): Deleted.
(WTF::MetaAllocatorHandle::containsIntegerAddress const): Deleted.
(WTF::MetaAllocatorHandle::contains const): Deleted.
(WTF::MetaAllocatorHandle::allocator): Deleted.
(WTF::MetaAllocatorHandle::key): Deleted.
* Source/WTF/wtf/RedBlackTree.h:
* Source/WTF/wtf/generic/RunLoopGeneric.cpp:
(WTF::RunLoop::TimerBase::ScheduledTask::create): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::ScheduledTask): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::fired): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::scheduledTimePoint const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::updateReadyTime): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::key const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::isScheduled const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::setScheduled): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::isActive const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::activate): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::deactivate): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp:
(TestWebKitAPI::TEST_F(RedBlackTreeTest, Iterate)):
(TestWebKitAPI::TestNode::TestNode): Deleted.
(TestWebKitAPI::TestNode::key): Deleted.

Canonical link: <a href="https://commits.webkit.org/303015@main">https://commits.webkit.org/303015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e86936e16bff520a70872223a3e240a20f7c952b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130827 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138254 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82481 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07751560-4c33-4ec4-9efe-44471661a7dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/113fc1e7-0600-41a2-b69b-f2675c01e8a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26514793-0d7f-4f69-b456-5a035018b776) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81507 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122841 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140730 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129280 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108185 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66354 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162297 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2783 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40482 "Found unexpected failure with change (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->