### PR TITLE
Remove EnhancedSecurityFeatureEnabled UserDefault

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -164,12 +164,6 @@ static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPol
 
 } // namespace WebKit
 
-// EnhancedSecurityFeatureEnabled is a temporary NSUserDefault, See: rdar://163369863
-static BOOL isEnhancedSecurityFeatureEnabled()
-{
-    return [[NSUserDefaults standardUserDefaults] boolForKey:@"EnhancedSecurityFeatureEnabled"];
-}
-
 static Ref<API::WebsitePolicies> protectedWebsitePolicies(WKWebpagePreferences *preferences)
 {
     return *preferences->_websitePolicies;
@@ -518,16 +512,11 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)_setEnhancedSecurityEnabled:(BOOL)enhancedSecurityEnabled
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return;
-
     _websitePolicies->setEnhancedSecurityEnabled(enhancedSecurityEnabled ? true : false);
 }
 
 - (BOOL)_enhancedSecurityEnabled
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return NO;
     return _websitePolicies->enhancedSecurityEnabled();
 }
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
@@ -853,9 +842,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)setSecurityRestrictionMode:(WKSecurityRestrictionMode)mode
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return;
-
     switch (mode) {
     case WKSecurityRestrictionModeNone:
         _websitePolicies->setEnhancedSecurityEnabled(false);
@@ -874,8 +860,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (WKSecurityRestrictionMode)securityRestrictionMode
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return WKSecurityRestrictionModeNone;
     if (Ref { *_websitePolicies }->lockdownModeEnabled())
         return WKSecurityRestrictionModeLockdown;
     if (_websitePolicies->enhancedSecurityEnabled())

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -41,19 +41,6 @@ namespace TestWebKitAPI {
 
 #if !PLATFORM(IOS)
 
-class EnhancedSecurityTest : public testing::Test {
-public:
-    virtual void SetUp()
-    {
-        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"EnhancedSecurityFeatureEnabled"];
-    }
-
-    virtual void TearDown()
-    {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"EnhancedSecurityFeatureEnabled"];
-    }
-};
-
 static bool isEnhancedSecurityEnabled(WKWebView *webView)
 {
     __block bool gotResponse = false;
@@ -80,7 +67,7 @@ static bool isJITEnabled(WKWebView *webView)
     return isJITEnabledResult;
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)
+TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -96,7 +83,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)
 #endif
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)
+TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -112,7 +99,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)
 #endif
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)
+TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -123,7 +110,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)
     EXPECT_EQ(false, isJITEnabled(webView.get()));
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -149,7 +136,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigati
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)
+TEST(EnhancedSecurity, PSONToEnhancedSecurity)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -193,7 +180,7 @@ TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySamePage)
+TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -247,7 +234,7 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
     return processPoolConfiguration;
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)
+TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -299,7 +286,7 @@ TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)
+TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -352,7 +339,7 @@ TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)
 }
 
 #if USE(APPLE_INTERNAL_SDK)
-TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)
+TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
 {
     auto webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration1.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -376,7 +363,7 @@ TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)
 }
 #endif
 
-TEST_F(EnhancedSecurityTest, ProcessCanLaunch)
+TEST(EnhancedSecurity, ProcessCanLaunch)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
@@ -410,7 +397,7 @@ TEST_F(EnhancedSecurityTest, ProcessCanLaunch)
 
 }
 
-TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)
+TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
@@ -446,7 +433,7 @@ TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)
     [WKProcessPool _clearCaptivePortalModeEnabledGloballyForTesting];
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)
 {
     HTTPServer server({
         { "/example"_s, { "<iframe id='webkit_frame' src='https://example.com/webkit'></iframe>"_s } },
@@ -494,7 +481,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrame
 
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)
 {
 
     HTTPServer server({
@@ -543,7 +530,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrame
 
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)
 {
 
     HTTPServer server({
@@ -592,7 +579,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFram
 
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)
 {
 
     HTTPServer server({
@@ -640,7 +627,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFram
 #endif
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenWithNoopenerFromEnhancedSecurityPage)
+TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
 {
     HTTPServer server({
         { "/example"_s, { "<script>w = window.open('https://webkit.org/webkit', '_blank', 'noopener')</script>"_s } },
@@ -683,7 +670,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenWithNoopenerFromEnhancedSecurityPage)
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenWithOpenerFromEnhancedSecurityPage)
+TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
 {
     HTTPServer server({
         { "/example"_s, { "<script>w = window.open('https://webkit.org/webkit')</script>"_s } },
@@ -724,7 +711,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenWithOpenerFromEnhancedSecurityPage)
 #endif
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
+TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
 {
     HTTPServer server({
         { "/target"_s, { "target page"_s } },
@@ -794,7 +781,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhan
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)
+TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)
 {
     HTTPServer server({
         { "/opener"_s, { "<script>function openwithnoopener() {w = window.open('https://webkit.org/opened', '_blank', 'noopener')}</script>"_s } },
@@ -863,7 +850,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromStandardWithEnhancedSecurityV
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)
+TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)
 {
     HTTPServer server({
         { "/opener"_s, { "<script>function openwithnoopener() {w = window.open('https://webkit.org/opened', '_blank', 'noopener')}</script>"_s } },
@@ -926,7 +913,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityWithStandardV
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, LockdownModeTakesPrecedenceOverEnhancedSecurity)
+TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
@@ -945,7 +932,7 @@ TEST_F(EnhancedSecurityTest, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 #endif
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityRequestedWhenLockdownModeActive)
+TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;


### PR DESCRIPTION
#### 4936e51d94124f4e6db9cf541c032bf68f5b1267
<pre>
Remove EnhancedSecurityFeatureEnabled UserDefault
<a href="https://bugs.webkit.org/show_bug.cgi?id=302475">https://bugs.webkit.org/show_bug.cgi?id=302475</a>
<a href="https://rdar.apple.com/163369863">rdar://163369863</a>

Reviewed by Per Arne Vollan.

Remove EnhancedSecurityFeatureEnabled UserDefault which is guarding the
securityRestrictionMode API.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setEnhancedSecurityEnabled:]):
(-[WKWebpagePreferences _enhancedSecurityEnabled]):
(-[WKWebpagePreferences setSecurityRestrictionMode:]):
(-[WKWebpagePreferences securityRestrictionMode]):
(isEnhancedSecurityFeatureEnabled): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessCanLaunch)):
(TestWebKitAPI::TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)):
(TestWebKitAPI::EnhancedSecurityTest::SetUp): Deleted.
(TestWebKitAPI::EnhancedSecurityTest::TearDown): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigation)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySamePage)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, ProcessCanLaunch)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenWithNoopenerFromEnhancedSecurityPage)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenWithOpenerFromEnhancedSecurityPage)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, LockdownModeTakesPrecedenceOverEnhancedSecurity)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityRequestedWhenLockdownModeActive)): Deleted.

Canonical link: <a href="https://commits.webkit.org/303003@main">https://commits.webkit.org/303003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8efacb719889da290019542b3ed80980fee628b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138283 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82514 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4de38c16-4bbb-48e4-bf4a-d5a6e0e41b6d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99701 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/82514 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0914f39-1308-4632-942d-9703fc39f217) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80395 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5b58279-917a-49ca-a3f4-f1237d9c5df1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35294 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81538 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140760 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108216 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55956 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66382 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2811 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->