### PR TITLE
SaferCPP: Remove unprotected WebProcess::*ProcessConnection() accessors

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -48,7 +48,7 @@ void NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary()
 
     if (request.url().protocolIsFile()) {
 #if HAVE(AUDIT_TOKEN)
-        if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken()) {
+        if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection()->networkProcessAuditToken()) {
             if (auto handle = SandboxExtension::createHandleForReadByAuditToken(request.url().fileSystemPath(), *networkProcessAuditToken))
                 resourceSandboxExtension = WTFMove(*handle);
         } else

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -166,7 +166,7 @@ void WebPaymentCoordinator::cancelPaymentSession()
 IPC::Connection* WebPaymentCoordinator::messageSenderConnection() const
 {
 #if ENABLE(APPLE_PAY_REMOTE_UI)
-    return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    return &WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 #else
     return WebProcess::singleton().parentProcessConnection();
 #endif

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -55,7 +55,7 @@ Ref<IPC::Connection> WebCacheStorageConnection::connection()
 
     RefPtr<IPC::Connection> connection;
     callOnMainRunLoopAndWait([this, &connection]() mutable {
-        connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         {
             Locker lock(m_connectionLock);
             m_connection = connection;

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -70,7 +70,7 @@ std::optional<IDBConnectionIdentifier> WebIDBConnectionToServer::identifier() co
 
 IPC::Connection* WebIDBConnectionToServer::messageSenderConnection() const
 {
-    return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    return &WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 IDBClient::IDBConnectionToServer& WebIDBConnectionToServer::coreConnectionToServer()

--- a/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
+++ b/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
@@ -67,7 +67,7 @@ WebDatabaseProvider::~WebDatabaseProvider()
 
 WebCore::IDBClient::IDBConnectionToServer& WebDatabaseProvider::idbConnectionToServerForSession(PAL::SessionID)
 {
-    return WebProcess::singleton().ensureProtectedNetworkProcessConnection()->idbConnectionToServer().coreConnectionToServer();
+    return WebProcess::singleton().ensureNetworkProcessConnection()->idbConnectionToServer().coreConnectionToServer();
 }
 
 }

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
@@ -50,62 +50,62 @@ void BlobRegistryProxy::registerInternalFileBlobURL(const URL& url, Ref<BlobData
     }
 
     String replacementPath = path == file->path() ? nullString() : file->path();
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalFileBlobURL(url, path, replacementPath, WTFMove(extensionHandle), contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalFileBlobURL(url, path, replacementPath, WTFMove(extensionHandle), contentType), 0);
 }
 
 void BlobRegistryProxy::registerInternalBlobURL(const URL& url, Vector<BlobPart>&& blobParts, const String& contentType)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURL(url, blobParts, contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURL(url, blobParts, contentType), 0);
 }
 
 void BlobRegistryProxy::registerBlobURL(const URL& url, const URL& srcURL, const PolicyContainer& policyContainer, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURL { url, srcURL, policyContainer, topOrigin }, 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURL { url, srcURL, policyContainer, topOrigin }, 0);
 }
 
 void BlobRegistryProxy::registerInternalBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<WebCore::BlobDataFileReference>&& file, const String& contentType)
 {
     ASSERT(file);
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLOptionallyFileBacked(url, srcURL, file->path(), contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLOptionallyFileBacked(url, srcURL, file->path(), contentType), 0);
 }
 
 void BlobRegistryProxy::unregisterBlobURL(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURL(url, topOrigin), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURL(url, topOrigin), 0);
 }
 
 void BlobRegistryProxy::registerInternalBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLForSlice(url, srcURL, start, end, contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLForSlice(url, srcURL, start, end, contentType), 0);
 }
 
 void BlobRegistryProxy::registerBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLHandle(url, topOrigin), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLHandle(url, topOrigin), 0);
 }
 
 void BlobRegistryProxy::unregisterBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURLHandle(url, topOrigin), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURLHandle(url, topOrigin), 0);
 }
 
 String BlobRegistryProxy::blobType(const URL& url)
 {
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::BlobType(url), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::BlobType(url), 0);
     auto [result] = sendResult.takeReplyOr(emptyString());
     return result;
 }
 
 unsigned long long BlobRegistryProxy::blobSize(const URL& url)
 {
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::BlobSize(url), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::BlobSize(url), 0);
     auto [resultSize] = sendResult.takeReplyOr(0);
     return resultSize;
 }
 
 void BlobRegistryProxy::writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler)
 {
-    WebProcess::singleton().ensureProtectedNetworkProcessConnection()->writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler));
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -214,7 +214,7 @@ RefPtr<WebCore::VideoFrame> RemoteGraphicsContextGLProxy::surfaceBufferToVideoFr
     auto [result] = sendResult.takeReply();
     if (!result)
         return nullptr;
-    return RemoteVideoFrameProxy::create(WebProcess::singleton().ensureGPUProcessConnection().connection(), WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy(), WTFMove(*result));
+    return RemoteVideoFrameProxy::create(WebProcess::singleton().ensureGPUProcessConnection()->connection(), WebProcess::singleton().ensureGPUProcessConnection()->protectedVideoFrameObjectHeapProxy(), WTFMove(*result));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -48,7 +48,7 @@ RemoteQueueProxy::RemoteQueueProxy(RemoteAdapterProxy& parent, ConvertToBackingC
 #if ENABLE(VIDEO) && PLATFORM(COCOA) && ENABLE(WEB_CODECS)
     RefPtr<RemoteVideoFrameObjectHeapProxy> videoFrameObjectHeapProxy;
     callOnMainRunLoopAndWait([&videoFrameObjectHeapProxy] {
-        videoFrameObjectHeapProxy = WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy();
+        videoFrameObjectHeapProxy = WebProcess::singleton().ensureGPUProcessConnection()->videoFrameObjectHeapProxy();
     });
 
     m_videoFrameObjectHeapProxy = videoFrameObjectHeapProxy;

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -53,7 +53,7 @@ RemoteWCLayerTreeHostProxy::~RemoteWCLayerTreeHostProxy()
 
 IPC::Connection* RemoteWCLayerTreeHostProxy::messageSenderConnection() const
 {
-    return &const_cast<RemoteWCLayerTreeHostProxy&>(*this).ensureGPUProcessConnection().connection();
+    return &const_cast<RemoteWCLayerTreeHostProxy&>(*this).ensureGPUProcessConnection()->connection();
 }
 
 GPUProcessConnection& RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection()

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -250,7 +250,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
 
         auto createExtension = [&] {
 #if HAVE(AUDIT_TOKEN)
-            if (auto auditToken = protectedManager()->protectedGPUProcessConnection()->auditToken()) {
+            if (auto auditToken = protectedManager()->gpuProcessConnection()->auditToken()) {
                 if (auto createdHandle = SandboxExtension::createHandleForReadByAuditToken(fileSystemPath, auditToken.value())) {
                     handle = WTFMove(*createdHandle);
                     return true;
@@ -757,7 +757,7 @@ void MediaPlayerPrivateRemote::addRemoteAudioTrack(AudioTrackPrivateRemoteConfig
 
     m_audioTracks.erase(configuration.trackId);
 
-    auto addResult = m_audioTracks.emplace(configuration.trackId, AudioTrackPrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), m_id, WTFMove(configuration)));
+    auto addResult = m_audioTracks.emplace(configuration.trackId, AudioTrackPrivateRemote::create(protectedManager()->gpuProcessConnection(), m_id, WTFMove(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -807,7 +807,7 @@ void MediaPlayerPrivateRemote::addRemoteTextTrack(TextTrackPrivateRemoteConfigur
 
     m_textTracks.erase(configuration.trackId);
 
-    auto addResult = m_textTracks.emplace(configuration.trackId, TextTrackPrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), m_id, WTFMove(configuration)));
+    auto addResult = m_textTracks.emplace(configuration.trackId, TextTrackPrivateRemote::create(protectedManager()->gpuProcessConnection(), m_id, WTFMove(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -971,7 +971,7 @@ void MediaPlayerPrivateRemote::addRemoteVideoTrack(VideoTrackPrivateRemoteConfig
 
     m_videoTracks.erase(configuration.trackId);
 
-    auto addResult = m_videoTracks.emplace(configuration.trackId, VideoTrackPrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), m_id, WTFMove(configuration)));
+    auto addResult = m_videoTracks.emplace(configuration.trackId, VideoTrackPrivateRemote::create(protectedManager()->gpuProcessConnection(), m_id, WTFMove(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -1047,7 +1047,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options, 
             // MediaSource can only be re-opened after RemoteMediaPlayerProxy::LoadMediaSource has been called.
             client.reOpen();
         } else
-            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), identifier, protectedManager()->checkedTypeCache(m_remoteEngineIdentifier), *this, client);
+            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(protectedManager()->gpuProcessConnection(), identifier, protectedManager()->checkedTypeCache(m_remoteEngineIdentifier), *this, client);
         return;
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -112,8 +112,8 @@ public:
 
     WebCore::MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier() const { return m_remoteEngineIdentifier; }
     std::optional<WebCore::MediaPlayerIdentifier> identifier() const final { return m_id; }
-    IPC::Connection& connection() const { return protectedManager()->gpuProcessConnection().connection(); }
-    Ref<IPC::Connection> protectedConnection() const { return protectedManager()->gpuProcessConnection().connection(); }
+    IPC::Connection& connection() const { return protectedManager()->gpuProcessConnection()->connection(); }
+    Ref<IPC::Connection> protectedConnection() const { return protectedManager()->gpuProcessConnection()->connection(); }
     RefPtr<WebCore::MediaPlayer> player() const { return m_player.get(); }
 
     WebCore::MediaPlayer::ReadyState readyState() const final { return m_readyState; }
@@ -497,7 +497,7 @@ private:
 #if PLATFORM(COCOA)
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);
 #endif
-    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return protectedManager()->protectedGPUProcessConnection()->videoFrameObjectHeapProxy(); }
+    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return protectedManager()->gpuProcessConnection()->videoFrameObjectHeapProxy(); }
     Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const { return videoFrameObjectHeapProxy(); }
 
     Ref<RemoteMediaPlayerManager> protectedManager() const;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -71,7 +71,7 @@ void RemoteAudioSourceProviderManager::setConnection(RefPtr<IPC::Connection>&& c
 void RemoteAudioSourceProviderManager::addProvider(Ref<RemoteAudioSourceProvider>&& provider)
 {
     ASSERT(WTF::isMainRunLoop());
-    setConnection(WebProcess::singleton().ensureGPUProcessConnection().connection());
+    setConnection(WebProcess::singleton().ensureGPUProcessConnection()->connection());
 
     m_queue->dispatch([this, protectedThis = Ref { *this }, provider = WTFMove(provider)]() mutable {
         auto identifier = provider->identifier();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
@@ -59,7 +59,7 @@ RemoteCDM::RemoteCDM(WeakPtr<RemoteCDMFactory>&& factory, RemoteCDMIdentifier&& 
 void RemoteCDM::setLogIdentifier(uint64_t logIdentifier)
 {
     if (RefPtr factory = m_factory.get())
-        factory->gpuProcessConnection().connection().send(Messages::RemoteCDMProxy::SetLogIdentifier(logIdentifier), m_identifier);
+        factory->gpuProcessConnection()->connection().send(Messages::RemoteCDMProxy::SetLogIdentifier(logIdentifier), m_identifier);
 }
 #endif
 
@@ -71,7 +71,7 @@ void RemoteCDM::getSupportedConfiguration(CDMKeySystemConfiguration&& configurat
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMProxy::GetSupportedConfiguration(WTFMove(configuration), access), WTFMove(callback), m_identifier);
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMProxy::GetSupportedConfiguration(WTFMove(configuration), access), WTFMove(callback), m_identifier);
 }
 
 bool RemoteCDM::supportsConfiguration(const CDMKeySystemConfiguration&) const
@@ -122,7 +122,7 @@ RefPtr<CDMInstance> RemoteCDM::createInstance()
     if (!factory)
         return nullptr;
 
-    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMProxy::CreateInstance(), m_identifier);
+    auto sendResult = factory->gpuProcessConnection()->connection().sendSync(Messages::RemoteCDMProxy::CreateInstance(), m_identifier);
     auto [identifier, configuration] = sendResult.takeReplyOr(std::nullopt, RemoteCDMInstanceConfiguration { });
     if (!identifier)
         return nullptr;
@@ -132,7 +132,7 @@ RefPtr<CDMInstance> RemoteCDM::createInstance()
 void RemoteCDM::loadAndInitialize()
 {
     if (RefPtr factory = m_factory.get())
-        factory->gpuProcessConnection().connection().send(Messages::RemoteCDMProxy::LoadAndInitialize(), m_identifier);
+        factory->gpuProcessConnection()->connection().send(Messages::RemoteCDMProxy::LoadAndInitialize(), m_identifier);
 }
 
 RefPtr<SharedBuffer> RemoteCDM::sanitizeResponse(const SharedBuffer& response) const

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -69,21 +69,21 @@ ASCIILiteral RemoteCDMFactory::supplementName()
     return "RemoteCDMFactory"_s;
 }
 
-GPUProcessConnection& RemoteCDMFactory::gpuProcessConnection()
+Ref<GPUProcessConnection> RemoteCDMFactory::gpuProcessConnection()
 {
     return WebProcess::singleton().ensureGPUProcessConnection();
 }
 
 bool RemoteCDMFactory::supportsKeySystem(const String& keySystem)
 {
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteCDMFactoryProxy::SupportsKeySystem(keySystem), { });
+    auto sendResult = gpuProcessConnection()->connection().sendSync(Messages::RemoteCDMFactoryProxy::SupportsKeySystem(keySystem), { });
     auto [supported] = sendResult.takeReplyOr(false);
     return supported;
 }
 
 std::unique_ptr<CDMPrivate> RemoteCDMFactory::createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&)
 {
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteCDMFactoryProxy::CreateCDM(keySystem, mediaKeysHashSalt), { });
+    auto sendResult = gpuProcessConnection()->connection().sendSync(Messages::RemoteCDMFactoryProxy::CreateCDM(keySystem, mediaKeysHashSalt), { });
     auto [identifier, configuration] = sendResult.takeReplyOr(std::nullopt, RemoteCDMConfiguration { });
     if (!identifier)
         return nullptr;
@@ -100,12 +100,12 @@ void RemoteCDMFactory::removeSession(RemoteCDMInstanceSessionIdentifier identifi
 {
     ASSERT(m_sessions.contains(identifier));
     m_sessions.remove(identifier);
-    gpuProcessConnection().connection().send(Messages::RemoteCDMFactoryProxy::RemoveSession(identifier), { });
+    gpuProcessConnection()->connection().send(Messages::RemoteCDMFactoryProxy::RemoveSession(identifier), { });
 }
 
 void RemoteCDMFactory::removeInstance(RemoteCDMInstanceIdentifier identifier)
 {
-    gpuProcessConnection().connection().send(Messages::RemoteCDMFactoryProxy::RemoveInstance(identifier), { });
+    gpuProcessConnection()->connection().send(Messages::RemoteCDMFactoryProxy::RemoveInstance(identifier), { });
 }
 
 void RemoteCDMFactory::didReceiveSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -66,7 +66,7 @@ public:
 
     static ASCIILiteral supplementName();
 
-    GPUProcessConnection& gpuProcessConnection();
+    Ref<GPUProcessConnection> gpuProcessConnection();
 
     void registerFactory(Vector<WebCore::CDMFactory*>&);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
@@ -51,7 +51,7 @@ RemoteCDMInstance::RemoteCDMInstance(WeakPtr<RemoteCDMFactory>&& factory, Remote
     , m_configuration(WTFMove(configuration))
 {
     if (RefPtr factory = m_factory.get())
-        factory->gpuProcessConnection().messageReceiverMap().addMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64(), *this);
+        factory->gpuProcessConnection()->messageReceiverMap().addMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64(), *this);
 }
 
 RemoteCDMInstance::~RemoteCDMInstance()
@@ -61,7 +61,7 @@ RemoteCDMInstance::~RemoteCDMInstance()
         return;
 
     factory->removeInstance(m_identifier);
-    factory->gpuProcessConnection().messageReceiverMap().removeMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64());
+    factory->gpuProcessConnection()->messageReceiverMap().removeMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteCDMInstance::unrequestedInitializationDataReceived(const String& type, Ref<SharedBuffer>&& initData)
@@ -78,7 +78,7 @@ void RemoteCDMInstance::initializeWithConfiguration(const WebCore::CDMKeySystemC
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::InitializeWithConfiguration(configuration, distinctiveIdentifiers, persistentState), WTFMove(callback), m_identifier);
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::InitializeWithConfiguration(configuration, distinctiveIdentifiers, persistentState), WTFMove(callback), m_identifier);
 }
 
 void RemoteCDMInstance::setServerCertificate(Ref<WebCore::SharedBuffer>&& certificate, SuccessCallback&& callback)
@@ -89,13 +89,13 @@ void RemoteCDMInstance::setServerCertificate(Ref<WebCore::SharedBuffer>&& certif
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::SetServerCertificate(WTFMove(certificate)), WTFMove(callback), m_identifier);
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::SetServerCertificate(WTFMove(certificate)), WTFMove(callback), m_identifier);
 }
 
 void RemoteCDMInstance::setStorageDirectory(const String& directory)
 {
     if (RefPtr factory = m_factory.get())
-        factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceProxy::SetStorageDirectory(directory), m_identifier);
+        factory->gpuProcessConnection()->connection().send(Messages::RemoteCDMInstanceProxy::SetStorageDirectory(directory), m_identifier);
 }
 
 RefPtr<WebCore::CDMInstanceSession> RemoteCDMInstance::createSession()
@@ -110,7 +110,7 @@ RefPtr<WebCore::CDMInstanceSession> RemoteCDMInstance::createSession()
         logIdentifier = reinterpret_cast<uint64_t>(client->logIdentifier());
 #endif
 
-    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMInstanceProxy::CreateSession(logIdentifier), m_identifier);
+    auto sendResult = factory->gpuProcessConnection()->connection().sendSync(Messages::RemoteCDMInstanceProxy::CreateSession(logIdentifier), m_identifier);
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
@@ -61,7 +61,7 @@ RefPtr<RemoteCDMFactory> RemoteCDMInstanceSession::protectedFactory() const
 #if !RELEASE_LOG_DISABLED
 void RemoteCDMInstanceSession::setLogIdentifier(uint64_t logIdentifier)
 {
-    protectedFactory()->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
+    protectedFactory()->gpuProcessConnection()->connection().send(Messages::RemoteCDMInstanceSessionProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
 }
 #endif
 
@@ -73,7 +73,7 @@ void RemoteCDMInstanceSession::requestLicense(LicenseType type, KeyGroupingStrat
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RequestLicense(type, keyGroupingStrategy, initDataType, WTFMove(initData)), [callback = WTFMove(callback)] (RefPtr<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, bool succeeded) mutable {
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RequestLicense(type, keyGroupingStrategy, initDataType, WTFMove(initData)), [callback = WTFMove(callback)] (RefPtr<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, bool succeeded) mutable {
         if (!message) {
             callback(SharedBuffer::create(), emptyString(), false, Failed);
             return;
@@ -90,7 +90,7 @@ void RemoteCDMInstanceSession::updateLicense(const String& sessionId, LicenseTyp
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::UpdateLicense(sessionId, type, WTFMove(response)), [callback = WTFMove(callback)] (bool sessionWasClosed, std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded) mutable {
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::UpdateLicense(sessionId, type, WTFMove(response)), [callback = WTFMove(callback)] (bool sessionWasClosed, std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded) mutable {
         callback(sessionWasClosed, WTFMove(changedKeys), WTFMove(changedExpiration), WTFMove(message), succeeded ? Succeeded : Failed);
     }, m_identifier);
 }
@@ -103,7 +103,7 @@ void RemoteCDMInstanceSession::loadSession(LicenseType type, const String& sessi
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::LoadSession(type, sessionId, origin), [callback = WTFMove(callback)] (std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded, SessionLoadFailure loadFailure) mutable {
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::LoadSession(type, sessionId, origin), [callback = WTFMove(callback)] (std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded, SessionLoadFailure loadFailure) mutable {
         callback(WTFMove(changedKeys), WTFMove(changedExpiration), WTFMove(message), succeeded ? Succeeded : Failed, loadFailure);
     }, m_identifier);
 }
@@ -116,7 +116,7 @@ void RemoteCDMInstanceSession::closeSession(const String& sessionId, CloseSessio
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::CloseSession(sessionId), [callback = WTFMove(callback)] () mutable {
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::CloseSession(sessionId), [callback = WTFMove(callback)] () mutable {
         callback();
     }, m_identifier);
 }
@@ -129,7 +129,7 @@ void RemoteCDMInstanceSession::removeSessionData(const String& sessionId, Licens
         return;
     }
 
-    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RemoveSessionData(sessionId, type), [callback = WTFMove(callback)] (KeyStatusVector&& changedKeys, RefPtr<SharedBuffer>&& message, bool succeeded) mutable {
+    factory->gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RemoveSessionData(sessionId, type), [callback = WTFMove(callback)] (KeyStatusVector&& changedKeys, RefPtr<SharedBuffer>&& message, bool succeeded) mutable {
         callback(WTFMove(changedKeys), WTFMove(message), succeeded ? Succeeded : Failed);
     }, m_identifier);
 }
@@ -137,7 +137,7 @@ void RemoteCDMInstanceSession::removeSessionData(const String& sessionId, Licens
 void RemoteCDMInstanceSession::storeRecordOfKeyUsage(const String& sessionId)
 {
     if (RefPtr factory = m_factory.get())
-        factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::StoreRecordOfKeyUsage(sessionId), m_identifier);
+        factory->gpuProcessConnection()->connection().send(Messages::RemoteCDMInstanceSessionProxy::StoreRecordOfKeyUsage(sessionId), m_identifier);
 }
 
 void RemoteCDMInstanceSession::updateKeyStatuses(KeyStatusVector&& keyStatuses)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -47,7 +47,7 @@ RefPtr<RemoteImageDecoderAVF> RemoteImageDecoderAVFManager::createImageDecoder(F
     if (!WebProcess::singleton().mediaPlaybackEnabled())
         return nullptr;
 
-    auto sendResult = ensureGPUProcessConnection().connection().sendSync(Messages::RemoteImageDecoderAVFProxy::CreateDecoder(IPC::SharedBufferReference(data), mimeType), 0);
+    auto sendResult = ensureGPUProcessConnection()->connection().sendSync(Messages::RemoteImageDecoderAVFProxy::CreateDecoder(IPC::SharedBufferReference(data), mimeType), 0);
     auto [imageDecoderIdentifier] = sendResult.takeReplyOr(std::nullopt);
     if (!imageDecoderIdentifier)
         return nullptr;
@@ -87,16 +87,16 @@ void RemoteImageDecoderAVFManager::gpuProcessConnectionDidClose(GPUProcessConnec
     // FIXME: Do we need to do more when m_remoteImageDecoders is not empty to re-create them?
 }
 
-GPUProcessConnection& RemoteImageDecoderAVFManager::ensureGPUProcessConnection()
+Ref<GPUProcessConnection> RemoteImageDecoderAVFManager::ensureGPUProcessConnection()
 {
-    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    RefPtr<GPUProcessConnection> gpuProcessConnection = m_gpuProcessConnection.get();
     if (!gpuProcessConnection) {
         gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName(), *this);
+        m_gpuProcessConnection = gpuProcessConnection;
     }
-    return *gpuProcessConnection.unsafeGet();
+    return *gpuProcessConnection;
 }
 
 void RemoteImageDecoderAVFManager::setUseGPUProcess(bool useGPUProcess)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -54,7 +54,7 @@ public:
     void deleteRemoteImageDecoder(const WebCore::ImageDecoderIdentifier&);
 
     void setUseGPUProcess(bool);
-    GPUProcessConnection& ensureGPUProcessConnection();
+    Ref<GPUProcessConnection> ensureGPUProcessConnection();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
@@ -55,7 +55,7 @@ Ref<RemoteLegacyCDMFactory> RemoteLegacyCDM::protectedFactory() const
 
 bool RemoteLegacyCDM::supportsMIMEType(const String& mimeType) const
 {
-    auto sendResult = protectedFactory()->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::SupportsMIMEType(mimeType), m_identifier);
+    auto sendResult = protectedFactory()->gpuProcessConnection()->connection().sendSync(Messages::RemoteLegacyCDMProxy::SupportsMIMEType(mimeType), m_identifier);
     auto [supported] = sendResult.takeReplyOr(false);
     return supported;
 }
@@ -68,7 +68,7 @@ RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::Legacy
 #endif
 
     Ref factory = m_factory.get();
-    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(logIdentifier), m_identifier);
+    auto sendResult = factory->gpuProcessConnection()->connection().sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(logIdentifier), m_identifier);
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
@@ -77,7 +77,7 @@ RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::Legacy
 
 void RemoteLegacyCDM::setPlayerId(std::optional<MediaPlayerIdentifier> identifier)
 {
-    protectedFactory()->gpuProcessConnection().connection().send(Messages::RemoteLegacyCDMProxy::SetPlayerId(identifier), m_identifier);
+    protectedFactory()->gpuProcessConnection()->connection().send(Messages::RemoteLegacyCDMProxy::SetPlayerId(identifier), m_identifier);
 }
 
 void RemoteLegacyCDM::ref() const

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -83,7 +83,7 @@ ASCIILiteral RemoteLegacyCDMFactory::supplementName()
     return "RemoteLegacyCDMFactory"_s;
 }
 
-GPUProcessConnection& RemoteLegacyCDMFactory::gpuProcessConnection()
+Ref<GPUProcessConnection> RemoteLegacyCDMFactory::gpuProcessConnection()
 {
     return WebProcess::singleton().ensureGPUProcessConnection();
 }
@@ -94,7 +94,7 @@ bool RemoteLegacyCDMFactory::supportsKeySystem(const String& keySystem)
     if (foundInCache != m_supportsKeySystemCache.end())
         return foundInCache->value;
 
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, std::nullopt), { });
+    auto sendResult = gpuProcessConnection()->connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, std::nullopt), { });
     auto [supported] = sendResult.takeReplyOr(false);
     m_supportsKeySystemCache.set(keySystem, supported);
     return supported;
@@ -107,7 +107,7 @@ bool RemoteLegacyCDMFactory::supportsKeySystemAndMimeType(const String& keySyste
     if (foundInCache != m_supportsKeySystemAndMimeTypeCache.end())
         return foundInCache->value;
 
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, mimeType), { });
+    auto sendResult = gpuProcessConnection()->connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, mimeType), { });
     auto [supported] = sendResult.takeReplyOr(false);
     m_supportsKeySystemAndMimeTypeCache.set(key, supported);
     return supported;
@@ -134,17 +134,17 @@ void RemoteLegacyCDMFactory::addSession(RemoteLegacyCDMSessionIdentifier identif
     ASSERT(!m_sessions.contains(identifier));
     m_sessions.set(identifier, WeakPtr { session });
 
-    gpuProcessConnection().messageReceiverMap().addMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64(), session);
+    gpuProcessConnection()->messageReceiverMap().addMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64(), session);
 }
 
 void RemoteLegacyCDMFactory::removeSession(RemoteLegacyCDMSessionIdentifier identifier)
 {
     ASSERT(m_sessions.contains(identifier));
     RefPtr session = m_sessions.get(identifier).get();
-    gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteLegacyCDMFactoryProxy::RemoveSession(identifier), [protectedThis = Ref { *this }, identifier, session = WTFMove(session)] {
+    gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteLegacyCDMFactoryProxy::RemoveSession(identifier), [protectedThis = Ref { *this }, identifier, session = WTFMove(session)] {
         ASSERT(protectedThis->m_sessions.contains(identifier));
         protectedThis->m_sessions.remove(identifier);
-        protectedThis->gpuProcessConnection().messageReceiverMap().removeMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64());
+        protectedThis->gpuProcessConnection()->messageReceiverMap().removeMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64());
         UNUSED_PARAM(session);
     }, { });
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -69,7 +69,7 @@ public:
 
     static ASCIILiteral supplementName();
 
-    GPUProcessConnection& gpuProcessConnection();
+    Ref<GPUProcessConnection> gpuProcessConnection();
 
     void addSession(RemoteLegacyCDMSessionIdentifier, RemoteLegacyCDMSession&);
     void removeSession(RemoteLegacyCDMSessionIdentifier);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -103,7 +103,7 @@ RefPtr<Uint8Array> RemoteLegacyCDMSession::generateKeyRequest(const String& mime
         return nullptr;
 
     auto ipcInitData = convertToSharedBuffer(initData);
-    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMSessionProxy::GenerateKeyRequest(mimeType, ipcInitData, m_client->mediaKeysHashSalt()), m_identifier);
+    auto sendResult = factory->gpuProcessConnection()->connection().sendSync(Messages::RemoteLegacyCDMSessionProxy::GenerateKeyRequest(mimeType, ipcInitData, m_client->mediaKeysHashSalt()), m_identifier);
 
     RefPtr<SharedBuffer> ipcNextMessage;
     if (sendResult.succeeded())
@@ -121,7 +121,7 @@ void RemoteLegacyCDMSession::releaseKeys()
     if (!factory)
         return;
 
-    factory->gpuProcessConnection().connection().send(Messages::RemoteLegacyCDMSessionProxy::ReleaseKeys(), m_identifier);
+    factory->gpuProcessConnection()->connection().send(Messages::RemoteLegacyCDMSessionProxy::ReleaseKeys(), m_identifier);
     m_cachedKeyCache.clear();
 }
 
@@ -135,7 +135,7 @@ bool RemoteLegacyCDMSession::update(Uint8Array* keyData, RefPtr<Uint8Array>& nex
         return false;
 
     auto ipcKeyData = convertToSharedBuffer(keyData);
-    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMSessionProxy::Update(ipcKeyData), m_identifier);
+    auto sendResult = factory->gpuProcessConnection()->connection().sendSync(Messages::RemoteLegacyCDMSessionProxy::Update(ipcKeyData), m_identifier);
 
     bool succeeded { false };
     RefPtr<SharedBuffer> ipcNextMessage;
@@ -158,7 +158,7 @@ RefPtr<ArrayBuffer> RemoteLegacyCDMSession::cachedKeyForKeyID(const String& keyI
     if (foundInCache != m_cachedKeyCache.end())
         return foundInCache->value;
 
-    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMSessionProxy::CachedKeyForKeyID(keyId), m_identifier);
+    auto sendResult = factory->gpuProcessConnection()->connection().sendSync(Messages::RemoteLegacyCDMSessionProxy::CachedKeyForKeyID(keyId), m_identifier);
     auto [ipcKey] = sendResult.takeReplyOr(nullptr);
 
     if (!ipcKey)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
@@ -84,7 +84,7 @@ ASCIILiteral RemoteMediaEngineConfigurationFactory::supplementName()
     return "RemoteMediaEngineConfigurationFactory"_s;
 }
 
-GPUProcessConnection& RemoteMediaEngineConfigurationFactory::gpuProcessConnection()
+Ref<GPUProcessConnection> RemoteMediaEngineConfigurationFactory::gpuProcessConnection()
 {
     return WebProcess::singleton().ensureGPUProcessConnection();
 }
@@ -94,7 +94,7 @@ void RemoteMediaEngineConfigurationFactory::createDecodingConfiguration(MediaDec
     if (!m_webProcess->mediaPlaybackEnabled())
         return callback({ });
 
-    gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteMediaEngineConfigurationFactoryProxy::CreateDecodingConfiguration(WTFMove(configuration)), [callback = WTFMove(callback)] (MediaCapabilitiesDecodingInfo&& info) mutable {
+    gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteMediaEngineConfigurationFactoryProxy::CreateDecodingConfiguration(WTFMove(configuration)), [callback = WTFMove(callback)] (MediaCapabilitiesDecodingInfo&& info) mutable {
         callback(WTFMove(info));
     });
 }
@@ -104,7 +104,7 @@ void RemoteMediaEngineConfigurationFactory::createEncodingConfiguration(MediaEnc
     if (!m_webProcess->mediaPlaybackEnabled())
         return callback({ });
 
-    gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteMediaEngineConfigurationFactoryProxy::CreateEncodingConfiguration(WTFMove(configuration)), [callback = WTFMove(callback)] (MediaCapabilitiesEncodingInfo&& info) mutable {
+    gpuProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteMediaEngineConfigurationFactoryProxy::CreateEncodingConfiguration(WTFMove(configuration)), [callback = WTFMove(callback)] (MediaCapabilitiesEncodingInfo&& info) mutable {
         callback(WTFMove(info));
     });
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
@@ -61,7 +61,7 @@ public:
 
     static ASCIILiteral supplementName();
 
-    GPUProcessConnection& gpuProcessConnection();
+    Ref<GPUProcessConnection> gpuProcessConnection();
 
     void didReceiveSessionMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -59,7 +59,7 @@ HashSet<String>& RemoteMediaPlayerMIMETypeCache::supportedTypes()
 {
     ASSERT(isMainRunLoop());
     if (!m_hasPopulatedSupportedTypesCacheFromGPUProcess) {
-        auto sendResult = protectedManager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::GetSupportedTypes(m_engineIdentifier), 0);
+        auto sendResult = protectedManager()->gpuProcessConnection()->connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::GetSupportedTypes(m_engineIdentifier), 0);
         if (sendResult.succeeded()) {
             auto& [types] = sendResult.reply();
             addSupportedTypes(types);
@@ -86,7 +86,7 @@ MediaPlayerEnums::SupportsType RemoteMediaPlayerMIMETypeCache::supportsTypeAndCo
     if (!m_supportsTypeAndCodecsCache)
         m_supportsTypeAndCodecsCache = HashMap<SupportedTypesAndCodecsKey, MediaPlayerEnums::SupportsType> { };
 
-    auto sendResult = protectedManager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::SupportsTypeAndCodecs(m_engineIdentifier, parameters), 0);
+    auto sendResult = protectedManager()->gpuProcessConnection()->connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::SupportsTypeAndCodecs(m_engineIdentifier, parameters), 0);
     auto [result] = sendResult.takeReplyOr(MediaPlayerEnums::SupportsType::IsNotSupported);
     if (sendResult.succeeded())
         m_supportsTypeAndCodecsCache->add(searchKey, result);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -198,7 +198,7 @@ Ref<MediaPlayerPrivateInterface> RemoteMediaPlayerManager::createRemoteMediaPlay
 
     auto identifier = MediaPlayerIdentifier::generate();
     auto clientIdentifier = player.clientIdentifier();
-    gpuProcessConnection().connection().send(Messages::RemoteMediaPlayerManagerProxy::CreateMediaPlayer(identifier, clientIdentifier, remoteEngineIdentifier, proxyConfiguration), 0);
+    gpuProcessConnection()->connection().send(Messages::RemoteMediaPlayerManagerProxy::CreateMediaPlayer(identifier, clientIdentifier, remoteEngineIdentifier, proxyConfiguration), 0);
 
     auto remotePlayer = MediaPlayerPrivateRemote::create(player, remoteEngineIdentifier, identifier, *this);
     m_players.add(identifier, remotePlayer.get());
@@ -209,7 +209,7 @@ Ref<MediaPlayerPrivateInterface> RemoteMediaPlayerManager::createRemoteMediaPlay
 void RemoteMediaPlayerManager::deleteRemoteMediaPlayer(MediaPlayerIdentifier identifier)
 {
     m_players.remove(identifier);
-    gpuProcessConnection().connection().send(Messages::RemoteMediaPlayerManagerProxy::DeleteMediaPlayer(identifier), 0);
+    gpuProcessConnection()->connection().send(Messages::RemoteMediaPlayerManagerProxy::DeleteMediaPlayer(identifier), 0);
 }
 
 std::optional<MediaPlayerIdentifier> RemoteMediaPlayerManager::findRemotePlayerId(const MediaPlayerPrivateInterface* player)
@@ -264,31 +264,24 @@ void RemoteMediaPlayerManager::setUseGPUProcess(bool useGPUProcess)
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     if (useGPUProcess) {
         WebCore::SampleBufferDisplayLayer::setCreator([](auto& client) -> RefPtr<WebCore::SampleBufferDisplayLayer> {
-            return WebProcess::singleton().ensureProtectedGPUProcessConnection()->sampleBufferDisplayLayerManager().createLayer(client);
+            return WebProcess::singleton().ensureGPUProcessConnection()->sampleBufferDisplayLayerManager().createLayer(client);
         });
         WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setNativeImageCreator([](auto& videoFrame) {
-            return WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy().getNativeImage(videoFrame);
+            return WebProcess::singleton().ensureGPUProcessConnection()->videoFrameObjectHeapProxy().getNativeImage(videoFrame);
         });
     }
 #endif
 }
 
-GPUProcessConnection& RemoteMediaPlayerManager::gpuProcessConnection()
+Ref<GPUProcessConnection> RemoteMediaPlayerManager::gpuProcessConnection()
 {
     RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
     if (!gpuProcessConnection) {
         gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        m_gpuProcessConnection = gpuProcessConnection;
-        gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
         gpuProcessConnection->addClient(*this);
+        m_gpuProcessConnection = gpuProcessConnection;
     }
-
-    return *gpuProcessConnection.unsafeGet();
-}
-
-Ref<GPUProcessConnection> RemoteMediaPlayerManager::protectedGPUProcessConnection()
-{
-    return gpuProcessConnection();
+    return *gpuProcessConnection;
 }
 
 void RemoteMediaPlayerManager::gpuProcessConnectionDidClose(GPUProcessConnection& connection)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -56,8 +56,7 @@ public:
 
     void setUseGPUProcess(bool);
 
-    GPUProcessConnection& gpuProcessConnection();
-    Ref<GPUProcessConnection> protectedGPUProcessConnection();
+    Ref<GPUProcessConnection> gpuProcessConnection();
 
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
@@ -57,7 +57,7 @@ RemoteRemoteCommandListener::~RemoteRemoteCommandListener()
     }
 }
 
-GPUProcessConnection& RemoteRemoteCommandListener::ensureGPUProcessConnection()
+Ref<GPUProcessConnection> RemoteRemoteCommandListener::ensureGPUProcessConnection()
 {
     RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
     if (!gpuProcessConnection) {
@@ -67,7 +67,7 @@ GPUProcessConnection& RemoteRemoteCommandListener::ensureGPUProcessConnection()
         gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteRemoteCommandListener::messageReceiverName(), identifier().toUInt64(), *this);
         gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateRemoteCommandListener(identifier()), { });
     }
-    return *gpuProcessConnection.unsafeGet();
+    return *gpuProcessConnection;
 }
 
 void RemoteRemoteCommandListener::gpuProcessConnectionDidClose(GPUProcessConnection& gpuProcessConnection)
@@ -95,7 +95,7 @@ void RemoteRemoteCommandListener::updateSupportedCommands()
     m_currentCommands = supportedCommands;
     m_currentSupportSeeking = supportsSeeking();
 
-    ensureGPUProcessConnection().connection().send(Messages::RemoteRemoteCommandListenerProxy::UpdateSupportedCommands { copyToVector(supportedCommands), m_currentSupportSeeking }, identifier());
+    ensureGPUProcessConnection()->connection().send(Messages::RemoteRemoteCommandListenerProxy::UpdateSupportedCommands { copyToVector(supportedCommands), m_currentSupportSeeking }, identifier());
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -68,7 +68,7 @@ private:
     // WebCore::RemoteCommandListener
     void updateSupportedCommands() final;
 
-    GPUProcessConnection& ensureGPUProcessConnection();
+    Ref<GPUProcessConnection> ensureGPUProcessConnection();
 
     WebCore::RemoteCommandListener::RemoteCommandsSet m_currentCommands;
     bool m_currentSupportSeeking { false };

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -74,7 +74,7 @@ Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(const We
 #if ENABLE(VIDEO) && ENABLE(GPU_PROCESS)
 RefPtr<AudioVideoRenderer> WebMediaStrategy::createAudioVideoRenderer(LoggerHelper* loggerHelper, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier) const
 {
-    return AudioVideoRendererRemote::create(loggerHelper, mediaElementIdentifier, playerIdentifier, WebProcess::singleton().ensureProtectedGPUProcessConnection());
+    return AudioVideoRendererRemote::create(loggerHelper, mediaElementIdentifier, playerIdentifier, WebProcess::singleton().ensureGPUProcessConnection());
 }
 #endif
 
@@ -92,7 +92,7 @@ std::unique_ptr<WebCore::NowPlayingManager> WebMediaStrategy::createNowPlayingMa
 
             void setNowPlayingInfoPrivate(const WebCore::NowPlayingInfo& nowPlayingInfo, bool) final
             {
-                Ref connection = WebProcess::singleton().ensureGPUProcessConnection().connection();
+                Ref connection = WebProcess::singleton().ensureGPUProcessConnection()->connection();
                 connection->send(Messages::GPUConnectionToWebProcess::SetNowPlayingInfo { nowPlayingInfo }, 0);
             }
         };
@@ -124,7 +124,7 @@ void WebMediaStrategy::enableMockMediaSource()
     m_mockMediaSourceEnabled = true;
 #if ENABLE(GPU_PROCESS)
     if (m_useGPUProcess) {
-        Ref connection = WebProcess::singleton().ensureGPUProcessConnection().connection();
+        Ref connection = WebProcess::singleton().ensureGPUProcessConnection()->connection();
         connection->send(Messages::GPUConnectionToWebProcess::EnableMockMediaSource { }, 0);
         return;
     }
@@ -137,7 +137,7 @@ void WebMediaStrategy::enableMockMediaSource()
 void WebMediaStrategy::nativeImageFromVideoFrame(const WebCore::VideoFrame& frame, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&& completionHandler)
 {
     // FIMXE: Move out of sync IPC.
-    completionHandler(WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(frame));
+    completionHandler(WebProcess::singleton().ensureGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(frame));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -67,7 +67,7 @@ RefPtr<NativeImage> MediaPlayerPrivateRemote::nativeImageForCurrentTime()
     if (!videoFrame)
         return nullptr;
 
-    return WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
+    return WebProcess::singleton().ensureGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
 }
 
 WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -149,7 +149,7 @@ AudioMediaStreamTrackRendererInternalUnitManagerProxy::AudioMediaStreamTrackRend
 AudioMediaStreamTrackRendererInternalUnitManagerProxy::~AudioMediaStreamTrackRendererInternalUnitManagerProxy()
 {
     WebProcess::singleton().audioMediaStreamTrackRendererInternalUnitManager().remove(*this);
-    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::DeleteUnit { identifier() }, 0);
+    WebProcess::singleton().ensureGPUProcessConnection()->connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::DeleteUnit { identifier() }, 0);
 
     while (!m_descriptionCallbacks.isEmpty())
         m_descriptionCallbacks.takeFirst()(std::nullopt);
@@ -157,7 +157,7 @@ AudioMediaStreamTrackRendererInternalUnitManagerProxy::~AudioMediaStreamTrackRen
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::createRemoteUnit()
 {
-    WebProcess::singleton().ensureGPUProcessConnection().connection().sendWithAsyncReply(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::CreateUnit { identifier(), m_deviceID }, [weakThis = ThreadSafeWeakPtr { *this }](auto&& description, auto frameChunkSize) {
+    WebProcess::singleton().ensureGPUProcessConnection()->connection().sendWithAsyncReply(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::CreateUnit { identifier(), m_deviceID }, [weakThis = ThreadSafeWeakPtr { *this }](auto&& description, auto frameChunkSize) {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && description && frameChunkSize)
             protectedThis->initialize(*description, frameChunkSize);
     }, 0);
@@ -202,7 +202,7 @@ void AudioMediaStreamTrackRendererInternalUnitManagerProxy::start()
     RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
     auto [ringBuffer, handle] = WTFMove(*result);
     m_ringBuffer = WTFMove(ringBuffer);
-    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StartUnit { identifier(), WTFMove(handle), *m_semaphore }, 0);
+    WebProcess::singleton().ensureGPUProcessConnection()->connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StartUnit { identifier(), WTFMove(handle), *m_semaphore }, 0);
 
     m_buffer = makeUnique<WebCore::WebAudioBufferList>(*m_description, m_numberOfFrames);
     m_buffer->setSampleCount(m_frameChunkSize);
@@ -213,7 +213,7 @@ void AudioMediaStreamTrackRendererInternalUnitManagerProxy::start()
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::stop()
 {
     m_isPlaying = false;
-    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StopUnit { identifier() }, 0);
+    WebProcess::singleton().ensureGPUProcessConnection()->connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StopUnit { identifier() }, 0);
 }
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::retrieveFormatDescription(CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>)>&& callback)
@@ -227,7 +227,7 @@ void AudioMediaStreamTrackRendererInternalUnitManagerProxy::retrieveFormatDescri
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::setLastDeviceUsed(const String& deviceID)
 {
-    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::SetLastDeviceUsed { deviceID }, 0);
+    WebProcess::singleton().ensureGPUProcessConnection()->connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::SetLastDeviceUsed { deviceID }, 0);
 }
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::stopThread()

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -237,7 +237,7 @@ void LibWebRTCCodecs::initializeIfNeeded()
     std::call_once(doInitializationOnce, [] {
         callOnMainRunLoopAndWait([] {
 #if HAVE(AUDIT_TOKEN)
-            WebProcess::singleton().ensureProtectedGPUProcessConnection()->auditToken();
+            WebProcess::singleton().ensureGPUProcessConnection()->auditToken();
 #else
             WebProcess::singleton().ensureGPUProcessConnection();
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -150,7 +150,7 @@ void RemoteVideoFrameObjectHeapProxyProcessor::newConvertedVideoFrameBuffer(std:
 
 RefPtr<NativeImage> RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage(const WebCore::VideoFrame& videoFrame)
 {
-    Ref connection = WebProcess::singleton().ensureGPUProcessConnection().connection();
+    Ref connection = WebProcess::singleton().ensureGPUProcessConnection()->connection();
 
     if (m_sharedVideoFrameWriter.isDisabled())
         m_sharedVideoFrameWriter = { };

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -48,7 +48,7 @@ Ref<SampleBufferDisplayLayer> SampleBufferDisplayLayer::create(SampleBufferDispl
 
 SampleBufferDisplayLayer::SampleBufferDisplayLayer(SampleBufferDisplayLayerManager& manager, WebCore::SampleBufferDisplayLayerClient& client)
     : WebCore::SampleBufferDisplayLayer(client)
-    , m_gpuProcessConnection(&WebProcess::singleton().ensureGPUProcessConnection())
+    , m_gpuProcessConnection(WebProcess::singleton().ensureGPUProcessConnection())
     , m_manager(manager)
     , m_connection(m_gpuProcessConnection.get()->connection())
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -141,19 +141,19 @@ void InjectedBundle::postSynchronousMessage(const String& messageName, API::Obje
 void InjectedBundle::addOriginAccessAllowListEntry(const String& sourceOrigin, const String& destinationProtocol, const String& destinationHost, bool allowDestinationSubdomains)
 {
     SecurityPolicy::addOriginAccessAllowlistEntry(SecurityOrigin::createFromString(sourceOrigin).get(), destinationProtocol, destinationHost, allowDestinationSubdomains);
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::AddOriginAccessAllowListEntry { sourceOrigin, destinationProtocol, destinationHost, allowDestinationSubdomains }, 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::AddOriginAccessAllowListEntry { sourceOrigin, destinationProtocol, destinationHost, allowDestinationSubdomains }, 0);
 }
 
 void InjectedBundle::removeOriginAccessAllowListEntry(const String& sourceOrigin, const String& destinationProtocol, const String& destinationHost, bool allowDestinationSubdomains)
 {
     SecurityPolicy::removeOriginAccessAllowlistEntry(SecurityOrigin::createFromString(sourceOrigin).get(), destinationProtocol, destinationHost, allowDestinationSubdomains);
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RemoveOriginAccessAllowListEntry { sourceOrigin, destinationProtocol, destinationHost, allowDestinationSubdomains }, 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RemoveOriginAccessAllowListEntry { sourceOrigin, destinationProtocol, destinationHost, allowDestinationSubdomains }, 0);
 }
 
 void InjectedBundle::resetOriginAccessAllowLists()
 {
     SecurityPolicy::resetOriginAccessAllowlists();
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ResetOriginAccessAllowLists { }, 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::ResetOriginAccessAllowLists { }, 0);
 }
 
 void InjectedBundle::setAsynchronousSpellCheckingEnabled(bool enabled)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -72,13 +72,13 @@ ModelProcessModelPlayer::~ModelProcessModelPlayer()
 template<typename T>
 ALWAYS_INLINE void ModelProcessModelPlayer::send(T&& message)
 {
-    WebProcess::singleton().modelProcessModelPlayerManager().modelProcessConnection().connection().send(std::forward<T>(message), m_id);
+    WebProcess::singleton().modelProcessModelPlayerManager().modelProcessConnection()->connection().send(std::forward<T>(message), m_id);
 }
 
 template<typename T, typename C>
 ALWAYS_INLINE void ModelProcessModelPlayer::sendWithAsyncReply(T&& message, C&& completionHandler)
 {
-    WebProcess::singleton().modelProcessModelPlayerManager().modelProcessConnection().connection().sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), m_id);
+    WebProcess::singleton().modelProcessModelPlayerManager().modelProcessConnection()->connection().sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), m_id);
 }
 
 bool ModelProcessModelPlayer::modelProcessEnabled() const

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
@@ -51,23 +51,21 @@ ModelProcessModelPlayerManager::ModelProcessModelPlayerManager() = default;
 
 ModelProcessModelPlayerManager::~ModelProcessModelPlayerManager() = default;
 
-ModelProcessConnection& ModelProcessModelPlayerManager::modelProcessConnection()
+Ref<ModelProcessConnection> ModelProcessModelPlayerManager::modelProcessConnection()
 {
-    RefPtr modelProcessConnection = m_modelProcessConnection.get();
+    Ref<ModelProcessConnection> modelProcessConnection = m_modelProcessConnection.get();
     if (!modelProcessConnection) {
         modelProcessConnection = WebProcess::singleton().ensureModelProcessConnection();
         m_modelProcessConnection = modelProcessConnection;
-        modelProcessConnection = WebProcess::singleton().ensureModelProcessConnection();
         modelProcessConnection->addClient(*this);
     }
-
-    return *modelProcessConnection.unsafeGet();
+    return *modelProcessConnection;
 }
 
 Ref<ModelProcessModelPlayer> ModelProcessModelPlayerManager::createModelProcessModelPlayer(WebPage& page, WebCore::ModelPlayerClient& client)
 {
     auto identifier = WebCore::ModelPlayerIdentifier::generate();
-    modelProcessConnection().connection().send(Messages::ModelProcessModelPlayerManagerProxy::CreateModelPlayer(identifier), 0);
+    modelProcessConnection()->connection().send(Messages::ModelProcessModelPlayerManagerProxy::CreateModelPlayer(identifier), 0);
 
     auto player = ModelProcessModelPlayer::create(identifier, page, client);
     if (page.shouldDisableModelLoadDelaysForTesting())
@@ -88,7 +86,7 @@ void ModelProcessModelPlayerManager::deleteModelProcessModelPlayer(WebCore::Mode
     m_players.take(identifier);
     if (previousPlayerCount && !m_players.size())
         WebProcess::singleton().send(Messages::WebProcessPool::StoppedPlayingModels(), 0);
-    modelProcessConnection().connection().send(Messages::ModelProcessModelPlayerManagerProxy::DeleteModelPlayer(identifier), 0);
+    modelProcessConnection()->connection().send(Messages::ModelProcessModelPlayerManagerProxy::DeleteModelPlayer(identifier), 0);
 }
 
 void ModelProcessModelPlayerManager::didReceivePlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
@@ -49,7 +49,7 @@ public:
     static Ref<ModelProcessModelPlayerManager> create();
     ~ModelProcessModelPlayerManager();
 
-    ModelProcessConnection& modelProcessConnection();
+    Ref<ModelProcessConnection> modelProcessConnection();
 
     Ref<ModelProcessModelPlayer> createModelProcessModelPlayer(WebPage&, WebCore::ModelPlayerClient&);
     void deleteModelProcessModelPlayer(WebCore::ModelPlayer&);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -609,7 +609,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WEBLOADERSTRATEGY_SCHEDULELOAD_RESOURCE_SCHEDULED_WITH_NETWORKPROCESS, static_cast<int>(resourceLoader.request().priority()), existingNetworkResourceLoadIdentifierToResume ? existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
 
     loadParameters.isInitiatedByDedicatedWorker = resourceLoader.options().initiatorContext == InitiatorContext::Worker && std::holds_alternative<std::monostate>(resourceLoader.options().workerIdentifier);
-    if (WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(WTFMove(loadParameters), existingNetworkResourceLoadIdentifierToResume), 0) != IPC::Error::NoError) {
+    if (WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(WTFMove(loadParameters), existingNetworkResourceLoadIdentifierToResume), 0) != IPC::Error::NoError) {
         WEBLOADERSTRATEGY_RELEASE_LOG_ERROR("scheduleLoad: Unable to schedule resource with the NetworkProcess (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
         // We probably failed to schedule this load with the NetworkProcess because it had crashed.
         // This load will never succeed so we will schedule it to fail asynchronously.
@@ -866,7 +866,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     HangDetectionDisabler hangDetectionDisabler;
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::PerformSynchronousLoad(WTFMove(loadParameters)), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::PerformSynchronousLoad(WTFMove(loadParameters)), 0);
     if (!sendResult.succeeded()) {
         WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: failed sending synchronous network process message %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()).characters());
         if (page)
@@ -948,7 +948,7 @@ void WebLoaderStrategy::startPingLoad(LocalFrame& frame, ResourceRequest& reques
     if (completionHandler)
         m_pingLoadCompletionHandlers.add(*loadParameters.identifier, WTFMove(completionHandler));
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::LoadPing { WTFMove(loadParameters) }, 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::LoadPing { WTFMove(loadParameters) }, 0);
 }
 
 void WebLoaderStrategy::didFinishPingLoad(WebCore::ResourceLoaderIdentifier pingLoadIdentifier, ResourceError&& error, ResourceResponse&& response)
@@ -1025,7 +1025,7 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
 
     // FIXME: Use sendWithAsyncReply instead of preconnectionIdentifier
     // FIXME: don't use WebCore::ResourceLoaderIdentifier for a preconnection identifier, too. It should have its own type.
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::PreconnectTo(preconnectionIdentifier, WTFMove(parameters)), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::PreconnectTo(preconnectionIdentifier, WTFMove(parameters)), 0);
 }
 
 void WebLoaderStrategy::didFinishPreconnection(WebCore::ResourceLoaderIdentifier preconnectionIdentifier, ResourceError&& error)
@@ -1057,7 +1057,7 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
         return;
     }
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::IsResourceLoadFinished(*resource.loader()->identifier()), WTFMove(callback), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::IsResourceLoadFinished(*resource.loader()->identifier()), WTFMove(callback), 0);
 }
 
 void WebLoaderStrategy::setOnLineState(bool isOnLine)
@@ -1072,26 +1072,26 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
 
 void WebLoaderStrategy::setCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetCaptureExtraNetworkLoadMetricsEnabled(enabled), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::SetCaptureExtraNetworkLoadMetricsEnabled(enabled), 0);
 }
 
 ResourceResponse WebLoaderStrategy::responseFromResourceLoadIdentifier(ResourceLoaderIdentifier resourceLoadIdentifier)
 {
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::GetNetworkLoadInformationResponse { resourceLoadIdentifier }, 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::GetNetworkLoadInformationResponse { resourceLoadIdentifier }, 0);
     auto [response] = sendResult.takeReplyOr(ResourceResponse { });
     return response;
 }
 
 Vector<NetworkTransactionInformation> WebLoaderStrategy::intermediateLoadInformationFromResourceLoadIdentifier(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier)
 {
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::GetNetworkLoadIntermediateInformation { resourceLoadIdentifier }, 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::GetNetworkLoadIntermediateInformation { resourceLoadIdentifier }, 0);
     auto [information] = sendResult.takeReplyOr(Vector<NetworkTransactionInformation> { });
     return information;
 }
 
 NetworkLoadMetrics WebLoaderStrategy::networkMetricsFromResourceLoadIdentifier(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier)
 {
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::TakeNetworkLoadInformationMetrics { resourceLoadIdentifier }, 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::TakeNetworkLoadInformationMetrics { resourceLoadIdentifier }, 0);
     auto [networkMetrics] = sendResult.takeReplyOr(NetworkLoadMetrics { });
     return networkMetrics;
 }
@@ -1125,7 +1125,7 @@ bool WebLoaderStrategy::havePerformedSecurityChecks(const ResourceResponse& resp
 
 void WebLoaderStrategy::setResourceLoadSchedulingMode(WebCore::Page& page, WebCore::LoadSchedulingMode mode)
 {
-    auto& connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    Ref connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
     connection.send(Messages::NetworkConnectionToWebProcess::SetResourceLoadSchedulingMode(WebPage::fromCorePage(page)->identifier(), mode), 0);
 }
 
@@ -1135,7 +1135,7 @@ void WebLoaderStrategy::prioritizeResourceLoads(const Vector<WebCore::Subresourc
         return *loader->identifier();
     });
 
-    auto& connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    Ref connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
     connection.send(Messages::NetworkConnectionToWebProcess::PrioritizeResourceLoads(identifiers), 0);
 }
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -88,7 +88,7 @@ WebResourceLoader::~WebResourceLoader() = default;
 
 IPC::Connection* WebResourceLoader::messageSenderConnection() const
 {
-    return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    return &WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 uint64_t WebResourceLoader::messageSenderDestinationID() const

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -101,7 +101,7 @@ WebSocketChannel::~WebSocketChannel()
 
 IPC::Connection* WebSocketChannel::messageSenderConnection() const
 {
-    return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    return &WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 uint64_t WebSocketChannel::messageSenderDestinationID() const

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
@@ -52,7 +52,7 @@ WebSocketProvider::~WebSocketProvider() = default;
 
 WebSocketProvider::WebSocketProvider(WebPageProxyIdentifier webPageProxyID)
     : m_webPageProxyID(webPageProxyID)
-    , m_networkProcessConnection(WebProcess::singleton().ensureNetworkProcessConnection().connection()) { }
+    , m_networkProcessConnection(WebProcess::singleton().ensureNetworkProcessConnection()->connection()) { }
 
 std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebTransportSessionPromise>> WebSocketProvider::initializeWebTransportSession(ScriptExecutionContext& context, WebTransportSessionClient& client, const URL& url, const WebCore::WebTransportOptions& options)
 {
@@ -69,7 +69,7 @@ std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebTransportSessionPromise>>
             WorkQueue::mainSingleton().dispatchSync([protectedThis = Ref { *this }] {
                 ASSERT(RunLoop::isMain());
                 Locker locker { protectedThis->m_networkProcessConnectionLock };
-                protectedThis->m_networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+                protectedThis->m_networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
             });
             connection = getConnection();
         }
@@ -81,7 +81,7 @@ std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebTransportSessionPromise>>
 
     Ref document = downcast<Document>(context);
     ASSERT(RunLoop::isMain());
-    auto [session, promise] = WebKit::WebTransportSession::initialize(WebProcess::singleton().ensureNetworkProcessConnection().connection(), client, url, options, m_webPageProxyID, document->clientOrigin());
+    auto [session, promise] = WebKit::WebTransportSession::initialize(WebProcess::singleton().ensureNetworkProcessConnection()->connection(), client, url, options, m_webPageProxyID, document->clientOrigin());
     return { WTFMove(session), WTFMove(promise) };
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -170,7 +170,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
                     .isRelayDisabled = true,
                     .enableServiceClass = false
                 };
-                WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkRTCProvider::GetInterfaceName { document->url(), webPage->webPageProxyIdentifier(), flags, WTFMove(domain) }, [weakThis = WeakPtr { *this }] (auto&& interfaceName) {
+                WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkRTCProvider::GetInterfaceName { document->url(), webPage->webPageProxyIdentifier(), flags, WTFMove(domain) }, [weakThis = WeakPtr { *this }] (auto&& interfaceName) {
                     RefPtr protectedThis = weakThis.get();
                     if (protectedThis && !interfaceName.isNull())
                         protectedThis->signalUsedInterface(WTFMove(interfaceName));

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCResolver);
 void LibWebRTCResolver::sendOnMainThread(Function<void(IPC::Connection&)>&& callback)
 {
     callOnMainRunLoop([callback = WTFMove(callback)]() {
-        Ref networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        Ref networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         callback(networkProcessConnection);
     });
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -53,7 +53,7 @@ RTCDataChannelRemoteManager& RTCDataChannelRemoteManager::singleton()
 
 RTCDataChannelRemoteManager::RTCDataChannelRemoteManager()
     : m_queue(WorkQueue::create("RTCDataChannelRemoteManager"_s))
-    , m_connection(WebProcess::singleton().ensureNetworkProcessConnection().connection())
+    , m_connection(WebProcess::singleton().ensureNetworkProcessConnection()->connection())
 {
 }
 
@@ -178,7 +178,7 @@ Ref<RTCDataChannelRemoteManager::RemoteHandlerConnection> RTCDataChannelRemoteMa
 }
 
 RTCDataChannelRemoteManager::RemoteHandlerConnection::RemoteHandlerConnection(Ref<WorkQueue>&& queue)
-    : m_connection(WebProcess::singleton().ensureNetworkProcessConnection().connection())
+    : m_connection(WebProcess::singleton().ensureNetworkProcessConnection()->connection())
     , m_queue(WTFMove(queue))
 {
 }
@@ -216,7 +216,7 @@ Ref<RTCDataChannelRemoteManager::RemoteSourceConnection> RTCDataChannelRemoteMan
 }
 
 RTCDataChannelRemoteManager::RemoteSourceConnection::RemoteSourceConnection()
-    : m_connection(WebProcess::singleton().ensureNetworkProcessConnection().connection())
+    : m_connection(WebProcess::singleton().ensureNetworkProcessConnection()->connection())
 {
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
@@ -69,7 +69,7 @@ void WebMDNSRegister::unregisterMDNSNames(ScriptExecutionContextIdentifier ident
     if (m_registeringDocuments.take(identifier).isEmpty())
         return;
 
-    Ref connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    Ref connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
     connection->send(Messages::NetworkMDNSRegister::UnregisterMDNSNames { identifier }, 0);
 }
 
@@ -85,8 +85,8 @@ void WebMDNSRegister::registerMDNSName(ScriptExecutionContextIdentifier identifi
         return;
     }
 
-    auto& connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
-    connection.sendWithAsyncReply(Messages::NetworkMDNSRegister::RegisterMDNSName { identifier, ipAddress }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback), identifier, ipAddress] (String&& mdnsName, std::optional<MDNSRegisterError> error) mutable {
+    Ref connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
+    connection->sendWithAsyncReply(Messages::NetworkMDNSRegister::RegisterMDNSName { identifier, ipAddress }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback), identifier, ipAddress] (String&& mdnsName, std::optional<MDNSRegisterError> error) mutable {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->finishedRegisteringMDNSName(identifier, ipAddress, WTFMove(mdnsName), error, WTFMove(callback));
         else

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp
@@ -59,7 +59,7 @@ void WebRTCMonitor::startUpdating()
 {
     WEBRTC_RELEASE_LOG("StartUpdating - Asking network process to start updating");
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkRTCMonitor::StartUpdatingIfNeeded(), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkRTCMonitor::StartUpdatingIfNeeded(), 0);
     ++m_clientCount;
 }
 
@@ -72,7 +72,7 @@ void WebRTCMonitor::stopUpdating()
         return;
 
     WEBRTC_RELEASE_LOG("StopUpdating - Asking network process to stop updating");
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkRTCMonitor::StopUpdating(), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkRTCMonitor::StopUpdating(), 0);
 }
 
 void WebRTCMonitor::networksChanged(Vector<RTCNetwork>&& networkList, RTCNetwork::IPAddress&& ipv4, RTCNetwork::IPAddress&& ipv6)

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -60,7 +60,7 @@ static bool sendMessage(WebPage* page, NOESCAPE const Function<bool(IPC::Connect
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     if (DeprecatedGlobalSettings::builtInNotificationsEnabled()) {
-        Ref networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        Ref networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         return sendMessage(networkProcessConnection, WebProcess::singleton().sessionID().toUInt64());
     }
 #endif
@@ -158,7 +158,7 @@ NotificationClient::Permission WebNotificationManager::policyForOrigin(const Str
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS) && ENABLE(NOTIFICATIONS)
     if (DeprecatedGlobalSettings::builtInNotificationsEnabled()) {
-        Ref connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        Ref connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         auto origin = SecurityOriginData::fromURL(URL { originString });
         auto result = connection->sendSync(Messages::NotificationManagerMessageHandler::GetPermissionStateSync(WTFMove(origin)), WebProcess::singleton().sessionID().toUInt64());
         if (!result.succeeded())

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -83,7 +83,7 @@ WebSWClientConnection::~WebSWClientConnection()
 
 IPC::Connection* WebSWClientConnection::messageSenderConnection() const
 {
-    return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    return &WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 void WebSWClientConnection::scheduleJobInServer(const ServiceWorkerJobData& jobData)
@@ -525,7 +525,7 @@ Ref<WebSWClientConnection::AddRoutePromise> WebSWClientConnection::addRoutes(Ser
             return makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::TypeError, "Internal error"_s });
         }
     };
-    return WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithPromisedReply<PromiseConverter>(Messages::WebSWServerConnection::AddRoutes { identifier, routes });
+    return WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithPromisedReply<PromiseConverter>(Messages::WebSWServerConnection::AddRoutes { identifier, routes });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp
@@ -51,7 +51,7 @@ WebServiceWorkerProvider::WebServiceWorkerProvider() = default;
 
 WebCore::SWClientConnection& WebServiceWorkerProvider::serviceWorkerConnection()
 {
-    return WebProcess::singleton().ensureProtectedNetworkProcessConnection()->serviceWorkerConnection();
+    return WebProcess::singleton().ensureNetworkProcessConnection()->serviceWorkerConnection();
 }
 
 WebCore::SWClientConnection* WebServiceWorkerProvider::existingServiceWorkerConnection()
@@ -75,7 +75,7 @@ void WebServiceWorkerProvider::updateThrottleState(bool isThrottleable)
 
 void WebServiceWorkerProvider::terminateWorkerForTesting(WebCore::ServiceWorkerIdentifier identifier, CompletionHandler<void()>&& callback)
 {
-    WebProcess::singleton().ensureProtectedNetworkProcessConnection()->protectedServiceWorkerConnection()->terminateWorkerForTesting(identifier, WTFMove(callback));
+    WebProcess::singleton().ensureNetworkProcessConnection()->protectedServiceWorkerConnection()->terminateWorkerForTesting(identifier, WTFMove(callback));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
@@ -52,7 +52,7 @@ WebSharedWorkerObjectConnection::~WebSharedWorkerObjectConnection()
 
 IPC::Connection* WebSharedWorkerObjectConnection::messageSenderConnection() const
 {
-    return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    return &WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 void WebSharedWorkerObjectConnection::requestSharedWorker(const WebCore::SharedWorkerKey& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&& port, const WebCore::WorkerOptions& workerOptions)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.cpp
@@ -42,7 +42,7 @@ WebSharedWorkerProvider::WebSharedWorkerProvider() = default;
 
 WebCore::SharedWorkerObjectConnection* WebSharedWorkerProvider::sharedWorkerConnection()
 {
-    return &WebProcess::singleton().ensureProtectedNetworkProcessConnection()->sharedWorkerConnection();
+    return &WebProcess::singleton().ensureNetworkProcessConnection()->sharedWorkerConnection();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -36,14 +36,9 @@
 
 namespace WebKit {
 
-static inline IPC::Connection& networkProcessConnection()
+static inline Ref<IPC::Connection> networkProcessConnection()
 {
-    return WebProcess::singleton().ensureNetworkProcessConnection().connection();
-}
-
-static inline Ref<IPC::Connection> protectedNetworkProcessConnection()
-{
-    return networkProcessConnection();
+    return WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 // Opaque origins are only stored in process in m_channelsPerOrigin and never sent to the NetworkProcess as a ClientOrigin.
@@ -67,7 +62,7 @@ void WebBroadcastChannelRegistry::registerChannel(const WebCore::PartitionedSecu
 
     if (channelsForName.size() == 1) {
         if (auto clientOrigin = toClientOrigin(origin))
-            protectedNetworkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
+            networkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
     }
 }
 
@@ -90,7 +85,7 @@ void WebBroadcastChannelRegistry::unregisterChannel(const WebCore::PartitionedSe
 
     channelsForOrigin.remove(channelsForOriginIterator);
     if (auto clientOrigin = toClientOrigin(origin))
-        protectedNetworkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::UnregisterChannel { *clientOrigin, name }, 0);
+        networkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::UnregisterChannel { *clientOrigin, name }, 0);
 
     if (channelsForOrigin.isEmpty())
         m_channelsPerOrigin.remove(channelsPerOriginIterator);
@@ -101,7 +96,7 @@ void WebBroadcastChannelRegistry::postMessage(const WebCore::PartitionedSecurity
     auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
     postMessageLocally(origin, name, source, message.copyRef(), callbackAggregator.copyRef());
     if (auto clientOrigin = toClientOrigin(origin))
-        protectedNetworkProcessConnection()->sendWithAsyncReply(Messages::NetworkBroadcastChannelRegistry::PostMessage { *clientOrigin, name, WebCore::MessageWithMessagePorts { WTFMove(message), { } } }, [callbackAggregator] { }, 0);
+        networkProcessConnection()->sendWithAsyncReply(Messages::NetworkBroadcastChannelRegistry::PostMessage { *clientOrigin, name, WebCore::MessageWithMessagePorts { WTFMove(message), { } } }, [callbackAggregator] { }, 0);
 }
 
 void WebBroadcastChannelRegistry::postMessageLocally(const WebCore::PartitionedSecurityOrigin& origin, const String& name, std::optional<WebCore::BroadcastChannelIdentifier> sourceInProcess, Ref<WebCore::SerializedScriptValue>&& message, Ref<WTF::CallbackAggregator>&& callbackAggregator)
@@ -135,12 +130,13 @@ void WebBroadcastChannelRegistry::networkProcessCrashed()
     if (!WebProcess::singleton().isBroadcastChannelEnabled())
         return;
 
+    RefPtr connection = networkProcessConnection();
     for (auto& [origin, channelsForOrigin] : m_channelsPerOrigin) {
         auto clientOrigin = toClientOrigin(origin);
         if (!clientOrigin)
             continue;
         for (auto& name : channelsForOrigin.keys())
-            protectedNetworkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
+            connection->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
     }
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -434,7 +434,7 @@ bool WebChromeClient::testProcessIncomingSyncMessagesWhenWaitingForSyncReply()
 
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(m_page->webPageProxyIdentifier()), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(m_page->webPageProxyIdentifier()), 0);
     auto [handled] = sendResult.takeReplyOr(false);
     return handled;
 }
@@ -1303,7 +1303,7 @@ unsigned WebChromeClient::remoteImagesCountForTesting() const
 
 void WebChromeClient::registerBlobPathForTesting(const String& path, CompletionHandler<void()>&& completionHandler)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::RegisterBlobPathForTesting(path), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::RegisterBlobPathForTesting(path), WTFMove(completionHandler));
 }
 
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1391,7 +1391,7 @@ void WebLocalFrameLoaderClient::loadStorageAccessQuirksIfNeeded()
     if (!WebProcess::singleton().haveStorageAccessQuirksForDomain(RegistrableDomain { documentURLWithoutFragmentOrQueries }))
         return;
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::StorageAccessQuirkForTopFrameDomain(documentURLWithoutFragmentOrQueries), [weakDocument = WeakPtr { *document }](Vector<RegistrableDomain>&& domains) {
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::StorageAccessQuirkForTopFrameDomain(documentURLWithoutFragmentOrQueries), [weakDocument = WeakPtr { *document }](Vector<RegistrableDomain>&& domains) {
         if (!domains.size())
             return;
         if (!weakDocument)
@@ -1887,7 +1887,7 @@ void WebLocalFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<voi
 #if ENABLE(APP_BOUND_DOMAINS)
     parameters.isNavigatingToAppBoundDomain = m_frame->isTopFrameNavigatingToAppBoundDomain();
 #endif
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SendH2Ping(WTFMove(parameters)), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SendH2Ping(WTFMove(parameters)), WTFMove(completionHandler));
 }
 
 void WebLocalFrameLoaderClient::didRestoreScrollPosition()
@@ -2044,7 +2044,7 @@ void WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold()
     if (document->shouldSkipResourceMonitorThrottling())
         action(true);
     else
-        WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::ShouldOffloadIFrameForHost(url.host().toStringWithoutCopying()), WTFMove(action), 0);
+        WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::ShouldOffloadIFrameForHost(url.host().toStringWithoutCopying()), WTFMove(action), 0);
 }
 
 #endif
@@ -2052,7 +2052,7 @@ void WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold()
 void WebLocalFrameLoaderClient::removeStorageAccess()
 {
     if (m_frameSpecificStorageAccessIdentifier) {
-        WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RemoveStorageAccessForFrame(
+        WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RemoveStorageAccessForFrame(
             m_frameSpecificStorageAccessIdentifier->frameID, m_frameSpecificStorageAccessIdentifier->pageID), 0);
         m_frameSpecificStorageAccessIdentifier = std::nullopt;
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -52,14 +52,9 @@ WebMessagePortChannelProvider::~WebMessagePortChannelProvider()
     ASSERT_NOT_REACHED();
 }
 
-static inline IPC::Connection& networkProcessConnection()
+static inline Ref<IPC::Connection> networkProcessConnection()
 {
-    return WebProcess::singleton().ensureNetworkProcessConnection().connection();
-}
-
-static inline Ref<IPC::Connection> protectedNetworkProcessConnection()
-{
-    return networkProcessConnection();
+    return WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2, bool siteIsolationEnabled)
@@ -71,19 +66,19 @@ void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePor
         m_inProcessPortMessages.add(port2, Vector<MessageWithMessagePorts> { });
     }
 
-    protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::CreateNewMessagePortChannel { port1, port2 }, 0);
+    networkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::CreateNewMessagePortChannel { port1, port2 }, 0);
 }
 
 void WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     m_inProcessPortMessages.add(local, Vector<MessageWithMessagePorts> { });
 
-    protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::EntangleLocalPortInThisProcessToRemote { local, remote }, 0);
+    networkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::EntangleLocalPortInThisProcessToRemote { local, remote }, 0);
 }
 
 void WebMessagePortChannelProvider::messagePortDisentangled(const MessagePortIdentifier& port)
 {
-    protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::MessagePortDisentangled { port }, 0);
+    networkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::MessagePortDisentangled { port }, 0);
 }
 
 void WebMessagePortChannelProvider::messagePortSentToRemote(const WebCore::MessagePortIdentifier& port)
@@ -96,12 +91,12 @@ void WebMessagePortChannelProvider::messagePortSentToRemote(const WebCore::Messa
 void WebMessagePortChannelProvider::messagePortClosed(const MessagePortIdentifier& port)
 {
     m_inProcessPortMessages.remove(port);
-    protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::MessagePortClosed { port }, 0);
+    networkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::MessagePortClosed { port }, 0);
 }
 
 void WebMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& completionHandler)
 {
-    protectedNetworkProcessConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::TakeAllMessagesForPort { port }, [completionHandler = WTFMove(completionHandler), port](Vector<WebCore::MessageWithMessagePorts>&& messages, std::optional<MessageBatchIdentifier> messageBatchIdentifier) mutable {
+    networkProcessConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::TakeAllMessagesForPort { port }, [completionHandler = WTFMove(completionHandler), port](Vector<WebCore::MessageWithMessagePorts>&& messages, std::optional<MessageBatchIdentifier> messageBatchIdentifier) mutable {
         if (!messageBatchIdentifier)
             return completionHandler({ }, [] { }); // IPC failure.
 
@@ -112,7 +107,7 @@ void WebMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortIden
             messages.appendVector(WTFMove(pendingMessages));
         }
         completionHandler(WTFMove(messages), [messageBatchIdentifier] {
-            protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::DidDeliverMessagePortMessages { *messageBatchIdentifier }, 0);
+            networkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::DidDeliverMessagePortMessages { *messageBatchIdentifier }, 0);
         });
     }, 0);
 }
@@ -129,7 +124,7 @@ void WebMessagePortChannelProvider::postMessageToRemote(MessageWithMessagePorts&
     for (auto& port : message.transferredPorts)
         messagePortSentToRemote(port.first);
 
-    protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::PostMessageToRemote { message, remoteTarget }, 0);
+    networkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::PostMessageToRemote { message, remoteTarget }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -71,7 +71,7 @@ void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::Per
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     if (WebCore::DeprecatedGlobalSettings::builtInNotificationsEnabled() && (descriptor.name == WebCore::PermissionName::Notifications || descriptor.name == WebCore::PermissionName::Push)) {
-        Ref connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        Ref connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         auto notificationPermissionHandler = [completionHandler = WTFMove(completionHandler)](WebCore::PushPermissionState pushPermissionState) mutable {
             auto state = [pushPermissionState]() -> WebCore::PermissionState {
                 switch (pushPermissionState) {
@@ -95,7 +95,7 @@ void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::Per
     }
 
     if (descriptor.name == WebCore::PermissionName::StorageAccess) {
-        Ref networkProcess = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        Ref networkProcess = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         networkProcess->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::QueryStorageAccessPermission(WebCore::RegistrableDomain { origin.clientOrigin }, WebCore::RegistrableDomain { origin.topOrigin }, proxyIdentifier), WTFMove(completionHandler));
         return;
     }
@@ -155,7 +155,7 @@ void WebPermissionController::permissionChanged(WebCore::PermissionName permissi
 void WebPermissionController::addChangeListener(WebCore::PermissionName permissionName, const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain)
 {
     if (permissionName == WebCore::PermissionName::StorageAccess) {
-        Ref networkProcess = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        Ref networkProcess = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         networkProcess->send(Messages::NetworkConnectionToWebProcess::SubscribeToStorageAccessPermissionChanges(topFrameDomain, subFrameDomain), 0);
     }
 }
@@ -163,7 +163,7 @@ void WebPermissionController::addChangeListener(WebCore::PermissionName permissi
 void WebPermissionController::removeChangeListener(WebCore::PermissionName permissionName, const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain)
 {
     if (permissionName == WebCore::PermissionName::StorageAccess) {
-        Ref networkProcess = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        Ref networkProcess = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         networkProcess->send(Messages::NetworkConnectionToWebProcess::UnsubscribeFromStorageAccessPermissionChanges(topFrameDomain, subFrameDomain), 0);
     }
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -547,7 +547,7 @@ void WebPlatformStrategies::windowSubscribeToPushService(const URL& scope, const
         callback(WTFMove(*valueOrException));
     };
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorSubscribeToPushService(scope, applicationServerKey), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorSubscribeToPushService(scope, applicationServerKey), WTFMove(completionHandler));
 }
 
 void WebPlatformStrategies::windowUnsubscribeFromPushService(const URL& scope, std::optional<PushSubscriptionIdentifier> subscriptionIdentifier, UnsubscribeFromPushServiceCallback&& callback)
@@ -560,7 +560,7 @@ void WebPlatformStrategies::windowUnsubscribeFromPushService(const URL& scope, s
         callback(WTFMove(*valueOrException));
     };
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorUnsubscribeFromPushService(scope, *subscriptionIdentifier), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorUnsubscribeFromPushService(scope, *subscriptionIdentifier), WTFMove(completionHandler));
 }
 
 void WebPlatformStrategies::windowGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&& callback)
@@ -573,7 +573,7 @@ void WebPlatformStrategies::windowGetPushSubscription(const URL& scope, GetPushS
         callback(WTFMove(*valueOrException));
     };
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorGetPushSubscription(scope), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorGetPushSubscription(scope), WTFMove(completionHandler));
 }
 
 void WebPlatformStrategies::windowGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&& callback)
@@ -584,7 +584,7 @@ void WebPlatformStrategies::windowGetPushPermissionState(const URL& scope, GetPu
         callback(static_cast<PushPermissionState>(*valueOrException));
     };
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorGetPushPermissionState(scope), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorGetPushPermissionState(scope), WTFMove(completionHandler));
 }
 
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -83,7 +83,7 @@ void WebResourceLoadObserver::requestStorageAccessUnderOpener(const RegistrableD
     if (domainInNeedOfStorageAccess != openerDomain
         && !openerDocument.hasRequestedPageSpecificStorageAccessWithUserInteraction(domainInNeedOfStorageAccess)
         && !openerUrl.isAboutBlank()) {
-        Ref { WebProcess::singleton().ensureNetworkProcessConnection().connection() }->send(Messages::NetworkConnectionToWebProcess::RequestStorageAccessUnderOpener(domainInNeedOfStorageAccess, openerPage.identifier(), openerDomain), 0);
+        Ref { WebProcess::singleton().ensureNetworkProcessConnection()->connection() }->send(Messages::NetworkConnectionToWebProcess::RequestStorageAccessUnderOpener(domainInNeedOfStorageAccess, openerPage.identifier(), openerDomain), 0);
         
         openerPage.addDomainWithPageLevelStorageAccess(openerDomain, domainInNeedOfStorageAccess);
 
@@ -115,7 +115,7 @@ void WebResourceLoadObserver::scheduleNotificationIfNeeded()
 void WebResourceLoadObserver::updateCentralStatisticsStore(CompletionHandler<void()>&& completionHandler)
 {
     m_notificationTimer.stop();
-    Ref { WebProcess::singleton().ensureNetworkProcessConnection().connection() }->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::ResourceLoadStatisticsUpdated(takeStatistics()), WTFMove(completionHandler));
+    Ref { WebProcess::singleton().ensureNetworkProcessConnection()->connection() }->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::ResourceLoadStatisticsUpdated(takeStatistics()), WTFMove(completionHandler));
 }
 
 
@@ -398,7 +398,7 @@ void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const 
 
     // We notify right away in case of a user interaction instead of waiting the usual 5 seconds because we want
     // to update cookie blocking state as quickly as possible.
-    Ref { WebProcess::singleton().ensureNetworkProcessConnection().connection() }->send(Messages::NetworkConnectionToWebProcess::LogUserInteraction(topFrameDomain), 0);
+    Ref { WebProcess::singleton().ensureNetworkProcessConnection()->connection() }->send(Messages::NetworkConnectionToWebProcess::LogUserInteraction(topFrameDomain), 0);
 
 #if !RELEASE_LOG_DISABLED
     if (shouldLogUserInteraction) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
@@ -79,7 +79,7 @@ void WebStorageConnection::fileSystemGetDirectory(WebCore::ClientOrigin&& origin
 
 IPC::Connection& WebStorageConnection::connection()
 {
-    return WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    return WebProcess::singleton().ensureNetworkProcessConnection()->connection();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
@@ -39,7 +39,7 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
 {
     if (!m_inMemoryStorageSession) {
         String sessionName = makeString("WebKitInProcessStorage-"_s, getCurrentProcessID());
-        auto cookieAcceptPolicy = WebProcess::singleton().ensureNetworkProcessConnection().cookieAcceptPolicy();
+        auto cookieAcceptPolicy = WebProcess::singleton().ensureNetworkProcessConnection()->cookieAcceptPolicy();
         auto storageSession = WebCore::createPrivateStorageSession(sessionName.createCFString().get(), cookieAcceptPolicy);
         auto cookieStorage = adoptCF(_CFURLStorageSessionCopyCookieStorage(kCFAllocatorDefault, storageSession.get()));
         m_inMemoryStorageSession = makeUnique<NetworkStorageSession>(WebProcess::singleton().sessionID(), WTFMove(storageSession), WTFMove(cookieStorage), NetworkStorageSession::IsInMemoryCookieStore::Yes);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1015,7 +1015,7 @@ URL WebPage::allowedQueryParametersForAdvancedPrivacyProtections(const URL& url)
 void WebPage::setMediaEnvironment(const String& mediaEnvironment)
 {
     m_mediaEnvironment = mediaEnvironment;
-    if (auto gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
+    if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
         gpuProcessConnection->setMediaEnvironment(identifier(), mediaEnvironment);
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1965,14 +1965,14 @@ RefPtr<JSIPCConnection> JSIPC::processTargetFromArgument(JSC::JSGlobalObject* gl
     }
 #if ENABLE(GPU_PROCESS)
     if (name == processTargetNameGPU) {
-        RefPtr connection = WebProcess::singleton().ensureGPUProcessConnection().connection();
+        RefPtr connection = WebProcess::singleton().ensureGPUProcessConnection()->connection();
         if (!m_gpuConnection || &m_gpuConnection->connection() != connection)
             m_gpuConnection = JSIPCConnection::create(connection.releaseNonNull());
         return m_gpuConnection;
     }
 #endif
     if (name == processTargetNameNetworking) {
-        RefPtr connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        RefPtr connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
         if (!m_networkConnection || &m_networkConnection->connection() != connection)
             m_networkConnection = JSIPCConnection::create(connection.releaseNonNull());
         return m_networkConnection;

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
@@ -75,7 +75,7 @@ String WebCookieCache::cookiesForDOM(const URL& firstParty, const SameSiteInfo& 
         if (!hasCacheForHost)
             WebProcess::singleton().protectedCookieJar()->addChangeListenerWithAccess(url, firstParty, frameID, pageID, webPageProxyID, *this);
 #endif
-        auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::DomCookiesForHost(url), 0);
+        auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::DomCookiesForHost(url), 0);
         if (!sendResult.succeeded())
             return { };
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -154,7 +154,7 @@ String WebCookieJar::cookies(WebCore::Document& document, const URL& url) const
     if (isEligibleForCache(*webFrame, document.firstPartyForCookies(), url))
         return m_cache->cookiesForDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, webPageProxyID, includeSecureCookies);
 
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::CookiesForDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, includeSecureCookies, webPageProxyID), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::CookiesForDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, includeSecureCookies, webPageProxyID), 0);
     auto [cookieString, secureCookiesAccessed] = sendResult.takeReplyOr(String { }, false);
 
     return cookieString;
@@ -183,7 +183,7 @@ void WebCookieJar::setCookies(WebCore::Document& document, const URL& url, const
     if (isEligibleForCache(*webFrame, document.firstPartyForCookies(), url))
         m_cache->setCookiesFromDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, cookieString, shouldRelaxThirdPartyCookieBlocking(webFrame.get()));
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetCookiesFromDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, cookieString, requiresPrivacyProtections, page->webPageProxyIdentifier()), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::SetCookiesFromDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, cookieString, requiresPrivacyProtections, page->webPageProxyIdentifier()), 0);
 }
 
 void WebCookieJar::cookiesAdded(const String& host, Vector<WebCore::Cookie>&& cookies)
@@ -257,7 +257,7 @@ bool WebCookieJar::remoteCookiesEnabledSync(Document& document) const
         return false;
 
     std::optional<FrameIdentifier> frameID = webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt;
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::CookiesEnabledSync(document.firstPartyForCookies(), cookieURL, frameID, page->identifier(), page->webPageProxyIdentifier()), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::CookiesEnabledSync(document.firstPartyForCookies(), cookieURL, frameID, page->identifier(), page->webPageProxyIdentifier()), 0);
 
     auto [result] = sendResult.takeReplyOr(false);
     return result;
@@ -278,7 +278,7 @@ void WebCookieJar::remoteCookiesEnabled(const Document& document, CompletionHand
         return completionHandler(false);
 
     std::optional<FrameIdentifier> frameID = webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt;
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::CookiesEnabled(document.firstPartyForCookies(), cookieURL, frameID, page->identifier(), page->webPageProxyIdentifier()), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::CookiesEnabled(document.firstPartyForCookies(), cookieURL, frameID, page->identifier(), page->webPageProxyIdentifier()), WTFMove(completionHandler));
 }
 
 std::pair<String, WebCore::SecureCookiesAccessed> WebCookieJar::cookieRequestHeaderFieldValue(const URL& firstParty, const WebCore::SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, WebCore::IncludeSecureCookies includeSecureCookies) const
@@ -288,7 +288,7 @@ std::pair<String, WebCore::SecureCookiesAccessed> WebCookieJar::cookieRequestHea
         return { };
 
     auto webPageProxyID = webFrame && webFrame->page() ? std::make_optional(webFrame->page()->webPageProxyIdentifier()) : std::nullopt;
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::CookieRequestHeaderFieldValue(firstParty, sameSiteInfo, url, frameID, pageID, includeSecureCookies, webPageProxyID), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::CookieRequestHeaderFieldValue(firstParty, sameSiteInfo, url, frameID, pageID, includeSecureCookies, webPageProxyID), 0);
     if (!sendResult.succeeded())
         return { };
 
@@ -305,7 +305,7 @@ bool WebCookieJar::getRawCookies(WebCore::Document& document, const URL& url, Ve
     auto frameID = webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt;
     auto pageID = webFrame && webFrame->page() ? std::make_optional(webFrame->page()->identifier()) : std::nullopt;
     auto webPageProxyID = webFrame && webFrame->page() ? std::make_optional(webFrame->page()->webPageProxyIdentifier()) : std::nullopt;
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::GetRawCookies(document.firstPartyForCookies(), sameSiteInfo(document), url, frameID, pageID, webPageProxyID), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendSync(Messages::NetworkConnectionToWebProcess::GetRawCookies(document.firstPartyForCookies(), sameSiteInfo(document), url, frameID, pageID, webPageProxyID), 0);
     if (!sendResult.succeeded())
         return false;
 
@@ -315,12 +315,12 @@ bool WebCookieJar::getRawCookies(WebCore::Document& document, const URL& url, Ve
 
 void WebCookieJar::setRawCookie(const WebCore::Document& document, const Cookie& cookie, ShouldPartitionCookie shouldPartitionCookie)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetRawCookie(document.firstPartyForCookies(), document.cookieURL(), cookie, shouldPartitionCookie), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::SetRawCookie(document.firstPartyForCookies(), document.cookieURL(), cookie, shouldPartitionCookie), 0);
 }
 
 void WebCookieJar::deleteCookie(const WebCore::Document& document, const URL& url, const String& cookieName, CompletionHandler<void()>&& completionHandler)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::DeleteCookie(document.firstPartyForCookies(), url, cookieName), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::DeleteCookie(document.firstPartyForCookies(), url, cookieName), WTFMove(completionHandler));
 }
 
 void WebCookieJar::getCookiesAsync(WebCore::Document& document, const URL& url, const WebCore::CookieStoreGetOptions& options, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&& completionHandler) const
@@ -343,7 +343,7 @@ void WebCookieJar::getCookiesAsync(WebCore::Document& document, const URL& url, 
     auto frameID = webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt;
     auto pageID = webFrame && webFrame->page() ? std::make_optional(webFrame->page()->identifier()) : std::nullopt;
     auto webPageProxyID = webFrame && webFrame->page() ? std::make_optional(webFrame->page()->webPageProxyIdentifier()) : std::nullopt;
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::CookiesForDOMAsync(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, includeSecureCookies, options, webPageProxyID), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::CookiesForDOMAsync(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, includeSecureCookies, options, webPageProxyID), WTFMove(completionHandler));
 }
 
 void WebCookieJar::setCookieAsync(WebCore::Document& document, const URL& url, const WebCore::Cookie& cookie, CompletionHandler<void(bool)>&& completionHandler) const
@@ -381,7 +381,7 @@ void WebCookieJar::setCookieAsync(WebCore::Document& document, const URL& url, c
         completionHandler(success);
     };
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SetCookieFromDOMAsync(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, cookie, requiresPrivacyProtections, webPageProxyIdentifier), WTFMove(completionHandlerWrapper));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SetCookieFromDOMAsync(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, cookie, requiresPrivacyProtections, webPageProxyIdentifier), WTFMove(completionHandlerWrapper));
 }
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
@@ -405,7 +405,7 @@ void WebCookieJar::addChangeListenerWithAccess(const URL& url, const URL& firstP
         listenersForHost.add(*listener);
     };
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SubscribeToCookieChangeNotifications(url, firstParty, frameID, pageID, webPageProxyID), WTFMove(completionHandler), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SubscribeToCookieChangeNotifications(url, firstParty, frameID, pageID, webPageProxyID), WTFMove(completionHandler), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 }
 
 void WebCookieJar::addChangeListener(const WebCore::Document& document, const WebCore::CookieChangeListener& listener)
@@ -435,7 +435,7 @@ void WebCookieJar::removeChangeListener(const String& host, const WebCore::Cooki
         return;
 
     m_changeListeners.remove(it);
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UnsubscribeFromCookieChangeNotifications(host), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::UnsubscribeFromCookieChangeNotifications(host), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -638,7 +638,7 @@ void WebFrame::startDownload(const WebCore::ResourceRequest& request, const Stri
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
     isAppBound = m_isNavigatingToAppBoundDomain;
     if (localFrame)
-        WebProcess::singleton().ensureProtectedNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::StartDownload(policyDownloadID, request, topOrigin, isAppBound, suggestedName, fromDownloadAttribute, localFrame->frameID(), localFrame->pageID()), 0);
+        WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::StartDownload(policyDownloadID, request, topOrigin, isAppBound, suggestedName, fromDownloadAttribute, localFrame->frameID(), localFrame->pageID()), 0);
 }
 
 void WebFrame::convertMainResourceLoadToDownload(DocumentLoader* documentLoader, const ResourceRequest& request, const ResourceResponse& response)
@@ -663,7 +663,7 @@ void WebFrame::convertMainResourceLoadToDownload(DocumentLoader* documentLoader,
 
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
     isAppBound = m_isNavigatingToAppBoundDomain;
-    webProcess.ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ConvertMainResourceLoadToDownload(mainResourceLoadIdentifier, policyDownloadID, request, topOrigin, response, isAppBound), 0);
+    webProcess.ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::ConvertMainResourceLoadToDownload(mainResourceLoadIdentifier, policyDownloadID, request, topOrigin, response, isAppBound), 0);
 }
 
 void WebFrame::addConsoleMessage(MessageSource messageSource, MessageLevel messageLevel, const String& message, uint64_t requestID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1498,12 +1498,12 @@ WebPage::~WebPage()
     WebStorageNamespaceProvider::decrementUseCount(sessionStorageNamespaceIdentifier());
 
 #if ENABLE(GPU_PROCESS) && HAVE(VISIBILITY_PROPAGATION_VIEW)
-    if (auto* gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
+    if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
         gpuProcessConnection->destroyVisibilityPropagationContextForPage(*this);
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS) && HAVE(VISIBILITY_PROPAGATION_VIEW)
-    if (auto* modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
+    if (RefPtr modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
         modelProcessConnection->destroyVisibilityPropagationContextForPage(*this);
 #endif // ENABLE(MODEL_PROCESS) && HAVE(VISIBILITY_PROPAGATION_VIEW)
 
@@ -1946,7 +1946,7 @@ void WebPage::close()
 
     WEBPAGE_RELEASE_LOG_FORWARDABLE(Loading, WEBPAGE_CLOSE);
 
-    if (auto networkProcessConnection = WebProcess::singleton().protectedNetworkProcessConnection())
+    if (RefPtr networkProcessConnection = WebProcess::singleton().existingNetworkProcessConnection())
         networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::ClearPageSpecificData(m_identifier), 0);
 
     m_isClosed = true;
@@ -4878,10 +4878,10 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     m_ipcTestingAPIEnabled = store.getBoolValueForKey(WebPreferencesKey::ipcTestingAPIEnabledKey());
 
     WebProcess::singleton().protectedParentProcessConnection()->setIgnoreInvalidMessageForTesting();
-    if (auto* gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
+    if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
         gpuProcessConnection->connection().setIgnoreInvalidMessageForTesting();
 #if ENABLE(MODEL_PROCESS)
-    if (auto* modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
+    if (RefPtr modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
         modelProcessConnection->connection().setIgnoreInvalidMessageForTesting();
 #endif // ENABLE(MODEL_PROCESS)
 #endif // ENABLE(IPC_TESTING_API)
@@ -7794,7 +7794,7 @@ void WebPage::scheduleFullEditorStateUpdate()
 void WebPage::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::optional<WebCore::FloatSize> sizeConstraint, uint64_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&&)>&& completionHandler)
 {
     URL url = request.url();
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::LoadImageForDecoding(WTFMove(request), m_webPageProxyIdentifier, maximumBytesFromNetwork), [completionHandler = WTFMove(completionHandler), sizeConstraint, url] (Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&& result) mutable {
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::LoadImageForDecoding(WTFMove(request), m_webPageProxyIdentifier, maximumBytesFromNetwork), [completionHandler = WTFMove(completionHandler), sizeConstraint, url] (Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&& result) mutable {
         if (!result)
             return completionHandler(makeUnexpected(WTFMove(result.error())));
 
@@ -8285,12 +8285,12 @@ void WebPage::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDo
         return;
     }
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::HasStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frame.frameID(), m_identifier), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::HasStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frame.frameID(), m_identifier), WTFMove(completionHandler));
 }
 
 void WebPage::requestStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebFrame& frame, StorageAccessScope scope, HasOrShouldIgnoreUserGesture hasOrShouldIgnoreUserGesture, CompletionHandler<void(WebCore::RequestStorageAccessResult)>&& completionHandler)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::RequestStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frame.frameID(), m_identifier, m_webPageProxyIdentifier, scope, hasOrShouldIgnoreUserGesture), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), frame = Ref { frame }, pageID = m_identifier, frameID = frame.frameID()](RequestStorageAccessResult result) mutable {
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::RequestStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frame.frameID(), m_identifier, m_webPageProxyIdentifier, scope, hasOrShouldIgnoreUserGesture), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), frame = Ref { frame }, pageID = m_identifier, frameID = frame.frameID()](RequestStorageAccessResult result) mutable {
         if (result.wasGranted == StorageAccessWasGranted::Yes) {
             switch (result.scope) {
             case StorageAccessScope::PerFrame:
@@ -8311,12 +8311,12 @@ void WebPage::setLoginStatus(RegistrableDomain&& domain, IsLoggedIn loggedInStat
     if (!page)
         return completionHandler();
     auto lastAuthentication = page->lastAuthentication() ? std::optional(*page->lastAuthentication()) : std::nullopt;
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SetLoginStatus(WTFMove(domain), loggedInStatus, lastAuthentication), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SetLoginStatus(WTFMove(domain), loggedInStatus, lastAuthentication), WTFMove(completionHandler));
 }
 
 void WebPage::isLoggedIn(RegistrableDomain&& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::IsLoggedIn(WTFMove(domain)), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::IsLoggedIn(WTFMove(domain)), WTFMove(completionHandler));
 }
 
 void WebPage::addDomainWithPageLevelStorageAccess(const RegistrableDomain& topLevelDomain, const RegistrableDomain& resourceDomain)
@@ -8758,7 +8758,7 @@ void WebPage::configureLoggingChannel(const String& channelName, WTFLogChannelSt
 #endif
 
 #if ENABLE(MODEL_PROCESS)
-    if (auto* modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
+    if (RefPtr modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
         modelProcessConnection->configureLoggingChannel(channelName, state, level);
 #endif
 
@@ -8843,7 +8843,7 @@ void WebPage::updateCORSDisablingPatterns(Vector<String>&& patterns)
 void WebPage::synchronizeCORSDisablingPatternsWithNetworkProcess()
 {
     // FIXME: We should probably have this mechanism done between UIProcess and NetworkProcess directly.
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetCORSDisablingPatterns(m_identifier, m_corsDisablingPatterns), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::SetCORSDisablingPatterns(m_identifier, m_corsDisablingPatterns), 0);
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
@@ -9526,7 +9526,7 @@ void WebPage::useRedirectionForCurrentNavigation(WebCore::ResourceResponse&& res
 
     if (RefPtr resourceLoader = loader->mainResourceLoader()) {
         WEBPAGE_RELEASE_LOG(Loading, "WebPage::useRedirectionForCurrentNavigation to network process");
-        WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UseRedirectionForCurrentNavigation(*resourceLoader->identifier(), response), 0);
+        WebProcess::singleton().ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::UseRedirectionForCurrentNavigation(*resourceLoader->identifier(), response), 0);
         return;
     }
 

--- a/Source/WebKit/WebProcess/WebPage/soup/WebCookieCacheSoup.cpp
+++ b/Source/WebKit/WebProcess/WebPage/soup/WebCookieCacheSoup.cpp
@@ -39,7 +39,7 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
     if (!m_inMemoryStorageSession) {
         m_inMemoryStorageSession = makeUnique<NetworkStorageSession>(WebProcess::singleton().sessionID(), NetworkStorageSession::IsInMemoryCookieStore::Yes);
 
-        auto acceptPolicy = WebProcess::singleton().ensureNetworkProcessConnection().cookieAcceptPolicy();
+        auto acceptPolicy = WebProcess::singleton().ensureNetworkProcessConnection()->cookieAcceptPolicy();
         m_inMemoryStorageSession->setCookieAcceptPolicy(acceptPolicy);
     }
     return *m_inMemoryStorageSession;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -903,7 +903,7 @@ void WebProcess::registerURLSchemeAsDisplayIsolated(const String& urlScheme) con
 void WebProcess::registerURLSchemeAsCORSEnabled(const String& urlScheme)
 {
     LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(urlScheme);
-    ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled({ urlScheme }), 0);
+    ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled({ urlScheme }), 0);
 }
 
 void WebProcess::registerURLSchemeAsAlwaysRevalidated(const String& urlScheme) const
@@ -1340,7 +1340,7 @@ static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection&
     return connectionInfo;
 }
 
-NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
+Ref<NetworkProcessConnection> WebProcess::ensureNetworkProcessConnection()
 {
     RELEASE_ASSERT(RunLoop::isMain());
     ASSERT(m_sessionID);
@@ -1356,7 +1356,7 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
         m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled(WebCore::LegacySchemeRegistry::allURLSchemesRegisteredAsCORSEnabled()), 0);
 
         if (!Document::allDocuments().isEmpty() || SharedWorkerThreadProxy::hasInstances())
-            protectedNetworkProcessConnection()->protectedServiceWorkerConnection()->registerServiceWorkerClients();
+            m_networkProcessConnection->protectedServiceWorkerConnection()->registerServiceWorkerClients();
 
 #if HAVE(LSDATABASECONTEXT)
         // On Mac, this needs to be called before NSApplication is being initialized.
@@ -1380,14 +1380,9 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
     return *m_networkProcessConnection;
 }
 
-Ref<NetworkProcessConnection> WebProcess::ensureProtectedNetworkProcessConnection()
+RefPtr<NetworkProcessConnection> WebProcess::existingNetworkProcessConnection() const
 {
-    return ensureNetworkProcessConnection();
-}
-
-RefPtr<NetworkProcessConnection> WebProcess::protectedNetworkProcessConnection()
-{
-    return existingNetworkProcessConnection();
+    return m_networkProcessConnection;
 }
 
 void WebProcess::logDiagnosticMessageForNetworkProcessCrash()
@@ -1484,7 +1479,7 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
 WebFileSystemStorageConnection& WebProcess::fileSystemStorageConnection()
 {
     if (!m_fileSystemStorageConnection)
-        m_fileSystemStorageConnection = WebFileSystemStorageConnection::create(Ref { ensureNetworkProcessConnection().connection() });
+        m_fileSystemStorageConnection = WebFileSystemStorageConnection::create(Ref { ensureNetworkProcessConnection()->connection() });
 
     return *m_fileSystemStorageConnection;
 }
@@ -1506,7 +1501,7 @@ Ref<WebLoaderStrategy> WebProcess::protectedWebLoaderStrategy()
 
 #if ENABLE(GPU_PROCESS)
 
-GPUProcessConnection& WebProcess::ensureGPUProcessConnection()
+Ref<GPUProcessConnection> WebProcess::ensureGPUProcessConnection()
 {
     RELEASE_ASSERT(RunLoop::isMain());
 
@@ -1529,9 +1524,9 @@ GPUProcessConnection& WebProcess::ensureGPUProcessConnection()
     return *m_gpuProcessConnection;
 }
 
-Ref<GPUProcessConnection> WebProcess::ensureProtectedGPUProcessConnection()
+RefPtr<GPUProcessConnection> WebProcess::existingGPUProcessConnection() const
 {
-    return ensureGPUProcessConnection();
+    return m_gpuProcessConnection;
 }
 
 Seconds WebProcess::gpuProcessTimeoutDuration() const
@@ -1587,7 +1582,7 @@ AudioMediaStreamTrackRendererInternalUnitManager& WebProcess::audioMediaStreamTr
 
 #if ENABLE(MODEL_PROCESS)
 
-ModelProcessConnection& WebProcess::ensureModelProcessConnection()
+Ref<ModelProcessConnection> WebProcess::ensureModelProcessConnection()
 {
     RELEASE_ASSERT(RunLoop::isMain());
 
@@ -1600,6 +1595,11 @@ ModelProcessConnection& WebProcess::ensureModelProcessConnection()
     }
 
     return *m_modelProcessConnection;
+}
+
+RefPtr<ModelProcessConnection> WebProcess::existingModelProcessConnection() const
+{
+    return m_modelProcessConnection;
 }
 
 void WebProcess::modelProcessConnectionClosed(ModelProcessConnection& connection)
@@ -2172,7 +2172,7 @@ void WebProcess::prefetchDNS(const String& hostname)
         return;
 
     if (m_dnsPrefetchedHosts.add(hostname).isNewEntry)
-        ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::PrefetchDNS(hostname), 0);
+        ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::PrefetchDNS(hostname), 0);
     // The DNS prefetched hosts cache is only to avoid asking for the same hosts too many times
     // in a very short period of time, producing a lot of IPC traffic. So we clear this cache after
     // some time of no DNS requests.
@@ -2218,7 +2218,7 @@ void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWo
     // We are in the Remote Worker context process and the call below establishes our connection to the Network Process
     // by calling ensureNetworkProcessConnection. SWContextManager / SharedWorkerContextManager need to use the same underlying IPC::Connection as the
     // NetworkProcessConnection for synchronization purposes.
-    Ref ipcConnection = ensureNetworkProcessConnection().connection();
+    Ref ipcConnection = ensureNetworkProcessConnection()->connection();
     switch (workerType) {
     case RemoteWorkerType::ServiceWorker:
         SWContextManager::singleton().setConnection(WebSWContextManagerConnection::create(WTFMove(ipcConnection), WTFMove(site), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData)));
@@ -2233,7 +2233,7 @@ void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWo
 
 void WebProcess::registerServiceWorkerClients(CompletionHandler<void(bool)>&& completionHandler)
 {
-    ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::PingPongForServiceWorkers { }, WTFMove(completionHandler));
+    ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::PingPongForServiceWorkers { }, WTFMove(completionHandler));
 }
 
 void WebProcess::addServiceWorkerRegistration(WebCore::ServiceWorkerRegistrationIdentifier identifier)
@@ -2365,7 +2365,7 @@ void WebProcess::setAppBadge(WebCore::Frame* frame, const WebCore::SecurityOrigi
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     if (DeprecatedGlobalSettings::builtInNotificationsEnabled()) {
         if (m_sessionID)
-            ensureNetworkProcessConnection().connection().send(Messages::NotificationManagerMessageHandler::SetAppBadge({ origin, badge }), m_sessionID->toUInt64());
+            ensureNetworkProcessConnection()->connection().send(Messages::NotificationManagerMessageHandler::SetAppBadge({ origin, badge }), m_sessionID->toUInt64());
         return;
     }
 #endif
@@ -2513,11 +2513,11 @@ void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)
 #if PLATFORM(COCOA)
     if (useGPUProcessForMedia) {
         SystemBatteryStatusTestingOverrides::singleton().setConfigurationChangedCallback([this, protectedThis = Ref { *this }] (bool forceUpdate) {
-            ensureProtectedGPUProcessConnection()->updateMediaConfiguration(forceUpdate);
+            ensureGPUProcessConnection()->updateMediaConfiguration(forceUpdate);
         });
 #if ENABLE(VP9)
         VP9TestingOverrides::singleton().setConfigurationChangedCallback([this, protectedThis = Ref { *this }] (bool forceUpdate) {
-            ensureProtectedGPUProcessConnection()->updateMediaConfiguration(forceUpdate);
+            ensureGPUProcessConnection()->updateMediaConfiguration(forceUpdate);
         });
 #endif
     } else {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -283,12 +283,10 @@ public:
     Ref<WasmDebuggerDispatcher> protectedWasmDebuggerDispatcher() { return m_wasmDebuggerDispatcher; }
 #endif
 
-    NetworkProcessConnection& ensureNetworkProcessConnection();
-    Ref<NetworkProcessConnection> ensureProtectedNetworkProcessConnection();
+    Ref<NetworkProcessConnection> ensureNetworkProcessConnection();
+    RefPtr<NetworkProcessConnection> existingNetworkProcessConnection() const;
 
     void networkProcessConnectionClosed(NetworkProcessConnection*);
-    NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
-    RefPtr<NetworkProcessConnection> protectedNetworkProcessConnection();
     WebLoaderStrategy& webLoaderStrategy();
     Ref<WebLoaderStrategy> protectedWebLoaderStrategy();
     WebFileSystemStorageConnection& fileSystemStorageConnection();
@@ -303,9 +301,8 @@ public:
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess); }
 
 #if ENABLE(GPU_PROCESS)
-    GPUProcessConnection& ensureGPUProcessConnection();
-    Ref<GPUProcessConnection> ensureProtectedGPUProcessConnection();
-    GPUProcessConnection* existingGPUProcessConnection() { return m_gpuProcessConnection.get(); }
+    Ref<GPUProcessConnection> ensureGPUProcessConnection();
+    RefPtr<GPUProcessConnection> existingGPUProcessConnection() const;
     // Returns timeout duration for GPU process connections. Thread-safe.
     Seconds gpuProcessTimeoutDuration() const;
     void gpuProcessConnectionClosed();
@@ -330,9 +327,9 @@ public:
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS)
-    ModelProcessConnection& ensureModelProcessConnection();
+    Ref<ModelProcessConnection> ensureModelProcessConnection();
+    RefPtr<ModelProcessConnection> existingModelProcessConnection() const;
     void modelProcessConnectionClosed(ModelProcessConnection&);
-    ModelProcessConnection* existingModelProcessConnection() { return m_modelProcessConnection.get(); }
 #endif // ENABLE(MODEL_PROCESS)
 
 #if USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -108,7 +108,7 @@ void StorageAreaMap::setItem(LocalFrame& sourceFrame, StorageAreaImpl* sourceAre
         if (weakThis)
             weakThis->didSetItem(seed, key, hasError, WTFMove(allItems));
     };
-    Ref connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    Ref connection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
     connection->sendWithAsyncReply(Messages::NetworkStorageManager::SetItem(*m_remoteAreaIdentifier, sourceArea->identifier(), key, value, sourceFrame.document()->url().string()), WTFMove(callback));
 }
 
@@ -134,7 +134,7 @@ void StorageAreaMap::removeItem(WebCore::LocalFrame& sourceFrame, StorageAreaImp
         if (weakThis)
             weakThis->didRemoveItem(seed, key, hasError, WTFMove(allItems));
     };
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkStorageManager::RemoveItem(*m_remoteAreaIdentifier, sourceArea->identifier(), key, sourceFrame.document()->url().string()), WTFMove(callback));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkStorageManager::RemoveItem(*m_remoteAreaIdentifier, sourceArea->identifier(), key, sourceFrame.document()->url().string()), WTFMove(callback));
 }
 
 void StorageAreaMap::clear(WebCore::LocalFrame& sourceFrame, StorageAreaImpl* sourceArea)
@@ -153,7 +153,7 @@ void StorageAreaMap::clear(WebCore::LocalFrame& sourceFrame, StorageAreaImpl* so
         if (weakThis)
             weakThis->didClear(seed);
     };
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkStorageManager::Clear(*m_remoteAreaIdentifier, sourceArea->identifier(), sourceFrame.document()->url().string()), WTFMove(callback));
+    WebProcess::singleton().ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkStorageManager::Clear(*m_remoteAreaIdentifier, sourceArea->identifier(), sourceFrame.document()->url().string()), WTFMove(callback));
 }
 
 bool StorageAreaMap::contains(const String& key)
@@ -287,7 +287,7 @@ WebCore::ClientOrigin StorageAreaMap::clientOrigin() const
 void StorageAreaMap::sendConnectMessage(SendMode mode)
 {
     m_isWaitingForConnectReply = true;
-    Ref ipcConnection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    Ref ipcConnection = WebProcess::singleton().ensureNetworkProcessConnection()->connection();
     auto namespaceIdentifier = m_namespace->storageNamespaceID();
     auto origin = clientOrigin();
     auto type = computeStorageType();

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -66,7 +66,7 @@ void RemoteRealtimeMediaSource::createRemoteMediaSource()
 
         m_proxy.setAsReady();
         if (m_proxy.shouldCaptureInGPUProcess())
-            WebProcess::singleton().ensureProtectedGPUProcessConnection()->addClient(*this);
+            WebProcess::singleton().ensureGPUProcessConnection()->addClient(*this);
     }, m_proxy.shouldCaptureInGPUProcess() && m_manager->shouldUseGPUProcessRemoteFrames());
 }
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -48,7 +48,7 @@ static Ref<IPC::Connection> getSourceConnection(bool shouldCaptureInGPUProcess)
     ASSERT(isMainRunLoop());
 #if ENABLE(GPU_PROCESS)
     if (shouldCaptureInGPUProcess)
-        return WebProcess::singleton().ensureGPUProcessConnection().connection();
+        return WebProcess::singleton().ensureGPUProcessConnection()->connection();
 #endif
     return *WebProcess::singleton().parentProcessConnection();
 }

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -236,7 +236,7 @@ CaptureSourceOrError UserMediaCaptureManager::VideoFactory::createVideoCaptureSo
         return CaptureSourceOrError { "Video capture in GPUProcess is not implemented"_s };
 #endif
     if (m_shouldCaptureInGPUProcess)
-        m_manager->protectedRemoteCaptureSampleManager()->setVideoFrameObjectHeapProxy(&WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy());
+        m_manager->protectedRemoteCaptureSampleManager()->setVideoFrameObjectHeapProxy(&WebProcess::singleton().ensureGPUProcessConnection()->videoFrameObjectHeapProxy());
 
     return RemoteRealtimeVideoSource::create(device, constraints, WTFMove(hashSalts), m_manager, m_shouldCaptureInGPUProcess, pageIdentifier);
 }
@@ -248,7 +248,7 @@ CaptureSourceOrError UserMediaCaptureManager::DisplayFactory::createDisplayCaptu
         return CaptureSourceOrError { "Display capture in GPUProcess is not implemented"_s };
 #endif
     if (m_shouldCaptureInGPUProcess) {
-        Ref videoFrameObjectHeapProxy = WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy();
+        Ref videoFrameObjectHeapProxy = WebProcess::singleton().ensureGPUProcessConnection()->videoFrameObjectHeapProxy();
         m_manager->protectedRemoteCaptureSampleManager()->setVideoFrameObjectHeapProxy(WTFMove(videoFrameObjectHeapProxy));
     }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -703,7 +703,7 @@ void WebProcess::updateProcessName(IsInProcessInitialization isInProcessInitiali
         auto auditToken = auditTokenForSelf();
         if (!auditToken)
             return;
-        ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(displayName, { }, *auditToken), 0);
+        ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(displayName, { }, *auditToken), 0);
         return;
     }
 #if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
@@ -1063,7 +1063,7 @@ void WebProcess::getProcessDisplayName(CompletionHandler<void(String&&)>&& compl
     auto auditToken = auditTokenForSelf();
     if (!auditToken)
         return completionHandler({ });
-    ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::GetProcessDisplayName(*auditToken), WTFMove(completionHandler));
+    ensureNetworkProcessConnection()->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::GetProcessDisplayName(*auditToken), WTFMove(completionHandler));
 #else
     completionHandler({ });
 #endif
@@ -1076,7 +1076,7 @@ void WebProcess::updateActivePages(const String& overrideDisplayName)
     auto auditToken = auditTokenForSelf();
     if (!auditToken)
         return;
-    ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(overrideDisplayName, activePagesOrigins(m_pageMap), *auditToken), 0);
+    ensureNetworkProcessConnection()->connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(overrideDisplayName, activePagesOrigins(m_pageMap), *auditToken), 0);
 #else
     if (!overrideDisplayName) {
         RunLoop::mainSingleton().dispatch([activeOrigins = activePagesOrigins(m_pageMap)] {


### PR DESCRIPTION
#### dd00c78c6a8fab85064b20b0eaab7380bb40134d
<pre>
SaferCPP: Remove unprotected WebProcess::*ProcessConnection() accessors
<a href="https://bugs.webkit.org/show_bug.cgi?id=302457">https://bugs.webkit.org/show_bug.cgi?id=302457</a>
<a href="https://rdar.apple.com/164625256">rdar://164625256</a>

Reviewed by NOBODY (OOPS!).

Use the protected variants to access GPUProcessConnection,
NetworkProcessConnection, ModelProcessConnection instances.

No new tests (OOPS!).
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
(WebKit::WebPaymentCoordinator::messageSenderConnection const):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::connection):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp:
(WebKit::WebIDBConnectionToServer::messageSenderConnection const):
* Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp:
(WebKit::WebDatabaseProvider::idbConnectionToServerForSession):
* Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp:
(WebKit::BlobRegistryProxy::registerInternalFileBlobURL):
(WebKit::BlobRegistryProxy::registerInternalBlobURL):
(WebKit::BlobRegistryProxy::registerBlobURL):
(WebKit::BlobRegistryProxy::registerInternalBlobURLOptionallyFileBacked):
(WebKit::BlobRegistryProxy::unregisterBlobURL):
(WebKit::BlobRegistryProxy::registerInternalBlobURLForSlice):
(WebKit::BlobRegistryProxy::registerBlobURLHandle):
(WebKit::BlobRegistryProxy::unregisterBlobURLHandle):
(WebKit::BlobRegistryProxy::blobType):
(WebKit::BlobRegistryProxy::blobSize):
(WebKit::BlobRegistryProxy::writeBlobsToTemporaryFilesForIndexedDB):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::surfaceBufferToVideoFrame):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::RemoteQueueProxy):
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp:
(WebKit::RemoteWCLayerTreeHostProxy::messageSenderConnection const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
(WebKit::MediaPlayerPrivateRemote::addRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteVideoTrack):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
(WebKit::RemoteAudioSourceProviderManager::addProvider):
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp:
(WebKit::RemoteCDM::setLogIdentifier):
(WebKit::RemoteCDM::getSupportedConfiguration):
(WebKit::RemoteCDM::createInstance):
(WebKit::RemoteCDM::loadAndInitialize):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::gpuProcessConnection):
(WebKit::RemoteCDMFactory::supportsKeySystem):
(WebKit::RemoteCDMFactory::createCDM):
(WebKit::RemoteCDMFactory::removeSession):
(WebKit::RemoteCDMFactory::removeInstance):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp:
(WebKit::RemoteCDMInstance::RemoteCDMInstance):
(WebKit::RemoteCDMInstance::~RemoteCDMInstance):
(WebKit::RemoteCDMInstance::initializeWithConfiguration):
(WebKit::RemoteCDMInstance::setServerCertificate):
(WebKit::RemoteCDMInstance::setStorageDirectory):
(WebKit::RemoteCDMInstance::createSession):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp:
(WebKit::RemoteCDMInstanceSession::setLogIdentifier):
(WebKit::RemoteCDMInstanceSession::requestLicense):
(WebKit::RemoteCDMInstanceSession::updateLicense):
(WebKit::RemoteCDMInstanceSession::loadSession):
(WebKit::RemoteCDMInstanceSession::closeSession):
(WebKit::RemoteCDMInstanceSession::removeSessionData):
(WebKit::RemoteCDMInstanceSession::storeRecordOfKeyUsage):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
(WebKit::RemoteImageDecoderAVFManager::createImageDecoder):
(WebKit::RemoteImageDecoderAVFManager::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::supportsMIMEType const):
(WebKit::RemoteLegacyCDM::createSession):
(WebKit::RemoteLegacyCDM::setPlayerId):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::gpuProcessConnection):
(WebKit::RemoteLegacyCDMFactory::supportsKeySystem):
(WebKit::RemoteLegacyCDMFactory::supportsKeySystemAndMimeType):
(WebKit::RemoteLegacyCDMFactory::addSession):
(WebKit::RemoteLegacyCDMFactory::removeSession):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp:
(WebKit::RemoteLegacyCDMSession::generateKeyRequest):
(WebKit::RemoteLegacyCDMSession::releaseKeys):
(WebKit::RemoteLegacyCDMSession::update):
(WebKit::RemoteLegacyCDMSession::cachedKeyForKeyID const):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp:
(WebKit::RemoteMediaEngineConfigurationFactory::gpuProcessConnection):
(WebKit::RemoteMediaEngineConfigurationFactory::createDecodingConfiguration):
(WebKit::RemoteMediaEngineConfigurationFactory::createEncodingConfiguration):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportedTypes):
(WebKit::RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::createRemoteMediaPlayer):
(WebKit::RemoteMediaPlayerManager::deleteRemoteMediaPlayer):
(WebKit::RemoteMediaPlayerManager::setUseGPUProcess):
(WebKit::RemoteMediaPlayerManager::gpuProcessConnection):
(WebKit::RemoteMediaPlayerManager::protectedGPUProcessConnection): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp:
(WebKit::RemoteRemoteCommandListener::ensureGPUProcessConnection):
(WebKit::RemoteRemoteCommandListener::updateSupportedCommands):
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::createAudioVideoRenderer const):
(WebKit::WebMediaStrategy::createNowPlayingManager const):
(WebKit::WebMediaStrategy::enableMockMediaSource):
(WebKit::WebMediaStrategy::nativeImageFromVideoFrame):
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::nativeImageForCurrentTime):
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::~AudioMediaStreamTrackRendererInternalUnitManagerProxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::createRemoteUnit):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::start):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::stop):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::setLastDeviceUsed):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::initializeIfNeeded):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::SampleBufferDisplayLayer):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::addOriginAccessAllowListEntry):
(WebKit::InjectedBundle::removeOriginAccessAllowListEntry):
(WebKit::InjectedBundle::resetOriginAccessAllowLists):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::send):
(WebKit::ModelProcessModelPlayer::sendWithAsyncReply):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
(WebKit::ModelProcessModelPlayerManager::modelProcessConnection):
(WebKit::ModelProcessModelPlayerManager::createModelProcessModelPlayer):
(WebKit::ModelProcessModelPlayerManager::deleteModelProcessModelPlayer):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
(WebKit::WebLoaderStrategy::startPingLoad):
(WebKit::WebLoaderStrategy::preconnectTo):
(WebKit::WebLoaderStrategy::isResourceLoadFinished):
(WebKit::WebLoaderStrategy::setCaptureExtraNetworkLoadMetricsEnabled):
(WebKit::WebLoaderStrategy::responseFromResourceLoadIdentifier):
(WebKit::WebLoaderStrategy::intermediateLoadInformationFromResourceLoadIdentifier):
(WebKit::WebLoaderStrategy::networkMetricsFromResourceLoadIdentifier):
(WebKit::WebLoaderStrategy::setResourceLoadSchedulingMode):
(WebKit::WebLoaderStrategy::prioritizeResourceLoads):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::messageSenderConnection const):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::messageSenderConnection const):
* Source/WebKit/WebProcess/Network/WebSocketProvider.cpp:
(WebKit::WebSocketProvider::WebSocketProvider):
(WebKit::WebSocketProvider::initializeWebTransportSession):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp:
(WebKit::LibWebRTCResolver::sendOnMainThread):
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::RTCDataChannelRemoteManager):
(WebKit::RTCDataChannelRemoteManager::RemoteHandlerConnection::RemoteHandlerConnection):
(WebKit::RTCDataChannelRemoteManager::RemoteSourceConnection::RemoteSourceConnection):
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp:
(WebKit::WebMDNSRegister::unregisterMDNSNames):
(WebKit::WebMDNSRegister::registerMDNSName):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp:
(WebKit::WebRTCMonitor::startUpdating):
(WebKit::WebRTCMonitor::stopUpdating):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::sendMessage):
(WebKit::WebNotificationManager::policyForOrigin const):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::messageSenderConnection const):
(WebKit::WebSWClientConnection::addRoutes):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp:
(WebKit::WebServiceWorkerProvider::serviceWorkerConnection):
(WebKit::WebServiceWorkerProvider::terminateWorkerForTesting):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp:
(WebKit::WebSharedWorkerObjectConnection::messageSenderConnection const):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.cpp:
(WebKit::WebSharedWorkerProvider::sharedWorkerConnection):
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
(WebKit::networkProcessConnection):
(WebKit::WebBroadcastChannelRegistry::registerChannel):
(WebKit::WebBroadcastChannelRegistry::unregisterChannel):
(WebKit::WebBroadcastChannelRegistry::postMessage):
(WebKit::WebBroadcastChannelRegistry::networkProcessCrashed):
(WebKit::protectedNetworkProcessConnection): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
(WebKit::WebChromeClient::registerBlobPathForTesting):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::loadStorageAccessQuirksIfNeeded):
(WebKit::WebLocalFrameLoaderClient::sendH2Ping):
(WebKit::WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold):
(WebKit::WebLocalFrameLoaderClient::removeStorageAccess):
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::networkProcessConnection):
(WebKit::WebMessagePortChannelProvider::createNewMessagePortChannel):
(WebKit::WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote):
(WebKit::WebMessagePortChannelProvider::messagePortDisentangled):
(WebKit::WebMessagePortChannelProvider::messagePortClosed):
(WebKit::WebMessagePortChannelProvider::takeAllMessagesForPort):
(WebKit::WebMessagePortChannelProvider::postMessageToRemote):
(WebKit::protectedNetworkProcessConnection): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
(WebKit::WebPermissionController::addChangeListener):
(WebKit::WebPermissionController::removeChangeListener):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::windowSubscribeToPushService):
(WebKit::WebPlatformStrategies::windowUnsubscribeFromPushService):
(WebKit::WebPlatformStrategies::windowGetPushSubscription):
(WebKit::WebPlatformStrategies::windowGetPushPermissionState):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::requestStorageAccessUnderOpener):
(WebKit::WebResourceLoadObserver::updateCentralStatisticsStore):
(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp:
(WebKit::WebStorageConnection::connection):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm:
(WebKit::WebCookieCache::inMemoryStorageSession):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::setMediaEnvironment):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::processTargetFromArgument):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::cookiesForDOM):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::cookies const):
(WebKit::WebCookieJar::setCookies):
(WebKit::WebCookieJar::remoteCookiesEnabledSync const):
(WebKit::WebCookieJar::remoteCookiesEnabled const):
(WebKit::WebCookieJar::cookieRequestHeaderFieldValue const):
(WebKit::WebCookieJar::getRawCookies const):
(WebKit::WebCookieJar::setRawCookie):
(WebKit::WebCookieJar::deleteCookie):
(WebKit::WebCookieJar::getCookiesAsync const):
(WebKit::WebCookieJar::setCookieAsync const):
(WebKit::WebCookieJar::addChangeListenerWithAccess):
(WebKit::WebCookieJar::removeChangeListener):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::startDownload):
(WebKit::WebFrame::convertMainResourceLoadToDownload):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::~WebPage):
(WebKit::WebPage::close):
(WebKit::WebPage::updatePreferences):
(WebKit::WebPage::loadAndDecodeImage):
(WebKit::WebPage::hasStorageAccess):
(WebKit::WebPage::requestStorageAccess):
(WebKit::WebPage::setLoginStatus):
(WebKit::WebPage::isLoggedIn):
(WebKit::WebPage::configureLoggingChannel):
(WebKit::WebPage::synchronizeCORSDisablingPatternsWithNetworkProcess):
(WebKit::WebPage::useRedirectionForCurrentNavigation):
* Source/WebKit/WebProcess/WebPage/soup/WebCookieCacheSoup.cpp:
(WebKit::WebCookieCache::inMemoryStorageSession):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::registerURLSchemeAsCORSEnabled):
(WebKit::WebProcess::ensureNetworkProcessConnection):
(WebKit::WebProcess::existingNetworkProcessConnection const):
(WebKit::WebProcess::fileSystemStorageConnection):
(WebKit::WebProcess::ensureGPUProcessConnection):
(WebKit::WebProcess::existingGPUProcessConnection const):
(WebKit::WebProcess::ensureModelProcessConnection):
(WebKit::WebProcess::existingModelProcessConnection const):
(WebKit::WebProcess::prefetchDNS):
(WebKit::WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcess::registerServiceWorkerClients):
(WebKit::WebProcess::setAppBadge):
(WebKit::WebProcess::setUseGPUProcessForMedia):
(WebKit::WebProcess::ensureProtectedNetworkProcessConnection): Deleted.
(WebKit::WebProcess::protectedNetworkProcessConnection): Deleted.
(WebKit::WebProcess::ensureProtectedGPUProcessConnection): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
(WebKit::StorageAreaMap::setItem):
(WebKit::StorageAreaMap::removeItem):
(WebKit::StorageAreaMap::clear):
(WebKit::StorageAreaMap::sendConnectMessage):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::createRemoteMediaSource):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::getSourceConnection):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::VideoFactory::createVideoCaptureSource):
(WebKit::UserMediaCaptureManager::DisplayFactory::createDisplayCaptureSource):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd00c78c6a8fab85064b20b0eaab7380bb40134d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130821 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3144 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41780 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138247 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82474 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1e3dfb4-c002-4e85-b1be-905f034f1fba) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3124 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2987 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/138247 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/82474 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58690cc5-c193-4a9f-93bc-061e28a84f90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133767 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/3124 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/41780 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/138247 "Hash dd00c78c for PR 53871 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/3124 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/41780 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81499 "Hash dd00c78c for PR 53871 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/3124 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/41780 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140723 "Hash dd00c78c for PR 53871 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2888 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/2987 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/140723 "Hash dd00c78c for PR 53871 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2934 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/41780 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/140723 "Hash dd00c78c for PR 53871 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/41780 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55932 "Hash dd00c78c for PR 53871 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2956 "Hash dd00c78c for PR 53871 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66348 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2777 "Hash dd00c78c for PR 53871 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2977 "Hash dd00c78c for PR 53871 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2885 "Hash dd00c78c for PR 53871 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->