### PR TITLE
[GStreamer] Use new gst_check_version() function when available

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
@@ -78,7 +78,7 @@ void GStreamerDtlsTransportBackendObserver::stateChanged()
 
         // Access to DTLS certificates is not memory-safe in GStreamer versions older than 1.22.3.
         // See also: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/d9c853f165288071b63af9a56b6d76e358fbdcc2
-        if (webkitGstCheckVersion(1, 22, 3)) {
+        if (gst_check_version(1, 22, 3)) {
             GUniqueOutPtr<char> remoteCertificate;
             GUniqueOutPtr<char> certificate;
             g_object_get(m_backend.get(), "remote-certificate", &remoteCertificate.outPtr(), "certificate", &certificate.outPtr(), nullptr);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -281,13 +281,13 @@ bool GStreamerMediaEndpoint::initializePipeline()
         });
     }), this);
 
-    if (webkitGstCheckVersion(1, 22, 0)) {
+    if (gst_check_version(1, 22, 0)) {
         g_signal_connect_swapped(m_webrtcBin.get(), "prepare-data-channel", G_CALLBACK(+[](GStreamerMediaEndpoint* endPoint, GstWebRTCDataChannel* channel, gboolean isLocal) {
             endPoint->prepareDataChannel(channel, isLocal);
         }), this);
 
         ASCIILiteral requestAuxSenderSignalName = "request-aux-sender"_s;
-        if (webkitGstCheckVersion(1, 25, 0))
+        if (gst_check_version(1, 25, 0))
             requestAuxSenderSignalName = "request-post-rtp-aux-sender"_s;
         g_signal_connect_swapped(m_webrtcBin.get(), requestAuxSenderSignalName.characters(), G_CALLBACK(+[](GStreamerMediaEndpoint* endPoint, GstWebRTCDTLSTransport* transport) -> GstElement* {
             // `sender` ownership is transferred to the signal caller.
@@ -1908,7 +1908,7 @@ void GStreamerMediaEndpoint::addIceCandidate(GStreamerIceCandidate& candidate, P
     m_statsCollector->invalidateCache();
 
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3960
-    if (webkitGstCheckVersion(1, 24, 0)) {
+    if (gst_check_version(1, 24, 0)) {
         auto* data = createAddIceCandidateCallData();
         data->webrtcBin = m_webrtcBin;
         data->callback = WTFMove(callback);
@@ -1988,7 +1988,7 @@ void GStreamerMediaEndpoint::prepareDataChannel(GstWebRTCDataChannel* dataChanne
 
 UniqueRef<GStreamerDataChannelHandler> GStreamerMediaEndpoint::findOrCreateIncomingChannelHandler(GRefPtr<GstWebRTCDataChannel>&& dataChannel)
 {
-    if (!webkitGstCheckVersion(1, 22, 0))
+    if (!gst_check_version(1, 22, 0))
         return makeUniqueRef<GStreamerDataChannelHandler>(WTFMove(dataChannel));
 
     auto identifier = ObjectIdentifier<GstWebRTCDataChannel>(reinterpret_cast<uintptr_t>(dataChannel.get()));

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -357,13 +357,13 @@ static gboolean fillReportCallback(const GValue* value, Ref<ReportHolder>& repor
         break;
     case GST_WEBRTC_STATS_LOCAL_CANDIDATE:
     case GST_WEBRTC_STATS_REMOTE_CANDIDATE:
-        if (webkitGstCheckVersion(1, 22, 0)) {
+        if (gst_check_version(1, 22, 0)) {
             RTCStatsReport::IceCandidateStats stats(statsType, structure);
             report.set<IDLDOMString, IDLDictionary<RTCStatsReport::IceCandidateStats>>(stats.id, WTFMove(stats));
         }
         break;
     case GST_WEBRTC_STATS_CANDIDATE_PAIR:
-        if (webkitGstCheckVersion(1, 22, 0)) {
+        if (gst_check_version(1, 22, 0)) {
             RTCStatsReport::IceCandidatePairStats stats(structure);
             report.set<IDLDOMString, IDLDictionary<RTCStatsReport::IceCandidatePairStats>>(stats.id, WTFMove(stats));
         }

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -69,7 +69,7 @@ static void initializeDMABufAvailability()
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        if (!webkitGstCheckVersion(1, 20, 0))
+        if (!gst_check_version(1, 20, 0))
             return;
 
         auto value = unsafeSpan(g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED"));

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -438,7 +438,7 @@ bool ensureGStreamerInitialized()
         // playbin3.
         // The USE_PLAYBIN3 environment variable is no longer supported.
         // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/6255
-        if (!webkitGstCheckVersion(1, 24, 0) && g_getenv("USE_PLAYBIN3"))
+        if (!gst_check_version(1, 24, 0) && g_getenv("USE_PLAYBIN3"))
             WTFLogAlways("The USE_PLAYBIN3 variable was detected in the environment. Expect playback issues or please unset it.");
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
@@ -558,7 +558,7 @@ void registerWebKitGStreamerElements()
         // The new demuxers based on adaptivedemux2 cannot be used in WebKit yet because this new
         // base class does not abstract away network access. They can't work in a sandboxed
         // media process, so demote their rank in order to prevent decodebin3 from auto-plugging them.
-        if (webkitGstCheckVersion(1, 22, 0)) {
+        if (gst_check_version(1, 22, 0)) {
             std::array<ASCIILiteral, 3> elementNames = { "dashdemux2"_s, "hlsdemux2"_s, "mssdemux2"_s };
             for (auto& elementName : elementNames) {
                 if (auto factory = adoptGRef(gst_element_factory_find(elementName)))
@@ -2113,7 +2113,7 @@ GRefPtr<GstElement> createVideoConvertScaleElement(const String& name)
     // Keep videoconvertscale disabled for now due to some performance issues.
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3815
     auto useVideoConvertScale = StringView::fromLatin1(std::getenv("WEBKIT_GST_USE_VIDEOCONVERT_SCALE"));
-    if (useVideoConvertScale == "1"_s && webkitGstCheckVersion(1, 22, 0)) {
+    if (useVideoConvertScale == "1"_s && gst_check_version(1, 22, 0)) {
         GRefPtr videoConvertScale = makeGStreamerElement("videoconvertscale"_s, name);
         if (!videoConvertScale)
             return nullptr;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -54,7 +54,8 @@ using TrackIDHashMap = HashMap<TrackID, MappedArg, WTF::IntHash<TrackID>, WTF::U
 #define GST_CHECK_VERSION_FULL(major, minor, micro, nano) \
     (GST_CHECK_VERSION(major, minor, micro) && (GST_VERSION_NANO >= nano))
 
-inline bool webkitGstCheckVersion(guint major, guint minor, guint micro)
+#if !GST_CHECK_VERSION(1, 28, 0)
+inline bool gst_check_version(guint major, guint minor, guint micro)
 {
     guint currentMajor, currentMinor, currentMicro, currentNano;
     gst_version(&currentMajor, &currentMinor, &currentMicro, &currentNano);
@@ -74,6 +75,7 @@ inline bool webkitGstCheckVersion(guint major, guint minor, guint micro)
 
     return true;
 }
+#endif
 
 #define GST_VIDEO_CAPS_TYPE_PREFIX  "video/"_s
 #define GST_AUDIO_CAPS_TYPE_PREFIX  "audio/"_s

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -114,7 +114,7 @@ private:
             return false;
         }
 
-        return !webkitGstCheckVersion(1, 24, 0);
+        return !gst_check_version(1, 24, 0);
     }
 
     static void initializeIsNeeded()

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2657,7 +2657,7 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
     // might not auto-plug hardware decoders.
     bool isBlob = m_url.protocolIs("blob"_s);
     auto nameView = StringView::fromLatin1(elementName.get());
-    if (webkitGstCheckVersion(1, 22, 0) && nameView.startsWith("urisourcebin"_s) && (isBlob || isMediaSource() || isMediaStreamPlayer()))
+    if (gst_check_version(1, 22, 0) && nameView.startsWith("urisourcebin"_s) && (isBlob || isMediaSource() || isMediaStreamPlayer()))
         g_object_set(element, "use-buffering", FALSE, "parse-streams", !isMediaStreamPlayer(), nullptr);
 
     if (nameView.startsWith("parsebin"_s))
@@ -3459,7 +3459,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     g_object_set(m_pipeline.get(), "mute", static_cast<gboolean>(player->muted()), nullptr);
 
     // From GStreamer 1.22.0, uridecodebin3 is created in playbin3's _init(), so "element-setup" isn't called with it.
-    if (!m_isLegacyPlaybin && webkitGstCheckVersion(1, 22, 0)) {
+    if (!m_isLegacyPlaybin && gst_check_version(1, 22, 0)) {
         if (auto uriDecodeBin3 = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), "uridecodebin3")))
             configureElement(uriDecodeBin3.get());
     }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -138,7 +138,7 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
     GUniquePtr<char> mimeCodec(gst_codec_utils_caps_get_mime_codec(caps.get()));
     if (mimeCodec) {
         String codec = unsafeSpan(mimeCodec.get());
-        if (!webkitGstCheckVersion(1, 22, 8)) {
+        if (!gst_check_version(1, 22, 8)) {
             // The gst_codec_utils_caps_get_mime_codec() function will return all the codec parameters,
             // including the default ones, so to strip them away, re-parse the returned string, using
             // WebCore VPx codec string parser.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -721,7 +721,7 @@ void AppendPipeline::resetParserState()
     // Flush approach requires these GStreamer patches, shipped in 1.24:
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4101.
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4199.
-    if (webkitGstCheckVersion(1, 24, 0)) {
+    if (gst_check_version(1, 24, 0)) {
         GST_DEBUG_OBJECT(pipeline(), "Handling resetParserState() in AppendPipeline by flushing the pipeline");
         gst_element_send_event(m_appsrc.get(), gst_event_new_flush_start());
         gst_element_send_event(m_appsrc.get(), gst_event_new_flush_stop(true));

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -273,7 +273,7 @@ static void webkit_media_src_class_init(WebKitMediaSrcClass* klass)
 
     // In GStreamer 1.20 and older urisourcebin mishandles source elements with dynamic pads. This
     // is not an issue in 1.22.
-    if (webkitGstCheckVersion(1, 22, 0))
+    if (gst_check_version(1, 22, 0))
         eklass->query = GST_DEBUG_FUNCPTR(webKitMediaSrcQuery);
 
     g_object_class_install_property(oklass,
@@ -339,7 +339,7 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
                 return GST_PAD_PROBE_OK;
             }, nullptr, nullptr);
 
-        if (!webkitGstCheckVersion(1, 20, 6)) {
+        if (!gst_check_version(1, 20, 6)) {
             // Workaround: gst_element_add_pad() should already call gst_pad_set_active() if the element is PAUSED or
             // PLAYING. Unfortunately, as of GStreamer 1.18.2 it does so with the element lock taken, causing a deadlock
             // in gst_pad_start_task(), who tries to post a `stream-status` message in the element, which also requires
@@ -713,7 +713,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
             streamingMembers->isFlushing = false;
             streamingMembers->doesNeedSegmentEvent = true;
 
-            if (!webkitGstCheckVersion(1, 22, 0)) {
+            if (!gst_check_version(1, 22, 0)) {
                 // In older GST versions STREAM_COLLECTION event is delivered to decodebin3
                 // from parsebin src pad probe. On the way, this event is cached inside
                 // parser element (GstBaseParse) and pushed downstream with first frame.

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -961,7 +961,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
         }
     });
 
-    if (webkitGstCheckVersion(1, 22, 0)) {
+    if (gst_check_version(1, 22, 0)) {
         Encoders::registerEncoder(Av1, "av1enc"_s, "av1parse"_s, "video/x-av1"_s, "video/x-av1,stream-format=obu-stream",
             [](WebKitVideoEncoder* self) {
                 g_object_set(self->priv->encoder.get(), "threads", NUMBER_OF_THREADS, nullptr);

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -110,7 +110,7 @@ bool MediaRecorderPrivateGStreamer::isTypeSupported(const ContentType& contentTy
     bool isSupported = scanner.isContentTypeSupported(GStreamerRegistryScanner::Configuration::Encoding, contentType, { }, GStreamerRegistryScanner::CaseSensitiveCodecName::No) > MediaPlayerEnums::SupportsType::IsNotSupported;
 
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7670
-    if (isSupported && !contentType.containerType().endsWith("mp4"_s) && !webkitGstCheckVersion(1, 24, 9))
+    if (isSupported && !contentType.containerType().endsWith("mp4"_s) && !gst_check_version(1, 24, 9))
         isSupported = false;
     return isSupported;
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1117,7 +1117,7 @@ static void webkit_media_stream_src_class_init(WebKitMediaStreamSrcClass* klass)
 
     // In GStreamer 1.20 and older urisourcebin mishandles source elements with dynamic pads. This
     // is not an issue in 1.22.
-    if (webkitGstCheckVersion(1, 22, 0))
+    if (gst_check_version(1, 22, 0))
         gstElementClass->query = GST_DEBUG_FUNCPTR(webkitMediaStreamSrcQuery);
 
     gst_element_class_add_pad_template(gstElementClass, gst_static_pad_template_get(&videoSrcTemplate));

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -73,7 +73,7 @@ GStreamerRTPPacketizer::~GStreamerRTPPacketizer() = default;
 
 void GStreamerRTPPacketizer::configureExtensions()
 {
-    if (!webkitGstCheckVersion(1, 24, 0)) {
+    if (!gst_check_version(1, 24, 0)) {
         GST_WARNING_OBJECT(m_bin.get(), "GStreamer 1.24 is required for configuring extensions on the RTP payloaders. Simulcast will not work.");
         return;
     }
@@ -118,7 +118,7 @@ void GStreamerRTPPacketizer::configureExtensions()
 
 void GStreamerRTPPacketizer::ensureMidExtension(const String& mid)
 {
-    if (!webkitGstCheckVersion(1, 24, 0)) {
+    if (!gst_check_version(1, 24, 0)) {
         GST_WARNING_OBJECT(m_bin.get(), "GStreamer 1.24 is required for ensuring mid extension on the RTP payloaders.");
         return;
     }


### PR DESCRIPTION
#### ebd1daf44860eb76dfca5fb484d02837835701d3
<pre>
[GStreamer] Use new gst_check_version() function when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=302459">https://bugs.webkit.org/show_bug.cgi?id=302459</a>

Reviewed by Xabier Rodriguez-Calvar.

And keep the vendored function until our minimal GStreamer version is bumped to 1.28.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp:
(WebCore::GStreamerDtlsTransportBackendObserver::stateChanged):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::addIceCandidate):
(WebCore::GStreamerMediaEndpoint::findOrCreateIncomingChannelHandler):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::fillReportCallback):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(initializeDMABufAvailability):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::ensureGStreamerInitialized):
(WebCore::registerWebKitGStreamerElements):
(WebCore::createVideoConvertScaleElement):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::gst_check_version):
(WebCore::webkitGstCheckVersion): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
(WebCore::BaseSinkPositionFlushWorkaroundProbe::checkIsNeeded):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureElement):
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::resetParserState):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webkit_media_src_class_init):
(webKitMediaSrcEmitStreams):
(webKitMediaSrcStreamFlush):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateGStreamer::isTypeSupported):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkit_media_stream_src_class_init):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::configureExtensions):
(WebCore::GStreamerRTPPacketizer::ensureMidExtension):

Canonical link: <a href="https://commits.webkit.org/303242@main">https://commits.webkit.org/303242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af1e7b823b531541e42f23c9603cf9add53ddb54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130823 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99673 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67506 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2166 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140725 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2890 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108186 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2209 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55904 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2958 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31899 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66350 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->