### PR TITLE
[GStreamer][WebAudio] Create the rendering pipeline only when needed

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
@@ -21,7 +21,6 @@
 #include "AudioBus.h"
 #include "AudioDestination.h"
 #include "GRefPtrGStreamer.h"
-#include <wtf/Condition.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -48,6 +47,7 @@ protected:
     virtual void stopRendering(CompletionHandler<void(bool)>&&);
 
 private:
+    void initializePipeline();
     void notifyStartupResult(bool);
     void notifyStopResult(bool);
 


### PR DESCRIPTION
#### bc43ac08a7be45371a16c6a848ba88706116ed3c
<pre>
[GStreamer][WebAudio] Create the rendering pipeline only when needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=302461">https://bugs.webkit.org/show_bug.cgi?id=302461</a>

Reviewed by Xabier Rodriguez-Calvar.

This is mostly a refactoring, deferring the pipeline initialization until the first playback request
has been done on the AudioDestination.

* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
(WebCore::AudioDestinationGStreamer::~AudioDestinationGStreamer):
(WebCore::AudioDestinationGStreamer::initializePipeline):
(WebCore::AudioDestinationGStreamer::start):
(WebCore::AudioDestinationGStreamer::startRendering):
(WebCore::AudioDestinationGStreamer::stop):
(WebCore::AudioDestinationGStreamer::stopRendering):
(WebCore::AudioDestinationGStreamer::notifyStopResult):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/303243@main">https://commits.webkit.org/303243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df3c266128598ef6c50014a0a1bf00bc692257d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130829 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3152 "Hash df3c2661 for PR 53874 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3132 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2995 "Hash df3c2661 for PR 53874 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99675 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67503 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2170 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81511 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110763 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2896 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2942 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/2995 "Hash df3c2661 for PR 53874 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2214 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55911 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2964 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31906 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2785 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66356 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->