### PR TITLE
[JSC] Implement `Promise.race` in C++

### DIFF
--- a/JSTests/microbenchmarks/promise-race.js
+++ b/JSTests/microbenchmarks/promise-race.js
@@ -1,0 +1,8 @@
+const promises = [];
+for (let i = 0; i < 12; i++)
+  promises.push(Promise.resolve(i));
+
+for (var i = 0; i < 1e4; ++i)
+    Promise.race(promises);
+
+drainMicrotasks();

--- a/JSTests/stress/new-promise-capabilities-requires-constructor.js
+++ b/JSTests/stress/new-promise-capabilities-requires-constructor.js
@@ -15,4 +15,4 @@ function shouldThrow(func, errorMessage) {
 
 shouldThrow(() => {
     Promise.race.call(() => { }, []);
-}, `TypeError: function is not a constructor`);
+}, `TypeError: argument is not a constructor`);

--- a/JSTests/stress/promise-race-empty-args.js
+++ b/JSTests/stress/promise-race-empty-args.js
@@ -1,0 +1,14 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const result = Promise.race();
+
+shouldBe(result instanceof Promise, true);
+let error;
+result.catch(e => {
+  error = e;
+})
+drainMicrotasks();
+shouldBe(error instanceof TypeError, true);

--- a/JSTests/stress/promise-race-fast-path-not-thenable.js
+++ b/JSTests/stress/promise-race-fast-path-not-thenable.js
@@ -1,0 +1,17 @@
+function shouldThrowAsync(run, errorType) {
+    let actual;
+    var hadError = false;
+    run().then(function(value) { actual = value; },
+               function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+}
+
+shouldThrowAsync(async function () {
+  var thenable = new Promise(function () {});
+  thenable.then = undefined;
+  await Promise.race([thenable]);
+}, TypeError);

--- a/JSTests/stress/promise-race-slow-path-non-thenable.js
+++ b/JSTests/stress/promise-race-slow-path-non-thenable.js
@@ -1,0 +1,17 @@
+function shouldThrowAsync(run, errorType) {
+    let actual;
+    var hadError = false;
+    run().then(function(value) { actual = value; },
+               function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+}
+
+shouldThrowAsync(async function () {
+  const nonThenable = {};
+  Promise.resolve = function (v) { return v; };
+  await Promise.race([nonThenable]);
+}, TypeError);

--- a/JSTests/stress/promsie-race-resolve-getter-throws.js
+++ b/JSTests/stress/promsie-race-resolve-getter-throws.js
@@ -1,0 +1,24 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+let count = 0;
+Object.defineProperty(Promise, "resolve", {
+  get() {
+    count++;
+    throw new Error("Error from get resolve");
+  }
+});
+
+let result;
+let caught = false;
+try {
+  result = Promise.race([]);
+} catch {
+  caught = true;
+}
+
+shouldBe(caught, false);
+shouldBe(count, 1);
+shouldBe(result instanceof Promise, true);

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -294,38 +294,6 @@ function any(iterable)
     return promise;
 }
 
-function race(iterable)
-{
-    "use strict";
-
-    if (!@isObject(this))
-        @throwTypeError("|this| is not an object");
-
-    var promiseCapability = @newPromiseCapability(this);
-    var resolve = promiseCapability.resolve;
-    var reject = promiseCapability.reject;
-    var promise = promiseCapability.promise;
-
-    try {
-        var promiseResolve = this.resolve;
-        if (!@isCallable(promiseResolve))
-            @throwTypeError("Promise resolve is not a function");
-
-        for (var value of iterable) {
-            var nextPromise = promiseResolve.@call(this, value);
-            var then = nextPromise.then;
-            if (@isPromise(nextPromise) && then === @defaultPromiseThen)
-                @performPromiseThen(nextPromise, resolve, reject, @undefined, /* context */ promise);
-            else
-                nextPromise.then(resolve, reject);
-        }
-    } catch (error) {
-        reject.@call(@undefined, error);
-    }
-
-    return promise;
-}
-
 function try(callback /*, ...args */)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2209,6 +2209,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->keys), m_setPrimordialPropertiesWatchpointSet);
 
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, promisePrototype(), vm.propertyNames->then), m_promiseThenWatchpointSet);
+    installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_promiseConstructor.get(), vm.propertyNames->resolve), m_promiseResolveWatchpointSet);
 
     // Detect property absence.
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->replaceSymbol, objectPrototype()), m_stringSymbolReplaceWatchpointSet);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -495,6 +495,7 @@ public:
     InlineWatchpointSet m_mapSetWatchpointSet { IsWatched };
     InlineWatchpointSet m_setAddWatchpointSet { IsWatched };
     InlineWatchpointSet m_promiseThenWatchpointSet { IsWatched };
+    InlineWatchpointSet m_promiseResolveWatchpointSet { IsWatched };
     InlineWatchpointSet m_promiseSpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_setPrimordialPropertiesWatchpointSet { IsWatched };
     InlineWatchpointSet m_arraySpeciesWatchpointSet { ClearWatchpoint };
@@ -568,6 +569,7 @@ public:
     InlineWatchpointSet& setAddWatchpointSet() { return m_setAddWatchpointSet; }
     InlineWatchpointSet& setPrimordialPropertiesWatchpointSet() { return m_setPrimordialPropertiesWatchpointSet; }
     InlineWatchpointSet& promiseThenWatchpointSet() { return m_promiseThenWatchpointSet; }
+    InlineWatchpointSet& promiseResolveWatchpointSet() { return m_promiseResolveWatchpointSet; }
     InlineWatchpointSet& arraySpeciesWatchpointSet() { return m_arraySpeciesWatchpointSet; }
     InlineWatchpointSet& promiseSpeciesWatchpointSet() { return m_promiseSpeciesWatchpointSet; }
     InlineWatchpointSet& arrayPrototypeChainIsSaneWatchpointSet() { return m_arrayPrototypeChainIsSaneWatchpointSet; }

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -27,11 +27,15 @@
 #include "JSPromiseConstructor.h"
 
 #include "BuiltinNames.h"
+#include "CachedCall.h"
 #include "GetterSetter.h"
+#include "InterpreterInlines.h"
+#include "IteratorOperations.h"
 #include "JSCBuiltins.h"
 #include "JSCInlines.h"
 #include "JSPromise.h"
 #include "JSPromisePrototype.h"
+#include "runtime/JSCJSValue.h"
 
 namespace JSC {
 
@@ -39,6 +43,7 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSPromiseConstructor);
 static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncResolve);
 static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncReject);
 static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncWithResolvers);
+static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncRace);
 
 }
 
@@ -52,7 +57,7 @@ const ClassInfo JSPromiseConstructor::s_info = { "Function"_s, &Base::s_info, &p
 @begin promiseConstructorTable
   resolve         promiseConstructorFuncResolve        DontEnum|Function 1 PromiseConstructorResolveIntrinsic
   reject          promiseConstructorFuncReject         DontEnum|Function 1 PromiseConstructorRejectIntrinsic
-  race            JSBuiltin                            DontEnum|Function 1
+  race            promiseConstructorFuncRace           DontEnum|Function 1
   all             JSBuiltin                            DontEnum|Function 1
   allSettled      JSBuiltin                            DontEnum|Function 1
   any             JSBuiltin                            DontEnum|Function 1
@@ -123,6 +128,166 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncWithResolvers, (JSGlobalObject* g
 {
     JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     return JSValue::encode(JSPromise::createNewPromiseCapability(globalObject, thisValue));
+}
+
+static bool isFastPromiseConstructor(JSGlobalObject* globalObject, JSValue value)
+{
+    if (value != globalObject->promiseConstructor()) [[unlikely]]
+        return false;
+
+    if (!globalObject->promiseResolveWatchpointSet().isStillValid()) [[unlikely]]
+        return false;
+
+    return true;
+}
+
+static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue thisValue)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto [promise, resolve, reject] = JSPromise::newPromiseCapability(globalObject, thisValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto callReject = [&](JSValue exception) -> void {
+        MarkedArgumentBuffer rejectArguments;
+        rejectArguments.append(exception);
+        ASSERT(!rejectArguments.hasOverflowed());
+        auto rejectCallData = getCallDataInline(reject);
+        scope.release();
+        call(globalObject, reject, rejectCallData, jsUndefined(), rejectArguments);
+    };
+    auto callRejectWithScopeException = [&]() -> void {
+        Exception* exception = scope.exception();
+        ASSERT(exception);
+        scope.clearException();
+        callReject(exception->value());
+    };
+
+    JSValue promiseResolveValue = thisValue.get(globalObject, vm.propertyNames->resolve);
+    if (scope.exception()) [[unlikely]] {
+        callRejectWithScopeException();
+        return promise;
+    }
+
+    if (!promiseResolveValue.isCallable()) [[unlikely]] {
+        callReject(createTypeError(globalObject, "Promise resolve is not a function"_s));
+        return promise;
+    }
+    CallData promiseResolveCallData = getCallDataInline(promiseResolveValue);
+    ASSERT(promiseResolveCallData.type != CallData::Type::None);
+
+    std::optional<CachedCall> cachedCallHolder;
+    CachedCall* cachedCall = nullptr;
+    if (promiseResolveCallData.type == CallData::Type::JS) [[likely]] {
+        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(promiseResolveValue), 1);
+        if (scope.exception()) [[unlikely]] {
+            callRejectWithScopeException();
+            return promise;
+        }
+        cachedCall = &cachedCallHolder.value();
+    }
+
+    JSValue iterable = callFrame->argument(0);
+    forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        JSValue nextPromise;
+        if (cachedCall) [[likely]] {
+            nextPromise = cachedCall->callWithArguments(globalObject, thisValue, value);
+            RETURN_IF_EXCEPTION(scope, void());
+        } else {
+            MarkedArgumentBuffer arguments;
+            arguments.append(value);
+            ASSERT(!arguments.hasOverflowed());
+            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, arguments);
+            RETURN_IF_EXCEPTION(scope, void());
+        }
+        ASSERT(nextPromise);
+
+        if (auto* nextPromiseObj = jsDynamicCast<JSPromise*>(nextPromise); nextPromiseObj && nextPromiseObj->isThenFastAndNonObservable()) [[likely]] {
+            scope.release();
+            nextPromiseObj->performPromiseThen(vm, globalObject, resolve, reject, jsUndefined(), promise);
+        } else {
+            JSValue then = nextPromise.get(globalObject, vm.propertyNames->then);
+            RETURN_IF_EXCEPTION(scope, void());
+            CallData thenCallData = getCallDataInline(then);
+            if (thenCallData.type == CallData::Type::None) [[unlikely]] {
+                throwTypeError(globalObject, scope, "then is not a function"_s);
+                return;
+            }
+            MarkedArgumentBuffer thenArguments;
+            thenArguments.append(resolve);
+            thenArguments.append(reject);
+            ASSERT(!thenArguments.hasOverflowed());
+            scope.release();
+            call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        }
+    });
+
+    if (scope.exception()) [[unlikely]]
+        callRejectWithScopeException();
+
+    return promise;
+}
+JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncRace, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
+
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "|this| is not an object"_s);
+
+    if (!isFastPromiseConstructor(globalObject, thisValue)) [[unlikely]]
+        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRaceSlow(globalObject, callFrame, thisValue)));
+
+    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+
+    auto callReject = [&]() -> void {
+        Exception* exception = scope.exception();
+        ASSERT(exception);
+        scope.clearException();
+        scope.release();
+        promise->reject(vm, globalObject, exception);
+    };
+
+    JSValue iterable = callFrame->argument(0);
+    JSFunction* resolve = nullptr;
+    JSFunction* reject = nullptr;
+    forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
+        RETURN_IF_EXCEPTION(scope, void());
+
+        if (nextPromise->isThenFastAndNonObservable()) [[likely]] {
+            scope.release();
+            nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFirstResolveWithoutHandlerJob, promise, promise);
+        } else {
+            if (!resolve || !reject)
+                std::tie(resolve, reject) = promise->createFirstResolvingFunctions(vm, globalObject);
+            JSValue then = nextPromise->get(globalObject, vm.propertyNames->then);
+            RETURN_IF_EXCEPTION(scope, void());
+            CallData thenCallData = getCallDataInline(then);
+            if (thenCallData.type == CallData::Type::None) [[unlikely]] {
+                throwTypeError(globalObject, scope, "then is not a function"_s);
+                return;
+            }
+            MarkedArgumentBuffer thenArguments;
+            thenArguments.append(resolve);
+            thenArguments.append(reject);
+            ASSERT(!thenArguments.hasOverflowed());
+            scope.release();
+            call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        }
+    });
+
+    if (scope.exception()) [[unlikely]]
+        callReject();
+
+    return JSValue::encode(promise);
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 73ab719b0b4d2ee1473e3297074c7515c4368505
<pre>
[JSC] Implement `Promise.race` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=300569">https://bugs.webkit.org/show_bug.cgi?id=300569</a>

Reviewed by Yusuke Suzuki.

This reverts commit 302934@main to reland 302567@main.

This patch fixes to  crash from original patch by throwing a
TypeError when elements of the argument&apos;s iterable are not thenable.

------
This patch changes to implement `Promise.race` in C++.

* JSTests/microbenchmarks/promise-race.js: Added.
* JSTests/stress/new-promise-capabilities-requires-constructor.js:
(shouldThrow):
* JSTests/stress/promise-race-empty-args.js: Added.
(shouldBe):
* JSTests/stress/promise-race-fast-path-not-thenable.js: Added.
(shouldThrowAsync):
(shouldThrowAsync.async var):
* JSTests/stress/promise-race-slow-path-non-thenable.js: Added.
(shouldThrowAsync):
(shouldThrowAsync.async const):
(shouldThrowAsync.Promise.resolve):
* JSTests/stress/promsie-race-resolve-getter-throws.js: Added.
(shouldBe):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(any):
(race): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::promiseResolveWatchpointSet):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::isFastPromiseConstructor):
(JSC::promiseRaceSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/303034@main">https://commits.webkit.org/303034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/545b03cec121c12bb8895e7038be91237a2d68e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82635 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99771 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133911 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2260 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35381 "Found 1 new test failure: inspector/animation/lifecycle-css-transition.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81652 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122982 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140899 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129418 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108288 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108245 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2297 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32005 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56069 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66495 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162435 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2921 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/40573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->