### PR TITLE
Skip in BBQ/OMG

### DIFF
--- a/JSTests/wasm/function-tests/memory-alignment.js
+++ b/JSTests/wasm/function-tests/memory-alignment.js
@@ -42,7 +42,7 @@ for (const op of WASM.opcodes("memory")) {
         if (alignLog2 <= maxAlignLog2)
             instance();
         else
-            assert.throws(instance, WebAssembly.CompileError, `WebAssembly.Module doesn't parse at byte ${start}: byte alignment ${1 << alignLog2} exceeds ${info.type}'s natural alignment ${1 << maxAlignLog2}, in function at index 0`);
+            assert.throws(instance, WebAssembly.CompileError, `WebAssembly.Module doesn't validate: byte alignment ${1 << alignLog2} exceeds ${info.type}'s natural alignment ${1 << maxAlignLog2}, in function at index 0`);
 
     }
 }

--- a/JSTests/wasm/stress/invalid-atomic-alignment.js
+++ b/JSTests/wasm/stress/invalid-atomic-alignment.js
@@ -21,7 +21,7 @@ async function testLoad()
       (func (export "i32.atomic.load") (param $addr i32) (result i32) (i32.atomic.load align=8 (local.get $addr)))
     )`;
     let error = await buildAndThrow(text);
-    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't parse at byte 6: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
+    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't validate: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
 }
 
 async function testStore()
@@ -32,7 +32,7 @@ async function testStore()
       (func (export "i32.atomic.store") (param $addr i32) (param $value i32) (i32.atomic.store align=8 (local.get $addr) (local.get $value)))
     )`;
     let error = await buildAndThrow(text);
-    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't parse at byte 8: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
+    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't validate: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
 }
 
 async function testRMW()
@@ -43,7 +43,7 @@ async function testRMW()
       (func (export "i32.atomic.rmw.add") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.add align=8 (local.get $addr) (local.get $value)))
     )`;
     let error = await buildAndThrow(text);
-    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't parse at byte 8: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
+    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't validate: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
 }
 
 async function testCmpXchg()
@@ -54,7 +54,7 @@ async function testCmpXchg()
       (func (export "i32.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw.cmpxchg align=8 (local.get $addr) (local.get $expected) (local.get $value)))
     )`;
     let error = await buildAndThrow(text);
-    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't parse at byte 10: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
+    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't validate: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
 }
 
 async function testAtomicNotify()
@@ -67,7 +67,7 @@ async function testAtomicNotify()
           (memory.atomic.notify align=8 (local.get 0) (local.get 1)))
     )`;
     let error = await buildAndThrow(text);
-    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't parse at byte 8: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 1 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
+    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't validate: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 1 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
 }
 
 async function testAtomicWait()
@@ -79,7 +79,7 @@ async function testAtomicWait()
           (memory.atomic.wait32 align=8 (local.get 0) (local.get 1) (local.get 2)))
     )`;
     let error = await buildAndThrow(text);
-    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't parse at byte 10: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
+    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't validate: byte alignment 8 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')`);
 }
 
 await testLoad();

--- a/JSTests/wasm/stress/too-many-locals.js
+++ b/JSTests/wasm/stress/too-many-locals.js
@@ -30,5 +30,5 @@ import * as assert from '../assert.js'
         exception = "" + e;
     }
 
-    assert.eq(exception, "CompileError: WebAssembly.Module doesn't parse at byte 100002: Function's number of locals is too big 50001 maximum 50000, in function at index 0 (evaluating 'new WebAssembly.Module(bin)')");
+    assert.eq(exception, "CompileError: WebAssembly.Module doesn't validate: Function's number of locals is too big 50001 maximum 50000, in function at index 0 (evaluating 'new WebAssembly.Module(bin)')");
 }

--- a/JSTests/wasm/v8/compare-exchange-stress.js
+++ b/JSTests/wasm/v8/compare-exchange-stress.js
@@ -1,7 +1,7 @@
 //@ requireOptions("--useBBQJIT=1")
 //@ skip
 // Failure:
-// Exception: CompileError: WebAssembly.Module doesn't parse at byte 90: byte alignment 1 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')
+// Exception: CompileError: WebAssembly.Module doesn't validate: byte alignment 1 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')
 //  Module@[native code]
 //  testOpcode@compare-exchange-stress.js:204:40
 //  global code@compare-exchange-stress.js:213:11

--- a/JSTests/wasm/v8/compare-exchange64-stress.js
+++ b/JSTests/wasm/v8/compare-exchange64-stress.js
@@ -1,7 +1,7 @@
 //@ requireOptions("--useBBQJIT=1")
 //@ skip
 // Failure:
-// Exception: CompileError: WebAssembly.Module doesn't parse at byte 94: byte alignment 1 does not match against atomic op's natural alignment 8, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')
+// Exception: CompileError: WebAssembly.Module doesn't validate: byte alignment 1 does not match against atomic op's natural alignment 8, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')
 //  Module@[native code]
 //  testOpcode@compare-exchange64-stress.js:209:40
 //  global code@compare-exchange64-stress.js:218:11

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -66,6 +66,8 @@ public:
     // Functions can have up to 1000000 instructions, so 32 bits is a sensible maximum number of stack items or locals.
     using LocalOrTempIndex = uint32_t;
 
+    static constexpr BytecodeValidationMode bytecodeValidationMode = BytecodeValidationMode::Skip;
+
     static constexpr unsigned LocalIndexBits = 21;
     static_assert(maxFunctionLocals < 1 << LocalIndexBits);
 

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -164,6 +164,8 @@ public:
         BlockSignature m_signature;
     };
 
+    static constexpr BytecodeValidationMode bytecodeValidationMode = BytecodeValidationMode::Validate;
+
     using ControlType = ControlData;
     using ControlEntry = FunctionParser<ConstExprGenerator>::ControlEntry;
     using ControlStack = FunctionParser<ConstExprGenerator>::ControlStack;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -371,8 +371,10 @@ private:
 
 
 #define WASM_VALIDATOR_FAIL_IF(condition, ...) do { \
-        if (condition) [[unlikely]] \
-            return validationFail(__VA_ARGS__); \
+        if constexpr (bytecodeValidationMode == BytecodeValidationMode::Validate) { \
+            if (condition) [[unlikely]] \
+                return validationFail(__VA_ARGS__); \
+        } \
     } while (0) \
 
     // FIXME add a macro as above for WASM_TRY_APPEND_TO_CONTROL_STACK https://bugs.webkit.org/show_bug.cgi?id=165862

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -227,7 +227,7 @@ private:
     void switchToBlock(ControlType&&, Stack&&);
 
 #define WASM_TRY_POP_EXPRESSION_STACK_INTO(result, what) do { \
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, what); \
+        WASM_VALIDATOR_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, what); \
         result = m_expressionStack.takeLast(); \
         m_context.didPopValueFromStack(result, "WasmFunctionParser.h " STRINGIZE_VALUE_OF(__LINE__) ""_s); \
     } while (0)
@@ -461,7 +461,7 @@ auto FunctionParser<Context>::parse() -> Result
 
         WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfLocals), "can't get Function's number of locals in group "_s, i);
         totalNumberOfLocals += numberOfLocals;
-        WASM_PARSER_FAIL_IF(totalNumberOfLocals > maxFunctionLocals, "Function's number of locals is too big "_s, totalNumberOfLocals, " maximum "_s, maxFunctionLocals);
+        WASM_VALIDATOR_FAIL_IF(totalNumberOfLocals > maxFunctionLocals, "Function's number of locals is too big "_s, totalNumberOfLocals, " maximum "_s, maxFunctionLocals);
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, typeOfLocal), "can't get Function local's type in group "_s, i);
         if (!isDefaultableType(typeOfLocal)) [[unlikely]]
             totalNonDefaultableLocals++;
@@ -715,7 +715,7 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
     uint32_t offset;
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds load's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
+    WASM_VALIDATOR_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds load's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
@@ -737,7 +737,7 @@ auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
     TypedExpression value;
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds store's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
+    WASM_VALIDATOR_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds store's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get store offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
@@ -772,7 +772,7 @@ auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) ->
     uint32_t offset;
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_VALIDATOR_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
@@ -794,7 +794,7 @@ auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -
     TypedExpression value;
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_VALIDATOR_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get store offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
@@ -816,7 +816,7 @@ auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryTyp
     TypedExpression pointer;
     TypedExpression value;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_VALIDATOR_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
@@ -841,7 +841,7 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
     TypedExpression expected;
     TypedExpression value;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment !=  memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_VALIDATOR_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(expected, "expected"_s);
@@ -868,7 +868,7 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
     TypedExpression value;
     TypedExpression timeout;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_VALIDATOR_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(timeout, "timeout"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
@@ -894,7 +894,7 @@ auto FunctionParser<Context>::atomicNotify(ExtAtomicOpType op) -> PartialResult
     TypedExpression pointer;
     TypedExpression count;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_VALIDATOR_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "count"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
@@ -913,7 +913,7 @@ auto FunctionParser<Context>::atomicFence(ExtAtomicOpType op) -> PartialResult
 {
     uint8_t flags;
     WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags"_s);
-    WASM_PARSER_FAIL_IF(flags != 0x0, "flags should be 0x0 but got "_s, flags);
+    WASM_VALIDATOR_FAIL_IF(flags != 0x0, "flags should be 0x0 but got "_s, flags);
     WASM_TRY_ADD_TO_CONTEXT(atomicFence(op, flags));
     return { };
 }
@@ -1537,7 +1537,7 @@ auto FunctionParser<Context>::parseFunctionIndex(FunctionSpaceIndex& resultIndex
 {
     uint32_t functionIndex;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't parse function index"_s);
-    WASM_PARSER_FAIL_IF(functionIndex >= m_info.functionIndexSpaceSize(), "function index "_s, functionIndex, " exceeds function index space "_s, m_info.functionIndexSpaceSize());
+    WASM_VALIDATOR_FAIL_IF(functionIndex >= m_info.functionIndexSpaceSize(), "function index "_s, functionIndex, " exceeds function index space "_s, m_info.functionIndexSpaceSize());
     resultIndex = FunctionSpaceIndex(functionIndex);
     return { };
 }
@@ -1562,7 +1562,7 @@ auto FunctionParser<Context>::parseBranchTarget(uint32_t& resultTarget, uint32_t
     // Take into account the unreachable blocks in the control stack that were not added because they were unrechable
     if (unreachableBlocks)
         controlStackSize += (unreachableBlocks - 1);
-    WASM_PARSER_FAIL_IF(target >= controlStackSize, "br / br_if's target "_s, target, " exceeds control stack size "_s, controlStackSize);
+    WASM_VALIDATOR_FAIL_IF(target >= controlStackSize, "br / br_if's target "_s, target, " exceeds control stack size "_s, controlStackSize);
 
     resultTarget = target;
     return { };
@@ -1578,8 +1578,8 @@ auto FunctionParser<Context>::parseDelegateTarget(uint32_t& resultTarget, uint32
     if (unreachableBlocks)
         controlStackSize += (unreachableBlocks - 1); // The first block is in the control stack already.
     controlStackSize -= 1; // delegate target does not include the current block.
-    WASM_PARSER_FAIL_IF(controlStackSize.hasOverflowed(), "invalid control stack size"_s);
-    WASM_PARSER_FAIL_IF(target >= controlStackSize.value(), "delegate target "_s, target, " exceeds control stack size "_s, controlStackSize.value());
+    WASM_VALIDATOR_FAIL_IF(controlStackSize.hasOverflowed(), "invalid control stack size"_s);
+    WASM_VALIDATOR_FAIL_IF(target >= controlStackSize.value(), "delegate target "_s, target, " exceeds control stack size "_s, controlStackSize.value());
     resultTarget = target;
     return { };
 }
@@ -1641,7 +1641,7 @@ auto FunctionParser<Context>::parseAnnotatedSelectImmediates(AnnotatedSelectImme
 {
     uint32_t sizeOfAnnotationVector;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(sizeOfAnnotationVector), "select can't parse the size of annotation vector"_s);
-    WASM_PARSER_FAIL_IF(sizeOfAnnotationVector != 1, "select invalid result arity for"_s);
+    WASM_VALIDATOR_FAIL_IF(sizeOfAnnotationVector != 1, "select invalid result arity for"_s);
 
     Type targetType;
     WASM_PARSER_FAIL_IF(!parseValueType(m_info, targetType), "select can't parse annotations"_s);
@@ -1656,7 +1656,7 @@ auto FunctionParser<Context>::parseMemoryFillImmediate() -> PartialResult
 {
     uint8_t auxiliaryByte;
     WASM_PARSER_FAIL_IF(!parseUInt8(auxiliaryByte), "can't parse auxiliary byte"_s);
-    WASM_PARSER_FAIL_IF(!!auxiliaryByte, "auxiliary byte for memory.fill should be zero, but got "_s, auxiliaryByte);
+    WASM_VALIDATOR_FAIL_IF(!!auxiliaryByte, "auxiliary byte for memory.fill should be zero, but got "_s, auxiliaryByte);
     return { };
 }
 
@@ -1665,11 +1665,11 @@ auto FunctionParser<Context>::parseMemoryCopyImmediates() -> PartialResult
 {
     uint8_t firstAuxiliaryByte;
     WASM_PARSER_FAIL_IF(!parseUInt8(firstAuxiliaryByte), "can't parse auxiliary byte"_s);
-    WASM_PARSER_FAIL_IF(!!firstAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got "_s, firstAuxiliaryByte);
+    WASM_VALIDATOR_FAIL_IF(!!firstAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got "_s, firstAuxiliaryByte);
 
     uint8_t secondAuxiliaryByte;
     WASM_PARSER_FAIL_IF(!parseUInt8(secondAuxiliaryByte), "can't parse auxiliary byte"_s);
-    WASM_PARSER_FAIL_IF(!!secondAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got "_s, secondAuxiliaryByte);
+    WASM_VALIDATOR_FAIL_IF(!!secondAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got "_s, secondAuxiliaryByte);
     return { };
 }
 
@@ -1681,7 +1681,7 @@ auto FunctionParser<Context>::parseMemoryInitImmediates(MemoryInitImmediates& re
 
     unsigned unused;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't parse unused"_s);
-    WASM_PARSER_FAIL_IF(!!unused, "memory.init invalid unsued byte"_s);
+    WASM_VALIDATOR_FAIL_IF(!!unused, "memory.init invalid unsued byte"_s);
 
     result.unused = unused;
     result.dataSegmentIndex = dataSegmentIndex;
@@ -1706,7 +1706,7 @@ auto FunctionParser<Context>::parseStructFieldIndex(uint32_t& structFieldIndex, 
 {
     uint32_t fieldIndex;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldIndex), "can't get type index for "_s, operation);
-    WASM_PARSER_FAIL_IF(fieldIndex >= structType.fieldCount(), operation, " field immediate "_s, fieldIndex, " is out of bounds"_s);
+    WASM_VALIDATOR_FAIL_IF(fieldIndex >= structType.fieldCount(), operation, " field immediate "_s, fieldIndex, " is out of bounds"_s);
 
     structFieldIndex = fieldIndex;
     return { };
@@ -2782,7 +2782,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         case ExtGCOpType::BrOnCastFail: {
             auto opName = op == ExtGCOpType::BrOnCast ? "br_on_cast"_s : "br_on_cast_fail"_s;
             uint8_t flags;
-            WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
+            WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
             bool hasNull1 = flags & 0x1;
             bool hasNull2 = flags & 0x2;
 
@@ -2806,7 +2806,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             // Manually pop the stack in order to avoid decreasing the stack size, as we will immediately put it back.
             TypedExpression ref;
-            WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, opName);
+            WASM_VALIDATOR_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, opName);
             ref = m_expressionStack.takeLast();
 
             WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), Type { hasNull1 ? TypeKind::RefNull : TypeKind::Ref, typeIndex1 }), opName, " to type "_s, ref.type(), " expected a reference type with source heaptype"_s);
@@ -2983,7 +2983,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         TypedExpression ref;
         // Pop the stack manually to avoid changing the stack size, because the branch needs the value with a different type.
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in br_on_non_null"_s);
+        WASM_VALIDATOR_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in br_on_non_null"_s);
         ref = m_expressionStack.takeLast();
         m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index }, ref.value());
         WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), "br_on_non_null ref to type "_s, ref.type(), " expected a reference type"_s);
@@ -3047,7 +3047,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(parseIndexForLocal(index));
         pushLocalInitialized(index);
 
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't tee_local on empty expression stack"_s);
+        WASM_VALIDATOR_FAIL_IF(m_expressionStack.isEmpty(), "can't tee_local on empty expression stack"_s);
         TypedExpression value;
         WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "tee_local"_s);
         WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to tee unknown local "_s, index, "_s, the number of locals is "_s, m_locals.size());
@@ -3163,9 +3163,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(!m_info.tableCount(), "call_indirect is only valid when a table is defined or imported"_s);
         WASM_PARSER_FAIL_IF(!parseVarUInt32(signatureIndex), "can't get call_indirect's signature index"_s);
         WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get call_indirect's table index"_s);
-        WASM_PARSER_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index "_s, tableIndex, " invalid, limit is "_s, m_info.tableCount());
-        WASM_PARSER_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index "_s, signatureIndex, " exceeds known signatures "_s, m_info.typeCount());
-        WASM_PARSER_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref"_s);
+        WASM_VALIDATOR_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index "_s, tableIndex, " invalid, limit is "_s, m_info.tableCount());
+        WASM_VALIDATOR_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index "_s, signatureIndex, " exceeds known signatures "_s, m_info.typeCount());
+        WASM_VALIDATOR_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref"_s);
 
         const TypeDefinition& typeDefinition = m_info.typeSignatures[signatureIndex].get();
         WASM_VALIDATOR_FAIL_IF(!typeDefinition.expand().is<FunctionSignature>(), "invalid type index (not a function signature) for call_indirect, got ", signatureIndex);
@@ -3229,7 +3229,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get call_ref's signature index"_s);
         WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), "call_ref index ", typeIndex, " is out of bounds");
 
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't call_ref on empty expression stack"_s);
+        WASM_VALIDATOR_FAIL_IF(m_expressionStack.isEmpty(), "can't call_ref on empty expression stack"_s);
 
         const TypeDefinition& typeDefinition = m_info.typeSignatures[typeIndex];
         const TypeIndex calleeTypeIndex = typeDefinition.index();
@@ -3489,7 +3489,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             }
             WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionLabel), "can't read label of try_table catch at index "_s, i);
 
-            WASM_PARSER_FAIL_IF(exceptionLabel >= m_controlStack.size(), "try_table's catch target "_s, exceptionLabel, " exceeds control stack size "_s, m_controlStack.size());
+            WASM_VALIDATOR_FAIL_IF(exceptionLabel >= m_controlStack.size(), "try_table's catch target "_s, exceptionLabel, " exceeds control stack size "_s, m_controlStack.size());
 
             // Type checking
             targets.append({
@@ -3647,7 +3647,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(!errorMessage.isNull(), errorMessage);
 
         WASM_PARSER_FAIL_IF(!parseVarUInt32(defaultTargetIndex), "can't get default target for br_table"_s);
-        WASM_PARSER_FAIL_IF(defaultTargetIndex >= m_controlStack.size(), "br_table's default target "_s, defaultTargetIndex, " exceeds control stack size "_s, m_controlStack.size());
+        WASM_VALIDATOR_FAIL_IF(defaultTargetIndex >= m_controlStack.size(), "br_table's default target "_s, defaultTargetIndex, " exceeds control stack size "_s, m_controlStack.size());
         ControlType& defaultTarget = m_controlStack[m_controlStack.size() - 1 - defaultTargetIndex].controlData;
 
         WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "br_table condition"_s);
@@ -4264,7 +4264,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         case ExtGCOpType::BrOnCastFail: {
             auto opName = op == ExtGCOpType::BrOnCast ? "br_on_cast"_s : "br_on_cast_fail"_s;
             uint8_t flags;
-            WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
+            WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
             bool hasNull1 = flags & 0x1;
             bool hasNull2 = flags & 0x2;
 
@@ -4333,14 +4333,14 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             uint32_t alignment;
             uint32_t unused;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
-            WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+            WASM_VALIDATOR_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
             WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for atomic "_s, static_cast<unsigned>(op), " in unreachable context"_s);
             break;
         }
         case ExtAtomicOpType::AtomicFence: {
             uint8_t flags;
             WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags"_s);
-            WASM_PARSER_FAIL_IF(flags != 0x0, "flags should be 0x0 but got "_s, flags);
+            WASM_VALIDATOR_FAIL_IF(flags != 0x0, "flags should be 0x0 but got "_s, flags);
             break;
         }
         default:

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -137,9 +137,39 @@ struct FunctionParserTypes {
 };
 
 template<typename Context>
-class FunctionParser : public Parser<void>, public FunctionParserTypes<typename Context::ControlType, typename Context::ExpressionType, typename Context::CallType> {
+class FunctionParser : public Parser<void, Context::bytecodeValidationMode>, public FunctionParserTypes<typename Context::ControlType, typename Context::ExpressionType, typename Context::CallType> {
     WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(FunctionParser);
 public:
+    using Parser<void, Context::bytecodeValidationMode>::bytecodeValidationMode;
+    using Parser<void, Context::bytecodeValidationMode>::fail;
+    using Parser<void, Context::bytecodeValidationMode>::parseVarUInt32;
+    using Parser<void, Context::bytecodeValidationMode>::parseVarUInt64;
+    using Parser<void, Context::bytecodeValidationMode>::parseVarInt32;
+    using Parser<void, Context::bytecodeValidationMode>::parseVarInt64;
+    using Parser<void, Context::bytecodeValidationMode>::parseUInt8;
+    using Parser<void, Context::bytecodeValidationMode>::parseUInt32;
+    using Parser<void, Context::bytecodeValidationMode>::parseUInt64;
+    using Parser<void, Context::bytecodeValidationMode>::parseInt7;
+    using Parser<void, Context::bytecodeValidationMode>::parseUInt7;
+    using Parser<void, Context::bytecodeValidationMode>::parseVarUInt1;
+    using Parser<void, Context::bytecodeValidationMode>::peekInt7;
+    using Parser<void, Context::bytecodeValidationMode>::peekUInt8;
+    using Parser<void, Context::bytecodeValidationMode>::peekVarUInt32;
+    using Parser<void, Context::bytecodeValidationMode>::parseImmByteArray16;
+    using Parser<void, Context::bytecodeValidationMode>::parseValueType;
+    using Parser<void, Context::bytecodeValidationMode>::parseRefType;
+    using Parser<void, Context::bytecodeValidationMode>::parseExternalKind;
+    using Parser<void, Context::bytecodeValidationMode>::parseHeapType;
+    using Parser<void, Context::bytecodeValidationMode>::consumeCharacter;
+    using Parser<void, Context::bytecodeValidationMode>::consumeString;
+    using Parser<void, Context::bytecodeValidationMode>::consumeUTF8String;
+    using Parser<void, Context::bytecodeValidationMode>::source;
+    using Parser<void, Context::bytecodeValidationMode>::offset;
+    using Parser<void, Context::bytecodeValidationMode>::m_offset;
+    using Parser<void, Context::bytecodeValidationMode>::m_typeInformation;
+    using Result = typename Parser<void, Context::bytecodeValidationMode>::Result;
+    using PartialResult = typename Parser<void, Context::bytecodeValidationMode>::PartialResult;
+    using UnexpectedResult = typename Parser<void, Context::bytecodeValidationMode>::UnexpectedResult;
     using CallType = typename FunctionParser::CallType;
     using ControlType = typename FunctionParser::ControlType;
     using ControlEntry = typename FunctionParser::ControlEntry;
@@ -427,7 +457,7 @@ static bool isTryOrCatch(ControlType& data)
 
 template<typename Context>
 FunctionParser<Context>::FunctionParser(Context& context, std::span<const uint8_t> function, const TypeDefinition& signature, const ModuleInformation& info)
-    : Parser(function)
+    : Parser<void, Context::bytecodeValidationMode>(function)
     , m_context(context)
     , m_signature(signature.expand())
     , m_info(info)

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -202,6 +202,7 @@ class IPIntGenerator {
 public:
     IPIntGenerator(ModuleInformation&, FunctionCodeIndex, const TypeDefinition&, std::span<const uint8_t>, FunctionDebugInfo* = nullptr);
 
+    static constexpr BytecodeValidationMode bytecodeValidationMode = BytecodeValidationMode::Validate;
     static constexpr bool shouldFuseBranchCompare = false;
 
     using ControlType = IPIntControlType;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -127,6 +127,7 @@ public:
     using CallPatchpointData = std::tuple<B3::PatchpointValue*, RefPtr<PatchpointExceptionHandle>, RefPtr<B3::StackmapGenerator>>;
     using WasmConstRefValue = Const64Value;
 
+    static constexpr BytecodeValidationMode bytecodeValidationMode = BytecodeValidationMode::Skip;
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool tierSupportsSIMD() { return true; }
     static constexpr bool validateFunctionBodySize = true;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -123,6 +123,7 @@ public:
     using CallPatchpointData = std::tuple<B3::PatchpointValue*, RefPtr<PatchpointExceptionHandle>, RefPtr<B3::StackmapGenerator>>;
     using WasmConstRefValue = Const64Value;
 
+    static constexpr BytecodeValidationMode bytecodeValidationMode = BytecodeValidationMode::Skip;
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool tierSupportsSIMD() { return true; }
     static constexpr bool validateFunctionBodySize = true;

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -57,6 +57,8 @@ template<typename T>
 inline String makeString(const T& failure) { return WTF::toString(failure); }
 }
 
+enum class BytecodeValidationMode : bool { Skip, Validate };
+
 class ParserBase {
 public:
     typedef String ErrorType;
@@ -109,9 +111,12 @@ protected:
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, m_offset, ": "_s, makeString(args)...));
     }
 #define WASM_PARSER_FAIL_IF(condition, ...) do { \
-    if (condition) [[unlikely]]                     \
-        return fail(__VA_ARGS__);                \
-    } while (0)
+    if (condition) [[unlikely]] { \
+        if constexpr (bytecodeValidationMode == BytecodeValidationMode::Validate) \
+            return fail(__VA_ARGS__); \
+        ASSERT_NOT_REACHED(); \
+    } \
+} while (0)
 
 #define WASM_ALLOCATOR_FAIL_IF(condition, ...) do { \
     if (condition) [[unlikely]]                     \
@@ -134,9 +139,12 @@ protected:
     RecursionGroupInformation m_recursionGroupInformation;
 };
 
-template<typename SuccessType> class Parser : public ParserBase {
+template<typename SuccessType, BytecodeValidationMode validationMode = BytecodeValidationMode::Validate>
+class Parser : public ParserBase {
 public:
     using Result = Expected<SuccessType, ErrorType>;
+
+    static constexpr BytecodeValidationMode bytecodeValidationMode = validationMode;
 
     explicit Parser(std::span<const uint8_t> span)
         : ParserBase { span }


### PR DESCRIPTION
#### eb9c616ac363c35be2552660fd722d931e91998f
<pre>
Skip in BBQ/OMG
</pre>
----------------------------------------------------------------------
#### 3184ff84c2b152f212226df7a4bd71d57072bd34
<pre>
Add BytecodeValidationMode
</pre>
----------------------------------------------------------------------
#### 1e17e32bd1a6651a2986c4379b911022d83f286b
<pre>
VALIDATOR errors not PARSER errors
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb9c616ac363c35be2552660fd722d931e91998f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/130899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/3223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/41858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/3065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/138327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/133845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/41858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/41858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/122916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/129352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/3065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/140809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/3012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/41858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/3034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/66429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/162369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/162369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->