### PR TITLE
[AutoFill Debugging] Add a simple versioning system for text extraction outputs

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -38,3 +38,4 @@ root
         '    \nFooter content with ',[…]
         role='img',aria-label='copyright symbol','©',[…]
         ' 2024',[…]
+version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
@@ -2,3 +2,4 @@ root
 	input,'email',placeholder='Enter your email'
 	input,'password',placeholder='Enter your password',secure
 	input,'number',placeholder='Security code','123456'
+version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -23,3 +23,4 @@ root
         '        \n\n        \n\n            \nReady\n\n            '
         button,'Update Status'
     '    \nThe quick brown fox jumped…\n\n\n\n\n    \nFooter content with © 2024'
+version=2

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -46,6 +46,8 @@ using NodeIdentifier = ObjectIdentifier<NodeIdentifierType>;
 
 namespace WebKit {
 
+using TextExtractionVersion = unsigned;
+
 enum class TextExtractionOptionFlag : uint8_t {
     IncludeURLs     = 1 << 0,
     IncludeRects    = 1 << 1,
@@ -61,14 +63,16 @@ struct TextExtractionOptions {
         : filterCallbacks(WTFMove(other.filterCallbacks))
         , nativeMenuItems(WTFMove(other.nativeMenuItems))
         , replacementStrings(WTFMove(other.replacementStrings))
+        , version(other.version)
         , flags(other.flags)
     {
     }
 
-    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, TextExtractionOptionFlags flags)
+    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags)
         : filterCallbacks(WTFMove(filters))
         , nativeMenuItems(WTFMove(items))
         , replacementStrings(WTFMove(replacementStrings))
+        , version(version)
         , flags(flags)
     {
     }
@@ -76,6 +80,7 @@ struct TextExtractionOptions {
     Vector<TextExtractionFilterCallback> filterCallbacks;
     Vector<String> nativeMenuItems;
     HashMap<String, String> replacementStrings;
+    std::optional<TextExtractionVersion> version;
     TextExtractionOptionFlags flags;
 };
 


### PR DESCRIPTION
#### 1044a1057b9527782a2206cb73cbc279dd5805e6
<pre>
[AutoFill Debugging] Add a simple versioning system for text extraction outputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=302493">https://bugs.webkit.org/show_bug.cgi?id=302493</a>
<a href="https://rdar.apple.com/164668165">rdar://164668165</a>

Reviewed by Abrar Rahman Protyasha and Lily Spiniolas.

Add support for a user default, `WebKit2TextExtractionOutputVersion`, which can be used to restore
some older text extraction behaviors (such as the replacing `textFormControls` with `input` /
`textarea`); we additionally include this version number as the last line in text extraction output,
for debugging convenience.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::TextExtractionAggregator):
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::useTagNameForTextFormControls const):
(WebKit::TextExtractionAggregator::addLineForVersionNumberIfNeeded):
(WebKit::TextExtractionAggregator::version const):
(WebKit::addPartsForItem):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _debugTextWithConfiguration:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/303032@main">https://commits.webkit.org/303032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cb9f781a200c19e933cdd0e0f20ead119c70257

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138409 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/baec3c2e-c017-49af-af52-e8ce1e73791d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99768 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c954999c-0796-49c7-855d-f3a552db05f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80474 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eb0f390c-b9ea-45ea-9795-256d4f7247ba) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35380 "Found 4 new test failures: inspector/animation/lifecycle-css-transition.html inspector/page/overrideSetting-ICECandidateFilteringEnabled.html js/ShadowRealm-iframe-detach.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81654 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140901 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108286 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32004 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56071 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66497 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2923 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3123 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->