### PR TITLE
RemoteImageBufferSet destructor should use GraphicsContext::unwindStateStack

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -107,6 +107,11 @@ void GraphicsContext::unwindStateStack(unsigned count)
     }
 }
 
+void GraphicsContext::unwindStateStack()
+{
+    unwindStateStack(stackSize());
+}
+
 FloatSize GraphicsContext::platformShadowOffset(const FloatSize& shadowOffset) const
 {
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -183,7 +183,7 @@ public:
     WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
 
     void unwindStateStack(unsigned count);
-    void unwindStateStack() { unwindStateStack(stackSize()); }
+    WEBCORE_EXPORT void unwindStateStack();
 
     unsigned stackSize() const { return m_stack.size(); }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -68,8 +68,7 @@ RemoteImageBufferSet::~RemoteImageBufferSet()
     // Unwind the context's state stack before destruction, since calls to restore may not have
     // been flushed yet, or the web process may have terminated.
     auto& context = frontBuffer->context();
-    while (context.stackSize())
-        context.restore();
+    context.unwindStateStack();
 }
 
 void RemoteImageBufferSet::startListeningForIPC()


### PR DESCRIPTION
#### be500683ac3fc48d208632323325e278b828a2cd
<pre>
RemoteImageBufferSet destructor should use GraphicsContext::unwindStateStack
<a href="https://bugs.webkit.org/show_bug.cgi?id=302499">https://bugs.webkit.org/show_bug.cgi?id=302499</a>
<a href="https://rdar.apple.com/164675301">rdar://164675301</a>

Reviewed by Matt Woodrow.

This patch changes the `RemoteImageBufferSet` destructor to use `GraphicsContext::unwindStateStack`.
Previously, it would call `GraphicsContext::restore` in a loop. However, just calling `restore`
repeatedely doesn&apos;t take into account the different purposes each item on the stack could have.
This could result in asserts being hit in `GraphicsContext::restore` due to inconsistent
purposes.

Instead `unwindStateStack` performs different cleanup operations depending on the purpose
of the item on the stack.

I also had to `WEBCORE_EXPORT` `GraphicsContext::unwindStateStack` to make the symbol
available to the linker. I also moved it to the `.cpp` file due to an error about
it being a weak symbol

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::unwindStateStack):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::unwindStateStack): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::~RemoteImageBufferSet):

Canonical link: <a href="https://commits.webkit.org/303296@main">https://commits.webkit.org/303296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d86a0e6f67b91815ddfce6ea1345b5de3b24de88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83233 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d660d02b-651c-481c-b59d-20280e2af67f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100383 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67937 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba269a35-3428-4b7b-ba50-b4be35480cd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4ef769dc-2e26-45ed-838c-76cd4d8eaef3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2668 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141610 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108749 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2682 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114000 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56723 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3596 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32416 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67007 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3526 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->