### PR TITLE
[webkitscmpy] Handle space in commit log editor program

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -129,7 +129,7 @@ class Git(mocks.Subprocess):
                     '\tmerge = refs/heads/{branch}\n'.format(
                         remote=self.remote,
                         branch=self.default_branch,
-                        editor='\teditor = /bin/example -n -w\n' if editor else '',
+                        editor='\teditor = /bin/Example\\ Program -n -w\n' if editor else '',
                     ))
                 for name, url in (remotes or {}).items():
                     config.write(
@@ -816,7 +816,7 @@ nothing to commit, working tree clean
                 self.executable, 'lfs', 'install',
                 generator=lambda *args, **kwargs: self._configure_git_lfs(),
             ), mocks.Subprocess.Route(
-                '/bin/example', '-n', '-w',
+                '/bin/Example Program', '-n', '-w',
                 generator=editor_generator,
             ), *git_svn_routes
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/review.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/review.py
@@ -23,6 +23,7 @@
 import difflib
 import os
 import re
+import shlex
 import shutil
 import sys
 import tempfile
@@ -73,7 +74,7 @@ class Review(Command):
         if not from_config:
             from_config = local.Git.config().get('core.editor', None)
         if from_config:
-            return from_config.split(' ')
+            return shlex.split(from_config)
         return [shutil.which('vim')]
 
     @classmethod

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py
@@ -100,8 +100,8 @@ class TestReview(testing.PathTestCase):
 
     def test_editor_repo(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, editor=lambda path: print(path)):
-            self.assertEqual(['/bin/example', '-n', '-w'], program.Review.editor(local.Git(self.path)))
-            self.assertEqual(run(['/bin/example', '-n', '-w', 'PATH']).returncode, 0)
+            self.assertEqual(['/bin/Example Program', '-n', '-w'], program.Review.editor(local.Git(self.path)))
+            self.assertEqual(run(['/bin/Example Program', '-n', '-w', 'PATH']).returncode, 0)
 
         self.assertEqual(captured.stdout.getvalue(), 'PATH\n')
 


### PR DESCRIPTION
#### e00aafc2af946304d89436f0a6f4cac11667ff81
<pre>
[webkitscmpy] Handle space in commit log editor program
<a href="https://bugs.webkit.org/show_bug.cgi?id=302501">https://bugs.webkit.org/show_bug.cgi?id=302501</a>
<a href="https://rdar.apple.com/164676866">rdar://164676866</a>

Reviewed by Sam Sneddon.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git): Insert space into mock editor program.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/review.py:
(Review.editor): Handle editor programs with spaces in them.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py:
(TestReview.test_editor_repo): Rebaseline.

Canonical link: <a href="https://commits.webkit.org/303167@main">https://commits.webkit.org/303167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/338111da652aea1bdb7d898784ee041daea1ac28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82608 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/24d15713-0ead-4a38-b55f-797e2d90ffe8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99752 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67557 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c0892650-6563-47c1-90be-699d73dfea48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b7534bd-3a47-4cac-9494-2db39b90ae28) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/130287 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2247 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81625 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110836 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35363 "Found 2 new test failures: inspector/animation/lifecycle-css-transition.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140872 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108267 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130367 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108221 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2285 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56042 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20439 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3073 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31988 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2894 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3094 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->