### PR TITLE
[intersection-observer] small refactoring to prepare for site isolation

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10323,6 +10323,10 @@ void Document::updateIntersectionObservations()
 
 void Document::updateIntersectionObservations(const Vector<WeakPtr<IntersectionObserver>>& intersectionObservers)
 {
+    RefPtr frame = this->frame();
+    if (!frame)
+        return;
+
     RefPtr frameView = view();
     if (!frameView)
         return;
@@ -10347,7 +10351,7 @@ void Document::updateIntersectionObservations(const Vector<WeakPtr<IntersectionO
         if (!observer)
             continue;
 
-        auto needNotify = observer->updateObservations(*this);
+        auto needNotify = observer->updateObservations(*frame);
         if (needNotify == IntersectionObserver::NeedNotify::Yes)
             intersectionObserversWithPendingNotifications.append(observer);
     }

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -107,7 +107,7 @@ public:
     void rootDestroyed();
 
     enum class NeedNotify : bool { No, Yes };
-    NeedNotify updateObservations(Document&);
+    NeedNotify updateObservations(const Frame&);
 
     std::optional<ReducedResolutionSeconds> nowTimestamp() const;
 


### PR DESCRIPTION
#### edaa1b5300436949ba004b154142bce3c0ce6bcd
<pre>
[intersection-observer] small refactoring to prepare for site isolation
<a href="https://rdar.apple.com/164675699">rdar://164675699</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302500">https://bugs.webkit.org/show_bug.cgi?id=302500</a>

Reviewed by Simon Fraser.

In the case of implicit root intersection observers, where the root and
target are in different frames, site isolation means layout information
of the root and target (and any frames in between) are in different processes.
Current intersection observer code assumes the layout information of all
frames in the document are available in process. This patch slightly refactors
the logic to avoid accessing potentially out-of-process info when able.

Tested by existing intersection observer test suites.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIntersectionObservations):
    - Change method to take a host Frame instead of host Document.
      With site isolation, it&apos;s not always possible to get the Document
      of the main frame.

* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):
  - Avoid some computations that rely on rootRenderer, which could
    be out-of-process.

(WebCore::IntersectionObserver::updateObservations):
  - Check for same-origin using the frame&apos;s security origin from
    Frame::frameDocumentSecurityOrigin(). This is always available
    for local/remote frames.

* Source/WebCore/page/IntersectionObserver.h:

Canonical link: <a href="https://commits.webkit.org/303055@main">https://commits.webkit.org/303055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc257d1fa57c0da05c326283180dfaae001932dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82684 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c21c2c3-b288-4b64-acd0-8492c6184f60) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99805 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2d8d9a6c-6dfc-4574-a0c6-36198dba31aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80513 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/217f2e52-0368-4c1e-9ed9-6479803a56b5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2291 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35412 "Found 2 new test failures: inspector/animation/lifecycle-css-transition.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81695 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140942 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108322 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56111 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3142 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66537 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2963 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3072 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->