### PR TITLE
Unreviewed, reverting 303015@main as it causes assertion failures in JSC stress tests

### DIFF
--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,3 +1,4 @@
 wtf/HashTable.h
 wtf/JSONValues.h
 wtf/RecursiveLockAdapter.h
+wtf/RedBlackTree.h

--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -36,7 +36,6 @@
 #include <wtf/PageBlock.h>
 #include <wtf/RedBlackTree.h>
 #include <wtf/RefPtr.h>
-#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 
@@ -140,9 +139,7 @@ private:
     
     friend class MetaAllocatorHandle;
     
-    class FreeSpaceNode final : public RedBlackTree<FreeSpaceNode, size_t>::Node {
-        WTF_MAKE_TZONE_ALLOCATED(FreeSpaceNode);
-        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FreeSpaceNode);
+    class FreeSpaceNode : public RedBlackTree<FreeSpaceNode, size_t>::Node {
     public:
         size_t sizeInBytes()
         {
@@ -190,8 +187,8 @@ private:
     unsigned m_logPageSize;
     
     Tree m_freeSpaceSizeMap;
-    UncheckedKeyHashMap<FreeSpacePtr, CheckedPtr<FreeSpaceNode>> m_freeSpaceStartAddressMap;
-    UncheckedKeyHashMap<FreeSpacePtr, CheckedPtr<FreeSpaceNode>> m_freeSpaceEndAddressMap;
+    UncheckedKeyHashMap<FreeSpacePtr, FreeSpaceNode*> m_freeSpaceStartAddressMap;
+    UncheckedKeyHashMap<FreeSpacePtr, FreeSpaceNode*> m_freeSpaceEndAddressMap;
     UncheckedKeyHashMap<uintptr_t, size_t> m_pageOccupancyMap;
     
     size_t m_bytesAllocated;

--- a/Source/WTF/wtf/MetaAllocatorHandle.h
+++ b/Source/WTF/wtf/MetaAllocatorHandle.h
@@ -39,9 +39,9 @@ class MetaAllocator;
 class PrintStream;
 
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetaAllocatorHandle);
-class MetaAllocatorHandle final : public ThreadSafeRefCounted<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::Node {
+class MetaAllocatorHandle : public ThreadSafeRefCounted<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::Node {
     WTF_DEPRECATED_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(MetaAllocatorHandle, MetaAllocatorHandle);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MetaAllocatorHandle);
+
 public:
     using MemoryPtr = CodePtr<HandleMemoryPtrTag>;
 

--- a/Source/WTF/wtf/RedBlackTree.h
+++ b/Source/WTF/wtf/RedBlackTree.h
@@ -29,10 +29,8 @@
 #pragma once
 
 #include <wtf/Assertions.h>
-#include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
-#include <wtf/TZoneMallocInlines.h>
 
 namespace WTF {
 
@@ -56,17 +54,16 @@ private:
     };
     
 public:
-    class Node : public CanMakeCheckedPtr<Node> {
-        WTF_MAKE_TZONE_ALLOCATED_INLINE(Node);
-        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Node);
+    class Node {
         friend class RedBlackTree;
+        
     public:
         const NodeType* successor() const
         {
-            CheckedPtr x = this;
+            const Node* x = this;
             if (x->right())
                 return treeMinimum(x->right());
-            auto* y = x->parent();
+            const NodeType* y = x->parent();
             unsigned depth = 0;
             while (y && x == y->right()) {
                 RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -78,10 +75,10 @@ public:
         
         const NodeType* predecessor() const
         {
-            CheckedPtr x = this;
+            const Node* x = this;
             if (x->left())
                 return treeMaximum(x->left());
-            auto* y = x->parent();
+            const NodeType* y = x->parent();
             unsigned depth = 0;
             while (y && x == y->left()) {
                 RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -123,7 +120,7 @@ public:
         
         NodeType* left() const
         {
-            return m_left.get();
+            return m_left;
         }
         
         void setLeft(NodeType* node)
@@ -133,7 +130,7 @@ public:
         
         NodeType* right() const
         {
-            return m_right.get();
+            return m_right;
         }
         
         void setRight(NodeType* node)
@@ -156,12 +153,15 @@ public:
                 m_parentAndRed &= ~static_cast<uintptr_t>(1);
         }
         
-        CheckedPtr<NodeType> m_left;
-        CheckedPtr<NodeType> m_right;
+        NodeType* m_left;
+        NodeType* m_right;
         uintptr_t m_parentAndRed;
     };
 
-    RedBlackTree() = default;
+    RedBlackTree()
+        : m_root(nullptr)
+    {
+    }
     
     void insert(NodeType* x)
     {
@@ -292,7 +292,7 @@ public:
     NodeType* findExact(const KeyType& key) const
     {
         unsigned depth = 0;
-        for (NodeType* current = m_root.get(); current;) {
+        for (NodeType* current = m_root; current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (current->key() == key)
                 return current;
@@ -308,7 +308,7 @@ public:
     {
         NodeType* best = nullptr;
         unsigned depth = 0;
-        for (NodeType* current = m_root.get(); current;) {
+        for (NodeType* current = m_root; current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (current->key() == key)
                 return current;
@@ -326,7 +326,7 @@ public:
     {
         NodeType* best = nullptr;
         unsigned depth = 0;
-        for (NodeType* current = m_root.get(); current;) {
+        for (NodeType* current = m_root; current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (current->key() == key)
                 return current;
@@ -346,19 +346,19 @@ public:
         if (!m_root)
             return;
 
-        Vector<CheckedPtr<NodeType>, 16> toIterate;
+        Vector<NodeType*, 16> toIterate;
         unsigned size = 0;
         toIterate.append(m_root);
         while (toIterate.size()) {
             RELEASE_ASSERT(++size < std::numeric_limits<unsigned>::max());
-            CheckedPtr current = toIterate.takeLast();
+            NodeType& current = *toIterate.takeLast();
             bool iterateLeft = false;
             bool iterateRight = false;
-            function(*current, iterateLeft, iterateRight);
-            if (iterateLeft && current->left())
-                toIterate.append(current->left());
-            if (iterateRight && current->right())
-                toIterate.append(current->right());
+            function(current, iterateLeft, iterateRight);
+            if (iterateLeft && current.left())
+                toIterate.append(current.left());
+            if (iterateRight && current.right())
+                toIterate.append(current.right());
         }
     }
     
@@ -366,14 +366,14 @@ public:
     {
         if (!m_root)
             return nullptr;
-        return treeMinimum(m_root.get());
+        return treeMinimum(m_root);
     }
     
     NodeType* last() const
     {
         if (!m_root)
             return 0;
-        return treeMaximum(m_root.get());
+        return treeMaximum(m_root);
     }
     
     // This is an O(n) operation.
@@ -442,7 +442,7 @@ private:
         ASSERT(z->color() == Red);
         
         NodeType* y = nullptr;
-        NodeType* x = m_root.get();
+        NodeType* x = m_root;
         unsigned depth = 0;
         while (x) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -569,7 +569,7 @@ private:
                     if (w->right())
                         w->right()->setColor(Black);
                     leftRotate(xParent);
-                    x = m_root.get();
+                    x = m_root;
                     xParent = x->parent();
                 }
             } else {
@@ -609,7 +609,7 @@ private:
                     if (w->left())
                         w->left()->setColor(Black);
                     rightRotate(xParent);
-                    x = m_root.get();
+                    x = m_root;
                     xParent = x->parent();
                 }
             }
@@ -618,7 +618,7 @@ private:
             x->setColor(Black);
     }
 
-    CheckedPtr<NodeType> m_root;
+    NodeType* m_root;
 };
 
 }

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -35,10 +35,10 @@ namespace WTF {
 
 static constexpr bool report = false;
 
-class RunLoop::TimerBase::ScheduledTask final : public ThreadSafeRefCounted<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::Node {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ScheduledTask);
+class RunLoop::TimerBase::ScheduledTask : public ThreadSafeRefCounted<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::Node {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(RunLoop);
     WTF_MAKE_NONCOPYABLE(ScheduledTask);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScheduledTask);
+
 public:
     static Ref<ScheduledTask> create(RunLoop::TimerBase& timer)
     {

--- a/Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp
@@ -29,16 +29,13 @@
 #include "config.h"
 #include <wtf/HashSet.h>
 #include <wtf/RedBlackTree.h>
-#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace TestWebKitAPI {
 
 using namespace WTF;
 
-class TestNode final : public RedBlackTree<TestNode, char>::Node {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(TestNode);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TestNode);
+class TestNode : public RedBlackTree<TestNode, char>::Node {
 public:
     TestNode(char key, unsigned value)
         : m_key(key)
@@ -323,16 +320,14 @@ TEST_F(RedBlackTreeTest, BiggerBestFitSearch)
     testDriver("+d+d+d+d+d+d+d+d+d+d+f+f+f+f+f+f+f+h+h+i+j+k+l+m+o+p+q+r+z@a@b@c@d@e@f@g@h@i@j@k@l@m@n@o@p@q@r@s@t@u@v@w@x@y@z");
 }
 
-class IterateTestNode final : public RedBlackTree<IterateTestNode, unsigned>::Node {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(IterateTestNode);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IterateTestNode);
-public:
-    unsigned key() { return value; }
-    unsigned value;
-};
-
 TEST_F(RedBlackTreeTest, Iterate)
 {
+    class Node : public RedBlackTree<Node, unsigned>::Node {
+    public:
+        unsigned value;
+        unsigned key() { return value; }
+    };
+
     HashSet<unsigned> items;
     items.add(2);
     items.add(42);
@@ -344,16 +339,16 @@ TEST_F(RedBlackTreeTest, Iterate)
     items.add(250);
     items.add(300);
 
-    RedBlackTree<IterateTestNode, unsigned> tree;
+    RedBlackTree<Node, unsigned> tree;
     for (unsigned value : items) {
-        IterateTestNode* node = new IterateTestNode;
+        Node* node = new Node;
         node->value = value;
         tree.insert(node);
     }
 
     {
         HashSet<unsigned> testItems;
-        tree.iterate([&] (IterateTestNode& node, bool& iterateLeft, bool& iterateRight) {
+        tree.iterate([&] (Node& node, bool& iterateLeft, bool& iterateRight) {
             testItems.add(node.value);
             iterateLeft = true;
             iterateRight = true;
@@ -364,7 +359,7 @@ TEST_F(RedBlackTreeTest, Iterate)
 
     {
         HashSet<unsigned> lessThanOrEqual73;
-        tree.iterate([&] (IterateTestNode& node, bool& iterateLeft, bool& iterateRight) {
+        tree.iterate([&] (Node& node, bool& iterateLeft, bool& iterateRight) {
             if (node.value < 73) {
                 iterateRight = true;
                 iterateLeft = true;
@@ -385,7 +380,7 @@ TEST_F(RedBlackTreeTest, Iterate)
 
     {
         HashSet<unsigned> greaterThan55;
-        tree.iterate([&] (IterateTestNode& node, bool& iterateLeft, bool& iterateRight) {
+        tree.iterate([&] (Node& node, bool& iterateLeft, bool& iterateRight) {
             if (node.value <= 55)
                 iterateRight = true;
             else {


### PR DESCRIPTION
#### efcdcc266ba76ac5e23c5114d565aca218291242
<pre>
Unreviewed, reverting 303015@main as it causes assertion failures in JSC stress tests
<a href="https://rdar.apple.com/164678753">rdar://164678753</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302503">https://bugs.webkit.org/show_bug.cgi?id=302503</a>

Causes 8630 JSC test failures on JSCOnly ports (using RunLoopGeneric).

Test: Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WTF/wtf/MetaAllocator.cpp:
(WTF::MetaAllocator::~MetaAllocator):
(WTF::MetaAllocator::findAndRemoveFreeSpace):
(WTF::MetaAllocator::debugFreeSpaceSize):
(WTF::MetaAllocator::addFreeSpace):
* Source/WTF/wtf/MetaAllocator.h:
* Source/WTF/wtf/MetaAllocatorHandle.h:
(): Deleted.
* Source/WTF/wtf/RedBlackTree.h:
* Source/WTF/wtf/generic/RunLoopGeneric.cpp:
* Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp:
(TestWebKitAPI::TEST_F(RedBlackTreeTest, Iterate)):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/303026@main">https://commits.webkit.org/303026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/005f78ff4d7cfd68c4556837136439674fa6ad15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130945 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/3269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132816 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/3111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/138387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133891 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/122962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129398 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/3012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/3111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/140879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/3058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/140879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20387 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/3080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/66475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/162415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/162415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/3010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->