### PR TITLE
Fix UITextSearching protocol functions in site isolation

### DIFF
--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -80,6 +80,8 @@ public:
     DOMWindow* window() const { return virtualWindow(); }
     RefPtr<DOMWindow> protectedWindow() const;
     FrameTree& tree() const { return m_treeNode; }
+    WEBCORE_EXPORT std::optional<size_t> indexInFrameTreeSiblings() const;
+    WEBCORE_EXPORT Vector<size_t> pathToFrame() const;
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in DocumentPage.h.
     inline RefPtr<Page> protectedPage() const; // Defined in DocumentPage.h.

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1032,6 +1032,15 @@ Ref<SecurityOrigin> Page::protectedMainFrameOrigin() const
     return mainFrameOrigin();
 }
 
+RefPtr<Frame> Page::findFrameByPath(const Vector<size_t>& path) const
+{
+    RefPtr current = m_mainFrame.get();
+    for (size_t i = 0; i < path.size() && current; i++)
+        current = current->tree().child(path[i]);
+
+    return current;
+}
+
 bool Page::openedByDOM() const
 {
     return m_openedByDOM;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -428,6 +428,7 @@ public:
     WEBCORE_EXPORT const URL& mainFrameURL() const;
     SecurityOrigin& mainFrameOrigin() const;
     Ref<SecurityOrigin> protectedMainFrameOrigin() const;
+    WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<size_t>& path) const;
 
     WEBCORE_EXPORT void setMainFrameURLAndOrigin(const URL&, RefPtr<SecurityOrigin>&&);
 #if ENABLE(DOM_AUDIO_SESSION)

--- a/Source/WebKit/Shared/WebFoundTextRange.cpp
+++ b/Source/WebKit/Shared/WebFoundTextRange.cpp
@@ -50,13 +50,13 @@ unsigned WebFoundTextRange::hash() const
 
 bool WebFoundTextRange::operator==(const WebFoundTextRange& other) const
 {
-    if (frameIdentifier.isHashTableDeletedValue())
-        return other.frameIdentifier.isHashTableDeletedValue();
-    if (other.frameIdentifier.isHashTableDeletedValue())
+    if (pathToFrame.isHashTableDeletedValue())
+        return other.pathToFrame.isHashTableDeletedValue();
+    if (other.pathToFrame.isHashTableDeletedValue())
         return false;
 
     return data == other.data
-        && frameIdentifier == other.frameIdentifier
+        && pathToFrame == other.pathToFrame
         && order == other.order;
 }
 
@@ -73,7 +73,7 @@ TextStream& operator<<(TextStream& ts, const WebFoundTextRange& range)
         }
     );
     ts.dumpProperty("order"_s, range.order);
-    ts.dumpProperty("frameIdentifier"_s, range.frameIdentifier);
+    ts.dumpProperty("pathToFrame"_s, range.pathToFrame);
     return ts;
 }
 

--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -55,7 +55,7 @@ struct WebFoundTextRange {
     };
 
     Variant<DOMData, PDFData> data { DOMData { } };
-    AtomString frameIdentifier;
+    Vector<size_t> pathToFrame;
     uint64_t order { 0 };
 
     unsigned hash() const;
@@ -105,8 +105,8 @@ public:
 template<> struct HashTraits<WebKit::WebFoundTextRange> : GenericHashTraits<WebKit::WebFoundTextRange> {
     static WebKit::WebFoundTextRange emptyValue() { return { }; }
 
-    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { new (NotNull, &slot.frameIdentifier) AtomString { HashTableDeletedValue }; }
-    static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range.frameIdentifier.isHashTableDeletedValue(); }
+    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { slot.pathToFrame = Vector<size_t> { HashTableDeletedValue }; }
+    static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range.pathToFrame.isHashTableDeletedValue(); }
 };
 
 }

--- a/Source/WebKit/Shared/WebFoundTextRange.serialization.in
+++ b/Source/WebKit/Shared/WebFoundTextRange.serialization.in
@@ -34,6 +34,6 @@
 
 struct WebKit::WebFoundTextRange {
     Variant<WebKit::WebFoundTextRange::DOMData, WebKit::WebFoundTextRange::PDFData> data;
-    AtomString frameIdentifier;
+    Vector<size_t> pathToFrame;
     uint64_t order;
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -809,6 +809,14 @@ WebFrameProxy* WebFrameProxy::previousSibling() const
     return (--it)->ptr();
 }
 
+RefPtr<WebFrameProxy> WebFrameProxy::childFrame(size_t index) const
+{
+    RefPtr child = firstChild();
+    for (size_t i = 0; i < index && child; i++)
+        child = child->nextSibling();
+    return child;
+}
+
 void WebFrameProxy::updateOpener(WebCore::FrameIdentifier newOpener)
 {
     m_opener = WebFrameProxy::webFrame(newOpener);

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -211,6 +211,8 @@ public:
 
     WebFrameProxy* parentFrame() const { return m_parentFrame.get(); }
     WebFrameProxy& rootFrame();
+    RefPtr<WebFrameProxy> childFrame(size_t index) const;
+
     WebProcessProxy& process() const;
     Ref<WebProcessProxy> protectedProcess() const;
     void setProcess(FrameProcess&);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -571,8 +571,8 @@ constexpr double fasterTapSignificantZoomThreshold = 0.8;
 
 @interface WKFoundTextRange : UITextRange
 
-@property (nonatomic, copy) NSString *frameIdentifier;
 @property (nonatomic) NSUInteger order;
+@property (nonatomic, copy) NSArray *pathToFrame;
 
 + (WKFoundTextRange *)foundTextRangeWithWebFoundTextRange:(WebKit::WebFoundTextRange)range;
 
@@ -15948,14 +15948,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     );
 
-    [range setFrameIdentifier:webRange.frameIdentifier.createNSString().get()];
+    [range setPathToFrame:createNSArray(webRange.pathToFrame, [](size_t index) {
+        return @(index);
+    }).get()];
     [range setOrder:webRange.order];
     return range.autorelease();
 }
 
 - (void)dealloc
 {
-    [_frameIdentifier release];
     [super dealloc];
 }
 
@@ -15991,7 +15992,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WebKit::WebFoundTextRange)webFoundTextRange
 {
     WebKit::WebFoundTextRange::DOMData data { self.location, self.length };
-    return { data, self.frameIdentifier, self.order };
+    auto pathToFrameVector = makeVector(self.pathToFrame, [](id number) -> std::optional<size_t> {
+        return [number unsignedLongValue];
+    });
+    return { data, WTFMove(pathToFrameVector), self.order };
 }
 
 @end
@@ -16025,7 +16029,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WebKit::WebFoundTextRange)webFoundTextRange
 {
     WebKit::WebFoundTextRange::PDFData data { self.startPage, self.startPageOffset, self.endPage, self.endPageOffset };
-    return { data, self.frameIdentifier, self.order };
+    auto pathToFrameVector = makeVector(self.pathToFrame, [](id number) -> std::optional<size_t> {
+        return [number unsignedLongValue];
+    });
+    return { data, WTFMove(pathToFrameVector), self.order };
 }
 
 @end

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -608,6 +608,15 @@ typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
 @property (nonatomic, readwrite) NSStringCompareOptions stringCompareOptions;
 @end
 
+#if !__has_include(<UIKit/_UITextSearching.h>)
+// Define SPI type when private header is not available (older SDKs)
+typedef NS_ENUM(NSUInteger, _UIFoundTextStyle) {
+    _UIFoundTextStyleNormal,
+    _UIFoundTextStyleFound,
+    _UIFoundTextStyleHighlighted,
+};
+#endif
+
 #endif
 
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.h
@@ -25,10 +25,13 @@
 
 #pragma once
 
+#include <WebKit/_WKFindDelegate.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/RetainPtr.h>
 
 #if HAVE(UIFINDINTERACTION)
+
+class InstanceMethodSwizzler;
 
 @interface TestSearchAggregator : NSObject <UITextSearchAggregator>
 
@@ -37,6 +40,16 @@
 
 - (instancetype)initWithCompletionHandler:(dispatch_block_t)completionHandler;
 
+@end
+
+@interface TestScrollViewDelegate : NSObject<UIScrollViewDelegate>  {
+    @public bool _finishedScrolling;
+}
+@end
+
+@interface TestFindDelegate : NSObject<_WKFindDelegate>
+@property (nonatomic, copy) void (^didAddLayerForFindOverlayHandler)(void);
+@property (nonatomic, copy) void (^didRemoveLayerForFindOverlayHandler)(void);
 @end
 
 void testPerformTextSearchWithQueryStringInWebView(WKWebView *, NSString *query, UITextSearchOptions *, NSUInteger expectedMatches);


### PR DESCRIPTION
#### 8c52c9461526901f003fb6f8482c42d7f8cabca9
<pre>
Fix UITextSearching protocol functions in site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=302986">https://bugs.webkit.org/show_bug.cgi?id=302986</a>
<a href="https://rdar.apple.com/165243794">rdar://165243794</a>

Reviewed by Sihui Liu and Alex Christensen.

This patch fixes issues with the `UITextSearching` protocol
in site isolation.

It fixes `replaceFoundTextInRange`, `decorateFoundTextRange`,
`scrollRangeToVisible`, `clearAllDecoratedFoundText`, and
`requestRectForFoundTextRange` in site isolation.

The main problem is that a client can search for string in
one WebView and then highlight or replace or scroll in another
that is hosting the same content. We address this issue by storing
the path from the mainFrame to the frame in which the match was
found on each WebFoundTextRange.

This way, we can traverse the frame tree for each
WebFoundTextRange and find, positionally, which frame the range
was found in. This means we do not have to store the frameIdentifier,
which will be different between WebViews.

* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::indexInFrameTreeSiblings const):
(WebCore::Frame::pathToFrame const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::findFrameByPath const):
* Source/WebCore/page/Page.h:
* Source/WebKit/Shared/WebFoundTextRange.cpp:
(WebKit::WebFoundTextRange::operator== const):
(WebKit::operator&lt;&lt;):
* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::isDeletedValue):
* Source/WebKit/Shared/WebFoundTextRange.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::childFrame const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::replaceFoundTextRangeWithString):
(WebKit::WebPageProxy::scrollTextRangeToVisible):
(WebKit::WebPageProxy::clearAllDecoratedFoundText):
(WebKit::WebPageProxy::didBeginTextSearchOperation):
(WebKit::WebPageProxy::requestRectForFoundTextRange):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(+[WKFoundTextRange foundTextRangeWithWebFoundTextRange:]):
(-[WKFoundTextRange dealloc]):
(-[WKFoundDOMTextRange webFoundTextRange]):
(-[WKFoundPDFTextRange webFoundTextRange]):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
(WebKit::WebFoundTextRangeController::frameForFoundTextRange const):
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST(WebKit, FindAndReplace)):
(swizzledIsEmbeddedScreen): Deleted.
(-[TestScrollViewDelegate init]): Deleted.
(-[TestScrollViewDelegate scrollViewDidEndScrollingAnimation:]): Deleted.
(-[TestFindDelegate setDidAddLayerForFindOverlayHandler:]): Deleted.
(-[TestFindDelegate didAddLayerForFindOverlayHandler]): Deleted.
(-[TestFindDelegate setDidRemoveLayerForFindOverlayHandler:]): Deleted.
(-[TestFindDelegate didRemoveLayerForFindOverlayHandler]): Deleted.
(-[TestFindDelegate _webView:didAddLayerForFindOverlay:]): Deleted.
(-[TestFindDelegate _webViewDidRemoveLayerForFindOverlay:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageUtilities.mm:
(swizzledIsEmbeddedScreen):
(-[TestScrollViewDelegate init]):
(-[TestScrollViewDelegate scrollViewDidEndScrollingAnimation:]):
(-[TestFindDelegate setDidAddLayerForFindOverlayHandler:]):
(-[TestFindDelegate didAddLayerForFindOverlayHandler]):
(-[TestFindDelegate setDidRemoveLayerForFindOverlayHandler:]):
(-[TestFindDelegate didRemoveLayerForFindOverlayHandler]):
(-[TestFindDelegate _webView:didAddLayerForFindOverlay:]):
(-[TestFindDelegate _webViewDidRemoveLayerForFindOverlay:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, FindStringInFrameAndReplaceIOS)):
(TestWebKitAPI::(SiteIsolation, DecorateFoundTextRangeIOS)):
(TestWebKitAPI::(SiteIsolation, ScrollTextRangeToVisibleIOS)):
(TestWebKitAPI::(SiteIsolation, ClearAllDecoratedFoundTextIOS)):
(TestWebKitAPI::(SiteIsolation, RequestRectForFoundTextRangeIOS)):

Canonical link: <a href="https://commits.webkit.org/303851@main">https://commits.webkit.org/303851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0671de4912f3395b6ca25ae7300b11915090917f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133793 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141368 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/edfae664-3e32-4c13-89bb-2c6796cdca3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135663 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/6830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102345 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7104fff8-df81-4f68-a15d-829a625dafd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136740 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/6830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83146 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e433dee3-1700-4204-bd0e-d4df5f74f6c4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/6830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/6830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/38061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144016 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5972 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/5102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110910 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28124 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/116198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6025 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69489 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->