### PR TITLE
[Site Isolation] Make MESSAGE_CHECK in commitLayerTree() robust against process swaps in Site Isolation

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -322,6 +322,9 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
         MESSAGE_CHECK_BASE(!state.committedLayerTreeTransactionID || bundle.transactionID == state.committedLayerTreeTransactionID->next(), connection);
     }
 
+    if (bundle.mainFrameData)
+        MESSAGE_CHECK_BASE(webProcessProxy().hasConnection(connection), connection);
+
     // The `sendRights` vector must have __block scope to be captured by
     // the commit handler block below without the need to copy it.
     __block Vector<MachSendRight, 16> sendRights;


### PR DESCRIPTION
#### 5d32c1ef78c3d11fa397fca3d8e46418b32e3abe
<pre>
[Site Isolation] Make MESSAGE_CHECK in commitLayerTree() robust against process swaps in Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=302497">https://bugs.webkit.org/show_bug.cgi?id=302497</a>
<a href="https://rdar.apple.com/164916965">rdar://164916965</a>

Reviewed by Matt Woodrow.

302408@main added a MESSAGE_CHECK at the start of commitLayerTree() to verify that main frame data is only provided
from the main frame process. This MESSAGE_CHECK caused API test SiteIsolation.NavigationAfterWindowOpen and layout
tests LayoutTests/http/tests/site-isolation/window-open-with-name-cross-site.html and
http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html to be flaky crashes.
And so, we reverted the MESSAGE_CHECK portion of 302408@main in 303201@main.

The flaky crashes are due to process swaps that occur due to cross site navigations in Site Isolation.
Let&apos;s say you&apos;re on site a.com and do window.open(b.com). If you take this scenario and then do
window.open(c.com, &quot;same target as b.com&quot;), a process swap gets triggered. A new WebProcessProxy gets spun up.
A new ProvisionalPageProxy (which is really just a weak reference to existing b.com WebPageProxy) with a new RemoteLayerTreeDrawingAreaProxy
gets spun up which corresponds to the new c.com WCP. When c.com WCP sends its CommitLayerTree message, if the swap isn&apos;t
done yet (WebPageProxy::swapToProvisionalPage() which does m_mainFrame = provisionalPage-&gt;mainFrame()), then the m_mainframe
in this ProvisionalPageProxy is still old (corresponds to b.com still) and so the MESSAGE_CHECK fails.

To solve this, we now add the MESSAGE_CHECK back but using m_webProcessProxy in DrawingAreaProxy. m_webProcessProxy is always set to the main frame process for that Page/PageProxy.
Non-mainframe processes (which are cross site iframe processes) take a different path by sending to RemotePageDrawingAreaProxy
which then gets forwarded to RemoteLayerTreeDrawingAreaProxy. So we can safely use this to verify main frame process identity.

This PR relies on <a href="https://github.com/WebKit/WebKit/pull/53683">https://github.com/WebKit/WebKit/pull/53683</a> being landed first since it makes bundle.mainFrameData
the sole source of truth for checking for main frame identity

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):

Canonical link: <a href="https://commits.webkit.org/303415@main">https://commits.webkit.org/303415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6b14667b28acf2aabda1e45d51f9ad84882b0ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84051 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101004 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68348 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135079 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81795 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/550415cd-0b49-46f0-b5ea-622d54b8cc34) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82867 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112073 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142294 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4295 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109378 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109553 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27803 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3261 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57541 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4349 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33017 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4180 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4440 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4308 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->