### PR TITLE
Address Safer CPP warnings in RedBlackTree.h

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -779,7 +779,7 @@ public:
                 visitRight = true;
         });
 
-        for (Islands* islands : toRemove)
+        SUPPRESS_UNCHECKED_LOCAL for (Islands* islands : toRemove)
             freeIslands(locker, islands);
 
         if (ASSERT_ENABLED) {
@@ -834,16 +834,16 @@ private:
 
     void* islandForJumpLocation(const Locker<Lock>& locker, uintptr_t jumpLocation, uintptr_t target, bool concurrently, bool useMemcpy)
     {
-        Islands* islands = m_islandsForJumpSourceLocation.findExact(std::bit_cast<void*>(jumpLocation));
+        CheckedPtr islands = m_islandsForJumpSourceLocation.findExact(std::bit_cast<void*>(jumpLocation));
         if (islands) {
             // FIXME: We could create some method of reusing already allocated islands here, but it's
             // unlikely to matter in practice.
             if (!concurrently)
-                freeJumpIslands(locker, islands);
+                freeJumpIslands(locker, islands.get());
         } else {
             islands = new Islands;
             islands->jumpSourceLocation = CodeLocationLabel<ExecutableMemoryPtrTag>(tagCodePtr<ExecutableMemoryPtrTag>(std::bit_cast<void*>(jumpLocation)));
-            m_islandsForJumpSourceLocation.insert(islands);
+            m_islandsForJumpSourceLocation.insert(islands.get());
         }
 
         RegionAllocator* allocator = findRegion(jumpLocation > target ? jumpLocation - m_regionSize : jumpLocation);
@@ -1099,8 +1099,9 @@ private:
     }
 
 #if ENABLE(JUMP_ISLANDS)
-    class Islands : public RedBlackTree<Islands, void*>::Node {
+    class Islands final : public RedBlackTree<Islands, void*>::ThreadSafeNode {
         WTF_MAKE_TZONE_ALLOCATED(Islands);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Islands);
     public:
         void* key() { return jumpSourceLocation.dataLocation(); }
         CodeLocationLabel<ExecutableMemoryPtrTag> jumpSourceLocation;

--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,3 +1,2 @@
 wtf/JSONValues.h
 wtf/RecursiveLockAdapter.h
-wtf/RedBlackTree.h

--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -36,6 +36,7 @@
 #include <wtf/PageBlock.h>
 #include <wtf/RedBlackTree.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 
@@ -139,7 +140,9 @@ private:
     
     friend class MetaAllocatorHandle;
     
-    class FreeSpaceNode : public RedBlackTree<FreeSpaceNode, size_t>::Node {
+    class FreeSpaceNode final : public RedBlackTree<FreeSpaceNode, size_t>::ThreadSafeNode {
+        WTF_MAKE_TZONE_ALLOCATED(FreeSpaceNode);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FreeSpaceNode);
     public:
         size_t sizeInBytes()
         {
@@ -187,8 +190,8 @@ private:
     unsigned m_logPageSize;
     
     Tree m_freeSpaceSizeMap;
-    UncheckedKeyHashMap<FreeSpacePtr, FreeSpaceNode*> m_freeSpaceStartAddressMap;
-    UncheckedKeyHashMap<FreeSpacePtr, FreeSpaceNode*> m_freeSpaceEndAddressMap;
+    UncheckedKeyHashMap<FreeSpacePtr, CheckedPtr<FreeSpaceNode>> m_freeSpaceStartAddressMap;
+    UncheckedKeyHashMap<FreeSpacePtr, CheckedPtr<FreeSpaceNode>> m_freeSpaceEndAddressMap;
     UncheckedKeyHashMap<uintptr_t, size_t> m_pageOccupancyMap;
     
     size_t m_bytesAllocated;

--- a/Source/WTF/wtf/MetaAllocatorHandle.h
+++ b/Source/WTF/wtf/MetaAllocatorHandle.h
@@ -39,9 +39,9 @@ class MetaAllocator;
 class PrintStream;
 
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetaAllocatorHandle);
-class MetaAllocatorHandle : public ThreadSafeRefCounted<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::Node {
+class MetaAllocatorHandle final : public ThreadSafeRefCounted<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::ThreadSafeNode {
     WTF_DEPRECATED_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(MetaAllocatorHandle, MetaAllocatorHandle);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MetaAllocatorHandle);
 public:
     using MemoryPtr = CodePtr<HandleMemoryPtrTag>;
 

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -35,19 +35,14 @@ namespace WTF {
 
 static constexpr bool report = false;
 
-class RunLoop::TimerBase::ScheduledTask : public ThreadSafeRefCounted<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::Node {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(RunLoop);
+class RunLoop::TimerBase::ScheduledTask final : public ThreadSafeRefCounted<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::ThreadSafeNode {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ScheduledTask);
     WTF_MAKE_NONCOPYABLE(ScheduledTask);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScheduledTask);
 public:
     static Ref<ScheduledTask> create(RunLoop::TimerBase& timer)
     {
         return adoptRef(*new ScheduledTask(timer));
-    }
-
-    ScheduledTask(RunLoop::TimerBase& timer)
-        : m_timer(timer)
-    {
     }
 
     void fired()
@@ -112,6 +107,11 @@ public:
     }
 
 private:
+    ScheduledTask(RunLoop::TimerBase& timer)
+        : m_timer(timer)
+    {
+    }
+
     RunLoop::TimerBase& m_timer;
     MonotonicTime m_scheduledTimePoint;
     Seconds m_fireInterval;


### PR DESCRIPTION
#### 63bd9144ba3f5d941572d4f865b711b6f62d8e95
<pre>
Address Safer CPP warnings in RedBlackTree.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302453">https://bugs.webkit.org/show_bug.cgi?id=302453</a>
<a href="https://rdar.apple.com/164670950">rdar://164670950</a>

Reviewed by Yusuke Suzuki.

Have `RedBlackTree::Node` subclass CanMakeCheckedPtr so we can use CheckedPtr
for safety in RedBlackTree. Since some users are using the tree from multiple
threads (with locks), also introduce a new `RedBlackTree::ThreadSafeNode`
which subclasses CanMakeThreadSafeCheckedPtr.

In particular, the following RedBlackTree Node subclasses are used from multiple
threads:
- JSC::Islands in ExecutableAllocator.cpp is used from multiple threads while holding
a lock:
```
    void handleWillBeReleased(const Locker&lt;Lock&gt;&amp; locker, ExecutableMemoryHandle&amp; handle)
    {
        if (m_islandsForJumpSourceLocation.isEmpty())
            return;
```
with `m_islandsForJumpSourceLocation` being a RedBlackTree of `Islands`.

- WTF::FreeSpaceNode in MetaAllocator.h:
```
size_t MetaAllocator::debugFreeSpaceSize()
{
    Locker locker { m_lock };
    size_t result = 0;
    for (CheckedPtr node = m_freeSpaceSizeMap.first(); node; node = node-&gt;successor())
```

- WTF::MetaAllocatorHandle that is marked as `ThreadSafeRefCounted`.

- RunLoop::TimerBase::ScheduledTask in RunLoopGeneric.cpp that is marked as `ThreadSafeRefCounted`.
```
inline bool RunLoop::populateTasks(RunMode runMode, Status&amp; statusOfThisLoop, Deque&lt;Ref&lt;TimerBase::ScheduledTask&gt;&gt;&amp; firedTimers)
{
    Locker locker { m_loopLock };

    if (runMode == RunMode::Drain) {
        MonotonicTime sleepUntil = MonotonicTime::infinity();
        if (!m_schedules.isEmpty())
            sleepUntil = m_schedules.first()-&gt;scheduledTimePoint();
```
with m_schedules being a RedBlackTree of `RunLoop::TimerBase::ScheduledTask`.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WTF/wtf/MetaAllocator.cpp:
(WTF::MetaAllocator::~MetaAllocator):
(WTF::MetaAllocator::findAndRemoveFreeSpace):
(WTF::MetaAllocator::debugFreeSpaceSize):
(WTF::MetaAllocator::addFreeSpace):
* Source/WTF/wtf/MetaAllocator.h:
(WTF::MetaAllocator::FreeSpaceNode::sizeInBytes): Deleted.
(WTF::MetaAllocator::FreeSpaceNode::key): Deleted.
* Source/WTF/wtf/MetaAllocatorHandle.h:
(WTF::MetaAllocatorHandle::start const): Deleted.
(WTF::MetaAllocatorHandle::end const): Deleted.
(WTF::MetaAllocatorHandle::startAsInteger const): Deleted.
(WTF::MetaAllocatorHandle::endAsInteger const): Deleted.
(WTF::MetaAllocatorHandle::sizeInBytes const): Deleted.
(WTF::MetaAllocatorHandle::containsIntegerAddress const): Deleted.
(WTF::MetaAllocatorHandle::contains const): Deleted.
(WTF::MetaAllocatorHandle::allocator): Deleted.
(WTF::MetaAllocatorHandle::key): Deleted.
* Source/WTF/wtf/RedBlackTree.h:
* Source/WTF/wtf/generic/RunLoopGeneric.cpp:
(WTF::RunLoop::TimerBase::ScheduledTask::create): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::ScheduledTask): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::fired): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::scheduledTimePoint const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::updateReadyTime): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::key const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::isScheduled const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::setScheduled): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::isActive const): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::activate): Deleted.
(WTF::RunLoop::TimerBase::ScheduledTask::deactivate): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/RedBlackTree.cpp:
(TestWebKitAPI::TEST_F(RedBlackTreeTest, Iterate)):
(TestWebKitAPI::TEST_F(RedBlackTreeTest, IterateBackgroundThread)):
(TestWebKitAPI::TestNode::TestNode): Deleted.
(TestWebKitAPI::TestNode::key): Deleted.

Canonical link: <a href="https://commits.webkit.org/303083@main">https://commits.webkit.org/303083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4260a9a0628c45c994ba3f97c89eeffa0a701d7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131178 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82883 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e75b7e60-b485-47e3-83f6-252c2651c93a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67695 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/82769350-f8fe-4d61-b543-457a4dae921f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80643 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2422 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/115 "Found 1 new API test failure: TestWebKitAPI.DrawingToPDF.SiteIsolationFormControl (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81869 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123200 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141118 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129632 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3253 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108463 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108405 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27566 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2439 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113757 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56312 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3315 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32181 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162649 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3137 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66722 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40611 "Found unexpected failure with change (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->