### PR TITLE
[Safer CPP] Stop storing Database raw pointers in a HashSet in DatabaseTracker.h

### DIFF
--- a/Source/WebCore/Modules/webdatabase/Database.h
+++ b/Source/WebCore/Modules/webdatabase/Database.h
@@ -53,7 +53,7 @@ template<typename> class ExceptionOr;
 
 using DatabaseGUID = int;
 
-class Database : public ThreadSafeRefCounted<Database> {
+class Database : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Database> {
 public:
     ~Database();
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
@@ -39,6 +39,7 @@
 #include <wtf/Platform.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/StringHash.h>
 
@@ -162,7 +163,7 @@ private:
 
     void deleteOriginLockFor(const SecurityOriginData&) WTF_REQUIRES_LOCK(m_databaseGuard);
 
-    using DatabaseSet = HashSet<Database*>;
+    using DatabaseSet = ThreadSafeWeakHashSet<Database>;
     using DatabaseNameMap = HashMap<String, DatabaseSet>;
     using DatabaseOriginMap = HashMap<SecurityOriginData, DatabaseNameMap>;
 


### PR DESCRIPTION
#### 6ad323fe75ab6c6fc7aff74fb5621cbbcc6659c0
<pre>
[Safer CPP] Stop storing Database raw pointers in a HashSet in DatabaseTracker.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302509">https://bugs.webkit.org/show_bug.cgi?id=302509</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webdatabase/Database.h:
* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
(WebCore::DatabaseTracker::openDatabases):
(WebCore::DatabaseTracker::addOpenDatabase):
(WebCore::DatabaseTracker::removeOpenDatabase):
(WebCore::DatabaseTracker::deleteDatabaseFile):
* Source/WebCore/Modules/webdatabase/DatabaseTracker.h:

Canonical link: <a href="https://commits.webkit.org/303064@main">https://commits.webkit.org/303064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5bf6527f74a75d90db3c2f174873a4013b08066

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82665 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7f5f263-7d24-4665-bc88-3e6f58256d2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99788 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67579 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c01f26e1-7094-42ce-a2ea-d918d8ae85e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80498 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43a621aa-10c2-4f01-94d9-c9f84fa93fd8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2278 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35399 "Found 3 new test failures: inspector/animation/lifecycle-css-transition.html inspector/debugger/async-stack-trace-truncate.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81677 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110869 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140925 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108307 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108264 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27556 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56094 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66520 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2946 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3055 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->