### PR TITLE
[MathML] Use font underlineThickness as MathML default rule thickness

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-parameters-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-parameters-3-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL nonzero linethickness, displaystyle=false assert_approx_equals: expected 89 +/- 1 but got 80
-FAIL nonzero linethickness, displaystyle=true assert_approx_equals: mfrac: thickness, axis height expected 101 +/- 1 but got 80
-FAIL linethickness=0, displaystyle=false assert_approx_equals: expected 6 +/- 1 but got 15
-FAIL linethickness=0, displaystyle=true assert_approx_equals: expected 14 +/- 1 but got 35
+PASS nonzero linethickness, displaystyle=false
+PASS nonzero linethickness, displaystyle=true
+PASS linethickness=0, displaystyle=false
+PASS linethickness=0, displaystyle=true
 
 
 

--- a/LayoutTests/platform/glib/mathml/radical-fallback-expected.txt
+++ b/LayoutTests/platform/glib/mathml/radical-fallback-expected.txt
@@ -1,23 +1,23 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x220
-  RenderBlock {HTML} at (0,0) size 800x220
-    RenderBody {BODY} at (8,16) size 784x188
-      RenderBlock {P} at (0,0) size 784x86
-        RenderText {#text} at (0,68) size 131x17
-          text run at (0,68) width 131: "Large LTR radicals: "
-        RenderMathMLMath {math} at (130,0) size 27x83
-          RenderMathMLRoot {msqrt} at (0,0) size 17x83
+layer at (0,0) size 800x222
+  RenderBlock {HTML} at (0,0) size 800x222
+    RenderBody {BODY} at (8,16) size 784x190
+      RenderBlock {P} at (0,0) size 784x87
+        RenderText {#text} at (0,69) size 131x17
+          text run at (0,69) width 131: "Large LTR radicals: "
+        RenderMathMLMath {math} at (130,0) size 27x84
+          RenderMathMLRoot {msqrt} at (0,1) size 17x83
             RenderMathMLSpace {mspace} at (17,2) size 0x81
-          RenderMathMLRoot {msqrt} at (17,0) size 9x82
-            RenderMathMLSpace {mspace} at (9,1) size 0x81
+          RenderMathMLRoot {msqrt} at (17,0) size 9x83
+            RenderMathMLSpace {mspace} at (9,2) size 0x81
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,102) size 784x86
-        RenderText {#text} at (0,68) size 131x17
-          text run at (0,68) width 131: "Large RTL radicals: "
-        RenderMathMLMath {math} at (130,0) size 27x83
-          RenderMathMLRoot {msqrt} at (9,0) size 17x83
+      RenderBlock {P} at (0,103) size 784x87
+        RenderText {#text} at (0,69) size 131x17
+          text run at (0,69) width 131: "Large RTL radicals: "
+        RenderMathMLMath {math} at (130,0) size 27x84
+          RenderMathMLRoot {msqrt} at (9,1) size 17x83
             RenderMathMLSpace {mspace} at (0,2) size 0x81
-          RenderMathMLRoot {msqrt} at (0,0) size 9x82
-            RenderMathMLSpace {mspace} at (0,1) size 0x81
+          RenderMathMLRoot {msqrt} at (0,0) size 9x83
+            RenderMathMLSpace {mspace} at (0,2) size 0x81
         RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
@@ -52,12 +52,10 @@ inline LayoutUnit RenderMathMLBlock::mirrorIfNeeded(LayoutUnit horizontalOffset,
     return mirrorIfNeeded(horizontalOffset, child.logicalWidth());
 }
 
+// https://w3c.github.io/mathml-core/#dfn-default-rule-thickness
 inline LayoutUnit RenderMathMLBlock::ruleThicknessFallback() const
 {
-    // This function returns a value for the default rule thickness (TeX's \xi_8) to be used as a fallback when we lack a MATH table.
-    // This arbitrary value of 0.05em was used in early WebKit MathML implementations for the thickness of the fraction bars.
-    // Note that Gecko has a slower but more accurate version that measures the thickness of U+00AF MACRON to be more accurate and otherwise fallback to some arbitrary value.
-    return LayoutUnit(0.05f * style().fontCascade().size());
+    return LayoutUnit(checkedStyle()->metricsOfPrimaryFont().underlineThickness().value_or(0.0f));
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### b9801cc6c15a25401ed0aba725b2bc46373ae8b8
<pre>
[MathML] Use font underlineThickness as MathML default rule thickness
<a href="https://bugs.webkit.org/show_bug.cgi?id=302510">https://bugs.webkit.org/show_bug.cgi?id=302510</a>
<a href="https://rdar.apple.com/164693673">rdar://164693673</a>

Reviewed by Frédéric Wang.

MathML Core defines [1] the default rule thickness as the value of the font’s
post.underlineThickness field. When this value is not available, the fallback
must be zero. WebKit previously used a legacy 0.05em heuristic for rule
thickness. This patch replaces that logic with a direct lookup of the primary
font’s underlineThickness and applies a LayoutUnit conversion. If the metric
is missing, the returned rule thickness is zero.

This aligns WebKit with MathML Core and Chromium’s behavior and removes the
legacy 0.05em fallback.

[1] <a href="https://w3c.github.io/mathml-core/#dfn-default-rule-thickness">https://w3c.github.io/mathml-core/#dfn-default-rule-thickness</a>

* Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h:
(WebCore::RenderMathMLBlock::ruleThicknessFallback const):
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-parameters-3-expected.txt: Progression
* LayoutTests/platform/glib/mathml/radical-fallback-expected.txt: Platform Specific Rebaseline (No Rendering Change)

Canonical link: <a href="https://commits.webkit.org/303108@main">https://commits.webkit.org/303108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4f8fc054027d93f5f65c24c0f15885f94c3d138

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138779 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07effdd3-961a-41bb-ab65-32a59adaef79) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100073 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/632caaba-708f-4def-bab2-5599a5ea7e33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134282 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/117572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80775 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e044ad75-fc89-47e7-ab6f-622e45581458) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2574 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/299 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141281 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36215 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108592 "Found 1 new test failure: fast/scrolling/rtl-scrollbars-sticky-document.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108536 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2575 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56576 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3473 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32325 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3295 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3403 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->