### PR TITLE
[Safer CPP] Reduce use of raw pointers in containers

### DIFF
--- a/Source/WebCore/loader/LoaderStrategy.cpp
+++ b/Source/WebCore/loader/LoaderStrategy.cpp
@@ -40,7 +40,7 @@ void LoaderStrategy::setResourceLoadSchedulingMode(Page&, LoadSchedulingMode)
 {
 }
 
-void LoaderStrategy::prioritizeResourceLoads(const Vector<SubresourceLoader*>&)
+void LoaderStrategy::prioritizeResourceLoads(const Vector<RefPtr<SubresourceLoader>>&)
 {
 }
 

--- a/Source/WebCore/loader/LoaderStrategy.h
+++ b/Source/WebCore/loader/LoaderStrategy.h
@@ -75,7 +75,7 @@ public:
     virtual void resumePendingRequests() = 0;
 
     virtual void setResourceLoadSchedulingMode(Page&, LoadSchedulingMode);
-    virtual void prioritizeResourceLoads(const Vector<SubresourceLoader*>&);
+    virtual void prioritizeResourceLoads(const Vector<RefPtr<SubresourceLoader>>&);
 
     virtual bool usePingLoad() const { return true; }
     using PingLoadCompletionHandler = Function<void(const ResourceError&, const ResourceResponse&)>;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2603,7 +2603,7 @@ void Page::prioritizeVisibleResources()
         return;
 
     auto resourceLoaders = toPrioritize.map([](auto& resource) {
-        return resource->loader();
+        return RefPtr { resource->loader() };
     });
 
     platformStrategies()->loaderStrategy()->prioritizeResourceLoads(resourceLoaders);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1697,7 +1697,7 @@ void NetworkConnectionToWebProcess::prioritizeResourceLoads(const Vector<WebCore
     if (!session)
         return;
 
-    Vector<NetworkLoad*> loads;
+    Vector<RefPtr<NetworkLoad>> loads;
     for (auto identifier : loadIdentifiers) {
         RefPtr loader = m_networkResourceLoaders.get(identifier);
         if (!loader || !loader->networkLoad())

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
@@ -278,7 +278,7 @@ void NetworkLoadScheduler::setResourceLoadSchedulingMode(WebCore::PageIdentifier
     }
 }
 
-void NetworkLoadScheduler::prioritizeLoads(const Vector<NetworkLoad*>& loads)
+void NetworkLoadScheduler::prioritizeLoads(const Vector<RefPtr<NetworkLoad>>& loads)
 {
     for (RefPtr load : loads) {
         if (auto* context = contextForLoad(*load))

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
@@ -61,7 +61,7 @@ public:
     void finishedPreconnectForMainResource(const URL&, const String& userAgent, const WebCore::ResourceError&);
 
     void setResourceLoadSchedulingMode(WebCore::PageIdentifier, WebCore::LoadSchedulingMode);
-    void prioritizeLoads(const Vector<NetworkLoad*>&);
+    void prioritizeLoads(const Vector<RefPtr<NetworkLoad>>&);
     void clearPageData(WebCore::PageIdentifier);
 
 private:

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -96,7 +96,7 @@ bool methodSignaturesAreCompatible(NSString *wire, NSString *local)
     RefPtr<API::Array> _objectStream;
 
     RefPtr<API::Dictionary> _currentDictionary;
-    HashSet<NSObject *> _objectsBeingEncoded; // Used to detect cycles.
+    HashSet<RetainPtr<NSObject>> _objectsBeingEncoded; // Used to detect cycles.
 }
 
 - (id)init

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -815,18 +815,18 @@ void WebProcessPool::registerNotificationObservers()
         return notifyToken;
     });
 
-    const Vector<NSString*> nsNotificationMessages = {
+    const Vector<RetainPtr<NSString>> nsNotificationMessages = {
         NSProcessInfoPowerStateDidChangeNotification
     };
-    m_notificationObservers = WTF::compactMap(nsNotificationMessages, [weakThis = WeakPtr { *this }](NSString* message) -> RetainPtr<NSObject>  {
-        RetainPtr observer = [[NSNotificationCenter defaultCenter] addObserverForName:message object:nil queue:[NSOperationQueue currentQueue] usingBlock:[weakThis, message](NSNotification *notification) {
+    m_notificationObservers = WTF::compactMap(nsNotificationMessages, [weakThis = WeakPtr { *this }](const RetainPtr<NSString>& message) -> RetainPtr<NSObject>  {
+        RetainPtr observer = [[NSNotificationCenter defaultCenter] addObserverForName:message.get() object:nil queue:[NSOperationQueue currentQueue] usingBlock:[weakThis, message](NSNotification *notification) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
             if (!protectedThis->m_processes.isEmpty()) {
-                String messageString(message);
+                String messageString(message.get());
                 for (auto& process : protectedThis->m_processes)
-                    process->send(Messages::WebProcess::PostObserverNotification(message), 0);
+                    process->send(Messages::WebProcess::PostObserverNotification(messageString), 0);
             }
         }];
         return observer;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -226,8 +226,8 @@ void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
 
     CALayer *container = node.ensureInteractionRegionsContainer();
 
-    HashMap<std::pair<IntRect, InteractionRegion::Type>, CALayer *>existingLayers;
-    HashMap<std::pair<UInt64, InteractionRegion::Type>, CALayer *>reusableLayers;
+    HashMap<std::pair<IntRect, InteractionRegion::Type>, RetainPtr<CALayer>> existingLayers;
+    HashMap<std::pair<UInt64, InteractionRegion::Type>, RetainPtr<CALayer>> reusableLayers;
     for (CALayer *sublayer in container.sublayers) {
         if (auto identifier = interactionRegionElementIdentifierForLayer(sublayer)) {
             if (auto type = interactionRegionTypeForLayer(sublayer)) {
@@ -338,7 +338,7 @@ void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
         insertionPoint++;
     }
 
-    for (CALayer *sublayer : existingLayers.values())
+    for (auto& sublayer : existingLayers.values())
         [sublayer removeFromSuperlayer];
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -1132,9 +1132,9 @@ void WebLoaderStrategy::setResourceLoadSchedulingMode(WebCore::Page& page, WebCo
     connection.send(Messages::NetworkConnectionToWebProcess::SetResourceLoadSchedulingMode(WebPage::fromCorePage(page)->identifier(), mode), 0);
 }
 
-void WebLoaderStrategy::prioritizeResourceLoads(const Vector<WebCore::SubresourceLoader*>& resources)
+void WebLoaderStrategy::prioritizeResourceLoads(const Vector<RefPtr<WebCore::SubresourceLoader>>& resources)
 {
-    auto identifiers = resources.map([](auto* loader) -> WebCore::ResourceLoaderIdentifier {
+    auto identifiers = resources.map([](auto& loader) -> WebCore::ResourceLoaderIdentifier {
         return *loader->identifier();
     });
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -146,7 +146,7 @@ private:
     void isResourceLoadFinished(WebCore::CachedResource&, CompletionHandler<void(bool)>&&) final;
 
     void setResourceLoadSchedulingMode(WebCore::Page&, WebCore::LoadSchedulingMode) final;
-    void prioritizeResourceLoads(const Vector<WebCore::SubresourceLoader*>&) final;
+    void prioritizeResourceLoads(const Vector<RefPtr<WebCore::SubresourceLoader>>&) final;
 
     Vector<WebCore::ResourceLoaderIdentifier> ongoingLoads() const final
     {


### PR DESCRIPTION
#### bfc52f7239ca4d842c747bc0177df125ebd70d1a
<pre>
[Safer CPP] Reduce use of raw pointers in containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=302516">https://bugs.webkit.org/show_bug.cgi?id=302516</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/LoaderStrategy.cpp:
(WebCore::LoaderStrategy::prioritizeResourceLoads):
* Source/WebCore/loader/LoaderStrategy.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::prioritizeVisibleResources):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::prioritizeResourceLoads):
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp:
(WebKit::NetworkLoadScheduler::prioritizeLoads):
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.h:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::prioritizeResourceLoads):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:

Canonical link: <a href="https://commits.webkit.org/303040@main">https://commits.webkit.org/303040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8d63af4cb0bb0f176922392c06d20fd10fa473b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82663 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5290dff3-e4fc-444b-bb83-780d3a718b1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132860 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99787 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09a33481-4e46-49a7-a03c-70ba52690f4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133935 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2359 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80497 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/53452443-1194-49b1-9ff8-9b00184e032c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2279 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35398 "Found 4 new test failures: inspector/animation/lifecycle-css-transition.html inspector/debugger/async-stack-trace-truncate.html inspector/page/hidpi-snapshot-size.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81676 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140924 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108306 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108263 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56093 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3124 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66519 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2945 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3145 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->