### PR TITLE
[MSE] MediaSourcePrivate's mediaPlayerReadyState calculation should transition to HAVE_CURRENT_DATA only once video frame is displayed

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -171,10 +171,17 @@ private:
         return m_private;
     }
 
-    void failedToCreateRenderer(RendererType type)
+    void failedToCreateRenderer(RendererType type) final
     {
         ensureWeakOnDispatcher([type](MediaSource& parent) {
             parent.failedToCreateRenderer(type);
+        });
+    }
+
+    void mediaPlayerHasAvailableVideoFrameChanged(bool available) final
+    {
+        ensureWeakOnDispatcher([available](MediaSource& parent) {
+            parent.mediaPlayerHasAvailableVideoFrameChanged(available);
         });
     }
 
@@ -615,6 +622,13 @@ void MediaSource::monitorSourceBuffers()
         msp->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
 
         // 3. Abort these steps.
+        return;
+    }
+
+    bool waitForAvailableFrame = msp->readyStateShouldAwaitHasAvailableVideoFrame() && msp->hasVideo() && !m_hasAvailableVideoFrame;
+    if (waitForAvailableFrame) {
+        if (m_pendingSeekTarget)
+            completeSeek();
         return;
     }
 
@@ -1597,6 +1611,17 @@ void MediaSource::failedToCreateRenderer(RendererType type)
 {
     if (RefPtr context = scriptExecutionContext())
         context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("MediaSource "_s, type == RendererType::Video ? "video"_s : "audio"_s, " renderer creation failed."_s));
+}
+
+void MediaSource::mediaPlayerHasAvailableVideoFrameChanged(bool available)
+{
+    if (isClosed())
+        return;
+    Ref msp = protectedPrivate().releaseNonNull();
+    if (!msp->readyStateShouldAwaitHasAvailableVideoFrame())
+        return;
+    if (std::exchange(m_hasAvailableVideoFrame, available) != available)
+        monitorSourceBuffers();
 }
 
 void MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged()

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -209,6 +209,8 @@ private:
     using RendererType = MediaSourcePrivateClient::RendererType;
     void failedToCreateRenderer(RendererType);
 
+    void mediaPlayerHasAvailableVideoFrameChanged(bool);
+
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final;
@@ -243,6 +245,7 @@ private:
     bool m_sourceopenPending { false };
     bool m_isAttached { false };
     std::optional<ReadyState> m_readyStateBeforeDetached;
+    bool m_hasAvailableVideoFrame { false };
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
     RefPtr<MediaSourceHandle> m_handle;
 #endif

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -339,6 +339,12 @@ bool MediaSourcePrivate::timeIsProgressing() const
     return false;
 }
 
+void MediaSourcePrivate::mediaPlayerHasAvailableVideoFrameChanged(bool available)
+{
+    if (RefPtr client = this->client())
+        return client->mediaPlayerHasAvailableVideoFrameChanged(available);
+}
+
 void MediaSourcePrivate::shutdown()
 {
 }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -127,6 +127,9 @@ public:
     void setStreamingAllowed(bool value) { m_streamingAllowed = value; }
     bool streamingAllowed() const { return m_streamingAllowed; }
 
+    virtual bool readyStateShouldAwaitHasAvailableVideoFrame() const { return false; }
+    void mediaPlayerHasAvailableVideoFrameChanged(bool);
+
 protected:
     MediaSourcePrivate(MediaSourcePrivateClient&, WorkQueue&);
     void ensureOnDispatcher(Function<void()>&&) const;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -54,6 +54,7 @@ public:
 
     enum class RendererType { Audio, Video };
     virtual void failedToCreateRenderer(RendererType) = 0;
+    virtual void mediaPlayerHasAvailableVideoFrameChanged(bool) { }
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -901,6 +901,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setHasAvailableVideoFrame(bool flag)
     ALWAYS_LOG(LOGIDENTIFIER, flag);
     m_hasAvailableVideoFrame = flag;
 
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->mediaPlayerHasAvailableVideoFrameChanged(flag);
+
     if (!m_hasAvailableVideoFrame)
         return;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -76,6 +76,7 @@ public:
 
     MediaPlayer::ReadyState mediaPlayerReadyState() const final;
     void setMediaPlayerReadyState(MediaPlayer::ReadyState) final;
+    bool readyStateShouldAwaitHasAvailableVideoFrame() const final { return true; };
 
     bool hasSelectedVideo() const;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -280,6 +280,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
     // This will also add support for fastSeek once done (see webkit.org/b/260607)
     if (!m_mediaSourcePrivate)
         return false;
+    m_mediaSourcePrivate->mediaPlayerHasAvailableVideoFrameChanged(false);
     m_mediaSourcePrivate->willSeek();
     m_mediaSourcePrivate->waitForTarget(target)->whenSettled(RunLoop::currentSingleton(), [this, weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         RefPtr self = weakThis.get();
@@ -396,6 +397,8 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
         return;
     }
     m_isWaitingForPreroll = false;
+    if (m_mediaSourcePrivate)
+        m_mediaSourcePrivate->mediaPlayerHasAvailableVideoFrameChanged(true);
 
     // The order of these sections is important. In the case of a seek, the "seeked" event must be emitted
     // before the "playing" event (which is emitted on HAVE_ENOUGH_DATA). Therefore, we take care of them in

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -69,6 +69,7 @@ public:
 
     MediaPlayer::ReadyState mediaPlayerReadyState() const override;
     void setMediaPlayerReadyState(MediaPlayer::ReadyState) override;
+    bool readyStateShouldAwaitHasAvailableVideoFrame() const final { return true; };
 
     void notifyActiveSourceBuffersChanged() final;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -100,6 +100,12 @@ Ref<MediaTimePromise> RemoteMediaSourceProxy::waitForTarget(const SeekTarget& ta
     return MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
 }
 
+void RemoteMediaSourceProxy::mediaPlayerHasAvailableVideoFrameChanged(bool available)
+{
+    if (RefPtr connection = connectionToWebProcess())
+        connection->connection().send(Messages::MediaSourcePrivateRemoteMessageReceiver::MediaPlayerHasAvailableVideoFrameChanged(available), m_identifier);
+}
+
 #if !RELEASE_LOG_DISABLED
 void RemoteMediaSourceProxy::setLogIdentifier(uint64_t)
 {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -70,6 +70,7 @@ public:
     void setPrivateAndOpen(Ref<WebCore::MediaSourcePrivate>&&) final;
     void reOpen() final;
     Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
+    void mediaPlayerHasAvailableVideoFrameChanged(bool) final;
     RefPtr<WebCore::MediaSourcePrivate> mediaSourcePrivate() const final { return m_private; }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -163,6 +163,15 @@ void MediaSourcePrivateRemote::shutdown()
     });
 }
 
+bool MediaSourcePrivateRemote::readyStateShouldAwaitHasAvailableVideoFrame() const
+{
+#if USE(AV_FOUNDATION) || USE(GSTREAMER)
+    return true;
+#else
+    return false;
+#endif
+}
+
 void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
 {
     // Called from the MediaSource's dispatcher.
@@ -269,6 +278,14 @@ void MediaSourcePrivateRemote::MessageReceiver::proxyWaitForTarget(const WebCore
         return;
     }
     completionHandler(makeUnexpected(PlatformMediaError::ClientDisconnected));
+}
+
+void MediaSourcePrivateRemote::MessageReceiver::mediaPlayerHasAvailableVideoFrameChanged(bool available)
+{
+    assertIsCurrent(MediaSourcePrivateRemote::queueSingleton());
+
+    if (auto client = this->client())
+        client->mediaPlayerHasAvailableVideoFrameChanged(available);
 }
 
 MediaSourcePrivateRemote::MessageReceiver::MessageReceiver(MediaSourcePrivateRemote& parent)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -75,6 +75,7 @@ public:
     void setMediaPlayerReadyState(WebCore::MediaPlayer::ReadyState) final;
     void setPlayer(WebCore::MediaPlayerPrivateInterface*) final;
     void shutdown() final;
+    bool readyStateShouldAwaitHasAvailableVideoFrame() const final;
 
     void setTimeFudgeFactor(const MediaTime&) final;
 
@@ -98,6 +99,7 @@ public:
         MessageReceiver(MediaSourcePrivateRemote&);
         void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
         void proxyWaitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
+        void mediaPlayerHasAvailableVideoFrameChanged(bool);
 
         RefPtr<WebCore::MediaSourcePrivateClient> client() const;
         ThreadSafeWeakPtr<MediaSourcePrivateRemote> m_parent;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
@@ -31,6 +31,7 @@
 ]
 messages -> MediaSourcePrivateRemoteMessageReceiver {
     ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (Expected<MediaTime, WebCore::PlatformMediaError> seekedTime);
+    MediaPlayerHasAvailableVideoFrameChanged(bool available)
 }
 
 #endif


### PR DESCRIPTION
#### 158758c1281b938f4cd78f5874ce59c9862ad8a9
<pre>
[MSE] MediaSourcePrivate&apos;s mediaPlayerReadyState calculation should transition to HAVE_CURRENT_DATA only once video frame is displayed
<a href="https://bugs.webkit.org/show_bug.cgi?id=302514">https://bugs.webkit.org/show_bug.cgi?id=302514</a>
<a href="https://rdar.apple.com/164695563">rdar://164695563</a>

Reviewed by NOBODY (OOPS!).

The MSE spec currently defines the value of the HTMLMediaElements&apos;s readyState
to be based on what data is buffered. It takes no account if a frame is actually
displayed or not.

Both WebKit&apos;s MSE platform player implementation: MediaPlayerPrivateMediaSourceAVFObjC
and MediaPlayerPrivateGStreamerMSE will not transition to HAVE_CURRENT_DATA
until a video frame is being displayed.

This behaviour isn&apos;t per spec but has been found to be required to guarantee
various tests to pass consistently.
For example, a common testing pattern is to seek at a particular time and perform
a reftest. So both MSE&apos;s MediaPlayerPrivate will not fire the seeked event
until a frame has been displayed (GStreamer&apos;s didPreroll() and AVFoundation&apos;s
hasFirstFrameAvailable).

A whatwg&apos;s spec issue will be raised to officially define this behaviour.

Covered by existing tests, will be fully tested once webkit.org/b/302242 lands

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::monitorSourceBuffers):
(WebCore::MediaSource::mediaPlayerHasAvailableVideoFrameChanged):
* Source/WebCore/Modules/mediasource/MediaSource.h:
(WebCore::MediaSource::hasAvailableVideoFrame const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::mediaPlayerHasAvailableVideoFrameChanged):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
(WebCore::MediaSourcePrivateClient::mediaPlayerHasAvailableVideoFrameChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setHasAvailableVideoFrame):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::doSeek):
(WebCore::MediaPlayerPrivateGStreamerMSE::didPreroll):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::mediaPlayerHasAvailableVideoFrameChanged):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::readyStateShouldAwaitHasAvailableVideoFrame const):
(WebKit::MediaSourcePrivateRemote::MessageReceiver::mediaPlayerHasAvailableVideoFrameChanged):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d97b5b76add625c1962b8f9e2589b93e2da1c6ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131183 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82903 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99947 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67706 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80646 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2423 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/128 "Found 1 new API test failure: TestWebKitAPI.DrawingToPDF.SiteIsolationFormControl (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81874 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141123 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3258 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108467 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3303 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2911 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108410 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2442 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113763 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56319 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3320 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32187 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3142 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->