### PR TITLE
[JSC] Add fast path for `Array.from({ length })`

### DIFF
--- a/JSTests/microbenchmarks/array-from-length-only-object.js
+++ b/JSTests/microbenchmarks/array-from-length-only-object.js
@@ -1,0 +1,9 @@
+function test(length) {
+  const args = Array.from({ length });
+  return args;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+  test(i % 1024);
+}

--- a/JSTests/stress/array-from-length-only-object.js
+++ b/JSTests/stress/array-from-length-only-object.js
@@ -1,0 +1,96 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(result, length) {
+  shouldBe(result.length, length);
+  let i = 0;
+  while (i < result.length) {
+    shouldBe(Object.hasOwn(result, 0), true);
+    shouldBe(result[i], void 0);
+    i++;
+  }
+  shouldBe(i, result.length);
+}
+noInline(test);
+
+{
+  const length = 100;
+  const result = Array.from({ length });
+
+  shouldBe(result.length, length);
+  let i = 0;
+  while (i < result.length) {
+    shouldBe(Object.hasOwn(result, i), true);
+    shouldBe(result[i], void 0);
+    i++;
+  }
+  shouldBe(i, result.length);
+}
+
+{
+  const length = 100;
+  const result = Array.from({ length, 0: "zero" });
+
+  shouldBe(result.length, length);
+  let i = 0;
+  while (i < result.length) {
+    shouldBe(Object.hasOwn(result, i), true);
+    shouldBe(result[i], i === 0 ? "zero" : void 0);
+    i++;
+  }
+  shouldBe(i, result.length);
+}
+
+{
+  const length = 100;
+  const result = Array.from({ length, prop: "prop" });
+
+  shouldBe(result.length, length);
+  let i = 0;
+  while (i < result.length) {
+    shouldBe(Object.hasOwn(result, i), true);
+    shouldBe(result[i], void 0);
+    i++;
+  }
+  shouldBe(i, result.length);
+}
+
+{
+  const length = 100;
+  class O {
+    constructor(length) {
+      this.length = length;
+    }
+  }
+  const result = Array.from(new O(length));
+
+  shouldBe(result.length, length);
+  let i = 0;
+  while (i < result.length) {
+    shouldBe(Object.hasOwn(result, i), true);
+    shouldBe(result[i], void 0);
+    i++;
+  }
+  shouldBe(i, result.length);
+}
+
+{
+  const result = Array.from({ length: "int32??" });
+  shouldBe(result.length, 0);
+}
+
+{
+  const length = 100.5;
+  const result = Array.from({ length });
+
+  shouldBe(result.length, Math.trunc(length));
+  let i = 0;
+  while (i < result.length) {
+    shouldBe(Object.hasOwn(result, i), true);
+    shouldBe(result[i], void 0);
+    i++;
+  }
+  shouldBe(i, result.length);
+}

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -312,6 +312,74 @@ static JSArray* tryCreateArrayFromDirectArguments(JSGlobalObject* globalObject, 
     return tryCreateArrayFromArguments(globalObject, arguments);
 }
 
+static int32_t getLengthFromLengthOnlyObject(JSGlobalObject* globalObject, JSValue value)
+{
+    VM& vm = globalObject->vm();
+
+    if (!value.isObject()) [[unlikely]]
+        return -1;
+
+    JSObject* object = asObject(value);
+    Structure* structure = object->structure();
+
+    if (object->getPrototypeDirect() != globalObject->objectPrototype())
+        return -1;
+    if (structure->maxOffset())
+        return -1;
+    if (hasIndexedProperties(structure->indexingType()))
+        return -1;
+    PropertyOffset lengthOffset = object->getDirectOffset(vm, vm.propertyNames->length);
+    if (lengthOffset == invalidOffset)
+        return -1;
+    JSValue lengthValue = object->getDirect(lengthOffset);
+    if (!lengthValue.isInt32()) [[unlikely]]
+        return -1;
+    return lengthValue.asInt32();
+}
+
+static ALWAYS_INLINE JSArray* tryCreateArrayFromLength(JSGlobalObject* globalObject, int32_t length)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!length)
+        RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
+
+    Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
+    IndexingType resultIndexingType = resultStructure->indexingType();
+
+    if (hasAnyArrayStorage(resultIndexingType)) [[unlikely]]
+        return nullptr;
+
+    ASSERT(!globalObject->isHavingABadTime());
+
+    auto vectorLength = Butterfly::optimalContiguousVectorLength(resultStructure, length);
+    void* memory = vm.auxiliarySpace().allocate(
+        vm,
+        Butterfly::totalSize(0, 0, true, vectorLength * sizeof(EncodedJSValue)),
+        nullptr, AllocationFailureMode::ReturnNull);
+    if (!memory) [[unlikely]]
+        return nullptr;
+    auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
+    resultButterfly->setVectorLength(vectorLength);
+    resultButterfly->setPublicLength(length);
+
+    ASSERT(hasContiguous(resultIndexingType));
+
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    auto* data = resultButterfly->contiguous().data();
+    auto pattern = std::bit_cast<const WriteBarrier<Unknown>>(JSValue::encode(jsUndefined()));
+#if OS(DARWIN)
+    memset_pattern8(data, &pattern, sizeof(JSValue) * length);
+#else
+    std::fill(data, data + length, pattern);
+#endif
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+    Butterfly::clearRange(resultIndexingType, resultButterfly, length, vectorLength);
+    return JSArray::createWithButterfly(vm, nullptr, resultStructure, resultButterfly);
+}
+
 JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -356,7 +424,12 @@ JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalO
             RELEASE_ASSERT_NOT_REACHED();
             break;
         }
+    } else if (int32_t length = getLengthFromLengthOnlyObject(globalObject, items); length >= 0) {
+        // For `Array.from({ length })
+        result = tryCreateArrayFromLength(globalObject, length);
+        RETURN_IF_EXCEPTION(scope, { });
     }
+
     if (result)
         return JSValue::encode(result);
     return JSValue::encode(jsUndefined());


### PR DESCRIPTION
#### 25417e2e076fc99230ef55d753eaf061841a2cdf
<pre>
[JSC] Add fast path for `Array.from({ length })`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302518">https://bugs.webkit.org/show_bug.cgi?id=302518</a>

Reviewed by NOBODY (OOPS!).

This patch changes to add fast path for `Array.from({ length })`.

                                       TipOfTree                  Patched

array-from-length-only-object       58.7637+-2.5059     ^     17.4000+-1.0529        ^ definitely 3.3772x faster
array-from-object                   51.2433+-2.2686     ^      5.3290+-0.2770        ^ definitely 9.6160x faster

* JSTests/microbenchmarks/array-from-length-only-object.js: Added.
(test):
* JSTests/stress/array-from-length-only-object.js: Added.
(shouldBe):
(test):
(noInline):
(shouldBe.O):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::getLengthFromLengthOnlyObject):
(JSC::tryCreateArrayFromLength):
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25417e2e076fc99230ef55d753eaf061841a2cdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82888 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67699 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2425 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81873 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123204 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141122 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129636 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108466 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108409 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2443 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56318 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3319 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32185 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162653 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3141 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66726 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40613 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->