### PR TITLE
[AppKit Gestures] Refactor wheel input handling to support NSPanGestureRecognizer

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8383,6 +8383,20 @@ UseAVCaptureDeviceRotationCoordinatorAPI:
       default: false
   sharedPreferenceForWebProcess: true
 
+UseAppKitGestures:
+  type: bool
+  status: internal
+  humanReadableName: "AppKit Gestures"
+  humanReadableDescription: "Use AppKit Gestures"
+  condition: PLATFORM(MAC)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 UseAsyncUIKitInteractions:
   type: bool
   status: internal

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -50,7 +50,7 @@ public:
 
     WEBCORE_EXPORT void setFrameRect(const IntRect&) final;
 
-    static int pixelsPerLineStep() { return 40; }
+    static constexpr int pixelsPerLineStep() { return 40; }
     WEBCORE_EXPORT static int pixelsPerLineStep(int viewWidthOrHeight);
     WEBCORE_EXPORT static void setShouldUseFixedPixelsPerLineStepForTesting(bool);
     static float minFractionToStepWhenPaging() { return 0.8; }

--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -48,6 +48,8 @@ DECLARE_SYSTEM_HEADER
 #import <AppKit/NSScrollPocket_Private.h>
 #endif
 
+#import <AppKit/NSPanGestureRecognizer_Private.h>
+
 #else
 
 @interface NSInspectorBar : NSObject
@@ -125,6 +127,10 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 
 @interface NSView (NSConstraintBasedLayout)
 - (void)_setHostsAutolayoutEngine:(BOOL)flag;
+@end
+
+@interface NSPanGestureRecognizer (SPI)
+@property (readonly) NSTimeInterval timestamp;
 @end
 
 #endif

--- a/Source/WebKit/Shared/NativeWebWheelEvent.h
+++ b/Source/WebKit/Shared/NativeWebWheelEvent.h
@@ -61,6 +61,7 @@ class NativeWebWheelEvent : public WebWheelEvent {
 public:
 #if USE(APPKIT)
     NativeWebWheelEvent(NSEvent *, NSView *);
+    explicit NativeWebWheelEvent(const WebWheelEvent&);
 #elif PLATFORM(GTK)
     NativeWebWheelEvent(const NativeWebWheelEvent&);
     NativeWebWheelEvent(GdkEvent*, const WebCore::IntPoint& position, const WebCore::IntPoint& globalPosition, const WebCore::FloatSize& delta, const WebCore::FloatSize& wheelTicks, WebWheelEvent::Phase, WebWheelEvent::Phase momentumPhase, bool hasPreciseDeltas = false);

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -636,6 +636,7 @@ UIProcess/mac/WebProcessProxyMac.mm @nonARC
 UIProcess/mac/WindowServerConnection.mm @nonARC
 UIProcess/mac/WKFullScreenWindowController.mm @nonARC
 UIProcess/mac/WKImmediateActionController.mm @nonARC
+UIProcess/mac/WKPanGestureController.mm @nonARC
 UIProcess/mac/WKPrintingView.mm @nonARC
 UIProcess/mac/WKQuickLookPreviewController.mm @nonARC
 UIProcess/mac/WKRevealItemPresenter.mm @nonARC

--- a/Source/WebKit/UIProcess/mac/WKPanGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKPanGestureController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,24 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "NativeWebWheelEvent.h"
+#pragma once
 
-#if USE(APPKIT)
+#if PLATFORM(MAC)
 
-#import "WebEventFactory.h"
+#import <AppKit/NSGestureRecognizer.h>
+#import <wtf/Forward.h>
 
 namespace WebKit {
-
-NativeWebWheelEvent::NativeWebWheelEvent(NSEvent *event, NSView *view)
-    : WebWheelEvent(WebEventFactory::createWebWheelEvent(event, view))
-    , m_nativeEvent(event)
-{
+class WebPageProxy;
+class WebViewImpl;
 }
 
-NativeWebWheelEvent::NativeWebWheelEvent(const WebWheelEvent& wheelEvent)
-    : WebWheelEvent(wheelEvent)
-    , m_nativeEvent(nil)
-{
-}
+OBJC_CLASS NSPanGestureRecognizer;
 
-} // namespace WebKit
+@interface WKPanGestureController : NSObject <NSGestureRecognizerDelegate>
 
-#endif // USE(APPKIT)
+- (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
+
+@end
+
+#endif

--- a/Source/WebKit/UIProcess/mac/WKPanGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKPanGestureController.mm
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKPanGestureController.h"
+
+#if PLATFORM(MAC)
+
+#import "AppKitSPI.h"
+#import "NativeWebWheelEvent.h"
+#import "WKWebView.h"
+#import "WebEventModifier.h"
+#import "WebEventType.h"
+#import "WebPageProxy.h"
+#import "WebViewImpl.h"
+#import "WebWheelEvent.h"
+#import <WebCore/FloatPoint.h>
+#import <WebCore/FloatSize.h>
+#import <WebCore/IntPoint.h>
+#import <WebCore/PlatformEventFactoryMac.h>
+#import <WebCore/Scrollbar.h>
+#import <wtf/CheckedPtr.h>
+#import <wtf/MonotonicTime.h>
+#import <wtf/RefPtr.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/UUID.h>
+#import <wtf/WeakPtr.h>
+
+static WebCore::FloatSize translationInView(NSPanGestureRecognizer *gesture, WKWebView *view)
+{
+    auto translation = WebCore::toFloatSize(WebCore::FloatPoint { [gesture translationInView:view] });
+    [gesture setTranslation:NSZeroPoint inView:view];
+    return translation;
+}
+
+static WebKit::WebWheelEvent::Phase toWheelEventPhase(NSGestureRecognizerState state)
+{
+    using enum WebKit::WebWheelEvent::Phase;
+    switch (state) {
+    case NSGestureRecognizerStatePossible:
+        return MayBegin;
+    case NSGestureRecognizerStateBegan:
+        return Began;
+    case NSGestureRecognizerStateChanged:
+        return Changed;
+    case NSGestureRecognizerStateEnded:
+        return Ended;
+    case NSGestureRecognizerStateCancelled:
+    case NSGestureRecognizerStateFailed:
+        return Cancelled;
+    default:
+        ASSERT_NOT_REACHED();
+        return None;
+    }
+}
+
+@implementation WKPanGestureController {
+    WeakPtr<WebKit::WebPageProxy> _page;
+    WeakPtr<WebKit::WebViewImpl> _viewImpl;
+    RetainPtr<NSPanGestureRecognizer> _panGestureRecognizer;
+}
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKPanGestureControllerAdditions.mm>)
+#import <WebKitAdditions/WKPanGestureControllerAdditions.mm>
+#else
+
+- (void)configureForScrolling:(NSPanGestureRecognizer *)gesture
+{
+}
+
+#endif
+
+- (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _page = page.get();
+    _viewImpl = viewImpl.get();
+
+    _panGestureRecognizer = adoptNS([[NSPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureRecognized:)]);
+    [self configureForScrolling:_panGestureRecognizer.get()];
+    [_panGestureRecognizer setDelegate:self];
+
+    CheckedPtr checkedViewImpl = _viewImpl.get();
+    [checkedViewImpl->protectedView() addGestureRecognizer:_panGestureRecognizer.get()];
+
+    return self;
+}
+
+- (void)panGestureRecognized:(NSGestureRecognizer *)gesture
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return;
+
+    RefPtr page = _page.get();
+    RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] panGestureRecognized: %@", page->identifier().toUInt64(), gesture);
+
+    RetainPtr panGesture = dynamic_objc_cast<NSPanGestureRecognizer>(gesture);
+    if (!panGesture || _panGestureRecognizer != panGesture)
+        return;
+
+    if (viewImpl->ignoresAllEvents()) {
+        RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] panGestureRecognized: ignored gesture", page->identifier().toUInt64());
+        return;
+    }
+
+    auto gestureState = [panGesture state];
+    if (gestureState == NSGestureRecognizerStateBegan)
+        viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
+
+    // FIXME: Need to supply a real event here.
+    if (viewImpl->allowsBackForwardNavigationGestures() && viewImpl->ensureProtectedGestureController()->handleScrollWheelEvent(nil)) {
+        RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] panGestureRecognized: View gesture controller handled gesture", page->identifier().toUInt64());
+        return;
+    }
+
+    auto timestamp = MonotonicTime::fromRawSeconds([panGesture timestamp]);
+    WebCore::IntPoint position { [gesture locationInView:webView.get()] };
+    auto globalPosition { WebCore::globalPoint([panGesture locationInView:nil], [webView window]) };
+    auto gestureDelta { translationInView(panGesture.get(), webView.get()) };
+    auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
+    auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
+    bool directionInvertedFromDevice = false;
+    auto phase = toWheelEventPhase(gestureState);
+    auto momentumPhase = WebKit::WebWheelEvent::Phase::None;
+    bool hasPreciseScrollingDeltas = true;
+
+    // FIXME: These are placeholder values.
+    uint32_t scrollCount = 1;
+    auto unacceleratedScrollingDelta = gestureDelta;
+    auto ioHIDEventTimestamp = timestamp;
+    std::optional<WebCore::FloatSize> rawPlatformDelta;
+    auto momentumEndType = WebKit::WebWheelEvent::MomentumEndType::Unknown;
+
+    WebKit::WebWheelEvent wheelEvent {
+        { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
+        WebCore::IntPoint { position },
+        WebCore::IntPoint { globalPosition },
+        gestureDelta,
+        wheelTicks,
+        granularity,
+        directionInvertedFromDevice,
+        phase,
+        momentumPhase,
+        hasPreciseScrollingDeltas,
+        scrollCount,
+        unacceleratedScrollingDelta,
+        ioHIDEventTimestamp,
+        rawPlatformDelta,
+        momentumEndType
+    };
+    page->handleNativeWheelEvent(WebKit::NativeWebWheelEvent { wheelEvent });
+}
+
+@end
+
+#endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -59,6 +59,7 @@ using _WKRectEdge = NSUInteger;
 
 OBJC_CLASS NSAccessibilityRemoteUIElement;
 OBJC_CLASS NSImmediateActionGestureRecognizer;
+OBJC_CLASS NSPanGestureRecognizer;
 OBJC_CLASS NSMenu;
 OBJC_CLASS NSPopover;
 OBJC_CLASS NSScrollPocket;
@@ -75,6 +76,7 @@ OBJC_CLASS WKFullScreenWindowController;
 OBJC_CLASS WKImageAnalysisOverlayViewDelegate;
 OBJC_CLASS WKImmediateActionController;
 OBJC_CLASS WKMouseTrackingObserver;
+OBJC_CLASS WKPanGestureController;
 OBJC_CLASS WKRevealItemPresenter;
 OBJC_CLASS _WKWarningView;
 OBJC_CLASS WKShareSheet;
@@ -922,6 +924,8 @@ private:
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
 
+    void configurePanGestureRecognizerIfNeeded();
+
     WeakObjCPtr<WKWebView> m_view;
     const UniqueRef<PageClient> m_pageClient;
     const Ref<WebPageProxy> m_page;
@@ -1108,6 +1112,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(INLINE_PREDICTIONS)
     bool m_inlinePredictionsEnabled { false };
 #endif
+
+    RetainPtr<WKPanGestureController> m_panGestureController;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -65,6 +65,7 @@
 #import "WKImmediateActionController.h"
 #import "WKNSURLExtras.h"
 #import "WKPDFHUDView.h"
+#import "WKPanGestureController.h"
 #import "WKPrintingView.h"
 #import "WKQuickLookPreviewController.h"
 #import "WKRevealItemPresenter.h"
@@ -1385,6 +1386,8 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
 #if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
     m_textInputNotifications = subscribeToTextInputNotifications(this);
 #endif
+
+    configurePanGestureRecognizerIfNeeded();
 
     WebProcessPool::statistics().wkViewCount++;
 }
@@ -7310,6 +7313,16 @@ void WebViewImpl::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& cal
     callback([menu popUpMenuPositioningItem:nil atLocation:NSMakePoint(0, 0) inView:[protectedWindow() contentView]]);
 }
 #endif
+
+void WebViewImpl::configurePanGestureRecognizerIfNeeded()
+{
+    Ref page = m_page.get();
+    if (!page->protectedPreferences()->useAppKitGestures())
+        return;
+
+    RetainPtr view = m_view.get();
+    m_panGestureController = adoptNS([[WKPanGestureController alloc] initWithPage:page viewImpl:*this]);
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -928,6 +928,7 @@
 		3326F2672B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = 3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3336763B130C99DC006C9DE2 /* WKResourceCacheManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		335698F62B19307700C7FEE4 /* WebExtensionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 335698F52B19307700C7FEE4 /* WebExtensionConstants.h */; };
+		336E07482EBCC1E400B4D635 /* WKPanGestureController.h in Headers */ = {isa = PBXBuildFile; fileRef = 336E07462EBCC1C100B4D635 /* WKPanGestureController.h */; };
 		337042042B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 337042032B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h */; };
 		337042092B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 337042072B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */; };
@@ -5213,6 +5214,8 @@
 		33367638130C99DC006C9DE2 /* WKResourceCacheManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKResourceCacheManager.cpp; sourceTree = "<group>"; };
 		33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKResourceCacheManager.h; sourceTree = "<group>"; };
 		335698F52B19307700C7FEE4 /* WebExtensionConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionConstants.h; sourceTree = "<group>"; };
+		336E07462EBCC1C100B4D635 /* WKPanGestureController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPanGestureController.h; sourceTree = "<group>"; };
+		336E07472EBCC1C100B4D635 /* WKPanGestureController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPanGestureController.mm; sourceTree = "<group>"; };
 		337041FF2B5895C00077FF78 /* WebExtensionAPIWebRequestEvent.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebRequestEvent.idl; sourceTree = "<group>"; };
 		337042002B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebRequestEvent.mm; sourceTree = "<group>"; };
 		337042012B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebRequestEvent.h; sourceTree = "<group>"; };
@@ -16193,6 +16196,8 @@
 				CDCA85C6132ABA4E00E961DF /* WKFullScreenWindowController.mm */,
 				9321D5851A38EE3C008052BE /* WKImmediateActionController.h */,
 				9321D5871A38EE74008052BE /* WKImmediateActionController.mm */,
+				336E07462EBCC1C100B4D635 /* WKPanGestureController.h */,
+				336E07472EBCC1C100B4D635 /* WKPanGestureController.mm */,
 				0FCB4E5C18BBE3D9000FCFC9 /* WKPrintingView.h */,
 				0FCB4E5D18BBE3D9000FCFC9 /* WKPrintingView.mm */,
 				F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */,
@@ -17647,8 +17652,8 @@
 				F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */,
 				F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */,
 				518198902B7585EB0084E292 /* CoreIPCDateComponents.h in Headers */,
-				F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */,
 				F4E2A3842EB5417300D7A783 /* CoreIPCDDScannerResult.h in Headers */,
+				F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */,
 				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
 				F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */,
 				F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */,
@@ -18910,6 +18915,7 @@
 				2794980522E80B7D0082E68C /* WKPageStateClient.h in Headers */,
 				1AB8A1F218400B6200E9AE69 /* WKPageUIClient.h in Headers */,
 				A5EFD38C16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h in Headers */,
+				336E07482EBCC1E400B4D635 /* WKPanGestureController.h in Headers */,
 				A15EEDE61E301CEE000069B0 /* WKPasswordView.h in Headers */,
 				A1798B49222E531D000764BD /* WKPaymentAuthorizationDelegate.h in Headers */,
 				51D7E0AD2356555E00A67D3A /* WKPDFConfiguration.h in Headers */,
@@ -21232,8 +21238,8 @@
 				5157AE032B23C34700C0E095 /* CoreIPCContacts.mm in Sources */,
 				52B060F92B745E4D009B1666 /* CoreIPCCVPixelBufferRef.mm in Sources */,
 				518198912B7585F80084E292 /* CoreIPCDateComponents.mm in Sources */,
-				F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */,
 				F4E2A3832EB5416C00D7A783 /* CoreIPCDDScannerResult.mm in Sources */,
+				F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */,
 				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,
 				F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */,
 				F4A30A6D2B08255B004E1F24 /* CoreIPCLocale.mm in Sources */,


### PR DESCRIPTION
#### 78ad297be7f772ab584bb4a1110e2cea163c57af
<pre>
[AppKit Gestures] Refactor wheel input handling to support NSPanGestureRecognizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=302494">https://bugs.webkit.org/show_bug.cgi?id=302494</a>
<a href="https://rdar.apple.com/163242714">rdar://163242714</a>

Reviewed by Lily Spiniolas and Wenson Hsieh.

This patch adds infrastructure to support scrolling web views using
NSPanGestureRecognizer, modernizing our gesture handling to adopt
AppKit&apos;s gesture recognizer APIs in place of lower-level event handling.

The implementation introduces WKPanGestureController, which translates
NSPanGestureRecognizer events into WebWheelEvents that can drive the
existing scrolling machinery. This behavior change is gated behind a new
UseAppKitGestures internal preference.

Test coverage will be added in a follow up patch.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/Scrollbar.h:
(WebCore::Scrollbar::pixelsPerLineStep): Drive-by: make this constexpr.
* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/Shared/NativeWebWheelEvent.h:
* Source/WebKit/Shared/mac/NativeWebWheelEventMac.mm:
(WebKit::NativeWebWheelEvent::NativeWebWheelEvent):
  Added constructor to create NativeWebWheelEvent from WebWheelEvent,
  enabling gesture-synthesized wheel events without a backing NSEvent.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/mac/WKPanGestureController.h: Added.
* Source/WebKit/UIProcess/mac/WKPanGestureController.mm: Added.
(translationInView):
(toWheelEventPhase):
(-[WKPanGestureController configureForScrolling:]):
(-[WKPanGestureController initWithPage:viewImpl:]):
(-[WKPanGestureController panGestureRecognized:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::configurePanGestureRecognizerIfNeeded):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/303084@main">https://commits.webkit.org/303084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71dda3dc9e66285cd5adb137a2d6219bea805fc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82886 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/747fea51-60b1-4a12-b66e-1fb31ab50bf0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99943 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67702 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6af1eccf-657d-4c1f-b779-4625eaa5255a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80642 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69d5f682-0f4f-4c14-91d3-faaa91434399) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/117 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81871 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123202 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141120 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129634 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3255 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108464 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108406 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2440 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56314 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20415 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32184 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162651 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66724 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40612 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3339 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3247 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->