### PR TITLE
[blocks-in-inline] Multicolumn does not work

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-expected.html
@@ -1,0 +1,10 @@
+<div style="columns:2; column-gap:0; column-fill:auto; width:100px; height:100px; orphans:1; widows:1; background:red;">
+  <span>
+    <!-- First column: -->
+    <div style="height:50px; background:green;">
+      <br>
+      <!-- Second column: -->
+      <div style=" height:100px; background:green;"></div>
+    </div>
+  </span>
+</div>

--- a/LayoutTests/fast/inline/blocks-in-inline-multicol.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<div style="columns:2; column-gap:0; column-fill:auto; width:100px; height:100px; orphans:1; widows:1; background:red;">
+  <span>
+    <!-- First column: -->
+    <div style="height:50px; background:green;">
+      <br>
+      <!-- Second column: -->
+      <div style=" height:100px; background:green;"></div>
+    </div>
+  </span>
+</div>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -187,7 +187,10 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
                 continue;
             }
 
-            if (box.isAtomicInlineBox()) {
+            if (box.isAtomicInlineBox() || box.isBlockLevelBox()) {
+                if (box.isBlockLevelBox())
+                    inlineContent.setHasBlockLevelBoxes();
+
                 auto& renderer = downcast<RenderBox>(*box.layoutBox().rendererForIntegration());
                 if (!renderer.hasSelfPaintingLayer()) {
                     auto childInkOverflow = renderer.logicalVisualOverflowRectForPropagation(renderer.parent()->writingMode());
@@ -206,10 +209,6 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
             if (box.isInlineBox()) {
                 if (!downcast<RenderElement>(*box.layoutBox().rendererForIntegration()).hasSelfPaintingLayer())
                     lineInkOverflowRect.unite(box.inkOverflow());
-                continue;
-            }
-            if (box.isBlockLevelBox()) {
-                inlineContent.setHasBlockLevelBoxes();
                 continue;
             }
         }


### PR DESCRIPTION
#### 623e769def504cfdc205006f3e0f9b4376bf7583
<pre>
[blocks-in-inline] Multicolumn does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=302525">https://bugs.webkit.org/show_bug.cgi?id=302525</a>
<a href="https://rdar.apple.com/164712340">rdar://164712340</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-multicol.html
* LayoutTests/fast/inline/blocks-in-inline-multicol-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-multicol.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::adjustDisplayLines const):

We failed to collect overflow from blocks-in-inline.
Turns out this broke multicol.

Canonical link: <a href="https://commits.webkit.org/303036@main">https://commits.webkit.org/303036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/794e6d6a07383c5b03f65b1a3219d4b0713a543d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138451 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00d422f0-0e23-497e-ba74-2f663f20b82b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3175 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/402400a6-7f1e-4df1-941f-fb905ca0e5e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80515 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/35fa770c-a30d-4d7d-8d5b-70997240e307) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2292 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81698 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140944 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2753 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27543 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2330 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32047 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56114 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66539 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2965 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->