### PR TITLE
Use xpc_retain() / xpc_release() for XPC objects

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -337,7 +337,8 @@ void RemoteInspector::setupXPCConnectionIfNeeded()
         return;
     }
 
-    auto connection = adoptOSObject(xpc_connection_create_mach_service(WIRXPCMachPortName, m_xpcQueue.get(), 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptXPCObject(xpc_connection_create_mach_service(WIRXPCMachPortName, m_xpcQueue.get(), 0));
     if (!connection) {
         WTFLogAlways("RemoteInspector failed to create XPC connection.");
         return;

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
@@ -31,6 +31,7 @@
 #import <wtf/Lock.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/darwin/XPCObjectPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 OBJC_CLASS NSDictionary;
@@ -64,7 +65,7 @@ private:
     // We make sure that m_client is thread safe and immediately cleared in close().
     Lock m_mutex;
 
-    OSObjectPtr<xpc_connection_t> m_connection;
+    XPCObjectPtr<xpc_connection_t> m_connection;
     OSObjectPtr<dispatch_queue_t> m_queue;
     Client* m_client;
     bool m_closed { false };

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
@@ -186,7 +186,8 @@ void RemoteInspectorXPCConnection::sendMessage(NSString *messageName, NSDictiona
     if (!xpcDictionary)
         return;
 
-    auto msg = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto msg = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_value(msg.get(), RemoteInspectorXPCConnectionSerializedMessageKey, xpcDictionary.get());
     xpc_connection_send_message(m_connection.get(), msg.get());
 }

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		46A6D0DA2D8A168400FC76C8 /* MappedFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 46A6D0D72D8A168400FC76C8 /* MappedFileData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46B0FB5D2D24BFBA0012184C /* ParsingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46B4C53C2D4F2D0A00BAA3FE /* NSStringExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46BD41CA2EC723B2002ED70B /* XPCObjectPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 46BD41C92EC723B2002ED70B /* XPCObjectPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
 		46BEB6EB22FFE24900269868 /* RefTrackerMixin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */; };
 		46CA183A2D83C17A00B68573 /* FileHandlePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46CA18392D83C17A00B68573 /* FileHandlePOSIX.cpp */; };
@@ -1318,6 +1319,7 @@
 		46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParsingUtilities.h; sourceTree = "<group>"; };
 		46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSStringExtras.h; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
+		46BD41C92EC723B2002ED70B /* XPCObjectPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPCObjectPtr.h; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269867 /* RefCounted.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefCounted.cpp; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefTrackerMixin.cpp; sourceTree = "<group>"; };
 		46BEB6E922FFDDD50026DEAD /* RefTrackerMixin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RefTrackerMixin.h; sourceTree = "<group>"; };
@@ -2164,6 +2166,7 @@
 				53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */,
 				37C7CC291EA40A73007BD956 /* WeakLinking.h */,
 				44235FF62D76448F00F4A6CB /* XPCExtras.h */,
+				46BD41C92EC723B2002ED70B /* XPCObjectPtr.h */,
 			);
 			path = darwin;
 			sourceTree = "<group>";
@@ -3954,6 +3957,7 @@
 				FFE39CB02B1D7472004972B0 /* wuint.h in Headers */,
 				FF41AC672A79C9BA00AC0FA5 /* WYHash.h in Headers */,
 				44235FF72D76449300F4A6CB /* XPCExtras.h in Headers */,
+				46BD41CA2EC723B2002ED70B /* XPCObjectPtr.h in Headers */,
 				DDF306EA27C08654006A526F /* XPCSPI.h in Headers */,
 				E32B4F3D2E0C698F00BDA4FD /* XTSPI.h in Headers */,
 				145DE2882CE95CE700F9F1D2 /* ZippedRange.h in Headers */,

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -75,6 +75,7 @@ class WallTime;
 class WorkQueue;
 
 struct AnyThreadsAccessTraits;
+struct ARCEnabled;
 struct FastMalloc;
 struct MachSendRightAnnotated;
 struct MainThreadAccessTraits;
@@ -111,6 +112,7 @@ enum class ConcurrencyTag : uint8_t {
     Atomic
 };
 
+template<typename, typename> struct DefaultOSObjectRetainTraits;
 template<typename> struct DefaultRefDerefTraits;
 
 template<typename> class Awaitable;
@@ -129,7 +131,7 @@ template<typename, typename> class LazyUniqueRef;
 template<typename> struct MarkableTraits;
 template<typename T, typename Traits = MarkableTraits<T>> class Markable;
 template<typename, typename = AnyThreadsAccessTraits> class NeverDestroyed;
-template<typename> class OSObjectPtr;
+template<typename T, typename = DefaultOSObjectRetainTraits<T, ARCEnabled>> class OSObjectPtr;
 template<typename, typename, typename> class ObjectIdentifierGeneric;
 template<typename T, typename RawValue = uint64_t> using ObjectIdentifier = ObjectIdentifierGeneric<T, ObjectIdentifierMainThreadAccessTraits<RawValue>, RawValue>;
 template<typename T, typename RawValue = uint64_t> using AtomicObjectIdentifier = ObjectIdentifierGeneric<T, ObjectIdentifierThreadSafeAccessTraits<RawValue>, RawValue>;

--- a/Source/WTF/wtf/OSObjectPtr.h
+++ b/Source/WTF/wtf/OSObjectPtr.h
@@ -26,42 +26,46 @@
 #pragma once
 
 #include <os/object.h>
+#include <wtf/Forward.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/HashTraits.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TypeTraits.h>
 
 // Because ARC enablement is a compile-time choice, and we compile this header
 // both ways, we need a separate copy of our code when ARC is enabled.
 #if __has_feature(objc_arc)
 #define adoptOSObject adoptOSObjectArc
-#define retainOSObject retainOSObjectArc
-#define releaseOSObject releaseOSObjectArc
-#define OSObjectPtr OSObjectPtrArc
 #endif
 
 namespace WTF {
 
-template<typename> class OSObjectPtr;
-template<typename T> OSObjectPtr<T> adoptOSObject(T) WARN_UNUSED_RETURN;
-
-template<typename T> static inline void retainOSObject(T ptr)
-{
+template<typename T, typename arcEnabled = ARCEnabled> struct DefaultOSObjectRetainTraits {
+    static ALWAYS_INLINE void retain(T ptr)
+    {
 #if __has_feature(objc_arc)
-    UNUSED_PARAM(ptr);
+        UNUSED_PARAM(ptr);
 #else
-    os_retain(ptr);
+        os_retain(ptr);
 #endif
-}
-
-template<typename T> static inline void releaseOSObject(T ptr)
-{
+    }
+    static ALWAYS_INLINE void release(T ptr)
+    {
 #if __has_feature(objc_arc)
-    UNUSED_PARAM(ptr);
+        UNUSED_PARAM(ptr);
 #else
-    os_release(ptr);
+        os_release(ptr);
 #endif
-}
+    }
+};
 
-template<typename T> class OSObjectPtr {
+template<typename T, typename RetainTraits = DefaultOSObjectRetainTraits<T, ARCEnabled>> OSObjectPtr<T, RetainTraits> adoptOSObject(T) WARN_UNUSED_RETURN;
+
+template<typename T, typename RetainTraits> class OSObjectPtr {
 public:
+    using ValueType = std::remove_pointer_t<T>;
+    using PtrType = ValueType*;
+
     OSObjectPtr()
         : m_ptr(nullptr)
     {
@@ -70,8 +74,12 @@ public:
     ~OSObjectPtr()
     {
         if (m_ptr)
-            releaseOSObject(m_ptr);
+            RetainTraits::release(m_ptr);
     }
+
+    // Hash table deleted values, which are only constructed and never copied or destroyed.
+    constexpr OSObjectPtr(HashTableDeletedValueType) : m_ptr(hashTableDeletedValue()) { }
+    constexpr bool isHashTableDeletedValue() const { return m_ptr == hashTableDeletedValue(); }
 
     T get() const LIFETIME_BOUND { return m_ptr; }
 
@@ -82,7 +90,7 @@ public:
         : m_ptr(other.m_ptr)
     {
         if (m_ptr)
-            retainOSObject(m_ptr);
+            RetainTraits::retain(m_ptr);
     }
 
     OSObjectPtr(OSObjectPtr&& other)
@@ -95,7 +103,7 @@ public:
         : m_ptr(WTFMove(ptr))
     {
         if (m_ptr)
-            retainOSObject(m_ptr);
+            RetainTraits::retain(m_ptr);
     }
 
     OSObjectPtr& operator=(const OSObjectPtr& other)
@@ -115,7 +123,7 @@ public:
     OSObjectPtr& operator=(std::nullptr_t)
     {
         if (m_ptr)
-            releaseOSObject(m_ptr);
+            RetainTraits::release(m_ptr);
         m_ptr = nullptr;
         return *this;
     }
@@ -137,7 +145,7 @@ public:
         return std::exchange(m_ptr, nullptr);
     }
 
-    friend OSObjectPtr adoptOSObject<T>(T) WARN_UNUSED_RETURN;
+    friend OSObjectPtr adoptOSObject<T, RetainTraits>(T) WARN_UNUSED_RETURN;
 
 private:
     struct AdoptOSObject { };
@@ -146,20 +154,35 @@ private:
     {
     }
 
+    static constexpr T hashTableDeletedValue() { return reinterpret_cast<T>(-1); }
+
     T m_ptr;
 };
 
-template<typename T> inline OSObjectPtr<T> adoptOSObject(T ptr)
+template<typename T, typename U, typename V> constexpr bool operator==(const OSObjectPtr<T, V>& a, const OSObjectPtr<U, V>& b)
 {
-    return OSObjectPtr<T> { typename OSObjectPtr<T>::AdoptOSObject { }, WTFMove(ptr) };
+    return a.get() == b.get();
 }
 
-template<typename T, typename U>
-ALWAYS_INLINE void lazyInitialize(const OSObjectPtr<T>& ptr, OSObjectPtr<U>&& obj)
+template<typename T, typename RetainTraits> inline OSObjectPtr<T, RetainTraits> adoptOSObject(T ptr)
+{
+    return OSObjectPtr<T, RetainTraits> { typename OSObjectPtr<T, RetainTraits>::AdoptOSObject { }, WTFMove(ptr) };
+}
+
+template<typename T, typename U, typename RetainTraits>
+ALWAYS_INLINE void lazyInitialize(const OSObjectPtr<T, RetainTraits>& ptr, OSObjectPtr<U, RetainTraits>&& obj)
 {
     RELEASE_ASSERT(!ptr);
-    const_cast<OSObjectPtr<T>&>(ptr) = std::move(obj);
+    const_cast<OSObjectPtr<T, RetainTraits>&>(ptr) = std::move(obj); // NOLINT
 }
+
+template<typename T, typename RetainTraits> struct IsSmartPtr<OSObjectPtr<T, RetainTraits>> {
+    static constexpr bool value = true;
+    static constexpr bool isNullable = true;
+};
+
+template<typename T, typename RetainTraits> struct HashTraits<OSObjectPtr<T, RetainTraits>> : SimpleClassHashTraits<OSObjectPtr<T, RetainTraits>> { };
+template<typename T, typename RetainTraits> struct DefaultHash<OSObjectPtr<T, RetainTraits>> : PtrHash<OSObjectPtr<T, RetainTraits>> { };
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -224,4 +224,14 @@ constexpr std::size_t parameterCount(ReturnType(*)(Args...))
     return ParameterCountImpl<Args...>::value;
 }
 
+#if defined(__has_feature)
+#if __has_feature(objc_arc)
+struct ARCEnabled : std::true_type { };
+#else
+struct ARCEnabled : std::false_type { };
+#endif
+#else
+struct ARCEnabled : std::false_type { };
+#endif
+
 } // namespace NTF

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -29,6 +29,7 @@
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/darwin/XPCObjectPtr.h>
 #import <wtf/text/WTFString.h>
 
 namespace WTF {
@@ -51,15 +52,15 @@ bool hasEntitlement(audit_token_t token, ASCIILiteral entitlement)
 
 bool hasEntitlement(xpc_connection_t connection, StringView entitlement)
 {
-    // FIXME: This is a false positive. <rdar://160953958>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptXPCObject(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 
 bool hasEntitlement(xpc_connection_t connection, ASCIILiteral entitlement)
 {
-    // FIXME: This is a false positive. <rdar://160953958>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptXPCObject(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 

--- a/Source/WebCore/platform/VideoReceiverEndpoint.h
+++ b/Source/WebCore/platform/VideoReceiverEndpoint.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-#include <wtf/OSObjectPtr.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 #include <xpc/xpc.h>
 #endif
 
@@ -37,7 +37,7 @@ struct VideoReceiverEndpointIdentifierType;
 using VideoReceiverEndpointIdentifier = ObjectIdentifier<VideoReceiverEndpointIdentifierType>;
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-using VideoReceiverEndpoint = OSObjectPtr<xpc_object_t>;
+using VideoReceiverEndpoint = XPCObjectPtr<xpc_object_t>;
 #else
 using VideoReceiverEndpoint = void*;
 #endif

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -36,7 +36,7 @@ namespace WebKit {
 
 class GPUServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    GPUServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    GPUServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
+++ b/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
@@ -36,7 +36,7 @@ namespace WebKit {
 
 class ModelServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    ModelServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    ModelServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
@@ -34,7 +34,7 @@ namespace WebKit {
 
 class NetworkServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    NetworkServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    NetworkServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -44,10 +44,11 @@ void Connection::newConnectionWasInitialized() const
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(m_configuration));
 }
 
-static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
+static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
     auto xpcData = encoderToXPCData(WTFMove(encoder));
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebPushD::protocolVersionKey, WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -75,7 +75,7 @@ private:
 
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)
-    OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final { return nullptr; }
+    XPCObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final { return nullptr; }
     void connectionReceivedEvent(xpc_object_t) final { }
 #endif
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
@@ -52,7 +52,7 @@ private:
 
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)
-    OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final;
+    XPCObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final;
     void connectionReceivedEvent(xpc_object_t) final;
 #endif
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -60,9 +60,10 @@ void Connection::connectionReceivedEvent(xpc_object_t request)
     m_networkSession->networkProcess().broadcastConsoleMessage(m_networkSession->sessionID(), MessageSource::PrivateClickMeasurement, messageLevel, debugMessage);
 }
 
-OSObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const
+XPCObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const
 {
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     addVersionAndEncodedMessageToDictionary(WTFMove(message), dictionary.get());
     xpc_dictionary_set_uint64(dictionary.get(), protocolMessageTypeKey, static_cast<uint64_t>(messageType));
     return dictionary;

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -44,7 +44,7 @@ public:
     static ASCIILiteral supplementName();
 
 private:
-    void startObserving(OSObjectPtr<xpc_connection_t>);
+    void startObserving(XPCObjectPtr<xpc_connection_t>);
 
     // XPCEndpoint
     ASCIILiteral xpcEndpointMessageNameKey() const override;
@@ -57,7 +57,7 @@ private:
 
     RetainPtr<id> m_observer;
     Lock m_connectionsLock;
-    Vector<OSObjectPtr<xpc_connection_t>> m_connections WTF_GUARDED_BY_LOCK(m_connectionsLock);
+    Vector<XPCObjectPtr<xpc_connection_t>> m_connections WTF_GUARDED_BY_LOCK(m_connectionsLock);
 };
 
 }

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -42,7 +42,8 @@ LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
 {
 #if HAVE(LSDATABASECONTEXT) && !HAVE(SYSTEM_CONTENT_LS_DATABASE)
     m_observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -60,7 +61,7 @@ ASCIILiteral LaunchServicesDatabaseObserver::supplementName()
     return "LaunchServicesDatabaseObserverSupplement"_s;
 }
 
-void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t> connection)
+void LaunchServicesDatabaseObserver::startObserving(XPCObjectPtr<xpc_connection_t> connection)
 {
     {
         Locker locker { m_connectionsLock };
@@ -71,7 +72,8 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
     [LSDatabaseContext.sharedDatabaseContext getSystemContentDatabaseObject4WebKit:makeBlockPtr([connection = connection] (xpc_object_t _Nullable object, NSError * _Nullable error) {
         if (!object)
             return;
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, object);
 
@@ -80,7 +82,8 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
     }).get()];
 #elif HAVE(LSDATABASECONTEXT)
     RetainPtr<id> observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -89,7 +92,8 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
 
     [LSDatabaseContext.sharedDatabaseContext removeDatabaseChangeObserver4WebKit:observer.get()];
 #else
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
     xpc_connection_send_message(connection.get(), message.get());
 #endif

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -75,6 +75,7 @@
 #if OS(DARWIN)
 #include <mach/mach_port.h>
 #include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 #if HAVE(XPC_API)
 #include <xpc/xpc.h>
@@ -328,20 +329,20 @@ public:
             : port(port)
         {
         }
-        Identifier(mach_port_t port, OSObjectPtr<xpc_connection_t> xpcConnection)
+        Identifier(mach_port_t port, XPCObjectPtr<xpc_connection_t> xpcConnection)
             : port(port)
             , xpcConnection(WTFMove(xpcConnection))
         {
         }
         operator bool() const { return MACH_PORT_VALID(port); }
         mach_port_t port { MACH_PORT_NULL };
-        OSObjectPtr<xpc_connection_t> xpcConnection;
+        XPCObjectPtr<xpc_connection_t> xpcConnection;
 #endif
     };
 
 #if OS(DARWIN)
     xpc_connection_t xpcConnection() const { return m_xpcConnection.get(); }
-    OSObjectPtr<xpc_connection_t> protectedXPCConnection() const { return xpcConnection(); }
+    XPCObjectPtr<xpc_connection_t> protectedXPCConnection() const { return xpcConnection(); }
     std::optional<audit_token_t> getAuditToken();
     pid_t remoteProcessID() const;
 #endif
@@ -813,7 +814,7 @@ private:
 
     std::unique_ptr<MachMessage> m_pendingOutgoingMachMessage;
 
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    XPCObjectPtr<xpc_connection_t> m_xpcConnection;
     std::atomic<bool> m_didRequestProcessTermination { false };
     std::optional<audit_token_t> m_auditToken;
 #elif OS(WINDOWS)

--- a/Source/WebKit/Platform/IPC/DaemonConnection.h
+++ b/Source/WebKit/Platform/IPC/DaemonConnection.h
@@ -45,7 +45,7 @@ using EncodedMessage = Vector<uint8_t>;
 class Connection : public RefCountedAndCanMakeWeakPtr<Connection> {
 public:
 #if PLATFORM(COCOA)
-    static Ref<Connection> create(OSObjectPtr<xpc_connection_t>&& connection)
+    static Ref<Connection> create(XPCObjectPtr<xpc_connection_t>&& connection)
     {
         return adoptRef(*new Connection(WTFMove(connection)));
     }
@@ -63,14 +63,14 @@ protected:
     Connection() = default;
 
 #if PLATFORM(COCOA)
-    explicit Connection(OSObjectPtr<xpc_connection_t>&& connection)
+    explicit Connection(XPCObjectPtr<xpc_connection_t>&& connection)
         : m_connection(WTFMove(connection)) { }
 #endif
 
     virtual void initializeConnectionIfNeeded() const { }
 
 #if PLATFORM(COCOA)
-    mutable OSObjectPtr<xpc_connection_t> m_connection;
+    mutable XPCObjectPtr<xpc_connection_t> m_connection;
 #endif
 };
 
@@ -85,7 +85,7 @@ public:
     virtual void newConnectionWasInitialized() const = 0;
 
 #if PLATFORM(COCOA)
-    virtual OSObjectPtr<xpc_object_t> dictionaryFromMessage(typename Traits::MessageType, EncodedMessage&&) const = 0;
+    virtual XPCObjectPtr<xpc_object_t> dictionaryFromMessage(typename Traits::MessageType, EncodedMessage&&) const = 0;
     virtual void connectionReceivedEvent(xpc_object_t) = 0;
 #endif
 

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -65,7 +65,8 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
 {
     if (m_connection)
         return;
-    m_connection = adoptOSObject(xpc_connection_create_mach_service(m_machServiceName.data(), mainDispatchQueueSingleton(), 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create_mach_service(m_machServiceName.data(), mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(m_connection.get(), [weakThis = WeakPtr { *this }](xpc_object_t event) {
         if (!weakThis)
             return;

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -109,7 +109,7 @@ public:
     static RetainPtr<BELayerHierarchyHostingTransactionCoordinator> createHostingUpdateCoordinator(WTF::MachSendRightAnnotated&&);
     static WTF::MachSendRightAnnotated fence(BELayerHierarchyHostingTransactionCoordinator *);
 #else
-    OSObjectPtr<xpc_object_t> xpcRepresentation() const;
+    XPCObjectPtr<xpc_object_t> xpcRepresentation() const;
     static RetainPtr<BELayerHierarchyHandle> createHostingHandle(uint64_t pid, uint64_t contextID);
     static RetainPtr<BELayerHierarchyHostingTransactionCoordinator> createHostingUpdateCoordinator(mach_port_t sendRight);
 #endif // ENABLE(MACH_PORT_LAYER_HOSTING)

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -223,7 +223,7 @@ RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(WTF::
     return handle;
 }
 #else
-OSObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
+XPCObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
 {
     if (!m_hostable)
         return nullptr;
@@ -232,7 +232,8 @@ OSObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
 
 RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::createHostingUpdateCoordinator(mach_port_t sendRight)
 {
-    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpcRepresentation = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_mach_send(xpcRepresentation.get(), machPortKey, sendRight);
     NSError* error = nil;
     auto coordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithXPCRepresentation:xpcRepresentation.get() error:&error];
@@ -243,7 +244,8 @@ RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::cr
 
 RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(uint64_t pid, uint64_t contextID)
 {
-    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpcRepresentation = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(xpcRepresentation.get(), processIDKey, pid);
     xpc_dictionary_set_uint64(xpcRepresentation.get(), contextIDKey, contextID);
     NSError* error = nil;

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -28,8 +28,8 @@
 
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
 #include "Logging.h"
-#include <wtf/OSObjectPtr.h>
 #include <wtf/WTFProcess.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/text/ASCIILiteral.h>
 #endif
 
@@ -50,7 +50,8 @@ void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
 
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
     // Give the process a chance to exit cleanly by sending a XPC message to request termination, then try xpc_connection_kill.
-    auto exitMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto exitMessage = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(exitMessage.get(), messageNameKey, exitProcessMessage.characters());
     xpc_connection_send_message(connection, exitMessage.get());
 #endif

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
@@ -43,7 +43,7 @@ public:
 
     static ASCIILiteral messageName() { return "video-receiver-endpoint"_s; }
     static VideoReceiverEndpointMessage decode(xpc_object_t);
-    OSObjectPtr<xpc_object_t> encode() const;
+    XPCObjectPtr<xpc_object_t> encode() const;
 
     std::optional<WebCore::ProcessIdentifier> processIdentifier() const { return m_processIdentifier; }
     WebCore::HTMLMediaElementIdentifier mediaElementIdentifier() const { return m_mediaElementIdentifier; }
@@ -65,7 +65,7 @@ public:
 
     static ASCIILiteral messageName() { return "video-receiver-swap-endpoint"_s; }
     static VideoReceiverSwapEndpointsMessage decode(xpc_object_t);
-    OSObjectPtr<xpc_object_t> encode() const;
+    XPCObjectPtr<xpc_object_t> encode() const;
 
     std::optional<WebCore::ProcessIdentifier> processIdentifier() const { return m_processIdentifier; }
     WebCore::HTMLMediaElementIdentifier sourceMediaElementIdentifier() const { return m_sourceMediaElementIdentifier; }

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
@@ -71,9 +71,10 @@ VideoReceiverEndpointMessage VideoReceiverEndpointMessage::decode(xpc_object_t m
     };
 }
 
-OSObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
+XPCObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
 {
-    OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
     xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier ? m_processIdentifier->toUInt64() : 0);
     xpc_dictionary_set_uint64(message.get(), mediaElementIdentifierKey.characters(), m_mediaElementIdentifier.toUInt64());
@@ -109,9 +110,10 @@ VideoReceiverSwapEndpointsMessage VideoReceiverSwapEndpointsMessage::decode(xpc_
     };
 }
 
-OSObjectPtr<xpc_object_t> VideoReceiverSwapEndpointsMessage::encode() const
+XPCObjectPtr<xpc_object_t> VideoReceiverSwapEndpointsMessage::encode() const
 {
-    OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
     xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier ? m_processIdentifier->toUInt64() : 0);
     xpc_dictionary_set_uint64(message.get(), sourceMediaElementIdentifierKey.characters(), m_sourceMediaElementIdentifier.toUInt64());

--- a/Source/WebKit/Shared/Cocoa/LaunchLogHook.h
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogHook.h
@@ -29,7 +29,7 @@
 
 #import <wtf/Lock.h>
 #import <wtf/NeverDestroyed.h>
-#import <wtf/OSObjectPtr.h>
+#import <wtf/darwin/XPCObjectPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 namespace WebKit {
@@ -46,7 +46,7 @@ private:
     LaunchLogHook() = default;
 
     UnfairLock m_lock;
-    OSObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_lock);
+    XPCObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
@@ -72,7 +72,8 @@ void LaunchLogHook::initialize(xpc_connection_t connection)
             type = OS_LOG_TYPE_ERROR;
 
         if (auto messageString = adoptSystemMalloc(os_log_copy_message_string(msg))) {
-            auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            // FIXME: This is a false positive. <rdar://164843889>
+            SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, logMessageName);
             if (auto* subsystem = msg->subsystem)
                 xpc_dictionary_set_string(message.get(), subsystemKey, subsystem);
@@ -92,13 +93,14 @@ void LaunchLogHook::disable()
 {
     RELEASE_LOG(Process, "Disabling launch log hook");
 
-    OSObjectPtr<xpc_connection_t> connection;
+    XPCObjectPtr<xpc_connection_t> connection;
     {
         Locker locker { m_lock };
         connection = m_connection;
         m_connection = nullptr;
     }
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, disableLogMessageName);
     xpc_connection_send_message(connection.get(), message.get());
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -41,8 +41,9 @@ namespace WebKit {
 
 XPCEndpoint::XPCEndpoint()
 {
-    m_connection = adoptOSObject(xpc_connection_create(nullptr, nullptr));
-    m_endpoint = adoptOSObject(xpc_endpoint_create(m_connection.get()));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create(nullptr, nullptr));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_endpoint = adoptXPCObject(xpc_endpoint_create(m_connection.get()));
 
     xpc_connection_set_target_queue(m_connection.get(), mainDispatchQueueSingleton());
     xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
@@ -51,7 +52,7 @@ XPCEndpoint::XPCEndpoint()
         handleXPCExitMessage(message);
 #endif
         if (type == XPC_TYPE_CONNECTION) {
-            OSObjectPtr<xpc_connection_t> connection = message;
+            XPCObjectPtr<xpc_connection_t> connection = message;
 #if USE(APPLE_INTERNAL_SDK)
             auto pid = xpc_connection_get_pid(connection.get());
 
@@ -84,14 +85,15 @@ void XPCEndpoint::sendEndpointToConnection(xpc_connection_t connection)
     if (!connection)
         return;
 
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), xpcEndpointMessageNameKey(), xpcEndpointMessageName());
     xpc_dictionary_set_value(message.get(), xpcEndpointNameKey(), m_endpoint.get());
 
     xpc_connection_send_message(connection, message.get());
 }
 
-OSObjectPtr<xpc_endpoint_t> XPCEndpoint::endpoint() const
+XPCObjectPtr<xpc_endpoint_t> XPCEndpoint::endpoint() const
 {
     return m_endpoint;
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpointClient.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpointClient.h
@@ -29,7 +29,7 @@
 
 #include <WebKit/WKBase.h>
 #include <wtf/Lock.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 namespace WebKit {
@@ -41,14 +41,14 @@ public:
     WK_EXPORT void setEndpoint(xpc_endpoint_t);
 
 protected:
-    WK_EXPORT OSObjectPtr<xpc_connection_t> connection();
+    WK_EXPORT XPCObjectPtr<xpc_connection_t> connection();
 
 private:
     virtual void handleEvent(xpc_object_t) = 0;
     virtual void didConnect() = 0;
 
     Lock m_connectionLock;
-    OSObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
+    XPCObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
@@ -42,7 +42,8 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
         if (m_connection)
             return;
 
-        m_connection = adoptOSObject(xpc_connection_create_from_endpoint(endpoint));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create_from_endpoint(endpoint));
 
         xpc_connection_set_target_queue(m_connection.get(), globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
         xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
@@ -76,7 +77,7 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
     didConnect();
 }
 
-OSObjectPtr<xpc_connection_t> XPCEndpointClient::connection()
+XPCObjectPtr<xpc_connection_t> XPCEndpointClient::connection()
 {
     Locker locker { m_connectionLock };
     return m_connection;

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.h
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.h
@@ -25,9 +25,8 @@
 
 #pragma once
 
-#include <wtf/OSObjectPtr.h>
-#include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 namespace IPC {
@@ -37,7 +36,7 @@ class Encoder;
 namespace WebKit {
 
 void startListeningForMachServiceConnections(const char* serviceName, ASCIILiteral entitlement, void(*connectionAdded)(xpc_connection_t), void(*connectionRemoved)(xpc_connection_t), void(*eventHandler)(xpc_object_t));
-RetainPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
-OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
+XPCObjectPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
+XPCObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
@@ -27,6 +27,7 @@
 
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 namespace JSC {
@@ -52,7 +53,7 @@ public:
     
 private:
     enum class DebugModeEnabled : bool { No, Yes };
-    HashMap<RetainPtr<xpc_connection_t>, DebugModeEnabled> m_connections;
+    HashMap<XPCObjectPtr<xpc_connection_t>, DebugModeEnabled> m_connections;
     size_t m_connectionsWithDebugModeEnabled { 0 };
 };
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
@@ -83,7 +83,8 @@ bool DaemonConnectionSet::debugModeEnabled() const
 
 void DaemonConnectionSet::broadcastConsoleMessage(JSC::MessageLevel messageLevel, const String& message)
 {
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), protocolDebugMessageLevelKey, static_cast<uint64_t>(messageLevel));
     xpc_dictionary_set_string(dictionary.get(), protocolDebugMessageKey, message.utf8().data());
     for (auto& connection : m_connections.keys())

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -55,7 +55,7 @@ namespace WebKit {
 
 class XPCServiceInitializerDelegate {
 public:
-    XPCServiceInitializerDelegate(OSObjectPtr<xpc_connection_t>, xpc_object_t initializerMessage);
+    XPCServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t>, xpc_object_t initializerMessage);
 
     virtual ~XPCServiceInitializerDelegate();
 
@@ -73,8 +73,8 @@ protected:
     bool hasEntitlement(ASCIILiteral entitlement);
     bool isClientSandboxed();
 
-    OSObjectPtr<xpc_connection_t> m_connection;
-    OSObjectPtr<xpc_object_t> m_initializerMessage;
+    XPCObjectPtr<xpc_connection_t> m_connection;
+    XPCObjectPtr<xpc_object_t> m_initializerMessage;
 };
 
 template<typename XPCServiceType>
@@ -94,7 +94,7 @@ void setJSCOptions(xpc_object_t initializerMessage, EnableLockdownMode, EnableEn
 void disableJSC(NOESCAPE WTF::CompletionHandler<void(void)>&& beforeFinalizeHandler);
 
 template<typename XPCServiceType, typename XPCServiceInitializerDelegateType, bool isWebContentProcess = false>
-void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+void XPCServiceInitializer(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
 {
     XPCServiceInitializerDelegateType delegate(WTFMove(connection), initializerMessage);
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -41,7 +41,7 @@
 
 namespace WebKit {
 
-XPCServiceInitializerDelegate::XPCServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+XPCServiceInitializerDelegate::XPCServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
     : m_connection(WTFMove(connection))
     , m_initializerMessage(initializerMessage)
 {

--- a/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
@@ -40,15 +40,18 @@ void AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc(IPC::C
 {
     ASSERT(secKeyProxyStore.isInitialized());
 
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), ClientCertificateAuthentication::XPCMessageNameKey, ClientCertificateAuthentication::XPCMessageNameValue);
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCChallengeIDKey, challengeID.toUInt64());
     xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, retainPtr(RetainPtr { secKeyProxyStore.get() }.get().endpoint._endpoint).get());
-    auto certificateDataArray = adoptOSObject(xpc_array_create(nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto certificateDataArray = adoptXPCObject(xpc_array_create(nullptr, 0));
     RetainPtr nsCredential = credential.nsCredential();
     for (id certificate in nsCredential.get().certificates) {
         auto data = adoptCF(SecCertificateCopyData((SecCertificateRef)certificate));
-        xpc_array_append_value(certificateDataArray.get(), adoptOSObject(xpc_data_create(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()))).get());
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT xpc_array_append_value(certificateDataArray.get(), adoptXPCObject(xpc_data_create(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()))).get());
     }
     xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCCertificatesKey, certificateDataArray.get());
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCPersistenceKey, static_cast<uint64_t>(nsCredential.get().persistence));

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1555,7 +1555,7 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
 #if ENABLE(MACH_PORT_LAYER_HOSTING)
         sendRightAnnotated = LayerHostingContext::fence(hostingUpdateCoordinator);
 #else
-        OSObjectPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
+        XPCObjectPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
         sendRightAnnotated.sendRight = MachSendRight::adopt(xpc_dictionary_copy_mach_send(xpcRepresentationHostingCoordinator.get(), machPortKey));
 #endif
         RELEASE_LOG(Media, "VideoPresentationManagerProxy::setVideoLayerFrame: x=%f y=%f w=%f h=%f send right %d, fence data size %lu", frame.x(), frame.y(), frame.width(), frame.height(), sendRightAnnotated.sendRight.sendRight(), sendRightAnnotated.data.size());

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -179,7 +179,7 @@ private:
     CheckedPtr<Client> m_client;
 
 #if PLATFORM(COCOA)
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    XPCObjectPtr<xpc_connection_t> m_xpcConnection;
 #endif
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
@@ -29,8 +29,8 @@
 #include "ExtensionCapabilityGrant.h"
 
 #include <wtf/BlockPtr.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 
 #if USE(EXTENSIONKIT)
 OBJC_CLASS BEWebContentProcess;
@@ -52,7 +52,7 @@ public:
     ExtensionProcess(BERenderingProcess *);
 
     void invalidate() const;
-    OSObjectPtr<xpc_connection_t> makeLibXPCConnection() const;
+    XPCObjectPtr<xpc_connection_t> makeLibXPCConnection() const;
     PlatformGrant grantCapability(const PlatformCapability&, BlockPtr<void()>&& invalidationHandler = ^{ }) const;
     RetainPtr<UIInteraction> createVisibilityPropagationInteraction() const;
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
@@ -66,10 +66,10 @@ void ExtensionProcess::invalidate() const
     });
 }
 
-OSObjectPtr<xpc_connection_t> ExtensionProcess::makeLibXPCConnection() const
+XPCObjectPtr<xpc_connection_t> ExtensionProcess::makeLibXPCConnection() const
 {
     NSError *error = nil;
-    OSObjectPtr<xpc_connection_t> xpcConnection;
+    XPCObjectPtr<xpc_connection_t> xpcConnection;
     WTF::switchOn(m_process, [&] (auto& process) {
         xpcConnection = [process makeLibXPCConnectionError:&error];
     });

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -240,7 +240,8 @@ void ProcessLauncher::launchProcess()
                 if (!launcher)
                     return;
                 auto name = serviceName(launcher->m_launchOptions, launcher->m_client);
-                launcher->m_xpcConnection = adoptOSObject(xpc_connection_create(name, nullptr));
+                // FIXME: This is a false positive. <rdar://164843889>
+                SUPPRESS_RETAINPTR_CTOR_ADOPT launcher->m_xpcConnection = adoptXPCObject(xpc_connection_create(name, nullptr));
                 launcher->finishLaunchingProcess(name);
             });
 #endif
@@ -277,7 +278,8 @@ void ProcessLauncher::launchProcess()
     launchWithExtensionKit(*this, m_launchOptions.processType, m_client.get(), WTFMove(handler));
 #else
     auto name = serviceName(m_launchOptions, m_client.get());
-    m_xpcConnection = adoptOSObject(xpc_connection_create(name, nullptr));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_xpcConnection = adoptXPCObject(xpc_connection_create(name, nullptr));
     finishLaunchingProcess(name);
 #endif
 }
@@ -294,7 +296,8 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
     // 1.1. An important case is WebKitTestRunner, where we should use English localizations for all system frameworks.
     // 2. When AppleLanguages is passed as command line argument for UI process, or set in its preferences, we should respect it in child processes.
 #if !USE(EXTENSIONKIT)
-    auto initializationMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto initializationMessage = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     _CFBundleSetupXPCBootstrap(initializationMessage.get());
     xpc_connection_set_bootstrap(m_xpcConnection.get(), initializationMessage.get());
 #endif
@@ -327,7 +330,8 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
         clientIdentifier = [[NSBundle mainBundle] bundleIdentifier];
 
     // FIXME: Switch to xpc_connection_set_bootstrap once it's available everywhere we need.
-    auto bootstrapMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto bootstrapMessage = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     xpc_dictionary_set_string(bootstrapMessage.get(), "WebKitBundleVersion", WEBKIT_BUNDLE_VERSION);
@@ -336,7 +340,8 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
     auto languagesIterator = m_launchOptions.extraInitializationData.find<HashTranslatorASCIILiteral>("OverrideLanguages"_s);
     if (languagesIterator != m_launchOptions.extraInitializationData.end()) {
         LOG_WITH_STREAM(Language, stream << "Process Launcher is copying OverrideLanguages into initialization message: " << languagesIterator->value);
-        auto languages = adoptOSObject(xpc_array_create(nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto languages = adoptXPCObject(xpc_array_create(nullptr, 0));
         for (auto language : StringView(languagesIterator->value).split(','))
             xpc_array_set_string(languages.get(), XPC_ARRAY_APPEND, language.utf8().data());
         xpc_dictionary_set_value(bootstrapMessage.get(), "OverrideLanguages", languages.get());
@@ -344,7 +349,8 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 
 #if PLATFORM(IOS_FAMILY)
     // Clients that set these environment variables explicitly do not have the values automatically forwarded by libxpc.
-    auto containerEnvironmentVariables = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto containerEnvironmentVariables = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     if (const char* environmentHOME = getenv("HOME"))
         xpc_dictionary_set_string(containerEnvironmentVariables.get(), "HOME", environmentHOME);
     if (const char* environmentCFFIXED_USER_HOME = getenv("CFFIXED_USER_HOME"))
@@ -401,7 +407,8 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
     auto sdkBehaviorBytes = sdkBehaviors.storageBytes();
     xpc_dictionary_set_data(bootstrapMessage.get(), "client-sdk-aligned-behaviors", sdkBehaviorBytes.data(), sdkBehaviorBytes.size());
 
-    auto extraInitializationData = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto extraInitializationData = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
 
     for (const auto& keyValuePair : m_launchOptions.extraInitializationData)
         xpc_dictionary_set_string(extraInitializationData.get(), keyValuePair.key.utf8().data(), keyValuePair.value.utf8().data());

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -476,7 +476,7 @@ private:
     private:
         WeakPtr<NetworkProcessProxy> m_networkProcess;
     };
-    OSObjectPtr<xpc_object_t> m_endpointMessage;
+    XPCObjectPtr<xpc_object_t> m_endpointMessage;
 #endif
 
     WeakHashSet<WebsiteDataStore> m_websiteDataStores;

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -65,7 +65,8 @@ void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
 
 void LaunchServicesDatabaseManager::didConnect()
 {
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName);
 
     auto connection = this->connection();

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -126,7 +126,7 @@ private:
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
     void setProtocolVersionForTesting(unsigned, CompletionHandler<void()>&&);
 
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    XPCObjectPtr<xpc_connection_t> m_xpcConnection;
     String m_hostAppCodeSigningIdentifier;
     bool m_hostAppHasPushInjectEntitlement { false };
     String m_pushPartitionString;

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -360,7 +360,8 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
     }
 #endif
 
-    auto reply = adoptOSObject(xpc_dictionary_create_reply(request));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto reply = adoptXPCObject(xpc_dictionary_create_reply(request));
     auto replyHandler = [xpcConnection = WTFMove(xpcConnection), reply = WTFMove(reply)] (UniqueRef<IPC::Encoder>&& encoder) {
         RELEASE_ASSERT(RunLoop::isMain());
         auto xpcData = WebKit::encoderToXPCData(WTFMove(encoder));

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -35,6 +35,7 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/darwin/XPCExtras.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 
 using WebKit::WebPushD::PushMessageForTesting;
 
@@ -77,7 +78,7 @@ private:
     String m_bundleIdentifier;
     String m_pushPartition;
 
-    RetainPtr<xpc_connection_t> m_connection;
+    XPCObjectPtr<xpc_connection_t> m_connection;
     ASCIILiteral m_serviceName;
 };
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -78,8 +78,8 @@ Connection::Connection(PreferTestService preferTestService, String bundleIdentif
 
 void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 {
-
-    m_connection = adoptNS(xpc_connection_create_mach_service(m_serviceName, mainDispatchQueueSingleton(), 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create_mach_service(m_serviceName, mainDispatchQueueSingleton(), 0));
 
     xpc_connection_set_event_handler(m_connection.get(), [](xpc_object_t event) {
         if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_CONNECTION_INTERRUPTED) {
@@ -150,10 +150,11 @@ void Connection::sendAuditToken()
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(WTFMove(configuration)));
 }
 
-static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
+static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
     auto xpcData = WebKit::encoderToXPCData(WTFMove(encoder));
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -125,25 +125,29 @@ static bool registerDaemonWithLaunchD(WebPushTool::PreferTestService preferTestS
 
     const char* serviceName = (preferTestService == WebPushTool::PreferTestService::Yes) ? "org.webkit.webpushtestdaemon.service" : "com.apple.webkit.webpushd.service";
 
-    auto plist = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto plist = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(plist.get(), "_ManagedBy", "webpushtool");
     xpc_dictionary_set_string(plist.get(), "Label", "org.webkit.webpushtestdaemon");
     xpc_dictionary_set_bool(plist.get(), "LaunchOnlyOnce", true);
     xpc_dictionary_set_bool(plist.get(), "RootedSimulatorPath", true);
 
     {
-        auto environmentVariables = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto environmentVariables = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_FRAMEWORK_PATH", currentExecutableDirectoryURL.get().fileSystemRepresentation);
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_LIBRARY_PATH", currentExecutableDirectoryURL.get().fileSystemRepresentation);
         xpc_dictionary_set_value(plist.get(), "EnvironmentVariables", environmentVariables.get());
     }
     {
-        auto machServices = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto machServices = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_bool(machServices.get(), serviceName, true);
         xpc_dictionary_set_value(plist.get(), "MachServices", machServices.get());
     }
     {
-        auto programArguments = adoptNS(xpc_array_create(nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto programArguments = adoptXPCObject(xpc_array_create(nullptr, 0));
 #if PLATFORM(MAC)
         xpc_array_set_string(programArguments.get(), XPC_ARRAY_APPEND, daemonExecutablePathURL.get().fileSystemRepresentation);
 #else

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2974,6 +2974,36 @@ def check_wtf_never_destroyed(clean_lines, line_number, file_state, error):
         error(line_number, 'runtime/wtf_never_destroyed', 4, "Use 'static Lock/Condition' instead of 'NeverDestroyed<Lock/Condition>'.")
 
 
+def check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error):
+    """Looks for usage of RetainPtr / OSObjectPtr with XPC objects, which should be replaced with XPCObjectPtr.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+    using_retain_ptr = search(r'RetainPtr<xpc_', line)
+    if using_retain_ptr:
+        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'XPCObjectPtr' instead of 'RetainPtr' for XPC objects.")
+        return
+    using_adoptns = search(r'adoptNS\(xpc_', line)
+    if using_adoptns:
+        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'adoptXPCObject()' instead of 'adoptNS()' for XPC objects.")
+        return
+    using_osobject_ptr = search(r'OSObjectPtr<xpc_', line)
+    if using_osobject_ptr:
+        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'XPCObjectPtr' instead of 'OSObjectPtr' for XPC objects.")
+        return
+    using_adoptosobject = search(r'adoptOSObject\(xpc_', line)
+    if using_adoptosobject:
+        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'adoptXPCObject()' instead of 'adoptOSObject()' for XPC objects.")
+        return
+
+
 def check_lock_guard(clean_lines, line_number, file_state, error):
     """Looks for use of 'std::lock_guard<>' which should be replaced with 'WTF::Locker'.
 
@@ -3773,6 +3803,7 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_unsafe_get(clean_lines, line_number, file_state, error)
     check_wtf_make_unique(clean_lines, line_number, file_state, error)
     check_wtf_never_destroyed(clean_lines, line_number, file_state, error)
+    check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error)
     check_lock_guard(clean_lines, line_number, file_state, error)
     check_log(clean_lines, line_number, file_state, error)
     check_ctype_functions(clean_lines, line_number, file_state, error)
@@ -5053,6 +5084,7 @@ class CppChecker(object):
         'runtime/wtf_make_unique',
         'runtime/wtf_move',
         'runtime/wtf_never_destroyed',
+        'runtime/wtf_xpc_object_ptr',
         'safercpp/atoi',
         'safercpp/checked_getter_for_init',
         'safercpp/dispatch_get_global_queue',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6186,6 +6186,36 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [runtime/wtf_never_destroyed] [4]",
             'foo.mm')
 
+    def test_wtf_xpc_object_ptr(self):
+        self.assert_lint(
+            'XPCObjectPtr<xpc_connection_t> connection = adoptXPCObject(xpc_connection_create_from_endpoint(endpoint));',
+            '',
+            'foo.cpp')
+
+        self.assert_lint(
+            'RetainPtr<xpc_connection_t> m_connection;',
+            "Use 'XPCObjectPtr' instead of 'RetainPtr' for XPC objects."
+            "  [runtime/wtf_xpc_object_ptr] [4]",
+            'foo.mm')
+
+        self.assert_lint(
+            'OSObjectPtr<xpc_connection_t> m_connection;',
+            "Use 'XPCObjectPtr' instead of 'OSObjectPtr' for XPC objects."
+            "  [runtime/wtf_xpc_object_ptr] [4]",
+            'foo.mm')
+
+        self.assert_lint(
+            'auto connection = adoptNS(xpc_connection_create_from_endpoint(endpoint));',
+            "Use 'adoptXPCObject()' instead of 'adoptNS()' for XPC objects."
+            "  [runtime/wtf_xpc_object_ptr] [4]",
+            'foo.mm')
+
+        self.assert_lint(
+            'auto connection = adoptOSObject(xpc_connection_create_from_endpoint(endpoint));',
+            "Use 'adoptXPCObject()' instead of 'adoptOSObject()' for XPC objects."
+            "  [runtime/wtf_xpc_object_ptr] [4]",
+            'foo.mm')
+
     def test_lock_guard(self):
         self.assert_lint(
             'Locker locker(lock);',

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp
@@ -61,17 +61,17 @@ TEST(OS_OBJECT_PTR_TEST_NAME, RetainRelease)
     auto fooPtr = reinterpret_cast<uintptr_t>(foo);
     EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)fooPtr));
 
-    WTF::retainOSObject(foo); // Does nothing under ARC.
+    WTF::DefaultOSObjectRetainTraits<dispatch_queue_t>::retain(foo); // Does nothing under ARC.
 #if __has_feature(objc_arc)
     EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)fooPtr));
 #else
     EXPECT_EQ(2, CFGetRetainCount((CFTypeRef)fooPtr));
 #endif
 
-    WTF::releaseOSObject(foo); // Does nothing under ARC.
+    WTF::DefaultOSObjectRetainTraits<dispatch_queue_t>::release(foo); // Does nothing under ARC.
     EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)fooPtr));
 
-    WTF::releaseOSObject(foo); // Balance dispatch_queue_create() without ARC.
+    WTF::DefaultOSObjectRetainTraits<dispatch_queue_t>::release(foo); // Balance dispatch_queue_create() without ARC.
 }
 
 TEST(OS_OBJECT_PTR_TEST_NAME, LeakRef)
@@ -90,7 +90,7 @@ TEST(OS_OBJECT_PTR_TEST_NAME, LeakRef)
     EXPECT_EQ(nullptr, foo.get());
     EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)fooPtr));
 
-    WTF::releaseOSObject(queue);
+    WTF::DefaultOSObjectRetainTraits<dispatch_queue_t>::release(queue);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -57,7 +57,8 @@ private:
         if (messageName == testMessageFromClient) {
             endpointReceivedMessageFromClient = true;
 
-            auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            // FIXME: This is a false positive. <rdar://164843889>
+            SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromEndpoint);
             xpc_connection_send_message(connection, message.get());
         }
@@ -74,7 +75,8 @@ private:
     }
     void didConnect() final
     {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        // FIXME: This is a false positive. <rdar://164843889>
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromClient);
         xpc_connection_send_message(connection().get(), message.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -58,6 +58,7 @@
 #include "CoreCryptoSPI.h"
 
 #include <WebCore/PrivateClickMeasurement.h>
+#include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/spi/cocoa/SecuritySPI.h>
 
 #endif // HAVE(RSA_BSSA)
@@ -507,13 +508,15 @@ static void attemptConnectionInProcessWithoutEntitlement()
 {
 #if USE(APPLE_INTERNAL_SDK)
     __block bool done = false;
-    auto connection = adoptNS(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", mainDispatchQueueSingleton(), 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptXPCObject(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t event) {
         EXPECT_EQ(event, XPC_ERROR_CONNECTION_INTERRUPTED);
         done = true;
     });
     xpc_connection_activate(connection.get());
-    auto dictionary = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_connection_send_message(connection.get(), dictionary.get());
     TestWebKitAPI::Util::run(&done);
 #endif

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -30,6 +30,7 @@
 
 #import <mach-o/dyld.h>
 #import <wtf/Vector.h>
+#import <wtf/darwin/XPCObjectPtr.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 // AppServerSupport cannot be safely imported within modules, so avoid putting
@@ -80,9 +81,10 @@ RetainPtr<NSURL> currentExecutableDirectory()
 }
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
-static RetainPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
+static XPCObjectPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 {
-    auto xpc = adoptNS(xpc_array_create(nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptXPCObject(xpc_array_create(nullptr, 0));
     for (id value in array) {
         if ([value isKindOfClass:NSString.class])
             xpc_array_set_string(xpc.get(), XPC_ARRAY_APPEND, [value UTF8String]);
@@ -92,9 +94,10 @@ static RetainPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
     return xpc;
 }
 
-static RetainPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
+static XPCObjectPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
 {
-    auto xpc = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    // FIXME: This is a false positive. <rdar://164843889>
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     for (NSString *key in dictionary) {
         ASSERT([key isKindOfClass:NSString.class]);
         const char* keyUTF8 = key.UTF8String;


### PR DESCRIPTION
#### 9d4a23ebe3ea59a1028bb930036be3612d213f7e
<pre>
Use xpc_retain() / xpc_release() for XPC objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=302524">https://bugs.webkit.org/show_bug.cgi?id=302524</a>

Reviewed by Darin Adler and Geoffrey Garen.

In our codebase, we currently sometimes use RetainPtr and sometimes
OSObjectPtr to hold XPC objects. This is inconsistent. Technically,
we&apos;re supposed to be calling `xpc_retain()` / `xpc_release()` as these
have logic internally to decide whether to call os_retain() / os_release()
or objc_retain() / objc_release(). They also have some extra validation
and special handling for certain XPC types.

As a result, I am introducing a new XPCObjectPtr which is based on
OSObjectPtr but uses traits to call `xpc_retain()` / `xpc_release()`
internally instead of `os_retain()` / `os_release()`. I ported to whole
codebase to use this new XPCObjectPtr type consistently and added a style
checker rule so that we don&apos;t regress things in the future.

I am also making OSObjectPtr compatible with hash containers.

* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::setupXPCConnectionIfNeeded):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm:
(Inspector::RemoteInspectorXPCConnection::sendMessage):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/OSObjectPtr.h:
(WTF::DefaultOSObjectRetainTraits::retain):
(WTF::DefaultOSObjectRetainTraits::release):
(WTF::OSObjectPtr::~OSObjectPtr):
(WTF::OSObjectPtr::OSObjectPtr):
(WTF::OSObjectPtr::isHashTableDeletedValue const):
(WTF::OSObjectPtr::operator=):
(WTF::OSObjectPtr::hashTableDeletedValue):
(WTF::operator==):
(WTF::adoptOSObject):
(WTF::lazyInitialize):
(WTF::retainOSObject): Deleted.
(WTF::releaseOSObject): Deleted.
* Source/WTF/wtf/TypeTraits.h:
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlement):
* Source/WTF/wtf/darwin/XPCObjectPtr.h: Copied from Source/WebKit/Shared/Cocoa/LaunchLogHook.h.
(WTF::XPCObjectRetainTraits::retain):
(WTF::XPCObjectRetainTraits::release):
* Source/WebCore/platform/VideoReceiverEndpoint.h:
* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm:
(WebKit::GPUServiceInitializerDelegate::GPUServiceInitializerDelegate):
* Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm:
(WebKit::ModelServiceInitializerDelegate::ModelServiceInitializerDelegate):
* Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm:
(WebKit::NetworkServiceInitializerDelegate::NetworkServiceInitializerDelegate):
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::messageDictionaryFromEncoder):
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm:
(WebKit::PCM::Connection::dictionaryFromMessage const):
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver):
(WebKit::LaunchServicesDatabaseObserver::startObserving):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Identifier::Identifier):
(IPC::Connection::protectedXPCConnection const):
* Source/WebKit/Platform/IPC/DaemonConnection.h:
(WebKit::Daemon::Connection::create):
(WebKit::Daemon::Connection::Connection):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::xpcRepresentation const):
(WebKit::LayerHostingContext::createHostingUpdateCoordinator):
(WebKit::LayerHostingContext::createHostingHandle):
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::terminateWithReason):
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h:
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm:
(WebKit::VideoReceiverEndpointMessage::encode const):
(WebKit::VideoReceiverSwapEndpointsMessage::encode const):
* Source/WebKit/Shared/Cocoa/LaunchLogHook.h:
* Source/WebKit/Shared/Cocoa/LaunchLogHook.mm:
(WebKit::LaunchLogHook::initialize):
(WebKit::LaunchLogHook::disable):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.h:
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
(WebKit::XPCEndpoint::sendEndpointToConnection):
(WebKit::XPCEndpoint::endpoint const):
* Source/WebKit/Shared/Cocoa/XPCEndpointClient.h:
* Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm:
(WebKit::XPCEndpointClient::setEndpoint):
(WebKit::XPCEndpointClient::connection):
* Source/WebKit/Shared/Daemon/DaemonUtilities.h:
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::startListeningForMachServiceConnections):
(WebKit::vectorToXPCData):
(WebKit::encoderToXPCData):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm:
(WebKit::PCM::DaemonConnectionSet::broadcastConsoleMessage):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::CompletionHandler&lt;void):
(WebKit::registerScheduledActivityHandler):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::XPCServiceInitializerDelegate::XPCServiceInitializerDelegate):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
(WebKit::XPCServiceMain):
* Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm:
(WebKit::AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm:
(WebKit::ExtensionProcess::makeLibXPCConnection const):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm:
(WebKit::LaunchServicesDatabaseManager::didConnect):
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::connectToService):
(WebPushTool::messageDictionaryFromEncoder):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(registerDaemonWithLaunchD):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_wtf_xpc_object_ptr):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_wtf_xpc_object_ptr):
* Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp:
(TestWebKitAPI::TEST(OS_OBJECT_PTR_TEST_NAME, RetainRelease)):
(TestWebKitAPI::TEST(OS_OBJECT_PTR_TEST_NAME, LeakRef)):
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::attemptConnectionInProcessWithoutEntitlement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
(TestWebKitAPI::createAndConfigureConnectionToService):
(TestWebKitAPI::TEST(WebPushD, BasicCommunication)):
* Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm:
(TestWebKitAPI::convertArrayToXPC):
(TestWebKitAPI::convertDictionaryToXPC):

Canonical link: <a href="https://commits.webkit.org/303104@main">https://commits.webkit.org/303104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55d4a1fb879adab42199aae15d8fcb44a87e0132

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83059 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5f3416b-dc75-4f78-83ef-c51451d06319) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133182 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100056 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0a0c2041-bb03-4aa1-8c53-054021b1be79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134258 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2638 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b985fc5a-4395-4b80-ae0d-6e8fa462ba22) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/130660 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2551 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82007 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123334 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141257 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129766 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3387 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108574 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108519 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27583 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2557 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56547 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3449 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32302 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162783 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3271 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66857 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3471 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->