### PR TITLE
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -377,7 +377,6 @@ void GStreamerDataChannelHandler::onMessageData(GBytes* bytes)
     });
 }
 
-IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
 void GStreamerDataChannelHandler::onMessageString(const char* message)
 {
     Locker locker { m_clientLock };
@@ -392,15 +391,15 @@ void GStreamerDataChannelHandler::onMessageString(const char* message)
     if (!*m_client)
         return;
 
-    DC_DEBUG("Dispatching string of size %zu", strlen(message));
-    postTask([client = m_client, string = String::fromUTF8(message)] {
+    auto string = String::fromUTF8(message);
+    DC_DEBUG("Dispatching string of size %u", string.length());
+    postTask([client = m_client, string = WTFMove(string)] {
         if (!*client)
             return;
 
         client.value()->didReceiveStringData(string);
     });
 }
-IGNORE_CLANG_WARNINGS_END
 
 void GStreamerDataChannelHandler::onError(GError* error)
 {

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -76,11 +76,9 @@ FFTFrame::FFTFrame(const FFTFrame& frame)
     m_fft.reset(gst_fft_f32_new(fftLength, FALSE));
     m_inverseFft.reset(gst_fft_f32_new(fftLength, TRUE));
 
-    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     // Copy/setup frame data.
-    memcpy(realData().data(), frame.realData().data(), sizeof(float) * realData().size());
-    memcpy(imagData().data(), frame.imagData().data(), sizeof(float) * imagData().size());
-    IGNORE_CLANG_WARNINGS_END
+    memcpySpan(m_realData.span(), frame.realData().span());
+    memcpySpan(m_imagData.span(), frame.imagData().span());
 }
 
 void FFTFrame::initialize()

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -227,7 +227,7 @@ public:
 
     GstVideoFrame* get();
 
-    uint8_t* componentData(int) const;
+    std::span<uint8_t> componentData(int) const;
     int componentStride(int) const;
     int componentWidth(int) const;
 
@@ -237,7 +237,7 @@ public:
     int height() const;
 
     int format() const;
-    void* planeData(uint32_t) const;
+    std::span<uint8_t> planeData(uint32_t) const;
     int planeStride(uint32_t) const;
 
     bool isValid() const { return m_frame.buffer; }

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
@@ -151,7 +151,8 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     // Copy the buffer data. Keeping the whole mapped GstVideoFrame alive would increase memory
     // pressure and the file descriptor(s) associated with the buffer pool open. We only need the
     // data here.
-    SkPixmap pixmap(imageInfo, videoFrame.planeData(0), videoFrame.planeStride(0));
+    auto planeData = videoFrame.planeData(0);
+    SkPixmap pixmap(imageInfo, planeData.data(), videoFrame.planeStride(0));
     m_image = SkImages::RasterFromPixmapCopy(pixmap);
 
     if (auto* cropMeta = gst_buffer_get_video_crop_meta(buffer))

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -111,7 +111,6 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(con
     return { inputCaps, outputCaps };
 }
 
-IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 const char* GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
 {
     ensureDebugCategoryInitialized();
@@ -133,8 +132,7 @@ const char* GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
         return nullptr;
     }
 
-    std::array<uint8_t, 11> profileTierLevel;
-    memset(profileTierLevel.data(), 0, 11);
+    std::array<uint8_t, 11> profileTierLevel = { 0 };
     profileTierLevel[0] = parameters->generalProfileIDC;
 
     if (profileTierLevel[0] >= 4) {
@@ -145,7 +143,6 @@ const char* GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
 
     return gst_codec_utils_h265_get_profile(profileTierLevel.data(), profileTierLevel.size());
 }
-IGNORE_CLANG_WARNINGS_END
 
 static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h265CapsFromCodecString(const String& codecString)
 {

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -117,12 +117,12 @@ webrtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC:
             return nullptr;
 
         GstMappedFrame frame(sample, GST_MAP_READ);
-        return webrtc::I420Buffer::Copy(frame.width(), frame.height(), frame.componentData(0), frame.componentStride(0),
-            frame.componentData(1), frame.componentStride(1), frame.componentData(2), frame.componentStride(2));
+        return webrtc::I420Buffer::Copy(frame.width(), frame.height(), frame.componentData(0).data(), frame.componentStride(0),
+            frame.componentData(1).data(), frame.componentStride(1), frame.componentData(2).data(), frame.componentStride(2));
     }
 
-    return webrtc::I420Buffer::Copy(inFrame.width(), inFrame.height(), inFrame.componentData(0), inFrame.componentStride(0),
-        inFrame.componentData(1), inFrame.componentStride(1), inFrame.componentData(2), inFrame.componentStride(2));
+    return webrtc::I420Buffer::Copy(inFrame.width(), inFrame.height(), inFrame.componentData(0).data(), inFrame.componentStride(0),
+        inFrame.componentData(1).data(), inFrame.componentStride(1), inFrame.componentData(2).data(), inFrame.componentStride(2));
 }
 
 }


### PR DESCRIPTION
#### 8cff56dfd0887ba4bb96093f621714ceeaa3ecc6
<pre>
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE
<a href="https://bugs.webkit.org/show_bug.cgi?id=302526">https://bugs.webkit.org/show_bug.cgi?id=302526</a>

Reviewed by Adrian Perez de Castro and Xabier Rodriguez-Calvar.

Remove unsafe-buffer-usage pragma usage in more places by using span and avoiding memcpy(),
memset() and strcmp() calls.

Also, driving-by, fixing a couple issues in the SDP time repeat attribute handling of the
SDPStringBuilder.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::onMessageString):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
(WebCore::GStreamerMediaEndpoint::processSDPMessage):
(WebCore::GStreamerMediaEndpoint::updatePtDemuxSrcPadCaps):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::generateCertificate):
(WebCore::setSsrcAudioLevelVadOn):
(WebCore::SDPStringBuilder::SDPStringBuilder):
(WebCore::extractMidAndRidFromRTPBuffer):
* Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp:
(WebCore::FFTFrame::FFTFrame):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::registerWebKitGStreamerElements):
(WebCore::GstMappedFrame::componentData const):
(WebCore::GstMappedFrame::planeData const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfTrack):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::setVisibleInViewport):
(WebCore::MediaPlayerPrivateGStreamer::createVideoSinkGL):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::copyPlane):
(WebCore::VideoFrame::copyTo):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkConfigure):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::GStreamerCodecUtilities::parseHEVCProfile):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp:
(WebCore::GStreamerVideoFrameLibWebRTC::ToI420):

Canonical link: <a href="https://commits.webkit.org/303317@main">https://commits.webkit.org/303317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/648b4bc5c8d534ba6da9b46c1b4109b55b7849d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139547 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134979 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81722 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82767 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111831 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142194 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36952 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4276 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27722 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57416 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4249 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32923 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67695 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->