### PR TITLE
Add a common way to get NativeImage from a VideoFrame (VideoFrame::copyNativeImage())

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -409,12 +409,12 @@ static void clampDimension(WebGPU::Extent3D& extent3D, size_t dimension, WebGPU:
     });
 }
 
-static void getImageBytesFromVideoFrame(WebGPU::Queue& backing, const RefPtr<VideoFrame>& videoFrame, WebGPU::Extent3D& backingCopySize, NOESCAPE const ImageDataCallback& callback)
+static void getImageBytesFromVideoFrame(const RefPtr<VideoFrame>& videoFrame, WebGPU::Extent3D& backingCopySize, NOESCAPE const ImageDataCallback& callback)
 {
     if (!videoFrame.get())
         return callback({ }, 0, 0);
 
-    RefPtr<NativeImage> nativeImage = backing.getNativeImage(*videoFrame.get());
+    RefPtr nativeImage = videoFrame->copyNativeImage();
     if (!nativeImage)
         return callback({ }, 0, 0);
 
@@ -627,14 +627,14 @@ static void imageBytesForSource(WebGPU::Queue& backing, const GPUImageCopyExtern
     }, [&](const RefPtr<HTMLVideoElement> videoElement) -> ResultType {
 #if PLATFORM(COCOA)
         if (RefPtr player = videoElement ? videoElement->player() : nullptr; player && player->isVideoPlayer())
-            return getImageBytesFromVideoFrame(backing, player->videoFrameForCurrentTime(), backingCopySize, callback);
+            return getImageBytesFromVideoFrame(player->videoFrameForCurrentTime(), backingCopySize, callback);
 #else
         UNUSED_PARAM(videoElement);
 #endif
         return callback({ }, 0, 0);
     }, [&](const RefPtr<WebCodecsVideoFrame> webCodecsFrame) -> ResultType {
 #if PLATFORM(COCOA)
-        return getImageBytesFromVideoFrame(backing, webCodecsFrame->internalFrame(), backingCopySize, callback);
+        return getImageBytesFromVideoFrame(webCodecsFrame->internalFrame(), backingCopySize, callback);
 #else
         UNUSED_PARAM(webCodecsFrame);
         return callback({ }, 0, 0);

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -142,11 +142,6 @@ void QueueImpl::setLabelInternal(const String& label)
     wgpuQueueSetLabel(m_backing.get(), label.utf8().data());
 }
 
-RefPtr<WebCore::NativeImage> QueueImpl::getNativeImage(WebCore::VideoFrame&)
-{
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 } // namespace WebCore::WebGPU
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -95,7 +95,6 @@ private:
         const Extent3D& copySize) final;
 
     void setLabelInternal(const String&) final;
-    RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) final;
 
     WebGPUPtr<WGPUQueue> m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -98,7 +98,6 @@ public:
         const ImageCopyTextureTagged& destination,
         const Extent3D& copySize) = 0;
 
-    virtual RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) = 0;
     virtual bool isRemoteQueueProxy() const { return false; }
 
 protected:

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -125,53 +125,24 @@ static ImageOrientation videoFrameOrientation(const VideoFrame& videoFrame)
     return ImageOrientation::Orientation::OriginTopLeft;
 }
 
-static Ref<ImageBitmap> createImageBitmapViaDrawing(Ref<ImageBuffer>&& imageBuffer, VideoFrame& videoFrame)
-{
-    bool shouldDiscardAlpha = false;
-    imageBuffer->context().drawVideoFrame(videoFrame, { { }, imageBuffer->backendSize() }, videoFrameOrientation(videoFrame), shouldDiscardAlpha);
-
-    bool isOriginClean = true;
-    return ImageBitmap::create(WTFMove(imageBuffer), isOriginClean);
-}
-
-static Ref<ImageBitmap> createImageBitmapFromNativeImage(Ref<ImageBuffer>&& imageBuffer, NativeImage& nativeImage, ImageOrientation orientation)
-{
-    imageBuffer->context().drawNativeImage(nativeImage, { { }, imageBuffer->backendSize() }, { { }, imageBuffer->backendSize() }, ImagePaintingOptions { orientation });
-
-    bool isOriginClean = true;
-    return ImageBitmap::create(WTFMove(imageBuffer), isOriginClean);
-}
-
 static void createImageBitmap(VideoFrame& videoFrame, CompletionHandler<void(RefPtr<ImageBitmap>&&)>&& completionHandler)
 {
-    IntSize size { static_cast<int>(videoFrame.presentationSize().width()), static_cast<int>(videoFrame.presentationSize().height()) };
+    auto size = videoFrame.presentationSize();
     if (videoFrame.has90DegreeRotation())
-        size = { size.height(), size.width() };
-    auto imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+        size = size.transposedSize();
+    RefPtr imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
     if (!imageBuffer) {
         completionHandler({ });
         return;
     }
-
-    if (hasPlatformStrategies()) {
-        platformStrategies()->mediaStrategy()->nativeImageFromVideoFrame(videoFrame, [videoFrame = Ref { videoFrame }, imageBuffer = imageBuffer.releaseNonNull(), completionHandler = WTFMove(completionHandler)](auto&& nativeImage) mutable {
-            if (!nativeImage) {
-                completionHandler(createImageBitmapViaDrawing(WTFMove(imageBuffer), videoFrame));
-                return;
-            }
-
-            RefPtr image = WTFMove(*nativeImage);
-            if (!image) {
-                completionHandler({ });
-                return;
-            }
-
-            completionHandler(createImageBitmapFromNativeImage(WTFMove(imageBuffer), *image, videoFrameOrientation(videoFrame)));
-        });
+    RefPtr image = videoFrame.copyNativeImage();
+    if (!image) {
+        completionHandler({ });
         return;
     }
-
-    completionHandler(createImageBitmapViaDrawing(imageBuffer.releaseNonNull(), videoFrame));
+    imageBuffer->context().drawNativeImage(*image, { { }, size }, { { }, size }, { videoFrameOrientation(videoFrame), CompositeOperator::Copy });
+    bool isOriginClean = true;
+    completionHandler(ImageBitmap::create(imageBuffer.releaseNonNull(), isOriginClean));
 }
 
 static Exception createImageCaptureException()

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3427,7 +3427,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
     }
 
     // Fallback pure SW path.
-    auto image = context->videoFrameToImage(*internalFrame);
+    RefPtr image = BitmapImage::create(internalFrame->copyNativeImage());
     if (!image)
         return { };
 

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -71,10 +71,6 @@ public:
     static void addMockMediaSourceEngine();
 #endif
 
-#if ENABLE(VIDEO)
-    virtual void nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&&);
-#endif
-
     virtual bool enableWebMMediaPlayer() const { return true; }
     virtual bool isWebMediaStrategy() const { return false; }
 
@@ -84,12 +80,5 @@ protected:
     bool m_mockMediaSourceEnabled { false };
     WTF::BitSet<16> m_remoteRenderersEnabled;
 };
-
-#if ENABLE(VIDEO)
-inline void MediaStrategy::nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&& completionHandler)
-{
-    completionHandler(std::nullopt);
-}
-#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/VideoFrame.cpp
+++ b/Source/WebCore/platform/VideoFrame.cpp
@@ -112,10 +112,6 @@ void VideoFrame::copyTo(std::span<uint8_t>, VideoPixelFormat, Vector<ComputedPla
     callback({ });
 }
 
-void VideoFrame::draw(GraphicsContext&, const FloatRect&, ImageOrientation, bool)
-{
-    // FIXME: Add support.
-}
 #endif // !PLATFORM(COCOA)
 
 }

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -102,6 +102,7 @@ public:
 
     virtual IntSize presentationSize() const = 0;
     virtual uint32_t pixelFormat() const = 0;
+    virtual RefPtr<NativeImage> copyNativeImage() const = 0;
 
     virtual bool isRemoteProxy() const { return false; }
     virtual bool isLibWebRTC() const { return false; }
@@ -116,8 +117,6 @@ public:
     WEBCORE_EXPORT virtual void setOwnershipIdentity(const ProcessIdentity&) { }
 
     void initializeCharacteristics(MediaTime presentationTime, bool isMirrored, Rotation);
-
-    void draw(GraphicsContext&, const FloatRect&, ImageOrientation, bool shouldDiscardAlpha);
 
     const PlatformVideoColorSpace& colorSpace() const { return m_colorSpace; }
 

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -450,7 +450,7 @@ ImageDrawResult BifurcatedGraphicsContext::drawTiledImage(Image& image, const Fl
 }
 
 #if ENABLE(VIDEO)
-void BifurcatedGraphicsContext::drawVideoFrame(VideoFrame& videoFrame, const FloatRect& destination, WebCore::ImageOrientation orientation, bool shouldDiscardAlpha)
+void BifurcatedGraphicsContext::drawVideoFrame(const VideoFrame& videoFrame, const FloatRect& destination, WebCore::ImageOrientation orientation, bool shouldDiscardAlpha)
 {
     m_primaryContext.drawVideoFrame(videoFrame, destination, orientation, shouldDiscardAlpha);
     m_secondaryContext.drawVideoFrame(videoFrame, destination, orientation, shouldDiscardAlpha);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -115,7 +115,7 @@ public:
     void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
 
 #if ENABLE(VIDEO)
-    void drawVideoFrame(VideoFrame&, const FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
+    void drawVideoFrame(const VideoFrame&, const FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
 #endif
 
     using GraphicsContext::scale;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -440,9 +440,16 @@ void GraphicsContext::drawControlPart(ControlPart& part, const FloatRoundedRect&
 }
 
 #if ENABLE(VIDEO)
-void GraphicsContext::drawVideoFrame(VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
+void GraphicsContext::drawVideoFrame(const VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
 {
-    frame.draw(*this, destination, orientation, shouldDiscardAlpha);
+    RefPtr image = frame.copyNativeImage();
+    if (!image)
+        return;
+    IntSize size = image->size();
+    if (orientation.usesWidthAsHeight())
+        size = size.transposedSize();
+    auto compositeOperator = !shouldDiscardAlpha && image->hasAlpha() ? CompositeOperator::SourceOver : CompositeOperator::Copy;
+    drawNativeImage(*image, destination, { { }, size }, { compositeOperator, orientation });
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -289,7 +289,7 @@ public:
     WEBCORE_EXPORT virtual void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&);
 
 #if ENABLE(VIDEO)
-    WEBCORE_EXPORT virtual void drawVideoFrame(VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha);
+    WEBCORE_EXPORT virtual void drawVideoFrame(const VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha);
 #endif
 
     // Clipping

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -645,18 +645,6 @@ void GraphicsContextGL::forceContextLost()
         m_client->forceContextLost();
 }
 
-#if ENABLE(VIDEO)
-RefPtr<Image> GraphicsContextGL::videoFrameToImage(VideoFrame& frame)
-{
-    IntSize size { static_cast<int>(frame.presentationSize().width()), static_cast<int>(frame.presentationSize().height()) };
-    auto imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-    if (!imageBuffer)
-        return { };
-    imageBuffer->context().drawVideoFrame(frame, { { }, size }, ImageOrientation::Orientation::None, true);
-    return BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTFMove(imageBuffer)));
-}
-#endif
-
 } // namespace WebCore
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1673,7 +1673,6 @@ public:
 
 #if ENABLE(VIDEO)
     virtual bool copyTextureFromVideoFrame(VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum  format, GCGLenum type, bool premultiplyAlpha, bool flipY) = 0;
-    WEBCORE_EXPORT virtual RefPtr<Image> videoFrameToImage(VideoFrame&);
 #endif
 
     IntSize getInternalFramebufferSize() const { return IntSize(m_currentWidth, m_currentHeight); }

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -139,7 +139,7 @@ private:
     void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final { }
 
 #if ENABLE(VIDEO)
-    void drawVideoFrame(VideoFrame&, const FloatRect&, ImageOrientation, bool) final { }
+    void drawVideoFrame(const VideoFrame&, const FloatRect&, ImageOrientation, bool) final { }
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -1182,7 +1182,7 @@ void OperationRecorder::append(std::unique_ptr<PaintingOperation>&& command)
 }
 
 #if ENABLE(VIDEO)
-void OperationRecorder::drawVideoFrame(VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
+void OperationRecorder::drawVideoFrame(const VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
 {
     // FIXME: Not implemented.
     GraphicsContext::drawVideoFrame(frame, destination, orientation, shouldDiscardAlpha);

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -104,7 +104,7 @@ private:
     WebCore::IntRect clipBounds() const override;
     void clipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect&) override;
 #if ENABLE(VIDEO)
-    void drawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) override;
+    void drawVideoFrame(const WebCore::VideoFrame&, const WebCore::FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) override;
 #endif
 
     void applyDeviceScaleFactor(float) override;

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
@@ -50,6 +50,7 @@ public:
     // VideoFrame overrides.
     WEBCORE_EXPORT WebCore::IntSize presentationSize() const final;
     WEBCORE_EXPORT uint32_t pixelFormat() const final;
+    WEBCORE_EXPORT RefPtr<NativeImage> copyNativeImage() const final;
     WEBCORE_EXPORT void setOwnershipIdentity(const ProcessIdentity&) final;
     bool isCV() const final { return true; }
 

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -481,22 +481,11 @@ void VideoFrame::copyTo(std::span<uint8_t> span, VideoPixelFormat format, Vector
     callback({ });
 }
 
-void VideoFrame::draw(GraphicsContext& context, const FloatRect& destination, ImageOrientation destinationImageRotation, bool shouldDiscardAlpha)
+RefPtr<NativeImage> VideoFrameCV::copyNativeImage() const
 {
-    // FIXME: Handle alpha discarding.
-    UNUSED_PARAM(shouldDiscardAlpha);
-
-    // FIXME: destination image rotation handling.
-    UNUSED_PARAM(destinationImageRotation);
-
     // FIXME: It is not efficient to create a conformer everytime. We might want to make it more efficient, for instance by storing it in GraphicsContext.
-    auto conformer = makeUnique<PixelBufferConformerCV>((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) });
-    auto image = NativeImage::create(conformer->createImageFromPixelBuffer(protectedPixelBuffer().get()));
-    if (!image)
-        return;
-
-    FloatRect imageRect { FloatPoint::zero(), image->size() };
-    context.drawNativeImage(*image, destination, imageRect);
+    auto conformer = makeUnique<PixelBufferConformerCV>(kCVPixelFormatType_32BGRA);
+    return NativeImage::create(conformer->createImageFromPixelBuffer(protectedPixelBuffer().get()));
 }
 
 Ref<VideoFrameCV> VideoFrameCV::create(CMSampleBufferRef sampleBuffer, bool isMirrored, Rotation rotation)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -373,7 +373,7 @@ void RecorderImpl::fillEllipse(const FloatRect& rect)
 }
 
 #if ENABLE(VIDEO)
-void RecorderImpl::drawVideoFrame(VideoFrame&, const FloatRect&, ImageOrientation, bool)
+void RecorderImpl::drawVideoFrame(const VideoFrame&, const FloatRect&, ImageOrientation, bool)
 {
     appendStateChangeItemIfNecessary();
     // FIXME: TODO

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -97,7 +97,7 @@ public:
     void drawGlyphsImmediate(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) final;
     void drawDisplayList(const DisplayList&, ControlFactory&) final;
 #if ENABLE(VIDEO)
-    void drawVideoFrame(VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha) final;
+    void drawVideoFrame(const VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha) final;
 #endif
     void strokeRect(const FloatRect&, float) final;
     void strokeEllipse(const FloatRect&) final;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4059,8 +4059,8 @@ void MediaPlayerPrivateGStreamer::paint(GraphicsContext& context, const FloatRec
     if (!presentationSize)
         return;
 
-    auto frame = VideoFrameGStreamer::create(WTFMove(sample), { IntSize(*presentationSize), { *m_videoInfo } });
-    frame->draw(context, rect, m_videoSourceOrientation, false);
+    Ref frame = VideoFrameGStreamer::create(WTFMove(sample), { IntSize(*presentationSize), { *m_videoInfo } });
+    context.drawVideoFrame(frame, rect, m_videoSourceOrientation, false);
 }
 
 DestinationColorSpace MediaPlayerPrivateGStreamer::colorSpace()

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -66,6 +66,7 @@ public:
     static Ref<VideoFrameGStreamer> createWrappedSample(const GRefPtr<GstSample>&, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation videoRotation = Rotation::None);
 
     static RefPtr<VideoFrameGStreamer> createFromPixelBuffer(Ref<PixelBuffer>&&, const IntSize& destinationSize, double frameRate, const CreateOptions&, PlatformVideoColorSpace&& = { });
+    ~VideoFrameGStreamer();
 
     void setFrameRate(double);
     void setMaxFrameRate(double);
@@ -85,6 +86,7 @@ public:
 
     IntSize presentationSize() const final { return m_presentationSize; }
     uint32_t pixelFormat() const final { return GST_VIDEO_INFO_FORMAT(&m_info.info); }
+    RefPtr<NativeImage> copyNativeImage() const final;
 
     enum class MemoryType : uint8_t {
         Unsupported,

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -56,6 +56,7 @@ private:
     IntSize presentationSize() const final { return m_size; }
     uint32_t pixelFormat() const final { return m_videoPixelFormat; }
     CVPixelBufferRef pixelBuffer() const final;
+    RefPtr<NativeImage> copyNativeImage() const final;
 
     Ref<VideoFrame> clone() final;
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -153,11 +153,14 @@ std::optional<audit_token_t> GPUProcessConnection::auditToken()
 }
 #endif
 
-Ref<RemoteSharedResourceCacheProxy> GPUProcessConnection::sharedResourceCache()
+RemoteSharedResourceCacheProxy& GPUProcessConnection::sharedResourceCache()
 {
-    if (!m_sharedResourceCache)
-        m_sharedResourceCache = RemoteSharedResourceCacheProxy::create();
-    return *m_sharedResourceCache;
+    return WebProcess::singleton().gpuProcessSharedResourceCache();
+}
+
+Ref<RemoteSharedResourceCacheProxy> GPUProcessConnection::protectedSharedResourceCache()
+{
+    return sharedResourceCache();
 }
 
 void GPUProcessConnection::invalidate()
@@ -211,9 +214,7 @@ void GPUProcessConnection::resetAudioMediaStreamTrackRendererInternalUnit(AudioM
 #if ENABLE(VIDEO)
 RemoteVideoFrameObjectHeapProxy& GPUProcessConnection::videoFrameObjectHeapProxy()
 {
-    if (!m_videoFrameObjectHeapProxy)
-        m_videoFrameObjectHeapProxy = RemoteVideoFrameObjectHeapProxy::create(*this);
-    return *m_videoFrameObjectHeapProxy;
+    return protectedSharedResourceCache()->videoFrameObjectHeapProxy();
 }
 
 Ref<RemoteVideoFrameObjectHeapProxy> GPUProcessConnection::protectedVideoFrameObjectHeapProxy()

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -88,7 +88,8 @@ public:
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> auditToken();
 #endif
-    Ref<RemoteSharedResourceCacheProxy> sharedResourceCache();
+    RemoteSharedResourceCacheProxy& sharedResourceCache();
+    Ref<RemoteSharedResourceCacheProxy> protectedSharedResourceCache();
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     SampleBufferDisplayLayerManager& sampleBufferDisplayLayerManager();
     Ref<SampleBufferDisplayLayerManager> protectedSampleBufferDisplayLayerManager();
@@ -165,15 +166,11 @@ private:
     IPC::MessageReceiverMap m_messageReceiverMap;
     GPUProcessConnectionIdentifier m_identifier { GPUProcessConnectionIdentifier::generate() };
     bool m_hasInitialized { false };
-    RefPtr<RemoteSharedResourceCacheProxy> m_sharedResourceCache;
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> m_auditToken;
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     const std::unique_ptr<SampleBufferDisplayLayerManager> m_sampleBufferDisplayLayerManager;
-#endif
-#if ENABLE(VIDEO)
-    RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
 #endif
 #if PLATFORM(COCOA) && ENABLE(WEB_AUDIO)
     RefPtr<RemoteAudioSourceProviderManager> m_audioSourceProviderManager;

--- a/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
@@ -32,6 +32,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebKit {
+class RemoteVideoFrameObjectHeapProxy;
 
 // Class for maintaining view of GPU process RemoteSharedResourceCache state in Web process.
 // Thread-safe.
@@ -41,8 +42,18 @@ public:
     static Ref<RemoteSharedResourceCacheProxy> create();
     virtual ~RemoteSharedResourceCacheProxy();
 
+#if ENABLE(VIDEO)
+    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy();
+    Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy();
+#endif
+
+    void gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection&);
+
 private:
     RemoteSharedResourceCacheProxy();
+#if ENABLE(VIDEO)
+    const RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
+#endif
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -255,21 +255,6 @@ bool RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame(WebCore::VideoFrame
 #endif
 }
 
-RefPtr<Image> RemoteGraphicsContextGLProxy::videoFrameToImage(WebCore::VideoFrame& frame)
-{
-    if (isContextLost())
-        return { };
-
-#if PLATFORM(COCOA)
-    RefPtr<NativeImage> nativeImage;
-    callOnMainRunLoopAndWait([&] {
-        nativeImage = protectedVideoFrameObjectHeapProxy()->getNativeImage(frame);
-    });
-    return BitmapImage::create(WTFMove(nativeImage));
-#else
-    return GraphicsContextGL::videoFrameToImage(frame);
-#endif
-}
 #endif
 
 GCGLErrorCodeSet RemoteGraphicsContextGLProxy::getErrors()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -86,7 +86,6 @@ public:
     GCGLErrorCodeSet getErrors() final;
 #if ENABLE(VIDEO)
     bool copyTextureFromVideoFrame(WebCore::VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type , bool premultiplyAlpha, bool flipY) final;
-    RefPtr<WebCore::Image> videoFrameToImage(WebCore::VideoFrame&) final;
 #endif
 
     void simulateEventForTesting(WebCore::GraphicsContextGLSimulatedEventForTesting) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -516,7 +516,7 @@ void RemoteGraphicsContextProxy::fillEllipse(const FloatRect& rect)
 }
 
 #if ENABLE(VIDEO)
-void RemoteGraphicsContextProxy::drawVideoFrame(VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
+void RemoteGraphicsContextProxy::drawVideoFrame(const VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
 {
     appendStateChangeItemIfNecessary();
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -125,7 +125,7 @@ private:
     void fillRectWithRoundedHole(const WebCore::FloatRect&, const WebCore::FloatRoundedRect&, const WebCore::Color&) final;
     void fillEllipse(const WebCore::FloatRect&) final;
 #if ENABLE(VIDEO)
-    void drawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& distination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
+    void drawVideoFrame(const WebCore::VideoFrame&, const WebCore::FloatRect& distination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
 #endif
     void strokePath(const WebCore::Path&) final;
     void strokeRect(const WebCore::FloatRect&, float) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -28,7 +28,6 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RemoteAdapterProxy.h"
-#include "RemoteVideoFrameObjectHeapProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUQueue.h>
 #include <wtf/TZoneMalloc.h>
@@ -110,17 +109,10 @@ private:
         const WebCore::WebGPU::Extent3D& copySize) final;
 
     void setLabelInternal(const String&) final;
-#if ENABLE(VIDEO)
-    RefPtr<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const;
-#endif
-    RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) final;
 
     WebGPUIdentifier m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
     const Ref<RemoteAdapterProxy> m_parent;
-#if ENABLE(VIDEO)
-    RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
-#endif
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -295,18 +295,8 @@ void AudioVideoRendererRemote::paintCurrentVideoFrameInContext(GraphicsContext& 
 
 RefPtr<NativeImage> AudioVideoRendererRemote::currentNativeImage() const
 {
-#if PLATFORM(COCOA)
-    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
     RefPtr videoFrame = currentVideoFrame();
-    if (!videoFrame)
-        return nullptr;
-    ASSERT(gpuProcessConnection);
-
-    return gpuProcessConnection->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
-#else
-    ASSERT_NOT_REACHED();
-    return nullptr;
-#endif
+    return videoFrame ? videoFrame->copyNativeImage() : nullptr;
 }
 
 std::optional<VideoPlaybackQualityMetrics> AudioVideoRendererRemote::videoPlaybackQualityMetrics()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -267,7 +267,7 @@ void RemoteMediaPlayerManager::setUseGPUProcess(bool useGPUProcess)
             return WebProcess::singleton().ensureProtectedGPUProcessConnection()->sampleBufferDisplayLayerManager().createLayer(client);
         });
         WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setNativeImageCreator([](auto& videoFrame) {
-            return WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy().getNativeImage(videoFrame);
+            return videoFrame.copyNativeImage();
         });
     }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -70,6 +70,7 @@ public:
     // WebCore::VideoFrame overrides.
     WebCore::IntSize presentationSize() const final { return m_size; }
     uint32_t pixelFormat() const final;
+    RefPtr<WebCore::NativeImage> copyNativeImage() const final;
     bool isRemoteProxy() const final { return true; }
 #if PLATFORM(COCOA)
     CVPixelBufferRef pixelBuffer() const final;
@@ -90,8 +91,7 @@ private:
     std::optional<RemoteVideoFrameReferenceTracker> m_referenceTracker;
     const WebCore::IntSize m_size;
     uint32_t m_pixelFormat { 0 };
-    // FIXME: Remove this.
-    mutable RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
+    const Ref<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
 #if PLATFORM(COCOA)
     mutable Lock m_pixelBufferLock;
     mutable RetainPtr<CVPixelBufferRef> m_pixelBuffer;

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -141,12 +141,4 @@ void WebMediaStrategy::enableMockMediaSource()
 }
 #endif
 
-#if PLATFORM(COCOA) && ENABLE(VIDEO)
-void WebMediaStrategy::nativeImageFromVideoFrame(const WebCore::VideoFrame& frame, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&& completionHandler)
-{
-    // FIMXE: Move out of sync IPC.
-    completionHandler(WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(frame));
-}
-#endif
-
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -54,9 +54,6 @@ private:
 #if ENABLE(MEDIA_SOURCE)
     void enableMockMediaSource() final;
 #endif
-#if PLATFORM(COCOA) && ENABLE(VIDEO)
-    void nativeImageFromVideoFrame(const WebCore::VideoFrame&, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&&) final;
-#endif
 
 #if ENABLE(GPU_PROCESS)
     std::atomic<bool> m_useGPUProcess { false };

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -64,10 +64,7 @@ RefPtr<NativeImage> MediaPlayerPrivateRemote::nativeImageForCurrentTime()
         return { };
 
     RefPtr videoFrame = videoFrameForCurrentTime();
-    if (!videoFrame)
-        return nullptr;
-
-    return WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
+    return videoFrame ? videoFrame->copyNativeImage() : nullptr;
 }
 
 WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
@@ -46,17 +46,18 @@ class RemoteVideoFrameProxy;
 // Wrapper around RemoteVideoFrameObjectHeapProxyProcessor that will always be destroyed on main thread.
 class RemoteVideoFrameObjectHeapProxy : public ThreadSafeRefCounted<RemoteVideoFrameObjectHeapProxy, WTF::DestructionThread::MainRunLoop> {
 public:
-    static Ref<RemoteVideoFrameObjectHeapProxy> create(GPUProcessConnection& connection) { return adoptRef(*new RemoteVideoFrameObjectHeapProxy(connection)); }
+    static Ref<RemoteVideoFrameObjectHeapProxy> create() { return adoptRef(*new RemoteVideoFrameObjectHeapProxy()); }
 
+    void gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection&);
 #if PLATFORM(COCOA)
     void getVideoFrameBuffer(const RemoteVideoFrameProxy& proxy, bool canUseIOSurface, RemoteVideoFrameObjectHeapProxyProcessor::Callback&& callback) { m_processor->getVideoFrameBuffer(proxy, canUseIOSurface, WTFMove(callback)); }
     RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame& frame) { return m_processor->getNativeImage(frame); }
 #endif
 
 private:
-    explicit RemoteVideoFrameObjectHeapProxy(GPUProcessConnection& connection)
+    explicit RemoteVideoFrameObjectHeapProxy()
 #if PLATFORM(COCOA)
-        : m_processor(RemoteVideoFrameObjectHeapProxyProcessor::create(connection))
+        : m_processor(RemoteVideoFrameObjectHeapProxyProcessor::create())
 #endif
     {
     }
@@ -64,6 +65,14 @@ private:
     const Ref<RemoteVideoFrameObjectHeapProxyProcessor> m_processor;
 #endif
 };
+
+inline void RemoteVideoFrameObjectHeapProxy::gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection& gpuProcessConnection)
+{
+    UNUSED_PARAM(gpuProcessConnection);
+#if PLATFORM(COCOA)
+    m_processor->gpuProcessConnectionDidBecomeAvailable(gpuProcessConnection);
+#endif
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -57,8 +57,9 @@ class RemoteVideoFrameProxy;
 
 class RemoteVideoFrameObjectHeapProxyProcessor : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>, public GPUProcessConnection::Client {
 public:
-    static Ref<RemoteVideoFrameObjectHeapProxyProcessor> create(GPUProcessConnection&);
+    static Ref<RemoteVideoFrameObjectHeapProxyProcessor> create();
     ~RemoteVideoFrameObjectHeapProxyProcessor();
+    void gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection&);
 
     using Callback = Function<void(RetainPtr<CVPixelBufferRef>&&)>;
     void getVideoFrameBuffer(const RemoteVideoFrameProxy&, bool canUseIOSurfce, Callback&&);
@@ -71,8 +72,8 @@ public:
     void deref() const final { IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::deref(); }
 
 private:
-    explicit RemoteVideoFrameObjectHeapProxyProcessor(GPUProcessConnection&);
-    void initialize();
+    explicit RemoteVideoFrameObjectHeapProxyProcessor();
+    RefPtr<IPC::Connection> connection();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -47,6 +47,7 @@
 #include "RemoteMediaEngineConfigurationFactory.h"
 #include "RemoteMediaSessionManagerProxyMessages.h"
 #include "RemoteRemoteCommandListener.h"
+#include "RemoteSharedResourceCacheProxy.h"
 #include "RemoteWebLockRegistry.h"
 #include "RemoteWorkerType.h"
 #include "SpeechRecognitionRealtimeMediaSourceManager.h"
@@ -1543,10 +1544,13 @@ GPUProcessConnection& WebProcess::ensureGPUProcessConnection()
         if (gpuConnection->ignoreInvalidMessageForTesting())
             gpuConnection->setIgnoreInvalidMessageForTesting();
 #endif
-        m_gpuProcessConnection = GPUProcessConnection::create(WTFMove(gpuConnection));
+        Ref gpuProcessConnection = GPUProcessConnection::create(WTFMove(gpuConnection));
+        m_gpuProcessConnection = gpuProcessConnection.ptr();
         protectedParentProcessConnection()->send(Messages::WebProcessProxy::CreateGPUProcessConnection(m_gpuProcessConnection->identifier(),  WTFMove(connectionIdentifiers->client)), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
         for (auto& page : m_pageMap.values())
-            page->gpuProcessConnectionDidBecomeAvailable(Ref { *m_gpuProcessConnection });
+            page->gpuProcessConnectionDidBecomeAvailable(gpuProcessConnection);
+        if (m_sharedResourceCache)
+            Ref { *m_sharedResourceCache }->gpuProcessConnectionDidBecomeAvailable(gpuProcessConnection);
     }
     return *m_gpuProcessConnection;
 }
@@ -1605,6 +1609,15 @@ AudioMediaStreamTrackRendererInternalUnitManager& WebProcess::audioMediaStreamTr
 }
 #endif
 
+RemoteSharedResourceCacheProxy& WebProcess::gpuProcessSharedResourceCache()
+{
+    if (!m_sharedResourceCache) {
+        m_sharedResourceCache = RemoteSharedResourceCacheProxy::create();
+        if (m_gpuProcessConnection)
+            Ref { *m_sharedResourceCache }->gpuProcessConnectionDidBecomeAvailable(Ref { *m_gpuProcessConnection });
+    }
+    return *m_sharedResourceCache;
+}
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -145,6 +145,7 @@ class RemoteImageDecoderAVFManager;
 class RemoteLegacyCDMFactory;
 class RemoteMediaEngineConfigurationFactory;
 class RemoteMediaPlayerManager;
+class RemoteSharedResourceCacheProxy;
 class StorageAreaMap;
 class UserData;
 class WebAutomationSessionProxy;
@@ -328,6 +329,7 @@ public:
     Ref<RemoteCDMFactory> protectedCDMFactory();
 #endif
     RemoteMediaEngineConfigurationFactory& mediaEngineConfigurationFactory();
+    RemoteSharedResourceCacheProxy& gpuProcessSharedResourceCache();
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS)
@@ -831,6 +833,7 @@ private:
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
     std::unique_ptr<AudioMediaStreamTrackRendererInternalUnitManager> m_audioMediaStreamTrackRendererInternalUnitManager;
 #endif
+    RefPtr<RemoteSharedResourceCacheProxy> m_sharedResourceCache;
 #endif
 
 #if ENABLE(MODEL_PROCESS)


### PR DESCRIPTION
#### ac871ed0a668bd6fdd43e8590039b83fb3fd5d3e
<pre>
Add a common way to get NativeImage from a VideoFrame (VideoFrame::copyNativeImage())
<a href="https://bugs.webkit.org/show_bug.cg?id=302527">https://bugs.webkit.org/show_bug.cg?id=302527</a>
<a href="https://rdar.apple.com/164713414">rdar://164713414</a>

Reviewed by Youenn Fablet.

In order to use NativeImage and VideoFrame as the basic building blocks
of WebCore code, add a polymorphic VideoFrame::copyNativeImage() for
converting VideoFrame to a NativeImage.

Previously the conversion was done in ad hoc manner in cases where
it could be done, e.g. where the code had some sort of unrelated context
object such as RemoteMediaPlayerManager, AudioVideoRendererRemote,
WebGL context or WebGPU queue. Those object do not have much to do
with a particular VideoFrame, rather they&apos;re the target sinks of
the operations.

Local VideoFrame types, VideoFrameCV, VideoFrameGStreamer,
VideoFrameLibWebRTC have the data and are able to construct the
NativeImage directly. Use the same code as before. Later on, the
construction could be optimized for speed and memory use.

Remote VideoFrame type, RemoteVideoFrameProxy, holds the correct context
object for the source data, the RemoteVideoFrameObjectHeapProxy that
connects the WebContent process side reference to GPU process side
actual object. Use this to construct the NativeImage, same code as
before but invoke it directly.

Fix RemoteVideoFrameObjectHeapProxy instances to preserve across
GPUP restarts, because the RemoteVideoFrameProxy objects themselves
are persistent, held by WebCore object graphs as VideoFrame.

Later on, the holding functionality is will be moved to
RemoteSharedResourceCacheProxy. This will allow reference-only
conversion, e.g. getting RemoteNativeImageProxy out of
RemoteVideoFrameProxy.

This is work towards being able to use NativeImage as the basic
abstraction of image draw source, while not needing to transfer
the data between WCP and GPUP.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromVideoFrame):
(WebCore::imageBytesForSource):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::getNativeImage): Deleted.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::createImageBitmap):
(WebCore::createImageBitmapViaDrawing): Deleted.
(WebCore::createImageBitmapFromNativeImage): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource):
* Source/WebCore/platform/MediaStrategy.h:
(WebCore::MediaStrategy::nativeImageFromVideoFrame): Deleted.
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::drawVideoFrame):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawVideoFrame):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::videoFrameToImage): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::OperationRecorder::drawVideoFrame):
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrameCV::copyNativeImage const):
(WebCore::VideoFrame::draw): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::drawVideoFrame):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::copyNativeImage const):
(WebCore::VideoFrame::draw): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp:
(WebCore::VideoFrameLibWebRTC::copyNativeImage const):
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::sharedResourceCache):
(WebKit::GPUProcessConnection::videoFrameObjectHeapProxy):
(WebKit::GPUProcessConnection::protectedVideoFrameObjectHeapProxy):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp:
(WebKit::RemoteSharedResourceCacheProxy::gpuProcessConnectionDidBecomeAvailable):
(WebKit::RemoteSharedResourceCacheProxy::videoFrameObjectHeapProxy):
* Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::videoFrameToImage): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::drawVideoFrame):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::RemoteQueueProxy):
(WebKit::WebGPU::RemoteQueueProxy::getNativeImage): Deleted.
(WebKit::WebGPU::RemoteQueueProxy::protectedVideoFrameObjectHeapProxy const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::currentNativeImage const):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::setUseGPUProcess):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:
(WebKit::RemoteVideoFrameProxy::RemoteVideoFrameProxy):
(WebKit::m_videoFrameObjectHeapProxy):
(WebKit::RemoteVideoFrameProxy::copyNativeImage const):
(WebKit::RemoteVideoFrameProxy::pixelBuffer const):
(WebKit::m_pixelFormat): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::nativeImageFromVideoFrame): Deleted.
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::nativeImageForCurrentTime):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h:
(WebKit::RemoteVideoFrameObjectHeapProxy::create):
(WebKit::RemoteVideoFrameObjectHeapProxy::RemoteVideoFrameObjectHeapProxy):
(WebKit::RemoteVideoFrameObjectHeapProxy::gpuProcessConnectionDidBecomeAvailable):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::create):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::RemoteVideoFrameObjectHeapProxyProcessor):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::gpuProcessConnectionDidBecomeAvailable):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::gpuProcessConnectionDidClose):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::connection):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::initialize): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureGPUProcessConnection):
(WebKit::WebProcess::gpuProcessSharedResourceCache):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/303533@main">https://commits.webkit.org/303533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c108e5ced4c96edddd0bf61f0558ea17d9f939dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ada9b8cd-df78-4e83-9ccd-6c10d0429b35) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4989 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9e5275b-87e7-4e50-99cf-5cc2f3cc4905) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135681 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82275 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d0b655af-fb76-48df-a578-719d402a8318) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83500 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4900 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/37613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4982 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110036 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27891 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3743 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58385 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4954 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33529 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68405 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5045 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4911 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->