### PR TITLE
REGRESSION(302861@main): Broke TestWebKitAPI.SafeBrowsing.PhishingInFrame on Sonoma

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.h
@@ -43,7 +43,11 @@ public:
     CoreIPCError& operator=(CoreIPCError&&) = default;
 
     CoreIPCError(NSError *);
-    CoreIPCError(String&& domain, int64_t code, std::unique_ptr<CoreIPCError>&& underlyingError, std::optional<Vector<RetainPtr<SecCertificateRef>>>&& clientCertificateChain, std::optional<Vector<RetainPtr<SecCertificateRef>>>&& peerCertificateChain, String&& localizedDescription, String&& localizedFailureReasonError, String&& localizedRecoverySuggestionError, std::optional<Vector<String>>&& localizedRecoveryOptionsError, String&& localizedFailureError, String&& helpAnchorError, String&& debugDescriptionError, RetainPtr<NSNumber>&& stringEncodingError, RetainPtr<SecTrustRef>&& failingURLPeerTrustError, RetainPtr<NSURL>&& urlError, RetainPtr<NSURL>&& failingURLError, String&& filePathError, String&& networkTaskDescription, String&& networkTaskMetricsPrivacyStance, String&& description)
+    CoreIPCError(String&& domain, int64_t code, std::unique_ptr<CoreIPCError>&& underlyingError, std::optional<Vector<RetainPtr<SecCertificateRef>>>&& clientCertificateChain, std::optional<Vector<RetainPtr<SecCertificateRef>>>&& peerCertificateChain, String&& localizedDescription, String&& localizedFailureReasonError, String&& localizedRecoverySuggestionError, std::optional<Vector<String>>&& localizedRecoveryOptionsError, String&& localizedFailureError, String&& helpAnchorError, String&& debugDescriptionError, RetainPtr<NSNumber>&& stringEncodingError, RetainPtr<SecTrustRef>&& failingURLPeerTrustError, RetainPtr<NSURL>&& urlError, RetainPtr<NSURL>&& failingURLError,
+#if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
+        String&& failingURLStringError,
+#endif
+        String&& filePathError, String&& networkTaskDescription, String&& networkTaskMetricsPrivacyStance, String&& description)
         : m_domain(WTFMove(domain))
         , m_code(WTFMove(code))
         , m_underlyingError(WTFMove(underlyingError))
@@ -60,6 +64,9 @@ public:
         , m_failingURLPeerTrustError(WTFMove(failingURLPeerTrustError))
         , m_urlError(WTFMove(urlError))
         , m_failingURLError(WTFMove(failingURLError))
+#if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
+        , m_failingURLStringError(WTFMove(failingURLStringError))
+#endif
         , m_filePathError(WTFMove(filePathError))
         , m_networkTaskDescription(WTFMove(networkTaskDescription))
         , m_networkTaskMetricsPrivacyStance(WTFMove(networkTaskMetricsPrivacyStance))
@@ -92,6 +99,9 @@ private:
     RetainPtr<SecTrustRef> m_failingURLPeerTrustError;
     RetainPtr<NSURL> m_urlError;
     RetainPtr<NSURL> m_failingURLError;
+#if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
+    String m_failingURLStringError;
+#endif
 
     String m_filePathError;
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -82,6 +82,9 @@ RetainPtr<id> CoreIPCError::toID() const
     INJECT_VALUE(NSURLErrorFailingURLPeerTrustErrorKey, m_failingURLPeerTrustError)
     INJECT_VALUE(NSURLErrorKey, m_urlError)
     INJECT_VALUE(NSURLErrorFailingURLErrorKey, m_failingURLError)
+#if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
+    INJECT_STRING_VALUE(NSURLErrorFailingURLStringErrorKey, m_failingURLStringError)
+#endif
 
     INJECT_STRING_VALUE(NSFilePathErrorKey, m_filePathError)
 
@@ -197,6 +200,9 @@ CoreIPCError::CoreIPCError(NSError *nsError)
 
     EXTRACT_TYPED_VALUE(NSURLErrorKey, NSURL, m_urlError)
     EXTRACT_TYPED_VALUE(NSURLErrorFailingURLErrorKey, NSURL, m_failingURLError)
+#if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
+    EXTRACT_STRING_VALUE(NSURLErrorFailingURLStringErrorKey, m_failingURLStringError)
+#endif
 
     EXTRACT_STRING_VALUE(NSFilePathErrorKey, m_filePathError)
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
@@ -46,6 +46,9 @@ webkit_platform_headers: "CoreIPCError.h"
     RetainPtr<SecTrustRef> m_failingURLPeerTrustError;
     RetainPtr<NSURL> m_urlError;
     RetainPtr<NSURL> m_failingURLError;
+#if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
+    String m_failingURLStringError;
+#endif
 
     String m_filePathError;
     


### PR DESCRIPTION
#### e7d5a632454e42ae6f077f998b02b1e34c268481
<pre>
REGRESSION(302861@main): Broke TestWebKitAPI.SafeBrowsing.PhishingInFrame on Sonoma
<a href="https://bugs.webkit.org/show_bug.cgi?id=302374">https://bugs.webkit.org/show_bug.cgi?id=302374</a>
<a href="https://rdar.apple.com/164534162">rdar://164534162</a>

Reviewed by Abrar Rahman Protyasha.

Adds missing NSURLErrorFailingURLStringErrorKey to serialization of CoreIPCError.

* Source/WebKit/Shared/Cocoa/CoreIPCError.h:
(WebKit::CoreIPCError::CoreIPCError):
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::toID const):
(WebKit::CoreIPCError::CoreIPCError):
* Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303059@main">https://commits.webkit.org/303059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cf2e843ada2007dc62e7878e28da90811871783

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131029 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82708 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0826ed91-20d2-4863-8a5e-773ed8f683fc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e08f1bef-bc5c-4a9e-abb6-5120a4c2d61b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80529 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/25674ebb-f1cd-4a9d-8e7c-d3a18ee64b51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2306 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110914 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140965 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108336 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108293 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2343 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113635 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56142 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20404 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3164 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32058 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3094 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->