### PR TITLE
Replace nullptr with nullPtr() in WTF

### DIFF
--- a/Source/WTF/benchmarks/ConditionSpeedTest.cpp
+++ b/Source/WTF/benchmarks/ConditionSpeedTest.cpp
@@ -60,14 +60,14 @@ unsigned numMessagesPerProducer;
     exit(1);
 }
 
-template<typename Functor, typename ConditionType, typename LockType, typename std::enable_if<!std::is_same<ConditionType, std::condition_variable>::value>::type* = nullptr>
+template<typename Functor, typename ConditionType, typename LockType, typename std::enable_if<!std::is_same<ConditionType, std::condition_variable>::value>::type* = nullPtr()>
 void wait(ConditionType& condition, LockType& lock, std::unique_lock<LockType>&, const Functor& predicate)
 {
     while (!predicate())
         condition.wait(lock);
 }
 
-template<typename Functor, typename ConditionType, typename LockType, typename std::enable_if<std::is_same<ConditionType, std::condition_variable>::value>::type* = nullptr>
+template<typename Functor, typename ConditionType, typename LockType, typename std::enable_if<std::is_same<ConditionType, std::condition_variable>::value>::type* = nullPtr()>
 void wait(ConditionType& condition, LockType&, std::unique_lock<LockType>& locker, const Functor& predicate)
 {
     while (!predicate())

--- a/Source/WTF/icu/unicode/dcfmtsym.h
+++ b/Source/WTF/icu/unicode/dcfmtsym.h
@@ -506,7 +506,7 @@ private:
 
     char actualLocale[ULOC_FULLNAME_CAPACITY];
     char validLocale[ULOC_FULLNAME_CAPACITY];
-    const char16_t* currPattern = nullptr;
+    const char16_t* currPattern = nullPtr();
 
     UnicodeString currencySpcBeforeSym[UNUM_CURRENCY_SPACING_COUNT];
     UnicodeString currencySpcAfterSym[UNUM_CURRENCY_SPACING_COUNT];

--- a/Source/WTF/icu/unicode/decimfmt.h
+++ b/Source/WTF/icu/unicode/decimfmt.h
@@ -2192,7 +2192,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
 
     // One instance field for the implementation, keep all fields inside of an implementation
     // class defined in number_mapper.h
-    number::impl::DecimalFormatFields* fields = nullptr;
+    number::impl::DecimalFormatFields* fields = nullPtr();
 
     // Allow child class CompactDecimalFormat to access fProperties:
     friend class CompactDecimalFormat;

--- a/Source/WTF/icu/unicode/localematcher.h
+++ b/Source/WTF/icu/unicode/localematcher.h
@@ -529,15 +529,15 @@ public:
         bool ensureSupportedLocaleVector();
 
         UErrorCode errorCode_ = U_ZERO_ERROR;
-        UVector *supportedLocales_ = nullptr;
+        UVector *supportedLocales_ = nullPtr();
         int32_t thresholdDistance_ = -1;
         ULocMatchDemotion demotion_ = ULOCMATCH_DEMOTION_REGION;
-        Locale *defaultLocale_ = nullptr;
+        Locale *defaultLocale_ = nullPtr();
         bool withDefault_ = true;
         ULocMatchFavorSubtag favor_ = ULOCMATCH_FAVOR_LANGUAGE;
         ULocMatchDirection direction_ = ULOCMATCH_DIRECTION_WITH_ONE_WAY;
-        Locale *maxDistanceDesired_ = nullptr;
-        Locale *maxDistanceSupported_ = nullptr;
+        Locale *maxDistanceDesired_ = nullPtr();
+        Locale *maxDistanceSupported_ = nullPtr();
     };
 
     // FYI No public LocaleMatcher constructors in C++; use the Builder.

--- a/Source/WTF/icu/unicode/numberformatter.h
+++ b/Source/WTF/icu/unicode/numberformatter.h
@@ -1573,10 +1573,10 @@ struct U_I18N_API MacroProps : public UMemory {
     StringProp unitDisplayCase;  // = StringProp();  (nominative)
 
     /** @internal */
-    const AffixPatternProvider* affixProvider = nullptr;  // no ownership
+    const AffixPatternProvider* affixProvider = nullPtr();  // no ownership
 
     /** @internal */
-    const PluralRules* rules = nullptr;  // no ownership
+    const PluralRules* rules = nullPtr();  // no ownership
 
     /** @internal */
     int32_t threshold = kInternalDefaultThreshold;

--- a/Source/WTF/icu/unicode/rbbi.h
+++ b/Source/WTF/icu/unicode/rbbi.h
@@ -134,7 +134,7 @@ public:
      * Not for general use; Public only for testing purposes.
      * @internal
      */
-    RBBIDataWrapper    *fData = nullptr;
+    RBBIDataWrapper    *fData = nullPtr();
 
 private:
     /**
@@ -158,14 +158,14 @@ private:
      *   Cache of previously determined boundary positions.
      */
     class BreakCache;
-    BreakCache         *fBreakCache = nullptr;
+    BreakCache         *fBreakCache = nullPtr();
 
     /**
      *  Cache of boundary positions within a region of text that has been
      *  sub-divided by dictionary based breaking.
      */
     class DictionaryCache;
-    DictionaryCache *fDictionaryCache = nullptr;
+    DictionaryCache *fDictionaryCache = nullPtr();
 
     /**
      *
@@ -174,7 +174,7 @@ private:
      * handle a given character.
      * @internal (private)
      */
-    UStack              *fLanguageBreakEngines = nullptr;
+    UStack              *fLanguageBreakEngines = nullPtr();
 
     /**
      *
@@ -183,7 +183,7 @@ private:
      * LanguageBreakEngine.
      * @internal (private)
      */
-    UnhandledEngine     *fUnhandledBreakEngine = nullptr;
+    UnhandledEngine     *fUnhandledBreakEngine = nullPtr();
 
     /**
      * Counter for the number of characters encountered with the "dictionary"
@@ -214,7 +214,7 @@ private:
     /**
      *  Array of look-ahead tentative results.
      */
-    int32_t *fLookAheadMatches = nullptr;
+    int32_t *fLookAheadMatches = nullPtr();
 
     /**
      *  A flag to indicate if phrase based breaking is enabled.

--- a/Source/WTF/icu/unicode/reldatefmt.h
+++ b/Source/WTF/icu/unicode/reldatefmt.h
@@ -697,7 +697,7 @@ private:
 #if !UCONFIG_NO_BREAK_ITERATION
     const SharedBreakIterator *fOptBreakIterator;
 #else
-    std::nullptr_t fOptBreakIterator = nullptr;
+    std::nullptr_t fOptBreakIterator = nullPtr();
 #endif // !UCONFIG_NO_BREAK_ITERATION
     Locale fLocale;
     void init(

--- a/Source/WTF/icu/unicode/simplenumberformatter.h
+++ b/Source/WTF/icu/unicode/simplenumberformatter.h
@@ -142,7 +142,7 @@ class U_I18N_API SimpleNumber : public UMemory {
     SimpleNumber(SimpleNumber&& other) noexcept {
         fData = other.fData;
         fSign = other.fSign;
-        other.fData = nullptr;
+        other.fData = nullPtr();
     }
 
     /**
@@ -154,7 +154,7 @@ class U_I18N_API SimpleNumber : public UMemory {
         cleanup();
         fData = other.fData;
         fSign = other.fSign;
-        other.fData = nullptr;
+        other.fData = nullPtr();
         return *this;
     }
 
@@ -165,7 +165,7 @@ class U_I18N_API SimpleNumber : public UMemory {
 
     void cleanup();
 
-    impl::UFormattedNumberData* fData = nullptr;
+    impl::UFormattedNumberData* fData = nullPtr();
     USimpleNumberSign fSign = UNUM_SIMPLE_NUMBER_NO_SIGN;
 
     friend class SimpleNumberFormatter;
@@ -272,9 +272,9 @@ class U_I18N_API SimpleNumberFormatter : public UMemory {
         fOwnedSymbols = other.fOwnedSymbols;
         fMicros = other.fMicros;
         fPatternModifier = other.fPatternModifier;
-        other.fOwnedSymbols = nullptr;
-        other.fMicros = nullptr;
-        other.fPatternModifier = nullptr;
+        other.fOwnedSymbols = nullPtr();
+        other.fMicros = nullPtr();
+        other.fPatternModifier = nullPtr();
     }
 
     /**
@@ -288,9 +288,9 @@ class U_I18N_API SimpleNumberFormatter : public UMemory {
         fOwnedSymbols = other.fOwnedSymbols;
         fMicros = other.fMicros;
         fPatternModifier = other.fPatternModifier;
-        other.fOwnedSymbols = nullptr;
-        other.fMicros = nullptr;
-        other.fPatternModifier = nullptr;
+        other.fOwnedSymbols = nullPtr();
+        other.fMicros = nullPtr();
+        other.fPatternModifier = nullPtr();
         return *this;
     }
 
@@ -310,9 +310,9 @@ class U_I18N_API SimpleNumberFormatter : public UMemory {
     UNumberGroupingStrategy fGroupingStrategy = UNUM_GROUPING_AUTO;
 
     // Owned Pointers:
-    DecimalFormatSymbols* fOwnedSymbols = nullptr; // can be empty
-    impl::SimpleMicroProps* fMicros = nullptr;
-    impl::AdoptingSignumModifierStore* fPatternModifier = nullptr;
+    DecimalFormatSymbols* fOwnedSymbols = nullPtr(); // can be empty
+    impl::SimpleMicroProps* fMicros = nullPtr();
+    impl::AdoptingSignumModifierStore* fPatternModifier = nullPtr();
 };
 
 

--- a/Source/WTF/icu/unicode/smpdtfmt.h
+++ b/Source/WTF/icu/unicode/smpdtfmt.h
@@ -1595,12 +1595,12 @@ private:
      * A pointer to an object containing the strings to use in formatting (e.g.,
      * month and day names, AM and PM strings, time zone names, etc.)
      */
-    DateFormatSymbols*  fSymbols = nullptr;   // Owned
+    DateFormatSymbols*  fSymbols = nullPtr();   // Owned
 
     /**
      * The time zone formatter
      */
-    TimeZoneFormat* fTimeZoneFormat = nullptr;
+    TimeZoneFormat* fTimeZoneFormat = nullPtr();
 
     /**
      * If dates have ambiguous years, we map them into the century starting
@@ -1640,7 +1640,7 @@ private:
      * The number format in use for each date field. nullptr means fall back
      * to fNumberFormat in DateFormat.
      */
-    const SharedNumberFormat    **fSharedNumberFormatters = nullptr;
+    const SharedNumberFormat    **fSharedNumberFormatters = nullPtr();
 
     /**
      * Number formatter pre-allocated for fast performance
@@ -1649,11 +1649,11 @@ private:
      * of DecimalFormat (and is otherwise null). This should always be cleaned up before
      * destroying fNumberFormatter.
      */
-    const number::SimpleNumberFormatter* fSimpleNumberFormatter = nullptr;
+    const number::SimpleNumberFormatter* fSimpleNumberFormatter = nullPtr();
 
     UBool fHaveDefaultCentury;
 
-    const BreakIterator* fCapitalizationBrkIter = nullptr;
+    const BreakIterator* fCapitalizationBrkIter = nullPtr();
 };
 
 inline UDate

--- a/Source/WTF/icu/unicode/stringpiece.h
+++ b/Source/WTF/icu/unicode/stringpiece.h
@@ -210,7 +210,7 @@ class U_COMMON_API StringPiece : public UMemory {
    * Sets to an empty string.
    * @stable ICU 4.2
    */
-  void clear() { ptr_ = nullptr; length_ = 0; }
+  void clear() { ptr_ = nullPtr(); length_ = 0; }
 
   /**
    * Reset the stringpiece to refer to new data.

--- a/Source/WTF/icu/unicode/uniset.h
+++ b/Source/WTF/icu/unicode/uniset.h
@@ -297,8 +297,8 @@ private:
     int32_t len = 1; // length of list used; 1 <= len <= capacity
     uint8_t fFlags = 0;         // Bit flag (see constants above)
 
-    BMPSet *bmpSet = nullptr; // The set is frozen iff either bmpSet or stringSpan is not nullptr.
-    UChar32* buffer = nullptr; // internal buffer, may be nullptr
+    BMPSet *bmpSet = nullPtr(); // The set is frozen iff either bmpSet or stringSpan is not nullptr.
+    UChar32* buffer = nullPtr(); // internal buffer, may be nullptr
     int32_t bufferCapacity = 0; // capacity of buffer
 
     /**
@@ -310,11 +310,11 @@ private:
      * indicating that toPattern() must generate a pattern
      * representation from the inversion list.
      */
-    char16_t *pat = nullptr;
+    char16_t *pat = nullPtr();
     int32_t patLen = 0;
 
-    UVector* strings = nullptr; // maintained in sorted order
-    UnicodeSetStringSpan *stringSpan = nullptr;
+    UVector* strings = nullPtr(); // maintained in sorted order
+    UnicodeSetStringSpan *stringSpan = nullPtr();
 
     /**
      * Initial list array.

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -84,7 +84,7 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
 #if USE(CF)
     if (contains(formatSpan, "%@"_span)) {
         auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
-        auto result = adoptCF(CFStringCreateWithFormatAndArguments(kCFAllocatorDefault, nullptr, cfFormat.get(), args));
+        auto result = adoptCF(CFStringCreateWithFormatAndArguments(kCFAllocatorDefault, nullPtr(), cfFormat.get(), args));
         va_end(argsCopy);
         return result.get();
     }
@@ -161,9 +161,9 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
 
 #if USE(CF)
     if (contains(formatSpan, "%@"_span)) {
-        auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, format, kCFStringEncodingUTF8, kCFAllocatorNull));
+        auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(nullPtr(), format, kCFStringEncodingUTF8, kCFAllocatorNull));
 
-        auto str = adoptCF(CFStringCreateWithFormatAndArguments(nullptr, nullptr, cfFormat.get(), args));
+        auto str = adoptCF(CFStringCreateWithFormatAndArguments(nullPtr(), nullPtr(), cfFormat.get(), args));
         CFIndex length = CFStringGetMaximumSizeForEncoding(CFStringGetLength(str.get()), kCFStringEncodingUTF8);
         constexpr unsigned InitialBufferSize { 256 };
         Vector<char, InitialBufferSize> buffer(length + 1);
@@ -224,7 +224,7 @@ static void vprintf_stderr_with_prefix(const char* rawPrefix, const char* rawFor
     formatWithPrefix[prefix.size() + format.size()] = 0;
 
 ALLOW_NONLITERAL_FORMAT_BEGIN
-    vprintf_stderr_common(nullptr, formatWithPrefix.span().data(), args);
+    vprintf_stderr_common(nullPtr(), formatWithPrefix.span().data(), args);
 ALLOW_NONLITERAL_FORMAT_END
 }
 
@@ -252,7 +252,7 @@ static void printf_stderr_common(const char* format, ...)
 {
     va_list args;
     va_start(args, format);
-    vprintf_stderr_common(nullptr, format, args);
+    vprintf_stderr_common(nullPtr(), format, args);
     va_end(args);
 }
 
@@ -304,7 +304,7 @@ public:
     WTF_ATTRIBUTE_NSSTRING(2, 0)
     void vprintf(const char* format, va_list argList) final
     {
-        vprintf_stderr_common(nullptr, format, argList);
+        vprintf_stderr_common(nullPtr(), format, argList);
     }
 };
 
@@ -417,7 +417,7 @@ bool WTFIsDebuggerAttached()
     struct kinfo_proc info;
     int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
     size_t size = sizeof(info);
-    if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), &info, &size, nullptr, 0) == -1)
+    if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), &info, &size, nullPtr(), 0) == -1)
         return false;
     return info.kp_proc.p_flag & P_TRACED;
 #else
@@ -570,7 +570,7 @@ ALLOW_NONLITERAL_FORMAT_END
 
 void WTFLogAlwaysV(const char* format, va_list args)
 {
-    vprintf_stderr_with_trailing_newline(nullptr, format, args);
+    vprintf_stderr_with_trailing_newline(nullPtr(), format, args);
 }
 
 void WTFLogAlways(const char* format, ...)
@@ -598,7 +598,7 @@ WTFLogChannel* WTFLogChannelByName(WTFLogChannel* channels[], size_t count, cons
             return channel;
     }
 
-    return nullptr;
+    return nullPtr();
 }
 
 static void setStateOfAllChannels(WTFLogChannel* channels[], size_t channelCount, WTFLogChannelState state)

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -314,14 +314,6 @@ inline void dependentLoadLoadFence() { compilerFence(); }
 inline void dependentLoadLoadFence() { loadLoadFence(); }
 #endif
 
-// We use this primitive to hide an atomic variable from the optimizer.
-template<typename T>
-inline T opaque(T value)
-{
-    asm ("" : "+r"(value) ::);
-    return value;
-}
-
 // We use this primitive on ARM to express memory ordering efficiently.
 template<typename T>
 inline T* addOpaqueZero(T* pointer, unsigned opaqueZero)

--- a/Source/WTF/wtf/Bag.h
+++ b/Source/WTF/wtf/Bag.h
@@ -44,7 +44,7 @@ public:
     { }
     
     T m_item;
-    typename PtrTraits::StorageType m_next { nullptr };
+    typename PtrTraits::StorageType m_next { nullPtr() };
 };
 
 template<typename T, typename PassedPtrTraits = RawPtrTraits<T>, typename Malloc = FastMalloc>
@@ -62,7 +62,7 @@ public:
     {
         ASSERT(!m_head);
         m_head = other.unwrappedHead();
-        other.m_head = nullptr;
+        other.m_head = nullPtr();
     }
 
     template<typename U>
@@ -74,7 +74,7 @@ public:
         Bag destroy;
         destroy.m_head = unwrappedHead();
         m_head = other.unwrappedHead();
-        other.m_head = nullptr;
+        other.m_head = nullPtr();
 
         return *this;
     }
@@ -93,7 +93,7 @@ public:
             current->~Node();
             Malloc::free(current);
         }
-        m_head = nullptr;
+        m_head = nullPtr();
     }
     
     template<typename... Args>
@@ -154,7 +154,7 @@ public:
 private:
     Node* unwrappedHead() const { return PtrTraits::unwrap(m_head); }
 
-    typename PtrTraits::StorageType m_head { nullptr };
+    typename PtrTraits::StorageType m_head { nullPtr() };
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -89,7 +89,7 @@ public:
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(iterator);
     public:
         constexpr iterator()
-            : m_bitSet(nullptr)
+            : m_bitSet(nullPtr())
             , m_index(0)
         {
         }

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -361,7 +361,7 @@ public:
         }
         
     private:
-        const BitVector* m_bitVector { nullptr };
+        const BitVector* m_bitVector { nullPtr() };
         size_t m_index { 0 };
     };
 

--- a/Source/WTF/wtf/BlockPtr.h
+++ b/Source/WTF/wtf/BlockPtr.h
@@ -109,7 +109,7 @@ public:
 
             // We keep the copy function null - the block is already on the heap
             // so it should never be copied.
-            nullptr,
+            nullPtr(),
 
             [](const void* ptr) {
                 static_cast<Block*>(const_cast<void*>(ptr))->f.~F();
@@ -144,7 +144,7 @@ public:
     }
 
     BlockPtr()
-        : m_block(nullptr)
+        : m_block(nullPtr())
     {
     }
 
@@ -167,7 +167,7 @@ public:
     }
     
     BlockPtr(BlockPtr&& other)
-        : m_block(std::exchange(other.m_block, nullptr))
+        : m_block(std::exchange(other.m_block, nullPtr()))
     {
     }
     
@@ -199,7 +199,7 @@ public:
 #if !__has_feature(objc_arc)
         Block_release(m_block);
 #endif
-        m_block = std::exchange(other.m_block, nullptr);
+        m_block = std::exchange(other.m_block, nullPtr());
 
         return *this;
     }

--- a/Source/WTF/wtf/Box.h
+++ b/Source/WTF/wtf/Box.h
@@ -60,7 +60,7 @@ public:
     T* get() const
     {
         if (!isValid())
-            return nullptr;
+            return nullPtr();
         return &m_data->value;
     }
 

--- a/Source/WTF/wtf/BumpPointerAllocator.h
+++ b/Source/WTF/wtf/BumpPointerAllocator.h
@@ -101,8 +101,8 @@ private:
     BumpPointerPool(const PageAllocation& allocation, size_t remainingCapacity)
         : m_current(allocation.base())
         , m_start(allocation.base())
-        , m_next(nullptr)
-        , m_previous(nullptr)
+        , m_next(nullPtr())
+        , m_previous(nullPtr())
         , m_allocation(allocation)
         , m_remainingCapacity(remainingCapacity)
     {
@@ -113,7 +113,7 @@ private:
         // Add size of BumpPointerPool object, check for overflow.
         minimumCapacity += sizeof(BumpPointerPool);
         if (minimumCapacity < sizeof(BumpPointerPool))
-            return nullptr;
+            return nullPtr();
 
         size_t poolSize = std::max(static_cast<size_t>(MINIMUM_BUMP_POOL_SIZE), WTF::pageSize());
         while (poolSize < minimumCapacity) {
@@ -121,16 +121,16 @@ private:
             // The following if check relies on MINIMUM_BUMP_POOL_SIZE being a power of 2!
             ASSERT(!(MINIMUM_BUMP_POOL_SIZE & (MINIMUM_BUMP_POOL_SIZE - 1)));
             if (!poolSize)
-                return nullptr;
+                return nullPtr();
         }
 
         if (poolSize > remainingCapacity)
-            return nullptr;
+            return nullPtr();
 
         PageAllocation allocation = PageAllocation::allocate(poolSize);
         if (!!allocation)
             return new (allocation) BumpPointerPool(allocation, remainingCapacity - poolSize);
-        return nullptr;
+        return nullPtr();
     }
 
     void shrink()
@@ -162,7 +162,7 @@ private:
                 // We've run to the end; allocate a new pool.
                 pool = BumpPointerPool::create(previousPool->m_remainingCapacity, size);
                 if (!pool) [[unlikely]]
-                    return nullptr;
+                    return nullPtr();
                 previousPool->m_next = pool;
                 pool->m_previous = previousPool;
                 return pool;
@@ -231,7 +231,7 @@ class BumpPointerAllocator {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(BumpPointerAllocator);
 public:
     BumpPointerAllocator()
-        : m_head(nullptr)
+        : m_head(nullPtr())
     {
     }
 

--- a/Source/WTF/wtf/CagedPtr.h
+++ b/Source/WTF/wtf/CagedPtr.h
@@ -46,9 +46,9 @@ public:
     static constexpr unsigned maxNumberOfAllowedPACBits = numberOfPointerBits - OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
     static constexpr uintptr_t nonPACBitsMask = (1ull << (numberOfPointerBits - maxNumberOfAllowedPACBits)) - 1;
 
-    CagedPtr() : CagedPtr(nullptr) { }
+    CagedPtr() : CagedPtr(nullPtr()) { }
     CagedPtr(std::nullptr_t)
-        : m_ptr(nullptr)
+        : m_ptr(nullPtr())
     { }
 
     CagedPtr(T* ptr)
@@ -66,7 +66,7 @@ public:
     {
         T* ptr = PtrTraits::unwrap(m_ptr);
         if (!ptr)
-            return nullptr;
+            return nullPtr();
         return Gigacage::caged(kind, ptr);
     }
 
@@ -95,13 +95,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     CagedPtr(CagedPtr&& other)
-        : m_ptr(PtrTraits::exchange(other.m_ptr, nullptr))
+        : m_ptr(PtrTraits::exchange(other.m_ptr, nullPtr()))
     {
     }
 
     CagedPtr& operator=(CagedPtr&& ptr)
     {
-        m_ptr = PtrTraits::exchange(ptr.m_ptr, nullptr);
+        m_ptr = PtrTraits::exchange(ptr.m_ptr, nullPtr());
         return *this;
     }
 

--- a/Source/WTF/wtf/CagedUniquePtr.h
+++ b/Source/WTF/wtf/CagedUniquePtr.h
@@ -76,7 +76,7 @@ public:
     {
         destroy();
         this->m_ptr = ptr.m_ptr;
-        ptr.m_ptr = nullptr;
+        ptr.m_ptr = nullPtr();
         return *this;
     }
     

--- a/Source/WTF/wtf/CancellableTask.h
+++ b/Source/WTF/wtf/CancellableTask.h
@@ -50,7 +50,7 @@ private:
 class TaskCancellationGroupHandle {
 public:
     bool isCancelled() const { return !m_impl; }
-    void clear() { m_impl = nullptr; }
+    void clear() { m_impl = nullPtr(); }
 private:
     friend class TaskCancellationGroup;
     explicit TaskCancellationGroupHandle(TaskCancellationGroupImpl& impl)

--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -44,11 +44,11 @@ class CheckedPtr {
 public:
 
     constexpr CheckedPtr()
-        : m_ptr(nullptr)
+        : m_ptr(nullPtr())
     { }
 
     constexpr CheckedPtr(std::nullptr_t)
-        : m_ptr(nullptr)
+        : m_ptr(nullPtr())
     { }
 
     ALWAYS_INLINE CheckedPtr(T* ptr)
@@ -64,7 +64,7 @@ public:
     }
 
     ALWAYS_INLINE CheckedPtr(CheckedPtr&& other)
-        : m_ptr { PtrTraits::exchange(other.m_ptr, nullptr) }
+        : m_ptr { PtrTraits::exchange(other.m_ptr, nullPtr()) }
     {
     }
 
@@ -78,7 +78,7 @@ public:
     { }
 
     template<typename OtherType, typename OtherPtrTraits> CheckedPtr(CheckedPtr<OtherType, OtherPtrTraits>&& other)
-        : m_ptr { OtherPtrTraits::exchange(other.m_ptr, nullptr) }
+        : m_ptr { OtherPtrTraits::exchange(other.m_ptr, nullPtr()) }
     {
     }
 
@@ -118,7 +118,7 @@ public:
     CheckedRef<T> releaseNonNull()
     {
         RELEASE_ASSERT(m_ptr);
-        auto& ptr = *PtrTraits::unwrap(std::exchange(m_ptr, nullptr));
+        auto& ptr = *PtrTraits::unwrap(std::exchange(m_ptr, nullPtr()));
         return CheckedRef { ptr, CheckedRef<T>::Adopt };
     }
 
@@ -133,7 +133,7 @@ public:
     CheckedPtr& operator=(std::nullptr_t)
     {
         derefIfNotNull();
-        m_ptr = nullptr;
+        m_ptr = nullPtr();
         return *this;
     }
 
@@ -216,7 +216,7 @@ inline bool is(const CheckedPtr<ArgType, ArgPtrTraits>& source)
 }
 
 template<typename P> struct HashTraits<CheckedPtr<P>> : SimpleClassHashTraits<CheckedPtr<P>> {
-    static P* emptyValue() { return nullptr; }
+    static P* emptyValue() { return nullPtr(); }
     static bool isEmptyValue(const CheckedPtr<P>& value) { return !value; }
 
     typedef P* PeekType;

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -52,7 +52,7 @@ public:
     ~CheckedRef()
     {
         unpoison(*this);
-        if (auto* ptr = PtrTraits::exchange(m_ptr, nullptr))
+        if (auto* ptr = PtrTraits::exchange(m_ptr, nullPtr()))
             PtrTraits::unwrap(ptr)->decrementCheckedPtrCount();
     }
 
@@ -101,7 +101,7 @@ public:
 
     CheckedRef(HashTableEmptyValueType) : m_ptr(hashTableEmptyValue()) { }
     bool isHashTableEmptyValue() const { return m_ptr == hashTableEmptyValue(); }
-    static T* hashTableEmptyValue() { return nullptr; }
+    static T* hashTableEmptyValue() { return nullPtr(); }
 
     const T* ptrAllowingHashTableEmptyValue() const { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
     T* ptrAllowingHashTableEmptyValue() { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
@@ -176,7 +176,7 @@ private:
 
     T* releasePtr()
     {
-        T* ptr = PtrTraits::exchange(m_ptr, nullptr);
+        T* ptr = PtrTraits::exchange(m_ptr, nullPtr());
         poison(*this);
         return ptr;
     }

--- a/Source/WTF/wtf/CodePtr.h
+++ b/Source/WTF/wtf/CodePtr.h
@@ -181,7 +181,7 @@ public:
     T dataLocation() const
     {
         ASSERT_VALID_CODE_POINTER(m_value);
-        return std::bit_cast<T>(m_value ? std::bit_cast<char*>(m_value) - 1 : nullptr);
+        return std::bit_cast<T>(m_value ? std::bit_cast<char*>(m_value) - 1 : nullPtr());
     }
 #else
     template<typename T = void*>
@@ -219,7 +219,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (m_value)
             CodePtrBase::dumpWithName(taggedPtr(), dataLocation(), name, out);
         else
-            CodePtrBase::dumpWithName(nullptr, nullptr, name, out);
+            CodePtrBase::dumpWithName(nullPtr(), nullPtr(), name, out);
     }
 
     void dump(PrintStream& out) const { dumpWithName("CodePtr"_s, out); }
@@ -274,7 +274,7 @@ private:
         return result;
     }
 
-    void* m_value { nullptr };
+    void* m_value { nullPtr() };
 
     template<PtrTag, FunctionAttributes> friend class CodePtr;
 };

--- a/Source/WTF/wtf/CompactPointerTuple.h
+++ b/Source/WTF/wtf/CompactPointerTuple.h
@@ -149,7 +149,7 @@ public:
     }
 
 private:
-    PointerType m_pointer { nullptr };
+    PointerType m_pointer { nullPtr() };
     Type m_type { 0 };
 #endif
 

--- a/Source/WTF/wtf/CompactPtr.h
+++ b/Source/WTF/wtf/CompactPtr.h
@@ -94,7 +94,7 @@ public:
 
     CompactPtr<T>& operator=(std::nullptr_t)
     {
-        exchange(nullptr);
+        exchange(nullPtr());
         return *this;
     }
 
@@ -149,7 +149,7 @@ public:
         return oldValue;
     }
 
-    void swap(std::nullptr_t) { set(nullptr); }
+    void swap(std::nullptr_t) { set(nullPtr()); }
 
     void swap(CompactPtr& other) { std::swap(m_ptr, other.m_ptr); }
 

--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -61,7 +61,7 @@ public:
     {
         m_data.setPointer(other.pointer());
         m_data.setType(other.type());
-        other.m_data.setPointer(nullptr);
+        other.m_data.setPointer(nullPtr());
         other.m_data.setType({ });
     }
 

--- a/Source/WTF/wtf/CompactUniquePtrTuple.h
+++ b/Source/WTF/wtf/CompactUniquePtrTuple.h
@@ -63,7 +63,7 @@ public:
 
     ~CompactUniquePtrTuple()
     {
-        setPointer(nullptr);
+        setPointer(nullPtr());
     }
 
     template<typename U, typename UDeleter>
@@ -80,14 +80,14 @@ public:
     std::unique_ptr<T, Deleter> moveToUniquePtr()
     {
         T* pointer = m_data.pointer();
-        m_data.setPointer(nullptr);
+        m_data.setPointer(nullPtr());
         return std::unique_ptr<T, Deleter>(pointer);
     }
 
     void setPointer(std::nullptr_t)
     {
         deletePointer();
-        m_data.setPointer(nullptr);
+        m_data.setPointer(nullPtr());
     }
 
     template<typename U, typename UDeleter>

--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -91,7 +91,7 @@ public:
     {
         assertIsCurrent(m_callThread);
         ASSERT_WITH_MESSAGE(m_function, "Completion handler should not be called more than once");
-        return std::exchange(m_function, nullptr)(std::forward<In>(in)...);
+        return std::exchange(m_function, nullPtr())(std::forward<In>(in)...);
     }
 
 private:
@@ -136,7 +136,7 @@ public:
     {
         assertIsCurrent(m_callThread);
         ASSERT_WITH_MESSAGE(m_function, "Completion handler should not be called more than once");
-        return std::exchange(m_function, nullptr)(std::forward<In>(in)...);
+        return std::exchange(m_function, nullPtr())(std::forward<In>(in)...);
     }
 
 private:

--- a/Source/WTF/wtf/ConcurrentBuffer.h
+++ b/Source/WTF/wtf/ConcurrentBuffer.h
@@ -109,7 +109,7 @@ private:
         return result;
     }
     
-    Array* m_array { nullptr };
+    Array* m_array { nullPtr() };
     Vector<ArrayPtr> m_allArrays;
 };
 

--- a/Source/WTF/wtf/ConcurrentPtrHashSet.cpp
+++ b/Source/WTF/wtf/ConcurrentPtrHashSet.cpp
@@ -74,7 +74,7 @@ bool ConcurrentPtrHashSet::addSlow(Table* table, unsigned mask, unsigned startIn
         return resizeAndAdd(ptr);
     
     for (;;) {
-        void* oldEntry = table->at(index).compareExchangeStrong(nullptr, ptr);
+        void* oldEntry = table->at(index).compareExchangeStrong(nullPtr(), ptr);
         if (!oldEntry) {
             if (m_table.load() != table) {
                 // We added an entry to an old table! We need to reexecute the add on the new table.
@@ -189,7 +189,7 @@ std::unique_ptr<ConcurrentPtrHashSet::Table> ConcurrentPtrHashSet::Table::create
     result->mask = size - 1;
     result->load.storeRelaxed(0);
     for (unsigned i = 0; i < size; ++i)
-        result->at(i).storeRelaxed(nullptr);
+        result->at(i).storeRelaxed(nullPtr());
     return result;
 }
 
@@ -206,7 +206,7 @@ std::unique_ptr<ConcurrentPtrHashSet::Table> ConcurrentPtrHashSet::Table::create
     result->size = 0;
     result->mask = 0;
     result->load.storeRelaxed(stubDefaultLoadValue);
-    result->at(0).storeRelaxed(nullptr);
+    result->at(0).storeRelaxed(nullPtr());
     return result;
 }
 

--- a/Source/WTF/wtf/ConcurrentPtrHashSet.h
+++ b/Source/WTF/wtf/ConcurrentPtrHashSet.h
@@ -129,7 +129,7 @@ private:
             void* ptr;
             T value;
         } u;
-        u.ptr = nullptr;
+        u.ptr = nullPtr();
         u.value = value;
         return u.ptr;
     }

--- a/Source/WTF/wtf/CoroutineUtilities.h
+++ b/Source/WTF/wtf/CoroutineUtilities.h
@@ -35,12 +35,12 @@ class CoroutineHandle {
 public:
     CoroutineHandle() = default;
     CoroutineHandle(std::coroutine_handle<PromiseType>&& handle)
-        : m_handle(std::exchange(handle, nullptr)) { }
+        : m_handle(std::exchange(handle, nullPtr())) { }
     CoroutineHandle(CoroutineHandle&& other)
-        : m_handle(std::exchange(other.m_handle, nullptr)) { }
+        : m_handle(std::exchange(other.m_handle, nullPtr())) { }
     CoroutineHandle& operator=(CoroutineHandle&& other)
     {
-        m_handle = std::exchange(other.m_handle, nullptr);
+        m_handle = std::exchange(other.m_handle, nullPtr());
         return *this;
     }
     CoroutineHandle(const CoroutineHandle&) = delete;
@@ -114,7 +114,7 @@ public:
         std::coroutine_handle<promise_type> m_coroutine;
     };
     Awaitable(std::coroutine_handle<promise_type> coroutine)
-        : m_coroutine(std::exchange(coroutine, nullptr)) { }
+        : m_coroutine(std::exchange(coroutine, nullPtr())) { }
     AwaitableHelper operator co_await() const { return { m_coroutine.handle() }; }
 private:
     CoroutineHandle<promise_type> m_coroutine;

--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -317,7 +317,7 @@ template<typename T, typename U> struct CrossThreadCopierBase<false, false, Mark
 
 template<> struct CrossThreadCopierBase<false, false, std::nullptr_t> {
     static constexpr bool IsNeeded = false;
-    static std::nullptr_t copy(std::nullptr_t) { return nullptr; }
+    static std::nullptr_t copy(std::nullptr_t) { return nullPtr(); }
 };
 
 // Default specialization for Variant of CrossThreadCopyable classes.

--- a/Source/WTF/wtf/CrossThreadTaskHandler.cpp
+++ b/Source/WTF/wtf/CrossThreadTaskHandler.cpp
@@ -75,7 +75,7 @@ void CrossThreadTaskHandler::taskRunLoop()
     }
 
     while (auto task = m_taskQueue.waitForMessage()) {
-        std::unique_ptr<AutodrainedPool> autodrainedPool = (m_useAutodrainedPool == AutodrainedPoolForRunLoop::Use) ? makeUnique<AutodrainedPool>() : nullptr;
+        std::unique_ptr<AutodrainedPool> autodrainedPool = (m_useAutodrainedPool == AutodrainedPoolForRunLoop::Use) ? makeUnique<AutodrainedPool>() : nullPtr();
 
         task.performTask();
     }

--- a/Source/WTF/wtf/DataLog.cpp
+++ b/Source/WTF/wtf/DataLog.cpp
@@ -73,7 +73,7 @@ static uint64_t s_lockedFileData[(sizeof(LockedPrintStream) + 7) / 8];
 
 static void initializeLogFileOnce()
 {
-    const char* filename = nullptr;
+    const char* filename = nullPtr();
 
     if (s_file)
         return;
@@ -133,7 +133,7 @@ static void initializeLogFile()
 
 void setDataFile(const char* path)
 {
-    FilePrintStream* file = nullptr;
+    FilePrintStream* file = nullPtr();
     std::array<char, maxPathLength + 1> formattedPath;
     const char* pathToOpen = path;
 
@@ -170,7 +170,7 @@ void setDataFile(const char* path)
         file = new (s_fileData) FilePrintStream(stderr, FilePrintStream::Borrow);
     }
 
-    setvbuf(file->file(), nullptr, _IONBF, 0); // Prefer unbuffered output, so that we get a full log upon crash or deadlock.
+    setvbuf(file->file(), nullPtr(), _IONBF, 0); // Prefer unbuffered output, so that we get a full log upon crash or deadlock.
 
     if (s_file)
         s_file->flush();

--- a/Source/WTF/wtf/DataMutex.h
+++ b/Source/WTF/wtf/DataMutex.h
@@ -59,7 +59,7 @@ private:
     Lock m_mutex;
     T m_data WTF_GUARDED_BY_LOCK(m_mutex);
 #if ENABLE_DATA_MUTEX_CHECKS
-    Thread* m_currentMutexHolder { nullptr };
+    Thread* m_currentMutexHolder { nullPtr() };
 #endif
 };
 
@@ -136,7 +136,7 @@ private:
         DATA_MUTEX_CHECK(mutex().isHeld());
         assertIsHeld(m_dataMutex.m_mutex);
 #if ENABLE_DATA_MUTEX_CHECKS
-        m_dataMutex.m_currentMutexHolder = nullptr;
+        m_dataMutex.m_currentMutexHolder = nullPtr();
 #endif
         m_isLocked = false;
         mutex().unlock();

--- a/Source/WTF/wtf/DataRef.h
+++ b/Source/WTF/wtf/DataRef.h
@@ -100,7 +100,7 @@ public:
     {
     }
     bool isHashTableEmptyValue() const { return m_data.isHashTableEmptyValue(); }
-    static T* hashTableEmptyValue() { return nullptr; }
+    static T* hashTableEmptyValue() { return nullPtr(); }
 
 private:
     Ref<T> m_data;

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -202,7 +202,7 @@ static int32_t calculateUTCOffset()
 
     SYSTEMTIME systemTime;
     ::GetSystemTime(&systemTime);
-    rc = ::GetTimeZoneInformationForYear(systemTime.wYear, nullptr, &timeZoneInformation);
+    rc = ::GetTimeZoneInformationForYear(systemTime.wYear, nullPtr(), &timeZoneInformation);
     if (rc == TIME_ZONE_ID_INVALID)
         return 0;
 
@@ -279,7 +279,7 @@ static double calculateDSTOffset(time_t localTime, double utcOffset)
     SYSTEMTIME utcSystemTime, localSystemTime;
     if (!::FileTimeToSystemTime(&utcFileTime, &utcSystemTime))
         return 0;
-    if (!::SystemTimeToTzSpecificLocalTime(nullptr, &utcSystemTime, &localSystemTime))
+    if (!::SystemTimeToTzSpecificLocalTime(nullPtr(), &utcSystemTime, &localSystemTime))
         return 0;
 
     double diff = ((localSystemTime.wHour - offsetHour) * secondsPerHour) + ((localSystemTime.wMinute - offsetMinute) * 60);
@@ -1011,7 +1011,7 @@ static std::optional<Vector<char16_t, 32>> validateTimeZone(StringView timeZone)
     auto buffer = timeZone.upconvertedCharacters();
     const char16_t* characters = buffer;
     Vector<char16_t, 32> canonicalBuffer;
-    auto status = callBufferProducingFunction(ucal_getCanonicalTimeZoneID, characters, timeZone.length(), canonicalBuffer, nullptr);
+    auto status = callBufferProducingFunction(ucal_getCanonicalTimeZoneID, characters, timeZone.length(), canonicalBuffer, nullPtr());
     if (!U_SUCCESS(status))
         return std::nullopt;
     return canonicalBuffer;

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -426,7 +426,7 @@ private:
         typename Graph::Node immediateDominator(typename Graph::Node block)
         {
             if (block == m_graph.root())
-                return nullptr;
+                return nullPtr();
             return m_graph.node(m_idoms[m_graph.index(block)]);
         }
 
@@ -624,12 +624,12 @@ private:
             WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(BlockData);
 
             BlockData()
-                : parent(nullptr)
+                : parent(nullPtr())
                 , preNumber(UINT_MAX)
                 , semiNumber(UINT_MAX)
-                , ancestor(nullptr)
-                , label(nullptr)
-                , dom(nullptr)
+                , ancestor(nullPtr())
+                , label(nullPtr())
+                , dom(nullPtr())
             {
             }
         
@@ -882,7 +882,7 @@ private:
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(BlockData);
 
         BlockData()
-            : idomParent(nullptr)
+            : idomParent(nullPtr())
             , preNumber(UINT_MAX)
             , postNumber(UINT_MAX)
         {

--- a/Source/WTF/wtf/DoublyLinkedList.h
+++ b/Source/WTF/wtf/DoublyLinkedList.h
@@ -41,8 +41,8 @@ public:
 
 template<typename T> inline DoublyLinkedListNode<T>::DoublyLinkedListNode()
 {
-    setPrev(nullptr);
-    setNext(nullptr);
+    setPrev(nullPtr());
+    setNext(nullPtr());
 }
 
 template<typename T> inline void DoublyLinkedListNode<T>::setPrev(T* prev)
@@ -92,8 +92,8 @@ private:
 };
 
 template<typename T> inline DoublyLinkedList<T>::DoublyLinkedList()
-    : m_head(nullptr)
-    , m_tail(nullptr)
+    : m_head(nullPtr())
+    , m_tail(nullPtr())
 {
 }
 
@@ -173,10 +173,10 @@ template<typename T> inline DoublyLinkedList<T> DoublyLinkedList<T>::splitAt(siz
     DoublyLinkedList<T> newList { };
     newList.m_head = p->next();
     newList.m_tail = m_tail;
-    newList.m_head->setPrev(nullptr);
+    newList.m_head->setPrev(nullPtr());
 
     m_tail = p;
-    m_tail->setNext(nullptr);
+    m_tail->setNext(nullPtr());
 
     return newList;
 }
@@ -198,8 +198,8 @@ template<typename T> inline void DoublyLinkedList<T>::remove(T* node)
         ASSERT(node == m_tail);
         m_tail = node->prev();
     }
-    node->setNext(nullptr);
-    node->setPrev(nullptr);
+    node->setNext(nullPtr());
+    node->setPrev(nullPtr());
 }
 
 template<typename T> inline T* DoublyLinkedList<T>::removeHead()

--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -102,7 +102,7 @@ public:
     {
         auto result = std::unique_ptr<EmbeddedFixedVector> { new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(typename Base::Failable { }, size, std::forward<FailableGenerator>(generator)) };
         if (result->size() != size)
-            return nullptr;
+            return nullPtr();
         return result;
     }
 

--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -59,7 +59,7 @@ public:
 private:
     std::span<const uint32_t> words() const { return unsafeMakeSpan(m_words, fastBitVectorArrayLength(m_numBits)); }
 
-    const uint32_t* m_words { nullptr };
+    const uint32_t* m_words { nullPtr() };
     size_t m_numBits { 0 };
 };
 
@@ -71,7 +71,7 @@ public:
     FastBitVectorWordOwner() = default;
     
     FastBitVectorWordOwner(FastBitVectorWordOwner&& other)
-        : m_words(std::exchange(other.m_words, nullptr))
+        : m_words(std::exchange(other.m_words, nullPtr()))
         , m_numBits(std::exchange(other.m_numBits, 0))
     {
     }
@@ -144,7 +144,7 @@ private:
     WTF_EXPORT_PRIVATE void setEqualsSlow(const FastBitVectorWordOwner& other);
     WTF_EXPORT_PRIVATE void resizeSlow(size_t numBits);
     
-    uint32_t* m_words { nullptr };
+    uint32_t* m_words { nullPtr() };
     size_t m_numBits { 0 };
 };
 
@@ -443,7 +443,7 @@ public:
     FastBitReference& operator&=(bool value) { return value ? *this : *this = value; }
 
 private:
-    uint32_t* m_word { nullptr };
+    uint32_t* m_word { nullPtr() };
     uint32_t m_mask { 0 };
 };
 

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -82,7 +82,7 @@ void fastSetMaxSingleAllocationSize(size_t size)
 
 #define FAIL_IF_EXCEEDS_LIMIT(size) do { \
         if ((size) > maxSingleAllocationSize) [[unlikely]] \
-            return nullptr; \
+            return nullPtr(); \
     } while (false)
 
 #else // !defined(NDEBUG)
@@ -105,7 +105,7 @@ char* fastStrDup(const char* src)
 void* fastMemDup(const void* mem, size_t bytes)
 {
     if (!mem || !bytes)
-        return nullptr;
+        return nullPtr();
 
     void* result = fastMalloc(bytes);
     memcpy(result, mem, bytes);
@@ -123,7 +123,7 @@ char* fastCompactStrDup(const char* src)
 void* fastCompactMemDup(const void* mem, size_t bytes)
 {
     if (!mem || !bytes)
-        return nullptr;
+        return nullPtr();
 
     void* result = fastCompactMalloc(bytes);
     memcpy(result, mem, bytes);
@@ -233,7 +233,7 @@ TryMallocReturnValue tryFastZeroedMalloc(size_t n)
 {
     void* result;
     if (!tryFastMalloc(n).getValue(result))
-        return nullptr;
+        return nullPtr();
     memset(result, 0, n);
     return result;
 }
@@ -668,7 +668,7 @@ TryMallocReturnValue tryFastCalloc(size_t numElements, size_t elementSize)
     CheckedSize checkedSize = elementSize;
     checkedSize *= numElements;
     if (checkedSize.hasOverflowed())
-        return nullptr;
+        return nullPtr();
     return tryFastZeroedMalloc(checkedSize);
 }
 
@@ -780,7 +780,7 @@ TryMallocReturnValue tryFastCompactCalloc(size_t numElements, size_t elementSize
     CheckedSize checkedSize = elementSize;
     checkedSize *= numElements;
     if (checkedSize.hasOverflowed())
-        return nullptr;
+        return nullPtr();
     return tryFastCompactZeroedMalloc(checkedSize);
 }
 

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -271,7 +271,7 @@ struct FastMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void* zeroedMalloc(size_t size) { return fastZeroedMalloc(size); }
@@ -282,7 +282,7 @@ struct FastMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void* realloc(void* p, size_t size) { return fastRealloc(p, size); }
@@ -293,7 +293,7 @@ struct FastMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
     
     static void free(void* p) { fastFree(p); }
@@ -323,7 +323,7 @@ struct FastCompactMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void* zeroedMalloc(size_t size) { return fastCompactZeroedMalloc(size); }
@@ -334,7 +334,7 @@ struct FastCompactMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void* realloc(void* p, size_t size) { return fastCompactRealloc(p, size); }
@@ -345,7 +345,7 @@ struct FastCompactMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void free(void* p) { fastFree(p); }

--- a/Source/WTF/wtf/FilePrintStream.cpp
+++ b/Source/WTF/wtf/FilePrintStream.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<FilePrintStream> FilePrintStream::open(const char* filename, con
 {
     FILE* file = fopen(filename, mode);
     if (!file)
-        return nullptr;
+        return nullPtr();
 
     return makeUnique<FilePrintStream>(file);
 }

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -198,9 +198,9 @@ WTF_EXPORT_PRIVATE std::optional<MappedFileData> mapFile(const String& path, Map
 
 // This creates the destination file, maps it, write the provided data to it and returns the mapped file.
 // This function fails if there is already a file at the destination path.
-WTF_EXPORT_PRIVATE MappedFileData mapToFile(const String& path, size_t bytesSize, NOESCAPE const Function<void(const Function<bool(std::span<const uint8_t>)>&)>& apply, FileHandle* = nullptr);
+WTF_EXPORT_PRIVATE MappedFileData mapToFile(const String& path, size_t bytesSize, NOESCAPE const Function<void(const Function<bool(std::span<const uint8_t>)>&)>& apply, FileHandle* = nullPtr());
 
-WTF_EXPORT_PRIVATE MappedFileData createMappedFileData(const String&, size_t, FileHandle* = nullptr);
+WTF_EXPORT_PRIVATE MappedFileData createMappedFileData(const String&, size_t, FileHandle* = nullPtr());
 WTF_EXPORT_PRIVATE void finalizeMappedFileData(MappedFileData&, size_t);
 
 } // namespace FileSystemImpl

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -51,12 +51,12 @@ public:
 
     FixedVector() = default;
     FixedVector(const FixedVector& other)
-        : m_storage(other.m_storage ? other.m_storage->clone().moveToUniquePtr() : nullptr)
+        : m_storage(other.m_storage ? other.m_storage->clone().moveToUniquePtr() : nullPtr())
     { }
     FixedVector(FixedVector&& other) = default;
 
     FixedVector(std::initializer_list<T> initializerList)
-        : m_storage(initializerList.size() ? Storage::create(initializerList).moveToUniquePtr() : nullptr)
+        : m_storage(initializerList.size() ? Storage::create(initializerList).moveToUniquePtr() : nullPtr())
     {
     }
 
@@ -85,11 +85,11 @@ public:
     }
 
     explicit FixedVector(size_t size)
-        : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullptr)
+        : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullPtr())
     { }
 
     FixedVector(size_t size, const T& value)
-        : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullptr)
+        : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullPtr())
     {
         fill(value);
     }
@@ -128,42 +128,42 @@ public:
     template<typename... Args>
     static FixedVector createWithSizeAndConstructorArguments(size_t size, Args&&... args)
     {
-        return Self { size ? Storage::createWithSizeAndConstructorArguments(size, std::forward<Args>(args)...).moveToUniquePtr() : std::unique_ptr<Storage> { nullptr } };
+        return Self { size ? Storage::createWithSizeAndConstructorArguments(size, std::forward<Args>(args)...).moveToUniquePtr() : std::unique_ptr<Storage> { nullPtr() } };
     }
 
     template<std::invocable<size_t> Generator>
     static FixedVector createWithSizeFromGenerator(size_t size, NOESCAPE Generator&& generator)
     {
-        return Self { size ? Storage::createWithSizeFromGenerator(size, std::forward<Generator>(generator)).moveToUniquePtr() : std::unique_ptr<Storage> { nullptr } };
+        return Self { size ? Storage::createWithSizeFromGenerator(size, std::forward<Generator>(generator)).moveToUniquePtr() : std::unique_ptr<Storage> { nullPtr() } };
     }
 
     template<std::invocable<size_t> FailableGenerator>
     static FixedVector createWithSizeFromFailableGenerator(size_t size, NOESCAPE FailableGenerator&& generator)
     {
-        return Self { size ? Storage::createWithSizeFromFailableGenerator(size, std::forward<FailableGenerator>(generator)) : std::unique_ptr<Storage> { nullptr } };
+        return Self { size ? Storage::createWithSizeFromFailableGenerator(size, std::forward<FailableGenerator>(generator)) : std::unique_ptr<Storage> { nullPtr() } };
     }
 
     template<typename SizedRange, typename Mapper>
     static FixedVector map(SizedRange&& range, NOESCAPE Mapper&& mapper)
     {
         auto size = std::size(range);
-        return Self { size ? Storage::map(size, std::forward<SizedRange>(range), std::forward<Mapper>(mapper)).moveToUniquePtr() : std::unique_ptr<Storage> { nullptr } };
+        return Self { size ? Storage::map(size, std::forward<SizedRange>(range), std::forward<Mapper>(mapper)).moveToUniquePtr() : std::unique_ptr<Storage> { nullPtr() } };
     }
 
     size_t size() const { return m_storage ? m_storage->size() : 0; }
     bool isEmpty() const { return m_storage ? m_storage->isEmpty() : true; }
     size_t byteSize() const { return m_storage ? m_storage->byteSize() : 0; }
 
-    iterator begin() LIFETIME_BOUND { return m_storage ? m_storage->begin() : nullptr; }
-    iterator end() LIFETIME_BOUND { return m_storage ? m_storage->end() : nullptr; }
+    iterator begin() LIFETIME_BOUND { return m_storage ? m_storage->begin() : nullPtr(); }
+    iterator end() LIFETIME_BOUND { return m_storage ? m_storage->end() : nullPtr(); }
 
     const_iterator begin() const LIFETIME_BOUND { return const_cast<FixedVector*>(this)->begin(); }
     const_iterator end() const LIFETIME_BOUND { return const_cast<FixedVector*>(this)->end(); }
 
-    reverse_iterator rbegin() LIFETIME_BOUND { return m_storage ? m_storage->rbegin() : reverse_iterator(nullptr); }
-    reverse_iterator rend() LIFETIME_BOUND { return m_storage ? m_storage->rend() : reverse_iterator(nullptr); }
-    const_reverse_iterator rbegin() const LIFETIME_BOUND { return m_storage ? m_storage->rbegin() : const_reverse_iterator(nullptr); }
-    const_reverse_iterator rend() const LIFETIME_BOUND { return m_storage ? m_storage->rend() : const_reverse_iterator(nullptr); }
+    reverse_iterator rbegin() LIFETIME_BOUND { return m_storage ? m_storage->rbegin() : reverse_iterator(nullPtr()); }
+    reverse_iterator rend() LIFETIME_BOUND { return m_storage ? m_storage->rend() : reverse_iterator(nullPtr()); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return m_storage ? m_storage->rbegin() : const_reverse_iterator(nullPtr()); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return m_storage ? m_storage->rend() : const_reverse_iterator(nullPtr()); }
 
     T& at(size_t i) LIFETIME_BOUND { return m_storage->at(i); }
     const T& at(size_t i) const LIFETIME_BOUND { return m_storage->at(i); }
@@ -176,7 +176,7 @@ public:
     T& last() LIFETIME_BOUND { return (*this)[size() - 1]; }
     const T& last() const LIFETIME_BOUND { return (*this)[size() - 1]; }
 
-    void clear() { m_storage = nullptr; }
+    void clear() { m_storage = nullPtr(); }
 
     void fill(const T& val)
     {

--- a/Source/WTF/wtf/Function.h
+++ b/Source/WTF/wtf/Function.h
@@ -123,7 +123,7 @@ public:
 
     Function& operator=(std::nullptr_t)
     {
-        m_callableWrapper = nullptr;
+        m_callableWrapper = nullPtr();
         return *this;
     }
 

--- a/Source/WTF/wtf/FunctionPtr.h
+++ b/Source/WTF/wtf/FunctionPtr.h
@@ -81,8 +81,8 @@ class FunctionPtr<tag, Out(In...), attr> : public FunctionPtrBase {
 public:
     using Ptr = typename FunctionCallConvention<attr, Out(In...)>::Type;
 
-    constexpr FunctionPtr() : m_ptr(nullptr) { }
-    constexpr FunctionPtr(std::nullptr_t) : m_ptr(nullptr) { }
+    constexpr FunctionPtr() : m_ptr(nullPtr()) { }
+    constexpr FunctionPtr(std::nullptr_t) : m_ptr(nullPtr()) { }
 
     constexpr FunctionPtr(Out(*ptr)(In...))
         : m_ptr(encode(ptr))
@@ -154,7 +154,7 @@ public:
 
     FunctionPtr& operator=(std::nullptr_t)
     {
-        m_ptr = nullptr;
+        m_ptr = nullPtr();
         return *this;
     }
 

--- a/Source/WTF/wtf/Gigacage.cpp
+++ b/Source/WTF/wtf/Gigacage.cpp
@@ -155,7 +155,7 @@ void* tryMallocArray(Kind kind, size_t numElements, size_t elementSize)
     CheckedSize checkedSize = elementSize;
     checkedSize *= numElements;
     if (checkedSize.hasOverflowed())
-        return nullptr;
+        return nullPtr();
     return tryMalloc(kind, checkedSize);
 }
 

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -242,8 +242,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         void checkValidity(const const_iterator&) const { }
 #endif
 
-        PointerType m_position { nullptr };
-        PointerType m_endPosition { nullptr };
+        PointerType m_position { nullPtr() };
+        PointerType m_endPosition { nullPtr() };
 
 #if CHECK_HASHTABLE_ITERATORS
     public:
@@ -575,8 +575,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         bool shouldExpand() const { return HashTableSizePolicy::shouldExpand(keyCount() + deletedCount(), tableSize()); }
         bool mustRehashInPlace() const { return keyCount() * minLoad < tableSize() * 2; }
         bool shouldShrink() const { return keyCount() * minLoad < tableSize() && tableSize() > KeyTraits::minimumTableSize; }
-        ValueType* expand(ValueType* entry = nullptr);
-        void shrink() { rehash(tableSize() / 2, nullptr); }
+        ValueType* expand(ValueType* entry = nullPtr());
+        void shrink() { rehash(tableSize() / 2, nullPtr()); }
         void shrinkToBestSize();
     
         void deleteReleasedWeakBuckets();
@@ -625,7 +625,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         unsigned deletedCount() const { ASSERT(m_table); return reinterpret_cast_ptr<unsigned*>(m_table)[deletedCountOffset]; }
         void setDeletedCount(unsigned count) const { ASSERT(m_table); reinterpret_cast_ptr<unsigned*>(m_table)[deletedCountOffset] = count; }
 
-        ValueType* m_table { nullptr };
+        ValueType* m_table { nullPtr() };
 
 #if CHECK_HASHTABLE_ITERATORS
     public:
@@ -643,7 +643,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     inline HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::HashTable()
-        : m_table(nullptr)
+        : m_table(nullPtr())
 #if CHECK_HASHTABLE_ITERATORS
         , m_iterators(0)
         , m_mutex(makeUnique<Lock>())
@@ -670,7 +670,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         ValueType* table = m_table;
         if (!table)
-            return nullptr;
+            return nullPtr();
 
         unsigned sizeMask = tableSizeMask();
         unsigned h = HashTranslator::hash(key);
@@ -694,10 +694,10 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
                     return entry;
                 
                 if (isEmptyBucket(*entry))
-                    return nullptr;
+                    return nullPtr();
             } else {
                 if (isEmptyBucket(*entry))
-                    return nullptr;
+                    return nullPtr();
                 
                 if (!isDeletedBucket(*entry) && HashTranslator::equal(Extractor::extract(*entry), key))
                     return entry;
@@ -779,7 +779,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         ++m_stats->numAccesses;
 #endif
 
-        ValueType* deletedEntry = nullptr;
+        ValueType* deletedEntry = nullPtr();
 
         while (true) {
             ValueType* entry = table + i;
@@ -860,7 +860,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         invalidateIterators(this);
 
         if (!m_table)
-            expand(nullptr);
+            expand(nullPtr());
 
         internalCheckTableConsistency();
 
@@ -880,7 +880,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         ++m_stats->numAccesses;
 #endif
 
-        ValueType* deletedEntry = nullptr;
+        ValueType* deletedEntry = nullPtr();
         ValueType* entry;
         while (true) {
             entry = table + i;
@@ -1249,7 +1249,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::shrinkToBestSize()
     {
-        rehash(computeBestTableSize(keyCount()), nullptr);
+        rehash(computeBestTableSize(keyCount()), nullPtr());
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
@@ -1291,7 +1291,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         setDeletedCount(0);
         setKeyCount(oldKeyCount);
 
-        Value* newEntry = nullptr;
+        Value* newEntry = nullPtr();
         for (unsigned i = 0; i != oldTableSize; ++i) {
             auto& oldEntry = oldTable[i];
             if (isDeletedBucket(oldEntry)) {
@@ -1334,14 +1334,14 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         if (!m_table)
             return;
 
-        deallocateTable(std::exchange(m_table, nullptr));
+        deallocateTable(std::exchange(m_table, nullPtr()));
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::HashTable(const HashTable& other)
-        : m_table(nullptr)
+        : m_table(nullPtr())
 #if CHECK_HASHTABLE_ITERATORS
-        , m_iterators(nullptr)
+        , m_iterators(nullPtr())
         , m_mutex(makeUnique<Lock>())
 #endif
 #if DUMP_HASHTABLE_STATS_PER_TABLE
@@ -1387,17 +1387,17 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     inline HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::HashTable(HashTable&& other)
 #if CHECK_HASHTABLE_ITERATORS
-        : m_iterators(nullptr)
+        : m_iterators(nullPtr())
         , m_mutex(makeUnique<Lock>())
 #endif
     {
         invalidateIterators(&other);
 
-        m_table = std::exchange(other.m_table, nullptr);
+        m_table = std::exchange(other.m_table, nullPtr());
 
 #if DUMP_HASHTABLE_STATS_PER_TABLE
         m_stats = WTFMove(other.m_stats);
-        other.m_stats = nullptr;
+        other.m_stats = nullPtr();
 #endif
     }
 
@@ -1464,22 +1464,22 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         typename HashTableType::const_iterator* next;
         for (auto* p = table->m_iterators; p; p = next) {
             next = p->m_next;
-            p->m_table = nullptr;
-            p->m_next = nullptr;
-            p->m_previous = nullptr;
+            p->m_table = nullPtr();
+            p->m_next = nullPtr();
+            p->m_previous = nullPtr();
         }
-        table->m_iterators = nullptr;
+        table->m_iterators = nullPtr();
     }
 
     template<typename HashTableType, typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits>
     void addIterator(const HashTableType* table, HashTableConstIterator<HashTableType, Key, Value, Extractor, HashFunctions, Traits, KeyTraits>* it)
     {
         it->m_table = table;
-        it->m_previous = nullptr;
+        it->m_previous = nullPtr();
 
         // Insert iterator at head of doubly-linked list of iterators.
         if (!table) {
-            it->m_next = nullptr;
+            it->m_next = nullPtr();
         } else {
             Locker locker { *table->m_mutex };
             ASSERT(table->m_iterators != it);
@@ -1515,9 +1515,9 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             }
         }
 
-        it->m_table = nullptr;
-        it->m_next = nullptr;
-        it->m_previous = nullptr;
+        it->m_table = nullPtr();
+        it->m_next = nullPtr();
+        it->m_previous = nullPtr();
     }
 
 #endif // CHECK_HASHTABLE_ITERATORS

--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -152,7 +152,7 @@ template<typename T> struct SimpleClassHashTraits : GenericHashTraits<T> {
 
 template<typename T, typename Deleter> struct HashTraits<std::unique_ptr<T, Deleter>> : SimpleClassHashTraits<std::unique_ptr<T, Deleter>> {
     typedef std::nullptr_t EmptyValueType;
-    static EmptyValueType emptyValue() { return nullptr; }
+    static EmptyValueType emptyValue() { return nullPtr(); }
     static bool isEmptyValue(const std::unique_ptr<T, Deleter>& value) { return !value; }
 
     static void constructDeletedValue(std::unique_ptr<T, Deleter>& slot) { new (NotNull, std::addressof(slot)) std::unique_ptr<T, Deleter> { reinterpret_cast<T*>(-1) }; }
@@ -160,7 +160,7 @@ template<typename T, typename Deleter> struct HashTraits<std::unique_ptr<T, Dele
 
     typedef T* PeekType;
     static T* peek(const std::unique_ptr<T, Deleter>& value) { return value.get(); }
-    static T* peek(std::nullptr_t) { return nullptr; }
+    static T* peek(std::nullptr_t) { return nullPtr(); }
 
     static void customDeleteBucket(std::unique_ptr<T, Deleter>& value)
     {
@@ -189,7 +189,7 @@ template<typename T, typename Deleter> struct HashTraits<std::unique_ptr<T, Dele
 
 template<typename T> struct HashTraits<UniqueRef<T>> : SimpleClassHashTraits<UniqueRef<T>> {
     typedef std::nullptr_t EmptyValueType;
-    static EmptyValueType emptyValue() { return nullptr; }
+    static EmptyValueType emptyValue() { return nullPtr(); }
 
     template <typename>
     static void constructEmptyValue(UniqueRef<T>& slot)
@@ -205,11 +205,11 @@ template<typename T> struct HashTraits<UniqueRef<T>> : SimpleClassHashTraits<Uni
     typedef T* PeekType;
     static const T* peek(const UniqueRef<T>& value) { return &value.get(); }
     static T* peek(UniqueRef<T>& value) { return &value.get(); }
-    static T* peek(std::nullptr_t) { return nullptr; }
+    static T* peek(std::nullptr_t) { return nullPtr(); }
 
     using TakeType = std::unique_ptr<T>;
     static TakeType take(UniqueRef<T>&& value) { return value.moveToUniquePtr(); }
-    static TakeType take(std::nullptr_t) { return nullptr; }
+    static TakeType take(std::nullptr_t) { return nullPtr(); }
 };
 
 template<> struct HashTraits<ASCIILiteral> : SimpleClassHashTraits<ASCIILiteral> {
@@ -221,7 +221,7 @@ template<> struct HashTraits<ASCIILiteral> : SimpleClassHashTraits<ASCIILiteral>
 };
 
 template<typename P, typename Q, typename R> struct HashTraits<RefPtr<P, Q, R>> : SimpleClassHashTraits<RefPtr<P, Q, R>> {
-    static P* emptyValue() { return nullptr; }
+    static P* emptyValue() { return nullPtr(); }
     static bool isEmptyValue(const RefPtr<P, Q, R>& value) { return !value; }
 
     using PeekType = P*;
@@ -266,7 +266,7 @@ template<typename P> struct HashTraits<Packed<P*>> : SimpleClassHashTraits<Packe
     using TargetType = Packed<P*>;
     static_assert(TargetType::alignment < 4 * KB, "The first page is always unmapped since it includes nullptr.");
 
-    static Packed<P*> emptyValue() { return nullptr; }
+    static Packed<P*> emptyValue() { return nullPtr(); }
     static bool isEmptyValue(const TargetType& value) { return value.get() == nullptr; }
 
     using PeekType = Packed<P*>;
@@ -278,7 +278,7 @@ template<typename P> struct HashTraits<CompactPtr<P>> : SimpleClassHashTraits<Co
     static constexpr bool hasIsEmptyValueFunction = true;
     using TargetType = CompactPtr<P>;
 
-    static CompactPtr<P> emptyValue() { return nullptr; }
+    static CompactPtr<P> emptyValue() { return nullPtr(); }
     static bool isEmptyValue(const TargetType& value) { return !value; }
 
     using PeekType = CompactPtr<P>;
@@ -322,9 +322,9 @@ template<typename Traits, typename T> inline bool isHashTraitsReleasedWeakValue(
 template<typename Traits, typename T>
 struct HashTraitHasCustomDelete {
     static T& bucketArg;
-    template<typename X> static std::true_type TestHasCustomDelete(X*, decltype(X::customDeleteBucket(bucketArg))* = nullptr);
+    template<typename X> static std::true_type TestHasCustomDelete(X*, decltype(X::customDeleteBucket(bucketArg))* = nullPtr());
     static std::false_type TestHasCustomDelete(...);
-    typedef decltype(TestHasCustomDelete(static_cast<Traits*>(nullptr))) ResultType;
+    typedef decltype(TestHasCustomDelete(static_cast<Traits*>(nullPtr()))) ResultType;
     static constexpr bool value = ResultType::value;
 };
 

--- a/Source/WTF/wtf/IndexSet.h
+++ b/Source/WTF/wtf/IndexSet.h
@@ -94,7 +94,7 @@ public:
             WTF_DEPRECATED_MAKE_FAST_ALLOCATED(iterator);
         public:
             iterator()
-                : m_collection(nullptr)
+                : m_collection(nullPtr())
             {
             }
 

--- a/Source/WTF/wtf/IndexSparseSet.h
+++ b/Source/WTF/wtf/IndexSparseSet.h
@@ -195,11 +195,11 @@ auto IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::get(unsigned v
 {
     unsigned position = m_map[value];
     if (position >= m_values.size())
-        return nullptr;
+        return nullPtr();
 
     EntryType& entry = m_values[position];
     if (EntryTypeTraits::key(entry) != value)
-        return nullptr;
+        return nullPtr();
     
     return &entry;
 }

--- a/Source/WTF/wtf/IndexedContainerIterator.h
+++ b/Source/WTF/wtf/IndexedContainerIterator.h
@@ -34,7 +34,7 @@ class IndexedContainerIterator {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(IndexedContainerIterator);
 public:
     IndexedContainerIterator()
-        : m_container(nullptr)
+        : m_container(nullPtr())
         , m_index(0)
     {
     }

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -500,13 +500,13 @@ inline RefPtr<Object> Value::asObject()
     case Type::Integer:
     case Type::String:
     case Type::Array:
-        return nullptr;
+        return nullPtr();
     case Type::Object:
         static_assert(sizeof(Object) == sizeof(ObjectBase));
         return static_cast<Object*>(this);
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return nullPtr();
 }
 
 inline RefPtr<const Object> Value::asObject() const
@@ -518,13 +518,13 @@ inline RefPtr<const Object> Value::asObject() const
     case Type::Integer:
     case Type::String:
     case Type::Array:
-        return nullptr;
+        return nullPtr();
     case Type::Object:
         static_assert(sizeof(Object) == sizeof(ObjectBase));
         return static_cast<const Object*>(this);
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return nullPtr();
 }
 
 inline RefPtr<Array> Value::asArray()
@@ -536,13 +536,13 @@ inline RefPtr<Array> Value::asArray()
     case Type::Integer:
     case Type::Object:
     case Type::String:
-        return nullptr;
+        return nullPtr();
     case Type::Array:
         static_assert(sizeof(ArrayBase) == sizeof(Array));
         return static_cast<Array*>(this);
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return nullPtr();
 }
 
 } // namespace JSONImpl

--- a/Source/WTF/wtf/LazyRef.h
+++ b/Source/WTF/wtf/LazyRef.h
@@ -84,7 +84,7 @@ public:
     {
         ASSERT(m_pointer);
         if (m_pointer & lazyTag)
-            return nullptr;
+            return nullPtr();
         return std::bit_cast<T*>(m_pointer);
     }
 

--- a/Source/WTF/wtf/LazyUniqueRef.h
+++ b/Source/WTF/wtf/LazyUniqueRef.h
@@ -84,7 +84,7 @@ public:
     {
         ASSERT(m_pointer);
         if (m_pointer & lazyTag)
-            return nullptr;
+            return nullPtr();
         return std::bit_cast<T*>(m_pointer);
     }
 

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -105,9 +105,9 @@ public:
     bool isEmpty() const;
 
     iterator begin() LIFETIME_BOUND { return makeIterator(m_head); }
-    iterator end() LIFETIME_BOUND { return makeIterator(nullptr); }
+    iterator end() LIFETIME_BOUND { return makeIterator(nullPtr()); }
     const_iterator begin() const LIFETIME_BOUND { return makeConstIterator(m_head); }
-    const_iterator end() const LIFETIME_BOUND { return makeConstIterator(nullptr); }
+    const_iterator end() const LIFETIME_BOUND { return makeConstIterator(nullPtr()); }
 
     iterator random() LIFETIME_BOUND { return makeIterator(m_impl.random()); }
     const_iterator random() const LIFETIME_BOUND { return makeIterator(m_impl.random()); }
@@ -191,8 +191,8 @@ private:
     const_iterator makeConstIterator(Node*) const;
 
     HashTable<Node*, Node*, IdentityExtractor, NodeHash, NodeTraits, NodeTraits> m_impl;
-    Node* m_head { nullptr };
-    Node* m_tail { nullptr };
+    Node* m_head { nullPtr() };
+    Node* m_tail { nullPtr() };
 };
 
 template<typename ValueArg> struct ListHashSetNode
@@ -208,8 +208,8 @@ template<typename ValueArg> struct ListHashSetNode
     }
 
     ValueArg m_value;
-    ListHashSetNode* m_prev { nullptr };
-    ListHashSetNode* m_next { nullptr };
+    ListHashSetNode* m_prev { nullPtr() };
+    ListHashSetNode* m_next { nullPtr() };
 };
 
 template<typename HashArg> struct ListHashSetNodeHashFunctions {
@@ -370,8 +370,8 @@ public:
 private:
     Node* node() { return m_position; }
 
-    const ListHashSetType* m_set { nullptr };
-    Node* m_position { nullptr };
+    const ListHashSetType* m_set { nullPtr() };
+    Node* m_position { nullPtr() };
 #if CHECK_HASHTABLE_ITERATORS
     WeakPtr<const ListHashSetType> m_weakSet;
     WeakPtr<Node> m_weakPosition;
@@ -415,8 +415,8 @@ inline ListHashSet<T, U>& ListHashSet<T, U>::operator=(const ListHashSet& other)
 template<typename T, typename U>
 inline ListHashSet<T, U>::ListHashSet(ListHashSet&& other)
     : m_impl(WTFMove(other.m_impl))
-    , m_head(std::exchange(other.m_head, nullptr))
-    , m_tail(std::exchange(other.m_tail, nullptr))
+    , m_head(std::exchange(other.m_head, nullPtr()))
+    , m_tail(std::exchange(other.m_tail, nullPtr()))
 {
 }
 
@@ -586,7 +586,7 @@ inline bool ListHashSet<T, U>::contains(const ValueType& value) const
 template<typename T, typename U>
 auto ListHashSet<T, U>::add(const ValueType& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullPtr(); });
     if (result.isNewEntry)
         appendNode(*result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
@@ -595,7 +595,7 @@ auto ListHashSet<T, U>::add(const ValueType& value) -> AddResult
 template<typename T, typename U>
 auto ListHashSet<T, U>::add(ValueType&& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(value), [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(value), [] { return nullPtr(); });
     if (result.isNewEntry)
         appendNode(*result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
@@ -604,7 +604,7 @@ auto ListHashSet<T, U>::add(ValueType&& value) -> AddResult
 template<typename T, typename U>
 auto ListHashSet<T, U>::appendOrMoveToLast(const ValueType& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullPtr(); });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -616,7 +616,7 @@ auto ListHashSet<T, U>::appendOrMoveToLast(const ValueType& value) -> AddResult
 template<typename T, typename U>
 auto ListHashSet<T, U>::appendOrMoveToLast(ValueType&& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(value), [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(value), [] { return nullPtr(); });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -640,7 +640,7 @@ bool ListHashSet<T, U>::moveToLastIfPresent(const ValueType& value)
 template<typename T, typename U>
 auto ListHashSet<T, U>::prependOrMoveToFirst(const ValueType& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullPtr(); });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -652,7 +652,7 @@ auto ListHashSet<T, U>::prependOrMoveToFirst(const ValueType& value) -> AddResul
 template<typename T, typename U>
 auto ListHashSet<T, U>::prependOrMoveToFirst(ValueType&& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(value), [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(value), [] { return nullPtr(); });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -676,7 +676,7 @@ auto ListHashSet<T, U>::insertBefore(const ValueType& beforeValue, ValueType&& n
 template<typename T, typename U>
 auto ListHashSet<T, U>::insertBefore(iterator it, const ValueType& newValue) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(newValue, [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(newValue, [] { return nullPtr(); });
     if (result.isNewEntry)
         insertNodeBefore(it.node(), *result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
@@ -685,7 +685,7 @@ auto ListHashSet<T, U>::insertBefore(iterator it, const ValueType& newValue) -> 
 template<typename T, typename U>
 auto ListHashSet<T, U>::insertBefore(iterator it, ValueType&& newValue) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(newValue), [] { return nullptr; });
+    auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTFMove(newValue), [] { return nullPtr(); });
     if (result.isNewEntry)
         insertNodeBefore(it.node(), *result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
@@ -712,8 +712,8 @@ inline void ListHashSet<T, U>::clear()
 {
     deleteAllNodes();
     m_impl.clear(); 
-    m_head = nullptr;
-    m_tail = nullptr;
+    m_head = nullPtr();
+    m_tail = nullPtr();
 }
 
 template<typename T, typename U>
@@ -837,7 +837,7 @@ template<typename T, typename U>
 void ListHashSet<T, U>::appendNode(Node* node)
 {
     node->m_prev = m_tail;
-    node->m_next = nullptr;
+    node->m_next = nullPtr();
 
     if (m_tail) {
         ASSERT(m_head);
@@ -853,7 +853,7 @@ void ListHashSet<T, U>::appendNode(Node* node)
 template<typename T, typename U>
 void ListHashSet<T, U>::prependNode(Node* node)
 {
-    node->m_prev = nullptr;
+    node->m_prev = nullPtr();
     node->m_next = m_head;
 
     if (m_head)
@@ -886,7 +886,7 @@ void ListHashSet<T, U>::deleteAllNodes()
     if (!m_head)
         return;
 
-    for (Node* node = m_head, *next = m_head->m_next; node; node = next, next = node ? node->m_next : nullptr)
+    for (Node* node = m_head, *next = m_head->m_next; node; node = next, next = node ? node->m_next : nullPtr())
         delete node;
 }
 

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -173,7 +173,7 @@ public:
             WTF_DEPRECATED_MAKE_FAST_ALLOCATED(iterator);
         public:
             iterator()
-                : m_liveness(nullptr)
+                : m_liveness(nullPtr())
                 , m_iter()
             {
             }

--- a/Source/WTF/wtf/Locker.h
+++ b/Source/WTF/wtf/Locker.h
@@ -76,7 +76,7 @@ public:
     // but it's not necessary to engage in that protocol yet. For example,
     // this often happens when an object is newly allocated and it can not
     // be accessed concurrently.
-    Locker(NoLockingNecessaryTag) : m_lockable(nullptr) { }
+    Locker(NoLockingNecessaryTag) : m_lockable(nullPtr()) { }
     
     Locker(std::underlying_type_t<NoLockingNecessaryTag>) = delete;
 
@@ -102,7 +102,7 @@ public:
     void unlockEarly()
     {
         unlock();
-        m_lockable = nullptr;
+        m_lockable = nullPtr();
     }
     
     // It's great to be able to pass lockers around. It enables custom locking adaptors like
@@ -111,14 +111,14 @@ public:
         : m_lockable(other.m_lockable)
     {
         ASSERT(&other != this);
-        other.m_lockable = nullptr;
+        other.m_lockable = nullPtr();
     }
     
     Locker& operator=(Locker&& other)
     {
         ASSERT(&other != this);
         m_lockable = other.m_lockable;
-        other.m_lockable = nullptr;
+        other.m_lockable = nullPtr();
         return *this;
     }
     
@@ -189,21 +189,21 @@ public:
     void unlockEarly()
     {
         unlock();
-        m_lockable = nullptr;
+        m_lockable = nullPtr();
     }
 
     ExternalLocker(ExternalLocker&& other)
         : m_lockable(other.m_lockable)
     {
         ASSERT(&other != this);
-        other.m_lockable = nullptr;
+        other.m_lockable = nullPtr();
     }
 
     ExternalLocker& operator=(ExternalLocker&& other)
     {
         ASSERT(&other != this);
         m_lockable = other.m_lockable;
-        other.m_lockable = nullptr;
+        other.m_lockable = nullPtr();
         return *this;
     }
 

--- a/Source/WTF/wtf/LocklessBag.h
+++ b/Source/WTF/wtf/LocklessBag.h
@@ -46,7 +46,7 @@ public:
     };
 
     LocklessBag()
-        : m_head(nullptr)
+        : m_head(nullPtr())
     {
     }
 
@@ -89,7 +89,7 @@ public:
 
     void consumeAllWithNode(NOESCAPE const Invocable<void(T&&, Node*)> auto& func)
     {
-        Node* node = m_head.exchange(nullptr);
+        Node* node = m_head.exchange(nullPtr());
         while (node) {
             Node* oldNode = node;
             node = node->next;

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -85,7 +85,7 @@ class HasToJSONString {
     template <class T> static std::false_type test(...);
 
 public:
-    static constexpr bool value = decltype(test<C>(nullptr))::value;
+    static constexpr bool value = decltype(test<C>(nullPtr()))::value;
 };
 
 template<typename Argument, bool hasJSON = HasToJSONString<Argument>::value>
@@ -322,7 +322,7 @@ public:
         WTF_EXPORT_PRIVATE String toString() const;
 
         ASCIILiteral className;
-        const char* methodName { nullptr };
+        const char* methodName { nullPtr() };
         const uint64_t objectIdentifier { 0 };
     };
 
@@ -376,7 +376,7 @@ private:
 #elif OS(ANDROID)
         __android_log_print(ANDROID_LOG_VERBOSE, LOG_CHANNEL_WEBKIT_SUBSYSTEM, "[%s] %s", channel.name, logMessage.utf8().data());
 #elif ENABLE(JOURNALD_LOG)
-        sd_journal_send("WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
+        sd_journal_send("WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullPtr());
 #else
         fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s\n", channel.name, logMessage.utf8().data());
 #endif
@@ -415,7 +415,7 @@ private:
 #elif ENABLE(JOURNALD_LOG)
         auto fileString = makeString("CODE_FILE="_s, unsafeSpan(file));
         auto lineString = makeString("CODE_LINE="_s, line);
-        sd_journal_send_with_location(fileString.utf8().data(), lineString.utf8().data(), function, "WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
+        sd_journal_send_with_location(fileString.utf8().data(), lineString.utf8().data(), function, "WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullPtr());
 #else
         fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s FILE=%s:%d %s\n", channel.name, logMessage.utf8().data(), file, line, function);
 #endif

--- a/Source/WTF/wtf/MallocCommon.h
+++ b/Source/WTF/wtf/MallocCommon.h
@@ -49,7 +49,7 @@ inline TryMallocReturnValue::TryMallocReturnValue(void* data)
 inline TryMallocReturnValue::TryMallocReturnValue(TryMallocReturnValue&& source)
     : m_data(source.m_data)
 {
-    source.m_data = nullptr;
+    source.m_data = nullPtr();
 }
 
 inline TryMallocReturnValue::~TryMallocReturnValue()
@@ -60,7 +60,7 @@ inline TryMallocReturnValue::~TryMallocReturnValue()
 template<typename T> inline bool TryMallocReturnValue::getValue(T*& data)
 {
     data = static_cast<T*>(m_data);
-    m_data = nullptr;
+    m_data = nullPtr();
     return data;
 }
 

--- a/Source/WTF/wtf/MallocPtr.h
+++ b/Source/WTF/wtf/MallocPtr.h
@@ -64,7 +64,7 @@ public:
 
     T *leakPtr() WARN_UNUSED_RETURN
     {
-        return std::exchange(m_ptr, nullptr);
+        return std::exchange(m_ptr, nullPtr());
     }
 
     explicit operator bool() const
@@ -142,7 +142,7 @@ private:
     {
     }
 
-    T* m_ptr { nullptr };
+    T* m_ptr { nullPtr() };
 };
 
 static_assert(sizeof(MallocPtr<int>) == sizeof(int*));

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -68,7 +68,7 @@ MemoryPressureHandler& MemoryPressureHandler::singleton()
 
 static MemoryPressureHandler* memoryPressureHandlerIfExists()
 {
-    return s_hasCreatedMemoryPressureHandler.load() ? &MemoryPressureHandler::singleton() : nullptr;
+    return s_hasCreatedMemoryPressureHandler.load() ? &MemoryPressureHandler::singleton() : nullPtr();
 }
 
 MemoryPressureHandler::MemoryPressureHandler()
@@ -94,7 +94,7 @@ void MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor(bool use)
         m_measurementTimer = makeUnique<RunLoop::Timer>(RunLoop::mainSingleton(), "MemoryPressureHandler::MeasurementTimer"_s, this, &MemoryPressureHandler::measurementTimerFired);
         m_measurementTimer->startRepeating(m_configuration.pollInterval);
     } else
-        m_measurementTimer = nullptr;
+        m_measurementTimer = nullPtr();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WTF/wtf/MessageQueue.h
+++ b/Source/WTF/wtf/MessageQueue.h
@@ -158,12 +158,12 @@ namespace WTF {
 
         if (m_killed) {
             result = MessageQueueTerminated;
-            return nullptr;
+            return nullPtr();
         }
 
         if (timedOut) {
             result = MessageQueueTimeout;
-            return nullptr;
+            return nullPtr();
         }
 
         ASSERT(found != m_queue.end());
@@ -178,9 +178,9 @@ namespace WTF {
     {
         Locker lock { m_lock };
         if (m_killed)
-            return nullptr;
+            return nullPtr();
         if (m_queue.isEmpty())
-            return nullptr;
+            return nullPtr();
 
         return m_queue.takeFirst();
     }
@@ -199,7 +199,7 @@ namespace WTF {
     {
         Locker lock { m_lock };
         if (m_queue.isEmpty())
-            return nullptr;
+            return nullPtr();
 
         return m_queue.takeFirst();
     }

--- a/Source/WTF/wtf/MetaAllocator.cpp
+++ b/Source/WTF/wtf/MetaAllocator.cpp
@@ -159,7 +159,7 @@ MetaAllocator::MetaAllocator(Lock& lock, size_t allocationGranule, size_t pageSi
 RefPtr<MetaAllocatorHandle> MetaAllocator::allocate(const Locker<Lock>&, size_t sizeInBytes)
 {
     if (!sizeInBytes)
-        return nullptr;
+        return nullPtr();
     
     sizeInBytes = roundUp(sizeInBytes);
 
@@ -170,7 +170,7 @@ RefPtr<MetaAllocatorHandle> MetaAllocator::allocate(const Locker<Lock>&, size_t 
         
         start = allocateNewSpace(numberOfPages);
         if (!start)
-            return nullptr;
+            return nullPtr();
         
         ASSERT(numberOfPages >= requestedNumberOfPages);
         
@@ -214,7 +214,7 @@ MetaAllocator::FreeSpacePtr MetaAllocator::findAndRemoveFreeSpace(size_t sizeInB
     FreeSpaceNode* node = m_freeSpaceSizeMap.findLeastGreaterThanOrEqual(sizeInBytes);
     
     if (!node)
-        return nullptr;
+        return nullPtr();
     
     size_t nodeSizeInBytes = node->sizeInBytes();
     RELEASE_ASSERT(nodeSizeInBytes >= sizeInBytes);

--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -52,7 +52,7 @@ public:
         MetaAllocatorHandle* handle = m_allocations.findGreatestLessThanOrEqual(address);
         if (handle && handle->start().untaggedPtr() <= address && address < handle->end().untaggedPtr())
             return handle;
-        return nullptr;
+        return nullPtr();
     }
 
     RedBlackTree<MetaAllocatorHandle, void*> m_allocations;
@@ -197,7 +197,7 @@ private:
     
     Lock& m_lock;
 
-    MetaAllocatorTracker* m_tracker { nullptr };
+    MetaAllocatorTracker* m_tracker { nullPtr() };
 
 #ifndef NDEBUG
     size_t m_mallocBalance;

--- a/Source/WTF/wtf/Mmap.h
+++ b/Source/WTF/wtf/Mmap.h
@@ -37,7 +37,7 @@ struct Mmap {
     {
         auto* data = ::mmap(addr, size, pageProtection, options, fileDescriptor, 0);
         if (data == MAP_FAILED)
-            return nullptr;
+            return nullPtr();
         RELEASE_ASSERT((pageProtection & PROT_EXEC) || WTF_DATA_ADDRESS_IS_SANE(data));
         return data;
     }

--- a/Source/WTF/wtf/NakedPtr.h
+++ b/Source/WTF/wtf/NakedPtr.h
@@ -35,7 +35,7 @@ namespace WTF {
 template <typename T> class NakedPtr {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NakedPtr);
 public:
-    ALWAYS_INLINE NakedPtr() : m_ptr(nullptr) { }
+    ALWAYS_INLINE NakedPtr() : m_ptr(nullPtr()) { }
     ALWAYS_INLINE NakedPtr(T* ptr) : m_ptr(ptr) { }
     ALWAYS_INLINE NakedPtr(const NakedPtr& o) : m_ptr(o.m_ptr) { }
     template<typename U> NakedPtr(const NakedPtr<U>& o) : m_ptr(o.get()) { }
@@ -45,7 +45,7 @@ public:
 
     T* get() const { return m_ptr; }
 
-    void clear() { m_ptr = nullptr; }
+    void clear() { m_ptr = nullPtr(); }
 
     T& operator*() const { ASSERT(m_ptr); return *m_ptr; }
     ALWAYS_INLINE T* operator->() const { return m_ptr; }

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -308,7 +308,7 @@ public:
     void complete()
     {
         ASSERT(m_callback);
-        m_callback = nullptr;
+        m_callback = nullPtr();
     }
 
     // Disconnect and forget an outstanding promise. The resolve/reject methods will never be called.
@@ -317,7 +317,7 @@ public:
         ASSERT(m_callback);
         if (!m_callback)
             return;
-        RefPtr callback = std::exchange(m_callback, nullptr);
+        RefPtr callback = std::exchange(m_callback, nullPtr());
         callback->disconnect();
     }
 
@@ -576,7 +576,7 @@ private:
                         return WTFMove(*resolveValue);
                     }));
                 }
-                m_producer = nullptr;
+                m_producer = nullPtr();
             }
         }
 
@@ -592,7 +592,7 @@ private:
                 m_producer->reject();
             else
                 m_producer->reject(std::forward<RejectValueType_>(rejectValue));
-            m_producer = nullptr;
+            m_producer = nullPtr();
             if constexpr (!std::is_void_v<ResolveValueT>)
                 m_resolveValues.clear();
         }
@@ -633,7 +633,7 @@ private:
                 m_producer->resolve(WTF::map(std::exchange(m_results, { }), [](auto&& result) {
                     return WTFMove(*result);
                 }));
-                m_producer = nullptr;
+                m_producer = nullPtr();
             }
         }
 
@@ -803,7 +803,7 @@ private:
         {
             assertIsCurrent(*ThenCallbackBase::m_targetQueue);
             ThenCallbackBase::disconnect();
-            m_settleFunction = nullptr;
+            m_settleFunction = nullPtr();
         }
 
         void processResult(NativePromise& promise, ResultParam result) override
@@ -826,7 +826,7 @@ private:
                     completionProducer->resolve({ "<chained completion promise>", 0 });
             }
 
-            m_settleFunction = nullptr;
+            m_settleFunction = nullPtr();
         }
 
         void setCompletionPromise(std::unique_ptr<typename ReturnPromiseType::Producer>&& completionProducer)
@@ -839,7 +839,7 @@ private:
         RefPtr<NativePromiseBase> completionPromise() override
         {
             Locker lock { m_lock };
-            return m_completionProducer ? m_completionProducer->promise().ptr() : nullptr;
+            return m_completionProducer ? m_completionProducer->promise().ptr() : nullPtr();
         }
 #endif
 
@@ -1288,7 +1288,7 @@ private:
         const Result* operator->() const
         {
             if (!hasResult())
-                return nullptr;
+                return nullPtr();
             return &(this->operator*());
         }
         template <typename Arg>

--- a/Source/WTF/wtf/NaturalLoops.h
+++ b/Source/WTF/wtf/NaturalLoops.h
@@ -39,8 +39,8 @@ class NaturalLoop {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NaturalLoop);
 public:
     NaturalLoop()
-        : m_graph(nullptr)
-        , m_header(nullptr)
+        : m_graph(nullPtr())
+        , m_header(nullPtr())
         , m_outerLoopIndex(UINT_MAX)
         , m_innerLoopIndex(UINT_MAX)
     {
@@ -288,28 +288,28 @@ public:
     {
         const NaturalLoop<Graph>* loop = innerMostLoopOf(block);
         if (!loop)
-            return nullptr;
+            return nullPtr();
         if (loop->header() == block)
             return loop;
 #if ASSERT_ENABLED
         for (; loop; loop = innerMostOuterLoop(*loop))
             ASSERT(loop->header() != block);
 #endif
-        return nullptr;
+        return nullPtr();
     }
     
     const NaturalLoop<Graph>* innerMostLoopOf(typename Graph::Node block) const
     {
         unsigned index = m_innerMostLoopIndices[block][0];
         if (index == UINT_MAX)
-            return nullptr;
+            return nullPtr();
         return &m_loops[index];
     }
     
     const NaturalLoop<Graph>* innerMostOuterLoop(const NaturalLoop<Graph>& loop) const
     {
         if (loop.m_outerLoopIndex == UINT_MAX)
-            return nullptr;
+            return nullPtr();
         return &m_loops[loop.m_outerLoopIndex];
     }
     

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -91,7 +91,7 @@ int numberOfPhysicalProcessorCores()
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         size_t valueSize = sizeof(numCores);
-        int result = sysctlbyname("hw.physicalcpu_max", &numCores, &valueSize, nullptr, 0);
+        int result = sysctlbyname("hw.physicalcpu_max", &numCores, &valueSize, nullPtr(), 0);
         if (result < 0)
             numCores = defaultIfUnavailable;
     });

--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -46,14 +46,14 @@ public:
     // The memory returned by this cannot be released as on Windows there's no guaranteed API to
     // get an aligned address and the size + alignment then rounding trick cannot release the unused parts
     // due to how the Windows syscalls work.
-    WTF_EXPORT_PRIVATE static void* tryReserveUncommittedAligned(size_t, size_t alignment, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void* tryReserveUncommittedAligned(size_t, size_t alignment, Usage = UnknownUsage, void* address = nullPtr(), bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
 
     // These methods are symmetric; reserveUncommitted allocates VM in an uncommitted state,
     // releaseDecommitted should be called on a region of VM allocated by a single reservation,
     // the memory must all currently be in a decommitted state. reserveUncommitted returns to
     // you memory that is zeroed.
-    WTF_EXPORT_PRIVATE static void* reserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
-    WTF_EXPORT_PRIVATE static void* tryReserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void* reserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullPtr(), bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void* tryReserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullPtr(), bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
     WTF_EXPORT_PRIVATE static void releaseDecommitted(void*, size_t, unsigned numberOfGuardPagesOnEachEnd);
 
     // These methods are symmetric; they commit or decommit a region of VM (uncommitted VM should
@@ -65,14 +65,14 @@ public:
     // These methods are symmetric; reserveAndCommit allocates VM in an committed state,
     // decommitAndRelease should be called on a region of VM allocated by a single reservation,
     // the memory must all currently be in a committed state.
-    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
-    WTF_EXPORT_PRIVATE static void* tryReserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullPtr(), bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void* tryReserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullPtr(), bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
     static void decommitAndRelease(void* base, size_t size);
 
     // These methods are akin to reserveAndCommit/decommitAndRelease, above - however rather than
     // committing/decommitting the entire region additional parameters allow a subregion to be
     // specified.
-    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t reserveSize, size_t commitSize, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false);
+    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t reserveSize, size_t commitSize, Usage = UnknownUsage, void* address = nullPtr(), bool writable = true, bool executable = false, bool jitCageEnabled = false);
 
     // Reallocate an existing, committed allocation.
     // The prior allocation must be fully comitted, and the new size will also be fully committed.
@@ -102,7 +102,7 @@ inline void OSAllocator::decommitAndRelease(void* releaseBase, size_t releaseSiz
 template<typename T>
 inline T* OSAllocator::reallocateCommitted(T* oldBase, size_t oldSize, size_t newSize, Usage usage, bool writable, bool executable, bool jitCageEnabled)
 {
-    void* newBase = reserveAndCommit(newSize, usage, nullptr, writable, executable, jitCageEnabled);
+    void* newBase = reserveAndCommit(newSize, usage, nullPtr(), writable, executable, jitCageEnabled);
     memcpy(newBase, oldBase, std::min(oldSize, newSize));
     decommitAndRelease(oldBase, oldSize);
     return static_cast<T*>(newBase);

--- a/Source/WTF/wtf/OSObjectPtr.h
+++ b/Source/WTF/wtf/OSObjectPtr.h
@@ -63,7 +63,7 @@ template<typename T> static inline void releaseOSObject(T ptr)
 template<typename T> class OSObjectPtr {
 public:
     OSObjectPtr()
-        : m_ptr(nullptr)
+        : m_ptr(nullPtr())
     {
     }
 
@@ -88,7 +88,7 @@ public:
     OSObjectPtr(OSObjectPtr&& other)
         : m_ptr(WTFMove(other.m_ptr))
     {
-        other.m_ptr = nullptr;
+        other.m_ptr = nullPtr();
     }
 
     OSObjectPtr(T ptr)
@@ -116,7 +116,7 @@ public:
     {
         if (m_ptr)
             releaseOSObject(m_ptr);
-        m_ptr = nullptr;
+        m_ptr = nullPtr();
         return *this;
     }
 
@@ -134,7 +134,7 @@ public:
 
     T leakRef() WARN_UNUSED_RETURN
     {
-        return std::exchange(m_ptr, nullptr);
+        return std::exchange(m_ptr, nullPtr());
     }
 
     friend OSObjectPtr adoptOSObject<T>(T) WARN_UNUSED_RETURN;

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -184,7 +184,7 @@ public:
 
     void clear()
     {
-        set(nullptr);
+        set(nullPtr());
     }
 
     T* operator->() const { return get(); }
@@ -197,7 +197,7 @@ public:
 
     // This conversion operator allows implicit conversion to bool but not to other integer types.
     typedef T* (PackedAlignedPtr::*UnspecifiedBoolType);
-    operator UnspecifiedBoolType() const { return get() ? &PackedAlignedPtr::m_storage : nullptr; }
+    operator UnspecifiedBoolType() const { return get() ? &PackedAlignedPtr::m_storage : nullPtr(); }
     explicit operator bool() const { return get(); }
 
     PackedAlignedPtr& operator=(T* value)

--- a/Source/WTF/wtf/PageAllocation.h
+++ b/Source/WTF/wtf/PageAllocation.h
@@ -77,7 +77,7 @@ public:
     static PageAllocation allocate(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false)
     {
         ASSERT(isPageAligned(size));
-        return PageAllocation(OSAllocator::reserveAndCommit(size, usage, nullptr, writable, executable), size);
+        return PageAllocation(OSAllocator::reserveAndCommit(size, usage, nullPtr(), writable, executable), size);
     }
 
     void deallocate()

--- a/Source/WTF/wtf/PageBlock.h
+++ b/Source/WTF/wtf/PageBlock.h
@@ -89,7 +89,7 @@ public:
     }
 
 private:
-    void* m_base { nullptr };
+    void* m_base { nullPtr() };
     size_t m_size { 0 };
 };
 

--- a/Source/WTF/wtf/PageReservation.h
+++ b/Source/WTF/wtf/PageReservation.h
@@ -89,7 +89,7 @@ public:
         return m_committed;
     }
 
-    static PageReservation reserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation reserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullPtr(), bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         ASSERT(isPageAligned(addressHint));
@@ -98,7 +98,7 @@ public:
         return PageReservation(OSAllocator::reserveUncommitted(size, usage, addressHint, writable, executable, jitCageEnabled), size, writable, executable, jitCageEnabled);
     }
 
-    static PageReservation tryReserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation tryReserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullPtr(), bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         ASSERT(isPageAligned(addressHint));
@@ -107,7 +107,7 @@ public:
         return PageReservation(OSAllocator::tryReserveUncommitted(size, usage, addressHint, writable, executable, jitCageEnabled), size, writable, executable, jitCageEnabled);
     }
 
-    static PageReservation reserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation reserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullPtr(), bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         ASSERT(isPageAligned(addressHint));
@@ -116,7 +116,7 @@ public:
         return PageReservation(OSAllocator::reserveUncommitted(size, usage, addressHint, writable, executable, jitCageEnabled, 1), size, writable, executable, jitCageEnabled, 1);
     }
 
-    static PageReservation tryReserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation tryReserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullPtr(), bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         ASSERT(isPageAligned(addressHint));

--- a/Source/WTF/wtf/ParallelHelperPool.cpp
+++ b/Source/WTF/wtf/ParallelHelperPool.cpp
@@ -91,7 +91,7 @@ void ParallelHelperClient::runTaskInParallel(RefPtr<SharedTask<void ()>>&& task)
 
 void ParallelHelperClient::finishWithLock()
 {
-    m_task = nullptr;
+    m_task = nullPtr();
     while (m_numActive)
         m_pool->m_workCompleteCondition.wait(*m_pool->m_lock);
 }
@@ -99,7 +99,7 @@ void ParallelHelperClient::finishWithLock()
 RefPtr<SharedTask<void ()>> ParallelHelperClient::claimTask()
 {
     if (!m_task)
-        return nullptr;
+        return nullPtr();
     
     m_numActive++;
     return m_task;
@@ -117,7 +117,7 @@ void ParallelHelperClient::runTask(const RefPtr<SharedTask<void ()>>& task)
         RELEASE_ASSERT(m_numActive);
         // No new task could have been installed, since we were still active.
         RELEASE_ASSERT(!m_task || m_task == task);
-        m_task = nullptr;
+        m_task = nullPtr();
         m_numActive--;
         if (!m_numActive)
             m_pool->m_workCompleteCondition.notifyAll();
@@ -209,13 +209,13 @@ private:
     WorkResult work() final
     {
         m_client->runTask(m_task);
-        m_client = nullptr;
-        m_task = nullptr;
+        m_client = nullPtr();
+        m_task = nullPtr();
         return WorkResult::Continue;
     }
 
     const CheckedRef<ParallelHelperPool> m_pool;
-    ParallelHelperClient* m_client { nullptr };
+    ParallelHelperClient* m_client { nullPtr() };
     RefPtr<SharedTask<void ()>> m_task;
 };
 
@@ -246,7 +246,7 @@ ParallelHelperClient* ParallelHelperPool::getClientWithTask()
             return client;
     }
 
-    return nullptr;
+    return nullPtr();
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/ParallelJobsGeneric.cpp
+++ b/Source/WTF/wtf/ParallelJobsGeneric.cpp
@@ -34,7 +34,7 @@
 
 namespace WTF {
 
-Vector< RefPtr<ParallelEnvironment::ThreadPrivate> >* ParallelEnvironment::s_threadPool = nullptr;
+Vector< RefPtr<ParallelEnvironment::ThreadPrivate> >* ParallelEnvironment::s_threadPool = nullPtr();
 
 ParallelEnvironment::ParallelEnvironment(ThreadFunction threadFunction, size_t sizeOfParameter, int requestedJobNumber) :
     m_threadFunction(threadFunction),
@@ -103,7 +103,7 @@ bool ParallelEnvironment::ThreadPrivate::tryLockFor(ParallelEnvironment* parent)
                 if (m_running) {
                     (*m_threadFunction)(m_parameters);
                     m_running = false;
-                    m_parent = nullptr;
+                    m_parent = nullPtr();
                     m_threadCondition.notifyOne();
                 }
 

--- a/Source/WTF/wtf/ParallelJobsGeneric.h
+++ b/Source/WTF/wtf/ParallelJobsGeneric.h
@@ -70,10 +70,10 @@ public:
 
         RefPtr<Thread> m_thread;
         bool m_running { false };
-        ParallelEnvironment* m_parent WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
+        ParallelEnvironment* m_parent WTF_GUARDED_BY_LOCK(m_lock) { nullPtr() };
 
-        ThreadFunction m_threadFunction { nullptr };
-        void* m_parameters { nullptr };
+        ThreadFunction m_threadFunction { nullPtr() };
+        void* m_parameters { nullPtr() };
     };
 
 private:

--- a/Source/WTF/wtf/PlatformRegisters.cpp
+++ b/Source/WTF/wtf/PlatformRegisters.cpp
@@ -58,7 +58,7 @@ void* threadStatePCInternal(PlatformRegisters& regs)
     // authing the value as it is using a custom ptrauth signing scheme.
     _STRUCT_ARM_THREAD_STATE64* ts = &(regs);
     if (!(ts->__opaque_flags & __DARWIN_ARM_THREAD_STATE64_FLAGS_KERNEL_SIGNED_PC))
-        return nullptr;
+        return nullPtr();
 #endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
 
     void* candidatePC = arm_thread_state64_get_pc_fptr(regs);

--- a/Source/WTF/wtf/PtrTag.h
+++ b/Source/WTF/wtf/PtrTag.h
@@ -235,7 +235,7 @@ template<PtrTagAction tagAction, PtrTag tag, typename PtrType>
 inline PtrType tagCodePtrImpl(PtrType ptr)
 {
     if (!ptr)
-        return nullptr;
+        return nullPtr();
     WTF_PTRTAG_ASSERT(tagAction, ptr, NoPtrTag, removeCodePtrTag(ptr) == ptr);
     return PtrTagTraits<tag>::tagCodePtr(ptr);
 }
@@ -255,7 +255,7 @@ template<PtrTagAction tagAction, PtrTag tag, typename PtrType>
 inline PtrType untagCodePtrImpl(PtrType ptr)
 {
     if (!ptr)
-        return nullptr;
+        return nullPtr();
     PtrType result = PtrTagTraits<tag>::untagCodePtr(ptr);
     WTF_PTRTAG_ASSERT(tagAction, ptr, tag, removeCodePtrTag(ptr) == result);
     return result;
@@ -298,7 +298,7 @@ template<PtrTagAction tagAction, PtrTag oldTag, PtrTag newTag, typename PtrType>
 inline PtrType retagCodePtrImpl(PtrType ptr)
 {
     if (!ptr)
-        return nullptr;
+        return nullPtr();
     WTF_PTRTAG_ASSERT(tagAction, ptr, oldTag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, oldTag>(removeCodePtrTag(ptr))));
     PtrType result = retagCodePtrImplHelper<tagAction, oldTag, newTag>(ptr);
     WTF_PTRTAG_ASSERT(tagAction, ptr, newTag, result == (tagCodePtrImpl<PtrTagAction::NoAssert, newTag>(removeCodePtrTag(ptr))));
@@ -375,7 +375,7 @@ template<PtrTagAction tagAction, PtrTag tag, typename PtrType>
 inline PtrType tagCFunctionPtrImpl(PtrType ptr)
 {
     if (!ptr)
-        return nullptr;
+        return nullPtr();
     WTF_PTRTAG_ASSERT(tagAction, ptr, CFunctionPtrTag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, CFunctionPtrTag>(removeCodePtrTag(ptr))));
     return retagCodePtrImpl<tagAction, CFunctionPtrTag, tag>(ptr);
 }
@@ -409,7 +409,7 @@ template<PtrTagAction tagAction, PtrTag tag, typename PtrType>
 inline PtrType untagCFunctionPtrImpl(PtrType ptr)
 {
     if (!ptr)
-        return nullptr;
+        return nullPtr();
     WTF_PTRTAG_ASSERT(tagAction, ptr, tag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, tag>(removeCodePtrTag(ptr))));
     return retagCodePtrImpl<tagAction, tag, CFunctionPtrTag>(ptr);
 }
@@ -528,7 +528,7 @@ template<typename T>
 inline T* tagArrayPtr(std::nullptr_t, size_t size)
 {
     ASSERT_UNUSED(size, !size);
-    return nullptr;
+    return nullPtr();
 }
 
 template<typename T>

--- a/Source/WTF/wtf/RandomDevice.cpp
+++ b/Source/WTF/wtf/RandomDevice.cpp
@@ -109,7 +109,7 @@ void RandomDevice::cryptographicallyRandomValues(std::span<uint8_t> buffer)
     // FIXME: We cannot ensure that Cryptographic Service Provider context and CryptGenRandom are safe across threads.
     // If it is safe, we can acquire context per RandomDevice.
     HCRYPTPROV hCryptProv = 0;
-    if (!CryptAcquireContext(&hCryptProv, nullptr, MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+    if (!CryptAcquireContext(&hCryptProv, nullPtr(), MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
         CRASH();
     if (!CryptGenRandom(hCryptProv, buffer.size(), buffer.data()))
         CRASH();

--- a/Source/WTF/wtf/RawHex.h
+++ b/Source/WTF/wtf/RawHex.h
@@ -96,7 +96,7 @@ private:
     bool m_is64Bit { false };
 #endif
     union {
-        const void* m_ptr { nullptr };
+        const void* m_ptr { nullPtr() };
 #if !CPU(ADDRESS64)
         uint64_t m_u64;
 #endif

--- a/Source/WTF/wtf/RawPointer.h
+++ b/Source/WTF/wtf/RawPointer.h
@@ -30,7 +30,7 @@ namespace WTF {
 class RawPointer {
 public:
     RawPointer()
-        : m_value(nullptr)
+        : m_value(nullPtr())
     {
     }
     

--- a/Source/WTF/wtf/RecursiveLockAdapter.h
+++ b/Source/WTF/wtf/RecursiveLockAdapter.h
@@ -33,7 +33,7 @@ namespace WTF {
 template<typename LockType>
 class RecursiveLockAdapter {
 public:
-    RecursiveLockAdapter() = default;
+    constexpr RecursiveLockAdapter() = default;
 
     // Use WTF_IGNORES_THREAD_SAFETY_ANALYSIS because the function does conditional locking, which is
     // not supported by analysis. Also RecursiveLockAdapter may wrap a lock type besides WTF::Lock
@@ -60,7 +60,7 @@ public:
     {
         if (--m_recursionCount)
             return;
-        m_owner = nullptr;
+        m_owner = nullPtr();
         m_lock.unlock();
     }
     

--- a/Source/WTF/wtf/RedBlackTree.h
+++ b/Source/WTF/wtf/RedBlackTree.h
@@ -101,8 +101,8 @@ public:
     private:
         void reset()
         {
-            m_left = nullptr;
-            m_right = nullptr;
+            m_left = nullPtr();
+            m_right = nullPtr();
             m_parentAndRed = 1; // initialize to red
         }
         
@@ -159,7 +159,7 @@ public:
     };
 
     RedBlackTree()
-        : m_root(nullptr)
+        : m_root(nullPtr())
     {
     }
     
@@ -306,7 +306,7 @@ public:
     
     NodeType* findLeastGreaterThanOrEqual(const KeyType& key) const
     {
-        NodeType* best = nullptr;
+        NodeType* best = nullPtr();
         unsigned depth = 0;
         for (NodeType* current = m_root; current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -324,7 +324,7 @@ public:
     
     NodeType* findGreatestLessThanOrEqual(const KeyType& key) const
     {
-        NodeType* best = nullptr;
+        NodeType* best = nullPtr();
         unsigned depth = 0;
         for (NodeType* current = m_root; current;) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
@@ -365,7 +365,7 @@ public:
     NodeType* first() const
     {
         if (!m_root)
-            return nullptr;
+            return nullPtr();
         return treeMinimum(m_root);
     }
     
@@ -441,7 +441,7 @@ private:
         ASSERT(!z->parent());
         ASSERT(z->color() == Red);
         
-        NodeType* y = nullptr;
+        NodeType* y = nullPtr();
         NodeType* x = m_root;
         unsigned depth = 0;
         while (x) {

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -81,7 +81,7 @@ public:
         if (__asan_address_is_poisoned(this))
             __asan_unpoison_memory_region(this, sizeof(*this));
 #endif
-        if (auto* ptr = PtrTraits::exchange(m_ptr, nullptr))
+        if (auto* ptr = PtrTraits::exchange(m_ptr, nullPtr()))
             RefDerefTraits::derefIfNotNull(ptr);
     }
 
@@ -128,7 +128,7 @@ public:
 
     Ref(HashTableEmptyValueType) : m_ptr(hashTableEmptyValue()) { }
     bool isHashTableEmptyValue() const { return m_ptr == hashTableEmptyValue(); }
-    static T* hashTableEmptyValue() { return nullptr; }
+    static T* hashTableEmptyValue() { return nullPtr(); }
 
     const T* ptrAllowingHashTableEmptyValue() const LIFETIME_BOUND { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
     T* ptrAllowingHashTableEmptyValue() LIFETIME_BOUND { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
@@ -151,7 +151,7 @@ public:
     {
         ASSERT(m_ptr);
 
-        T& result = *PtrTraits::exchange(m_ptr, nullptr);
+        T& result = *PtrTraits::exchange(m_ptr, nullPtr());
 #if ASAN_ENABLED
         __asan_poison_memory_region(this, sizeof(*this));
 #endif
@@ -349,7 +349,7 @@ inline RefPtr<match_constness_t<Source, Target>> dynamicDowncast(Ref<Source, Ptr
     static_assert(!std::same_as<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::derived_from<Target, Source>, "Should be a downcast");
     if (!is<Target>(source))
-        return nullptr;
+        return nullPtr();
     return unsafeRefDowncast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 

--- a/Source/WTF/wtf/RefCounted.cpp
+++ b/Source/WTF/wtf/RefCounted.cpp
@@ -60,11 +60,11 @@ public:
         RefLogStackShot* stackShot = new RefLogStackShot(ptr);
 
         size_t index = s_end.fetch_add(1, std::memory_order_acquire) & s_sizeMask;
-        if (RefLogStackShot* old = s_buffer[index].exchange(nullptr, std::memory_order_acquire))
+        if (RefLogStackShot* old = s_buffer[index].exchange(nullPtr(), std::memory_order_acquire))
             delete old;
 
         // Other threads may have raced ahead and filled the log. If so, our stack shot is oldest, so we drop it.
-        RefLogStackShot* expected = nullptr;
+        RefLogStackShot* expected = nullPtr();
         if (!s_buffer[index].compare_exchange_strong(expected, stackShot, std::memory_order_release))
             delete stackShot;
     }

--- a/Source/WTF/wtf/RefCountedFixedVector.h
+++ b/Source/WTF/wtf/RefCountedFixedVector.h
@@ -81,7 +81,7 @@ public:
     {
         auto result = adoptRef(*new (NotNull, fastMalloc(Base::allocationSize(size))) RefCountedFixedVectorBase(typename Base::Failable { }, size, std::forward<FailableGenerator>(generator)));
         if (result->size() != size)
-            return nullptr;
+            return nullPtr();
         return result;
     }
 

--- a/Source/WTF/wtf/RefCounter.h
+++ b/Source/WTF/wtf/RefCounter.h
@@ -65,7 +65,7 @@ public:
     using Token = RefPtr<Count>;
     using ValueChangeFunction = WTF::Function<void (RefCounterEvent)>;
 
-    RefCounter(ValueChangeFunction&& = nullptr);
+    RefCounter(ValueChangeFunction&& = nullPtr());
     ~RefCounter();
 
     Token count() const
@@ -121,7 +121,7 @@ inline void RefCounter<T>::Count::refCounterWasDeleted()
     // If the reference count of the Count is already zero then delete it now, otherwise
     // clear its m_refCounter pointer.
 
-    m_refCounter = nullptr;
+    m_refCounter = nullPtr();
 
     if (m_inValueDidChange)
         return;

--- a/Source/WTF/wtf/RefTrackerMixin.cpp
+++ b/Source/WTF/wtf/RefTrackerMixin.cpp
@@ -33,7 +33,7 @@ void RefTracker::reportLive(void* id)
     RELEASE_ASSERT(id);
     Locker locker(lock);
 
-    std::unique_ptr<StackShot> stack = nullptr;
+    std::unique_ptr<StackShot> stack = nullPtr();
     if (!loggingDisabledDepth.load())
         stack = makeUnique<StackShot>(16);
     RELEASE_ASSERT(map.add(id, WTFMove(stack)).isNewEntry);

--- a/Source/WTF/wtf/RefTrackerMixin.h
+++ b/Source/WTF/wtf/RefTrackerMixin.h
@@ -108,7 +108,7 @@ struct RefTrackerMixin final {
     }
 
     // This guards against seeing an unconstructed object (say, if we are zero-initialized)
-    RefTrackerMixin* originalThis = nullptr;
+    RefTrackerMixin* originalThis = nullPtr();
 };
 
 #define REFTRACKER_DECL(T, initializer) \

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -109,12 +109,12 @@ public:
 
     template<typename U = StorageType>
     std::enable_if_t<IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() NS_RETURNS_RETAINED WARN_UNUSED_RETURN {
-        return std::exchange(m_ptr, nullptr);
+        return std::exchange(m_ptr, nullPtr());
     }
 
     template<typename U = StorageType>
     std::enable_if_t<!IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
-        return std::exchange(m_ptr, nullptr);
+        return std::exchange(m_ptr, nullPtr());
     }
 
     PtrType autorelease();
@@ -176,7 +176,7 @@ private:
 #endif
 #endif
 
-    StorageType m_ptr { nullptr };
+    StorageType m_ptr { nullPtr() };
 };
 
 template<typename T> RetainPtr(T) -> RetainPtr<RetainPtrType<T>>;
@@ -186,7 +186,7 @@ template<typename T> RetainPtr<RetainPtrType<T>> retainPtr(T) WARN_UNUSED_RETURN
 
 template<typename T> inline RetainPtr<T>::~RetainPtr()
 {
-    if (auto ptr = std::exchange(m_ptr, nullptr))
+    if (auto ptr = std::exchange(m_ptr, nullPtr()))
         releaseFoundationPtr(ptr);
 }
 
@@ -211,13 +211,13 @@ template<typename T> template<typename U> inline RetainPtr<T>::RetainPtr(const R
 
 template<typename T> inline void RetainPtr<T>::clear()
 {
-    if (auto ptr = std::exchange(m_ptr, nullptr))
+    if (auto ptr = std::exchange(m_ptr, nullPtr()))
         releaseFoundationPtr(ptr);
 }
 
 template<typename T> inline auto RetainPtr<T>::autorelease() -> PtrType
 {
-    auto ptr = std::exchange(m_ptr, nullptr);
+    auto ptr = std::exchange(m_ptr, nullPtr());
     if (ptr)
         autoreleaseFoundationPtr(ptr);
     return ptr;

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -295,7 +295,7 @@ private:
     unsigned keyCount() const { return m_keyCount; }
     unsigned tableHash() const { return m_tableHash; }
 
-    ValueType* m_table { nullptr };
+    ValueType* m_table { nullPtr() };
     unsigned m_tableSize { 0 };
     unsigned m_keyCount { 0 };
     unsigned m_tableHash { 0 };
@@ -304,7 +304,7 @@ private:
 #if CHECK_HASHTABLE_ITERATORS
 public:
     // All access to m_iterators should be guarded with m_mutex.
-    mutable const_iterator* m_iterators { nullptr };
+    mutable const_iterator* m_iterators { nullPtr() };
     // Use std::unique_ptr so HashTable can still be memmove'd or memcpy'ed.
     mutable std::unique_ptr<Lock> m_mutex { makeUnique<Lock>() };
 #endif
@@ -341,7 +341,7 @@ ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
 
     ValueType* table = m_table;
     if (!table)
-        return nullptr;
+        return nullPtr();
 
     unsigned size = tableSize();
     unsigned sizeMask = tableSizeMask();
@@ -353,14 +353,14 @@ ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
     while (true) {
         ValueType* entry = m_table + index;
         if (isEmptyBucket(*entry))
-            return nullptr;
+            return nullPtr();
 
         // RobinHoodHashTable maintains this invariant so that we can stop
         // probing when distance exceeds probing distance of the existing entry.
         auto& entryKey = Extractor::extract(*entry);
         unsigned entryHash = IdentityTranslatorType::hash(entryKey) ^ tableHash;
         if (distance > probeDistance(entryHash, index, size, sizeMask))
-            return nullptr;
+            return nullPtr();
 
         if (entryHash == hash && HashTranslator::equal(entryKey, key))
             return entry;
@@ -400,7 +400,7 @@ ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
     unsigned index = desiredIndex(hash, sizeMask);
     unsigned distance = 0;
 
-    ValueType* entry = nullptr;
+    ValueType* entry = nullPtr();
     while (true) {
         entry = m_table + index;
         if (isEmptyBucket(*entry)) {
@@ -491,7 +491,7 @@ inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
     unsigned index = desiredIndex(hash, sizeMask);
     unsigned distance = 0;
 
-    ValueType* entry = nullptr;
+    ValueType* entry = nullPtr();
     while (true) {
         entry = m_table + index;
         if (isEmptyBucket(*entry)) {
@@ -798,7 +798,7 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     m_keyCount = 0;
     m_tableHash = 0;
     m_willExpand = false;
-    deallocateTable(std::exchange(m_table, nullptr), oldTableSize);
+    deallocateTable(std::exchange(m_table, nullPtr()), oldTableSize);
     internalCheckTableConsistency();
 }
 
@@ -854,7 +854,7 @@ inline RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTrait
 {
     invalidateIterators(&other);
 
-    m_table = std::exchange(other.m_table, nullptr);
+    m_table = std::exchange(other.m_table, nullPtr());
     m_tableSize = std::exchange(other.m_tableSize, 0);
     m_keyCount = std::exchange(other.m_keyCount, 0);
     m_tableHash = std::exchange(other.m_tableHash, 0);

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -421,7 +421,7 @@ ALWAYS_INLINE std::optional<uint8_t> findFirstNonZeroIndex(simde_uint16x8_t valu
     // includes multiple found characters. We perform [0, 1, 2, 3, 4, 5, 6, 7] OR-NOT with this value,
     // to assign the index to found characters.
     // Find the smallest value. Because of [0, 1, 2, 3, 4, 5, 6, 7], the value should be index in this vector.
-    // If the index less than length, it is within the requested pointer. Otherwise, nullptr.
+    // If the index less than length, it is within the requested pointer. Otherwise, nullPtr().
     //
     // Example
     //     value       |0|0|0|X|0|X|0|0| (X is all-one)

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -61,7 +61,7 @@ private:
         : m_runLoop(runLoop)
     {
         if (mode)
-            lazyInitialize(m_mode, adoptCF(CFStringCreateCopy(nullptr, mode)));
+            lazyInitialize(m_mode, adoptCF(CFStringCreateCopy(nullPtr(), mode)));
     }
 
 #if PLATFORM(COCOA)

--- a/Source/WTF/wtf/ScopedLambda.h
+++ b/Source/WTF/wtf/ScopedLambda.h
@@ -46,7 +46,7 @@ template<typename ResultType, typename... ArgumentTypes>
 class ScopedLambda<ResultType (ArgumentTypes...)> {
     WTF_FORBID_HEAP_ALLOCATION;
 public:
-    ScopedLambda(ResultType (*impl)(void* arg, ArgumentTypes...) = nullptr, void* arg = nullptr)
+    ScopedLambda(ResultType (*impl)(void* arg, ArgumentTypes...) = nullPtr(), void* arg = nullPtr())
         : m_impl(impl)
         , m_arg(arg)
     {

--- a/Source/WTF/wtf/SentinelLinkedList.h
+++ b/Source/WTF/wtf/SentinelLinkedList.h
@@ -75,8 +75,8 @@ public:
     void append(BasicRawSentinelNode*);
     
 private:
-    typename PtrTraits::StorageType m_next { nullptr };
-    typename PtrTraits::StorageType m_prev { nullptr };
+    typename PtrTraits::StorageType m_next { nullPtr() };
+    typename PtrTraits::StorageType m_prev { nullPtr() };
 };
 
 template <typename T, typename RawNode = T> class SentinelLinkedList {
@@ -240,8 +240,8 @@ template <typename T, typename RawNode> inline void SentinelLinkedList<T, RawNod
     prev->setNext(next);
     next->setPrev(prev);
     
-    node->setPrev(nullptr);
-    node->setNext(nullptr);
+    node->setPrev(nullPtr());
+    node->setNext(nullPtr());
 }
 
 template <typename T, typename RawNode>

--- a/Source/WTF/wtf/SequesteredAllocator.h
+++ b/Source/WTF/wtf/SequesteredAllocator.h
@@ -182,7 +182,7 @@ private:
             }
             if constexpr (!canExpand) {
                 if constexpr (mode == AllocationFailureMode::ReturnNull)
-                    return nullptr;
+                    return nullPtr();
                 ASSERT(mode == AllocationFailureMode::Assert);
                 RELEASE_ASSERT_NOT_REACHED();
             }
@@ -200,7 +200,7 @@ private:
             }
             if constexpr (!canExpand) {
                 if constexpr (mode == AllocationFailureMode::ReturnNull)
-                    return nullptr;
+                    return nullPtr();
                 ASSERT(mode == AllocationFailureMode::Assert);
                 RELEASE_ASSERT_NOT_REACHED();
             }
@@ -238,7 +238,7 @@ private:
             GranuleHeader* granule = reinterpret_cast<GranuleHeader*>(mapGranule<mode>(minArenaGranuleSize));
             if constexpr (mode == AllocationFailureMode::ReturnNull) {
                 if (!granule) [[unlikely]]
-                    return nullptr;
+                    return nullPtr();
             }
 
             m_granules.push(granule);

--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -81,7 +81,7 @@ void ConcurrentDecommitQueue::decommit()
 
 void SequesteredImmortalHeap::installScavenger()
 {
-    RELEASE_ASSERT(pas_scavenger_try_install_foreign_work_callback(scavenge, 11, nullptr));
+    RELEASE_ASSERT(pas_scavenger_try_install_foreign_work_callback(scavenge, 11, nullPtr()));
 }
 
 bool SequesteredImmortalHeap::scavengeImpl(void* /*userdata*/)

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -220,7 +220,7 @@ public:
     template <typename T> requires (sizeof(T) <= slotSize)
     T* allocateAndInstall()
     {
-        T* slot = nullptr;
+        T* slot = nullPtr();
         {
             Locker locker { m_scavengerLock };
             ASSERT(!getUnchecked());
@@ -233,7 +233,7 @@ public:
             WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
         _pthread_setspecific_direct(key, reinterpret_cast<void*>(slot));
-        pthread_key_init_np(key, nullptr);
+        pthread_key_init_np(key, nullPtr());
 
         dataLogIf(verbose, "SequesteredImmortalHeap: thread (", Thread::currentSingleton(), ") allocated slot ", instance().m_nextFreeIndex - 1, " (", slot, ")");
         return slot;
@@ -272,11 +272,11 @@ public:
     template<AllocationFailureMode mode>
     GranuleHeader* mapGranule(size_t bytes)
     {
-        void* p = mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
+        void* p = mmap(nullPtr(), bytes, PROT_READ | PROT_WRITE,
             MAP_PRIVATE | MAP_ANON, -1, 0);
         if (p == MAP_FAILED) [[unlikely]] {
             if constexpr (mode == AllocationFailureMode::ReturnNull)
-                return nullptr;
+                return nullPtr();
             RELEASE_ASSERT_NOT_REACHED();
         }
         RELEASE_ASSERT_DATA_ADDRESS_IS_SANE(p);

--- a/Source/WTF/wtf/SequesteredMalloc.cpp
+++ b/Source/WTF/wtf/SequesteredMalloc.cpp
@@ -54,7 +54,7 @@ void sequesteredArenaSetMaxSingleAllocationSize(size_t size)
 
 #define FAIL_IF_EXCEEDS_LIMIT(size) do { \
         if ((size) > maxSingleSequesteredArenaAllocationSize) [[unlikely]] \
-            return nullptr; \
+            return nullPtr(); \
     } while (false)
 #else // !ASSERT_ENABLED
 
@@ -120,7 +120,7 @@ TryMallocReturnValue trySequesteredArenaCalloc(size_t numElements, size_t elemen
     CheckedSize checkedSize = elementSize;
     checkedSize *= numElements;
     if (checkedSize.hasOverflowed())
-        return nullptr;
+        return nullPtr();
     return trySequesteredArenaZeroedMalloc(checkedSize);
 }
 TryMallocReturnValue trySequesteredArenaRealloc(void* object, size_t newSize)

--- a/Source/WTF/wtf/SequesteredMalloc.h
+++ b/Source/WTF/wtf/SequesteredMalloc.h
@@ -102,7 +102,7 @@ struct SequesteredArenaMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void* zeroedMalloc(size_t size) { return sequesteredArenaZeroedMalloc(size); }
@@ -113,7 +113,7 @@ struct SequesteredArenaMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void* realloc(void* p, size_t size) { return sequesteredArenaRealloc(p, size); }
@@ -124,7 +124,7 @@ struct SequesteredArenaMalloc {
         void* realResult;
         if (result.getValue(realResult))
             return realResult;
-        return nullptr;
+        return nullPtr();
     }
 
     static void free(void* p) { sequesteredArenaFree(p); }

--- a/Source/WTF/wtf/SignedPtr.h
+++ b/Source/WTF/wtf/SignedPtr.h
@@ -38,12 +38,12 @@ public:
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SignedPtr);
 public:
     constexpr SignedPtr()
-        : m_value(nullptr)
+        : m_value(nullPtr())
     {
     }
 
     constexpr SignedPtr(std::nullptr_t)
-        : m_value(nullptr)
+        : m_value(nullPtr())
     {
     }
 
@@ -56,7 +56,7 @@ public:
     {
 #if CPU(ARM64E)
         if (!m_value)
-            return nullptr;
+            return nullPtr();
         return ptrauth_auth_data(m_value, ptrauth_key_process_dependent_data, Tag);
 #else
         return m_value;
@@ -76,7 +76,7 @@ public:
 
     void clear()
     {
-        set(nullptr);
+        set(nullPtr());
     }
 
     T* operator->() const { return get(); }
@@ -89,7 +89,7 @@ public:
     
     // This conversion operator allows implicit conversion to bool but not to other integer types.
     typedef T* (SignedPtr::*UnspecifiedBoolType);
-    operator UnspecifiedBoolType() const { return get() ? &SignedPtr::m_value : nullptr; }
+    operator UnspecifiedBoolType() const { return get() ? &SignedPtr::m_value : nullPtr(); }
     explicit operator bool() const { return get(); }
 
     SignedPtr& operator=(T* value)

--- a/Source/WTF/wtf/SinglyLinkedListWithTail.h
+++ b/Source/WTF/wtf/SinglyLinkedListWithTail.h
@@ -53,8 +53,8 @@ public:
     T* last() const { return m_last; }
     
 private:
-    T* m_first { nullptr };
-    T* m_last { nullptr };
+    T* m_first { nullPtr() };
+    T* m_last { nullPtr() };
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/SmallMap.h
+++ b/Source/WTF/wtf/SmallMap.h
@@ -83,7 +83,7 @@ public:
             if (auto it = map->find(key); it != map->end())
                 return std::addressof(it->value);
         }
-        return nullptr;
+        return nullPtr();
     }
 
     void forEach(NOESCAPE const auto& callback) const

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -178,20 +178,20 @@ template<typename ArrayType> template<typename KeyArgument> inline auto SortedAr
     using KeyType = typename ElementType::first_type;
     auto parsedKey = SortedArrayKeyTraits<KeyType>::parse(key);
     if (!parsedKey)
-        return nullptr;
+        return nullPtr();
     decltype(std::begin(m_array)) iterator;
     if (std::size(m_array) < binarySearchThreshold) {
         iterator = std::find_if(std::begin(m_array), std::end(m_array), [&parsedKey](auto& pair) {
             return pair.first == *parsedKey;
         });
         if (iterator == std::end(m_array))
-            return nullptr;
+            return nullPtr();
     } else {
         iterator = std::lower_bound(std::begin(m_array), std::end(m_array), *parsedKey, [](auto& pair, auto& value) {
             return pair.first < value;
         });
         if (iterator == std::end(m_array) || !(iterator->first == *parsedKey))
-            return nullptr;
+            return nullPtr();
     }
     return &iterator->second;
 }

--- a/Source/WTF/wtf/StackBounds.cpp
+++ b/Source/WTF/wtf/StackBounds.cpp
@@ -112,7 +112,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)
 {
-    void* bound = nullptr;
+    void* bound = nullPtr();
     size_t stackSize = 0;
 
     pthread_attr_t sattr;

--- a/Source/WTF/wtf/StackPointer.h
+++ b/Source/WTF/wtf/StackPointer.h
@@ -34,7 +34,7 @@ namespace WTF {
 // needs to be inlinable in order to be correct.
 ALWAYS_INLINE void* currentStackPointer()
 {
-    void* stackPointer = nullptr;
+    void* stackPointer = nullPtr();
 #if CPU(X86_64)
     __asm__ volatile ("movq %%rsp, %0" : "=r"(stackPointer) ::);
 #elif CPU(X86)

--- a/Source/WTF/wtf/StackShot.h
+++ b/Source/WTF/wtf/StackShot.h
@@ -46,7 +46,7 @@ public:
             RELEASE_ASSERT(static_cast<size_t>(intSize) <= size);
             m_size = intSize;
             if (!m_size)
-                m_array = nullptr;
+                m_array = nullPtr();
         }
     }
     

--- a/Source/WTF/wtf/StackTrace.cpp
+++ b/Source/WTF/wtf/StackTrace.cpp
@@ -42,7 +42,7 @@ void WTFGetBacktrace(void** stack, int* size)
 #if HAVE(BACKTRACE)
     *size = backtrace(stack, *size);
 #elif OS(WINDOWS)
-    *size = RtlCaptureStackBackTrace(0, *size, stack, nullptr);
+    *size = RtlCaptureStackBackTrace(0, *size, stack, nullPtr());
 #else
     UNUSED_PARAM(stack);
     *size = 0;
@@ -54,7 +54,7 @@ namespace WTF {
 #if USE(LIBBACKTRACE)
 static struct backtrace_state* backtraceState()
 {
-    static NeverDestroyed<struct backtrace_state*> backtraceState = backtrace_create_state(nullptr, 1, nullptr, nullptr);
+    static NeverDestroyed<struct backtrace_state*> backtraceState = backtrace_create_state(nullPtr(), 1, nullPtr(), nullPtr());
     return backtraceState;
 }
 
@@ -76,7 +76,7 @@ char** symbolize(void* const* addresses, int size)
 {
     struct backtrace_state* state = backtraceState();
     if (!state)
-        return nullptr;
+        return nullPtr();
 
     char** symbols = static_cast<char**>(malloc(sizeof(char*) * size));
 
@@ -84,12 +84,12 @@ char** symbolize(void* const* addresses, int size)
         uintptr_t pc = reinterpret_cast<uintptr_t>(addresses[i]);
         char* symbol;
 
-        backtrace_pcinfo(state, pc, backtraceFullCallback, nullptr, &symbol);
+        backtrace_pcinfo(state, pc, backtraceFullCallback, nullPtr(), &symbol);
         if (!symbol)
-            backtrace_syminfo(backtraceState(), pc, backtraceSyminfoCallback, nullptr, &symbol);
+            backtrace_syminfo(backtraceState(), pc, backtraceSyminfoCallback, nullPtr(), &symbol);
 
         if (symbol) {
-            char* demangled = abi::__cxa_demangle(symbol, nullptr, nullptr, nullptr);
+            char* demangled = abi::__cxa_demangle(symbol, nullPtr(), nullPtr(), nullPtr());
             if (demangled)
                 symbols[i] = demangled;
             else
@@ -134,14 +134,14 @@ String StackTrace::toString() const
 auto StackTraceSymbolResolver::demangle(void* pc) -> std::optional<DemangleEntry>
 {
 #if HAVE(DLADDR)
-    const char* mangledName = nullptr;
-    const char* cxaDemangled = nullptr;
+    const char* mangledName = nullPtr();
+    const char* cxaDemangled = nullPtr();
     Dl_info info;
     if (dladdr(pc, &info) && info.dli_sname)
         mangledName = info.dli_sname;
     if (mangledName) {
         int status = 0;
-        cxaDemangled = abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
+        cxaDemangled = abi::__cxa_demangle(mangledName, nullPtr(), nullPtr(), &status);
         UNUSED_PARAM(status);
     }
     if (mangledName || cxaDemangled)

--- a/Source/WTF/wtf/StackTrace.h
+++ b/Source/WTF/wtf/StackTrace.h
@@ -109,7 +109,7 @@ public:
             , m_demangledName(demangledName)
         { }
 
-        const char* m_mangledName { nullptr };
+        const char* m_mangledName { nullPtr() };
         std::unique_ptr<const char, SystemFree<const char>> m_demangledName;
     };
 
@@ -134,7 +134,7 @@ public:
         symbolInfo->MaxNameLen = MAX_SYM_NAME;
 #endif
         for (size_t i = 0; i < m_stack.size(); ++i) {
-            const char* name = nullptr;
+            const char* name = nullPtr();
             auto demangled = demangle(m_stack[i]);
             if (demangled)
                 name = demangled->demangledName() ? demangled->demangledName() : demangled->mangledName();
@@ -142,7 +142,7 @@ public:
             if (!name || !strcmp(name, "<redacted>"))
                 name = symbols[i];
 #elif OS(WINDOWS)
-            if (!name && DbgHelper::SymFromAddress(hProc, reinterpret_cast<DWORD64>(m_stack[i]), nullptr, symbolInfo))
+            if (!name && DbgHelper::SymFromAddress(hProc, reinterpret_cast<DWORD64>(m_stack[i]), nullPtr(), symbolInfo))
                 name = symbolInfo->Name;
 #endif
             functor(i + 1, m_stack[i], name);

--- a/Source/WTF/wtf/StatisticsManager.cpp
+++ b/Source/WTF/wtf/StatisticsManager.cpp
@@ -35,7 +35,7 @@ namespace WTF {
 StatisticsManager& StatisticsManager::singleton()
 {
     static std::once_flag onceFlag;
-    static StatisticsManager* instance = nullptr;
+    static StatisticsManager* instance = nullPtr();
     std::call_once(onceFlag, [] {
         instance = new StatisticsManager();
     });

--- a/Source/WTF/wtf/SystemMalloc.h
+++ b/Source/WTF/wtf/SystemMalloc.h
@@ -76,7 +76,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     {
         T* result = static_cast<T*>(::malloc(size));
         if (!result)
-            return nullptr;
+            return nullPtr();
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memset(result, 0, size);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/TaggedArrayStoragePtr.h
+++ b/Source/WTF/wtf/TaggedArrayStoragePtr.h
@@ -33,7 +33,7 @@ template<typename PtrType>
 class TaggedArrayStoragePtr {
 public:
     TaggedArrayStoragePtr()
-        : m_ptr(tagArrayPtr<PtrType>(nullptr, 0))
+        : m_ptr(tagArrayPtr<PtrType>(nullPtr(), 0))
     { }
 
     TaggedArrayStoragePtr(PtrType* ptr, unsigned length)

--- a/Source/WTF/wtf/TaggedPtr.h
+++ b/Source/WTF/wtf/TaggedPtr.h
@@ -67,7 +67,7 @@ public:
     T* operator->() { return ptr(); }
 
 private:
-    StorageType m_ptr { Traits::wrap(nullptr, Traits::defaultTag) };
+    StorageType m_ptr { Traits::wrap(nullPtr(), Traits::defaultTag) };
 };
 
 

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -171,7 +171,7 @@ public:
                 if (RefPtr strongReference = pair.first->template makeStrongReferenceIfPossible<T>(pair.second))
                     return strongReference;
                 hasNullReferences = true;
-                return nullptr;
+                return nullPtr();
             });
             if (hasNullReferences)
                 m_set.removeIf([](auto& pair) { return pair.first->objectHasStartedDeletion(); });

--- a/Source/WTF/wtf/ThreadSpecific.h
+++ b/Source/WTF/wtf/ThreadSpecific.h
@@ -97,7 +97,7 @@ private:
         ~Data()
         {
             storagePointer()->~T();
-            owner->setInTLS(nullptr);
+            owner->setInTLS(nullPtr());
         }
 
         PointerType storagePointer() const { return const_cast<PointerType>(reinterpret_cast<const T*>(&m_storage)); }
@@ -136,7 +136,7 @@ inline T* ThreadSpecific<T, canBeGCThread>::get()
     Data* data = static_cast<Data*>(pthread_getspecific(m_key));
     if (data)
         return data->storagePointer();
-    return nullptr;
+    return nullPtr();
 }
 
 template<typename T, CanBeGCThread canBeGCThread>
@@ -161,7 +161,7 @@ inline T* ThreadSpecific<T, canBeGCThread>::get()
 {
     auto data = static_cast<Data*>(Thread::currentSingleton().specificStorage().get(m_key));
     if (!data)
-        return nullptr;
+        return nullPtr();
     return data->storagePointer();
 }
 

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -409,7 +409,7 @@ protected:
 #if OS(LINUX)
     ThreadIdentifier m_id { 0 };
 #endif
-    PlatformRegisters* m_platformRegisters { nullptr };
+    PlatformRegisters* m_platformRegisters { nullPtr() };
     unsigned m_suspendCount { 0 };
 #endif
 
@@ -417,17 +417,17 @@ protected:
     SpecificStorage m_specificStorage;
 #endif
 
-    AtomStringTable* m_currentAtomStringTable { nullptr };
+    AtomStringTable* m_currentAtomStringTable { nullPtr() };
     AtomStringTable m_defaultAtomStringTable;
 
 #if ENABLE(STACK_STATS)
     StackStats::PerThreadStats m_stackStats;
 #endif
-    void* m_savedStackPointerAtVMEntry { nullptr };
+    void* m_savedStackPointerAtVMEntry { nullPtr() };
     void* m_savedLastStackTop;
 public:
-    void* m_apiData { nullptr };
-    RefPtr<ClientData> m_clientData { nullptr };
+    void* m_apiData { nullPtr() };
+    RefPtr<ClientData> m_clientData { nullPtr() };
 };
 
 #if !OS(WINDOWS)

--- a/Source/WTF/wtf/TinyPtrSet.h
+++ b/Source/WTF/wtf/TinyPtrSet.h
@@ -317,7 +317,7 @@ public:
     class iterator {
     public:
         iterator()
-            : m_set(nullptr)
+            : m_set(nullPtr())
             , m_index(0)
         {
         }

--- a/Source/WTF/wtf/TranslatedProcess.cpp
+++ b/Source/WTF/wtf/TranslatedProcess.cpp
@@ -40,7 +40,7 @@ bool isX86BinaryRunningOnARM()
     std::call_once(onceFlag, [&] {
         int value = 0;
         size_t size = sizeof(value);
-        if (sysctlbyname("sysctl.proc_translated", &value, &size, nullptr, 0) < 0)
+        if (sysctlbyname("sysctl.proc_translated", &value, &size, nullPtr(), 0) < 0)
             return;
         result = !!value;        
     });

--- a/Source/WTF/wtf/TypeCasts.h
+++ b/Source/WTF/wtf/TypeCasts.h
@@ -30,6 +30,7 @@
 #include <type_traits>
 #include <utility>
 #include <wtf/Compiler.h>
+#include <wtf/TypeTraits.h>
 
 namespace WTF {
 
@@ -115,7 +116,7 @@ inline match_constness_t<Source, Target>* dynamicDowncast(Source& source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    SUPPRESS_MEMORY_UNSAFE_CAST return is<Target>(source) ? &static_cast<match_constness_t<Source, Target>&>(source) : nullptr;
+    SUPPRESS_MEMORY_UNSAFE_CAST return is<Target>(source) ? &static_cast<match_constness_t<Source, Target>&>(source) : nullPtr();
 }
 
 template<typename Target, typename Source>
@@ -123,7 +124,7 @@ inline match_constness_t<Source, Target>* dynamicDowncast(Source* source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    SUPPRESS_MEMORY_UNSAFE_CAST return is<Target>(source) ? static_cast<match_constness_t<Source, Target>*>(source) : nullptr;
+    SUPPRESS_MEMORY_UNSAFE_CAST return is<Target>(source) ? static_cast<match_constness_t<Source, Target>*>(source) : nullPtr();
 }
 
 // Add support for type checking / casting using is<>() / downcast<>() helpers for a specific class.

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -45,6 +45,17 @@
 
 namespace WTF {
 
+// Use this function to hide a value from the compiler.
+template<typename T> T inline opaque(T pointer)
+{
+    asm volatile("" : "+r"(pointer) ::);
+    return pointer;
+}
+
+// Use this function to indicate an invalid pointer. This function works around the
+// fact that store-load forwarding of nullptr can turn *nullptr into undefined behavior.
+inline nullptr_t nullPtr() { return opaque(nullptr); }
+
 namespace detail {
 
 // IsRefcountedSmartPointer implementation.
@@ -225,3 +236,5 @@ constexpr std::size_t parameterCount(ReturnType(*)(Args...))
 }
 
 } // namespace NTF
+
+using WTF::nullPtr;

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -63,12 +63,12 @@ public:
     // Resolves the relative URL with the given base URL. If provided, the
     // URLTextEncoding is used to encode non-ASCII characters. The base URL can be
     // null or empty, in which case the relative URL will be interpreted as absolute.
-    WTF_EXPORT_PRIVATE URL(const URL& base, const String& relative, const URLTextEncoding* = nullptr);
+    WTF_EXPORT_PRIVATE URL(const URL& base, const String& relative, const URLTextEncoding* = nullPtr());
 
     // Parses the input string as an absolute URL. If you need to parse a relative URL, call the constructor above
     // taking a base URL and a relative URL string.
-    WTF_EXPORT_PRIVATE explicit URL(String&& absoluteURL, const URLTextEncoding* = nullptr);
-    explicit URL(const String& absoluteURL, const URLTextEncoding* encoding = nullptr)
+    WTF_EXPORT_PRIVATE explicit URL(String&& absoluteURL, const URLTextEncoding* = nullPtr());
+    explicit URL(const String& absoluteURL, const URLTextEncoding* encoding = nullPtr())
         : URL(String { absoluteURL }, encoding)
     {
     }

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -964,7 +964,7 @@ String userVisibleURL(const CString& url)
 
     if (mayNeedHostNameDecoding) {
         // FIXME: Is it good to ignore the failure of mapHostNames and keep result intact?
-        auto mappedResult = mapHostNames(result, nullptr);
+        auto mappedResult = mapHostNames(result, nullPtr());
         if (!!mappedResult)
             result = mappedResult;
     }

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -844,7 +844,7 @@ void URLParser::copyURLPartsUntil(const URL& base, URLPart part, const CodePoint
     switch (scheme(m_asciiBuffer.subspan(0, m_url.m_schemeEnd))) {
     case Scheme::WS:
     case Scheme::WSS:
-        nonUTF8QueryEncoding = nullptr;
+        nonUTF8QueryEncoding = nullPtr();
         m_urlIsSpecial = true;
         return;
     case Scheme::File:
@@ -857,7 +857,7 @@ void URLParser::copyURLPartsUntil(const URL& base, URLPart part, const CodePoint
         return;
     case Scheme::NonSpecial:
         m_urlIsSpecial = false;
-        nonUTF8QueryEncoding = nullptr;
+        nonUTF8QueryEncoding = nullPtr();
         auto pathStart = m_url.m_hostEnd + m_url.m_portLength;
         if (pathStart + 2 < m_asciiBuffer.size()
             && m_asciiBuffer[pathStart] == '/'
@@ -1136,7 +1136,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
 
     auto endIndex = input.size();
     if (nonUTF8QueryEncoding == URLTextEncodingSentinelAllowingC0AtEnd) [[unlikely]]
-        nonUTF8QueryEncoding = nullptr;
+        nonUTF8QueryEncoding = nullPtr();
     else {
         while (endIndex && isC0ControlOrSpace(input[endIndex - 1])) [[unlikely]] {
             syntaxViolation<CharacterType>(input);
@@ -1229,7 +1229,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     break;
                 case Scheme::WS:
                 case Scheme::WSS:
-                    nonUTF8QueryEncoding = nullptr;
+                    nonUTF8QueryEncoding = nullPtr();
                     m_urlIsSpecial = true;
                     if (base.protocolIs(urlScheme))
                         state = State::SpecialRelativeOrAuthority;
@@ -1250,7 +1250,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     ++c;
                     break;
                 case Scheme::NonSpecial:
-                    nonUTF8QueryEncoding = nullptr;
+                    nonUTF8QueryEncoding = nullPtr();
                     auto maybeSlash = c;
                     advance(maybeSlash);
                     if (!maybeSlash.atEnd() && *maybeSlash == '/') {

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -70,7 +70,7 @@ public:
     WTF_EXPORT_PRIVATE static std::optional<String> formURLDecode(StringView input);
 
 private:
-    URLParser(String&&, const URL& = { }, const URLTextEncoding* = nullptr);
+    URLParser(String&&, const URL& = { }, const URLTextEncoding* = nullPtr());
     URL result() { return m_url; }
 
     friend class URL;
@@ -82,7 +82,7 @@ private:
     bool m_hostHasPercentOrNonASCII { false };
     bool m_didSeeSyntaxViolation { false };
     String m_inputString;
-    const void* m_inputBegin { nullptr };
+    const void* m_inputBegin { nullPtr() };
 
     static constexpr size_t defaultInlineBufferSize = 2048;
     using Latin1Buffer = Vector<Latin1Character, defaultInlineBufferSize>;

--- a/Source/WTF/wtf/UUID.cpp
+++ b/Source/WTF/wtf/UUID.cpp
@@ -198,7 +198,7 @@ String bootSessionUUIDString()
         constexpr size_t maxUUIDLength = 37;
         std::array<char, maxUUIDLength> uuid;
         size_t uuidLength = maxUUIDLength;
-        if (sysctlbyname("kern.bootsessionuuid", uuid.data(), &uuidLength, nullptr, 0))
+        if (sysctlbyname("kern.bootsessionuuid", uuid.data(), &uuidLength, nullPtr(), 0))
             return;
         bootSessionUUID.construct(std::span<const char> { uuid }.first(uuidLength - 1));
     });

--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -237,6 +237,7 @@ namespace std {
 #include <new>
 #include <type_traits>
 #include <utility>
+#include <wtf/TypeTraits.h>
 
 // MPark.Variant
 //
@@ -2227,7 +2228,7 @@ namespace mpark {
     template <typename Arg, std::size_t I, typename T>
     struct overload_leaf<Arg, I, T, false> {
       using impl = lib::size_constant<I> (*)(T);
-      operator impl() const { return nullptr; };
+      operator impl() const { return nullPtr(); };
     };
 
     template <typename Arg, std::size_t I, typename T>
@@ -2245,7 +2246,7 @@ namespace mpark {
 #endif
         > {
       using impl = lib::size_constant<I> (*)(T);
-      operator impl() const { return nullptr; };
+      operator impl() const { return nullPtr(); };
     };
 
     template <typename Arg, typename... Ts>
@@ -2549,7 +2550,7 @@ namespace mpark {
     inline constexpr /* auto * */ AUTO generic_get_if(V *v) noexcept
       AUTO_RETURN(v && holds_alternative<I>(*v)
                       ? lib::addressof(access::variant::get_alt<I>(*v).value)
-                      : nullptr)
+                      : nullPtr())
 
   }  // namespace detail
 

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -228,7 +228,7 @@ public:
         }
 
         size_t sizeToAllocate = newCapacity * sizeof(T);
-        T* newBuffer = nullptr;
+        T* newBuffer = nullPtr();
         if constexpr (action == FailureAction::Crash)
             newBuffer = static_cast<T*>(Malloc::malloc(sizeToAllocate));
         else {
@@ -265,7 +265,7 @@ public:
             return;
         
         if (m_buffer == bufferToDeallocate) {
-            m_buffer = nullptr;
+            m_buffer = nullPtr();
             m_capacity = 0;
         }
 
@@ -283,12 +283,12 @@ public:
     MallocSpan<T, Malloc> releaseBuffer()
     {
         m_capacity = 0;
-        return adoptMallocSpan<T, Malloc>(unsafeMakeSpan(std::exchange(m_buffer, nullptr), std::exchange(m_size, 0)));
+        return adoptMallocSpan<T, Malloc>(unsafeMakeSpan(std::exchange(m_buffer, nullPtr()), std::exchange(m_size, 0)));
     }
 
 protected:
     VectorBufferBase()
-        : m_buffer(nullptr)
+        : m_buffer(nullPtr())
         , m_capacity(0)
         , m_size(0)
     {
@@ -369,7 +369,7 @@ protected:
 
     VectorBuffer(VectorBuffer<T, 0, Malloc>&& other)
     {
-        m_buffer = std::exchange(other.m_buffer, nullptr);
+        m_buffer = std::exchange(other.m_buffer, nullPtr());
         m_capacity = std::exchange(other.m_capacity, 0);
         m_size = std::exchange(other.m_size, 0);
     }
@@ -377,7 +377,7 @@ protected:
     void adopt(VectorBuffer&& other)
     {
         deallocateBuffer(buffer());
-        m_buffer = std::exchange(other.m_buffer, nullptr);
+        m_buffer = std::exchange(other.m_buffer, nullPtr());
         m_capacity = std::exchange(other.m_capacity, 0);
         m_size = std::exchange(other.m_size, 0);
     }
@@ -1161,7 +1161,7 @@ NEVER_INLINE T* Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>:
         bool success = expandCapacity<action>(newMinCapacity);
         if constexpr (action == FailureAction::Report) {
             if (!success) [[unlikely]]
-                return nullptr;
+                return nullPtr();
         }
         UNUSED_PARAM(success);
         return ptr;
@@ -1170,7 +1170,7 @@ NEVER_INLINE T* Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>:
     bool success = expandCapacity<action>(newMinCapacity);
     if constexpr (action == FailureAction::Report) {
         if (!success) [[unlikely]]
-            return nullptr;
+            return nullPtr();
     }
     UNUSED_PARAM(success);
     return begin() + index;
@@ -1184,7 +1184,7 @@ inline U* Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::expan
     bool success = expandCapacity<action>(newMinCapacity);
     if constexpr (action == FailureAction::Report) {
         if (!success) [[unlikely]]
-            return nullptr;
+            return nullPtr();
     }
     UNUSED_PARAM(success);
     return ptr;

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -396,7 +396,7 @@ private:
     {
         if (auto* impl = key.weakImplIfExists(); impl && *impl)
             return impl;
-        return nullptr;
+        return nullPtr();
     }
 
     WeakHashImplMap m_map;

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -93,7 +93,7 @@ public:
     private:
         template <typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
 
-        const WeakHashSet* m_set { nullptr };
+        const WeakHashSet* m_set { nullPtr() };
         typename WeakPtrImplSet::const_iterator m_position;
         typename WeakPtrImplSet::const_iterator m_endPosition;
     };
@@ -130,7 +130,7 @@ public:
     {
         auto iterator = begin();
         if (iterator == end())
-            return nullptr;
+            return nullPtr();
         return static_cast<T*>(m_set.take(iterator.m_position)->template get<T>());
     }
 

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -339,7 +339,7 @@ public:
     {
         auto it = begin();
         if (it == end())
-            return nullptr;
+            return nullPtr();
         auto* first = it.get();
         remove(it);
         return first;

--- a/Source/WTF/wtf/WeakObjCPtr.h
+++ b/Source/WTF/wtf/WeakObjCPtr.h
@@ -101,9 +101,9 @@ public:
 
 private:
 #if __has_feature(objc_arc)
-    mutable __weak id m_weakReference { nullptr };
+    mutable __weak id m_weakReference { nullPtr() };
 #else
-    mutable id m_weakReference { nullptr };
+    mutable id m_weakReference { nullPtr() };
 #endif
 };
 

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -54,7 +54,7 @@ public:
     template<typename U> WeakPtr(WeakRef<U, WeakPtrImpl>&&);
 
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const T* object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : m_impl(object ? &object->weakImpl() : nullptr)
+        : m_impl(object ? &object->weakImpl() : nullPtr())
 #if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
@@ -99,7 +99,7 @@ public:
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
         ASSERT(canSafelyBeUsed());
-        return m_impl ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
+        return m_impl ? static_cast<T*>(m_impl->template get<T>()) : nullPtr();
     }
 
     WeakRef<T> releaseNonNull()
@@ -110,7 +110,7 @@ public:
     bool operator!() const { return !m_impl || !*m_impl; }
     explicit operator bool() const { return m_impl && *m_impl; }
 
-    WeakPtr& operator=(std::nullptr_t) { m_impl = nullptr; return *this; }
+    WeakPtr& operator=(std::nullptr_t) { m_impl = nullPtr(); return *this; }
     template<typename U> WeakPtr& operator=(const WeakPtr<U, WeakPtrImpl, PtrTraits>&);
     template<typename U> WeakPtr& operator=(WeakPtr<U, WeakPtrImpl, PtrTraits>&&);
     template<typename U> WeakPtr& operator=(const WeakRef<U, WeakPtrImpl>&);
@@ -146,7 +146,7 @@ public:
         return *result;
     }
 
-    void clear() { m_impl = nullptr; }
+    void clear() { m_impl = nullPtr(); }
 
     EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions() const
     {
@@ -311,7 +311,7 @@ inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> dynami
     static_assert(!std::same_as<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::derived_from<Target, Source>, "Should be a downcast");
     if (!is<Target>(source))
-        return nullptr;
+        return nullPtr();
     return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> { unsafeRefPtrDowncast<match_constness_t<Source, Target>, WeakPtrImpl>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -97,7 +97,7 @@ public:
 
     void revokeAll()
     {
-        if (RefPtr impl = std::exchange(m_impl, nullptr))
+        if (RefPtr impl = std::exchange(m_impl, nullPtr()))
             impl->clear();
     }
 
@@ -173,7 +173,7 @@ public:
     {
         if (auto* pointer = m_impl.pointer()) {
             pointer->clear();
-            m_impl.setPointer(nullptr);
+            m_impl.setPointer(nullPtr());
         }
     }
 

--- a/Source/WTF/wtf/WeakPtrImpl.h
+++ b/Source/WTF/wtf/WeakPtrImpl.h
@@ -47,7 +47,7 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear() { m_ptr = nullptr; }
+    void clear() { m_ptr = nullPtr(); }
 
 #if ASSERT_ENABLED
     bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
@@ -91,7 +91,7 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear() { m_ptr = nullptr; }
+    void clear() { m_ptr = nullPtr(); }
 
 #if ASSERT_ENABLED
     bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -78,7 +78,7 @@ public:
             HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
 
-        return !m_impl.isHashTableEmptyValue() ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
+        return !m_impl.isHashTableEmptyValue() ? static_cast<T*>(m_impl->template get<T>()) : nullPtr();
     }
 
     T* ptr() const
@@ -213,7 +213,7 @@ inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> dynamicDowncast(W
     static_assert(!std::same_as<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::derived_from<Target, Source>, "Should be a downcast");
     if (!is<Target>(source))
-        return nullptr;
+        return nullPtr();
     return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> { unsafeRefDowncast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 

--- a/Source/WTF/wtf/WordLock.cpp
+++ b/Source/WTF/wtf/WordLock.cpp
@@ -51,10 +51,10 @@ struct ThreadData {
     std::condition_variable parkingCondition;
 
     // The queue node.
-    ThreadData* nextInQueue { nullptr };
+    ThreadData* nextInQueue { nullPtr() };
 
     // The queue itself.
-    ThreadData* queueTail { nullptr };
+    ThreadData* queueTail { nullPtr() };
 };
 
 } // anonymous namespace
@@ -227,8 +227,8 @@ NEVER_INLINE void WordLock::unlockSlow()
     // Now the lock is available for acquisition. But we just have to wake up the old queue head.
     // After that, we're done!
 
-    queueHead->nextInQueue = nullptr;
-    queueHead->queueTail = nullptr;
+    queueHead->nextInQueue = nullPtr();
+    queueHead->queueTail = nullPtr();
 
     // We do this carefully because this may run either before or during the parkingLock critical
     // section in lockSlow().

--- a/Source/WTF/wtf/WorkerPool.cpp
+++ b/Source/WTF/wtf/WorkerPool.cpp
@@ -57,7 +57,7 @@ public:
     WorkResult work() final
     {
         m_task();
-        m_task = nullptr;
+        m_task = nullPtr();
         return WorkResult::Continue;
     }
 
@@ -103,7 +103,7 @@ WorkerPool::~WorkerPool()
     {
         Locker locker { *m_lock };
         for (unsigned i = m_workers.size(); i--;)
-            m_tasks.append(nullptr); // Use null task to indicate that we want the thread to terminate.
+            m_tasks.append(nullPtr()); // Use null task to indicate that we want the thread to terminate.
         m_condition->notifyAll(locker);
     }
     for (auto& worker : m_workers)

--- a/Source/WTF/wtf/android/LoggingAndroid.cpp
+++ b/Source/WTF/wtf/android/LoggingAndroid.cpp
@@ -32,7 +32,7 @@ namespace WTF {
 
 String logLevelString()
 {
-    const char* propertyValue = nullptr;
+    const char* propertyValue = nullPtr();
 
     if (const auto* propertyInfo = __system_property_find("debug." LOG_CHANNEL_WEBKIT_SUBSYSTEM ".log")) {
         __system_property_read_callback(propertyInfo, [](void *userData, const char*, const char* value, unsigned) {

--- a/Source/WTF/wtf/cf/CFURLExtras.cpp
+++ b/Source/WTF/wtf/cf/CFURLExtras.cpp
@@ -35,14 +35,14 @@ namespace WTF {
 
 RetainPtr<CFDataRef> bytesAsCFData(std::span<const uint8_t> bytes)
 {
-    return adoptCF(CFDataCreate(nullptr, bytes.data(), bytes.size()));
+    return adoptCF(CFDataCreate(nullPtr(), bytes.data(), bytes.size()));
 }
 
 RetainPtr<CFDataRef> bytesAsCFData(CFURLRef url)
 {
     if (!url)
-        return nullptr;
-    auto bytesLength = CFURLGetBytes(url, nullptr, 0);
+        return nullPtr();
+    auto bytesLength = CFURLGetBytes(url, nullPtr(), 0);
     RELEASE_ASSERT(bytesLength != -1);
     auto buffer = MallocSpan<uint8_t, SystemMalloc>::malloc(bytesLength);
     RELEASE_ASSERT(buffer);
@@ -54,7 +54,7 @@ String bytesAsString(CFURLRef url)
 {
     if (!url)
         return { };
-    auto bytesLength = CFURLGetBytes(url, nullptr, 0);
+    auto bytesLength = CFURLGetBytes(url, nullPtr(), 0);
     RELEASE_ASSERT(bytesLength != -1);
     RELEASE_ASSERT(bytesLength <= static_cast<CFIndex>(String::MaxLength));
     std::span<Latin1Character> buffer;
@@ -73,7 +73,7 @@ Vector<uint8_t, URLBytesVectorInlineCapacity> bytesAsVector(CFURLRef url)
     if (bytesLength != -1)
         result.shrink(bytesLength);
     else {
-        bytesLength = CFURLGetBytes(url, nullptr, 0);
+        bytesLength = CFURLGetBytes(url, nullPtr(), 0);
         RELEASE_ASSERT(bytesLength != -1);
         result.grow(bytesLength);
         CFURLGetBytes(url, result.mutableSpan().data(), bytesLength);

--- a/Source/WTF/wtf/cf/FileSystemCF.cpp
+++ b/Source/WTF/wtf/cf/FileSystemCF.cpp
@@ -62,7 +62,7 @@ String FileSystem::stringFromFileSystemRepresentation(const char* fileSystemRepr
 
 RetainPtr<CFURLRef> FileSystem::pathAsURL(const String& path)
 {
-    return adoptCF(CFURLCreateWithFileSystemPath(nullptr, path.createCFString().get(), kCFURLPOSIXPathStyle, FALSE));
+    return adoptCF(CFURLCreateWithFileSystemPath(nullPtr(), path.createCFString().get(), kCFURLPOSIXPathStyle, FALSE));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/cf/LanguageCF.cpp
+++ b/Source/WTF/wtf/cf/LanguageCF.cpp
@@ -83,7 +83,7 @@ void listenForLanguageChangeNotifications()
 #if PLATFORM(MAC)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        CFNotificationCenterAddObserver(CFNotificationCenterGetDistributedCenterSingleton(), nullptr, &languagePreferencesDidChange, CFSTR("AppleLanguagePreferencesChangedNotification"), nullptr, CFNotificationSuspensionBehaviorCoalesce);
+        CFNotificationCenterAddObserver(CFNotificationCenterGetDistributedCenterSingleton(), nullPtr(), &languagePreferencesDidChange, CFSTR("AppleLanguagePreferencesChangedNotification"), nullPtr(), CFNotificationSuspensionBehaviorCoalesce);
     });
 #endif
 }

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -145,7 +145,7 @@ void RunLoop::TimerBase::stop()
         return;
     
     CFRunLoopTimerInvalidate(m_timer.get());
-    m_timer = nullptr;
+    m_timer = nullPtr();
 }
 
 bool RunLoop::TimerBase::isActive() const

--- a/Source/WTF/wtf/cf/TypeCastsCF.h
+++ b/Source/WTF/wtf/cf/TypeCastsCF.h
@@ -43,10 +43,10 @@ template <typename> struct CFTypeTrait;
 template<typename T> T dynamic_cf_cast(CFTypeRef object)
 {
     if (!object)
-        return nullptr;
+        return nullPtr();
 
     if (CFGetTypeID(object) != CFTypeTrait<T>::typeID())
-        return nullptr;
+        return nullPtr();
 
     return static_cast<T>(const_cast<CF_BRIDGED_TYPE(id) void*>(object));
 }
@@ -54,10 +54,10 @@ template<typename T> T dynamic_cf_cast(CFTypeRef object)
 template<typename T, typename U> RetainPtr<T> dynamic_cf_cast(RetainPtr<U>&& object)
 {
     if (!object)
-        return nullptr;
+        return nullPtr();
 
     if (CFGetTypeID(object.get()) != CFTypeTrait<T>::typeID())
-        return nullptr;
+        return nullPtr();
 
     return adoptCF(static_cast<T>(const_cast<CF_BRIDGED_TYPE(id) void*>(object.leakRef())));
 }
@@ -67,7 +67,7 @@ template<typename T, typename U> RetainPtr<T> dynamic_cf_cast(RetainPtr<U>&& obj
 template<typename T> T checked_cf_cast(CFTypeRef object)
 {
     if (!object)
-        return nullptr;
+        return nullPtr();
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(CFGetTypeID(object) == CFTypeTrait<T>::typeID());
 

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -47,23 +47,23 @@ RetainPtr<CFURLRef> URL::createCFURL(const String& string)
 {
     if (string.is8Bit() && string.containsOnlyASCII()) [[likely]] {
         auto characters = string.span8();
-        return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingUTF8, nullptr, true));
+        return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullPtr(), byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingUTF8, nullPtr(), true));
     }
     CString utf8 = string.utf8();
     auto utf8Span = utf8.span();
-    return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(utf8Span.data()), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
+    return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullPtr(), byteCast<UInt8>(utf8Span.data()), utf8Span.size(), kCFStringEncodingUTF8, nullPtr(), true));
 }
 
 RetainPtr<CFURLRef> URL::createCFURL() const
 {
     if (isNull())
-        return nullptr;
+        return nullPtr();
 
     if (isEmpty())
         return emptyCFURL();
 
     if (!isValid() && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull))
-        return nullptr;
+        return nullPtr();
 
     RetainPtr result = createCFURL(m_string);
 
@@ -71,7 +71,7 @@ RetainPtr<CFURLRef> URL::createCFURL() const
     if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull)
         && protocolIsInHTTPFamily()
         && !isSameOrigin(result.get(), *this))
-        return nullptr;
+        return nullPtr();
 
     return result;
 }

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -109,7 +109,7 @@ std::optional<float> makeVectorElement(const float*, CFNumberRef);
 
 template<typename CollectionType> RetainPtr<CFMutableArrayRef> createCFArray(CollectionType&& collection)
 {
-    auto array = adoptCF(CFArrayCreateMutable(nullptr, Checked<CFIndex>(std::size(collection)), &kCFTypeArrayCallBacks));
+    auto array = adoptCF(CFArrayCreateMutable(nullPtr(), Checked<CFIndex>(std::size(collection)), &kCFTypeArrayCallBacks));
     for (auto&& element : collection)
         addUnlessNil(array.get(), getPtr(makeCFArrayElement(std::forward<decltype(element)>(element))));
     return array;
@@ -117,7 +117,7 @@ template<typename CollectionType> RetainPtr<CFMutableArrayRef> createCFArray(Col
 
 template<typename CollectionType, typename MapFunctionType> RetainPtr<CFMutableArrayRef> createCFArray(CollectionType&& collection, MapFunctionType&& function)
 {
-    auto array = adoptCF(CFArrayCreateMutable(nullptr, Checked<CFIndex>(std::size(collection)), &kCFTypeArrayCallBacks));
+    auto array = adoptCF(CFArrayCreateMutable(nullPtr(), Checked<CFIndex>(std::size(collection)), &kCFTypeArrayCallBacks));
     for (auto&& element : collection)
         addUnlessNil(array.get(), getPtr(std::invoke(std::forward<MapFunctionType>(function), std::forward<decltype(element)>(element))));
     return array;
@@ -126,7 +126,7 @@ template<typename CollectionType, typename MapFunctionType> RetainPtr<CFMutableA
 template<typename VectorElementType, typename CFType> Vector<VectorElementType> makeVector(CFArrayRef array)
 {
     return Vector<VectorElementType>(CFArrayGetCount(array), [&](size_t index) -> std::optional<VectorElementType> {
-        constexpr const VectorElementType* typedNull = nullptr;
+        const VectorElementType* typedNull = nullPtr();
         if (RetainPtr element = dynamic_cf_cast<CFType>(CFArrayGetValueAtIndex(array, index)))
             return makeVectorElement(typedNull, element.get());
         return std::nullopt;
@@ -193,7 +193,7 @@ inline Vector<uint8_t> makeVector(CFDataRef data)
 
 inline RetainPtr<CFNumberRef> makeCFArrayElement(const float& number)
 {
-    return adoptCF(CFNumberCreate(nullptr, kCFNumberFloatType, &number));
+    return adoptCF(CFNumberCreate(nullPtr(), kCFNumberFloatType, &number));
 }
 
 inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber)

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -39,7 +39,7 @@ bool hasEntitlement(SecTaskRef task, ASCIILiteral entitlement)
         return false;
     auto savedErrno = errno;
     auto string = entitlement.createCFString();
-    auto result = adoptCF(SecTaskCopyValueForEntitlement(task, string.get(), nullptr)) == kCFBooleanTrue;
+    auto result = adoptCF(SecTaskCopyValueForEntitlement(task, string.get(), nullPtr())) == kCFBooleanTrue;
     errno = savedErrno;
     return result;
 }
@@ -75,7 +75,7 @@ bool hasEntitlementValue(audit_token_t token, ASCIILiteral entitlement, ASCIILit
         return false;
 
     auto string = entitlement.createCFString();
-    String entitlementValue = dynamic_cf_cast<CFStringRef>(adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get());
+    String entitlementValue = dynamic_cf_cast<CFStringRef>(adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullPtr())).get());
     return entitlementValue == value;
 }
 
@@ -86,7 +86,7 @@ bool hasEntitlementValueInArray(audit_token_t token, ASCIILiteral entitlement, A
         return false;
 
     auto string = entitlement.createCFString();
-    RetainPtr array = adoptCF(dynamic_cf_cast<CFArrayRef>(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)));
+    RetainPtr array = adoptCF(dynamic_cf_cast<CFArrayRef>(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullPtr())));
     if (!array)
         return false;
 

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -150,7 +150,7 @@ void MemoryPressureHandler::install()
         beginSimulatedMemoryPressure();
 
         WTF::releaseFastMallocFreeMemory();
-        malloc_zone_pressure_relief(nullptr, 0);
+        malloc_zone_pressure_relief(nullPtr(), 0);
 
 #if ENABLE(FMW_FOOTPRINT_COMPARISON)
         auto footprintAfter = pagesPerVMTag();
@@ -180,12 +180,12 @@ void MemoryPressureHandler::uninstall()
     dispatch_async(m_dispatchQueue.get(), ^{
         if (memoryPressureEventSource()) {
             dispatch_source_cancel(memoryPressureEventSource().get());
-            memoryPressureEventSource() = nullptr;
+            memoryPressureEventSource() = nullPtr();
         }
 
         if (timerEventSource()) {
             dispatch_source_cancel(timerEventSource().get());
-            timerEventSource() = nullptr;
+            timerEventSource() = nullPtr();
         }
     });
 
@@ -208,7 +208,7 @@ void MemoryPressureHandler::holdOff(Seconds seconds)
             dispatch_source_set_event_handler(timerEventSource().get(), ^{
                 if (timerEventSource().get()) {
                     dispatch_source_cancel(timerEventSource().get());
-                    timerEventSource() = nullptr;
+                    timerEventSource() = nullPtr();
                 }
                 MemoryPressureHandler::singleton().install();
             });

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -94,7 +94,7 @@ void loadIDNAllowedScriptList()
     
 static String decodePercentEscapes(const String& string)
 {
-    auto substring = adoptCF(CFURLCreateStringByReplacingPercentEscapes(nullptr, string.createCFString().get(), CFSTR("")));
+    auto substring = adoptCF(CFURLCreateStringByReplacingPercentEscapes(nullPtr(), string.createCFString().get(), CFSTR("")));
     if (!substring)
         return string;
     return substring.get();
@@ -102,7 +102,7 @@ static String decodePercentEscapes(const String& string)
 
 NSString *decodeHostName(NSString *string)
 {
-    std::optional<String> host = URLHelpers::mapHostName(string, nullptr);
+    std::optional<String> host = URLHelpers::mapHostName(string, nullPtr());
     if (!host)
         return nil;
     if (!*host)
@@ -132,15 +132,15 @@ NSURL *URLByTruncatingOneCharacterBeforeComponent(NSURL *URL, CFURLComponentType
     if (!URL)
         return nil;
     
-    CFRange range = CFURLGetByteRangeForComponent(bridge_cast(URL), component, nullptr);
+    CFRange range = CFURLGetByteRangeForComponent(bridge_cast(URL), component, nullPtr());
     if (range.location == kCFNotFound)
         return URL;
 
     auto bytes = bytesAsVector(bridge_cast(URL));
 
-    auto result = adoptCF(CFURLCreateWithBytes(nullptr, bytes.span().data(), range.location - 1, kCFStringEncodingUTF8, nullptr));
+    auto result = adoptCF(CFURLCreateWithBytes(nullPtr(), bytes.span().data(), range.location - 1, kCFStringEncodingUTF8, nullPtr()));
     if (!result)
-        result = adoptCF(CFURLCreateWithBytes(nullptr, bytes.span().data(), range.location - 1, kCFStringEncodingISOLatin1, nullptr));
+        result = adoptCF(CFURLCreateWithBytes(nullPtr(), bytes.span().data(), range.location - 1, kCFStringEncodingISOLatin1, nullPtr()));
 
     return result ? result.bridgingAutorelease() : URL;
 }
@@ -165,9 +165,9 @@ NSURL *URLWithData(NSData *data, NSURL *baseURL)
         // (e.g calls to NSURL -path). However, this function is not tolerant of illegal UTF-8 sequences, which
         // could either be a malformed string or bytes in a different encoding, like shift-jis, so we fall back
         // onto using ISO Latin 1 in those cases.
-        auto result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, length, kCFStringEncodingUTF8, (__bridge CFURLRef)baseURL, YES));
+        auto result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullPtr(), bytes, length, kCFStringEncodingUTF8, (__bridge CFURLRef)baseURL, YES));
         if (!result)
-            result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, length, kCFStringEncodingISOLatin1, (__bridge CFURLRef)baseURL, YES));
+            result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullPtr(), bytes, length, kCFStringEncodingISOLatin1, (__bridge CFURLRef)baseURL, YES));
         return result.bridgingAutorelease();
     }
     return [NSURL URLWithString:@""];
@@ -250,7 +250,7 @@ static bool hasQuestionMarkOnlyQueryString(NSURL *URL)
 
 NSData *dataForURLComponentType(NSURL *URL, CFURLComponentType componentType)
 {
-    CFRange range = CFURLGetByteRangeForComponent(bridge_cast(URL), componentType, nullptr);
+    CFRange range = CFURLGetByteRangeForComponent(bridge_cast(URL), componentType, nullPtr());
     if (range.location == kCFNotFound)
         return nil;
 
@@ -298,9 +298,9 @@ static NSURL *URLByRemovingComponentAndSubsequentCharacter(NSURL *URL, CFURLComp
 
     memmoveSpan(urlBytes.subspan(range.location), urlBytes.subspan(range.location + range.length));
 
-    auto result = adoptCF(CFURLCreateWithBytes(nullptr, urlBytes.data(), numBytes - range.length, kCFStringEncodingUTF8, nullptr));
+    auto result = adoptCF(CFURLCreateWithBytes(nullPtr(), urlBytes.data(), numBytes - range.length, kCFStringEncodingUTF8, nullPtr()));
     if (!result)
-        result = adoptCF(CFURLCreateWithBytes(nullptr, urlBytes.data(), numBytes - range.length, kCFStringEncodingISOLatin1, nullptr));
+        result = adoptCF(CFURLCreateWithBytes(nullPtr(), urlBytes.data(), numBytes - range.length, kCFStringEncodingISOLatin1, nullPtr()));
 
     return result ? result.bridgingAutorelease() : URL;
 }

--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -114,7 +114,7 @@ inline bool is_objc(ArgType * source)
 template<typename T> inline T *checked_objc_cast(id object)
 {
     if (!object)
-        return nullptr;
+        return nullPtr();
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(is_objc<T>(object));
 
@@ -125,7 +125,7 @@ template<typename T, typename U> inline T *checked_objc_cast(U *object)
 {
     static_assert(std::is_base_of_v<U, T>);
     if (!object)
-        return nullptr;
+        return nullPtr();
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(is_objc<T>(object));
 
@@ -144,14 +144,14 @@ RetainPtr<T> dynamic_objc_cast(RetainPtr<U>&& object)
     static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);
     if (!is_objc<T>(object.get()))
-        return nullptr;
+        return nullPtr();
     return adoptNS(static_cast<T*>(object.leakRef()));
 }
 
 template<typename T> RetainPtr<T> dynamic_objc_cast(RetainPtr<id>&& object)
 {
     if (!is_objc<T>(object.get()))
-        return nullptr;
+        return nullPtr();
     return adoptNS(reinterpret_cast<T*>(object.leakRef()));
 }
 
@@ -162,28 +162,28 @@ RetainPtr<T> dynamic_objc_cast(const RetainPtr<U>& object)
     static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);
     if (!is_objc<T>(object.get()))
-        return nullptr;
+        return nullPtr();
     return static_cast<T*>(object.get());
 }
 
 template<typename T> RetainPtr<T> dynamic_objc_cast(const RetainPtr<id>& object)
 {
     if (!is_objc<T>(object.get()))
-        return nullptr;
+        return nullPtr();
     return reinterpret_cast<T*>(object.get());
 }
 
 template<typename T> T *dynamic_objc_cast(NSObject *object)
 {
     if (!is_objc<T>(object))
-        return nullptr;
+        return nullPtr();
     return static_cast<T*>(object);
 }
 
 template<typename T> T *dynamic_objc_cast(id object)
 {
     if (!is_objc<T>(object))
-        return nullptr;
+        return nullPtr();
     return reinterpret_cast<T*>(object);
 }
 

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -95,7 +95,7 @@ template<typename CollectionType, typename MapFunctionType> RetainPtr<NSMutableA
 template<typename VectorElementType> Vector<VectorElementType> makeVector(NSArray *array)
 {
     return Vector<VectorElementType>(array.count, [&](size_t index) {
-        constexpr const VectorElementType* typedNull = nullptr;
+        const VectorElementType* typedNull = nullPtr();
         return makeVectorElement(typedNull, array[index]);
     });
 }

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -92,7 +92,7 @@ void WorkQueueBase::platformInitialize(ASCIILiteral name, Type type, QOS qos)
     // This makes it possible to assert that code runs in the expected sequence, regardless of if it is
     // in a thread or a work queue.
     m_threadID = ++s_uid;
-    dispatch_queue_set_specific(m_dispatchQueue.get(), &s_uid, reinterpret_cast<void*>(m_threadID), nullptr);
+    dispatch_queue_set_specific(m_dispatchQueue.get(), &s_uid, reinterpret_cast<void*>(m_threadID), nullPtr());
 }
 
 void WorkQueueBase::platformInvalidate()

--- a/Source/WTF/wtf/dragonbox/dragonbox_to_chars.h
+++ b/Source/WTF/wtf/dragonbox/dragonbox_to_chars.h
@@ -80,7 +80,7 @@ char* to_chars_n_impl(float_bits<Float, FloatTraits> br, char* buffer) noexcept
             case Mode::ToExponential:
                 return to_chars_impl<Float, FloatTraits, Mode::ToExponential, PrintTrailingZero::No>(result.significand, result.exponent, buffer);
             default:
-                return nullptr;
+                return nullPtr();
             }
         } else {
             switch (mode) {
@@ -91,7 +91,7 @@ char* to_chars_n_impl(float_bits<Float, FloatTraits> br, char* buffer) noexcept
                 memcpy(buffer, "0e+0", 4);
                 return buffer + 4;
             default:
-                return nullptr;
+                return nullPtr();
             }
         }
     } else {

--- a/Source/WTF/wtf/fast_float/float_common.h
+++ b/Source/WTF/wtf/fast_float/float_common.h
@@ -202,7 +202,7 @@ struct span {
   const T* ptr;
   size_t length;
   constexpr span(const T* _ptr, size_t _length) : ptr(_ptr), length(_length) {}
-  constexpr span() : ptr(nullptr), length(0) {}
+  constexpr span() : ptr(nullPtr()), length(0) {}
 
   constexpr size_t len() const noexcept {
     return length;
@@ -622,7 +622,7 @@ static constexpr int int_cmp_len()
 template<typename UC>
 static constexpr UC const * str_const_nan()
 {
-    return nullptr;
+    return nullPtr();
 }
 template<>
 constexpr char const * str_const_nan<char>()
@@ -647,7 +647,7 @@ constexpr char32_t const * str_const_nan<char32_t>()
 template<typename UC>
 static constexpr UC const * str_const_inf()
 {
-    return nullptr;
+    return nullPtr();
 }
 template<>
 constexpr char const * str_const_inf<char>()

--- a/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp
+++ b/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp
@@ -47,7 +47,7 @@ void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus)
         return;
 
     size_t pageSize = WTF::pageSize();
-    char* end = nullptr;
+    char* end = nullPtr();
     unsigned long long intValue = strtoull(line, &end, 10);
     memoryStatus.size = intValue * pageSize;
     intValue = strtoull(end, &end, 10);

--- a/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
+++ b/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
@@ -38,7 +38,7 @@ static const Seconds s_memoryFootprintUpdateInterval = 1_s;
 template<typename Functor>
 static void forEachLine(FILE* file, Functor functor)
 {
-    char* buffer = nullptr;
+    char* buffer = nullPtr();
     size_t size = 0;
     while (getline(&buffer, &size, file) != -1) {
         functor(buffer);

--- a/Source/WTF/wtf/linux/RealTimeThreads.cpp
+++ b/Source/WTF/wtf/linux/RealTimeThreads.cpp
@@ -80,7 +80,7 @@ RealTimeThreads::RealTimeThreads()
             RealTimeThreads::singleton().demoteAllThreadsFromRealTime();
         };
         action.sa_flags = SA_SIGINFO;
-        sigaction(SIGXCPU, &action, nullptr);
+        sigaction(SIGXCPU, &action, nullPtr());
     });
 }
 
@@ -157,7 +157,7 @@ static int64_t realTimeKitGetProperty(GDBusProxy* proxy, const char* propertyNam
 {
     const char* interfaceName = shouldUsePortal() ? "org.freedesktop.portal.Realtime" : "org.freedesktop.RealtimeKit1";
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_sync(proxy, "org.freedesktop.DBus.Properties.Get",
-        g_variant_new("(ss)", interfaceName, propertyName), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, error));
+        g_variant_new("(ss)", interfaceName, propertyName), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullPtr(), error));
     if (!result)
         return -1;
 
@@ -180,12 +180,12 @@ void RealTimeThreads::realTimeKitMakeThreadRealTime(uint64_t processID, uint64_t
     if (!m_realTimeKitProxy) {
         if (shouldUsePortal()) {
             m_realTimeKitProxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
-                static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
-                "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Realtime", nullptr, &error.outPtr()));
+                static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullPtr(),
+                "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Realtime", nullPtr(), &error.outPtr()));
         } else {
             m_realTimeKitProxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SYSTEM,
-                static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
-                "org.freedesktop.RealtimeKit1", "/org/freedesktop/RealtimeKit1", "org.freedesktop.RealtimeKit1", nullptr, &error.outPtr()));
+                static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullPtr(),
+                "org.freedesktop.RealtimeKit1", "/org/freedesktop/RealtimeKit1", "org.freedesktop.RealtimeKit1", nullPtr(), &error.outPtr()));
         }
 
         if (!m_realTimeKitProxy.value()) {
@@ -205,7 +205,7 @@ void RealTimeThreads::realTimeKitMakeThreadRealTime(uint64_t processID, uint64_t
         if (error) {
             LOG_ERROR("Failed to get RTTimeUSecMax from RealtimeKit: %s", error->message);
             if (!g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_INTERFACE))
-                m_realTimeKitProxy = nullptr;
+                m_realTimeKitProxy = nullPtr();
 
             scheduleDiscardRealTimeKitProxy();
             return;
@@ -219,11 +219,11 @@ void RealTimeThreads::realTimeKitMakeThreadRealTime(uint64_t processID, uint64_t
 #endif
 
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_sync(m_realTimeKitProxy->get(), "MakeThreadRealtimeWithPID",
-        g_variant_new("(ttu)", processID, threadID, priority), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
+        g_variant_new("(ttu)", processID, threadID, priority), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullPtr(), &error.outPtr()));
     if (!result) {
         LOG_ERROR("Failed to make thread real time: %s", error->message);
         if (!g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_INTERFACE))
-            m_realTimeKitProxy = nullptr;
+            m_realTimeKitProxy = nullPtr();
     }
 
     scheduleDiscardRealTimeKitProxy();

--- a/Source/WTF/wtf/malloc_heap_breakdown/main.cpp
+++ b/Source/WTF/wtf/malloc_heap_breakdown/main.cpp
@@ -83,7 +83,7 @@ public:
     {
         const std::lock_guard<std::recursive_mutex> lock(m_mutex);
         if (!zone || !m_zoneNames.count(zone))
-            return nullptr;
+            return nullPtr();
         void* memory = malloc(size);
         m_zoneAllocations[zone].emplace(memory, size);
         return memory;
@@ -92,7 +92,7 @@ public:
     {
         const std::lock_guard<std::recursive_mutex> lock(m_mutex);
         if (!zone || !m_zoneNames.count(zone))
-            return nullptr;
+            return nullPtr();
         void* memory = calloc(numItems, size);
         if (memory)
             m_zoneAllocations[zone].emplace(memory, numItems * size);
@@ -102,12 +102,12 @@ public:
     {
         const std::lock_guard<std::recursive_mutex> lock(m_mutex);
         if (!zone || !m_zoneNames.count(zone))
-            return nullptr;
+            return nullPtr();
         if (!memory)
             return zoneMalloc(zone, size);
         if (!size) {
             zoneFree(zone, memory);
-            return nullptr;
+            return nullPtr();
         }
         void* ptr = realloc(memory, size);
         if (ptr) {
@@ -121,7 +121,7 @@ public:
     {
         const std::lock_guard<std::recursive_mutex> lock(m_mutex);
         if (!zone || !m_zoneNames.count(zone))
-            return nullptr;
+            return nullPtr();
         void* memory = aligned_alloc(alignment, size);
         m_zoneAllocations[zone].emplace(memory, size);
         return memory;
@@ -228,7 +228,7 @@ private:
                         grandTotalBytesAllocated += totalBytesAllocated;
                         setCounter(zonePtr, zoneName.c_str(), totalBytesAllocated);
                     }
-                    setCounter(nullptr, "Total bytes", grandTotalBytesAllocated);
+                    setCounter(nullPtr(), "Total bytes", grandTotalBytesAllocated);
 
                     if (!counterIdsToSet.empty())
                         sysprof_collector_set_counters(counterIdsToSet.data(), counterValuesToSet.data(), counterIdsToSet.size());

--- a/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
@@ -135,7 +135,7 @@ bool deleteNonEmptyDirectory(const String& path)
 String realPath(const String& filePath)
 {
     CString fsRep = fileSystemRepresentation(filePath);
-    std::unique_ptr<char, decltype(free)*> resolvedPath(realpath(fsRep.data(), nullptr), free);
+    std::unique_ptr<char, decltype(free)*> resolvedPath(realpath(fsRep.data(), nullPtr()), free);
     return resolvedPath ? String::fromUTF8(resolvedPath.get()) : filePath;
 }
 

--- a/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
@@ -47,12 +47,12 @@ void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address,
 
     void* result = memory_extra::vss::reserve(bytes);
     if (!result)
-        return nullptr;
+        return nullPtr();
 
     bool success = memory_extra::vss::commit(result, bytes, writable, usage);
     if (!success) {
         memory_extra::vss::release(result, bytes);
-        return nullptr;
+        return nullPtr();
     }
 
     return result;
@@ -69,7 +69,7 @@ void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, void* addres
 
     void* result = memory_extra::vss::reserve(bytes);
     if (!result)
-        return nullptr;
+        return nullPtr();
 
     return result;
 }
@@ -93,7 +93,7 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
 
     void* result = memory_extra::vss::reserve(bytes, alignment);
     if (!result)
-        return nullptr;
+        return nullPtr();
 
     return result;
 }

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -182,7 +182,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode mapMode, FileOpenMo
 #endif
     }
 
-    auto fileData = MallocSpan<uint8_t, Mmap>::mmap(nullptr, size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), platformHandle());
+    auto fileData = MallocSpan<uint8_t, Mmap>::mmap(nullPtr(), size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), platformHandle());
     if (!fileData)
         return { };
 

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -185,7 +185,7 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
 
     void* result = mmap(address, bytes, protection, MAP_NORESERVE | MAP_PRIVATE | MAP_ANON | MAP_ALIGNED(getLSBSet(alignment)), -1, 0);
     if (result == MAP_FAILED)
-        return nullptr;
+        return nullPtr();
     if (result)
         while (madvise(result, bytes, MADV_DONTNEED) == -1 && errno == EAGAIN) { }
     return result;
@@ -195,7 +195,7 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
     size_t mappedSize = bytes + alignment;
     auto* rawMapped = reinterpret_cast<uint8_t*>(tryReserveUncommitted(mappedSize, usage, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd));
     if (!rawMapped)
-        return nullptr;
+        return nullPtr();
     auto mappedSpan = unsafeMakeSpan(rawMapped, mappedSize);
 
     auto* rawAligned = reinterpret_cast<uint8_t*>(roundUpToMultipleOf(alignment, reinterpret_cast<uintptr_t>(mappedSpan.data())));

--- a/Source/WTF/wtf/posix/SocketPOSIX.h
+++ b/Source/WTF/wtf/posix/SocketPOSIX.h
@@ -41,7 +41,7 @@ inline const struct sockaddr_in* dynamicCastToIPV4SocketAddress(const struct soc
 {
     if (isIPV4SocketAddress(socket))
         SUPPRESS_MEMORY_UNSAFE_CAST return reinterpret_cast<const struct sockaddr_in*>(&socket);
-    return nullptr;
+    return nullPtr();
 }
 
 inline const struct sockaddr_in& asIPV4SocketAddress(const struct sockaddr& socket)
@@ -69,7 +69,7 @@ inline const struct sockaddr_in6* dynamicCastToIPV6SocketAddress(const struct so
 {
     if (isIPV6SocketAddress(socket))
         SUPPRESS_MEMORY_UNSAFE_CAST return reinterpret_cast<const struct sockaddr_in6*>(&socket);
-    return nullptr;
+    return nullPtr();
 }
 
 inline const struct sockaddr_in6& asIPV6SocketAddress(const struct sockaddr& socket)

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -114,7 +114,7 @@ private:
 };
 static LazyNeverDestroyed<Semaphore> globalSemaphoreForSuspendResume;
 
-static std::atomic<Thread*> targetThread { nullptr };
+static std::atomic<Thread*> targetThread { nullPtr() };
 
 void Thread::signalHandlerSuspendResume(int, siginfo_t*, void* ucontext)
 {
@@ -139,7 +139,7 @@ void Thread::signalHandlerSuspendResume(int, siginfo_t*, void* ucontext)
         // 3. A nested signal handler is executed.
         // 4. The stack pointer saved in the machine context will be pointing to the alternative signal stack.
         // In this case, we back off the suspension and retry a bit later.
-        thread->m_platformRegisters = nullptr;
+        thread->m_platformRegisters = nullPtr();
         globalSemaphoreForSuspendResume->post();
         return;
     }
@@ -168,7 +168,7 @@ void Thread::signalHandlerSuspendResume(int, siginfo_t*, void* ucontext)
     sigdelset(&blockedSignalSet, g_wtfConfig.sigThreadSuspendResume);
     sigsuspend(&blockedSignalSet);
 
-    thread->m_platformRegisters = nullptr;
+    thread->m_platformRegisters = nullPtr();
 
     // Allow resume caller to see that this thread is resumed.
     globalSemaphoreForSuspendResume->post();
@@ -209,7 +209,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         // initialization which also installs specific signals. If this is the problem, applications should
         // change how to initialize things.
         struct sigaction oldAction;
-        if (sigaction(signal, nullptr, &oldAction))
+        if (sigaction(signal, nullPtr(), &oldAction))
             return false;
         // It has signal already.
         if (oldAction.sa_handler != SIG_DFL || std::bit_cast<void*>(oldAction.sa_sigaction) != std::bit_cast<void*>(SIG_DFL))
@@ -243,7 +243,7 @@ void Thread::initializeCurrentThreadEvenIfNonWTFCreated()
 static void* wtfThreadEntryPoint(void* context)
 {
     Thread::entryPoint(reinterpret_cast<Thread::NewThreadContext*>(context));
-    return nullptr;
+    return nullPtr();
 }
 
 #if HAVE(QOS_CLASSES)
@@ -351,7 +351,7 @@ void Thread::initializeCurrentThreadInternal(const char* threadName)
 #if HAVE(PTHREAD_SETNAME_NP)
     pthread_setname_np(normalizeThreadName(threadName));
 #elif OS(HAIKU)
-    rename_thread(find_thread(nullptr), normalizeThreadName(threadName));
+    rename_thread(find_thread(nullPtr()), normalizeThreadName(threadName));
 #elif OS(LINUX)
     prctl(PR_SET_NAME, normalizeThreadName(threadName));
 #else
@@ -612,7 +612,7 @@ void Thread::destructTLS(void* data)
     // Destructor of ClientData can rely on Thread::currentSingleton() (e.g. AtomStringTable).
     // We destroy it after re-setting Thread::currentSingleton() so that we can ensure destruction
     // can still access to it.
-    thread->m_clientData = nullptr;
+    thread->m_clientData = nullPtr();
 }
 
 Mutex::~Mutex()

--- a/Source/WTF/wtf/simde/arm/sve.h
+++ b/Source/WTF/wtf/simde/arm/sve.h
@@ -1999,7 +1999,7 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 #if defined(__cplusplus)
 #  if __cplusplus >= 201103L
-#    define HEDLEY_NULL HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(nullptr)
+#    define HEDLEY_NULL HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(nullPtr())
 #  elif defined(NULL)
 #    define HEDLEY_NULL NULL
 #  else

--- a/Source/WTF/wtf/simde/wasm/simd128.h
+++ b/Source/WTF/wtf/simde/wasm/simd128.h
@@ -1948,7 +1948,7 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 #if defined(__cplusplus)
 #  if __cplusplus >= 201103L
-#    define HEDLEY_NULL HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(nullptr)
+#    define HEDLEY_NULL HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(nullPtr())
 #  elif defined(NULL)
 #    define HEDLEY_NULL NULL
 #  else

--- a/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
@@ -8918,7 +8918,7 @@ template <typename T> struct base32 {
     return vec_xst(this->value, 0, reinterpret_cast<vector_type *>(dst));
 #endif // defined(__clang__)
   }
-  void dump(const char *name = nullptr) const {
+  void dump(const char *name = nullPtr()) const {
 #ifdef SIMDUTF_LOGGING
     if (name != nullptr) {
       printf("%-10s = ", name);
@@ -18258,11 +18258,11 @@ public:
     return 0;
   }
   const char *find(const char *, const char *, char) const noexcept override {
-    return nullptr;
+    return nullPtr();
   }
   const char16_t *find(const char16_t *, const char16_t *,
                        char16_t) const noexcept override {
-    return nullptr;
+    return nullPtr();
   }
 #endif // SIMDUTF_FEATURE_BASE64
 
@@ -19885,7 +19885,7 @@ const char16_t *arm_validate_utf16(const char16_t *input, size_t size) {
         // one, 2) reject sole high surrogate.
         input += 15;
       } else {
-        return nullptr;
+        return nullPtr();
       }
     }
   }
@@ -19907,7 +19907,7 @@ const char16_t *arm_validate_utf16_as_ascii(const char16_t *input,
     uint16x8_t cmp = vcgtq_u16(inor, vdupq_n_u16(0x7f));
     uint64_t mask = vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(cmp, 4)), 0);
     if (mask) {
-      return nullptr;
+      return nullPtr();
     }
     input += 16;
   }
@@ -20011,13 +20011,13 @@ const char32_t *arm_validate_utf32le(const char32_t *input, size_t size) {
   uint32x4_t is_zero =
       veorq_u32(vmaxq_u32(currentmax, standardmax), standardmax);
   if (vmaxvq_u32(is_zero) != 0) {
-    return nullptr;
+    return nullPtr();
   }
 
   is_zero = veorq_u32(vmaxq_u32(currentoffsetmax, standardoffsetmax),
                       standardoffsetmax);
   if (vmaxvq_u32(is_zero) != 0) {
-    return nullptr;
+    return nullPtr();
   }
 
   return input;
@@ -20786,7 +20786,7 @@ arm_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -20935,7 +20935,7 @@ arm_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char32_t *>(utf32_output));
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
@@ -21321,7 +21321,7 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
@@ -22683,7 +22683,7 @@ arm_convert_utf32_to_latin1(const char32_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -22829,7 +22829,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       buf += 8;
     } else {
       if (simdutf_unlikely(fast_invalid_utf32(in) || max_val > 0x10ffff)) {
-        return std::make_pair(nullptr,
+        return std::make_pair(nullPtr(),
                               reinterpret_cast<char16_t *>(utf16_output));
       }
       expansion_result_t res = neon_expand_surrogate<big_endian>(in.val[0]);
@@ -22844,7 +22844,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (vmaxvq_u32(vreinterpretq_u32_u16(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
+    return std::make_pair(nullPtr(), reinterpret_cast<char16_t *>(utf16_output));
   }
 
   return std::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
@@ -23164,7 +23164,7 @@ arm_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
@@ -23172,7 +23172,7 @@ arm_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
@@ -23187,7 +23187,7 @@ arm_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
 
   // check for invalid input
   if (vmaxvq_u16(forbidden_bytemask) != 0) {
-    return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+    return std::make_pair(nullPtr(), reinterpret_cast<char *>(utf8_output));
   }
   return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
@@ -28450,7 +28450,7 @@ validating_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
   }
   checker.check_eof();
   if (checker.errors()) {
-    return {ptr, nullptr}; // We found an error.
+    return {ptr, nullPtr()}; // We found an error.
   }
   return {ptr, output};
 }
@@ -29263,7 +29263,7 @@ fast_avx512_convert_utf8_to_utf16(const char *in, size_t len, char16_t *out) {
     }
   }
   if (!result) {
-    out = nullptr;
+    out = nullPtr();
   }
   return std::make_pair(in, out);
 }
@@ -29874,14 +29874,14 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) { // 3-byte
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else { // 4-byte
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -29897,11 +29897,11 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
   const __m256i v_10ffff = _mm256_set1_epi32((uint32_t)0x10ffff);
   if (static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi32(
           _mm256_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffffffff) {
-    return std::make_pair(nullptr, utf8_output);
+    return std::make_pair(nullPtr(), utf8_output);
   }
 
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf8_output);
+    return std::make_pair(nullPtr(), utf8_output);
   }
 
   return std::make_pair(buf, utf8_output);
@@ -30250,7 +30250,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
           saturation_bitmask, _mm512_and_si512(in, v_f800), v_d800);
       error |= _mm512_mask_cmpgt_epu32_mask(surrogate_bitmask, in, v_10ffff);
       if (simdutf_unlikely(error)) {
-        return std::make_pair(nullptr, utf16_output);
+        return std::make_pair(nullPtr(), utf16_output);
       }
       __m512i v1, v2, v;
       // for the bits saturation_bitmask == 0, we need to unpack the 32-bit word
@@ -30315,7 +30315,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
           saturation_bitmask, _mm512_and_si512(in, v_f800), v_d800);
       error |= _mm512_mask_cmpgt_epu32_mask(surrogate_bitmask, in, v_10ffff);
       if (simdutf_unlikely(error)) {
-        return std::make_pair(nullptr, utf16_output);
+        return std::make_pair(nullPtr(), utf16_output);
       }
       __m512i v1, v2, v;
       in = _mm512_mask_sub_epi32(in, surrogate_bitmask, in, v_10000);
@@ -30347,7 +30347,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (forbidden_bytemask != 0) {
-    return std::make_pair(nullptr, utf16_output);
+    return std::make_pair(nullPtr(), utf16_output);
   }
 
   return std::make_pair(buf, utf16_output);
@@ -34153,7 +34153,7 @@ avx2_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 32;
       latin1_output += 32;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -34518,7 +34518,7 @@ avx2_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf8_output++ = char((value >> 18) | 0b11110000);
@@ -34933,7 +34933,7 @@ avx2_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf32_output);
+            return std::make_pair(nullPtr(), utf32_output);
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf32_output++ = char32_t(value);
@@ -35051,7 +35051,7 @@ avx2_convert_utf32_to_latin1(const char32_t *buf, size_t len,
         _mm256_or_si256(_mm256_or_si256(a, b), _mm256_or_si256(c, d));
 
     if (!_mm256_testz_si256(check_combined, high_bytes_mask)) {
-      return std::make_pair(nullptr, latin1_output);
+      return std::make_pair(nullPtr(), latin1_output);
     }
 
     b = _mm256_slli_epi32(b, 1 * 8);
@@ -35403,14 +35403,14 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) { // 3-byte
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else { // 4-byte
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -35426,11 +35426,11 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const __m256i v_10ffff = _mm256_set1_epi32((uint32_t)0x10ffff);
   if (static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi32(
           _mm256_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffffffff) {
-    return std::make_pair(nullptr, utf8_output);
+    return std::make_pair(nullPtr(), utf8_output);
   }
 
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf8_output);
+    return std::make_pair(nullPtr(), utf8_output);
   }
 
   return std::make_pair(buf, utf8_output);
@@ -35774,7 +35774,7 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf16_output);
+            return std::make_pair(nullPtr(), utf16_output);
           }
           *utf16_output++ =
               big_endian
@@ -35783,7 +35783,7 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf16_output);
+            return std::make_pair(nullPtr(), utf16_output);
           }
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
@@ -35804,7 +35804,7 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf16_output);
+    return std::make_pair(nullPtr(), utf16_output);
   }
 
   return std::make_pair(buf, utf16_output);
@@ -50024,7 +50024,7 @@ sse_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -50333,7 +50333,7 @@ sse_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf8_output++ = char((value >> 18) | 0b11110000);
@@ -50697,7 +50697,7 @@ sse_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf32_output);
+            return std::make_pair(nullPtr(), utf32_output);
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf32_output++ = char32_t(value);
@@ -50815,7 +50815,7 @@ sse_convert_utf32_to_latin1(const char32_t *buf, size_t len,
     check_combined = _mm_or_si128(check_combined, in4);
 
     if (!_mm_testz_si128(check_combined, high_bytes_mask)) {
-      return std::make_pair(nullptr, latin1_output);
+      return std::make_pair(nullPtr(), latin1_output);
     }
     __m128i pack1 = _mm_unpacklo_epi32(_mm_shuffle_epi8(in1, shufmask),
                                        _mm_shuffle_epi8(in2, shufmask));
@@ -51180,14 +51180,14 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return std::make_pair(nullPtr(), utf8_output);
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -51203,11 +51203,11 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const __m128i v_10ffff = _mm_set1_epi32((uint32_t)0x10ffff);
   if (static_cast<uint16_t>(_mm_movemask_epi8(_mm_cmpeq_epi32(
           _mm_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffff) {
-    return std::make_pair(nullptr, utf8_output);
+    return std::make_pair(nullPtr(), utf8_output);
   }
 
   if (static_cast<uint32_t>(_mm_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf8_output);
+    return std::make_pair(nullPtr(), utf8_output);
   }
 
   return std::make_pair(buf, utf8_output);
@@ -51576,7 +51576,7 @@ sse_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       buf += 16;
     } else {
       if (!validate_utf32(in0, in1) || !validate_utf32(in2, in3)) {
-        return std::make_pair(nullptr, utf16_output);
+        return std::make_pair(nullPtr(), utf16_output);
       }
 
       const auto ret0 = sse_expand_surrogate<big_endian>(in0);
@@ -51601,7 +51601,7 @@ sse_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (static_cast<uint32_t>(_mm_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf16_output);
+    return std::make_pair(nullPtr(), utf16_output);
   }
 
   return std::make_pair(buf, utf16_output);
@@ -56548,13 +56548,13 @@ const char32_t *lsx_validate_utf32le(const char32_t *input, size_t size) {
   __m128i is_zero =
       __lsx_vxor_v(__lsx_vmax_wu(currentmax, standardmax), standardmax);
   if (__lsx_bnz_v(is_zero)) {
-    return nullptr;
+    return nullPtr();
   }
 
   is_zero = __lsx_vxor_v(__lsx_vmax_wu(currentoffsetmax, standardoffsetmax),
                          standardoffsetmax);
   if (__lsx_bnz_v(is_zero)) {
-    return nullptr;
+    return nullPtr();
   }
 
   return input;
@@ -57313,7 +57313,7 @@ lsx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 16;
       latin1_output += 16;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -57627,7 +57627,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
@@ -57939,7 +57939,7 @@ lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char32_t *>(utf32_output));
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
@@ -58050,7 +58050,7 @@ lsx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -58298,7 +58298,7 @@ lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
@@ -58306,7 +58306,7 @@ lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
@@ -58321,7 +58321,7 @@ lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
 
   // check for invalid input
   if (__lsx_bnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+    return std::make_pair(nullPtr(), reinterpret_cast<char *>(utf8_output));
   }
 
   return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
@@ -58602,7 +58602,7 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char16_t *>(utf16_output));
           }
           *utf16_output++ = !match_system(big_endian)
@@ -58611,7 +58611,7 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char16_t *>(utf16_output));
           }
           word -= 0x10000;
@@ -58632,7 +58632,7 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (__lsx_bnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
+    return std::make_pair(nullPtr(), reinterpret_cast<char16_t *>(utf16_output));
   }
   return std::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
 }
@@ -63125,7 +63125,7 @@ const char32_t *lasx_validate_utf32le(const char32_t *input, size_t size) {
   while (((uint64_t)input & 0x1F) && input < end) {
     uint32_t word = *input++;
     if (word > 0x10FFFF || (word >= 0xD800 && word <= 0xDFFF)) {
-      return nullptr;
+      return nullPtr();
     }
   }
 
@@ -63146,13 +63146,13 @@ const char32_t *lasx_validate_utf32le(const char32_t *input, size_t size) {
   __m256i is_zero =
       __lasx_xvxor_v(__lasx_xvmax_wu(currentmax, standardmax), standardmax);
   if (__lasx_xbnz_v(is_zero)) {
-    return nullptr;
+    return nullPtr();
   }
 
   is_zero = __lasx_xvxor_v(__lasx_xvmax_wu(currentoffsetmax, standardoffsetmax),
                            standardoffsetmax);
   if (__lasx_xbnz_v(is_zero)) {
-    return nullptr;
+    return nullPtr();
   }
   return input;
 }
@@ -64008,7 +64008,7 @@ lasx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 16;
       latin1_output += 16;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -64338,7 +64338,7 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
@@ -64630,7 +64630,7 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
       buf++;
     } else {
       if (buf + 1 >= end) {
-        return std::make_pair(nullptr,
+        return std::make_pair(nullPtr(),
                               reinterpret_cast<char32_t *>(utf32_output));
       }
       // must be a surrogate pair
@@ -64639,7 +64639,7 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           !match_system(big_endian) ? scalar::u16_swap_bytes(buf[1]) : buf[1];
       uint16_t diff2 = uint16_t(next_word - 0xDC00);
       if ((diff | diff2) > 0x3FF) {
-        return std::make_pair(nullptr,
+        return std::make_pair(nullPtr(),
                               reinterpret_cast<char32_t *>(utf32_output));
       }
       uint32_t value = (diff << 10) + diff2 + 0x10000;
@@ -64693,7 +64693,7 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char32_t *>(utf32_output));
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
@@ -64835,7 +64835,7 @@ lasx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
       buf += 16;
       latin1_output += 16;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return std::make_pair(nullPtr(), reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
@@ -64902,14 +64902,14 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
     } else if ((word & 0xFFFF0000) == 0) {
       if (word >= 0xD800 && word <= 0xDFFF) {
-        return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+        return std::make_pair(nullPtr(), reinterpret_cast<char *>(utf8_output));
       }
       *utf8_output++ = char((word >> 12) | 0b11100000);
       *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
     } else {
       if (word > 0x10FFFF) {
-        return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+        return std::make_pair(nullPtr(), reinterpret_cast<char *>(utf8_output));
       }
       *utf8_output++ = char((word >> 18) | 0b11110000);
       *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -65151,7 +65151,7 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
@@ -65159,7 +65159,7 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char *>(utf8_output));
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
@@ -65174,7 +65174,7 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
 
   // check for invalid input
   if (__lasx_xbnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+    return std::make_pair(nullPtr(), reinterpret_cast<char *>(utf8_output));
   }
   return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
@@ -65493,7 +65493,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
     if ((word & 0xFFFF0000) == 0) {
       // will not generate a surrogate pair
       if (word >= 0xD800 && word <= 0xDFFF) {
-        return std::make_pair(nullptr,
+        return std::make_pair(nullPtr(),
                               reinterpret_cast<char16_t *>(utf16_output));
       }
       *utf16_output++ = !match_system(big_endian)
@@ -65503,7 +65503,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
     } else {
       // will generate a surrogate pair
       if (word > 0x10FFFF) {
-        return std::make_pair(nullptr,
+        return std::make_pair(nullPtr(),
                               reinterpret_cast<char16_t *>(utf16_output));
       }
       word -= 0x10000;
@@ -65553,7 +65553,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char16_t *>(utf16_output));
           }
           *utf16_output++ = !match_system(big_endian)
@@ -65562,7 +65562,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
+            return std::make_pair(nullPtr(),
                                   reinterpret_cast<char16_t *>(utf16_output));
           }
           word -= 0x10000;
@@ -65583,7 +65583,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (__lasx_xbnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
+    return std::make_pair(nullPtr(), reinterpret_cast<char16_t *>(utf16_output));
   }
   return std::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
 }

--- a/Source/WTF/wtf/simdutf/simdutf_impl.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.h
@@ -906,7 +906,7 @@ static inline uint32_t detect_supported_architectures() {
   #if defined(__linux__)
   simdutf_riscv_hwprobe probes[] = {{SIMDUTF_RISCV_HWPROBE_KEY_IMA_EXT_0, 0}};
   long ret = simdutf_riscv_hwprobe(&probes, sizeof probes / sizeof *probes, 0,
-                                   nullptr, 0);
+                                   nullPtr(), 0);
   if (ret == 0) {
     uint64_t extensions = probes[0].value;
     if (extensions & SIMDUTF_RISCV_HWPROBE_IMA_V)
@@ -6557,7 +6557,7 @@ public:
         return impl;
       }
     }
-    return nullptr;
+    return nullPtr();
   }
 
   /**
@@ -6571,7 +6571,7 @@ public:
    *
    * @return the most advanced supported implementation for the current host, or
    * an implementation that returns UNSUPPORTED_ARCHITECTURE if there is no
-   * supported implementation. Will never return nullptr.
+   * supported implementation. Will never return nullPtr().
    */
   const implementation *detect_best_supported() const noexcept;
 };

--- a/Source/WTF/wtf/text/AdaptiveStringSearcher.h
+++ b/Source/WTF/wtf/text/AdaptiveStringSearcher.h
@@ -81,7 +81,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const SubjectChar searchCharacter = static_cast<SubjectChar>(patternFirstChar);
         const auto* start = subjectPtr + index;
         const auto searchLength = maxN - index;
-        const SubjectChar* charPos = nullptr;
+        const SubjectChar* charPos = nullPtr();
         ASSERT(maxN - index >= 0);
         if constexpr (sizeof(SubjectChar) == 2)
             charPos = std::bit_cast<const SubjectChar*>(find16(std::bit_cast<const uint16_t*>(start), searchCharacter, searchLength));

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -101,8 +101,8 @@ public:
     WTF_EXPORT_PRIVATE AtomString convertToASCIILowercase() const;
     WTF_EXPORT_PRIVATE AtomString convertToASCIIUppercase() const;
 
-    double toDouble(bool* ok = nullptr) const { return m_string.toDouble(ok); }
-    float toFloat(bool* ok = nullptr) const { return m_string.toFloat(ok); }
+    double toDouble(bool* ok = nullPtr()) const { return m_string.toDouble(ok); }
+    float toFloat(bool* ok = nullPtr()) const { return m_string.toFloat(ok); }
 
     bool isNull() const { return m_string.isNull(); }
     bool isEmpty() const { return m_string.isEmpty(); }

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -161,7 +161,7 @@ struct HashedUTF8CharactersTranslator {
 RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char16_t> characters)
 {
     if (!characters.data())
-        return nullptr;
+        return nullPtr();
 
     if (characters.empty())
         return uncheckedDowncast<AtomStringImpl>(StringImpl::empty());
@@ -173,7 +173,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char16_t> characters)
 RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<char16_t>& buffer)
 {
     if (!buffer.characters.data())
-        return nullptr;
+        return nullPtr();
 
     if (buffer.characters.empty())
         return uncheckedDowncast<AtomStringImpl>(StringImpl::empty());
@@ -224,7 +224,7 @@ struct SubstringTranslator16 : SubstringTranslator {
 RefPtr<AtomStringImpl> AtomStringImpl::add(StringImpl* baseString, unsigned start, unsigned length)
 {
     if (!baseString)
-        return nullptr;
+        return nullPtr();
 
     if (!length || start >= baseString->length())
         return uncheckedDowncast<AtomStringImpl>(StringImpl::empty());
@@ -288,7 +288,7 @@ struct BufferFromStaticDataTranslator {
 RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<Latin1Character>& buffer)
 {
     if (!buffer.characters.data())
-        return nullptr;
+        return nullPtr();
 
     if (buffer.characters.empty())
         return uncheckedDowncast<AtomStringImpl>(StringImpl::empty());
@@ -299,7 +299,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<Latin1Charac
 RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const Latin1Character> characters)
 {
     if (!characters.data())
-        return nullptr;
+        return nullPtr();
 
     if (characters.empty())
         return uncheckedDowncast<AtomStringImpl>(StringImpl::empty());
@@ -471,14 +471,14 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)
     auto iterator = atomStringTable.find(&string);
     if (iterator != atomStringTable.end())
         return uncheckedDowncast<AtomStringImpl>(iterator->get());
-    return nullptr;
+    return nullPtr();
 }
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char8_t> characters)
 {
     HashedUTF8Characters buffer { characters, computeUTF16LengthWithHash(characters) };
     if (!buffer.length.hash)
-        return nullptr;
+        return nullPtr();
     return addToStringTable<HashedUTF8Characters, HashedUTF8CharactersTranslator>(buffer);
 }
 
@@ -491,7 +491,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const Latin1Character> c
     auto iterator = table.find<Latin1BufferTranslator>(buffer);
     if (iterator != table.end())
         return uncheckedDowncast<AtomStringImpl>(iterator->get());
-    return nullptr;
+    return nullPtr();
 }
 
 RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const char16_t> characters)
@@ -503,7 +503,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const char16_t> characte
     auto iterator = table.find<UTF16BufferTranslator>(buffer);
     if (iterator != table.end())
         return uncheckedDowncast<AtomStringImpl>(iterator->get());
-    return nullptr;
+    return nullPtr();
 }
 
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -81,7 +81,7 @@ private:
 inline RefPtr<AtomStringImpl> AtomStringImpl::lookUp(StringImpl* string)
 {
     if (!string)
-        return nullptr;
+        return nullPtr();
     if (auto* atom = dynamicDowncast<AtomStringImpl>(*string))
         return atom;
     return lookUpSlowCase(*string);
@@ -95,14 +95,14 @@ ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char> c
 ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::add(StringImpl* string)
 {
     if (!string)
-        return nullptr;
+        return nullPtr();
     return add(*string);
 }
 
 ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::add(RefPtr<StringImpl>&& string)
 {
     if (!string)
-        return nullptr;
+        return nullPtr();
     return add(string.releaseNonNull());
 }
 
@@ -115,7 +115,7 @@ template<typename StringTableProvider>
 ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addWithStringTableProvider(StringTableProvider& stringTableProvider, StringImpl* string)
 {
     if (!string)
-        return nullptr;
+        return nullPtr();
     return add(*stringTableProvider.atomStringTable(), *string);
 }
 

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -140,7 +140,7 @@ inline CString::CString(const std::string& value)
 
 inline const char* CString::data() const
 {
-    return m_buffer ? m_buffer->spanIncludingNullTerminator().data() : nullptr;
+    return m_buffer ? m_buffer->spanIncludingNullTerminator().data() : nullPtr();
 }
 
 inline std::span<const char> CString::span() const

--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -53,7 +53,7 @@ static typename IntegerToStringConversionTrait<T>::ReturnType numberToStringImpl
 }
 
 template<typename T, typename SignedIntegerType>
-inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringSigned(SignedIntegerType number, typename IntegerToStringConversionTrait<T>::AdditionalArgumentType* additionalArgument = nullptr)
+inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringSigned(SignedIntegerType number, typename IntegerToStringConversionTrait<T>::AdditionalArgumentType* additionalArgument = nullPtr())
 {
     if (number < 0)
         return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, NegativeNumber>(-unsignedCast(number), additionalArgument);
@@ -61,7 +61,7 @@ inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringSign
 }
 
 template<typename T, typename UnsignedIntegerType>
-inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringUnsigned(UnsignedIntegerType number, typename IntegerToStringConversionTrait<T>::AdditionalArgumentType* additionalArgument = nullptr)
+inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringUnsigned(UnsignedIntegerType number, typename IntegerToStringConversionTrait<T>::AdditionalArgumentType* additionalArgument = nullPtr())
 {
     return numberToStringImpl<T, UnsignedIntegerType, PositiveNumber>(number, additionalArgument);
 }

--- a/Source/WTF/wtf/text/MakeString.h
+++ b/Source/WTF/wtf/text/MakeString.h
@@ -48,7 +48,7 @@ RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool a
         std::span<Latin1Character> buffer;
         RefPtr result = StringImpl::tryCreateUninitialized(length, buffer);
         if (!result)
-            return nullptr;
+            return nullPtr();
 
         if (buffer.data())
             stringTypeAdapterAccumulator(buffer, adapters...);
@@ -59,7 +59,7 @@ RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool a
     std::span<char16_t> buffer;
     RefPtr result = StringImpl::tryCreateUninitialized(length, buffer);
     if (!result)
-        return nullptr;
+        return nullPtr();
 
     if (buffer.data())
         stringTypeAdapterAccumulator(buffer, adapters...);

--- a/Source/WTF/wtf/text/StringBuffer.h
+++ b/Source/WTF/wtf/text/StringBuffer.h
@@ -47,7 +47,7 @@ class StringBuffer {
 public:
     explicit StringBuffer(unsigned length)
         : m_length(length)
-        , m_data(m_length ? static_cast<CharType*>(StringBufferMalloc::malloc(Checked<size_t>(m_length) * sizeof(CharType))) : nullptr)
+        , m_data(m_length ? static_cast<CharType*>(StringBufferMalloc::malloc(Checked<size_t>(m_length) * sizeof(CharType))) : nullPtr())
     {
     }
 
@@ -77,7 +77,7 @@ public:
 
     MallocSpan<CharType, StringBufferMalloc> release()
     {
-        return adoptMallocSpan<CharType, StringBufferMalloc>(unsafeMakeSpan(std::exchange(m_data, nullptr), std::exchange(m_length, 0)));
+        return adoptMallocSpan<CharType, StringBufferMalloc>(unsafeMakeSpan(std::exchange(m_data, nullPtr()), std::exchange(m_length, 0)));
     }
 
 private:

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -187,7 +187,7 @@ void StringBuilder::shrinkToFit()
 {
     if (shouldShrinkToFit()) {
         reallocateBuffer(m_length);
-        m_string = std::exchange(m_buffer, nullptr);
+        m_string = std::exchange(m_buffer, nullPtr());
     }
 }
 

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -140,7 +140,7 @@ inline StringBuilder::StringBuilder(OverflowPolicy policy)
 inline void StringBuilder::clear()
 {
     m_string = { };
-    m_buffer = nullptr;
+    m_buffer = nullPtr();
     m_length = 0;
     // We intentionally do not change m_shouldCrashOnOverflow.
 }

--- a/Source/WTF/wtf/text/StringCommon.cpp
+++ b/Source/WTF/wtf/text/StringCommon.cpp
@@ -51,10 +51,10 @@ const float* findFloatAlignedImpl(const float* pointer, float target, size_t len
         if (simde_vget_lane_u64(simde_vreinterpret_u64_u16(simde_vmovn_u32(mask)), 0)) {
             simde_uint32x4_t ranked = simde_vornq_u32(indexMask, mask);
             uint32_t index = simde_vminvq_u32(ranked);
-            return (index < length) ? cursor + index : nullptr;
+            return (index < length) ? cursor + index : nullPtr();
         }
         if (length <= stride)
-            return nullptr;
+            return nullPtr();
         length -= stride;
         cursor += stride;
     }
@@ -82,10 +82,10 @@ const double* findDoubleAlignedImpl(const double* pointer, double target, size_t
         if (simde_vget_lane_u64(simde_vreinterpret_u64_u32(reducedMask), 0)) {
             simde_uint32x2_t ranked = simde_vorn_u32(indexMask, reducedMask);
             uint32_t index = simde_vminv_u32(ranked);
-            return (index < length) ? cursor + index : nullptr;
+            return (index < length) ? cursor + index : nullPtr();
         }
         if (length <= stride)
-            return nullptr;
+            return nullPtr();
         length -= stride;
         cursor += stride;
     }
@@ -112,10 +112,10 @@ const Latin1Character* find8NonASCIIAlignedImpl(std::span<const Latin1Character>
         if (simde_vmaxvq_u8(mask)) {
             simde_uint8x16_t ranked = simde_vornq_u8(indexMask, mask);
             uint8_t index = simde_vminvq_u8(ranked);
-            return std::bit_cast<const Latin1Character*>((index < length) ? cursor + index : nullptr);
+            return std::bit_cast<const Latin1Character*>((index < length) ? cursor + index : nullPtr());
         }
         if (length <= stride)
-            return nullptr;
+            return nullPtr();
         length -= stride;
         cursor += stride;
     }
@@ -144,10 +144,10 @@ const char16_t* find16NonASCIIAlignedImpl(std::span<const char16_t> data)
         if (simde_vget_lane_u64(simde_vreinterpret_u64_u8(simde_vmovn_u16(mask)), 0)) {
             simde_uint16x8_t ranked = simde_vornq_u16(indexMask, mask);
             uint16_t index = simde_vminvq_u16(ranked);
-            return std::bit_cast<const char16_t*>((index < length) ? cursor + index : nullptr);
+            return std::bit_cast<const char16_t*>((index < length) ? cursor + index : nullPtr());
         }
         if (length <= stride)
-            return nullptr;
+            return nullPtr();
         length -= stride;
         cursor += stride;
     }

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -602,7 +602,7 @@ ALWAYS_INLINE const uint8_t* find8(const uint8_t* pointer, uint8_t character, si
             return pointer + index;
     }
     if (runway == length)
-        return nullptr;
+        return nullPtr();
 
     ASSERT(index < length);
     // We rely on memchr already having SIMD optimization, so we don’t have to write our own.
@@ -626,7 +626,7 @@ ALWAYS_INLINE const UnsignedType* findImpl(const UnsignedType* pointer, Unsigned
     auto* end = pointer + length;
     auto* cursor = SIMD::find<UnsignedType, threshold>(std::span { pointer, end }, vectorMatch, scalarMatch);
     if (cursor == end)
-        return nullptr;
+        return nullPtr();
     return cursor;
 }
 
@@ -651,7 +651,7 @@ ALWAYS_INLINE const Float16* findFloat16(const Float16* pointer, Float16 target,
         if (pointer[index] == target)
             return pointer + index;
     }
-    return nullptr;
+    return nullPtr();
 }
 
 WTF_EXPORT_PRIVATE const float* findFloatAlignedImpl(const float* pointer, float target, size_t length);
@@ -671,7 +671,7 @@ ALWAYS_INLINE const float* findFloat(const float* pointer, float target, size_t 
             return pointer + index;
     }
     if (runway == length)
-        return nullptr;
+        return nullPtr();
 
     ASSERT(index < length);
     return findFloatAlignedImpl(pointer + index, target, length - index);
@@ -683,7 +683,7 @@ ALWAYS_INLINE const float* findFloat(const float* pointer, float target, size_t 
         if (pointer[index] == target)
             return pointer + index;
     }
-    return nullptr;
+    return nullPtr();
 }
 #endif
 
@@ -704,7 +704,7 @@ ALWAYS_INLINE const double* findDouble(const double* pointer, double target, siz
             return pointer + index;
     }
     if (runway == length)
-        return nullptr;
+        return nullPtr();
 
     ASSERT(index < length);
     return findDoubleAlignedImpl(pointer + index, target, length - index);
@@ -716,7 +716,7 @@ ALWAYS_INLINE const double* findDouble(const double* pointer, double target, siz
         if (pointer[index] == target)
             return pointer + index;
     }
-    return nullptr;
+    return nullPtr();
 }
 #endif
 
@@ -739,7 +739,7 @@ ALWAYS_INLINE const Latin1Character* find8NonASCII(std::span<const Latin1Charact
             return pointer + index;
     }
     if (runway == length)
-        return nullptr;
+        return nullPtr();
 
     ASSERT(index < length);
     return find8NonASCIIAlignedImpl({ pointer + index, length - index });
@@ -760,7 +760,7 @@ ALWAYS_INLINE const char16_t* find16NonASCII(std::span<const char16_t> data)
             return pointer + index;
     }
     if (runway == length)
-        return nullptr;
+        return nullPtr();
 
     ASSERT(index < length);
     return find16NonASCIIAlignedImpl({ pointer + index, length - index });
@@ -1364,7 +1364,7 @@ ALWAYS_INLINE bool charactersContain(std::span<const CharacterType> span)
 #if CPU(ARM64) || CPU(X86_64)
     constexpr size_t stride = SIMD::stride<CharacterType>;
     using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
-    using BulkType = decltype(SIMD::load(static_cast<const UnsignedType*>(nullptr)));
+    using BulkType = decltype(SIMD::load(static_cast<const UnsignedType*>(nullPtr())));
     if (length >= stride) {
         size_t index = 0;
         BulkType accumulated { };

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -214,7 +214,7 @@ template<typename CharacterType> inline Expected<Ref<StringImpl>, UTF8Conversion
     ASSERT(originalString->bufferOwnership() == BufferInternal);
 
     if (!length) {
-        data = nullptr;
+        data = nullPtr();
         return Ref<StringImpl>(*empty());
     }
 
@@ -282,7 +282,7 @@ RefPtr<StringImpl> StringImpl::create(std::span<const char8_t> codeUnits)
     RELEASE_ASSERT(codeUnits.size() <= String::MaxLength);
 
     if (!codeUnits.data())
-        return nullptr;
+        return nullPtr();
     if (codeUnits.empty())
         return empty();
 
@@ -293,7 +293,7 @@ RefPtr<StringImpl> StringImpl::create(std::span<const char8_t> codeUnits)
 
     auto result = Unicode::convert(codeUnits, buffer.mutableSpan());
     if (result.code != Unicode::ConversionResultCode::Success)
-        return nullptr;
+        return nullPtr();
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(result.buffer.size() <= codeUnits.size());
     return create(result.buffer);

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -452,8 +452,8 @@ public:
     // FIXME: Like the strict functions above, these give false for "ok" when there is trailing garbage.
     // Like the non-strict functions above, these return the value when there is trailing garbage.
     // It would be better if these were more consistent with the above functions instead.
-    double toDouble(bool* ok = nullptr);
-    float toFloat(bool* ok = nullptr);
+    double toDouble(bool* ok = nullPtr());
+    float toFloat(bool* ok = nullPtr());
 
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToASCIILowercase();
     WTF_EXPORT_PRIVATE Ref<StringImpl> convertToASCIIUppercase();
@@ -1091,12 +1091,12 @@ template<typename CharacterType> ALWAYS_INLINE RefPtr<StringImpl> StringImpl::tr
 
     if (length > maxInternalLength<CharacterType>()) {
         output = { };
-        return nullptr;
+        return nullPtr();
     }
     SUPPRESS_UNCOUNTED_LOCAL StringImpl* result = (StringImpl*)StringImplMalloc::tryMalloc(allocationSize<CharacterType>(length));
     if (!result) {
         output = { };
-        return nullptr;
+        return nullPtr();
     }
     output = unsafeMakeSpan(result->tailPointer<CharacterType>(), length);
 

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -383,7 +383,7 @@ StringViewWithUnderlyingString normalizedNFC(StringView string)
     if (checkResult)
         return { string, { } };
 
-    unsigned normalizedLength = unorm2_normalize(normalizer, span.data(), span.size(), nullptr, 0, &status);
+    unsigned normalizedLength = unorm2_normalize(normalizer, span.data(), span.size(), nullPtr(), 0, &status);
     ASSERT(needsToGrowToProduceBuffer(status));
 
     std::span<char16_t> characters;
@@ -577,10 +577,10 @@ void StringView::setUnderlyingStringImpl(const StringImpl* string)
 {
     UnderlyingString* underlyingString;
     if (!string)
-        underlyingString = nullptr;
+        underlyingString = nullPtr();
     else {
         Locker locker { underlyingStringsLock };
-        auto result = underlyingStrings().add(string, nullptr);
+        auto result = underlyingStrings().add(string, nullPtr());
         if (result.isNewEntry)
             result.iterator->value = new UnderlyingString(*string);
         else

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -243,12 +243,12 @@ private:
 
     void clear();
 
-    const void* m_characters { nullptr };
+    const void* m_characters { nullPtr() };
     unsigned m_length { 0 };
     bool m_is8Bit { true };
 
 #if CHECK_STRINGVIEW_LIFETIME
-    UnderlyingString* m_underlyingString { nullptr };
+    UnderlyingString* m_underlyingString { nullPtr() };
 #endif
 };
 
@@ -327,7 +327,7 @@ inline AtomString StringViewWithUnderlyingString::toAtomString() const
 
 inline StringView::~StringView()
 {
-    setUnderlyingString(nullptr);
+    setUnderlyingString(nullPtr());
 }
 
 inline StringView::StringView(StringView&& other)
@@ -340,7 +340,7 @@ inline StringView::StringView(StringView&& other)
     other.clear();
 
     setUnderlyingString(other);
-    other.setUnderlyingString(nullptr);
+    other.setUnderlyingString(nullPtr());
 }
 
 inline StringView::StringView(const StringView& other)
@@ -364,7 +364,7 @@ inline StringView& StringView::operator=(StringView&& other)
     other.clear();
 
     setUnderlyingString(other);
-    other.setUnderlyingString(nullptr);
+    other.setUnderlyingString(nullPtr());
 
     return *this;
 }
@@ -472,7 +472,7 @@ inline StringView::StringView(const AtomString& atomString)
 
 inline void StringView::clear()
 {
-    m_characters = nullptr;
+    m_characters = nullPtr();
     m_length = 0;
     m_is8Bit = true;
 }

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -154,7 +154,7 @@ private:
     friend class SymbolRegistry;
 
     SymbolRegistry* symbolRegistry() const { return m_symbolRegistry.get(); }
-    void clearSymbolRegistry() { m_symbolRegistry = nullptr; }
+    void clearSymbolRegistry() { m_symbolRegistry = nullPtr(); }
 
     static Ref<RegisteredSymbolImpl> create(StringImpl& rep, SymbolRegistry&);
     static Ref<RegisteredSymbolImpl> createPrivate(StringImpl& rep, SymbolRegistry&);
@@ -192,7 +192,7 @@ inline SymbolRegistry* SymbolImpl::symbolRegistry() const
 {
     if (isRegistered())
         return static_cast<const RegisteredSymbolImpl*>(this)->symbolRegistry();
-    return nullptr;
+    return nullPtr();
 }
 
 inline RegisteredSymbolImpl* SymbolImpl::asRegisteredSymbolImpl()

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -325,7 +325,7 @@ public:
         m_stringView = stringView;
         m_locale = locale;
         m_iterator = std::nullopt;
-        m_cachedPriorContext = nullptr;
+        m_cachedPriorContext = nullPtr();
         m_mode = mode;
         m_contentAnalysis = contentAnalysis;
     }
@@ -344,7 +344,7 @@ private:
     StringView m_stringView;
     AtomString m_locale;
     std::optional<CachedTextBreakIterator> m_iterator;
-    const char16_t* m_cachedPriorContext { nullptr };
+    const char16_t* m_cachedPriorContext { nullPtr() };
     TextBreakIterator::LineMode::Behavior m_mode { TextBreakIterator::LineMode::Behavior::Default };
     TextBreakIterator::ContentAnalysis m_contentAnalysis { TextBreakIterator::ContentAnalysis::Mechanical };
     PriorContext m_priorContext;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -41,13 +41,13 @@ namespace WTF {
 
 // Construct a string with UTF-16 data.
 String::String(std::span<const char16_t> characters)
-    : m_impl(characters.data() ? RefPtr { StringImpl::create(characters) } : nullptr)
+    : m_impl(characters.data() ? RefPtr { StringImpl::create(characters) } : nullPtr())
 {
 }
 
 // Construct a string with latin1 data.
 String::String(std::span<const Latin1Character> characters)
-    : m_impl(characters.data() ? RefPtr { StringImpl::create(characters) } : nullptr)
+    : m_impl(characters.data() ? RefPtr { StringImpl::create(characters) } : nullPtr())
 {
 }
 
@@ -59,13 +59,13 @@ String::String(std::span<const char8_t> characters)
 
 // Construct a string with Latin-1 data.
 String::String(std::span<const char> characters)
-    : m_impl(characters.data() ? RefPtr { StringImpl::create(byteCast<Latin1Character>(characters)) } : nullptr)
+    : m_impl(characters.data() ? RefPtr { StringImpl::create(byteCast<Latin1Character>(characters)) } : nullPtr())
 {
 }
 
 // Construct a string with Latin-1 data, from a null-terminated source.
 String::String(const char* nullTerminatedString)
-    : m_impl(nullTerminatedString ? RefPtr { StringImpl::createFromCString(nullTerminatedString) } : nullptr)
+    : m_impl(nullTerminatedString ? RefPtr { StringImpl::createFromCString(nullTerminatedString) } : nullPtr())
 {
 }
 
@@ -572,13 +572,13 @@ float charactersToFloat(std::span<const char16_t> data, bool* ok)
 float charactersToFloat(std::span<const Latin1Character> data, size_t& parsedLength)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Allow>(data, nullptr, parsedLength));
+    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Allow>(data, nullPtr(), parsedLength));
 }
 
 float charactersToFloat(std::span<const char16_t> data, size_t& parsedLength)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Allow>(data, nullptr, parsedLength));
+    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Allow>(data, nullPtr(), parsedLength));
 }
 
 const StaticString nullStringData { nullptr };

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -44,10 +44,10 @@ namespace WTF {
 
 // Declarations of string operations
 
-WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const Latin1Character>, bool* ok = nullptr);
-WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const char16_t>, bool* ok = nullptr);
-WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const Latin1Character>, bool* ok = nullptr);
-WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const char16_t>, bool* ok = nullptr);
+WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const Latin1Character>, bool* ok = nullPtr());
+WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const char16_t>, bool* ok = nullPtr());
+WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const Latin1Character>, bool* ok = nullPtr());
+WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const char16_t>, bool* ok = nullPtr());
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const Latin1Character>, size_t& parsedLength);
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const char16_t>, size_t& parsedLength);
 
@@ -228,8 +228,8 @@ public:
     WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN splitAllowingEmptyEntries(char16_t separator) const;
     WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN splitAllowingEmptyEntries(StringView separator) const;
 
-    WTF_EXPORT_PRIVATE double toDouble(bool* ok = nullptr) const;
-    WTF_EXPORT_PRIVATE float toFloat(bool* ok = nullptr) const;
+    WTF_EXPORT_PRIVATE double toDouble(bool* ok = nullPtr()) const;
+    WTF_EXPORT_PRIVATE float toFloat(bool* ok = nullPtr()) const;
 
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN isolatedCopy() const &;
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN isolatedCopy() &&;
@@ -489,7 +489,7 @@ inline std::optional<UCharDirection> String::defaultWritingDirection() const
 inline void String::clearImplIfNotShared()
 {
     if (m_impl && m_impl->hasOneRef())
-        m_impl = nullptr;
+        m_impl = nullPtr();
 }
 
 inline String String::substring(unsigned position, unsigned length) const

--- a/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
@@ -37,7 +37,7 @@ namespace WTF {
 RefPtr<AtomStringImpl> AtomStringImpl::add(CFStringRef string)
 {
     if (!string)
-        return nullptr;
+        return nullPtr();
 
     if (auto span = byteCast<Latin1Character>(CFStringGetLatin1CStringSpan(string)); span.data())
         return add(span);

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -69,7 +69,7 @@ public:
         auto localeObject = adoptCF(CFLocaleCreate(kCFAllocatorDefault, locale.string().createCFString().get()));
         m_stringTokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, stringObject.get(), CFRangeMake(0, m_stringLength + m_priorContextLength), options, localeObject.get()));
         if (!m_stringTokenizer)
-            m_stringTokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, stringObject.get(), CFRangeMake(0, m_stringLength + m_priorContextLength), options, nullptr));
+            m_stringTokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, stringObject.get(), CFRangeMake(0, m_stringLength + m_priorContextLength), options, nullPtr()));
         ASSERT(m_stringTokenizer);
     }
 

--- a/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
+++ b/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
@@ -64,7 +64,7 @@ static RetainPtr<CFStringRef> topLanguagePreference()
 {
     auto languagesArray = adoptCF(CFLocaleCopyPreferredLanguages());
     if (!languagesArray || !CFArrayGetCount(languagesArray.get()))
-        return nullptr;
+        return nullPtr();
     return static_cast<CFStringRef>(CFArrayGetValueAtIndex(languagesArray.get(), 0));
 }
 

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -106,7 +106,7 @@ public:
         textLocal.text.pExtra = textLocal.buffer;
 
         UErrorCode status = U_ZERO_ERROR;
-        UText* text = nullptr;
+        UText* text = nullPtr();
         if (string.is8Bit())
             text = openLatin1ContextAwareUTextProvider(&textLocal, string.span8(), priorContext, &status);
         else
@@ -159,7 +159,7 @@ private:
         Vector<char> scratchBuffer(utf8Locale.length() + 11, 0);
         memcpySpan(scratchBuffer.mutableSpan(), utf8Locale.span());
 
-        const char* keywordValue = nullptr;
+        const char* keywordValue = nullPtr();
         switch (behavior) {
         case LineMode::Behavior::Default:
             // nullptr will cause any existing values to be removed.

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -220,7 +220,7 @@ static int32_t uTextLatin1MapNativeIndexToUTF16(const UText* uText, int64_t nati
 
 static void uTextLatin1Close(UText* uText)
 {
-    uText->context = nullptr;
+    uText->context = nullPtr();
 }
 
 UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, std::span<const Latin1Character> string, UErrorCode* status)
@@ -386,7 +386,7 @@ static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, char16_t
 
 static void uTextLatin1ContextAwareClose(UText* text)
 {
-    text->context = nullptr;
+    text->context = nullPtr();
 }
 
 UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, std::span<const Latin1Character> string, std::span<const char16_t> priorContext, UErrorCode* status)

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
@@ -159,7 +159,7 @@ static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, char16_t*
 
 static void uTextUTF16ContextAwareClose(UText* text)
 {
-    text->context = nullptr;
+    text->context = nullPtr();
 }
 
 UText* openUTF16ContextAwareUTextProvider(UText* text, std::span<const char16_t> string, std::span<const char16_t> priorContext, UErrorCode* status)

--- a/Source/WTF/wtf/text/unix/TextBreakIteratorInternalICUUnix.cpp
+++ b/Source/WTF/wtf/text/unix/TextBreakIteratorInternalICUUnix.cpp
@@ -26,14 +26,14 @@ namespace WTF {
 
 const char* currentSearchLocaleID()
 {
-    if (auto* localeDefault = setlocale(LC_MESSAGES, nullptr))
+    if (auto* localeDefault = setlocale(LC_MESSAGES, nullPtr()))
         return localeDefault;
     return "";
 }
 
 const char* currentTextBreakLocaleID()
 {
-    if (auto* localeDefault = setlocale(LC_MESSAGES, nullptr))
+    if (auto* localeDefault = setlocale(LC_MESSAGES, nullPtr()))
         return localeDefault;
     return "en_us";
 }

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -499,7 +499,7 @@ static void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
         defaultAction.sa_handler = SIG_DFL;
         sigfillset(&defaultAction.sa_mask);
         defaultAction.sa_flags = 0;
-        auto result = sigaction(sig, &defaultAction, nullptr);
+        auto result = sigaction(sig, &defaultAction, nullPtr());
         dataLogLnIf(result == -1, "Unable to restore the default handler while processing signal ", sig, " the process is probably deadlocked. (errno: ", errno, ")");
     };
 

--- a/Source/WTF/wtf/unicode/Collator.h
+++ b/Source/WTF/wtf/unicode/Collator.h
@@ -45,7 +45,7 @@ class StringView;
 class Collator {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Collator);
 public:
-    explicit Collator(const char* = nullptr, bool = false) { }
+    explicit Collator(const char* = nullPtr(), bool = false) { }
 
     WTF_EXPORT_PRIVATE static int collate(StringView, StringView);
     WTF_EXPORT_PRIVATE static int collate(const char8_t*, const char8_t*);
@@ -59,7 +59,7 @@ class Collator {
 public:
     // The value nullptr is a special one meaning the system default locale.
     // Locale name parsing is lenient; e.g. language identifiers (such as "en-US") are accepted, too.
-    WTF_EXPORT_PRIVATE explicit Collator(const char* locale = nullptr, bool shouldSortLowercaseFirst = false);
+    WTF_EXPORT_PRIVATE explicit Collator(const char* locale = nullPtr(), bool shouldSortLowercaseFirst = false);
     WTF_EXPORT_PRIVATE ~Collator();
 
     WTF_EXPORT_PRIVATE int collate(StringView, StringView) const;

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -118,8 +118,8 @@ Collator::Collator(const char* locale, bool shouldSortLowercaseFirst)
             m_collator = cachedCollator;
             m_locale = cachedCollatorLocale;
             m_shouldSortLowercaseFirst = shouldSortLowercaseFirst;
-            cachedCollator = nullptr;
-            cachedCollatorLocale = nullptr;
+            cachedCollator = nullPtr();
+            cachedCollatorLocale = nullPtr();
             return;
         }
     }
@@ -237,7 +237,7 @@ static UCharIterator createLatin1Iterator(std::span<const Latin1Character> chara
     iterator.current = currentLatin1;
     iterator.next = nextLatin1;
     iterator.previous = previousLatin1;
-    iterator.reservedFn = nullptr;
+    iterator.reservedFn = nullPtr();
     iterator.getState = getStateLatin1;
     iterator.setState = setStateLatin1;
     return iterator;

--- a/Source/WTF/wtf/unix/LanguageUnix.cpp
+++ b/Source/WTF/wtf/unix/LanguageUnix.cpp
@@ -32,7 +32,7 @@ namespace WTF {
 // always the same value.
 static String platformLanguage()
 {
-    auto localeDefault = String::fromLatin1(setlocale(LC_CTYPE, nullptr));
+    auto localeDefault = String::fromLatin1(setlocale(LC_CTYPE, nullPtr()));
     if (localeDefault.isEmpty() || equalIgnoringASCIICase(localeDefault, "C"_s) || equalIgnoringASCIICase(localeDefault, "POSIX"_s))
         return "en-US"_s;
 

--- a/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
+++ b/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
@@ -126,7 +126,7 @@ static size_t processMemoryUsage()
     mib[2] = KERN_PROC_PID;
     mib[3] = getpid();
 
-    if (sysctl(mib, 4, &info, &infolen, nullptr, 0))
+    if (sysctl(mib, 4, &info, &infolen, nullPtr(), 0))
         return 0;
 
     return static_cast<size_t>(info.ki_rssize - info.ki_tsize) * pageSize;
@@ -136,7 +136,7 @@ static size_t processMemoryUsage()
         return 0;
 
     procfs_asinfo info;
-    int rc = devctl(fd, DCMD_PROC_ASINFO, &info, sizeof(info), nullptr);
+    int rc = devctl(fd, DCMD_PROC_ASINFO, &info, sizeof(info), nullPtr());
     close(fd);
 
     if (rc)

--- a/Source/WTF/wtf/win/DbgHelperWin.cpp
+++ b/Source/WTF/wtf/win/DbgHelperWin.cpp
@@ -42,7 +42,7 @@ static void initializeSymbols(HANDLE hProc)
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&]() {
-        if (!SymInitialize(hProc, nullptr, TRUE))
+        if (!SymInitialize(hProc, nullPtr(), TRUE))
             LOG_ERROR("Failed to initialze symbol information %d", GetLastError());
     });
 }

--- a/Source/WTF/wtf/win/FileHandleWin.cpp
+++ b/Source/WTF/wtf/win/FileHandleWin.cpp
@@ -58,7 +58,7 @@ std::optional<uint64_t> FileHandle::read(std::span<uint8_t> data)
         return { };
 
     DWORD bytesRead;
-    bool success = ::ReadFile(*m_handle, data.data(), data.size(), &bytesRead, nullptr);
+    bool success = ::ReadFile(*m_handle, data.data(), data.size(), &bytesRead, nullPtr());
 
     if (!success)
         return { };
@@ -71,7 +71,7 @@ std::optional<uint64_t> FileHandle::write(std::span<const uint8_t> data)
         return { };
 
     DWORD bytesWritten;
-    bool success = WriteFile(*m_handle, data.data(), data.size(), &bytesWritten, nullptr);
+    bool success = WriteFile(*m_handle, data.data(), data.size(), &bytesWritten, nullPtr());
 
     if (!success)
         return { };
@@ -171,7 +171,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode, FileOpenMode openM
         break;
     }
 
-    Win32Handle fileMapping = Win32Handle::adopt(CreateFileMapping(platformHandle(), nullptr, pageProtection, 0, 0, nullptr));
+    Win32Handle fileMapping = Win32Handle::adopt(CreateFileMapping(platformHandle(), nullPtr(), pageProtection, 0, 0, nullPtr()));
     if (!fileMapping)
         return { };
 

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -103,7 +103,7 @@ CString fileSystemRepresentation(const String& path)
 static String storageDirectory(DWORD pathIdentifier)
 {
     Vector<char16_t> buffer(MAX_PATH);
-    if (FAILED(SHGetFolderPathW(nullptr, pathIdentifier | CSIDL_FLAG_CREATE, nullptr, 0, wcharFrom(buffer.mutableSpan().data()))))
+    if (FAILED(SHGetFolderPathW(nullPtr(), pathIdentifier | CSIDL_FLAG_CREATE, nullPtr(), 0, wcharFrom(buffer.mutableSpan().data()))))
         return String();
 
     buffer.shrink(wcslen(wcharFrom(buffer.span().data())));
@@ -168,7 +168,7 @@ std::pair<String, FileHandle> openTemporaryFile(StringView, StringView suffix)
 
     String proposedPath = generateTemporaryPath([&handle](const String& proposedPath) {
         // use CREATE_NEW to avoid overwriting an existing file with the same name
-        handle = FileHandle::adopt(::CreateFileW(proposedPath.wideCharacters().span().data(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr));
+        handle = FileHandle::adopt(::CreateFileW(proposedPath.wideCharacters().span().data(), GENERIC_READ | GENERIC_WRITE, 0, nullPtr(), CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullPtr()));
 
         return handle || GetLastError() == ERROR_ALREADY_EXISTS;
     });
@@ -204,7 +204,7 @@ FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission,
         creationDisposition = CREATE_NEW;
 
     String destination = path;
-    return FileHandle::adopt(CreateFile(destination.wideCharacters().span().data(), desiredAccess, shareMode, nullptr, creationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr), lockMode);
+    return FileHandle::adopt(CreateFile(destination.wideCharacters().span().data(), desiredAccess, shareMode, nullPtr(), creationDisposition, FILE_ATTRIBUTE_NORMAL, nullPtr()), lockMode);
 }
 
 String localUserSpecificStorageDirectory()

--- a/Source/WTF/wtf/win/LanguageWin.cpp
+++ b/Source/WTF/wtf/win/LanguageWin.cpp
@@ -41,7 +41,7 @@ static Lock platformLanguageMutex;
 static String localeInfo(LCTYPE localeType, const String& fallback)
 {
     LANGID langID = GetUserDefaultUILanguage();
-    int localeChars = GetLocaleInfo(langID, localeType, nullptr, 0);
+    int localeChars = GetLocaleInfo(langID, localeType, nullPtr(), 0);
     if (!localeChars)
         return fallback;
     std::span<char16_t> localeNameBuf;

--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -67,7 +67,7 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
         addressReqs.Alignment = alignment;
         param.Type = MemExtendedParameterAddressRequirements;
         param.Pointer = &addressReqs;
-        void* result = VirtualAlloc2Ptr()(nullptr, address, bytes, MEM_RESERVE, protection(writable, executable), &param, 1);
+        void* result = VirtualAlloc2Ptr()(nullPtr(), address, bytes, MEM_RESERVE, protection(writable, executable), &param, 1);
         return result;
     }
 

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -58,13 +58,13 @@ LRESULT RunLoop::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         performWork();
         return 0;
     case SetTimerMessage:
-        ::SetTimer(hWnd, wParam, lParam, nullptr);
+        ::SetTimer(hWnd, wParam, lParam, nullPtr());
         return 0;
     case KillTimerMessage:
         ::KillTimer(hWnd, wParam);
         return 0;
     case WM_TIMER:
-        RunLoop::TimerBase* timer = nullptr;
+        RunLoop::TimerBase* timer = nullPtr();
         {
             Locker locker { m_loopLock };
             if (m_liveTimers.contains(wParam))
@@ -81,7 +81,7 @@ LRESULT RunLoop::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 void RunLoop::run()
 {
     MSG message;
-    while (BOOL result = ::GetMessage(&message, nullptr, 0, 0)) {
+    while (BOOL result = ::GetMessage(&message, nullPtr(), 0, 0)) {
         if (result == -1)
             break;
         ::TranslateMessage(&message);
@@ -115,8 +115,8 @@ void RunLoop::registerRunLoopMessageWindowClass()
 
 RunLoop::RunLoop()
 {
-    m_runLoopMessageWindow = ::CreateWindow(kRunLoopMessageWindowClassName, nullptr, 0,
-        CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, HWND_MESSAGE, nullptr, nullptr, this);
+    m_runLoopMessageWindow = ::CreateWindow(kRunLoopMessageWindowClassName, nullPtr(), 0,
+        CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, HWND_MESSAGE, nullPtr(), nullPtr(), this);
     RELEASE_ASSERT(::IsWindow(m_runLoopMessageWindow));
 }
 
@@ -138,7 +138,7 @@ void RunLoop::wakeUp()
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode)
 {
     MSG message;
-    while (::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+    while (::PeekMessage(&message, nullPtr(), 0, 0, PM_REMOVE)) {
         if (message.message == WM_QUIT)
             return CycleResult::Stop;
 

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -151,7 +151,7 @@ bool Thread::establishHandle(NewThreadContext* data, std::optional<size_t> stack
 {
     unsigned threadIdentifier = 0;
     unsigned initFlag = stackSize ? STACK_SIZE_PARAM_IS_A_RESERVATION : 0;
-    HANDLE threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(nullptr, stackSize.value_or(0), wtfThreadEntryPoint, data, initFlag, &threadIdentifier));
+    HANDLE threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(nullPtr(), stackSize.value_or(0), wtfThreadEntryPoint, data, initFlag, &threadIdentifier));
     if (!threadHandle) {
         LOG_ERROR("Failed to create thread at entry point %p with data %p: %ld", wtfThreadEntryPoint, data, errno);
         return false;
@@ -266,7 +266,7 @@ struct Thread::ThreadHolder {
         if (isMainThread())
             return;
         if (thread) {
-            thread->m_clientData = nullptr;
+            thread->m_clientData = nullPtr();
             thread->specificStorage().destroySlots();
             thread->didExit();
         }
@@ -320,7 +320,7 @@ void Thread::SpecificStorage::destroySlots()
         auto destroy = s_destroyFunctions[i].load();
         if (destroy && m_slots[i]) {
             destroy(m_slots[i]);
-            m_slots[i] = nullptr;
+            m_slots[i] = nullPtr();
         }
     }
 }


### PR DESCRIPTION
#### 5eb14e6e76bf8631d2b387039c07f0707c2d7506
<pre>
Replace nullptr with nullPtr() in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=302530">https://bugs.webkit.org/show_bug.cgi?id=302530</a>
<a href="https://rdar.apple.com/164718744">rdar://164718744</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

No new tests (OOPS!).
* Source/WTF/benchmarks/ConditionSpeedTest.cpp:
* Source/WTF/icu/unicode/dcfmtsym.h:
* Source/WTF/icu/unicode/decimfmt.h:
* Source/WTF/icu/unicode/localematcher.h:
* Source/WTF/icu/unicode/numberformatter.h:
* Source/WTF/icu/unicode/rbbi.h:
* Source/WTF/icu/unicode/reldatefmt.h:
* Source/WTF/icu/unicode/simplenumberformatter.h:
* Source/WTF/icu/unicode/smpdtfmt.h:
* Source/WTF/icu/unicode/stringpiece.h:
* Source/WTF/icu/unicode/uniset.h:
* Source/WTF/wtf/Assertions.cpp:
(WTF::createWithFormatAndArguments):
* Source/WTF/wtf/Atomics.h:
(WTF::opaque): Deleted.
* Source/WTF/wtf/Bag.h:
* Source/WTF/wtf/BitSet.h:
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/BlockPtr.h:
(WTF::BlockPtr&lt;R):
* Source/WTF/wtf/Box.h:
(WTF::Box::get const):
* Source/WTF/wtf/BumpPointerAllocator.h:
(WTF::BumpPointerPool::BumpPointerPool):
(WTF::BumpPointerPool::create):
(WTF::BumpPointerPool::ensureCapacityCrossPool):
(WTF::BumpPointerAllocator::BumpPointerAllocator):
* Source/WTF/wtf/CagedPtr.h:
(WTF::CagedPtr::CagedPtr):
(WTF::CagedPtr::getMayBeNull const):
(WTF::CagedPtr::operator=):
* Source/WTF/wtf/CagedUniquePtr.h:
(WTF::CagedUniquePtr::operator=):
* Source/WTF/wtf/CancellableTask.h:
(WTF::TaskCancellationGroupHandle::clear):
* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::CheckedPtr):
(WTF::CheckedPtr::releaseNonNull):
(WTF::CheckedPtr::operator=):
(WTF::HashTraits&lt;CheckedPtr&lt;P&gt;&gt;::emptyValue):
* Source/WTF/wtf/CheckedRef.h:
(WTF::CheckedRef::~CheckedRef):
(WTF::CheckedRef::hashTableEmptyValue):
(WTF::CheckedRef::releasePtr):
* Source/WTF/wtf/CodePtr.h:
(WTF::CodePtr:: const):
(WTF::CodePtr::dumpWithName const):
* Source/WTF/wtf/CompactPointerTuple.h:
* Source/WTF/wtf/CompactPtr.h:
(WTF::CompactPtr::operator=):
(WTF::CompactPtr::swap):
* Source/WTF/wtf/CompactRefPtrTuple.h:
* Source/WTF/wtf/CompactUniquePtrTuple.h:
* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
(WTF::CompletionHandlerWithFinalizer&lt;Out):
* Source/WTF/wtf/ConcurrentBuffer.h:
* Source/WTF/wtf/ConcurrentPtrHashSet.cpp:
(WTF::ConcurrentPtrHashSet::addSlow):
(WTF::ConcurrentPtrHashSet::Table::create):
(WTF::ConcurrentPtrHashSet::Table::createStub):
* Source/WTF/wtf/ConcurrentPtrHashSet.h:
* Source/WTF/wtf/CoroutineUtilities.h:
(WTF::CoroutineHandle::CoroutineHandle):
(WTF::CoroutineHandle::operator=):
* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/CrossThreadTaskHandler.cpp:
(WTF::CrossThreadTaskHandler::taskRunLoop):
* Source/WTF/wtf/DataLog.cpp:
(WTF::initializeLogFileOnce):
(WTF::setDataFile):
* Source/WTF/wtf/DataMutex.h:
* Source/WTF/wtf/DataRef.h:
(WTF::DataRef::hashTableEmptyValue):
* Source/WTF/wtf/DateMath.cpp:
(WTF::calculateUTCOffset):
(WTF::calculateDSTOffset):
(WTF::validateTimeZone):
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::IterativeDominance::immediateDominator):
(WTF::Dominators::LengauerTarjan::BlockData::BlockData):
(WTF::Dominators::BlockData::BlockData):
* Source/WTF/wtf/DoublyLinkedList.h:
(WTF::DoublyLinkedListNode&lt;T&gt;::DoublyLinkedListNode):
(WTF::DoublyLinkedList&lt;T&gt;::DoublyLinkedList):
(WTF::DoublyLinkedList&lt;T&gt;::splitAt):
(WTF::DoublyLinkedList&lt;T&gt;::remove):
* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVectorWordOwner::FastBitVectorWordOwner):
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastMemDup):
(WTF::fastCompactMemDup):
(WTF::tryFastZeroedMalloc):
(WTF::tryFastCalloc):
(WTF::tryFastCompactCalloc):
* Source/WTF/wtf/FastMalloc.h:
(WTF::FastMalloc::tryMalloc):
(WTF::FastMalloc::tryZeroedMalloc):
(WTF::FastMalloc::tryRealloc):
(WTF::FastCompactMalloc::tryMalloc):
(WTF::FastCompactMalloc::tryZeroedMalloc):
(WTF::FastCompactMalloc::tryRealloc):
* Source/WTF/wtf/FilePrintStream.cpp:
(WTF::FilePrintStream::open):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::FixedVector):
(WTF::FixedVector::createWithSizeAndConstructorArguments):
(WTF::FixedVector::createWithSizeFromGenerator):
(WTF::FixedVector::createWithSizeFromFailableGenerator):
(WTF::FixedVector::map):
(WTF::FixedVector::clear):
* Source/WTF/wtf/Function.h:
(WTF::Function&lt;Out):
* Source/WTF/wtf/FunctionPtr.h:
* Source/WTF/wtf/Gigacage.cpp:
(Gigacage::tryMallocArray):
* Source/WTF/wtf/HashTable.h:
(WTF::HashTable::shrink):
(WTF::Malloc&gt;::HashTable):
(WTF::Malloc&gt;::inlineLookup):
(WTF::Malloc&gt;::fullLookupForWriting):
(WTF::Malloc&gt;::add):
(WTF::Malloc&gt;::shrinkToBestSize):
(WTF::Malloc&gt;::rehash):
(WTF::Malloc&gt;::clear):
(WTF::invalidateIterators):
(WTF::addIterator):
(WTF::removeIterator):
* Source/WTF/wtf/HashTraits.h:
(WTF::HashTraits&lt;UniqueRef&lt;T&gt;&gt;::emptyValue):
(WTF::HashTraits&lt;UniqueRef&lt;T&gt;&gt;::peek):
(WTF::HashTraits&lt;UniqueRef&lt;T&gt;&gt;::take):
(WTF::HashTraits&lt;CompactPtr&lt;P&gt;&gt;::emptyValue):
* Source/WTF/wtf/IndexSet.h:
(WTF::IndexSet::Iterable::iterator::iterator):
* Source/WTF/wtf/IndexSparseSet.h:
(WTF::OverflowHandler&gt;::get):
* Source/WTF/wtf/IndexedContainerIterator.h:
(WTF::IndexedContainerIterator::IndexedContainerIterator):
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::parseJSON):
(WTF::JSONImpl::ObjectBase::getObject const):
(WTF::JSONImpl::ObjectBase::getArray const):
(WTF::JSONImpl::ObjectBase::getValue const):
* Source/WTF/wtf/JSONValues.h:
(WTF::JSONImpl::Value::asObject):
(WTF::JSONImpl::Value::asObject const):
(WTF::JSONImpl::Value::asArray):
* Source/WTF/wtf/LazyRef.h:
(WTF::LazyRef::getIfExists):
* Source/WTF/wtf/LazyUniqueRef.h:
(WTF::LazyUniqueRef::getIfExists):
* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::ListHashSet):
(WTF::U&gt;::add):
(WTF::U&gt;::appendOrMoveToLast):
(WTF::U&gt;::prependOrMoveToFirst):
(WTF::U&gt;::insertBefore):
(WTF::U&gt;::clear):
(WTF::U&gt;::appendNode):
(WTF::U&gt;::prependNode):
(WTF::U&gt;::deleteAllNodes):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::Iterable::iterator::iterator):
* Source/WTF/wtf/Locker.h:
(WTF::unlockFunction):
* Source/WTF/wtf/LocklessBag.h:
* Source/WTF/wtf/Logger.h:
(WTF::Logger::log):
(WTF::Logger::logVerbose):
* Source/WTF/wtf/MallocCommon.h:
(WTF::TryMallocReturnValue::TryMallocReturnValue):
(WTF::TryMallocReturnValue::getValue):
* Source/WTF/wtf/MallocPtr.h:
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::memoryPressureHandlerIfExists):
(WTF::MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor):
* Source/WTF/wtf/MessageQueue.h:
(WTF::MessageQueue&lt;DataType&gt;::waitForMessageFilteredWithTimeout):
(WTF::MessageQueue&lt;DataType&gt;::tryGetMessage):
(WTF::MessageQueue&lt;DataType&gt;::tryGetMessageIgnoringKilled):
* Source/WTF/wtf/MetaAllocator.cpp:
(WTF::MetaAllocator::allocate):
(WTF::MetaAllocator::findAndRemoveFreeSpace):
* Source/WTF/wtf/MetaAllocator.h:
(WTF::MetaAllocatorTracker::find):
* Source/WTF/wtf/Mmap.h:
(WTF::Mmap::mmap):
* Source/WTF/wtf/NakedPtr.h:
(WTF::NakedPtr::NakedPtr):
(WTF::NakedPtr::clear):
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/NaturalLoops.h:
(WTF::NaturalLoop::NaturalLoop):
(WTF::NaturalLoops::headerOf const):
(WTF::NaturalLoops::innerMostLoopOf const):
(WTF::NaturalLoops::innerMostOuterLoop const):
* Source/WTF/wtf/NumberOfCores.cpp:
(WTF::numberOfPhysicalProcessorCores):
* Source/WTF/wtf/OSAllocator.h:
(WTF::OSAllocator::reallocateCommitted):
* Source/WTF/wtf/OSObjectPtr.h:
(WTF::OSObjectPtr::OSObjectPtr):
(WTF::OSObjectPtr::operator=):
* Source/WTF/wtf/Packed.h:
(WTF::PackedAlignedPtr::clear):
(WTF::PackedAlignedPtr::operator UnspecifiedBoolType const):
* Source/WTF/wtf/PageAllocation.h:
(WTF::PageAllocation::allocate):
* Source/WTF/wtf/PageBlock.h:
* Source/WTF/wtf/PageReservation.h:
(WTF::PageReservation::reserve):
(WTF::PageReservation::tryReserve):
(WTF::PageReservation::reserveWithGuardPages):
(WTF::PageReservation::tryReserveWithGuardPages):
* Source/WTF/wtf/ParallelHelperPool.cpp:
(WTF::ParallelHelperClient::finishWithLock):
(WTF::ParallelHelperClient::claimTask):
(WTF::ParallelHelperClient::runTask):
(WTF::ParallelHelperPool::getClientWithTask):
* Source/WTF/wtf/ParallelJobsGeneric.cpp:
(WTF::ParallelEnvironment::ThreadPrivate::tryLockFor):
* Source/WTF/wtf/ParallelJobsGeneric.h:
(WTF::ParallelEnvironment::ThreadPrivate::WTF_GUARDED_BY_LOCK):
* Source/WTF/wtf/ParkingLot.cpp:
(WTF::ParkingLot::parkConditionallyImpl):
(WTF::ParkingLot::unparkOne):
(WTF::ParkingLot::unparkOneImpl):
(WTF::ParkingLot::unparkCount):
* Source/WTF/wtf/PlatformRegisters.cpp:
(WTF::threadStatePCInternal):
* Source/WTF/wtf/PtrTag.h:
(WTF::tagCodePtrImpl):
(WTF::untagCodePtrImpl):
(WTF::retagCodePtrImpl):
(WTF::tagCFunctionPtrImpl):
(WTF::untagCFunctionPtrImpl):
(WTF::tagArrayPtr):
* Source/WTF/wtf/RandomDevice.cpp:
(WTF::RandomDevice::cryptographicallyRandomValues):
* Source/WTF/wtf/RawHex.h:
* Source/WTF/wtf/RawPointer.h:
(WTF::RawPointer::RawPointer):
* Source/WTF/wtf/RecursiveLockAdapter.h:
* Source/WTF/wtf/RedBlackTree.h:
* Source/WTF/wtf/Ref.h:
(WTF::Ref::~Ref):
(WTF::Ref::hashTableEmptyValue):
(WTF::dynamicDowncast):
* Source/WTF/wtf/RefCounted.cpp:
(WTF::RefLogSingleton::append):
* Source/WTF/wtf/RefCountedFixedVector.h:
* Source/WTF/wtf/RefCounter.h:
(WTF::RefCounter&lt;T&gt;::Count::refCounterWasDeleted):
* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::RefPtr):
(WTF::RefPtr::~RefPtr):
(WTF::RefPtr::releaseNonNull):
(WTF::RefPtr::operator UnspecifiedBoolType const):
(WTF::V&gt;::leakRef):
(WTF::=):
(WTF::dynamicDowncast):
* Source/WTF/wtf/RefTrackerMixin.cpp:
(WTF::RefTracker::reportLive):
* Source/WTF/wtf/RefTrackerMixin.h:
* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr&lt;T&gt;::~RetainPtr):
(WTF::RetainPtr&lt;T&gt;::clear):
(WTF::RetainPtr&lt;T&gt;::autorelease):
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::Malloc&gt;::inlineLookup):
(WTF::Malloc&gt;::add):
(WTF::Malloc&gt;::addPassingHashCode):
(WTF::Malloc&gt;::clear):
(WTF::Malloc&gt;::RobinHoodHashTable):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::findFirstNonZeroIndex):
* Source/WTF/wtf/SchedulePair.h:
(WTF::SchedulePair::SchedulePair):
* Source/WTF/wtf/ScopedLambda.h:
(WTF::ScopedLambda&lt;ResultType):
* Source/WTF/wtf/SentinelLinkedList.h:
(WTF::RawNode&gt;::remove):
* Source/WTF/wtf/SequesteredAllocator.h:
* Source/WTF/wtf/SequesteredImmortalHeap.cpp:
(WTF::SequesteredImmortalHeap::installScavenger):
* Source/WTF/wtf/SequesteredImmortalHeap.h:
* Source/WTF/wtf/SequesteredMalloc.cpp:
(WTF::trySequesteredArenaCalloc):
* Source/WTF/wtf/SequesteredMalloc.h:
(WTF::SequesteredArenaMalloc::tryMalloc):
(WTF::SequesteredArenaMalloc::tryZeroedMalloc):
(WTF::SequesteredArenaMalloc::tryRealloc):
* Source/WTF/wtf/SignedPtr.h:
(WTF::SignedPtr::SignedPtr):
(WTF::SignedPtr::get const):
(WTF::SignedPtr::clear):
(WTF::SignedPtr::operator UnspecifiedBoolType const):
* Source/WTF/wtf/SinglyLinkedListWithTail.h:
* Source/WTF/wtf/SmallMap.h:
(WTF::SmallMap::get const):
* Source/WTF/wtf/SortedArrayMap.h:
(WTF::SortedArrayMap&lt;ArrayType&gt;::tryGet const const):
* Source/WTF/wtf/StackBounds.cpp:
(WTF::StackBounds::newThreadStackBounds):
* Source/WTF/wtf/StackPointer.h:
(WTF::currentStackPointer):
* Source/WTF/wtf/StackShot.h:
(WTF::StackShot::StackShot):
* Source/WTF/wtf/StackTrace.cpp:
(WTFGetBacktrace):
(WTF::backtraceState):
(WTF::symbolize):
(WTF::StackTraceSymbolResolver::demangle):
* Source/WTF/wtf/StackTrace.h:
(WTF::StackTraceSymbolResolver::forEach const):
* Source/WTF/wtf/StatisticsManager.cpp:
(WTF::StatisticsManager::singleton):
* Source/WTF/wtf/SystemMalloc.h:
(WTF::SystemMallocBase::tryZeroedMalloc):
* Source/WTF/wtf/TaggedArrayStoragePtr.h:
(WTF::TaggedArrayStoragePtr::TaggedArrayStoragePtr):
* Source/WTF/wtf/TaggedPtr.h:
* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::strongDeref const):
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrControlBlock::WTF_GUARDED_BY_LOCK):
(WTF::ThreadSafeWeakPtrControlBlockRefDerefTraits::refIfNotNull):
(WTF::ThreadSafeWeakOrStrongPtr::tryConvertToStrong):
(WTF::ThreadSafeWeakOrStrongPtr::swap):
(WTF::ThreadSafeWeakOrStrongPtr::moveConstructFrom):
* Source/WTF/wtf/ThreadSpecific.h:
(WTF::ThreadSpecific::Data::~Data):
(WTF::canBeGCThread&gt;::get):
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/TinyPtrSet.h:
(WTF::TinyPtrSet::iterator::iterator):
* Source/WTF/wtf/TranslatedProcess.cpp:
(WTF::isX86BinaryRunningOnARM):
* Source/WTF/wtf/TypeCasts.h:
(WTF::dynamicDowncast):
* Source/WTF/wtf/TypeTraits.h:
(WTF::opaque):
(WTF::nullPtr):
* Source/WTF/wtf/URL.h:
(WTF::URL::URL):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::userVisibleURL):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::copyURLPartsUntil):
(WTF::URLParser::parse):
* Source/WTF/wtf/URLParser.h:
(WTF::URLParser::URLParser):
* Source/WTF/wtf/UUID.cpp:
(WTF::bootSessionUUIDString):
* Source/WTF/wtf/Variant.h:
* Source/WTF/wtf/Vector.h:
(WTF::VectorBufferBase::allocateBuffer):
(WTF::VectorBufferBase::deallocateBuffer):
(WTF::VectorBufferBase::releaseBuffer):
(WTF::VectorBufferBase::VectorBufferBase):
(WTF::Malloc&gt;::expandCapacity):
* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WTF/wtf/WeakObjCPtr.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::WeakPtr):
(WTF::WeakPtr::get const):
(WTF::WeakPtr::operator=):
(WTF::WeakPtr::clear):
(WTF::dynamicDowncast):
* Source/WTF/wtf/WeakPtrFactory.h:
(WTF::WeakPtrFactory::revokeAll):
(WTF::WeakPtrFactoryWithBitField::revokeAll):
* Source/WTF/wtf/WeakPtrImpl.h:
(WTF::WeakPtrImplBase::clear):
(WTF::WeakPtrImplBaseSingleThread::clear):
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::ptrAllowingHashTableEmptyValue const):
(WTF::dynamicDowncast):
* Source/WTF/wtf/WordLock.cpp:
(WTF::WordLock::unlockSlow):
* Source/WTF/wtf/WorkerPool.cpp:
(WTF::WorkerPool::~WorkerPool):
* Source/WTF/wtf/android/LoggingAndroid.cpp:
(WTF::logLevelString):
* Source/WTF/wtf/cf/CFURLExtras.cpp:
(WTF::bytesAsCFData):
(WTF::bytesAsString):
(WTF::bytesAsVector):
* Source/WTF/wtf/cf/FileSystemCF.cpp:
(WTF::FileSystem::pathAsURL):
* Source/WTF/wtf/cf/LanguageCF.cpp:
(WTF::listenForLanguageChangeNotifications):
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::RunLoop::TimerBase::stop):
* Source/WTF/wtf/cf/TypeCastsCF.h:
(WTF::dynamic_cf_cast):
(WTF::checked_cf_cast):
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL):
(WTF::URL::createCFURL const):
* Source/WTF/wtf/cf/VectorCF.h:
(WTF::createCFArray):
(WTF::makeVector):
(WTF::makeCFArrayElement):
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlement):
(WTF::hasEntitlementValue):
(WTF::hasEntitlementValueInArray):
* Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm:
(WTF::MemoryPressureHandler::install):
(WTF::MemoryPressureHandler::uninstall):
(WTF::MemoryPressureHandler::holdOff):
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::decodePercentEscapes):
(WTF::decodeHostName):
(WTF::URLByTruncatingOneCharacterBeforeComponent):
(WTF::URLWithData):
(WTF::dataForURLComponentType):
(WTF::URLByRemovingComponentAndSubsequentCharacter):
* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
(WTF::checked_objc_cast):
(WTF::dynamic_objc_cast):
* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::makeVector):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::platformInitialize):
* Source/WTF/wtf/dragonbox/dragonbox_to_chars.h:
* Source/WTF/wtf/fast_float/float_common.h:
(fast_float::span::span):
(fast_float::str_const_nan):
(fast_float::str_const_inf):
* Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp:
(WTF::currentProcessMemoryStatus):
* Source/WTF/wtf/linux/MemoryFootprintLinux.cpp:
(WTF::forEachLine):
* Source/WTF/wtf/linux/RealTimeThreads.cpp:
(WTF::RealTimeThreads::RealTimeThreads):
(WTF::realTimeKitGetProperty):
(WTF::RealTimeThreads::realTimeKitMakeThreadRealTime):
* Source/WTF/wtf/malloc_heap_breakdown/main.cpp:
(MallocZoneHeapManager::zoneMalloc):
(MallocZoneHeapManager::zoneCalloc):
(MallocZoneHeapManager::zoneRealloc):
(MallocZoneHeapManager::zoneMemalign):
(MallocZoneHeapManager::monitoringThreadMain):
* Source/WTF/wtf/playstation/FileSystemPlayStation.cpp:
(WTF::FileSystemImpl::realPath):
* Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp:
(WTF::OSAllocator::tryReserveAndCommit):
(WTF::OSAllocator::tryReserveUncommitted):
(WTF::OSAllocator::tryReserveUncommittedAligned):
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveUncommittedAligned):
* Source/WTF/wtf/posix/SocketPOSIX.h:
(WTF::dynamicCastToIPV4SocketAddress):
(WTF::dynamicCastToIPV6SocketAddress):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::Thread::signalHandlerSuspendResume):
(WTF::Thread::initializePlatformThreading):
(WTF::wtfThreadEntryPoint):
(WTF::Thread::initializeCurrentThreadInternal):
(WTF::Thread::destructTLS):
* Source/WTF/wtf/simde/arm/neon.h:
* Source/WTF/wtf/simde/arm/sve.h:
* Source/WTF/wtf/simde/wasm/simd128.h:
* Source/WTF/wtf/simdutf/simdutf_impl.cpp.h:
* Source/WTF/wtf/simdutf/simdutf_impl.h:
(simdutf::internal::detect_supported_architectures):
* Source/WTF/wtf/text/AdaptiveStringSearcher.h:
(WTF::AdaptiveStringSearcherBase::findFirstCharacter):
* Source/WTF/wtf/text/AtomString.h:
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringImpl::add):
(WTF::AtomStringImpl::lookUpSlowCase):
(WTF::AtomStringImpl::lookUp):
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::lookUp):
(WTF::AtomStringImpl::add):
(WTF::AtomStringImpl::addWithStringTableProvider):
* Source/WTF/wtf/text/CString.h:
(WTF::CString::data const):
* Source/WTF/wtf/text/IntegerToStringConversion.h:
(WTF::numberToStringSigned):
(WTF::numberToStringUnsigned):
* Source/WTF/wtf/text/MakeString.h:
(WTF::tryMakeStringImplFromAdaptersInternal):
* Source/WTF/wtf/text/StringBuffer.h:
(WTF::StringBuffer::StringBuffer):
(WTF::StringBuffer::release):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::shrinkToFit):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::clear):
* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::findFloatAlignedImpl):
(WTF::findDoubleAlignedImpl):
(WTF::find8NonASCIIAlignedImpl):
(WTF::find16NonASCIIAlignedImpl):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::find8):
(WTF::findImpl):
(WTF::findFloat16):
(WTF::findFloat):
(WTF::findDouble):
(WTF::find8NonASCII):
(WTF::find16NonASCII):
(WTF::charactersContain):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::reallocateInternal):
(WTF::StringImpl::create):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryCreateUninitialized):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::normalizedNFC):
(WTF::StringView::setUnderlyingStringImpl):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::~StringView):
(WTF::StringView::StringView):
(WTF::StringView::operator=):
(WTF::StringView::clear):
* Source/WTF/wtf/text/SymbolImpl.h:
(WTF::SymbolImpl::symbolRegistry const):
* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::initializeIterator):
(WTF::setTextForIterator):
(WTF::wordBreakIterator):
(WTF::sentenceBreakIterator):
(WTF::getNonSharedCharacterBreakIterator):
(WTF::NonSharedCharacterBreakIterator::NonSharedCharacterBreakIterator):
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::CachedLineBreakIteratorFactory::resetStringAndReleaseIterator):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::String):
(WTF::charactersToFloat):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::clearImplIfNotShared):
* Source/WTF/wtf/text/cf/AtomStringImplCF.cpp:
(WTF::AtomStringImpl::add):
* Source/WTF/wtf/text/cf/StringImplCF.cpp:
(WTF::StringWrapperCFAllocator::allocate):
(WTF::StringWrapperCFAllocator::allocatorSingleton):
(WTF::StringImpl::createCFString):
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
(WTF::TextBreakIteratorCFStringTokenizer::TextBreakIteratorCFStringTokenizer):
* Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp:
(WTF::topLanguagePreference):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::setText):
(WTF::TextBreakIteratorICU::makeLocaleWithBreakKeyword):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::uTextLatin1Close):
(WTF::uTextLatin1ContextAwareClose):
* Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp:
(WTF::uTextUTF16ContextAwareClose):
* Source/WTF/wtf/text/unix/TextBreakIteratorInternalICUUnix.cpp:
(WTF::currentSearchLocaleID):
(WTF::currentTextBreakLocaleID):
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::jscSignalHandler):
* Source/WTF/wtf/unicode/Collator.h:
(WTF::Collator::Collator):
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::Collator::Collator):
(WTF::createLatin1Iterator):
* Source/WTF/wtf/unix/LanguageUnix.cpp:
(WTF::platformLanguage):
* Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp:
(WTF::processMemoryUsage):
* Source/WTF/wtf/win/DbgHelperWin.cpp:
(WTF::DbgHelper::initializeSymbols):
* Source/WTF/wtf/win/FileHandleWin.cpp:
(WTF::FileSystemImpl::FileHandle::read):
(WTF::FileSystemImpl::FileHandle::write):
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::storageDirectory):
(WTF::FileSystemImpl::openTemporaryFile):
(WTF::FileSystemImpl::openFile):
* Source/WTF/wtf/win/LanguageWin.cpp:
(WTF::localeInfo):
* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryReserveUncommittedAligned):
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::wndProc):
(WTF::RunLoop::run):
(WTF::RunLoop::RunLoop):
(WTF::RunLoop::cycle):
* Source/WTF/wtf/win/ThreadingWin.cpp:
(WTF::Thread::establishHandle):
(WTF::Thread::ThreadHolder::~ThreadHolder):
(WTF::Thread::SpecificStorage::destroySlots):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eb14e6e76bf8631d2b387039c07f0707c2d7506

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131071 "39 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42032 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138512 "Hash 5eb14e6e for PR 53936 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2929bb3f-f20b-41ee-9785-fbebfec572f7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3239 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/138512 "Hash 5eb14e6e for PR 53936 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67639 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/30291812-a60a-4de0-b3de-800acd57f79f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117344 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/138512 "Hash 5eb14e6e for PR 53936 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d620cbd-9ddc-479f-a009-0099d8184c2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2338 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81759 "Hash 5eb14e6e for PR 53936 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123092 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110934 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35465 "Found 2 new test failures: http/tests/local/formdata/form-data-with-unknown-file-extension.html inspector/animation/lifecycle-css-transition.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141006 "Hash 5eb14e6e for PR 53936 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129524 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35980 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/141006 "Hash 5eb14e6e for PR 53936 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3189 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2807 "Found 2 new test failures: fast/images/individual-animation-toggle.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/141006 "Hash 5eb14e6e for PR 53936 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2374 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113674 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56199 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3208 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32096 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162541 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3028 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66604 "Found 627 new failures in rendering/LegacyRootInlineBox.cpp, testing/MockCDMFactory.cpp, WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.mm, editing/HTMLInterchange.cpp, UIProcess/WebPageProxy.cpp, bytecode/InlineCacheCompiler.h, runtime/JSSymbolTableObject.h, wtf/cf/FileSystemCF.cpp, wtf/ParkingLot.cpp, runtime/JSDataView.h ...") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40585 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3229 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3138 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->