### PR TITLE
[web-animations] adopt `hasMatchingEffect()` in `KeyframeEffectStack::hasAcceleratedEffects()`

### DIFF
--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -319,11 +319,9 @@ bool KeyframeEffectStack::hasAcceleratedEffects(const Settings& settings) const
 #else
     UNUSED_PARAM(settings);
 #endif
-    for (auto& effect : m_effects) {
-        if (effect->isRunningAccelerated())
-            return true;
-    }
-    return false;
+    return hasMatchingEffect([](const auto& effect) {
+        return effect.isRunningAccelerated();
+    });
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### b5a6180dcd79a505f3dfa28b8009dd36d5accd01
<pre>
[web-animations] adopt `hasMatchingEffect()` in `KeyframeEffectStack::hasAcceleratedEffects()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302535">https://bugs.webkit.org/show_bug.cgi?id=302535</a>

Reviewed by Simon Fraser.

* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::hasAcceleratedEffects const):

Canonical link: <a href="https://commits.webkit.org/303046@main">https://commits.webkit.org/303046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a6b825c48c91cc7874bffe76651cd70aec4f44e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ style](https://ews-build.webkit.org/#/builders/38/builds/131034 "Pass") | [✅ ios](https://ews-build.webkit.org/#/builders/159/builds/3359 "Pass") | [✅ mac](https://ews-build.webkit.org/#/builders/138/builds/41993 "Pass") | [✅ wpe](https://ews-build.webkit.org/#/builders/5/builds/138476 "Pass") | [✅ win](https://ews-build.webkit.org/#/builders/59/builds/82715 "Pass") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4f4b98c8-84f2-4563-aab4-93c35ac9a594) 
| [✅ bindings](https://ews-build.webkit.org/#/builders/9/builds/132905 "Pass") | [✅ ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3344 "Pass") | [✅ mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3200 "Pass") | [✅ wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99824 "Pass") | [  ~~win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c3e92c24-90c5-41e5-9e7c-bd98c1eee360) 
| [✅ webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133980 "Pass") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2400 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 8 new passes 28 flakes; Uploaded test results; Running re-run-layout-tests") | [✅ api-mac](https://ews-build.webkit.org/#/builders/18/builds/117316 "Pass") | [✅ api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80533 "Pass") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b59f2b04-beec-4857-8e19-5655871d14d7) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2321 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [⏳ api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/41993 "Waiting to run tests") | [✅ wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81723 "Pass") | | 
| | [✅ api-ios](https://ews-build.webkit.org/#/builders/13/builds/110918 "Pass") | [  ~~mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ gtk](https://ews-build.webkit.org/#/builders/2/builds/140970 "Pass") | | 
| | [✅ vision](https://ews-build.webkit.org/#/builders/153/builds/3101 "Pass") | [✅ mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35949 "Pass") | [✅ gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108340 "Pass") | | 
| | [✅ vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3147 "Pass") | [  ~~mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108297 "Pass") | | 
| | [✅ vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2350 "Pass") | [✅ mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113645 "Pass") | [✅ playstation](https://ews-build.webkit.org/#/builders/134/builds/56156 "Pass") | | 
| [✅ unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20397 "Pass") | [✅ tv](https://ews-build.webkit.org/#/builders/158/builds/3169 "Pass") | [✅ mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32068 "Pass") | | | 
| | [✅ tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2990 "Pass") | [✅ mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66564 "Pass") | | | 
| | [✅ watch](https://ews-build.webkit.org/#/builders/163/builds/3190 "Pass") | | | | 
| | [✅ watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3099 "Pass") | | | | 
<!--EWS-Status-Bubble-End-->