### PR TITLE
CustomElementRegistry.prototype.initialize should upgrade custom elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window-expected.txt
@@ -1,5 +1,5 @@
 
 PASS "uncustomized" :defined doesn't care about your registry'
 PASS "custom" :defined doesn't care about your registry
-PASS pseudo-class-defined
+PASS "custom" :defined should apply after initialize
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.js
@@ -23,7 +23,5 @@ test(() => {
   const registry = new CustomElementRegistry();
   registry.define("sw-r2d2", class extends HTMLElement {});
   registry.initialize(element);
-  assert_false(element.matches(":defined"));
-  registry.upgrade(element);
   assert_true(element.matches(":defined"));
-});
+}, `"custom" :defined should apply after initialize`);

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Document: customElementRegistry.prototype.initialize should upgrade the element given to the first argument
+PASS Document: customElementRegistry.prototype.initialize should upgrade elements in tree order
+PASS Document: customElementRegistry.prototype.initialize only upgrades elements beloning to the registry
+PASS HTMLDocument: customElementRegistry.prototype.initialize should upgrade the element given to the first argument
+PASS HTMLDocument: customElementRegistry.prototype.initialize should upgrade elements in tree order
+PASS HTMLDocument: customElementRegistry.prototype.initialize only upgrades elements beloning to the registry
+PASS XHTMLDocument: customElementRegistry.prototype.initialize should upgrade the element given to the first argument
+PASS XHTMLDocument: customElementRegistry.prototype.initialize should upgrade elements in tree order
+PASS XHTMLDocument: customElementRegistry.prototype.initialize only upgrades elements beloning to the registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-initialize">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+function runTest(title, makeDocument, makeCustomElementRegistry) {
+    test(() => {
+        const element = makeDocument().createElement('a-b');
+        assert_equals(element.customElementRegistry, null);
+        const registry = new CustomElementRegistry;
+        registry.define('a-b', class ABElement extends HTMLElement { });
+        assert_equals(element.customElementRegistry, null);
+        registry.initialize(element);
+        assert_equals(element.customElementRegistry, registry);
+    }, `${title}: customElementRegistry.prototype.initialize should upgrade the element given to the first argument`);
+
+    test(() => {
+        const doc = makeDocument();
+        const container = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+        container.innerHTML = '<a-b id="ab1"></a-b><a-b id="ab2"></a-b>';
+        const elements = Array.from(container.querySelectorAll('a-b'));
+        assert_equals(elements[0].id, 'ab1');
+        assert_equals(elements[0].customElementRegistry, null);
+        assert_equals(elements[1].id, 'ab2');
+        assert_equals(elements[1].customElementRegistry, null);
+        const registry = new CustomElementRegistry;
+        let registryInConstructor = [];
+        class ABElement extends HTMLElement {
+            constructor() {
+                super();
+                registryInConstructor[elements.indexOf(this)] = this.customElementRegistry;
+            }
+        };
+        registry.define('a-b', ABElement);
+        assert_false(elements[0] instanceof ABElement);
+        assert_false(elements[1] instanceof ABElement);
+        assert_equals(registryInConstructor.length, 0);
+        registry.initialize(container);
+        assert_equals(elements[0].customElementRegistry, registry);
+        assert_true(elements[0] instanceof ABElement);
+        assert_equals(elements[1].customElementRegistry, registry);
+        assert_true(elements[1] instanceof ABElement);
+        assert_equals(registryInConstructor.length, 2);
+        assert_equals(registryInConstructor[0], registry);
+        assert_equals(registryInConstructor[1], registry);
+    }, `${title}: customElementRegistry.prototype.initialize should upgrade elements in tree order`);
+
+    test(() => {
+        const doc1 = makeDocument();
+        const htmlNS = 'http://www.w3.org/1999/xhtml';
+        if (!doc1.documentElement)
+            doc1.appendChild(doc1.createElementNS(htmlNS, 'html')).appendChild(doc1.createElementNS(htmlNS, 'body'));
+
+        const undefinedElement1 = doc1.createElementNS(htmlNS, 'a-b');
+
+        const registry1 = new CustomElementRegistry;
+        class ABElement extends HTMLElement { };
+        registry1.define('a-b', ABElement);
+
+        const registry2 = new CustomElementRegistry;
+        undefinedElement2 = doc1.createElementNS(htmlNS, 'a-b', {customElementRegistry: registry2});
+
+        undefinedElement1.appendChild(undefinedElement2);
+
+        assert_equals(undefinedElement1.customElementRegistry, null);
+        assert_equals(undefinedElement1.__proto__.constructor.name, 'HTMLElement');
+        assert_equals(undefinedElement2.customElementRegistry, registry2);
+        assert_equals(undefinedElement2.__proto__.constructor.name, 'HTMLElement');
+
+        registry1.initialize(undefinedElement1);
+        assert_equals(undefinedElement1.customElementRegistry, registry1);
+        assert_true(undefinedElement1 instanceof ABElement);
+        assert_equals(undefinedElement2.customElementRegistry, registry2);
+        assert_equals(undefinedElement2.__proto__.constructor.name, 'HTMLElement');
+    }, `${title}: customElementRegistry.prototype.initialize only upgrades elements beloning to the registry`);
+}
+
+runTest('Document', () => new Document);
+runTest('HTMLDocument', () => document.implementation.createHTMLDocument());
+runTest('XHTMLDocument', () => document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null));
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -120,15 +120,15 @@ RefPtr<Element> JSCustomElementInterface::tryToConstructCustomElement(Document& 
     if (!m_constructor)
         return nullptr;
 
-    ASSERT(&document == scriptExecutionContext());
-    auto* lexicalGlobalObject = document.globalObject();
+    RefPtr contextDocument = downcast<Document>(scriptExecutionContext());
+    auto* lexicalGlobalObject = scriptExecutionContext()->globalObject();
     ASSERT(lexicalGlobalObject);
     if (!lexicalGlobalObject)
         return nullptr;
-    auto* oldRegistry = document.activeCustomElementRegistry();
-    document.setActiveCustomElementRegistry(&registry);
+    auto* oldRegistry = contextDocument->activeCustomElementRegistry();
+    contextDocument->setActiveCustomElementRegistry(&registry);
     auto element = constructCustomElementSynchronously(document, vm, *lexicalGlobalObject, m_constructor.get(), localName, parserConstructElementWithEmptyStack);
-    document.setActiveCustomElementRegistry(oldRegistry);
+    contextDocument->setActiveCustomElementRegistry(oldRegistry);
     EXCEPTION_ASSERT(!!scope.exception() == !element);
     if (!element) {
         auto* exception = scope.exception();

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -219,11 +219,19 @@ ExceptionOr<void> CustomElementRegistry::initialize(Node& root)
         if (this != registryOfTreeScope)
             addToScopedCustomElementRegistryMap(element, *this);
     };
+    auto upgradeElementIfPossible = [&](Element& element) {
+        if (element.isCustomElementUpgradeCandidate() && CustomElementRegistry::registryForElement(element) == this)
+            CustomElementReactionQueue::tryToUpgradeElement(element);
+    };
 
-    if (RefPtr element = dynamicDowncast<Element>(*containerRoot))
+    if (RefPtr element = dynamicDowncast<Element>(*containerRoot)) {
         updateRegistryIfNeeded(*element);
-    for (Ref element : descendantsOfType<Element>(*containerRoot))
+        upgradeElementIfPossible(*element);
+    }
+    for (Ref element : descendantsOfType<Element>(*containerRoot)) {
         updateRegistryIfNeeded(element);
+        upgradeElementIfPossible(element);
+    }
     return { };
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1524,10 +1524,6 @@ static ALWAYS_INLINE Ref<HTMLElement> createUpgradeCandidateElement(Document& do
     }
 
     Ref element = HTMLMaybeFormAssociatedCustomElement::create(name, document);
-
-    if (!registry && document.usesNullCustomElementRegistry())
-        element->setUsesNullCustomElementRegistry();
-
     element->setIsCustomElementUpgradeCandidate();
 
     return element;
@@ -1597,12 +1593,14 @@ ExceptionOr<Ref<Element>> Document::createElementForBindings(const AtomString& n
 
     if (result.hasException())
         return result;
+    Ref element = result.releaseReturnValue();
     if (registry && registry->isScoped()) [[unlikely]] {
-        Ref element = result.releaseReturnValue();
         CustomElementRegistry::addToScopedCustomElementRegistryMap(element, *registry);
         return element;
     }
-    return result;
+    if (!registry && usesNullCustomElementRegistry())
+        element->setUsesNullCustomElementRegistry();
+    return element;
 }
 
 ExceptionOr<Ref<Element>> Document::createElementForBindings(const AtomString& name)
@@ -2035,12 +2033,14 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
 
     if (result.hasException())
         return result;
+    Ref element = result.releaseReturnValue();
     if (registry && registry->isScoped()) [[unlikely]] {
-        Ref element = result.releaseReturnValue();
         CustomElementRegistry::addToScopedCustomElementRegistryMap(element, *registry);
         return element;
     }
-    return result;
+    if (!registry && usesNullCustomElementRegistry())
+        element->setUsesNullCustomElementRegistry();
+    return element;
 }
 
 ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName)


### PR DESCRIPTION
#### c13b9f161be7e2cfeb05c08a3041a722516c7fed
<pre>
CustomElementRegistry.prototype.initialize should upgrade custom elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=302534">https://bugs.webkit.org/show_bug.cgi?id=302534</a>

Reviewed by Anne van Kesteren.

Implement <a href="https://github.com/whatwg/html/pull/11913.">https://github.com/whatwg/html/pull/11913.</a> This PR also fixes a few bugs in the existing code, which were revealed by
the newly introduced test.

Test: imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.js:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades.html: Added.

* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::tryToConstructCustomElement): Replaced the bad assertion with a code to get the global object
through the script execution context associated with this custom element interface.

* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::initialize): Implement the new semantics.

* Source/WebCore/dom/Document.cpp:
(WebCore::createUpgradeCandidateElement): Call setUsesNullCustomElementRegistry in the callers of this function (createElementNS
and createElementForBindings).
(WebCore::Document::createElementForBindings):
(WebCore::Document::createElementNS):

Canonical link: <a href="https://commits.webkit.org/303250@main">https://commits.webkit.org/303250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed7bc9ccff4efd77d8e90623b7562681858b9921

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83627 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100707 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134702 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81489 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82487 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141911 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109079 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3998 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3447 "Found 1 new test failure: fast/webgpu/present-without-compute-pipeline.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109241 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2979 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57127 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20492 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3971 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32699 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3803 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4063 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->