### PR TITLE
[AutoFill Debugging] Replace `includeNodeIdentifiers` with an enum type representing the kinds of nodes to identify

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -135,7 +135,7 @@ addEventListener("load", async () => {
         normalize: true,
         includeRects: true,
         includeURLs: true,
-        includeNodeIdentifiers: true,
+        nodeIdentifierInclusion: "interactive",
         includeEventListeners: true,
         includeAccessibilityAttributes: true,
         includeTextInAutoFilledControls: true,

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -1,0 +1,37 @@
+root
+    role='banner'
+        aria-label='Main Page Title','Welcome to Test Page'
+    navigation,role='navigation',aria-label='Main navigation'
+        list
+            list-item
+                link,'Section 1'
+            list-item
+                link,'Section 2'
+    role='main'
+        section,aria-label='Interactive Elements'
+            button,aria-label='Test button','Click Me'
+            '        \nThis button does nothing\n\n        '
+            input,'text',uid=…,placeholder='Enter text here'
+            role='button','Clickable Div'
+        section,aria-label='Content with Roles'
+            article,role='article','            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.\n\n\n        '
+            role='complementary',aria-label='Related information'
+                '            \nRelated Links\n\n\n            '
+                list
+                    list-item
+                        link,'Example Link'
+                    list-item
+                        link,'Test Link'
+            role='region'
+                role='status','Ready'
+                button,'Update Status'
+            textarea,uid=…,'This is a text box'
+            contentEditable,uid=…,role='textbox'
+                subscript
+                    'WebKit home page:'
+                    link
+    role='contentinfo'
+        '    \nFooter content with '
+        role='img',aria-label='copyright symbol','©'
+        ' 2024'
+version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -40,7 +40,6 @@ body {
     </ul>
 </nav>
 <main role="main">
-    <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
     <section id="section1" aria-label="Interactive Elements">
         <button class="clickable" onclick="console.log('clicked')" aria-label="Test button" aria-describedby="btn-help">Click Me</button>
         <div id="btn-help" aria-hidden="true">This button does nothing</div>
@@ -66,8 +65,11 @@ body {
             <div role="status" aria-live="polite" id="status-msg">Ready</div>
             <button onclick="document.getElementById('status-msg').textContent = 'Updated!'">Update Status</button>
         </div>
+        <textarea rows="15" cols="40">This is a text box</textarea>
+        <div contenteditable role="textbox">
+            <sub>WebKit home page:<a href="https://webkit.org">webkit.org</a></sub>
+        </div>
     </section>
-    <p>The quick brown fox jumped over the lazy dog.</p>
 </main>
 <footer role="contentinfo">
     <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024</p>
@@ -75,7 +77,6 @@ body {
 <div role="dialog" aria-hidden="true" style="display: none;">
     <p>This dialog is hidden and should not be extracted.</p>
 </div>
-
 <script>
 addEventListener("load", async () => {
     if (!window.testRunner)
@@ -88,10 +89,10 @@ addEventListener("load", async () => {
         normalize: true,
         includeRects: false,
         includeURLs: false,
-        nodeIdentifierInclusion: "none",
+        nodeIdentifierInclusion: "editableOnly",
         includeEventListeners: false,
-        includeAccessibilityAttributes: false,
-        wordLimit: 5
+        includeAccessibilityAttributes: true,
+        includeTextInAutoFilledControls: true,
     });
 
     testRunner.notifyDone();

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
@@ -33,7 +33,7 @@
             return;
 
         const debugText = await UIHelper.requestDebugText({
-            includeNodeIdentifiers: true,
+            nodeIdentifierInclusion: "interactive",
             includeEventListeners: true,
             includeAccessibilityAttributes: true,
             includeTextInAutoFilledControls: true,

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html
@@ -41,7 +41,7 @@ addEventListener("load", async () => {
     document.body.textContent = await UIHelper.requestDebugText({
         includeRects: false,
         includeURLs: false,
-        includeNodeIdentifiers: false,
+        nodeIdentifierInclusion: "none",
         includeTextInAutoFilledControls: false,
     });
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -35,7 +35,7 @@
             return;
 
         const debugText = await UIHelper.requestDebugText({
-            includeNodeIdentifiers: true,
+            nodeIdentifierInclusion: "interactive",
             includeEventListeners: true,
             includeAccessibilityAttributes: true,
         });

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -72,13 +72,19 @@ enum class EventListenerCategory : uint8_t {
     Keyboard    = 1 << 4,
 };
 
+enum class NodeIdentifierInclusion : uint8_t {
+    None,
+    EditableOnly,
+    Interactive,
+};
+
 struct Request {
     HashMap<String, HashMap<JSHandleIdentifier, String>> clientNodeAttributes;
     std::optional<FloatRect> collectionRectInRootView;
     std::optional<JSHandleIdentifier> targetNodeHandleIdentifier;
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
-    bool includeNodeIdentifiers { false };
+    NodeIdentifierInclusion nodeIdentifierInclusion { NodeIdentifierInclusion::None };
     bool includeEventListeners { false };
     bool includeAccessibilityAttributes { false };
     bool includeTextInAutoFilledControls { false };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6718,6 +6718,13 @@ header: <WebCore/TextExtractionTypes.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] enum class WebCore::TextExtraction::NodeIdentifierInclusion : uint8_t {
+    None,
+    EditableOnly,
+    Interactive,
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Interaction {
     WebCore::TextExtraction::Action action;
     String text;
@@ -6746,7 +6753,7 @@ header: <WebCore/TextExtractionTypes.h>
     std::optional<WebCore::JSHandleIdentifier> targetNodeHandleIdentifier;
     bool mergeParagraphs;
     bool skipNearlyTransparentContent;
-    bool includeNodeIdentifiers;
+    WebCore::TextExtraction::NodeIdentifierInclusion nodeIdentifierInclusion;
     bool includeEventListeners;
     bool includeAccessibilityAttributes;
     bool includeTextInAutoFilledControls;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6899,7 +6899,17 @@ static HashMap<String, HashMap<WebCore::JSHandleIdentifier, String>> extractClie
 
     auto rectInWebView = configuration.targetRect;
     bool mergeParagraphs = configuration.mergeParagraphs;
-    bool includeNodeIdentifiers = configuration.includeNodeIdentifiers;
+    auto nodeIdentifierInclusion = [&] {
+        switch (configuration.nodeIdentifierInclusion) {
+        case _WKTextExtractionNodeIdentifierInclusionNone:
+            return WebCore::TextExtraction::NodeIdentifierInclusion::None;
+        case _WKTextExtractionNodeIdentifierInclusionEditableOnly:
+            return WebCore::TextExtraction::NodeIdentifierInclusion::EditableOnly;
+        case _WKTextExtractionNodeIdentifierInclusionInteractive:
+            return WebCore::TextExtraction::NodeIdentifierInclusion::Interactive;
+        }
+        return WebCore::TextExtraction::NodeIdentifierInclusion::None;
+    }();
     bool skipNearlyTransparentContent = configuration.skipNearlyTransparentContent;
     auto rectInRootView = [&] -> std::optional<WebCore::FloatRect> {
         if (CGRectIsNull(rectInWebView))
@@ -6918,7 +6928,7 @@ static HashMap<String, HashMap<WebCore::JSHandleIdentifier, String>> extractClie
         .targetNodeHandleIdentifier = mainFrameJSHandleIdentifier(configuration.targetNode),
         .mergeParagraphs = mergeParagraphs,
         .skipNearlyTransparentContent = skipNearlyTransparentContent,
-        .includeNodeIdentifiers = includeNodeIdentifiers,
+        .nodeIdentifierInclusion = nodeIdentifierInclusion,
         .includeEventListeners = !!configuration.includeEventListeners,
         .includeAccessibilityAttributes = !!configuration.includeAccessibilityAttributes,
         .includeTextInAutoFilledControls = !!configuration.includeTextInAutoFilledControls,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -39,6 +39,12 @@ typedef NS_OPTIONS(NSUInteger, _WKTextExtractionFilterOptions) {
     _WKTextExtractionFilterAll = _WKTextExtractionFilterTextRecognition | _WKTextExtractionFilterClassifier,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+typedef NS_ENUM(NSInteger, _WKTextExtractionNodeIdentifierInclusion) {
+    _WKTextExtractionNodeIdentifierInclusionNone = 0,
+    _WKTextExtractionNodeIdentifierInclusionEditableOnly,
+    _WKTextExtractionNodeIdentifierInclusionInteractive
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
 
@@ -64,10 +70,13 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic) BOOL includeRects;
 
 /*!
- Include node IDs for interactive nodes.
- The default value is `YES`.
+ Policy determining which nodes should be uniquely identified in the output.
+ `.none`          	Prevents collection of any identifiers.
+ `.editableOnly`    Limits collection of identifiers to editable elements and form controls.
+ `.interactive`     Collects identifiers for all buttons, links, and other interactive elements.
+ The default value is `.interactive`.
  */
-@property (nonatomic) BOOL includeNodeIdentifiers;
+@property (nonatomic) _WKTextExtractionNodeIdentifierInclusion nodeIdentifierInclusion;
 
 /*!
  Include information about event listeners.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -56,7 +56,7 @@
     _filterOptions = _WKTextExtractionFilterAll;
     _includeURLs = !onlyVisibleText;
     _includeRects = !onlyVisibleText;
-    _includeNodeIdentifiers = !onlyVisibleText;
+    _nodeIdentifierInclusion = onlyVisibleText ? _WKTextExtractionNodeIdentifierInclusionNone : _WKTextExtractionNodeIdentifierInclusionInteractive;
     _includeEventListeners = !onlyVisibleText;
     _includeAccessibilityAttributes = !onlyVisibleText;
     _includeTextInAutoFilledControls = !onlyVisibleText;
@@ -122,11 +122,11 @@
     _includeRects = value;
 }
 
-- (void)setIncludeNodeIdentifiers:(BOOL)value
+- (void)setNodeIdentifierInclusion:(_WKTextExtractionNodeIdentifierInclusion)value
 {
     ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
 
-    _includeNodeIdentifiers = value;
+    _nodeIdentifierInclusion = value;
 }
 
 - (void)setIncludeEventListeners:(BOOL)value

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -111,7 +111,7 @@ extension WKWebView {
             configuration.targetRect = visibleRect
             configuration.mergeParagraphs = true
             configuration.skipNearlyTransparentContent = true
-            configuration.includeNodeIdentifiers = false
+            configuration.nodeIdentifierInclusion = .none
             configuration.includeEventListeners = false
             configuration.includeAccessibilityAttributes = false
             configuration.filterOptions = []

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -47,7 +47,7 @@ dictionary TextExtractionTestOptions {
     boolean clipToBounds = false;
     boolean includeRects = false;
     boolean includeURLs = false;
-    boolean includeNodeIdentifiers = false;
+    DOMString nodeIdentifierInclusion = "none";
     boolean includeEventListeners = false;
     boolean includeAccessibilityAttributes = false;
     boolean includeTextInAutoFilledControls = false;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -62,7 +62,7 @@ struct TextExtractionTestOptions {
     bool clipToBounds { false };
     bool includeRects { false };
     bool includeURLs { false };
-    bool includeNodeIdentifiers { false };
+    JSRetainPtr<JSStringRef> nodeIdentifierInclusion;
     bool includeEventListeners { false };
     bool includeAccessibilityAttributes { false };
     bool includeTextInAutoFilledControls { false };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -80,7 +80,7 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.wordLimit = static_cast<unsigned>(numericProperty(context, (JSObjectRef)argument, "wordLimit"));
     options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
     options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);
-    options.includeNodeIdentifiers = booleanProperty(context, (JSObjectRef)argument, "includeNodeIdentifiers", false);
+    options.nodeIdentifierInclusion = stringProperty(context, (JSObjectRef)argument, "nodeIdentifierInclusion");
     return &options;
 }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -345,7 +345,19 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
     [configuration setIncludeRects:options && options->includeRects];
     [configuration setIncludeURLs:options && options->includeURLs];
-    [configuration setIncludeNodeIdentifiers:options && options->includeNodeIdentifiers];
+    [configuration setNodeIdentifierInclusion:^{
+        if (!options)
+            return _WKTextExtractionNodeIdentifierInclusionNone;
+
+        auto inclusion = toWTFString(options->nodeIdentifierInclusion.get());
+        if (equalLettersIgnoringASCIICase(inclusion, "interactive"_s))
+            return _WKTextExtractionNodeIdentifierInclusionInteractive;
+
+        if (equalLettersIgnoringASCIICase(inclusion, "editableonly"_s))
+            return _WKTextExtractionNodeIdentifierInclusionEditableOnly;
+
+        return _WKTextExtractionNodeIdentifierInclusionNone;
+    }()];
     [configuration setIncludeEventListeners:options && options->includeEventListeners];
     [configuration setIncludeAccessibilityAttributes:options && options->includeAccessibilityAttributes];
     [configuration setIncludeTextInAutoFilledControls:options && options->includeTextInAutoFilledControls];


### PR DESCRIPTION
#### e2ce65d3cafe318d4d1f9e2b1c3d9dfd02326865
<pre>
[AutoFill Debugging] Replace `includeNodeIdentifiers` with an enum type representing the kinds of nodes to identify
<a href="https://bugs.webkit.org/show_bug.cgi?id=302537">https://bugs.webkit.org/show_bug.cgi?id=302537</a>
<a href="https://rdar.apple.com/164726774">rdar://164726774</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Currently, `_WKTextExtractionConfiguration` has a single boolean flag that clients can set, to
either include or exclude node identifiers `uid=…` in the output. Some clients require more nuanced
identification heuristics, such as uniquely identifying only form controls and other editable
elements.

To facilitate this, we replace `includeNodeIdentifier` with `nodeIdentifierInclusion`, which
encompasses 3 possible policy enums; they&apos;re currently:

-   `None`, meaning &quot;don&apos;t collect any node identifiers&quot;
-   `EditableOnly`, meaning &quot;only collect node identifiers for editable elements and text fields&quot;
-   `Interactive`, which is the current default behavior that collects node identifiers for anything
    which the user might be able to interact with

Test: fast/text-extraction/debug-text-extraction-form-controls.html

* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html: Copied from LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html.

Add a new layout test that exercises `nodeIdentifierInclusion : &quot;editableOnly&quot;`.

* LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html:

Rebaseline existing tests to use the new property.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration _initForOnlyVisibleText:]):
(-[_WKTextExtractionConfiguration setNodeIdentifierInclusion:]):
(-[_WKTextExtractionConfiguration setIncludeNodeIdentifiers:]): Deleted.
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/303057@main">https://commits.webkit.org/303057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcf0cc75f7bec3ec62b022b812a12d23374d2cd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82735 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbf639eb-4be7-43e8-ad4b-00f4276e6ea4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99840 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6eb5be5-64ea-4980-aea1-1902edd9ad7a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133993 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2407 "layout-tests (failure)") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80543 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2328 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81736 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110925 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140983 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108357 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2359 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113652 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56176 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3182 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3206 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3117 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->