### PR TITLE
[Style] Convert the 'contain' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3305,6 +3305,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/color/StyleOpacity.h
     style/values/color/StyleResolvedColor.h
 
+    style/values/contain/StyleContain.h
     style/values/contain/StyleContainerName.h
 
     style/values/content/StyleContent.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -85,6 +85,7 @@ style/StyleCustomProperty.cpp
 style/Styleable.cpp
 style/values/StyleValueTypes.h
 style/values/backgrounds/StyleFillLayers.h
+style/values/fonts/StyleFontFeatureSettings.cpp
 style/values/fonts/StyleFontVariationSettings.cpp
 style/values/images/StyleGradient.cpp
 style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3208,6 +3208,7 @@ style/values/color/StyleKeywordColor.cpp
 style/values/color/StyleLightDarkColor.cpp
 style/values/color/StyleOpacity.cpp
 style/values/color/StyleResolvedColor.cpp
+style/values/contain/StyleContain.cpp
 style/values/content/StyleContent.cpp
 style/values/content/StyleQuotes.cpp
 style/values/counter-styles/StyleCounterStyle.cpp

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -45,6 +45,7 @@
 #include "SVGRenderStyleDefs.h"
 #include "ScrollAxis.h"
 #include "ScrollTypes.h"
+#include "StyleContain.h"
 #include "StyleImageOrientation.h"
 #include "StyleMarginTrim.h"
 #include "StylePositionVisibility.h"
@@ -2615,6 +2616,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 
 #define TYPE Style::WebkitLineBoxContainValue
 #define FOR_EACH(CASE) CASE(Block) CASE(Inline) CASE(Font) CASE(Glyphs) CASE(Replaced) CASE(InlineBox) CASE(InitialLetter)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE Style::ContainValue
+#define FOR_EACH(CASE) CASE(Size) CASE(InlineSize) CASE(Layout) CASE(Style) CASE(Paint)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8619,8 +8619,7 @@
             "animation-type": "not animatable",
             "initial": "none",
             "codegen-properties": {
-                "style-converter": "Contain",
-                "render-style-initial": "initialContainment",
+                "style-converter": "StyleType<Contain>",
                 "parser-grammar": "none | strict | content | [ [size | inline-size] || layout || style || paint ]@(no-single-item-opt)"
             },
             "specification": {

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -188,7 +188,7 @@ static OptionSet<FlexAvoidanceReason> canUseForFlexLayoutWithReason(const Render
         if (flexItemStyle.minHeight() != RenderStyle::initialMinSize() || flexItemStyle.maxHeight() != RenderStyle::initialMaxSize())
             ADD_REASON_AND_RETURN_IF_NEEDED(FlexWithNonInitialMinMaxHeight, reasons, includeReasons);
 
-        if (flexItemStyle.containsSize())
+        if (flexItemStyle.usedContain().contains(Style::ContainValue::Size))
             ADD_REASON_AND_RETURN_IF_NEEDED(FlexItemHasContainsSize, reasons, includeReasons);
 
         if (mayHaveScrollbarOrScrollableOverflow(flexItemStyle))

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -242,7 +242,7 @@ static OptionSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid
         }
     }
 
-    if (renderGridStyle->containsSize())
+    if (renderGridStyle->usedContain().contains(Style::ContainValue::Size))
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasContainsSize, reasons, reasonCollectionMode);
 
     auto linesFromGridTemplateColumnsCount = gridTemplateColumns.sizes.size() + 1;
@@ -332,7 +332,7 @@ static OptionSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid
         if (!gridItemStyle->isOverflowVisible())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridItemHasNonVisibleOverflow, reasons, reasonCollectionMode);
 
-        if (gridItemStyle->containsSize())
+        if (gridItemStyle->usedContain().contains(Style::ContainValue::Size))
             ADD_REASON_AND_RETURN_IF_NEEDED(GridItemHasContainsSize, reasons, reasonCollectionMode);
     }
     return reasons;

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -315,7 +315,7 @@ bool Box::isLayoutContainmentBox() const
             return isAtomicInlineBox();
         return true;
     };
-    return m_style.usedContain().contains(Containment::Layout) && supportsLayoutContainment();
+    return m_style.usedContain().contains(Style::ContainValue::Layout) && supportsLayoutContainment();
 }
 
 bool Box::isRubyAnnotationBox() const
@@ -347,7 +347,7 @@ bool Box::isSizeContainmentBox() const
             return isAtomicInlineBox();
         return true;
     };
-    return m_style.usedContain().contains(Containment::Size) && supportsSizeContainment();
+    return m_style.usedContain().contains(Style::ContainValue::Size) && supportsSizeContainment();
 }
 
 bool Box::isInternalTableBox() const

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -234,7 +234,7 @@ CandidateExaminationResult ScrollAnchoringController::examineAnchorCandidate(Ele
     }
 
     auto isExcludedSubtree = [this](RenderElement* renderer, bool intersects) {
-        return renderer->style().overflowAnchor() == OverflowAnchor::None || renderer->isStickilyPositioned() || renderer->isFixedPositioned() || renderer->isPseudoElement() || renderer->isAnonymousBlock() || (renderer->isAbsolutelyPositioned() && absolutePositionedElementOutsideScroller(*renderer, m_owningScrollableArea)) || (!intersects && renderer->style().containsPaint());
+        return renderer->style().overflowAnchor() == OverflowAnchor::None || renderer->isStickilyPositioned() || renderer->isFixedPositioned() || renderer->isPseudoElement() || renderer->isAnonymousBlock() || (renderer->isAbsolutelyPositioned() && absolutePositionedElementOutsideScroller(*renderer, m_owningScrollableArea)) || (!intersects && renderer->style().usedContain().contains(Style::ContainValue::Paint));
     };
 
     if (auto renderer = element.renderer()) {

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1303,7 +1303,7 @@ bool RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType(con
     return style.isFloating()
         || style.hasOutOfFlowPosition()
         || isBlockBoxWithPotentiallyScrollableOverflow()
-        || style.containsLayout()
+        || style.usedContain().contains(Style::ContainValue::Layout)
         || style.containerType() != ContainerType::Normal
         || WebCore::shouldApplyPaintContainment(style, *protectedElement())
         || (style.isDisplayBlockLevel() && !style.blockStepSize().isNone());

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -522,8 +522,8 @@ void RenderBox::updateFromStyle()
             if (is<HTMLHtmlElement>(documentElement)
                 && document().body() == element()
                 && documentElementRenderer.effectiveOverflowX() == Overflow::Visible
-                && !styleToUse.usedContain()
-                && !documentElementRenderer.style().usedContain()) {
+                && styleToUse.usedContain().isNone()
+                && documentElementRenderer.style().usedContain().isNone()) {
                 boxHasNonVisibleOverflow = false;
             }
         }
@@ -5251,7 +5251,7 @@ bool RenderBox::requiresLayer() const
     return RenderBoxModelObject::requiresLayer()
         || hasNonVisibleOverflow()
         || style().specifiesColumns()
-        || style().containsLayout()
+        || style().usedContain().contains(Style::ContainValue::Layout)
         || !style().usedZIndex().isAuto()
         || hasRunningAcceleratedAnimations();
 }

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -68,7 +68,7 @@ static Element* ancestorStyleContainmentObject(const Element& element)
     Element* ancestor = pseudoElement ? pseudoElement->hostElement() : element.parentElement();
     while (ancestor) {
         if (auto* style = ancestor->existingComputedStyle()) {
-            if (style->containsStyle())
+            if (style->usedContain().contains(Style::ContainValue::Style))
                 break;
         }
         // FIXME: this should use parentInComposedTree but for now matches the rest of RenderCounter.
@@ -133,7 +133,7 @@ static Element* previousSiblingOrParentElement(const Element& element)
     auto* parent = element.parentElement();
     if (parent && !parent->renderer())
         parent = previousSiblingOrParentElement(*parent);
-    if (parent && parent->renderer() && parent->renderer()->style().containsStyle())
+    if (parent && parent->renderer() && parent->renderer()->style().usedContain().contains(Style::ContainValue::Style))
         return nullptr;
     return parent;
 }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2365,8 +2365,8 @@ void RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded(con
 #if HAVE(CORE_MATERIAL)
         || oldStyle.hasAppleVisualEffectRequiringBackdropFilter() != newStyle.hasAppleVisualEffectRequiringBackdropFilter()
 #endif
-        || oldStyle.containsLayout() != newStyle.containsLayout()
-        || oldStyle.containsSize() != newStyle.containsSize();
+        || oldStyle.usedContain().contains(Style::ContainValue::Layout) != newStyle.usedContain().contains(Style::ContainValue::Layout)
+        || oldStyle.usedContain().contains(Style::ContainValue::Size) != newStyle.usedContain().contains(Style::ContainValue::Size);
     if (!mayNotBeContainingBlockForDescendantsAnymore)
         return;
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -810,12 +810,12 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
     if (first.inputSecurity != second.inputSecurity)
         return true;
 
-    if (first.usedContain().contains(Containment::Size) != second.usedContain().contains(Containment::Size)
-        || first.usedContain().contains(Containment::InlineSize) != second.usedContain().contains(Containment::InlineSize)
-        || first.usedContain().contains(Containment::Layout) != second.usedContain().contains(Containment::Layout))
+    if (first.usedContain().contains(Style::ContainValue::Size) != second.usedContain().contains(Style::ContainValue::Size)
+        || first.usedContain().contains(Style::ContainValue::InlineSize) != second.usedContain().contains(Style::ContainValue::InlineSize)
+        || first.usedContain().contains(Style::ContainValue::Layout) != second.usedContain().contains(Style::ContainValue::Layout))
         return true;
 
-    // content-visibiliy:hidden turns on contain:size which requires relayout.
+    // content-visibility:hidden turns on contain:size which requires relayout.
     if ((static_cast<ContentVisibility>(first.contentVisibility) == ContentVisibility::Hidden) != (static_cast<ContentVisibility>(second.contentVisibility) == ContentVisibility::Hidden))
         return true;
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -106,7 +106,6 @@ enum class ColumnProgression : bool;
 enum class ColumnSpan : bool;
 enum class CompositeOperator : uint8_t;
 enum class ContainerType : uint8_t;
-enum class Containment : uint8_t;
 enum class ContentDistribution : uint8_t;
 enum class ContentPosition : uint8_t;
 enum class ContentVisibility : uint8_t;
@@ -255,6 +254,7 @@ struct Color;
 struct ColorScheme;
 struct ColumnCount;
 struct ColumnWidth;
+struct Contain;
 struct ContainIntrinsicSize;
 struct ContainerNames;
 struct Content;
@@ -907,15 +907,8 @@ public:
     inline double logicalAspectRatio() const;
     inline bool hasAspectRatio() const;
 
-    inline OptionSet<Containment> contain() const;
-    inline OptionSet<Containment> usedContain() const;
-    inline bool containsLayout() const;
-    inline bool containsSize() const;
-    inline bool containsInlineSize() const;
-    inline bool containsSizeOrInlineSize() const;
-    inline bool containsStyle() const;
-    inline bool containsPaint() const;
-    inline bool containsLayoutOrPaint() const;
+    inline Style::Contain contain() const;
+    inline Style::Contain usedContain() const;
     inline ContainerType containerType() const;
     inline const Style::ContainerNames& containerNames() const;
     inline bool containerTypeAndNamesEqual(const RenderStyle&) const;
@@ -1463,7 +1456,7 @@ public:
 
     inline void setAspectRatio(Style::AspectRatio&&);
 
-    inline void setContain(OptionSet<Containment>);
+    inline void setContain(Style::Contain);
     inline void setContainerType(ContainerType);
     inline void setContainerNames(Style::ContainerNames&&);
 
@@ -2149,9 +2142,7 @@ public:
     static constexpr Resize initialResize();
     static constexpr StyleAppearance initialAppearance();
     static inline Style::AspectRatio initialAspectRatio();
-    static constexpr OptionSet<Containment> initialContainment();
-    static constexpr OptionSet<Containment> strictContainment();
-    static constexpr OptionSet<Containment> contentContainment();
+    static constexpr Style::Contain initialContain();
     static constexpr ContainerType initialContainerType();
     static Style::ContainerNames initialContainerNames();
     static inline Style::Content initialContent();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1097,14 +1097,6 @@ enum class MathStyle : bool {
     Compact,
 };
 
-enum class Containment : uint8_t {
-    Layout      = 1 << 0,
-    Paint       = 1 << 1,
-    Size        = 1 << 2,
-    InlineSize  = 1 << 3,
-    Style       = 1 << 4,
-};
-
 enum class ContainerType : uint8_t {
     Normal,
     Size,

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -134,7 +134,7 @@ inline void RenderStyle::setColumnRuleStyle(BorderStyle b) { SET_DOUBLY_NESTED(m
 inline void RenderStyle::setColumnRuleWidth(Style::LineWidth width) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_width, width); }
 inline void RenderStyle::setColumnSpan(ColumnSpan span) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, columnSpan, static_cast<unsigned>(span)); }
 inline void RenderStyle::setColumnWidth(Style::ColumnWidth width) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, width, width); }
-inline void RenderStyle::setContain(OptionSet<Containment> containment) { SET_NESTED(m_nonInheritedData, rareData, contain, containment); }
+inline void RenderStyle::setContain(Style::Contain contain) { SET_NESTED(m_nonInheritedData, rareData, contain, contain.toRaw()); }
 inline void RenderStyle::setContainIntrinsicHeight(Style::ContainIntrinsicSize&& height) { SET_NESTED(m_nonInheritedData, rareData, containIntrinsicHeight, WTFMove(height)); }
 inline void RenderStyle::setContainIntrinsicWidth(Style::ContainIntrinsicSize&& width) { SET_NESTED(m_nonInheritedData, rareData, containIntrinsicWidth, WTFMove(width)); }
 inline void RenderStyle::setContainerNames(Style::ContainerNames&& names) { SET_NESTED(m_nonInheritedData, rareData, containerNames, WTFMove(names)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -48,7 +48,6 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , maxLines(RenderStyle::initialMaxLines())
     , overflowContinue(RenderStyle::initialOverflowContinue())
     , touchActions(RenderStyle::initialTouchActions())
-    , contain(RenderStyle::initialContainment())
     , initialLetter(RenderStyle::initialInitialLetter())
     , marquee(StyleMarqueeData::create())
     , backdropFilter(StyleFilterData::create())
@@ -143,6 +142,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , isPopoverInvoker(false)
     , useSVGZoomRulesForLength(false)
     , marginTrim(RenderStyle::initialMarginTrim().toRaw())
+    , contain(RenderStyle::initialContain().toRaw())
 {
 }
 
@@ -155,7 +155,6 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , maxLines(o.maxLines)
     , overflowContinue(o.overflowContinue)
     , touchActions(o.touchActions)
-    , contain(o.contain)
     , initialLetter(o.initialLetter)
     , marquee(o.marquee)
     , backdropFilter(o.backdropFilter)
@@ -250,6 +249,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , isPopoverInvoker(o.isPopoverInvoker)
     , useSVGZoomRulesForLength(o.useSVGZoomRulesForLength)
     , marginTrim(o.marginTrim)
+    , contain(o.contain)
 {
 }
 
@@ -269,7 +269,6 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && maxLines == o.maxLines
         && overflowContinue == o.overflowContinue
         && touchActions == o.touchActions
-        && contain == o.contain
         && initialLetter == o.initialLetter
         && marquee == o.marquee
         && backdropFilter == o.backdropFilter
@@ -363,25 +362,26 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && anchorFunctionScrollCompensatedAxes == o.anchorFunctionScrollCompensatedAxes
         && isPopoverInvoker == o.isPopoverInvoker
         && useSVGZoomRulesForLength == o.useSVGZoomRulesForLength
-        && marginTrim == o.marginTrim;
+        && marginTrim == o.marginTrim
+        && contain == o.contain;
 }
 
-OptionSet<Containment> StyleRareNonInheritedData::usedContain() const
+Style::Contain StyleRareNonInheritedData::usedContain() const
 {
-    auto containment = contain;
+    auto result = Style::Contain::fromRaw(contain);
 
     switch (static_cast<ContainerType>(containerType)) {
     case ContainerType::Normal:
         break;
     case ContainerType::Size:
-        containment.add({ Containment::Style, Containment::Size });
+        result.add({ Style::ContainValue::Style, Style::ContainValue::Size });
         break;
     case ContainerType::InlineSize:
-        containment.add({ Containment::Style, Containment::InlineSize });
+        result.add({ Style::ContainValue::Style, Style::ContainValue::InlineSize });
         break;
     };
 
-    return containment;
+    return result;
 }
 
 bool StyleRareNonInheritedData::hasBackdropFilters() const
@@ -408,7 +408,6 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT(overflowContinue);
 
     LOG_IF_DIFFERENT(touchActions);
-    LOG_IF_DIFFERENT(contain);
 
     LOG_IF_DIFFERENT(initialLetter);
 
@@ -538,6 +537,7 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT_WITH_CAST(bool, useSVGZoomRulesForLength);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::MarginTrim, marginTrim);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::Contain, contain);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -37,6 +37,7 @@
 #include <WebCore/StyleClip.h>
 #include <WebCore/StyleClipPath.h>
 #include <WebCore/StyleColor.h>
+#include <WebCore/StyleContain.h>
 #include <WebCore/StyleContainIntrinsicSize.h>
 #include <WebCore/StyleContainerName.h>
 #include <WebCore/StyleGapGutter.h>
@@ -130,7 +131,7 @@ public:
     bool hasScrollTimelines() const { return !scrollTimelines.isEmpty() || !scrollTimelineNames.isNone(); }
     bool hasViewTimelines() const { return !viewTimelines.isEmpty() || !viewTimelineNames.isNone(); }
 
-    OptionSet<Containment> usedContain() const;
+    Style::Contain usedContain() const;
 
     Style::ContainIntrinsicSize containIntrinsicWidth;
     Style::ContainIntrinsicSize containIntrinsicHeight;
@@ -144,7 +145,6 @@ public:
     OverflowContinue overflowContinue { OverflowContinue::Auto };
 
     OptionSet<TouchAction> touchActions;
-    OptionSet<Containment> contain;
 
     Style::WebkitInitialLetter initialLetter;
 
@@ -272,6 +272,7 @@ public:
     PREFERRED_TYPE(bool) unsigned isPopoverInvoker : 1;
     PREFERRED_TYPE(bool) unsigned useSVGZoomRulesForLength : 1;
     PREFERRED_TYPE(Style::MarginTrim) unsigned marginTrim : 4;
+    PREFERRED_TYPE(Style::Contain) unsigned contain : 5;
 
 private:
     StyleRareNonInheritedData();

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -981,7 +981,7 @@ void Adjuster::adjustThemeStyle(RenderStyle& style, const RenderStyle& parentSty
 
     RenderTheme::singleton().adjustStyle(style, parentStyle, m_element.get());
 
-    if (style.containsSize()) {
+    if (style.usedContain().contains(Style::ContainValue::Size)) {
         if (!style.containIntrinsicWidth().isNone()) {
             if (isOldWidthAuto)
                 style.setWidth(CSS::Keyword::Auto { });
@@ -1128,9 +1128,9 @@ void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& updat
     // "Additionally, when any containments are active on either the HTML html or body elements, propagation of
     // properties from the body element to the initial containing block, the viewport, or the canvas background, is disabled."
     auto shouldPropagateFromBody = [&] {
-        if (bodyStyle && !bodyStyle->usedContain().isEmpty())
+        if (bodyStyle && !bodyStyle->usedContain().isNone())
             return false;
-        return documentElementStyle->usedContain().isEmpty();
+        return documentElementStyle->usedContain().isNone();
     }();
 
     auto writingMode = [&] {

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -128,8 +128,6 @@ public:
 
     static OptionSet<SpeakAs> convertSpeakAs(BuilderState&, const CSSValue&);
 
-    static OptionSet<Containment> convertContain(BuilderState&, const CSSValue&);
-
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
     static std::optional<PositionArea> convertPositionArea(BuilderState&, const CSSValue&);
 
@@ -359,47 +357,6 @@ inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation
             result.add(fromCSSValue<HangingPunctuation>(currentValue));
     }
     return result;
-}
-
-inline OptionSet<Containment> BuilderConverter::convertContain(BuilderState& builderState, const CSSValue& value)
-{
-    if (is<CSSPrimitiveValue>(value)) {
-        if (value.valueID() == CSSValueNone)
-            return RenderStyle::initialContainment();
-        if (value.valueID() == CSSValueStrict)
-            return RenderStyle::strictContainment();
-        return RenderStyle::contentContainment();
-    }
-
-    OptionSet<Containment> containment;
-
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    for (auto& value : *list) {
-        switch (value.valueID()) {
-        case CSSValueSize:
-            containment.add(Containment::Size);
-            break;
-        case CSSValueInlineSize:
-            containment.add(Containment::InlineSize);
-            break;
-        case CSSValueLayout:
-            containment.add(Containment::Layout);
-            break;
-        case CSSValuePaint:
-            containment.add(Containment::Paint);
-            break;
-        case CSSValueStyle:
-            containment.add(Containment::Style);
-            break;
-        default:
-            ASSERT_NOT_REACHED();
-            break;
-        };
-    }
-    return containment;
 }
 
 inline std::optional<ScopedName> BuilderConverter::convertPositionAnchor(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -133,7 +133,6 @@ public:
 
     // MARK: Shared conversions
 
-    static Ref<CSSValue> convertContain(ExtractorState&, OptionSet<Containment>);
     static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const FixedVector<PositionTryFallback>&);
     static Ref<CSSValue> convertTouchAction(ExtractorState&, OptionSet<TouchAction>);
     static Ref<CSSValue> convertTextTransform(ExtractorState&, OptionSet<TextTransform>);
@@ -249,28 +248,6 @@ inline Ref<CSSValue> ExtractorConverter::convertTransformationMatrix(const Rende
 }
 
 // MARK: - Shared conversions
-
-inline Ref<CSSValue> ExtractorConverter::convertContain(ExtractorState&, OptionSet<Containment> containment)
-{
-    if (!containment)
-        return CSSPrimitiveValue::create(CSSValueNone);
-    if (containment == RenderStyle::strictContainment())
-        return CSSPrimitiveValue::create(CSSValueStrict);
-    if (containment == RenderStyle::contentContainment())
-        return CSSPrimitiveValue::create(CSSValueContent);
-    CSSValueListBuilder list;
-    if (containment & Containment::Size)
-        list.append(CSSPrimitiveValue::create(CSSValueSize));
-    if (containment & Containment::InlineSize)
-        list.append(CSSPrimitiveValue::create(CSSValueInlineSize));
-    if (containment & Containment::Layout)
-        list.append(CSSPrimitiveValue::create(CSSValueLayout));
-    if (containment & Containment::Style)
-        list.append(CSSPrimitiveValue::create(CSSValueStyle));
-    if (containment & Containment::Paint)
-        list.append(CSSPrimitiveValue::create(CSSValuePaint));
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
 
 inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorState& state, const FixedVector<PositionTryFallback>& fallbacks)
 {

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -68,7 +68,6 @@ public:
 
     // MARK: Shared serializations
 
-    static void serializeContain(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<Containment>);
     static void serializeSmoothScrolling(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, bool);
     static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<PositionTryFallback>&);
     static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
@@ -193,37 +192,6 @@ inline void ExtractorSerializer::serializeTransformationMatrix(const RenderStyle
 }
 
 // MARK: - Shared serializations
-
-inline void ExtractorSerializer::serializeContain(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<Containment> containment)
-{
-    if (!containment) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-    if (containment == RenderStyle::strictContainment()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Strict { });
-        return;
-    }
-    if (containment == RenderStyle::contentContainment()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Content { });
-        return;
-    }
-
-    bool listEmpty = true;
-    auto appendOption = [&](Containment test, CSSValueID value) {
-        if (containment & test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(Containment::Size, CSSValueSize);
-    appendOption(Containment::InlineSize, CSSValueInlineSize);
-    appendOption(Containment::Layout, CSSValueLayout);
-    appendOption(Containment::Style, CSSValueStyle);
-    appendOption(Containment::Paint, CSSValuePaint);
-}
 
 inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<PositionTryFallback>& fallbacks)
 {

--- a/Source/WebCore/style/values/contain/StyleContain.cpp
+++ b/Source/WebCore/style/values/contain/StyleContain.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleContain.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<Contain>::operator()(BuilderState& state, const CSSValue& value) -> Contain
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        case CSSValueStrict:
+            return CSS::Keyword::Strict { };
+        case CSSValueContent:
+            return CSS::Keyword::Content { };
+        case CSSValueSize:
+            return { ContainValue::Size };
+        case CSSValueInlineSize:
+            return { ContainValue::InlineSize };
+        case CSSValueLayout:
+            return { ContainValue::Layout };
+        case CSSValueStyle:
+            return { ContainValue::Style };
+        case CSSValuePaint:
+            return { ContainValue::Paint };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return CSS::Keyword::None { };
+
+    ContainValueEnumSet result;
+    for (Ref item : *list) {
+        switch (item->valueID()) {
+        case CSSValueSize:
+            if (result.contains(ContainValue::InlineSize)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::None { };
+            }
+            result.value.add(ContainValue::Size);
+            break;
+        case CSSValueInlineSize:
+            if (result.contains(ContainValue::Size)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::None { };
+            }
+            result.value.add(ContainValue::InlineSize);
+            break;
+        case CSSValueLayout:
+            result.value.add(ContainValue::Layout);
+            break;
+        case CSSValueStyle:
+            result.value.add(ContainValue::Style);
+            break;
+        case CSSValuePaint:
+            result.value.add(ContainValue::Paint);
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+    return result;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/contain/StyleContain.h
+++ b/Source/WebCore/style/values/contain/StyleContain.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'contain'> = none | strict@(aliased-to=[size layout paint style]) | content@(aliased-to=[layout paint style]) | [ [size | inline-size] || layout || style || paint ]
+// https://drafts.csswg.org/css-contain-2/#contain-property
+
+enum class ContainValue : uint8_t {
+    Size,
+    InlineSize,
+    Layout,
+    Style,
+    Paint,
+};
+
+using ContainValueEnumSet = SpaceSeparatedEnumSet<ContainValue>;
+
+struct Contain {
+    using EnumSet = ContainValueEnumSet;
+    using value_type = ContainValueEnumSet::value_type;
+
+    static constexpr ContainValueEnumSet strict { ContainValue::Size, ContainValue::Layout, ContainValue::Style, ContainValue::Paint };
+    static constexpr ContainValueEnumSet content { ContainValue::Layout, ContainValue::Style, ContainValue::Paint };
+
+    constexpr Contain(CSS::Keyword::None) : m_value { } { }
+    constexpr Contain(CSS::Keyword::Strict) : m_value { strict } { }
+    constexpr Contain(CSS::Keyword::Content) : m_value { content } { }
+    constexpr Contain(EnumSet&& set) : m_value { WTFMove(set) } { }
+    constexpr Contain(value_type value) : Contain { EnumSet { value } } { }
+    constexpr Contain(std::initializer_list<value_type> initializerList) : Contain { EnumSet { initializerList } } { }
+
+    static constexpr Contain fromRaw(EnumSet::StorageType rawValue)
+    {
+        if (!rawValue)
+            return CSS::Keyword::None { };
+        return EnumSet::fromRaw(rawValue);
+    }
+    constexpr EnumSet::StorageType toRaw() const { return m_value.toRaw(); }
+
+    constexpr bool contains(value_type e) const { return m_value.contains(e); }
+    constexpr bool containsAny(EnumSet other) const { return m_value.containsAny(other.value); }
+    constexpr bool containsAll(EnumSet other) const { return m_value.containsAll(other.value); }
+    constexpr bool containsOnly(EnumSet other) const { return m_value.containsOnly(other.value); }
+    constexpr void add(EnumSet other) { m_value.value.add(other.value); }
+
+    constexpr bool isNone() const { return m_value.isEmpty(); }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isNone())
+            return visitor(CSS::Keyword::None { });
+
+        // Handle "strict" and "content" shorthands
+        if (m_value == strict)
+            return visitor(CSS::Keyword::Strict { });
+        if (m_value == content)
+            return visitor(CSS::Keyword::Content { });
+
+        return visitor(m_value);
+    }
+
+    constexpr bool operator==(const Contain&) const = default;
+
+private:
+    EnumSet m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<Contain> { auto operator()(BuilderState&, const CSSValue&) -> Contain; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Contain)

--- a/Source/WebCore/style/values/fonts/StyleFontFeatureSettings.h
+++ b/Source/WebCore/style/values/fonts/StyleFontFeatureSettings.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <WebCore/FontTaggedSettings.h>
-#include <WebCore/StyleValueTypes.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -42,6 +42,7 @@
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 namespace Style {


### PR DESCRIPTION
#### a2d7227d496c7ca14ec56335653dd4b8dfac2c71
<pre>
[Style] Convert the &apos;contain&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302539">https://bugs.webkit.org/show_bug.cgi?id=302539</a>

Reviewed by Darin Adler.

Converts the &apos;contain&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderCounter.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/contain/StyleContain.cpp: Added.
* Source/WebCore/style/values/contain/StyleContain.h: Added.

Canonical link: <a href="https://commits.webkit.org/303082@main">https://commits.webkit.org/303082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/303fe5e7af1bf2144c518f295899ed40f5ac8bf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131213 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99970 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80670 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/161 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111050 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141155 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27565 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2471 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3350 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32215 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66757 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->