### PR TITLE
[GTK][WPE][GStreamer][Media] Using the `loop` property in a media element breaks the seeking and looping.

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1030,8 +1030,6 @@ void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomStr
         return;
     case AttributeNames::loopAttr:
         updateSleepDisabling();
-        if (RefPtr player = m_player)
-            player->isLoopingChanged();
         return;
     case AttributeNames::preloadAttr:
         if (equalLettersIgnoringASCIICase(newValue, "none"_s))
@@ -4655,8 +4653,6 @@ void HTMLMediaElement::setLoop(bool loop)
 {
     ALWAYS_LOG(LOGIDENTIFIER, loop);
     setBooleanAttribute(loopAttr, loop);
-    if (RefPtr player = m_player)
-        player->isLoopingChanged();
 }
 
 bool HTMLMediaElement::controls() const

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1894,11 +1894,6 @@ bool MediaPlayer::shouldIgnoreIntrinsicSize()
     return protectedPrivate()->shouldIgnoreIntrinsicSize();
 }
 
-void MediaPlayer::isLoopingChanged()
-{
-    protectedPrivate()->isLoopingChanged();
-}
-
 void MediaPlayer::remoteEngineFailedToLoad()
 {
     protectedClient()->mediaPlayerEngineFailedToLoad();

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -739,7 +739,6 @@ public:
     void mediaEngineUpdated() { protectedClient()->mediaPlayerEngineUpdated(); }
     void resourceNotSupported() { protectedClient()->mediaPlayerResourceNotSupported(); }
     bool isLooping() const { return protectedClient()->mediaPlayerIsLooping(); }
-    void isLoopingChanged();
 
     void remoteEngineFailedToLoad();
     SecurityOriginData documentSecurityOrigin() const;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -347,8 +347,6 @@ public:
 
     virtual void mediaPlayerWillBeDestroyed() { }
 
-    virtual void isLoopingChanged() { }
-
     virtual void setShouldCheckHardwareSupport(bool value) { m_shouldCheckHardwareSupport = value; }
     bool shouldCheckHardwareSupport() const { return m_shouldCheckHardwareSupport; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -207,7 +207,6 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer& player)
 
     ensureGStreamerInitialized();
     m_audioSink = createAudioSink();
-    ensureSeekFlags();
 }
 
 MediaPlayerPrivateGStreamer::~MediaPlayerPrivateGStreamer()
@@ -486,13 +485,8 @@ void MediaPlayerPrivateGStreamer::play()
         MediaTelemetryReport::singleton().reportPlaybackState(MediaTelemetryReport::AVPipelineState::Play);
 #endif
         RefPtr player = m_player.get();
-        if (player) {
-            if (player->isLooping()) {
-                GST_DEBUG_OBJECT(pipeline(), "Scheduling initial SEGMENT seek");
-                doSeek(SeekTarget { playbackPosition() }, m_playbackRate, true);
-            } else
-                updateDownloadBufferingFlag();
-        }
+        if (player && !player->isLooping())
+            updateDownloadBufferingFlag();
     } else
         loadingFailed(MediaPlayer::NetworkState::Empty);
 }
@@ -563,7 +557,7 @@ bool MediaPlayerPrivateGStreamer::paused() const
     return !m_isPipelinePlaying;
 }
 
-bool MediaPlayerPrivateGStreamer::doSeek(const SeekTarget& target, float rate, bool isAsync)
+bool MediaPlayerPrivateGStreamer::doSeek(const SeekTarget& target, float rate, GstSeekFlags seekFlags, bool isAsync)
 {
     RefPtr player = m_player.get();
 
@@ -584,11 +578,6 @@ bool MediaPlayerPrivateGStreamer::doSeek(const SeekTarget& target, float rate, b
         g_object_set(m_downloadBuffer.get(), "high-percent", 0, nullptr);
     }
 
-    if (paused() && !m_isEndReached && player && player->isLooping()) {
-        GST_DEBUG_OBJECT(pipeline(), "Segment non-flushing seek attempt not supported on a paused pipeline, enabling flush");
-        m_seekFlags = static_cast<GstSeekFlags>((m_seekFlags | GST_SEEK_FLAG_FLUSH) & ~GST_SEEK_FLAG_SEGMENT);
-    }
-
     if (rate >= 0.0 && startTime >= duration()) {
         didEnd();
         return false;
@@ -597,7 +586,7 @@ bool MediaPlayerPrivateGStreamer::doSeek(const SeekTarget& target, float rate, b
     // Stream mode. Seek will automatically deplete buffer level, so we always want to pause the pipeline and wait until the
     // buffer is replenished. But we don't want this behaviour on immediate seeks that only change the playback rate.
     // We restrict this behaviour to protocols that use NetworkProcess.
-    if (!isSeamlessSeekingEnabled() && !m_downloadBuffer && !m_isChangingRate && m_url.protocolIsInHTTPFamily() && currentTime() != startTime) {
+    if (!m_downloadBuffer && !m_isChangingRate && m_url.protocolIsInHTTPFamily() && currentTime() != startTime) {
         GST_DEBUG_OBJECT(pipeline(), "[Buffering] Pausing pipeline, resetting buffering level to 0 and forcing m_isBuffering true before seeking on stream mode");
 
         auto& quirksManager = GStreamerQuirksManager::singleton();
@@ -611,7 +600,7 @@ bool MediaPlayerPrivateGStreamer::doSeek(const SeekTarget& target, float rate, b
 
     auto seekStart = toGstClockTime(startTime);
     auto seekStop = toGstClockTime(endTime);
-    GstEvent* event = gst_event_new_seek(rate, GST_FORMAT_TIME, m_seekFlags, GST_SEEK_TYPE_SET, seekStart, GST_SEEK_TYPE_SET, seekStop);
+    GstEvent* event = gst_event_new_seek(rate, GST_FORMAT_TIME, seekFlags, GST_SEEK_TYPE_SET, seekStart, GST_SEEK_TYPE_SET, seekStop);
 
     GST_DEBUG_OBJECT(pipeline(), "[Seek] Performing actual seek to %" GST_TIMEP_FORMAT " (endTime: %" GST_TIMEP_FORMAT ") at rate %f", &seekStart, &seekStop, rate);
 
@@ -674,26 +663,9 @@ void MediaPlayerPrivateGStreamer::seekToTarget(const SeekTarget& inTarget)
         return;
     }
 
-    if (player->isLooping()) {
-        if (isSeamlessSeekingEnabled() && state > GST_STATE_PAUSED) {
-            // Segment seeking is synchronous, the pipeline state has not changed, no flush is done.
-            GST_DEBUG_OBJECT(pipeline(), "Performing segment seek");
-            m_isSeeking = true;
-            if (!doSeek(target, player->rate())) {
-                GST_DEBUG_OBJECT(pipeline(), "[Seek] seeking to %s failed", toString(target.time).utf8().data());
-                return;
-            }
-        }
-        m_isEndReached = false;
-        m_isSeeking = false;
-        m_cachedPosition = MediaTime::zeroTime();
-        timeChanged(target.time);
-        return;
-    }
-
     if (getStateResult == GST_STATE_CHANGE_ASYNC || state < GST_STATE_PAUSED || m_isEndReached) {
         m_isSeekPending = true;
-        if (m_isEndReached && (!player->isLooping() || !isSeamlessSeekingEnabled())) {
+        if (m_isEndReached) {
             GST_DEBUG_OBJECT(pipeline(), "[Seek] reset pipeline");
             m_shouldResetPipeline = true;
             if (changePipelineState(GST_STATE_PAUSED) == ChangePipelineStateResult::Failed)
@@ -701,7 +673,7 @@ void MediaPlayerPrivateGStreamer::seekToTarget(const SeekTarget& inTarget)
         }
     } else {
         // We can seek now.
-        if (!doSeek(target, player->rate())) {
+        if (!doSeek(target, player->rate(), static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE))) {
             GST_DEBUG_OBJECT(pipeline(), "[Seek] seeking to %s failed", toString(target.time).utf8().data());
             return;
         }
@@ -730,7 +702,7 @@ void MediaPlayerPrivateGStreamer::updatePlaybackRate()
             m_isPipelinePlaying, isPipelineWaitingPreroll(), m_playbackRate, mute, pipeline());
         if (processed && didInstantRateChange)
                 m_lastPlaybackRate = m_playbackRate;
-        else if (doSeek(SeekTarget { playbackPosition() }, m_playbackRate)) {
+        else if (doSeek(SeekTarget { playbackPosition() }, m_playbackRate, static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH))) {
             g_object_set(m_pipeline.get(), "mute", mute, nullptr);
             m_lastPlaybackRate = m_playbackRate;
         } else {
@@ -3020,7 +2992,7 @@ void MediaPlayerPrivateGStreamer::updateStates()
         if (player && m_isSeekPending) {
             GST_DEBUG_OBJECT(pipeline(), "[Seek] committing pending seek to %s", toString(m_seekTarget.time).utf8().data());
             m_isSeekPending = false;
-            m_isSeeking = doSeek(m_seekTarget, player->rate());
+            m_isSeeking = doSeek(m_seekTarget, player->rate(), static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE));
             if (!m_isSeeking) {
                 invalidateCachedPosition();
                 GST_DEBUG_OBJECT(pipeline(), "[Seek] seeking to %s failed", toString(m_seekTarget.time).utf8().data());
@@ -3431,19 +3403,6 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
         player->handleNeedContextMessage(message);
     }), this);
 
-    g_signal_connect_swapped(bus.get(), "message::segment-done", G_CALLBACK(+[](MediaPlayerPrivateGStreamer* player, GstMessage*) {
-        callOnMainThread([weakThis = ThreadSafeWeakPtr { *player }, player] {
-            RefPtr self = weakThis.get();
-            if (!self)
-                return;
-            RefPtr mediaPlayer = player->m_player.get();
-            if (!mediaPlayer || !mediaPlayer->isLooping())
-                return;
-            GST_DEBUG_OBJECT(player->pipeline(), "Handling segment-done message");
-            player->didEnd();
-        });
-    }), this);
-
     // In the MSE case stream collection messages are emitted from the main thread right before the
     // initilization segment is parsed and "updateend" is fired. We need therefore to handle these
     // synchronously in the same main thread tick to make the tracks information available to JS no
@@ -3663,13 +3622,6 @@ bool MediaPlayerPrivateGStreamer::performTaskAtTime(Function<void(const MediaTim
     return true;
 }
 
-void MediaPlayerPrivateGStreamer::isLoopingChanged()
-{
-    RefPtr player = m_player.get();
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Looping attribute changed to: %s", player ? boolForPrinting(player->isLooping()) : nullptr);
-    ensureSeekFlags();
-}
-
 #if USE(COORDINATED_GRAPHICS)
 PlatformLayer* MediaPlayerPrivateGStreamer::platformLayer() const
 {
@@ -3844,13 +3796,6 @@ void MediaPlayerPrivateGStreamer::invalidateCachedPositionOnNextIteration() cons
             return;
         invalidateCachedPosition();
     });
-}
-
-void MediaPlayerPrivateGStreamer::ensureSeekFlags()
-{
-    RefPtr player = m_player.get();
-    auto flag = (player && player->isLooping()) ? GST_SEEK_FLAG_SEGMENT : GST_SEEK_FLAG_FLUSH;
-    m_seekFlags = static_cast<GstSeekFlags>(flag | GST_SEEK_FLAG_ACCURATE);
 }
 
 void MediaPlayerPrivateGStreamer::triggerRepaint(GRefPtr<GstSample>&& sample)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -185,7 +185,6 @@ public:
     unsigned droppedFrameCount() const final;
     void acceleratedRenderingStateChanged() final;
     bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&) override;
-    void isLoopingChanged() final;
     void audioOutputDeviceChanged() final;
 
     GstElement* pipeline() const { return m_pipeline.get(); }
@@ -345,9 +344,8 @@ protected:
     void ensureAudioSourceProvider();
     virtual void checkPlayingConsistency();
 
-    virtual bool doSeek(const SeekTarget& position, float rate, bool isAsync = false);
+    virtual bool doSeek(const SeekTarget& position, float rate, GstSeekFlags, bool isAsync = false);
     void invalidateCachedPosition() const;
-    void ensureSeekFlags();
 
     static void sourceSetupCallback(MediaPlayerPrivateGStreamer*, GstElement*);
 
@@ -446,7 +444,6 @@ protected:
 #endif
 
     std::optional<GstVideoDecoderPlatform> m_videoDecoderPlatform;
-    GstSeekFlags m_seekFlags;
     bool m_ignoreErrors { false };
     Atomic<unsigned> m_queuedSyncErrors { 0 };
 
@@ -682,8 +679,6 @@ private:
     void setupCodecProbe(GstElement*);
     Lock m_codecsLock;
     TrackIDHashMap<String> m_codecs WTF_GUARDED_BY_LOCK(m_codecsLock);
-
-    bool isSeamlessSeekingEnabled() const { return m_seekFlags & GST_SEEK_FLAG_SEGMENT; }
 
     Ref<PlatformMediaResourceLoader> m_loader;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -235,10 +235,10 @@ void MediaPlayerPrivateGStreamerMSE::seekToTarget(const SeekTarget& target)
     if (!m_pipeline)
         return;
     GST_DEBUG_OBJECT(pipeline(), "Requested seek to %s", target.time.toString().utf8().data());
-    doSeek(target, m_playbackRate);
+    doSeek(target, m_playbackRate, GST_SEEK_FLAG_FLUSH);
 }
 
-bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate, bool isAsync)
+bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate, GstSeekFlags seekFlags, bool isAsync)
 {
     UNUSED_PARAM(isAsync);
     // This method should only be called outside of MediaPlayerPrivateGStreamerMSE by MediaPlayerPrivateGStreamer::setRate().
@@ -270,7 +270,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
         // the seek event, but since we're sending the event directly to the source element we need to take the
         // STATE_LOCK on the pipeline ourselves.
         auto locker = GstStateLocker(pipeline());
-        gst_element_seek(m_source.get(), rate, GST_FORMAT_TIME, m_seekFlags,
+        gst_element_seek(m_source.get(), rate, GST_FORMAT_TIME, seekFlags,
             GST_SEEK_TYPE_SET, toGstClockTime(target.time), GST_SEEK_TYPE_NONE, 0);
     }
     invalidateCachedPosition();

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -57,7 +57,7 @@ public:
     void play() override;
     void pause() override;
     void seekToTarget(const SeekTarget&) override;
-    bool doSeek(const SeekTarget&, float rate, bool isAsync = false) override;
+    bool doSeek(const SeekTarget&, float rate, GstSeekFlags, bool isAsync = false) override;
 
     void updatePipelineState(GstState);
 


### PR DESCRIPTION
[GTK][WPE][GStreamer][Media] Using the `loop` property in a media element breaks the seeking and looping.
https://bugs.webkit.org/show_bug.cgi?id=302541

Reviewed by NOBODY (OOPS!).

The segment looping feature has broken the seeking and looping of the media element. This patch is mainly a revert of the original commit: bc8bd3bac663f00e61c47c23bded08056ca348b0

* Source/WebCore/html/HTMLMediaElement.cpp: (WebCore::HTMLMediaElement::attributeChanged):
(WebCore::HTMLMediaElement::setLoop):
* Source/WebCore/platform/graphics/MediaPlayer.cpp: (WebCore::MediaPlayer::isLoopingChanged): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h: (WebCore::MediaPlayerPrivateInterface::isLoopingChanged): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp: (WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer): (WebCore::MediaPlayerPrivateGStreamer::play):
(WebCore::MediaPlayerPrivateGStreamer::doSeek):
(WebCore::MediaPlayerPrivateGStreamer::seekToTarget): (WebCore::MediaPlayerPrivateGStreamer::updatePlaybackRate): (WebCore::MediaPlayerPrivateGStreamer::updateStates): (WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin): (WebCore::MediaPlayerPrivateGStreamer::isLoopingChanged): Deleted. (WebCore::MediaPlayerPrivateGStreamer::ensureSeekFlags): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: (WebCore::MediaPlayerPrivateGStreamer::isSeamlessSeekingEnabled const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp: (WebCore::MediaPlayerPrivateGStreamerMSE::seekToTarget): (WebCore::MediaPlayerPrivateGStreamerMSE::doSeek):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b4096deab6302249b730afa1dbfed8d50560e60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99849 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67627 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2336 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/49 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81752 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110933 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35454 "Found 5 new test failures: inspector/animation/lifecycle-css-transition.html inspector/debugger/async-stack-trace-truncate.html inspector/page/hidpi-snapshot-size.html js/ShadowRealm-iframe-detach.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3134 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108366 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108318 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2370 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113662 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56192 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3201 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32084 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66597 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->