### PR TITLE
[WebXR Hit Test] Unreviewed non-unified source build fix after 302828@main

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -32,6 +32,7 @@
 #include "ExceptionOr.h"
 #include "WebXRBoundedReferenceSpace.h"
 #include "WebXRHitTestSource.h"
+#include "WebXRInputSource.h"
 #include "WebXRJointPose.h"
 #include "WebXRJointSpace.h"
 #include "WebXRReferenceSpace.h"
@@ -102,11 +103,6 @@ bool WebXRFrame::mustPosesBeLimited(const WebXRSpace& space, const WebXRSpace& b
 
     return false;
 }
-
-struct WebXRFrame::PopulatedPose {
-    TransformationMatrix transform;
-    bool emulatedPosition { false };
-};
 
 // https://immersive-web.github.io/webxr/#populate-the-pose
 ExceptionOr<std::optional<WebXRFrame::PopulatedPose>> WebXRFrame::populatePose(const Document& document, const WebXRSpace& space, const WebXRSpace& baseSpace)

--- a/Source/WebCore/Modules/webxr/WebXRFrame.h
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.h
@@ -85,7 +85,11 @@ public:
 
     static TransformationMatrix matrixFromPose(const PlatformXR::FrameData::Pose&);
 
-    struct PopulatedPose;
+    struct PopulatedPose {
+        TransformationMatrix transform;
+        bool emulatedPosition { false };
+    };
+
     ExceptionOr<std::optional<PopulatedPose>> populatePose(const Document&, const WebXRSpace&, const WebXRSpace&);
 
 private:

--- a/Source/WebCore/Modules/webxr/WebXRHitTestResult.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRHitTestResult.cpp
@@ -29,6 +29,7 @@
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBXR_HIT_TEST)
+#include "WebXRInputSpace.h"
 #include "WebXRPose.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSpace.h"

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(WEBXR)
 
 #include "ContextDestructionObserverInlines.h"
+#include "DOMPointReadOnly.h"
 #include "DocumentPage.h"
 #include "EventNames.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebXRTransientInputHitTestSource.h"
 
+#include "WebXRSession.h"
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBXR_HIT_TEST)


### PR DESCRIPTION
#### d65f25a81adc715bc66690aa7aa6818bde0e5d58
<pre>
[WebXR Hit Test] Unreviewed non-unified source build fix after 302828@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=302141">https://bugs.webkit.org/show_bug.cgi?id=302141</a>

Adding missing #include.

* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
* Source/WebCore/Modules/webxr/WebXRFrame.h:
* Source/WebCore/Modules/webxr/WebXRHitTestResult.cpp:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
* Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp:

Canonical link: <a href="https://commits.webkit.org/303049@main">https://commits.webkit.org/303049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f73b2a434ad5923de0dd781faaa2bd7667578ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131065 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42026 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132935 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/138506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134011 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/117334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81753 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/35970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141000 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/3135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/3183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/113664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/108317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20399 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/3202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66598 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/3022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/3132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->