### PR TITLE
[Cocoa] Add support for experimental showCaptionDisplaySettings() API

### DIFF
--- a/LayoutTests/media/caption-display-settings/caption-display-settings-anchorBounds-expected.txt
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings-anchorBounds-expected.txt
@@ -1,0 +1,8 @@
+
+RUN(video.showCaptionDisplaySettings({anchorNode: target}))
+EXPECTED (options.anchorBounds.x == '10') OK
+EXPECTED (options.anchorBounds.y == '20') OK
+EXPECTED (options.anchorBounds.width == '30') OK
+EXPECTED (options.anchorBounds.height == '40') OK
+END OF TEST
+

--- a/LayoutTests/media/caption-display-settings/caption-display-settings-anchorBounds.html
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings-anchorBounds.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CaptionDisplaySettingsEnabled=true ] -->
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>caption-display-settings</title>
+	<script src="../video-test.js"></script>
+	<style>
+		#target {
+			position: absolute;
+			left: 10px;
+			top: 20px;
+			width: 30px;
+			height: 40px;
+			background-color: green;
+		}
+	</style>
+	<script>
+	async function runTest() {
+		findMediaElement();
+
+		if (!window.internals)
+			return;
+
+		window.options = null;
+		internals.setMockCaptionDisplaySettingsClientCallback(async (element, inOptions) => {
+			options = inOptions;
+		});
+
+		await run('video.showCaptionDisplaySettings({anchorNode: target})');
+
+		testExpected('options.anchorBounds.x', 10);
+		testExpected('options.anchorBounds.y', 20);
+		testExpected('options.anchorBounds.width', 30);
+		testExpected('options.anchorBounds.height', 40);
+	}
+
+	window.addEventListener('load', event => {
+		requestAnimationFrame(() => {
+			runTest().then(endTest).catch(failTest);	
+		});
+	});
+	</script>
+</head>
+<body>
+	<div id=target></div>
+	<video muted autoplay></video>
+</body>
+</html>

--- a/LayoutTests/media/caption-display-settings/caption-display-settings-expected.txt
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings-expected.txt
@@ -1,0 +1,4 @@
+
+EXPECTED (video.showCaptionDisplaySettings != 'undefined') OK
+END OF TEST
+

--- a/LayoutTests/media/caption-display-settings/caption-display-settings-positionArea-expected.txt
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings-positionArea-expected.txt
@@ -1,0 +1,55 @@
+
+
+RUN(video.showCaptionDisplaySettings({positionArea: "top left"}))
+EXPECTED (options.xPositionArea == 'Left') OK
+EXPECTED (options.yPositionArea == 'Top') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "left top"}))
+EXPECTED (options.xPositionArea == 'Left') OK
+EXPECTED (options.yPositionArea == 'Top') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "top center"}))
+EXPECTED (options.xPositionArea == 'Center') OK
+EXPECTED (options.yPositionArea == 'Top') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "top right"}))
+EXPECTED (options.xPositionArea == 'Right') OK
+EXPECTED (options.yPositionArea == 'Top') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "top x-start"}))
+EXPECTED (options.xPositionArea == 'Left') OK
+EXPECTED (options.yPositionArea == 'Top') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "top x-end"}))
+EXPECTED (options.xPositionArea == 'Right') OK
+EXPECTED (options.yPositionArea == 'Top') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "center center"}))
+EXPECTED (options.xPositionArea == 'Center') OK
+EXPECTED (options.yPositionArea == 'Center') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "bottom left"}))
+EXPECTED (options.xPositionArea == 'Left') OK
+EXPECTED (options.yPositionArea == 'Bottom') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "left bottom"}))
+EXPECTED (options.xPositionArea == 'Left') OK
+EXPECTED (options.yPositionArea == 'Bottom') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "bottom center"}))
+EXPECTED (options.xPositionArea == 'Center') OK
+EXPECTED (options.yPositionArea == 'Bottom') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "bottom right"}))
+EXPECTED (options.xPositionArea == 'Right') OK
+EXPECTED (options.yPositionArea == 'Bottom') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "bottom x-start"}))
+EXPECTED (options.xPositionArea == 'Left') OK
+EXPECTED (options.yPositionArea == 'Bottom') OK
+
+RUN(video.showCaptionDisplaySettings({positionArea: "bottom x-end"}))
+EXPECTED (options.xPositionArea == 'Right') OK
+EXPECTED (options.yPositionArea == 'Bottom') OK
+END OF TEST
+

--- a/LayoutTests/media/caption-display-settings/caption-display-settings-positionArea.html
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings-positionArea.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CaptionDisplaySettingsEnabled=true ] -->
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>caption-display-settings-positionArea</title>
+	<script src="../video-test.js"></script>
+	<script>
+	async function runTest() {
+		findMediaElement();
+
+		if (!window.internals)
+			return;
+
+		window.options = null;
+		internals.setMockCaptionDisplaySettingsClientCallback(async (element, inOptions) => {
+			options = inOptions;
+		});
+
+		let runPositionTest = async (positionArea, xPositionAreaExpected, yPositionAreaExpected) => {
+			consoleWrite('');
+			await run(`video.showCaptionDisplaySettings({positionArea: "${ positionArea }"})`);
+			testExpected('options.xPositionArea', xPositionAreaExpected);
+			testExpected('options.yPositionArea', yPositionAreaExpected);
+		}
+
+		await runPositionTest('top left', 'Left', 'Top');
+		await runPositionTest('left top', 'Left', 'Top');
+		await runPositionTest('top center', 'Center', 'Top');
+		await runPositionTest('top right', 'Right', 'Top');
+		await runPositionTest('top x-start', 'Left', 'Top');
+		await runPositionTest('top x-end', 'Right', 'Top');
+		await runPositionTest('center center', 'Center', 'Center');
+		await runPositionTest('bottom left', 'Left', 'Bottom');
+		await runPositionTest('left bottom', 'Left', 'Bottom');
+		await runPositionTest('bottom center', 'Center', 'Bottom');
+		await runPositionTest('bottom right', 'Right', 'Bottom');
+		await runPositionTest('bottom x-start', 'Left', 'Bottom');
+		await runPositionTest('bottom x-end', 'Right', 'Bottom');
+	}
+
+	window.addEventListener('load', event => {
+		requestAnimationFrame(() => {
+			runTest().then(endTest).catch(failTest);	
+		});
+	});
+	</script>
+</head>
+<body>
+	<video muted autoplay></video>
+</body>
+</html>

--- a/LayoutTests/media/caption-display-settings/caption-display-settings.html
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CaptionDisplaySettingsEnabled=true ] -->
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>caption-display-settings</title>
+	<script src="../video-test.js"></script>
+	<script>
+	async function runTest() {
+		findMediaElement();
+
+		testExpected('video.showCaptionDisplaySettings', undefined, '!=');
+	}
+
+	window.addEventListener('load', event => {
+		runTest().then(endTest).catch(failTest);
+	});
+	</script>
+</head>
+<body>
+	<video muted autoplay></video>
+</body>
+</html>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1326,6 +1326,7 @@ set(WebCore_NON_SVG_IDL_FILES
     fileapi/FileReader.idl
     fileapi/FileReaderSync.idl
 
+    html/CaptionDisplaySettingsOptions.idl
     html/DOMFormData.idl
     html/DOMTokenList.idl
     html/DOMURL.idl
@@ -1412,6 +1413,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/HTMLTrackElement.idl
     html/HTMLUListElement.idl
     html/HTMLUnknownElement.idl
+    html/HTMLVideoElement+CaptionDisplaySettings.idl
     html/HTMLVideoElement+RequestVideoFrameCallback.idl
     html/HTMLVideoElement.idl
     html/ImageBitmap.idl
@@ -1425,6 +1427,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/OffscreenCanvas.idl
     html/PopoverInvokerElement.idl
     html/RadioNodeList.idl
+    html/ResolvedCaptionDisplaySettingsOptions.idl
     html/SubmitEvent.idl
     html/TextMetrics.idl
     html/TimeRanges.idl
@@ -2483,6 +2486,7 @@ set(WebCoreTestSupport_IDL_FILES
     testing/MallocStatistics.idl
     testing/MemoryInfo.idl
     testing/MockCDMFactory.idl
+    testing/MockCaptionDisplaySettingsClientCallback.idl
     testing/MockContentFilterSettings.idl
     testing/MockPageOverlay.idl
     testing/MockWebAuthenticationConfiguration.idl
@@ -2498,6 +2502,7 @@ list(APPEND WebCoreTestSupport_SOURCES
     testing/InternalsMapLike.cpp
     testing/InternalsSetLike.cpp
     testing/MockCDMFactory.cpp
+    testing/MockCaptionDisplaySettingsClientCallback.cpp
     testing/MockGamepad.cpp
     testing/MockGamepadProvider.cpp
     testing/MockLibWebRTCPeerConnection.cpp

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1614,6 +1614,7 @@ $(PROJECT_DIR)/fileapi/File.idl
 $(PROJECT_DIR)/fileapi/FileList.idl
 $(PROJECT_DIR)/fileapi/FileReader.idl
 $(PROJECT_DIR)/fileapi/FileReaderSync.idl
+$(PROJECT_DIR)/html/CaptionDisplaySettingsOptions.idl
 $(PROJECT_DIR)/html/DOMFormData.idl
 $(PROJECT_DIR)/html/DOMTokenList.idl
 $(PROJECT_DIR)/html/DOMURL.idl
@@ -1703,6 +1704,7 @@ $(PROJECT_DIR)/html/HTMLTitleElement.idl
 $(PROJECT_DIR)/html/HTMLTrackElement.idl
 $(PROJECT_DIR)/html/HTMLUListElement.idl
 $(PROJECT_DIR)/html/HTMLUnknownElement.idl
+$(PROJECT_DIR)/html/HTMLVideoElement+CaptionDisplaySettings.idl
 $(PROJECT_DIR)/html/HTMLVideoElement+RequestVideoFrameCallback.idl
 $(PROJECT_DIR)/html/HTMLVideoElement.idl
 $(PROJECT_DIR)/html/ImageBitmap.idl
@@ -1716,6 +1718,7 @@ $(PROJECT_DIR)/html/MediaError.idl
 $(PROJECT_DIR)/html/OffscreenCanvas.idl
 $(PROJECT_DIR)/html/PopoverInvokerElement.idl
 $(PROJECT_DIR)/html/RadioNodeList.idl
+$(PROJECT_DIR)/html/ResolvedCaptionDisplaySettingsOptions.idl
 $(PROJECT_DIR)/html/SubmitEvent.idl
 $(PROJECT_DIR)/html/TextMetrics.idl
 $(PROJECT_DIR)/html/TimeRanges.idl
@@ -2140,6 +2143,7 @@ $(PROJECT_DIR)/testing/MallocStatistics.idl
 $(PROJECT_DIR)/testing/MemoryInfo.idl
 $(PROJECT_DIR)/testing/MockApplePaySetupFeature.idl
 $(PROJECT_DIR)/testing/MockCDMFactory.idl
+$(PROJECT_DIR)/testing/MockCaptionDisplaySettingsClientCallback.idl
 $(PROJECT_DIR)/testing/MockContentFilterSettings.idl
 $(PROJECT_DIR)/testing/MockPageOverlay.idl
 $(PROJECT_DIR)/testing/MockPaymentAddress.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -608,6 +608,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasTransform.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasTransform.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasUserInterface.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasUserInterface.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaptionDisplaySettingsOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaptionDisplaySettingsOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaretPosition.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaretPosition.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaretPositionFromPointOptions.cpp
@@ -1680,6 +1682,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLUListElement.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLUListElement.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLUnknownElement.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLUnknownElement.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLVideoElement+CaptionDisplaySettings.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLVideoElement+CaptionDisplaySettings.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLVideoElement+PictureInPicture.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLVideoElement+PictureInPicture.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLVideoElement+RequestVideoFrameCallback.cpp
@@ -1990,6 +1994,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMobileDocumentRequest.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMobileDocumentRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCDMFactory.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCDMFactory.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCaptionDisplaySettingsClientCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCaptionDisplaySettingsClientCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockContentFilterSettings.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockContentFilterSettings.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockPageOverlay.cpp
@@ -2616,6 +2622,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverSize.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverSize.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResolvedCaptionDisplaySettingsOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResolvedCaptionDisplaySettingsOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterCondition.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterCondition.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterRule.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1289,6 +1289,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/fileapi/FileList.idl \
     $(WebCore)/fileapi/FileReader.idl \
     $(WebCore)/fileapi/FileReaderSync.idl \
+    $(WebCore)/html/CaptionDisplaySettingsOptions.idl \
     $(WebCore)/html/DOMFormData.idl \
     $(WebCore)/html/DOMTokenList.idl \
     $(WebCore)/html/DOMURL.idl \
@@ -1376,6 +1377,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/HTMLUListElement.idl \
     $(WebCore)/html/HTMLUnknownElement.idl \
     $(WebCore)/html/HTMLVideoElement.idl \
+	$(WebCore)/html/HTMLVideoElement+CaptionDisplaySettings.idl \
     $(WebCore)/html/HTMLVideoElement+RequestVideoFrameCallback.idl \
     $(WebCore)/html/ImageBitmap.idl \
     $(WebCore)/html/ImageBitmapOptions.idl \
@@ -1388,6 +1390,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/OffscreenCanvas.idl \
     $(WebCore)/html/PopoverInvokerElement.idl \
     $(WebCore)/html/RadioNodeList.idl \
+    $(WebCore)/html/ResolvedCaptionDisplaySettingsOptions.idl \
     $(WebCore)/html/SubmitEvent.idl \
     $(WebCore)/html/TextMetrics.idl \
     $(WebCore)/html/TimeRanges.idl \
@@ -1780,6 +1783,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/testing/MallocStatistics.idl \
     $(WebCore)/testing/MemoryInfo.idl \
     $(WebCore)/testing/MockCDMFactory.idl \
+    $(WebCore)/testing/MockCaptionDisplaySettingsClientCallback.idl \
     $(WebCore)/testing/MockContentFilterSettings.idl \
     $(WebCore)/testing/MockPageOverlay.idl \
     $(WebCore)/testing/MockPaymentAddress.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1618,6 +1618,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/CanvasBase.h
     html/CanvasNoiseInjection.h
     html/CanvasObserver.h
+    html/CaptionDisplaySettingsClient.h
+    html/CaptionDisplaySettingsOptions.h
     html/CollectionTraversal.h
     html/CollectionTraversalInlines.h
     html/CollectionType.h
@@ -1731,6 +1733,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/PDFDocument.h
     html/PermissionsPolicy.h
     html/PluginDocument.h
+    html/ResolvedCaptionDisplaySettingsOptions.h
+    html/ResolvedCaptionDisplaySettingsOptionsWrapper.h
     html/StepRange.h
     html/SwitchTrigger.h
     html/TimeRanges.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1622,6 +1622,7 @@ html/HTMLTrackElement.cpp
 html/HTMLUListElement.cpp
 html/HTMLUnknownElement.cpp
 html/HTMLVideoElement.cpp
+html/HTMLVideoElementCaptionDisplaySettings.cpp
 html/HTMLWBRElement.cpp
 html/HiddenInputType.cpp
 html/ImageBitmap.cpp
@@ -3863,6 +3864,7 @@ JSCanvasTextBaseline.cpp
 JSCanvasTextDrawingStyles.cpp
 JSCanvasTransform.cpp
 JSCanvasUserInterface.cpp
+JSCaptionDisplaySettingsOptions.cpp
 JSCaretPosition.cpp
 JSCaretPositionFromPointOptions.cpp
 JSChannelCountMode.cpp

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -45,7 +45,7 @@ public:
     }
 
     enum class IsCallbackRegistered : bool { No, Yes };
-    IsCallbackRegistered whenSettled(Function<void()>&&);
+    WEBCORE_EXPORT IsCallbackRegistered whenSettled(Function<void()>&&);
     JSC::JSValue result() const;
 
     void markAsHandled();

--- a/Source/WebCore/html/CaptionDisplaySettingsClient.h
+++ b/Source/WebCore/html/CaptionDisplaySettingsClient.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FloatRect.h>
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/CompletionHandler.h>
+
+namespace WebCore {
+
+class HTMLMediaElement;
+struct ResolvedCaptionDisplaySettingsOptions;
+template<typename> class ExceptionOr;
+
+class CaptionDisplaySettingsClient : public AbstractRefCounted {
+public:
+    virtual ~CaptionDisplaySettingsClient() = default;
+    virtual void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&) = 0;
+};
+
+}
+

--- a/Source/WebCore/html/CaptionDisplaySettingsOptions.h
+++ b/Source/WebCore/html/CaptionDisplaySettingsOptions.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/Node.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+struct CaptionDisplaySettingsOptions {
+    RefPtr<Node> anchorNode;
+    String positionArea;
+};
+
+}

--- a/Source/WebCore/html/CaptionDisplaySettingsOptions.idl
+++ b/Source/WebCore/html/CaptionDisplaySettingsOptions.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+typedef USVString CSSOMString;
+
+[Conditional=VIDEO] dictionary CaptionDisplaySettingsOptions {
+    Node? anchorNode;
+    CSSOMString? positionArea;
+};

--- a/Source/WebCore/html/HTMLVideoElement+CaptionDisplaySettings.idl
+++ b/Source/WebCore/html/HTMLVideoElement+CaptionDisplaySettings.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=VIDEO,
+    EnabledBySetting=CaptionDisplaySettingsEnabled,
+    Exposed=Window,
+    ImplementedBy=HTMLVideoElementCaptionDisplaySettings,
+] partial interface HTMLVideoElement {
+    Promise<undefined> showCaptionDisplaySettings(optional CaptionDisplaySettingsOptions options);
+};

--- a/Source/WebCore/html/HTMLVideoElementCaptionDisplaySettings.cpp
+++ b/Source/WebCore/html/HTMLVideoElementCaptionDisplaySettings.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "HTMLVideoElementCaptionDisplaySettings.h"
+
+#if ENABLE(VIDEO)
+
+#include "CSSParserContext.h"
+#include "CSSParserMode.h"
+#include "CSSParserTokenRange.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSPropertyParserConsumer+Anchor.h"
+#include "CSSPropertyParserState.h"
+#include "CSSTokenizer.h"
+#include "CSSValuePair.h"
+#include "CaptionDisplaySettingsOptions.h"
+#include "Element.h"
+#include "HTMLVideoElement.h"
+#include "JSDOMPromiseDeferred.h"
+#include "ResolvedCaptionDisplaySettingsOptions.h"
+
+namespace WebCore {
+
+static void parsePositionAreaString(const String& positionArea, ResolvedCaptionDisplaySettingsOptions& options)
+{
+    CSSParserContext context { HTMLStandardMode };
+    CSS::PropertyParserState state { context };
+    CSSTokenizer tokenizer { positionArea };
+
+    auto tokenRange = tokenizer.tokenRange();
+
+    options.xPositionArea = std::nullopt;
+    options.yPositionArea = std::nullopt;
+
+    RefPtr value = CSSPropertyParserHelpers::consumePositionArea(tokenRange, state);
+    if (!value)
+        return;
+
+    RefPtr valuePair = dynamicDowncast<CSSValuePair>(value.get());
+    if (!valuePair)
+        return;
+
+    RefPtr firstValue = valuePair->first();
+    RefPtr secondValue = valuePair->second();
+
+    if (!firstValue->isValueID() || !secondValue->isValueID())
+        return;
+
+    using XPositionArea = ResolvedCaptionDisplaySettingsOptions::XPositionArea;
+    switch (firstValue->valueID()) {
+    case CSSValueLeft:
+    case CSSValueSpanLeft:
+    case CSSValueXStart:
+    case CSSValueSpanXStart:
+    case CSSValueSelfXStart:
+    case CSSValueSpanSelfXStart:
+        options.xPositionArea = XPositionArea::Left;
+        break;
+
+    case CSSValueCenter:
+        options.xPositionArea = XPositionArea::Center;
+        break;
+
+    case CSSValueRight:
+    case CSSValueSpanRight:
+    case CSSValueXEnd:
+    case CSSValueSpanXEnd:
+    case CSSValueSelfXEnd:
+    case CSSValueSpanSelfXEnd:
+        options.xPositionArea = XPositionArea::Right;
+        break;
+
+    default:
+        return;
+    }
+
+    using YPositionArea = ResolvedCaptionDisplaySettingsOptions::YPositionArea;
+    switch (secondValue->valueID()) {
+    case CSSValueTop:
+    case CSSValueSpanTop:
+    case CSSValueYStart:
+    case CSSValueSpanYStart:
+    case CSSValueSelfYStart:
+    case CSSValueSpanSelfYStart:
+        options.yPositionArea = YPositionArea::Top;
+        break;
+
+    case CSSValueCenter:
+        options.yPositionArea = YPositionArea::Center;
+        break;
+
+    case CSSValueBottom:
+    case CSSValueSpanBottom:
+    case CSSValueYEnd:
+    case CSSValueSpanYEnd:
+    case CSSValueSelfYEnd:
+    case CSSValueSpanSelfYEnd:
+        options.yPositionArea = YPositionArea::Bottom;
+        break;
+
+    default:
+        return;
+    }
+}
+
+void HTMLVideoElementCaptionDisplaySettings::showCaptionDisplaySettings(HTMLVideoElement& element, std::optional<CaptionDisplaySettingsOptions>&& options, Ref<DeferredPromise>&& promise)
+{
+    RefPtr page = element.document().page();
+    if (!page) {
+        promise->reject();
+        return;
+    }
+
+    ResolvedCaptionDisplaySettingsOptions resolvedOptions;
+    if (options) {
+        if (RefPtr anchorElement = dynamicDowncast<Element>(options->anchorNode.get()))
+            resolvedOptions.anchorBounds = anchorElement->boundingBoxInRootViewCoordinates();
+        if (!options->positionArea.isEmpty())
+            parsePositionAreaString(options->positionArea, resolvedOptions);
+    }
+
+    element.showCaptionDisplaySettingsPreview();
+
+    page->showCaptionDisplaySettings(element, resolvedOptions, [weakElement = WeakPtr { element }, promise = WTFMove(promise)] (ExceptionOr<void>&& result) {
+
+        if (RefPtr element = weakElement.get())
+            element->hideCaptionDisplaySettingsPreview();
+
+        if (result.hasException())
+            promise->reject(result.releaseException());
+        else
+            promise->resolve();
+
+    });
+}
+
+}
+
+#endif

--- a/Source/WebCore/html/HTMLVideoElementCaptionDisplaySettings.h
+++ b/Source/WebCore/html/HTMLVideoElementCaptionDisplaySettings.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO)
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class HTMLVideoElement;
+
+struct CaptionDisplaySettingsOptions;
+
+class HTMLVideoElementCaptionDisplaySettings {
+public:
+    static void showCaptionDisplaySettings(HTMLVideoElement&, std::optional<CaptionDisplaySettingsOptions>&&, Ref<DeferredPromise>&&);
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptions.h
+++ b/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptions.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FloatRect.h>
+
+namespace WebCore {
+
+enum class ResolvedCaptionDisplaySettingsOptionsXPositionArea : uint8_t {
+    Center,
+    Left,
+    Right,
+};
+
+enum class ResolvedCaptionDisplaySettingsOptionsYPositionArea : uint8_t {
+    Center,
+    Top,
+    Bottom,
+};
+
+struct ResolvedCaptionDisplaySettingsOptions {
+    std::optional<WebCore::FloatRect> anchorBounds;
+
+    using XPositionArea = ResolvedCaptionDisplaySettingsOptionsXPositionArea;
+    std::optional<XPositionArea> xPositionArea;
+
+    using YPositionArea = ResolvedCaptionDisplaySettingsOptionsYPositionArea;
+    std::optional<YPositionArea> yPositionArea;
+};
+
+}

--- a/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptions.idl
+++ b/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptions.idl
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+enum ResolvedCaptionDisplaySettingsOptionsXPositionArea {
+    "Center",
+    "Left",
+    "Right",
+};
+
+enum ResolvedCaptionDisplaySettingsOptionsYPositionArea {
+    "Center",
+    "Top",
+    "Bottom",
+};
+
+[
+    ExportMacro=WEBCORE_EXPORT,
+    JSGenerateToJSObject,
+    ImplementedAs=ResolvedCaptionDisplaySettingsOptionsWrapper
+]
+dictionary ResolvedCaptionDisplaySettingsOptions {
+    DOMRect? anchorBounds;
+    ResolvedCaptionDisplaySettingsOptionsXPositionArea? xPositionArea;
+    ResolvedCaptionDisplaySettingsOptionsYPositionArea? yPositionArea;
+};

--- a/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptionsWrapper.h
+++ b/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptionsWrapper.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/DOMRect.h>
+#include <WebCore/ResolvedCaptionDisplaySettingsOptions.h>
+
+namespace WebCore {
+
+struct ResolvedCaptionDisplaySettingsOptionsWrapper {
+    RefPtr<DOMRect> anchorBounds;
+
+    using XPositionArea = ResolvedCaptionDisplaySettingsOptions::XPositionArea;
+    std::optional<XPositionArea> xPositionArea;
+
+    using YPositionArea = ResolvedCaptionDisplaySettingsOptions::YPositionArea;
+    std::optional<YPositionArea> yPositionArea;
+
+    ResolvedCaptionDisplaySettingsOptionsWrapper() = default;
+    ResolvedCaptionDisplaySettingsOptionsWrapper(const ResolvedCaptionDisplaySettingsOptions& options)
+        : xPositionArea { options.xPositionArea }
+        , yPositionArea { options.yPositionArea }
+    {
+        if (options.anchorBounds)
+            anchorBounds = DOMRect::create(*options.anchorBounds);
+    }
+};
+
+}

--- a/Source/WebCore/page/ChromeClient.cpp
+++ b/Source/WebCore/page/ChromeClient.cpp
@@ -127,4 +127,11 @@ void ChromeClient::requestTextRecognition(Element&, TextRecognitionOptions&&, Co
 }
 #endif
 
+#if ENABLE(VIDEO)
+void ChromeClient::showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
+{
+    completionHandler(Exception { ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s });
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -164,6 +164,7 @@ struct DateTimeChooserParameters;
 struct FocusOptions;
 struct GraphicsDeviceAdapter;
 struct MockWebAuthenticationConfiguration;
+struct ResolvedCaptionDisplaySettingsOptions;
 struct ShareDataWithParsedURL;
 struct SimpleRange;
 struct StringWithDirection;
@@ -778,7 +779,7 @@ public:
     virtual bool usePluginRendererScrollableArea(LocalFrame&) const { return true; }
 
 #if ENABLE(VIDEO)
-    virtual void showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback) { callback(false); }
+    WEBCORE_EXPORT virtual void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&);
 #endif
 
     WEBCORE_EXPORT virtual ~ChromeClient();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -43,6 +43,7 @@
 #include "BroadcastChannelRegistry.h"
 #include "CacheStorageProvider.h"
 #include "CachedImage.h"
+#include "CaptionDisplaySettingsClient.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "CommonAtomStrings.h"
@@ -6109,6 +6110,28 @@ void Page::didUpdateHardwareKeyboardAttachment(bool attached)
 
     m_hardwareKeyboardAttached = attached;
     flushHardwareKeyboardAttachmentObservers();
+}
+#endif
+
+#if ENABLE(VIDEO)
+void Page::setCaptionDisplaySettingsClientForTesting(Ref<CaptionDisplaySettingsClient>&& client)
+{
+    m_captionDisplaySettingsClientForTesting = WTFMove(client);
+}
+
+void Page::clearCaptionDisplaySettingsClientForTesting()
+{
+    m_captionDisplaySettingsClientForTesting = nullptr;
+}
+
+void Page::showCaptionDisplaySettings(HTMLMediaElement& element, const ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(ExceptionOr<void>)>&& callback)
+{
+    if (RefPtr client = m_captionDisplaySettingsClientForTesting) {
+        client->showCaptionDisplaySettings(element, options, WTFMove(callback));
+        return;
+    }
+
+    chrome().client().showCaptionDisplaySettings(element, options, WTFMove(callback));
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -109,6 +109,7 @@ class BackForwardController;
 class BadgeClient;
 class BroadcastChannelRegistry;
 class CacheStorageProvider;
+class CaptionDisplaySettingsClient;
 class Chrome;
 class CompositeEditCommand;
 class ContextMenuController;
@@ -231,6 +232,7 @@ struct ClientOrigin;
 struct DocumentSyncSerializationData;
 struct FixedContainerEdges;
 struct NavigationAPIMethodTracker;
+struct ResolvedCaptionDisplaySettingsOptions;
 struct SpatialBackdropSource;
 struct SystemPreviewInfo;
 struct TextRecognitionResult;
@@ -1398,6 +1400,13 @@ public:
 
     WEBCORE_EXPORT void clearIsShowingInputView();
 #endif
+
+#if ENABLE(VIDEO)
+    WEBCORE_EXPORT void setCaptionDisplaySettingsClientForTesting(Ref<CaptionDisplaySettingsClient>&&);
+    WEBCORE_EXPORT void clearCaptionDisplaySettingsClientForTesting();
+    void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&);
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1878,6 +1887,9 @@ private:
     void flushHardwareKeyboardAttachmentObservers();
 #endif
 
+#if ENABLE(VIDEO)
+    RefPtr<CaptionDisplaySettingsClient> m_captionDisplaySettingsClientForTesting;
+#endif
 }; // class Page
 
 WTF::TextStream& operator<<(WTF::TextStream&, RenderingUpdateStep);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -310,6 +310,7 @@
 #if ENABLE(VIDEO)
 #include "CaptionUserPreferences.h"
 #include "HTMLMediaElement.h"
+#include "MockCaptionDisplaySettingsClientCallback.h"
 #include "PageGroup.h"
 #include "TextTrack.h"
 #include "TextTrackCueGeneric.h"
@@ -4850,6 +4851,31 @@ void Internals::showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElemen
 void Internals::hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement& element)
 {
     element.hideCaptionDisplaySettingsPreview();
+}
+
+void Internals::setMockCaptionDisplaySettingsClientCallback(RefPtr<MockCaptionDisplaySettingsClientCallback>&& callback)
+{
+    if (m_mockCaptionDisplaySettingsClientCallback == callback)
+        return;
+
+    m_mockCaptionDisplaySettingsClientCallback = WTFMove(callback);
+
+    auto frame = this->frame();
+    if (!frame)
+        return;
+
+    auto page = frame->page();
+    if (!page)
+        return;
+
+    page->clearCaptionDisplaySettingsClientForTesting();
+    if (m_mockCaptionDisplaySettingsClientCallback)
+        page->setCaptionDisplaySettingsClientForTesting(*m_mockCaptionDisplaySettingsClientCallback);
+}
+
+MockCaptionDisplaySettingsClientCallback* Internals::mockCaptionDisplaySettingsClientCallback() const
+{
+    return m_mockCaptionDisplaySettingsClientCallback.get();
 }
 
 #endif

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -116,6 +116,7 @@ class MediaStreamTrack;
 class MemoryInfo;
 class MessagePort;
 class MockCDMFactory;
+class MockCaptionDisplaySettingsClientCallback;
 class MockContentFilterSettings;
 class MockPageOverlay;
 class MockPaymentCoordinator;
@@ -846,6 +847,8 @@ public:
     void showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement&);
     void hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement&);
 
+    void setMockCaptionDisplaySettingsClientCallback(RefPtr<MockCaptionDisplaySettingsClientCallback>&&);
+    MockCaptionDisplaySettingsClientCallback* mockCaptionDisplaySettingsClientCallback() const;
 #endif
 
     ExceptionOr<Ref<DOMRect>> selectionBounds();
@@ -1720,6 +1723,7 @@ private:
 #endif
 #if ENABLE(VIDEO)
     std::unique_ptr<CaptionUserPreferencesTestingModeToken> m_testingModeToken;
+    RefPtr<MockCaptionDisplaySettingsClientCallback> m_mockCaptionDisplaySettingsClientCallback;
 #endif
 };
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1026,6 +1026,7 @@ enum ContentsFormat {
 
     [Conditional=VIDEO] undefined showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
     [Conditional=VIDEO] undefined hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
+    [Conditional=VIDEO] undefined setMockCaptionDisplaySettingsClientCallback(MockCaptionDisplaySettingsClientCallback? callback);
 
     boolean isSelectPopupVisible(HTMLSelectElement element);
 

--- a/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.cpp
+++ b/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MockCaptionDisplaySettingsClientCallback.h"
+
+#include "ExceptionOr.h"
+#include "JSDOMPromise.h"
+
+namespace WebCore {
+
+void MockCaptionDisplaySettingsClientCallback::showCaptionDisplaySettings(HTMLMediaElement& element, const ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
+{
+    if (!hasCallback()) {
+        completionHandler(Exception { ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s });
+        return;
+    }
+
+    if (RefPtr promise = invoke(element, options).releaseReturnValue()) {
+        promise->whenSettled([completionHandler = WTFMove(completionHandler)] () mutable {
+            completionHandler({ });
+        });
+    }
+}
+
+
+}

--- a/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h
+++ b/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/ActiveDOMCallback.h>
+#include <WebCore/CallbackResult.h>
+#include <WebCore/CaptionDisplaySettingsClient.h>
+#include <WebCore/ResolvedCaptionDisplaySettingsOptionsWrapper.h>
+
+namespace WebCore {
+
+class DOMPromise;
+class HTMLMediaElement;
+struct ResolvedCaptionDisplaySettingsOptions;
+
+class MockCaptionDisplaySettingsClientCallback
+    : public RefCounted<MockCaptionDisplaySettingsClientCallback>
+    , public ActiveDOMCallback
+    , public CaptionDisplaySettingsClient {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+    void ref() const override { RefCounted::ref(); }
+    void deref() const override { RefCounted::deref(); }
+
+    virtual CallbackResult<RefPtr<DOMPromise>> invoke(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptionsWrapper&) = 0;
+
+    void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&) override;
+
+private:
+    virtual bool hasCallback() const = 0;
+};
+
+}

--- a/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.idl
+++ b/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    GenerateIsReachable=ImplScriptExecutionContext
+] callback MockCaptionDisplaySettingsClientCallback = Promise<undefined> (HTMLMediaElement element, ResolvedCaptionDisplaySettingsOptions options);

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -85,11 +85,11 @@ public:
     // forbidExecution()/isExecutionForbidden() to guard against reentry into JS.
     // Can be called from any thread.
     void scheduleExecutionTermination();
-    bool isTerminatingExecution() const;
+    WEBCORE_EXPORT bool isTerminatingExecution() const;
 
     // Called on Worker thread when JS exits with termination exception caused by forbidExecution() request,
     // or by Worker thread termination code to prevent future entry into JS.
-    void forbidExecution();
+    WEBCORE_EXPORT void forbidExecution();
     bool isExecutionForbidden() const;
 
     JSC::VM& vm() { return *m_vm; }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9047,3 +9047,24 @@ struct WebCore::FocusOptions {
 };
 
 enum class WebKit::CommitTiming : bool;
+
+header: <WebCore/ResolvedCaptionDisplaySettingsOptions.h>
+[CustomHeader] enum class WebCore::ResolvedCaptionDisplaySettingsOptionsXPositionArea : uint8_t {
+    Center,
+    Left,
+    Right,
+};
+
+header: <WebCore/ResolvedCaptionDisplaySettingsOptions.h>
+[CustomHeader] enum class WebCore::ResolvedCaptionDisplaySettingsOptionsYPositionArea : uint8_t {
+    Center,
+    Top,
+    Bottom,
+};
+
+header: <WebCore/ResolvedCaptionDisplaySettingsOptions.h>
+[CustomHeader] struct WebCore::ResolvedCaptionDisplaySettingsOptions {
+    std::optional<WebCore::FloatRect> anchorBounds;
+    std::optional<WebCore::ResolvedCaptionDisplaySettingsOptionsXPositionArea> xPositionArea;
+    std::optional<WebCore::ResolvedCaptionDisplaySettingsOptionsYPositionArea> yPositionArea;
+};

--- a/Source/WebKit/UIProcess/PageClient.cpp
+++ b/Source/WebKit/UIProcess/PageClient.cpp
@@ -50,4 +50,11 @@ CheckedRef<WebCore::WebMediaSessionManager> PageClient::checkedMediaSessionManag
 }
 #endif
 
+#if ENABLE(VIDEO)
+void PageClient::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
+{
+    completionHandler(makeUnexpected<WebCore::ExceptionData>({ WebCore::ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s }));
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -137,6 +137,7 @@ struct DataDetectorElementInfo;
 struct DictionaryPopupInfo;
 struct ElementContext;
 struct FixedContainerEdges;
+struct ResolvedCaptionDisplaySettingsOptions;
 struct TextIndicatorData;
 struct ShareDataWithParsedURL;
 
@@ -847,7 +848,7 @@ public:
 #endif
 
 #if ENABLE(VIDEO)
-    virtual void showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback) { callback(false); }
+    virtual void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&);
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1488,14 +1488,14 @@ void WebPageProxy::setBrowsingContextGroup(BrowsingContextGroup& browsingContext
 }
 
 #if ENABLE(VIDEO)
-void WebPageProxy::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback)
+void WebPageProxy::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier identifier, const WebCore::ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     if (RefPtr pageClient = this->pageClient()) {
-        pageClient->showCaptionDisplaySettings(WTFMove(callback));
+        pageClient->showCaptionDisplaySettings(identifier, options, WTFMove(completionHandler));
         return;
     }
 
-    callback(false);
+    completionHandler(makeUnexpected<WebCore::ExceptionData>({ ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s }));
 }
 
 void WebPageProxy::showCaptionDisplaySettingsPreview(const FrameInfoData& frameInfo, WebCore::HTMLMediaElementIdentifier identifier)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -271,6 +271,7 @@ struct DictionaryPopupInfo;
 struct DocumentSyncSerializationData;
 struct DragItem;
 struct ElementContext;
+struct ExceptionData;
 struct ExceptionDetails;
 struct FileChooserSettings;
 struct FocusOptions;
@@ -337,7 +338,6 @@ struct WrappedCryptoKey;
 struct MockWebAuthenticationConfiguration;
 struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
-struct ExceptionData;
 struct MobileDocumentRequest;
 struct OpenID4VPRequest;
 #endif
@@ -436,9 +436,10 @@ class ShareableBitmapHandle;
 class ShareableResourceHandle;
 class Site;
 class TransformationMatrix;
+struct NodeIdentifierType;
+struct ResolvedCaptionDisplaySettingsOptions;
 struct TextAnimationData;
 enum class ImageDecodingError : uint8_t;
-struct NodeIdentifierType;
 enum class ExceptionCode : uint8_t;
 
 using NodeIdentifier = ObjectIdentifier<NodeIdentifierType>;
@@ -3468,7 +3469,7 @@ private:
     void setBrowsingContextGroup(BrowsingContextGroup&);
 
 #if ENABLE(VIDEO)
-    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&);
+    void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&);
 #endif
 
     struct Internals;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -675,6 +675,6 @@ messages -> WebPageProxy {
     SetAllowsLayoutViewportHeightExpansion(bool newValue)
 
 #if ENABLE(VIDEO)
-    ShowCaptionDisplaySettings() -> (bool success)
+    ShowCaptionDisplaySettings(WebCore::MediaPlayerClientIdentifier identifier, struct WebCore::ResolvedCaptionDisplaySettingsOptions options) -> (Expected<void, WebCore::ExceptionData> response)
 #endif
 }

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -382,6 +382,10 @@ private:
     void endPointerLockMouseTracking() final;
 #endif
 
+#if ENABLE(VIDEO)
+    void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&) final;
+#endif
+
     RetainPtr<WKContentView> contentView() const { return m_contentView.get(); }
 
     WeakObjCPtr<WKContentView> m_contentView;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -80,6 +80,7 @@
 #import <WebCore/NotImplemented.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/PromisedAttachmentInfo.h>
+#import <WebCore/ResolvedCaptionDisplaySettingsOptions.h>
 #import <WebCore/ScreenOrientationType.h>
 #import <WebCore/ShareData.h>
 #import <WebCore/SharedBuffer.h>
@@ -1392,6 +1393,15 @@ void PageClientImpl::removeAnyPDFPageNumberIndicator()
 }
 
 #endif
+
+void PageClientImpl::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier identifier, const WebCore::ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
+{
+#if USE(UICONTEXTMENU)
+    [contentView() showCaptionDisplaySettingsMenu:identifier withOptions:options completionHandler:WTFMove(completionHandler)];
+#else
+    completionHandler(makeUnexpected<WebCore::ExceptionData>({ ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s }));
+#endif
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
@@ -32,6 +32,7 @@
 #import <WebCore/HTMLMediaElementIdentifier.h>
 #import <WebCore/MediaControlsContextMenuItem.h>
 #import <pal/spi/ios/DataDetectorsUISPI.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/Forward.h>
 #import <wtf/RetainPtr.h>
 
@@ -121,6 +122,9 @@ UIContextMenuInteractionDelegate>
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 - (void)showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items frameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
+#if ENABLE(VIDEO) && USE(UICONTEXTMENU)
+- (void)showCaptionDisplaySettingsMenu:(WebCore::HTMLMediaElementIdentifier)identifier withOptions:(const WebCore::ResolvedCaptionDisplaySettingsOptions&)options completionHandler:(CompletionHandler<void(Expected<void, WebCore::ExceptionData>)>&&)completionHandler;
+#endif
 - (void)cleanupSheet;
 - (void)updateSheetPosition;
 - (RetainPtr<NSArray<_WKElementAction *>>)defaultActionsForLinkSheet:(_WKActivatedElementInfo *)elementInfo;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -982,6 +982,10 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items frameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
+#if ENABLE(VIDEO) && USE(UICONTEXTMENU)
+- (void)showCaptionDisplaySettingsMenu:(WebCore::HTMLMediaElementIdentifier)identifier withOptions:(const WebCore::ResolvedCaptionDisplaySettingsOptions&)options completionHandler:(CompletionHandler<void(Expected<void, WebCore::ExceptionData>)>&&)completionHandler;
+#endif
+
 - (BOOL)_formControlRefreshEnabled;
 
 - (WebCore::DataOwnerType)_dataOwnerForPasteboard:(WebKit::PasteboardAccessIntent)intent;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12281,6 +12281,13 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 }
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
+#if ENABLE(VIDEO) && USE(UICONTEXTMENU)
+- (void)showCaptionDisplaySettingsMenu:(WebCore::HTMLMediaElementIdentifier)identifier withOptions:(const WebCore::ResolvedCaptionDisplaySettingsOptions&)options completionHandler:(CompletionHandler<void(Expected<void, WebCore::ExceptionData>)>&&)completionHandler
+{
+    [_actionSheetAssistant showCaptionDisplaySettingsMenu:identifier withOptions:options completionHandler:WTFMove(completionHandler)];
+}
+#endif
+
 #if HAVE(UI_POINTER_INTERACTION)
 
 - (void)setUpPointerInteraction

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -327,7 +327,7 @@ private:
 #endif
 
 #if ENABLE(VIDEO)
-    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&) final;
+    void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&) final;
 #endif
 
     CheckedPtr<WebViewImpl> checkedImpl() const { return m_impl.get(); }

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1182,9 +1182,9 @@ void PageClientImpl::didChangeLocalInspectorAttachment()
 #endif
 }
 
-void PageClientImpl::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback)
+void PageClientImpl::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier identifier, const WebCore::ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    checkedImpl()->showCaptionDisplaySettings(WTFMove(callback));
+    checkedImpl()->showCaptionDisplaySettings(identifier, options, WTFMove(completionHandler));
 }
 
 RetainPtr<NSView> PageClient::protectedViewForPresentingRevealPopover() const

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -132,6 +132,8 @@ struct TextRecognitionResult;
 struct TranslationContextMenuInfo;
 #endif
 
+template<typename> class ExceptionOr;
+
 namespace WritingTools {
 enum class ReplacementBehavior : uint8_t;
 }
@@ -187,6 +189,7 @@ using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
 
 namespace WebCore {
 struct DragItem;
+struct ResolvedCaptionDisplaySettingsOptions;
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)
 struct DigitalCredentialsRequestData;
@@ -211,6 +214,7 @@ class WebFrameProxy;
 class WebPageProxy;
 class WebProcessPool;
 class WebProcessProxy;
+
 struct WebHitTestResultData;
 
 enum class ContinueUnsafeLoad : bool;
@@ -818,7 +822,7 @@ public:
 #endif
 
 #if ENABLE(VIDEO)
-    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&);
+    void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&);
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionDisplaySettingsOptions.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionDisplaySettingsOptions.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FloatRect.h>
+#include <WebCore/HTMLMediaElementIdentifier.h>
+
+namespace WebCore {
+
+struct WebCaptionDisplaySettingsOptions {
+    HTMLMediaElementIdentifier identifier;
+    std::optional<WebCore::FloatRect> anchorBounds;
+
+    enum class PositionArea {
+        Center,
+        TopLeft,
+        TopCenter,
+        TopRight,
+        CenterLeft,
+        CenterRight,
+        BottomLeft,
+        BottomCenter,
+        BottomRight,
+    };
+    std::optional<PositionArea> positionArea;
+};
+
+}

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2383,15 +2383,20 @@ bool WebChromeClient::usePluginRendererScrollableArea(LocalFrame& frame) const
     return true;
 }
 
-void WebChromeClient::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback)
+void WebChromeClient::showCaptionDisplaySettings(HTMLMediaElement& element, const ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
 {
     RefPtr page = m_page.get();
     if (!page) {
-        callback(false);
+        completionHandler(Exception { ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s });
         return;
     }
 
-    page->sendWithAsyncReply(Messages::WebPageProxy::ShowCaptionDisplaySettings(), WTFMove(callback));
+    page->sendWithAsyncReply(Messages::WebPageProxy::ShowCaptionDisplaySettings(element.identifier(), options), [completionHandler = WTFMove(completionHandler)] (auto&& expected) mutable {
+        if (expected)
+            completionHandler({ });
+        else
+            completionHandler(expected.error().toException());
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -578,7 +578,7 @@ private:
     bool usePluginRendererScrollableArea(WebCore::LocalFrame&) const final;
 
 #if ENABLE(VIDEO)
-    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&) final;
+    void showCaptionDisplaySettings(WebCore::HTMLMediaElement&, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(WebCore::ExceptionOr<void>)>&&) final;
 #endif
 
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };


### PR DESCRIPTION
#### 79fb1f414fe35c868ee79a0c859d31bf29fab720
<pre>
[Cocoa] Add support for experimental showCaptionDisplaySettings() API
<a href="https://rdar.apple.com/164744943">rdar://164744943</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302547">https://bugs.webkit.org/show_bug.cgi?id=302547</a>

Reviewed by Eric Carlson.

In <a href="https://github.com/WebKit/explainers/tree/main/CaptionDisplaySettings">https://github.com/WebKit/explainers/tree/main/CaptionDisplaySettings</a>, WebKit proposed
a new API which allows web apps to trigger a system-provided UI for picking subtitle
display styles. This patch adds initial support for that API.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/CaptionDisplaySettingsOptions.h: Copied from Source/WebKit/UIProcess/PageClient.cpp.
* Source/WebCore/html/CaptionDisplaySettingsOptions.idl: Copied from Source/WebKit/UIProcess/PageClient.cpp.
* Source/WebCore/html/HTMLVideoElement+CaptionDisplaySettings.idl: Copied from Source/WebKit/UIProcess/PageClient.cpp.
* Source/WebCore/html/HTMLVideoElementCaptionDisplaySettings.cpp: Added.
(WebCore::parsePositionAreaString):
(WebCore::HTMLVideoElementCaptionDisplaySettings::showCaptionDisplaySettings):
* Source/WebCore/html/HTMLVideoElementCaptionDisplaySettings.h: Copied from Source/WebKit/UIProcess/PageClient.cpp.
* Source/WebCore/page/ChromeClient.cpp:
(WebCore::ChromeClient::showCaptionDisplaySettings):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::showCaptionDisplaySettings): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/PageClient.cpp:
(WebKit::PageClient::showCaptionDisplaySettings):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::showCaptionDisplaySettings): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showCaptionDisplaySettings):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::showCaptionDisplaySettings):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant _resetMediaControlsContextMenuPresenter]):
(-[WKActionSheetAssistant captionStyleMenuDidClose:]):
(-[WKActionSheetAssistant showCaptionDisplaySettingsMenu:withOptions:completionHandler:]):
(-[WKActionSheetAssistant contextMenuInteraction:willEndForConfiguration:animator:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView showCaptionDisplaySettingsMenu:withOptions:completionHandler:]):
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::showCaptionDisplaySettings):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::showCaptionDisplaySettings):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::showCaptionDisplaySettings):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/303334@main">https://commits.webkit.org/303334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b9ae82f599a35bc489b4231bd44cfc38ba38282

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83914 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e3ba73f-e593-40a2-9e61-f9dda49009c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100912 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb212d96-ba77-4c77-bcfd-23f573dade5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81702 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72a253a0-c158-46b0-b1a8-44f62eb17955) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3062 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82741 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142168 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4171 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109280 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3160 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114507 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57392 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4224 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32902 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4184 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->