### PR TITLE
[Site Isolation] Begin filling out and connecting RemoteMediaSessionManager and RemoteMediaSessionManagerProxy

### DIFF
--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -628,9 +628,6 @@ void MediaSessionManagerInterface::addSession(PlatformMediaSessionInterface& ses
 {
 #if !RELEASE_LOG_DISABLED && (ENABLE(VIDEO) || ENABLE(WEB_AUDIO))
     m_logger->addLogger(session.protectedLogger());
-#endif
-
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
     MEDIASESSIONMANAGERINTERFACE_RELEASE_LOG(ADDSESSION, session.logIdentifier());
 #endif
 

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -167,6 +167,10 @@ public:
     virtual void scheduleSessionStatusUpdate() { }
     virtual void resetSessionState() { };
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const final;
+#endif
+
 protected:
     MediaSessionManagerInterface(PageIdentifier);
 
@@ -200,7 +204,6 @@ protected:
     void scheduleStateLog();
     void dumpSessionStates();
 
-    const Logger& logger() const final { return m_logger; }
     uint64_t logIdentifier() const final { return 0; }
     ASCIILiteral logClassName() const override { return "MediaSessionManagerInterface"_s; }
     WTFLogChannel& logChannel() const final;
@@ -239,5 +242,9 @@ private:
     bool m_becameActive { false };
 #endif
 };
+
+#if !RELEASE_LOG_DISABLED
+inline const Logger& MediaSessionManagerInterface::logger() const { return m_logger; }
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class PlatformMediaSession : public PlatformMediaSessionInterface {
+class WEBCORE_EXPORT PlatformMediaSession : public PlatformMediaSessionInterface {
     WTF_MAKE_TZONE_ALLOCATED(PlatformMediaSession);
 public:
     static Ref<PlatformMediaSession> create(PlatformMediaSessionClient& client)
@@ -82,7 +82,7 @@ public:
 
     bool canPlayConcurrently(const PlatformMediaSessionInterface&) const final;
 
-    WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlaybackControlsPurpose) final;
+    WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlaybackControlsPurpose) override;
 
     bool isActiveNowPlayingSession() const final { return m_isActiveNowPlayingSession; }
     void setActiveNowPlayingSession(bool) final;

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -54,7 +54,7 @@ class PlatformMediaSession;
 class PlatformMediaSessionInterface;
 class PlatformMediaSessionManager;
 
-class PlatformMediaSessionClient : public CanMakeCheckedPtr<PlatformMediaSessionClient> {
+class WEBCORE_EXPORT PlatformMediaSessionClient : public CanMakeCheckedPtr<PlatformMediaSessionClient> {
     WTF_MAKE_NONCOPYABLE(PlatformMediaSessionClient);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(PlatformMediaSessionClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformMediaSessionClient);
@@ -117,7 +117,7 @@ protected:
 
 PlatformMediaSessionClient& emptyPlatformMediaSessionClient();
 
-class PlatformMediaSessionInterface
+class WEBCORE_EXPORT PlatformMediaSessionInterface
     : public RefCountedAndCanMakeWeakPtr<PlatformMediaSessionInterface>
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     , public MediaPlaybackTargetClient
@@ -223,6 +223,7 @@ public:
 
     virtual bool isLongEnoughForMainContent() const { return false; }
 
+    void setMediaSessionIdentifier(MediaSessionIdentifier);
     virtual MediaSessionIdentifier mediaSessionIdentifier() const { return m_mediaSessionIdentifier; }
 
     virtual bool isActiveNowPlayingSession() const = 0;
@@ -238,7 +239,8 @@ public:
     virtual bool isPlayingOnSecondScreen() const { return client().isPlayingOnSecondScreen(); }
 
     void invalidateClient() { m_client = emptyPlatformMediaSessionClient(); }
-    PlatformMediaSessionClient& client() const { return m_client; }
+    PlatformMediaSessionClient& client() const;
+    CheckedRef<PlatformMediaSessionClient> checkedClient() const;
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
@@ -262,5 +264,9 @@ private:
     MediaSessionIdentifier m_mediaSessionIdentifier;
     bool m_hasPlayedAudiblySinceLastInterruption { false };
 };
+
+inline void PlatformMediaSessionInterface::setMediaSessionIdentifier(MediaSessionIdentifier identifier) { m_mediaSessionIdentifier = identifier; }
+inline PlatformMediaSessionClient& PlatformMediaSessionInterface::client() const { return m_client; }
+inline CheckedRef<PlatformMediaSessionClient> PlatformMediaSessionInterface::checkedClient() const { return m_client; }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -72,6 +72,12 @@ void PlatformMediaSessionManager::addSession(PlatformMediaSessionInterface& sess
     MediaSessionManagerInterface::addSession(session);
 }
 
+WeakListHashSet<PlatformMediaSessionInterface>& PlatformMediaSessionManager::sessions() const
+{
+    m_sessions.removeNullReferences();
+    return m_sessions;
+}
+
 void PlatformMediaSessionManager::removeSession(PlatformMediaSessionInterface& session)
 {
     m_sessions.removeNullReferences();

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -51,7 +51,7 @@ protected:
     void setCurrentSession(PlatformMediaSessionInterface&) override;
     RefPtr<PlatformMediaSessionInterface> currentSession() const final;
 
-    WeakListHashSet<PlatformMediaSessionInterface>& sessions() const final { return m_sessions; }
+    WeakListHashSet<PlatformMediaSessionInterface>& sessions() const final;
     Vector<WeakPtr<PlatformMediaSessionInterface>> copySessionsToVector() const final;
     WeakPtr<PlatformMediaSessionInterface> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&, PlatformMediaSessionPlaybackControlsPurpose) final;
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -42,15 +42,21 @@ struct NowPlayingInfo;
 
 enum class MediaPlayerPitchCorrectionAlgorithm : uint8_t;
 
-class MediaSessionManagerCocoa
+class WEBCORE_EXPORT MediaSessionManagerCocoa
     : public PlatformMediaSessionManager
-    , private NowPlayingManagerClient
-    , private AudioHardwareListener::Client {
+    , public NowPlayingManagerClient
+    , public AudioHardwareListener::Client {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManagerCocoa);
 public:
     MediaSessionManagerCocoa(PageIdentifier);
     
-    void updateSessionState() final;
+    static WEBCORE_EXPORT void clearNowPlayingInfo();
+    static WEBCORE_EXPORT void setNowPlayingInfo(bool setAsNowPlayingApplication, bool shouldUpdateNowPlayingSuppression, const NowPlayingInfo&);
+
+    static String audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(MediaPlayerPitchCorrectionAlgorithm, bool preservesPitch, double rate);
+
+protected:
+    void updateSessionState() override;
     void beginInterruption(PlatformMediaSession::InterruptionType) final;
 
     bool hasActiveNowPlayingSession() const final { return m_nowPlayingActive; }
@@ -62,12 +68,7 @@ public:
     bool haveEverRegisteredAsNowPlayingApplication() const final { return m_haveEverRegisteredAsNowPlayingApplication; }
 
     std::optional<NowPlayingInfo> nowPlayingInfo() const final { return m_nowPlayingInfo; }
-    static WEBCORE_EXPORT void clearNowPlayingInfo();
-    static WEBCORE_EXPORT void setNowPlayingInfo(bool setAsNowPlayingApplication, bool shouldUpdateNowPlayingSuppression, const NowPlayingInfo&);
 
-    static String audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(MediaPlayerPitchCorrectionAlgorithm, bool preservesPitch, double rate);
-
-protected:
     void scheduleSessionStatusUpdate() final;
     void updateNowPlayingInfo();
     void updateActiveNowPlayingSession(RefPtr<PlatformMediaSessionInterface>);

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -45,7 +45,7 @@ extern NSString *WebUIApplicationDidEnterBackgroundNotification;
 
 namespace WebCore {
 
-class MediaSessionManageriOS
+class WEBCORE_EXPORT MediaSessionManageriOS
     : public MediaSessionManagerCocoa
     , public MediaSessionHelperClient
     , public AudioSessionInterruptionObserver {
@@ -82,9 +82,7 @@ private:
     void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<MediaPlaybackTarget>&&) final;
     void isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit) final;
     void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) final;
-#if !RELEASE_LOG_DISABLED
-    ASCIILiteral logClassName() const final { return "MediaSessionManageriOS"_s; }
-#endif
+    ASCIILiteral logClassName() const override;
 
 #if !PLATFORM(WATCHOS)
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
@@ -93,6 +91,8 @@ private:
 
     bool m_isMonitoringWirelessRoutes { false };
 };
+
+inline ASCIILiteral MediaSessionManageriOS::logClassName() const { return "MediaSessionManageriOS"_s; }
 
 } // namespace WebCore
 

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -639,8 +639,10 @@ UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
 
 UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
 UIProcess/Media/MediaUsageManager.cpp
+UIProcess/Media/RemoteMediaSessionClientProxy.cpp
 UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
 UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+UIProcess/Media/RemoteMediaSessionProxy.cpp
 
 UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
 UIProcess/Notifications/WebNotification.cpp

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
@@ -28,10 +28,10 @@
     EnabledBy=RemoteMediaSessionManagerEnabled
 ]
 messages -> RemoteMediaSessionManagerProxy {
-    void UpdateSessionState()
-    void AddSession(struct WebKit::RemoteMediaSessionState session);
-    void RemoveSession(struct WebKit::RemoteMediaSessionState session);
-    void SetCurrentSession(struct WebKit::RemoteMediaSessionState session);
+    void UpdateMediaSessionState()
+    void AddMediaSession(struct WebKit::RemoteMediaSessionState session);
+    void RemoveMediaSession(struct WebKit::RemoteMediaSessionState session);
+    void SetCurrentMediaSession(struct WebKit::RemoteMediaSessionState session);
 }
 
 #endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "PlatformXRCoordinator.h"
 #include "ProcessThrottler.h"
+#include <WebCore/ExceptionData.h>
 #include <WebCore/PlatformXR.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -192,7 +192,7 @@ void SystemSettingsManagerProxy::updateFontProperties(const String& fontName, We
     int size = pango_font_description_get_size(pangoDescription) / PANGO_SCALE;
     // If the size of the font is in points, we need to convert it to pixels.
     if (!pango_font_description_get_size_is_absolute(pangoDescription))
-        size = size * (fontDPI() / 72.0);
+        size = size * (WebCore::fontDPI() / 72.0);
     changedState.fontFamily = String::fromUTF8(unsafeSpan8(pango_font_description_get_family(pangoDescription)));
     changedState.fontSize = static_cast<float>(size);
     changedState.fontWeight = pango_font_description_get_weight(pangoDescription);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3328,6 +3328,8 @@
 		076897EF2D07B330006F9FA7 /* WKUIDelegateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKUIDelegateAdapter.swift; sourceTree = "<group>"; };
 		076E884D1A13CADF005E90FC /* APIContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuClient.h; sourceTree = "<group>"; };
 		076E884F1A13CBC6005E90FC /* APIInjectedBundlePageContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIInjectedBundlePageContextMenuClient.h; sourceTree = "<group>"; };
+		0779D7BB2EA8101800C389D5 /* RemoteMediaSessionProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaSessionProxy.h; sourceTree = "<group>"; };
+		0779D7BC2EA8101800C389D5 /* RemoteMediaSessionProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionProxy.cpp; sourceTree = "<group>"; };
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
 		077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKIntelligenceReplacementTextEffectCoordinator.swift; sourceTree = "<group>"; };
 		0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformIntelligenceTextEffectView.swift; sourceTree = "<group>"; };
@@ -16849,6 +16851,8 @@
 				07E2457A2E7CBFDE00AD1014 /* RemoteMediaSessionManagerProxy.cpp */,
 				07E245792E7CBFDE00AD1014 /* RemoteMediaSessionManagerProxy.h */,
 				072939C22E9DA78B001BE8FE /* RemoteMediaSessionManagerProxy.messages.in */,
+				0779D7BC2EA8101800C389D5 /* RemoteMediaSessionProxy.cpp */,
+				0779D7BB2EA8101800C389D5 /* RemoteMediaSessionProxy.h */,
 			);
 			path = Media;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "RemoteMediaSessionManagerMessages.h"
 #include "RemoteMediaSessionManagerProxyMessages.h"
 #include "RemoteMediaSessionState.h"
@@ -44,37 +45,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionManager);
 
-static RemoteMediaSessionState platformSessionState(const WebCore::PlatformMediaSessionInterface& session)
-{
-    return {
-        .sessionIdentifier = session.mediaSessionIdentifier(),
-#if !RELEASE_LOG_DISABLED
-        .logIdentifier = session.logIdentifier(),
-#endif
-        .mediaType = session.mediaType(),
-        .presentationType = session.presentationType(),
-        .displayType = session.displayType(),
-
-        .duration = session.duration(),
-
-        .groupIdentifier = session.mediaSessionGroupIdentifier(),
-        .nowPlayingInfo = session.nowPlayingInfo(),
-
-        .shouldOverrideBackgroundLoadingRestriction = session.shouldOverrideBackgroundLoadingRestriction(),
-        .isPlayingToWirelessPlaybackTarget = session.isPlayingToWirelessPlaybackTarget(),
-        .isPlayingOnSecondScreen = session.isPlayingOnSecondScreen(),
-        .hasMediaStreamSource = session.hasMediaStreamSource(),
-        .shouldOverridePauseDuringRouteChange = session.shouldOverridePauseDuringRouteChange(),
-        .isNowPlayingEligible = session.isNowPlayingEligible(),
-        .canProduceAudio = session.canProduceAudio(),
-        .isSuspended = session.isSuspended(),
-        .isPlaying = session.isPlaying(),
-        .isAudible = session.isAudible(),
-        .isEnded = session.isEnded(),
-        .canReceiveRemoteControlCommands = session.canReceiveRemoteControlCommands(),
-        .supportsSeeking = session.supportsSeeking(),
-    };
-}
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionState);
 
 RefPtr<RemoteMediaSessionManager> RemoteMediaSessionManager::create(WebPage& topPage, WebPage& localPage)
 {
@@ -101,27 +72,164 @@ RemoteMediaSessionManager::~RemoteMediaSessionManager()
 void RemoteMediaSessionManager::addSession(WebCore::PlatformMediaSessionInterface& session)
 {
     PlatformMediaSessionManager::addSession(session);
-    send(Messages::RemoteMediaSessionManagerProxy::AddSession(platformSessionState(session)));
+    send(Messages::RemoteMediaSessionManagerProxy::AddMediaSession(currentSessionState(session)));
 }
 
 void RemoteMediaSessionManager::removeSession(WebCore::PlatformMediaSessionInterface& session)
 {
     PlatformMediaSessionManager::removeSession(session);
-    send(Messages::RemoteMediaSessionManagerProxy::RemoveSession(platformSessionState(session)));
+
+    if (!m_cachedSessionState.contains(session.mediaSessionIdentifier()))
+        return;
+
+    m_cachedSessionState.remove(session.mediaSessionIdentifier());
+
+    send(Messages::RemoteMediaSessionManagerProxy::RemoveMediaSession(currentSessionState(session)));
 }
 
 void RemoteMediaSessionManager::setCurrentSession(WebCore::PlatformMediaSessionInterface& session)
 {
     ALWAYS_LOG(LOGIDENTIFIER, session.logIdentifier(), ", size = ", sessions().computeSize());
     PlatformMediaSessionManager::setCurrentSession(session);
-    send(Messages::RemoteMediaSessionManagerProxy::SetCurrentSession(platformSessionState(session)));
+
+    send(Messages::RemoteMediaSessionManagerProxy::SetCurrentMediaSession(currentSessionState(session)));
 }
 
 void RemoteMediaSessionManager::updateSessionState()
 {
-    send(Messages::RemoteMediaSessionManagerProxy::UpdateSessionState());
+    send(Messages::RemoteMediaSessionManagerProxy::UpdateMediaSessionState());
 }
 
+RefPtr<WebCore::PlatformMediaSessionInterface> RemoteMediaSessionManager::sessionWithIdentifier(WebCore::MediaSessionIdentifier identifier)
+{
+    return firstSessionMatching([identifier](auto& session) {
+        return session.mediaSessionIdentifier() == identifier;
+    }).get();
+}
+
+void RemoteMediaSessionManager::clientShouldResumeAutoplaying(WebCore::MediaSessionIdentifier identifier)
+{
+    if (RefPtr session = sessionWithIdentifier(identifier))
+        session->checkedClient()->resumeAutoplaying();
+}
+
+void RemoteMediaSessionManager::clientMayResumePlayback(WebCore::MediaSessionIdentifier identifier, bool shouldResume)
+{
+    if (RefPtr session = sessionWithIdentifier(identifier))
+        session->checkedClient()->mayResumePlayback(shouldResume);
+}
+
+void RemoteMediaSessionManager::clientShouldSuspendPlayback(WebCore::MediaSessionIdentifier identifier)
+{
+    if (RefPtr session = sessionWithIdentifier(identifier))
+        session->checkedClient()->suspendPlayback();
+}
+
+void RemoteMediaSessionManager::clientSetShouldPlayToPlaybackTarget(WebCore::MediaSessionIdentifier identifier, bool shouldPlay)
+{
+    if (RefPtr session = sessionWithIdentifier(identifier))
+        session->checkedClient()->setShouldPlayToPlaybackTarget(shouldPlay);
+}
+
+void RemoteMediaSessionManager::clientDidReceiveRemoteControlCommand(WebCore::MediaSessionIdentifier identifier, WebCore::PlatformMediaSessionRemoteControlCommandType command, WebCore::PlatformMediaSessionRemoteCommandArgument argument)
+{
+    if (RefPtr session = sessionWithIdentifier(identifier))
+        session->checkedClient()->didReceiveRemoteControlCommand(command, argument);
+}
+
+RemoteMediaSessionState& RemoteMediaSessionManager::currentSessionState(const WebCore::PlatformMediaSessionInterface& session)
+{
+    auto addResult = m_cachedSessionState.ensure(session.mediaSessionIdentifier(), [&] {
+        return makeUniqueRef<RemoteMediaSessionState>(fullSessionState(session));
+    });
+
+    if (!addResult.isNewEntry)
+        updateCachedSessionState(session, addResult.iterator->value);
+
+    return addResult.iterator->value;
+}
+
+void RemoteMediaSessionManager::updateCachedSessionState(const WebCore::PlatformMediaSessionInterface& session, RemoteMediaSessionState& state)
+{
+    state.state = session.state();
+    state.stateToRestore = session.stateToRestore();
+    state.interruptionType = session.interruptionType();
+
+    state.duration = session.duration();
+
+    state.nowPlayingInfo = session.nowPlayingInfo();
+
+    state.shouldOverrideBackgroundLoadingRestriction = session.shouldOverrideBackgroundLoadingRestriction();
+    state.isPlayingToWirelessPlaybackTarget = session.isPlayingToWirelessPlaybackTarget();
+    state.isPlayingOnSecondScreen = session.isPlayingOnSecondScreen();
+    state.hasMediaStreamSource = session.hasMediaStreamSource();
+    state.shouldOverridePauseDuringRouteChange = session.shouldOverridePauseDuringRouteChange();
+    state.isNowPlayingEligible = session.isNowPlayingEligible();
+    state.canProduceAudio = session.canProduceAudio();
+    state.isSuspended = session.isSuspended();
+    state.isPlaying = session.isPlaying();
+    state.isAudible = session.isAudible();
+    state.isEnded = session.isEnded();
+    state.canReceiveRemoteControlCommands = session.canReceiveRemoteControlCommands();
+    state.supportsSeeking = session.supportsSeeking();
+    state.hasPlayedAudiblySinceLastInterruption = session.hasPlayedAudiblySinceLastInterruption();
+    state.isLongEnoughForMainContent = session.isLongEnoughForMainContent();
+    state.blockedBySystemInterruption = session.blockedBySystemInterruption();
+    state.activeAudioSessionRequired = session.activeAudioSessionRequired();
+    state.preparingToPlay = session.preparingToPlay();
+    state.isActiveNowPlayingSession = session.isActiveNowPlayingSession();
+
+#if PLATFORM(IOS_FAMILY)
+    state.requiresPlaybackTargetRouteMonitoring = session.requiresPlaybackTargetRouteMonitoring();
+#endif
+}
+
+RemoteMediaSessionState RemoteMediaSessionManager::fullSessionState(const WebCore::PlatformMediaSessionInterface& session)
+{
+    return {
+        .pageIdentifier = m_localPageID,
+        .sessionIdentifier = session.mediaSessionIdentifier(),
+#if !RELEASE_LOG_DISABLED
+        .logIdentifier = session.logIdentifier(),
+#endif
+        .mediaType = session.mediaType(),
+        .presentationType = session.presentationType(),
+        .displayType = session.displayType(),
+
+        .state = session.state(),
+        .stateToRestore = session.stateToRestore(),
+        .interruptionType = session.interruptionType(),
+
+        .duration = session.duration(),
+
+        .groupIdentifier = session.mediaSessionGroupIdentifier(),
+        .nowPlayingInfo = session.nowPlayingInfo(),
+
+        .shouldOverrideBackgroundLoadingRestriction = session.shouldOverrideBackgroundLoadingRestriction(),
+        .isPlayingToWirelessPlaybackTarget = session.isPlayingToWirelessPlaybackTarget(),
+        .isPlayingOnSecondScreen = session.isPlayingOnSecondScreen(),
+        .hasMediaStreamSource = session.hasMediaStreamSource(),
+        .shouldOverridePauseDuringRouteChange = session.shouldOverridePauseDuringRouteChange(),
+        .isNowPlayingEligible = session.isNowPlayingEligible(),
+        .canProduceAudio = session.canProduceAudio(),
+        .isSuspended = session.isSuspended(),
+        .isPlaying = session.isPlaying(),
+        .isAudible = session.isAudible(),
+        .isEnded = session.isEnded(),
+        .canReceiveRemoteControlCommands = session.canReceiveRemoteControlCommands(),
+        .supportsSeeking = session.supportsSeeking(),
+        .hasPlayedAudiblySinceLastInterruption = session.hasPlayedAudiblySinceLastInterruption(),
+        .isLongEnoughForMainContent = session.isLongEnoughForMainContent(),
+        .blockedBySystemInterruption = session.blockedBySystemInterruption(),
+        .activeAudioSessionRequired = session.activeAudioSessionRequired(),
+        .preparingToPlay = session.preparingToPlay(),
+        .isActiveNowPlayingSession = session.isActiveNowPlayingSession(),
+
+#if PLATFORM(IOS_FAMILY)
+        .requiresPlaybackTargetRouteMonitoring = session.requiresPlaybackTargetRouteMonitoring(),
+#endif
+    };
+}
 IPC::Connection* RemoteMediaSessionManager::messageSenderConnection() const
 {
     return WebProcess::singleton().parentProcessConnection();
@@ -130,6 +238,11 @@ IPC::Connection* RemoteMediaSessionManager::messageSenderConnection() const
 uint64_t RemoteMediaSessionManager::messageSenderDestinationID() const
 {
     return m_topPageID.toUInt64();
+}
+
+std::optional<SharedPreferencesForWebProcess> RemoteMediaSessionManager::sharedPreferencesForWebProcess() const
+{
+    return WebProcess::singleton().sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in
@@ -24,9 +24,15 @@
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 [
     DispatchedFrom=UI,
-    DispatchedTo=WebContent
+    DispatchedTo=WebContent,
+    EnabledBy=RemoteMediaSessionManagerEnabled
 ]
 messages -> RemoteMediaSessionManager {
+    void ClientShouldResumeAutoplaying(WebCore::MediaSessionIdentifier identifier)
+    void ClientMayResumePlayback(WebCore::MediaSessionIdentifier identifier, bool shouldResume)
+    void ClientShouldSuspendPlayback(WebCore::MediaSessionIdentifier identifier)
+    void ClientSetShouldPlayToPlaybackTarget(WebCore::MediaSessionIdentifier identifier, bool shouldPlay)
+    void ClientDidReceiveRemoteControlCommand(WebCore::MediaSessionIdentifier identifier, enum:uint8_t WebCore::PlatformMediaSessionRemoteControlCommandType command, struct WebCore::PlatformMediaSessionRemoteCommandArgument argument);
 }
 
 #endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionState.h
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionState.h
@@ -30,23 +30,27 @@
 #include <WebCore/MediaSessionGroupIdentifier.h>
 #include <WebCore/MediaSessionIdentifier.h>
 #include <WebCore/NowPlayingInfo.h>
+#include <WebCore/PageIdentifier.h>
 #include <WebCore/PlatformMediaSessionTypes.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 
-namespace WebCore {
-class PlatformMediaSessionInterface;
-}
-
 namespace WebKit {
 
 struct RemoteMediaSessionState {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(RemoteMediaSessionState);
+
+    WebCore::PageIdentifier pageIdentifier;
     WebCore::MediaSessionIdentifier sessionIdentifier;
     uint64_t logIdentifier { 0 };
 
     WebCore::PlatformMediaSessionMediaType mediaType { WebCore::PlatformMediaSessionMediaType::None };
     WebCore::PlatformMediaSessionMediaType presentationType { WebCore::PlatformMediaSessionMediaType::None };
     WebCore::PlatformMediaSessionDisplayType displayType { WebCore::PlatformMediaSessionDisplayType::Normal };
+
+    WebCore::PlatformMediaSessionState state { WebCore::PlatformMediaSessionState::Idle };
+    WebCore::PlatformMediaSessionState stateToRestore { WebCore::PlatformMediaSessionState::Idle };
+    WebCore::PlatformMediaSessionInterruptionType interruptionType { WebCore::PlatformMediaSessionInterruptionType::NoInterruption };
 
     MediaTime duration { MediaTime::invalidTime() };
 
@@ -66,7 +70,17 @@ struct RemoteMediaSessionState {
     bool isEnded { false };
     bool canReceiveRemoteControlCommands { false };
     bool supportsSeeking { false };
+    bool hasPlayedAudiblySinceLastInterruption { false };
+    bool isLongEnoughForMainContent { false };
+    bool blockedBySystemInterruption { false };
+    bool activeAudioSessionRequired { false };
+    bool preparingToPlay { false };
+    bool isActiveNowPlayingSession { false };
+#if PLATFORM(IOS_FAMILY)
+    bool requiresPlaybackTargetRouteMonitoring { false };
+#endif
 };
+
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionState.serialization.in
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionState.serialization.in
@@ -24,12 +24,17 @@
 
 header: "RemoteMediaSessionState.h"
 struct WebKit::RemoteMediaSessionState {
+    WebCore::PageIdentifier pageIdentifier;
     WebCore::MediaSessionIdentifier sessionIdentifier;
     uint64_t logIdentifier;
 
     WebCore::PlatformMediaSessionMediaType mediaType;
     WebCore::PlatformMediaSessionMediaType presentationType;
     WebCore::PlatformMediaSessionDisplayType displayType;
+
+    WebCore::PlatformMediaSessionState state;
+    WebCore::PlatformMediaSessionState stateToRestore;
+    WebCore::PlatformMediaSessionInterruptionType interruptionType
 
     MediaTime duration;
 
@@ -49,6 +54,16 @@ struct WebKit::RemoteMediaSessionState {
     bool isEnded;
     bool canReceiveRemoteControlCommands;
     bool supportsSeeking;
+    bool hasPlayedAudiblySinceLastInterruption;
+    bool isLongEnoughForMainContent;
+    bool blockedBySystemInterruption;
+    bool activeAudioSessionRequired;
+    bool preparingToPlay;
+    bool isActiveNowPlayingSession;
+
+#if PLATFORM(IOS_FAMILY)
+    bool requiresPlaybackTargetRouteMonitoring;
+#endif
 };
 
 #endif


### PR DESCRIPTION
#### fa789dd834b7818cff1cf2ee9ca080aa122c887e
<pre>
[Site Isolation] Begin filling out and connecting RemoteMediaSessionManager and RemoteMediaSessionManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=302546">https://bugs.webkit.org/show_bug.cgi?id=302546</a>
<a href="https://rdar.apple.com/164742719">rdar://164742719</a>

Reviewed by Jean Yves Avenard.

Beging filling out the implementations of RemoteMediaSessionManager and
RemoteMediaSessionManagerProxy.

No new tests, the remote session manager is disabled by default and is not testable yet.

* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::addSession):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
(WebCore::MediaSessionManagerInterface::logger const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSession::create): Deleted.
(WebCore::PlatformMediaSession::PlatformMediaSession): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
(WebCore::PlatformMediaSessionInterface::setMediaSessionIdentifier):
(WebCore::PlatformMediaSessionInterface::client const):
(WebCore::PlatformMediaSessionInterface::checkedClient const):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::sessions const):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
(WebCore::MediaSessionManagerCocoa::scheduleSessionStatusUpdate):
(WebCore::MediaSessionManagerCocoa::addSession):
(WebCore::MediaSessionManagerCocoa::removeSession):
(WebCore::MediaSessionManagerCocoa::setCurrentSession):
(WebCore::MediaSessionManagerCocoa::addSupportedCommand):
(WebCore::MediaSessionManagerCocoa::removeSupportedCommand):
(WebCore::MediaSessionManagerCocoa::supportedCommands const):
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
(WebCore::MediaSessionManageriOS::logClassName const):
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.cpp:
(WebKit::RemoteMediaSessionClientProxy::RemoteMediaSessionClientProxy):
(WebKit::RemoteMediaSessionClientProxy::resumeAutoplaying):
(WebKit::RemoteMediaSessionClientProxy::mayResumePlayback):
(WebKit::RemoteMediaSessionClientProxy::suspendPlayback):
(WebKit::RemoteMediaSessionClientProxy::didReceiveRemoteControlCommand):
(WebKit::RemoteMediaSessionClientProxy::shouldOverrideBackgroundPlaybackRestriction const):
(WebKit::RemoteMediaSessionClientProxy::setShouldPlayToPlaybackTarget):
(WebKit::RemoteMediaSessionClientProxy::sessionManager const):
(WebKit::RemoteMediaSessionClientProxy): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.h:
(WebKit::RemoteMediaSessionClientProxy::create): Deleted.
(WebKit::RemoteMediaSessionClientProxy::selectBestMediaSession): Deleted.
(WebKit::RemoteMediaSessionClientProxy::protectedLogger const): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy):
(WebKit::RemoteMediaSessionManagerProxy::addMediaSession):
(WebKit::RemoteMediaSessionManagerProxy::removeMediaSession):
(WebKit::RemoteMediaSessionManagerProxy::setCurrentMediaSession):
(WebKit::RemoteMediaSessionManagerProxy::updateMediaSessionState):
(WebKit::RemoteMediaSessionManagerProxy::findSession):
(WebKit::RemoteMediaSessionManagerProxy::addSession): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::removeSession): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::setCurrentSession): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::updateSessionState): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
(WebKit::RemoteMediaSessionManagerProxy::process const):
(WebKit::RemoteMediaSessionManagerProxy::ref const): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::deref const): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
(WebKit::RemoteMediaSessionProxy::RemoteMediaSessionProxy):
(WebKit::RemoteMediaSessionProxy::~RemoteMediaSessionProxy):
(WebKit::RemoteMediaSessionProxy::updateState):
(WebKit::RemoteMediaSessionProxy::setShouldPlayToPlaybackTarget):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h: Added.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::updateFontProperties):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::addSession):
(WebKit::RemoteMediaSessionManager::removeSession):
(WebKit::RemoteMediaSessionManager::setCurrentSession):
(WebKit::RemoteMediaSessionManager::updateSessionState):
(WebKit::RemoteMediaSessionManager::sessionWithIdentifier):
(WebKit::RemoteMediaSessionManager::clientShouldResumeAutoplaying):
(WebKit::RemoteMediaSessionManager::clientMayResumePlayback):
(WebKit::RemoteMediaSessionManager::clientShouldSuspendPlayback):
(WebKit::RemoteMediaSessionManager::clientSetShouldPlayToPlaybackTarget):
(WebKit::RemoteMediaSessionManager::clientDidReceiveRemoteControlCommand):
(WebKit::RemoteMediaSessionManager::currentSessionState):
(WebKit::RemoteMediaSessionManager::updateCachedSessionState):
(WebKit::RemoteMediaSessionManager::fullSessionState):
(WebKit::RemoteMediaSessionManager::sharedPreferencesForWebProcess const):
(WebKit::platformSessionState): Deleted.
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionState.h:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionState.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303123@main">https://commits.webkit.org/303123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c82e62fdd01d5bc6bfb83861651dbddaeb27977a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138916 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3a350235-e790-4a87-98b0-62329a429134) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3593 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57a67ca3-f815-4c73-9ad6-c9f567ed8e1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134367 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81131 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9ff66192-1a98-4d97-89dd-9589cf755047) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82119 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141562 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3496 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36280 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3542 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/108934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27597 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2655 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113967 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56681 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3558 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32383 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3380 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->