### PR TITLE
Fix issue with Lockdown mode SharedPref sync

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -50,7 +50,7 @@ messages -> WebSWServerConnection {
     [EnabledBy=ServiceWorkersEnabled] TerminateWorkerFromClient(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
     [EnabledBy=ServiceWorkersEnabled] WhenServiceWorkerIsTerminatedForTesting(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
 
-    [EnabledBy=ServiceWorkersEnabled] SetThrottleState(bool isThrottleable)
+    SetThrottleState(bool isThrottleable)
     [EnabledBy=ServiceWorkersEnabled] StoreRegistrationsOnDisk() -> ()
 
     [EnabledBy=PushAPIEnabled] SubscribeToPushService(WebCore::ServiceWorkerRegistrationIdentifier identifier, Vector<uint8_t> applicationServerKey) -> (Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData> result)

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
@@ -33,14 +33,18 @@
 
 namespace WebKit {
 
-SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferencesStore& preferencesStore)
+SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferencesStore& preferencesStore, bool isLockdownModeEnabled)
 {
     SharedPreferencesForWebProcess sharedPreferences;
 <% for @pref in @sharedPreferencesForWebProcess do -%>
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
-        sharedPreferences.<%= @pref.nameLower %> = preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
+<%- if @pref.opts["disableInLockdownMode"] -%>
+    sharedPreferences.<%= @pref.nameLower %> = isLockdownModeEnabled ? false : preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
+<%- else -%>
+    sharedPreferences.<%= @pref.nameLower %> = preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
+<%- end -%>
 <%- if @pref.condition -%>
 #endif
 <%- end -%>
@@ -48,17 +52,24 @@ SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferenc
     return sharedPreferences;
 }
 
-bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess& sharedPreferences, const WebPreferencesStore& preferencesStore)
+bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess& sharedPreferences, const WebPreferencesStore& preferencesStore, bool isLockdownModeEnabled)
 {
     bool didChange = false;
 <% for @pref in @sharedPreferencesForWebProcess do -%>
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
+<%- if @pref.opts["disableInLockdownMode"] -%>
+    if (!isLockdownModeEnabled && preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key()) && !sharedPreferences.<%= @pref.nameLower %>) {
+        sharedPreferences.<%= @pref.nameLower %> = true;
+        didChange = true;
+    }
+<%- else -%>
     if (preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key()) && !sharedPreferences.<%= @pref.nameLower %>) {
         sharedPreferences.<%= @pref.nameLower %> = true;
         didChange = true;
     }
+<%- end -%>
 <%- if @pref.condition -%>
 #endif
 <%- end -%>

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
@@ -46,7 +46,7 @@ struct SharedPreferencesForWebProcess {
     bool operator==(const SharedPreferencesForWebProcess&) const = default;
 };
 
-SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferencesStore&);
-bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&, const WebPreferencesStore&);
+SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferencesStore&, bool isLockdownModeEnabled);
+bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&, const WebPreferencesStore&, bool isLockdownModeEnabled);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1332,8 +1332,8 @@ void WebPageProxy::handleSynchronousMessage(IPC::Connection& connection, const S
 
 bool WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfiguration& configuration) const
 {
-    auto sharedPreferences = WebKit::sharedPreferencesForWebProcess(preferences().store());
-    return !updateSharedPreferencesForWebProcess(sharedPreferences, configuration.preferences().store());
+    auto sharedPreferences = WebKit::sharedPreferencesForWebProcess(preferences().store(), shouldEnableLockdownMode());
+    return !updateSharedPreferencesForWebProcess(sharedPreferences, configuration.preferences().store(), shouldEnableLockdownMode());
 }
 
 bool WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs(const WebPageProxy& page) const

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -482,7 +482,7 @@ void WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses(const WebPa
     } else {
 #if ASSERT_ENABLED
         auto sharedPreferencesForWebProcess = m_sharedPreferencesForWebProcess;
-        ASSERT(!WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, page.preferences().store()));
+        ASSERT(!WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, page.preferences().store(), lockdownMode() == WebProcessProxy::LockdownMode::Enabled));
 #endif
     }
 
@@ -492,7 +492,7 @@ bool WebProcessProxy::hasSameGPUAndNetworkProcessPreferencesAs(const API::PageCo
 {
     if (m_sharedPreferencesForWebProcess.version) {
         auto sharedPreferencesForWebProcess = m_sharedPreferencesForWebProcess;
-        if (WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, pageConfiguration.preferences().store()))
+        if (WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, pageConfiguration.preferences().store(), lockdownMode() == WebProcessProxy::LockdownMode::Enabled))
             return false;
     }
     return true;
@@ -2383,7 +2383,7 @@ void WebProcessProxy::sharedPreferencesDidChange()
 
 std::optional<SharedPreferencesForWebProcess> WebProcessProxy::updateSharedPreferences(const WebPreferencesStore& preferencesStore)
 {
-    if (WebKit::updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess, preferencesStore)) {
+    if (WebKit::updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess, preferencesStore, lockdownMode() == WebProcessProxy::LockdownMode::Enabled)) {
         ++m_sharedPreferencesForWebProcess.version;
         sharedPreferencesDidChange();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4914,7 +4914,7 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
         pluginView->didChangeSettings();
 #endif
 
-    WebProcess::singleton().updateSharedPreferencesForWebProcess(WebKit::sharedPreferencesForWebProcess(store));
+    WebProcess::singleton().updateSharedPreferencesForWebProcess(WebKit::sharedPreferencesForWebProcess(store, WebProcess::singleton().isLockdownModeEnabled()));
 
     protectedCorePage()->settingsDidChange();
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -290,6 +290,8 @@
 		579651E7216BFDED006EBFE5 /* FidoHidMessageTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 579651E6216BFD53006EBFE5 /* FidoHidMessageTest.cpp */; };
 		57C3FA661F7C248F009D4B80 /* WeakPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CB9BC371A67482300FE5678 /* WeakPtr.cpp */; };
 		57F1C91125DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */; };
+		58EFB70F2E571EAA00D9F43E /* speechsynthesis_feature_test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 58EFB70D2E571EAA00D9F43E /* speechsynthesis_feature_test.html */; };
+		58EFB7102E571EAA00D9F43E /* speechsynthesis_lockdown_test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 58EFB70E2E571EAA00D9F43E /* speechsynthesis_lockdown_test.html */; };
 		5C0BF88D1DD5964D00B00328 /* MemoryPressureHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C0BF88C1DD5957400B00328 /* MemoryPressureHandler.mm */; };
 		5C0BF8911DD599A900B00328 /* WebViewCanPasteZeroPng.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C0BF88F1DD5999B00B00328 /* WebViewCanPasteZeroPng.mm */; };
 		5C0BF8921DD599B600B00328 /* EarlyKVOCrash.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A9FB6CC1CA34BE500966124 /* EarlyKVOCrash.mm */; };
@@ -2267,6 +2269,8 @@
 				CDEEC7D02DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html in Copy Resources */,
 				A17C47FD2C98E5C20023F3C7 /* speechrecognition-basic.html in Copy Resources */,
 				A17C47FE2C98E5C20023F3C7 /* speechrecognition-user-permission-persistence.html in Copy Resources */,
+				58EFB70F2E571EAA00D9F43E /* speechsynthesis_feature_test.html in Copy Resources */,
+				58EFB7102E571EAA00D9F43E /* speechsynthesis_lockdown_test.html in Copy Resources */,
 				EEA52EAB2D69203B00D578B5 /* stagemode-model-page.html in Copy Resources */,
 				A17C47FF2C98E5C20023F3C7 /* start-offset.ts in Copy Resources */,
 				A17C46872C98E4D20023F3C7 /* StopLoadingFromDidReceiveResponse.html in Copy Resources */,
@@ -3156,6 +3160,8 @@
 		57F10D921C7E7B3800ECDF30 /* IsNavigationActionTrusted.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IsNavigationActionTrusted.mm; sourceTree = "<group>"; };
 		57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PrivateClickMeasurementCocoa.mm; sourceTree = "<group>"; };
 		57F56A5B1C7F8A4000F31D7E /* IsNavigationActionTrusted.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IsNavigationActionTrusted.html; sourceTree = "<group>"; };
+		58EFB70D2E571EAA00D9F43E /* speechsynthesis_feature_test.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = speechsynthesis_feature_test.html; sourceTree = "<group>"; };
+		58EFB70E2E571EAA00D9F43E /* speechsynthesis_lockdown_test.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = speechsynthesis_lockdown_test.html; sourceTree = "<group>"; };
 		5C0160C021A132320077FA32 /* JITEnabled.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JITEnabled.mm; sourceTree = "<group>"; };
 		5C050D542A8ADBC7004A2BA4 /* FrameTreeChecks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameTreeChecks.h; sourceTree = "<group>"; };
 		5C0BF88C1DD5957400B00328 /* MemoryPressureHandler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryPressureHandler.mm; sourceTree = "<group>"; };
@@ -5990,6 +5996,8 @@
 				CDEEC7CF2DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html */,
 				9360270525A3B28E00367670 /* speechrecognition-basic.html */,
 				9342589D255B66A00059EEDD /* speechrecognition-user-permission-persistence.html */,
+				58EFB70D2E571EAA00D9F43E /* speechsynthesis_feature_test.html */,
+				58EFB70E2E571EAA00D9F43E /* speechsynthesis_lockdown_test.html */,
 				0721D4582838295400A95853 /* start-offset.ts */,
 				515BE16E1D4288FF00DD7C68 /* StoreBlobToBeDeleted.html */,
 				F42A9E6F2CC2FE84002280C0 /* subframes.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/speechsynthesis_feature_test.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/speechsynthesis_feature_test.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SpeechSynthesis Feature Flag Test with CoreIPC Helper</title>
+    <script src="coreipc.js"></script>
+</head>
+<body>
+    <h1>SpeechSynthesis EnabledBy Feature Flag Test</h1>
+    <div id="status">Loading...</div>
+    
+    <script>
+        console.log('SpeechSynthesis feature flag test starting...');
+        
+        function runSpeechSynthesisTest() {
+            try {
+                if (typeof CoreIPC === 'undefined') {
+                    alert('coreipc_framework_not_available');
+                    return;
+                }
+                
+                // Check if the SpeechSynthesisVoiceList message exists
+                const messageExists = CoreIPC.messages.WebPageProxy_SpeechSynthesisVoiceList;
+                console.log('SpeechSynthesisVoiceList message exists:', !!messageExists);
+                
+                if (!messageExists) {
+                    alert('speechsynthesis_message_not_found');
+                    return;
+                }
+                
+                // Use the proper sync message pattern like the example
+                const reply = IPC.sendSyncMessage(
+                    'UI',
+                    IPC.webPageProxyID,
+                    IPC.messages.WebPageProxy_SpeechSynthesisVoiceList.name,
+                    1000, // timeout in ms
+                    [] // no arguments needed
+                );
+                
+                // For EnabledBy testing, we just need to verify we got a valid reply
+                // The EnabledBy mechanism will throw an error if the message is blocked
+                if (reply && reply.buffer) {
+                    // Check if we have a buffer with some data (skip the 16-byte header)
+                    const buffer = new Uint8Array(reply.buffer);
+                    console.log('Reply buffer length:', buffer.length);
+                    console.log('Reply buffer (first 32 bytes):', Array.from(buffer.slice(0, 32)));
+                    
+                    if (buffer.length > 16) { // More than just the header
+                        alert('speechsynthesis_message_sent_successfully');
+                    } else {
+                        alert('speechsynthesis_message_sent_empty_reply');
+                    }
+                } else if (reply) {
+                    console.log('Got reply but no buffer:', reply);
+                    alert('speechsynthesis_message_sent_no_buffer');
+                } else {
+                    console.log('No reply returned');
+                    alert('speechsynthesis_message_sent_but_no_result');
+                }
+                
+            } catch (error) {
+                console.error('SpeechSynthesis test error:', error);
+                
+                // Check if this is the specific EnabledBy validation error
+                if (error.message && error.message.includes('Receiver cancelled the reply due to invalid destination or deserialization error')) {
+                    alert('speechsynthesis_enabledby_blocked: ' + error.message);
+                } else {
+                    alert('speechsynthesis_test_error: ' + error.message);
+                }
+            }
+        }
+        
+        // Auto-run the test when page loads
+        window.addEventListener('load', function() {
+            console.log('Page loaded, starting SpeechSynthesis test...');
+            setTimeout(runSpeechSynthesisTest, 100);
+        });
+        
+        // Also run immediately in case load event already fired
+        if (document.readyState === 'complete') {
+            console.log('Document already complete, running SpeechSynthesis test immediately');
+            setTimeout(runSpeechSynthesisTest, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/speechsynthesis_lockdown_test.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/speechsynthesis_lockdown_test.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SpeechSynthesis Lockdown Mode Test with CoreIPC Helper</title>
+    <script src="coreipc.js"></script>
+</head>
+<body>
+    <h1>SpeechSynthesis EnabledBy Lockdown Mode Test</h1>
+    <div id="status">Loading...</div>
+    
+    <script>
+        console.log('SpeechSynthesis lockdown mode test starting...');
+        
+        function runSpeechSynthesisLockdownTest() {
+            try {
+                if (typeof CoreIPC === 'undefined') {
+                    alert('coreipc_framework_not_available');
+                    return;
+                }
+                
+                // Check if the SpeechSynthesisVoiceList message exists
+                const messageExists = CoreIPC.messages.WebPageProxy_SpeechSynthesisVoiceList;
+                if (!messageExists) {
+                    alert('speechsynthesis_message_not_found');
+                    return;
+                }
+                
+                // Use CoreIPC helper to send the message
+                const result = CoreIPC.UI.WebPageProxy.SpeechSynthesisVoiceList(
+                    IPC.webPageProxyID, // connection identifier
+                    {} // no arguments needed
+                );
+                
+                // Check if we got a valid result
+                if (result !== null && result !== undefined) {
+                    alert('speechsynthesis_lockdown_unexpected_success');
+                } else {
+                    alert('speechsynthesis_lockdown_unexpected_success_no_result');
+                }
+                
+            } catch (error) {
+                console.error('SpeechSynthesis lockdown test error:', error);
+                
+                // Check if this is the specific EnabledBy validation error
+                if (error.message && error.message.includes('Receiver cancelled the reply due to invalid destination or deserialization error')) {
+                    // This is the expected behavior in lockdown mode
+                    console.log('SUCCESS: EnabledBy correctly blocked SpeechSynthesis message in lockdown mode');
+                    alert('speechsynthesis_lockdown_correctly_blocked: ' + error.message);
+                } else {
+                    alert('speechsynthesis_lockdown_test_error: ' + error.message);
+                }
+            }
+        }
+        
+        // Auto-run the test when page loads
+        window.addEventListener('load', function() {
+            console.log('Page loaded, starting SpeechSynthesis lockdown test...');
+            setTimeout(runSpeechSynthesisLockdownTest, 100);
+        });
+        
+        // Also run immediately in case load event already fired
+        if (document.readyState === 'complete') {
+            console.log('Document already complete, running SpeechSynthesis lockdown test immediately');
+            setTimeout(runSpeechSynthesisLockdownTest, 100);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 53ede32c8f5724ce09595e86510114dfd2d35958
<pre>
Fix issue with Lockdown mode SharedPref sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=297740">https://bugs.webkit.org/show_bug.cgi?id=297740</a>
<a href="https://rdar.apple.com/158421827">rdar://158421827</a>

Reviewed by Ryosuke Niwa.

SharedPreferenceForWebProcess syncing wasn&apos;t accounting for preferences marked to be disabled in lockdown mode. See radar for details.

* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb:
* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses):
(WebKit::WebProcessProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
(WebKit::WebProcessProxy::updateSharedPreferences):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(createWebViewWithIPCTestingAPIAndLockdownMode):
(LockdownModeDisablesWebGL)):
(LockdownModeDisabledAllowsWebGL)):
(LockdownModeDetection)):
(SpeechSynthesisWithFeatureFlag)):
(SpeechSynthesisWithLockdownMode)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/speechsynthesis_feature_test.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/speechsynthesis_lockdown_test.html: Added.

Originally-landed-as: 297297.301@safari-7622-branch (ce9b10b51a05). <a href="https://rdar.apple.com/164280156">rdar://164280156</a>
Canonical link: <a href="https://commits.webkit.org/303145@main">https://commits.webkit.org/303145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db5a68b1b0e4ad99d75c2e950f4b38e6340e6d5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138535 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82788 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2f9e5635-297b-4ea7-97fa-bad90d5426bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99869 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/82788 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b14440b9-1e29-4063-9300-f45488760d82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80575 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/130442 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2655 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81782 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111267 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35785 "Found 3 new test failures: inspector/debugger/async-stack-trace-truncate.html inspector/page/hidpi-snapshot-size.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108388 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108342 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2391 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56222 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20433 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32112 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3252 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->