### PR TITLE
Exponential ramp can produce NaN when starting value is zero

### DIFF
--- a/LayoutTests/webaudio/AudioParam/exponential-ramp-crash-expected.txt
+++ b/LayoutTests/webaudio/AudioParam/exponential-ramp-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS exponential-ramp-crash
+

--- a/LayoutTests/webaudio/AudioParam/exponential-ramp-crash.html
+++ b/LayoutTests/webaudio/AudioParam/exponential-ramp-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Test if a corner case crashes the exponential ramp.
+    </title>
+    <script src="../../imported/w3c/web-platform-tests/resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../resources/audit-util.js"></script>
+    <script src="../resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      const t = async_test('exponential-ramp-crash');
+      const onload = () => {
+        const context = new OfflineAudioContext(2, 441000, 44100);
+        const source = new ConstantSourceNode(context);
+        const delay_node = context.createDelay(30);
+        delay_node.connect(context.destination);
+  
+        delay_node.delayTime.exponentialRampToValueAtTime(2, 4.1);
+        delay_node.delayTime.cancelAndHoldAtTime(4);
+        context.oncomplete = t.step_func_done(() => {
+          assert_equals(delay_node.delayTime.value, 0);
+          assert_equals(context.state, 'closed');
+        });
+        context.startRendering();
+      };
+      window.addEventListener('load', t.step_func(onload));
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -836,9 +836,16 @@ float AudioParamTimeline::linearRampAtTime(Seconds t, float value1, Seconds time
     return value1 + (value2 - value1) * (t - time1).value() / (time2 - time1).value();
 }
 
+// See : https://webaudio.github.io/web-audio-api/#dom-audioparam-exponentialramptovalueattime
 float AudioParamTimeline::exponentialRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2)
 {
-    return value1 * pow(value2 / value1, (t - time1).value() / (time2 - time1).value());
+    ASSERT(std::isfinite(value1));
+    ASSERT(std::isfinite(value2));
+    ASSERT(time2 > time1);
+
+    return (!value1 || (value2 && std::signbit(value1) != std::signbit(value2)))
+        ? value1
+        : value1 * std::pow(value2 / value1, (t - time1).value() / (time2 - time1).value());
 }
 
 float AudioParamTimeline::valueCurveAtTime(Seconds t, Seconds time1, Seconds duration, std::span<const float> curveData, size_t curveLength)

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
@@ -65,6 +65,7 @@ public:
 
     bool hasValues(size_t startFrame, double sampleRate) const;
 
+    WEBCORE_EXPORT static float exponentialRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2);
 private:
     class ParamEvent {
         WTF_MAKE_TZONE_ALLOCATED(ParamEvent);
@@ -197,7 +198,6 @@ private:
     ExceptionOr<void> insertEvent(ParamEvent&&) WTF_REQUIRES_LOCK(m_eventsLock);
     float valuesForFrameRangeImpl(size_t startFrame, size_t endFrame, float defaultValue, std::span<float> values, double sampleRate, double controlRate) WTF_REQUIRES_LOCK(m_eventsLock);
     float linearRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2);
-    float exponentialRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2);
     float valueCurveAtTime(Seconds t, Seconds time1, Seconds duration, std::span<const float> curveData, size_t curveLength);
     void handleCancelValues(ParamEvent&, ParamEvent* nextEvent, float& value2, Seconds& time2, ParamEvent::Type& nextEventType);
     bool isEventCurrent(const ParamEvent&, const ParamEvent* nextEvent, size_t currentFrame, double sampleRate) const;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3559,6 +3559,7 @@
 		95B6B3B6251EBF2F00FC4382 /* MediaDocument.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaDocument.mm; sourceTree = "<group>"; };
 		95C52728275F35E100DA7E40 /* FontShadowTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontShadowTests.cpp; sourceTree = "<group>"; };
 		96E05A012DF7B66F00285827 /* WKWebExtensionAPIBookmarks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIBookmarks.mm; sourceTree = "<group>"; };
+		9739F73F2E5C548E002E7C61 /* ExponentialRampAtTimeTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExponentialRampAtTimeTest.cpp; sourceTree = "<group>"; };
 		97DAA8CD2DF1F325004B3040 /* MetalCompilationTests.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MetalCompilationTests.mm; sourceTree = "<group>"; };
 		97DAA8CF2DF70B91004B3040 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		97FB42D52E1D633600C63F41 /* access-expression.wgsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "access-expression.wgsl"; sourceTree = "<group>"; };
@@ -5254,6 +5255,7 @@
 				26F6E1EF1ADC749B00DE696B /* DFAMinimizer.cpp */,
 				7BC8628729B8B33500217CB5 /* DisplayListRecorderTests.cpp */,
 				93915A1624DB66C70019FF43 /* DocumentOrder.cpp */,
+				9739F73F2E5C548E002E7C61 /* ExponentialRampAtTimeTest.cpp */,
 				579651E6216BFD53006EBFE5 /* FidoHidMessageTest.cpp */,
 				572B40352176A029000AD43E /* FidoTestData.h */,
 				7A32D7491F02151500162C44 /* FileMonitor.cpp */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/ExponentialRampAtTimeTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ExponentialRampAtTimeTest.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "config.h"
+
+#if ENABLE(WEB_AUDIO)
+#include <WebCore/AudioParamTimeline.h>
+#include <cmath>
+
+using namespace WebCore;
+using WTF::Seconds;
+
+static float expInterp(float v1, float v2, Seconds t, Seconds t1, Seconds t2)
+{
+    double ratio = static_cast<double>(v2) / static_cast<double>(v1);
+    double alpha = (t - t1) / (t2 - t1);
+    return static_cast<float>(static_cast<double>(v1) * std::pow(ratio, alpha));
+}
+
+TEST(WebCore, AudioParamTimeline_OppositeSigns_PositiveToNegative)
+{
+    const float value1 = 2.0f;
+    const float value2 = -1.0f;
+    const Seconds time1 { 0.0 };
+    const Seconds time2 { 1.0 };
+
+    float r = AudioParamTimeline::exponentialRampAtTime(Seconds { 0.5 }, value1, time1, value2, time2);
+    EXPECT_FLOAT_EQ(r, value1);
+}
+
+TEST(WebCore, AudioParamTimeline_OppositeSigns_NegativeToPositive)
+{
+    const float value1 = -5.0f;
+    const float value2 = 3.0f;
+    const Seconds time1 { 0.0 };
+    const Seconds time2 { 1.0 };
+
+    float r = AudioParamTimeline::exponentialRampAtTime(Seconds { 0.3 }, value1, time1, value2, time2);
+    EXPECT_FLOAT_EQ(r, value1);
+}
+
+TEST(WebCore, AudioParamTimeline_OppositeSigns_MultipleTimes)
+{
+    const float value1 = 4.0f;
+    const float value2 = -2.0f;
+    const Seconds time1 { 0.0 };
+    const Seconds time2 { 2.0 };
+
+    EXPECT_FLOAT_EQ(AudioParamTimeline::exponentialRampAtTime(time1, value1, time1, value2, time2), value1);
+    EXPECT_FLOAT_EQ(AudioParamTimeline::exponentialRampAtTime(Seconds { 0.5 }, value1, time1, value2, time2), value1);
+    EXPECT_FLOAT_EQ(AudioParamTimeline::exponentialRampAtTime(Seconds { 1.5 }, value1, time1, value2, time2), value1);
+    EXPECT_FLOAT_EQ(AudioParamTimeline::exponentialRampAtTime(time2, value1, time1, value2, time2), value1);
+}
+
+TEST(WebCore, AudioParamTimeline_OppositeSigns_SmallMagnitudes)
+{
+    const float value1 = 0.001f;
+    const float value2 = -0.001f;
+    const Seconds time1 { 0.0 };
+    const Seconds time2 { 1.0 };
+
+    float r = AudioParamTimeline::exponentialRampAtTime(Seconds { 0.7 }, value1, time1, value2, time2);
+    EXPECT_NEAR(r, value1, 1e-7f);
+}
+
+TEST(WebCore, AudioParamTimeline_OppositeSigns_LargeMagnitudes)
+{
+    const float value1 = -1000.0f;
+    const float value2 = 500.0f;
+    const Seconds time1 { 0.5 };
+    const Seconds time2 { 1.5 };
+
+    float r = AudioParamTimeline::exponentialRampAtTime(Seconds { 0.9 }, value1, time1, value2, time2);
+    EXPECT_FLOAT_EQ(r, value1);
+}
+
+TEST(WebCore, AudioParamTimeline_SameSign_PositiveFollowsExponential)
+{
+    const float value1 = 1.0f;
+    const float value2 = 4.0f;
+    const Seconds time1 { 0.0 };
+    const Seconds time2 { 1.0 };
+    const Seconds t { 0.5 };
+
+    float r = AudioParamTimeline::exponentialRampAtTime(t, value1, time1, value2, time2);
+    float expected = expInterp(value1, value2, t, time1, time2);
+    EXPECT_NEAR(r, expected, 1e-3f);
+}
+
+TEST(WebCore, AudioParamTimeline_SameSign_NegativeFollowsExponential)
+{
+    const float value1 = -2.0f;
+    const float value2 = -8.0f;
+    const Seconds time1 { 0.0 };
+    const Seconds time2 { 1.0 };
+    const Seconds t { 0.5 };
+
+    float r = AudioParamTimeline::exponentialRampAtTime(t, value1, time1, value2, time2);
+    float expected = expInterp(value1, value2, t, time1, time2);
+    EXPECT_NEAR(r, expected, 1e-3f);
+}
+
+#endif // ENABLE(WEB_AUDIO)


### PR DESCRIPTION
#### 042baf1bcedc7f8b3ceefce31a7b813b040aa854
<pre>
Exponential ramp can produce NaN when starting value is zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=297579">https://bugs.webkit.org/show_bug.cgi?id=297579</a>
<a href="https://rdar.apple.com/157301250">rdar://157301250</a>

Reviewed by Darin Adler and Youenn Fablet.

Return the start value when value1 == 0 or value1 and value2 have opposite signs, matching Blink
and the spec. This prevents invalid exponential ramps across zero. Added test cases for
positive→negative, negative→positive, and zero start.

* LayoutTests/webaudio/AudioParam/exponential-ramp-crash-expected.txt: Added.
* LayoutTests/webaudio/AudioParam/exponential-ramp-crash.html: Added.
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::AudioParamTimeline::exponentialRampAtTime):
* Source/WebCore/Modules/webaudio/AudioParamTimeline.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/ExponentialRampAtTimeTest.cpp: Added.
(expInterp):
(TEST(WebCore, AudioParamTimeline_OppositeSigns_PositiveToNegative)):
(TEST(WebCore, AudioParamTimeline_OppositeSigns_NegativeToPositive)):
(TEST(WebCore, AudioParamTimeline_OppositeSigns_MultipleTimes)):
(TEST(WebCore, AudioParamTimeline_OppositeSigns_SmallMagnitudes)):
(TEST(WebCore, AudioParamTimeline_OppositeSigns_LargeMagnitudes)):
(TEST(WebCore, AudioParamTimeline_SameSign_PositiveFollowsExponential)):
(TEST(WebCore, AudioParamTimeline_SameSign_NegativeFollowsExponential)):

Originally-landed-as: 297297.313@safari-7622-branch (6d65d918b410). <a href="https://rdar.apple.com/164280107">rdar://164280107</a>
Canonical link: <a href="https://commits.webkit.org/303190@main">https://commits.webkit.org/303190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f4c0d7cee8c0ba46c516f85f2fc5893445cd693

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82793 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/157075ee-ede4-412c-827c-c964ebe0b19d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67642 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80578 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6aea1d9-309e-44ab-bd52-4aa11097fc6b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81787 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141034 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3169 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108389 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108343 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2393 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56227 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3236 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32117 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66632 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->