### PR TITLE
Crash under MediaResourceLoader::requestResource()

### DIFF
--- a/LayoutTests/http/tests/media/resources/hls/.htaccess
+++ b/LayoutTests/http/tests/media/resources/hls/.htaccess
@@ -1,0 +1,3 @@
+<Files playlist-with-cookie.m3u8>
+Header always set Access-Control-Allow-Origin "http://127.0.0.1:8000"
+</Files>

--- a/LayoutTests/http/tests/media/resources/video-cookie-check-cookie.py
+++ b/LayoutTests/http/tests/media/resources/video-cookie-check-cookie.py
@@ -12,6 +12,11 @@ from resources.portabilityLayer import get_cookies
 cookies = get_cookies()
 test = cookies.get('TEST', None)
 
+sys.stdout.write(
+    'Access-Control-Allow-Origin: *\r\n'
+)
+
+
 filename = 'test.'
 if test is not None:
     extension = test.split('.')[-1]

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-expected.txt
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-expected.txt
@@ -1,0 +1,3 @@
+http://127.0.0.1:8000/resources/js-test-pre.js
+http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8
+

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors-expected.txt
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors-expected.txt
@@ -1,0 +1,4 @@
+http://127.0.0.1:8000/resources/js-test-pre.js
+http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8
+http://localhost:8000/media/resources/hls/sub-playlist-with-cookie.py
+

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText()
+        testRunner.waitUntilDone();
+    }
+    if (window.internals)
+        internals.settings.setEnableOpaqueLoadingForMedia(true);
+</script>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<video src="http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8" crossorigin>
+<script>
+    var entries = new Set();
+    let gotMetadata = false;
+    const expectedEntries = 3;
+    let runTest = function() {
+        for (let entry of performance.getEntriesByType('resource')) {
+            if (entries.has(entry.name))
+                continue;
+            entries.add(entry.name);
+            if (entries.size <= expectedEntries)
+                debug(entry.name);
+        }
+
+        if (window.testRunner && gotMetadata && entries.size >= expectedEntries)
+            testRunner.notifyDone();
+    };
+    let video = document.querySelector("video");
+    setInterval(runTest, 100);
+
+    video.addEventListener("loadedmetadata", (e) => {
+        gotMetadata = true;
+        if (window.testRunner && gotMetadata && entries.size >= expectedEntries)
+            testRunner.notifyDone();
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media.html
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText()
+        testRunner.waitUntilDone();
+    }
+    if (window.internals)
+        internals.settings.setEnableOpaqueLoadingForMedia(true);
+</script>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<video id=video src="http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8">
+<script>
+    var entries = new Set();
+    let gotMetadata = false;
+
+    let runTest = function() {
+        for (let entry of performance.getEntriesByType('resource')) {
+            if (entries.has(entry.name))
+                continue;
+            entries.add(entry.name);
+            if (entry.initiatorType == "video" && entry.name != video.src)
+                testFailed("Unexpected entry: " + entry.name);
+            else
+                debug(entry.name);
+        }
+
+        if (window.testRunner && gotMetadata && entries.size)
+            testRunner.notifyDone();
+    };
+    setInterval(runTest, 100);
+
+    video.addEventListener("loadedmetadata", (e) => {
+        gotMetadata = true;
+        if (window.testRunner && gotMetadata && entries.size)
+            testRunner.notifyDone();
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-expected.txt
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-expected.txt
@@ -1,0 +1,4 @@
+http://127.0.0.1:8000/resources/js-test-pre.js
+http://127.0.0.1:8000/resources/redirect.py?url=http%3A%2F%2Flocalhost%3A8000%2Fmedia%2Fresources%2Fhls%2Fplaylist-with-cookie.m3u8%3F
+http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8?
+

--- a/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-with-cors-expected.txt
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-with-cors-expected.txt
@@ -1,0 +1,4 @@
+http://127.0.0.1:8000/resources/js-test-pre.js
+http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8%3F
+http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8?
+

--- a/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-with-cors.html
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-with-cors.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText()
+        testRunner.waitUntilDone();
+    }
+    if (window.internals)
+        internals.settings.setEnableOpaqueLoadingForMedia(true);
+</script>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<video id=video crossorigin>
+<script>
+    const testId = Math.random() + "";
+    const entries = new Set();
+    let gotMetadata = false;
+    const expectedEntries = 3;
+    let runTest = function() {
+        for (let entry of performance.getEntriesByType('resource')) {
+            if (entries.has(entry.name))
+                continue;
+            entries.add(entry.name);
+            if (entries.size <= expectedEntries)
+                debug(entry.name.replace(testId, ""));
+        }
+
+        if (window.testRunner && gotMetadata && entries.size >= expectedEntries)
+            testRunner.notifyDone();
+    };
+    let video = document.querySelector("video");
+    setInterval(runTest, 100);
+
+    video.addEventListener("loadedmetadata", (e) => {
+        gotMetadata = true;
+        if (window.testRunner && gotMetadata && entries.size >= expectedEntries)
+            testRunner.notifyDone();
+    });
+    video.src = "/resources/redirect.py?url=http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8" + "%3F" + testId;
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText()
+        testRunner.waitUntilDone();
+    }
+    if (window.internals)
+        internals.settings.setEnableOpaqueLoadingForMedia(true);
+</script>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<video id=video></video>
+<script>
+    const testId = Math.random() + "";
+    const entries = new Set();
+    let gotMetadata = false;
+
+    const videoURL = "http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8?" + testId;
+    video.src = "/resources/redirect.py?url=" + encodeURIComponent(videoURL);
+
+    let runTest = function() {
+        for (let entry of performance.getEntriesByType('resource')) {
+            if (entries.has(entry.name))
+                continue;
+            entries.add(entry.name);
+            if (entry.initiatorType == "video" && entry.name != video.src && entry.name != videoURL)
+                testFailed("Unexpected entry: " + entry.name);
+            else
+                debug(entry.name.replace(testId, ""));
+        }
+
+        if (window.testRunner && gotMetadata && entries.size)
+            testRunner.notifyDone();
+    };
+    setInterval(runTest, 100);
+
+    video.addEventListener("loadedmetadata", (e) => {
+        gotMetadata = true;
+        if (window.testRunner && gotMetadata && entries.size)
+            testRunner.notifyDone();
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4851,6 +4851,12 @@ webkit.org/b/303873 imported/w3c/web-platform-tests/trusted-types/navigate-to-ja
 # No USE(AUDIO_SESSION) support:
 media/volume-activate-audio-session.html [ Skip ]
 
+# Does not work on glib platforms
+http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html [ Skip ]
+http/tests/performance/performance-resource-timing-cross-origin-media.html [ Skip ] 
+http/tests/performance/performance-resource-timing-redirection-cross-origin-media-with-cors.html [ Skip ] 
+http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2727,6 +2727,20 @@ EnableInheritURIQueryComponent:
     WebCore:
       default: false
 
+EnableOpaqueLoadingForMedia:
+  type: bool
+  status: internal
+  category: media
+  humanReadableName: "Opaque loading for media"
+  humanReadableDescription: "Enable opaque loading for media"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: true
+    WebCore:
+      default: false
+
 EncryptedMediaAPIEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -96,7 +96,7 @@ void MediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<void(Expe
 
 static LoadedFromOpaqueSource computeLoadedFromOpaqueSource(const Document& document, const HashSet<URL>& nonOpaqueLoadURLs, const URL& url, const std::optional<LoadedFromOpaqueSource> loadedFromOpaqueSource)
 {
-    if (!document.settings().enableOpaqueLoadingForMedia())
+    if (!document.settings().enableOpaqueLoadingForMedia() || url.isEmpty())
         return LoadedFromOpaqueSource::No;
 
     if (loadedFromOpaqueSource.value_or(LoadedFromOpaqueSource::No) == LoadedFromOpaqueSource::No)
@@ -113,7 +113,7 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
     if (!document)
         return nullptr;
 
-    if (!m_loadedFromOpaqueSource)
+    if (!m_loadedFromOpaqueSource && !request.url().isEmpty())
         m_nonOpaqueLoadURLs.add(request.url());
 
     DataBufferingPolicy bufferingPolicy = options & LoadOption::BufferData ? DataBufferingPolicy::BufferData : DataBufferingPolicy::DoNotBufferData;
@@ -266,6 +266,7 @@ bool MediaResourceLoader::verifyMediaResponse(const URL& requestURL, const Resou
 
 void MediaResourceLoader::redirectReceived(const URL& url)
 {
+    ASSERT(!url.isEmpty());
     if (!m_loadedFromOpaqueSource)
         m_nonOpaqueLoadURLs.add(url);
 }

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -49,6 +49,8 @@ class Element;
 class MediaResource;
 class WeakPtrImplWithEventTargetData;
 
+enum class LoadedFromOpaqueSource : bool;
+
 class MediaResourceLoader final : public PlatformMediaResourceLoader, public ContextDestructionObserver {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(MediaResourceLoader, WEBCORE_EXPORT);
 public:
@@ -72,6 +74,7 @@ public:
     void addResponseForTesting(const ResourceResponse&);
 
     bool verifyMediaResponse(const URL& requestURL, const ResourceResponse&, const SecurityOrigin*);
+    void redirectReceived(const URL&);
 
 private:
     WEBCORE_EXPORT MediaResourceLoader(Document&, Element&, const String& crossOriginMode, FetchOptions::Destination);
@@ -91,6 +94,9 @@ private:
         bool usedServiceWorker { false };
     };
     HashMap<URL, ValidationInformation> m_validationLoadInformations WTF_GUARDED_BY_CAPABILITY(mainThread);
+
+    HashSet<URL> m_nonOpaqueLoadURLs;
+    std::optional<LoadedFromOpaqueSource> m_loadedFromOpaqueSource;
 };
 
 class MediaResource : public PlatformMediaResource, public CachedRawResourceClient {


### PR DESCRIPTION
#### 5e904fc9e42d6b164bda401b8a6407d055c28e0a
<pre>
Crash under MediaResourceLoader::requestResource()
<a href="https://rdar.apple.com/161217814">rdar://161217814</a>

Reviewed by Jean-Yves Avenard.

We add checks to protect from empty URLs.

* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::computeLoadedFromOpaqueSource):
(WebCore::MediaResourceLoader::requestResource):
(WebCore::MediaResourceLoader::redirectReceived):

Originally-landed-as: 297297.477@safari-7622-branch (6cfacf6782cd). <a href="https://rdar.apple.com/164212243">rdar://164212243</a>
Canonical link: <a href="https://commits.webkit.org/304317@main">https://commits.webkit.org/304317@main</a>
</pre>
----------------------------------------------------------------------
#### da2cbccc6c635200700a4dde1f2d9ddb5b747dab
<pre>
HLS: Performance.getEntries() leaks contents of cross-site playlists
<a href="https://rdar.apple.com/133406290">rdar://133406290</a>

Reviewed by Eric Carlson.

When loading a manifest and the manifest is opaque, we cannot let the web page know about loads triggered from that manifest.
We thus need to use LoadedFromOpaqueSource, like done for CSS. This will prevent service worker interception and performance exposure.

We do not know whether a media load is triggered from a particular manifest unfortunately.
We do the following heuristic as a workaround:
- As long as opaque source loading is not enabled, we check each opaque response mime type.
- If an opaque response mime type is a manifest mime type, all remaining loads of the current media will be LoadedFromOpaqueSource::Yes.
- If a load was previously done in non opaque mode, we continue doing so, to not disrupt successive media range requests.

* LayoutTests/http/tests/media/resources/hls/.htaccess: Added.
* LayoutTests/http/tests/media/resources/video-cookie-check-cookie.py:
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-expected.txt: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors-expected.txt: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media.html: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-expected.txt: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-with-cors-expected.txt: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media-with-cors.html: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::computeLoadedFromOpaqueSource):
(WebCore::MediaResourceLoader::requestResource):
(WebCore::isManifestMIMEType):
(WebCore::MediaResourceLoader::verifyMediaResponse):
(WebCore::MediaResourceLoader::redirectReceived):
(WebCore::MediaResource::redirectReceived):
* Source/WebCore/loader/MediaResourceLoader.h:

Originally-landed-as: 297297.327@safari-7622-branch (73b19a9b10d5). <a href="https://rdar.apple.com/164279835">rdar://164279835</a>
Canonical link: <a href="https://commits.webkit.org/304316@main">https://commits.webkit.org/304316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06871e6824bda61cc1706db10628fc17a02063e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86977 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84183 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3272 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3307 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127214 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145413 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133699 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111707 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112071 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5513 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117494 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20850 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35628 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166560 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70890 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->