### PR TITLE
[web-animations] remove `KeyframeEffectStack::hasEffectWithImplicitKeyframes()` and `KeyframeEffect::hasImplicitKeyframes()`

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1774,23 +1774,6 @@ void KeyframeEffect::computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoint
     }
 }
 
-bool KeyframeEffect::hasImplicitKeyframes() const
-{
-    auto numberOfKeyframes = m_parsedKeyframes.size();
-
-    // If we have no keyframes, then there cannot be any implicit keyframes.
-    if (!numberOfKeyframes)
-        return false;
-
-    // If we have a single keyframe, then there has to be at least one implicit keyframe.
-    if (numberOfKeyframes == 1)
-        return true;
-
-    // If we have two or more keyframes, then we have implicit keyframes if the first and last
-    // keyframes don't have 0 and 1 respectively as their computed offset.
-    return m_parsedKeyframes[0].computedOffset || m_parsedKeyframes[numberOfKeyframes - 1].computedOffset != 1;
-}
-
 void KeyframeEffect::getAnimatedStyle(std::unique_ptr<RenderStyle>& animatedStyle)
 {
     if (!renderer() || !animation())

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -174,7 +174,6 @@ public:
     bool isRunningAcceleratedTransformRelatedAnimation() const;
 
     bool requiresPseudoElement() const;
-    bool hasImplicitKeyframes() const;
 
     void customPropertyRegistrationDidChange(const AtomString&);
 

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -110,13 +110,6 @@ bool KeyframeEffectStack::requiresPseudoElement() const
     });
 }
 
-bool KeyframeEffectStack::hasEffectWithImplicitKeyframes() const
-{
-    return hasMatchingEffect([] (const KeyframeEffect& effect) {
-        return effect.hasImplicitKeyframes();
-    });
-}
-
 bool KeyframeEffectStack::isCurrentlyAffectingProperty(CSSPropertyID property) const
 {
     return hasMatchingEffect([property] (const KeyframeEffect& effect) {

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -67,7 +67,6 @@ public:
     bool isCurrentlyAffectingProperty(CSSPropertyID) const;
     bool requiresPseudoElement() const;
     OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);
-    bool hasEffectWithImplicitKeyframes() const;
 
     void effectAbilityToBeAcceleratedDidChange(const KeyframeEffect&);
     bool allowsAcceleration() const;


### PR DESCRIPTION
#### 28a936716e9be4a7083694dd1c4cd5f4db492593
<pre>
[web-animations] remove `KeyframeEffectStack::hasEffectWithImplicitKeyframes()` and `KeyframeEffect::hasImplicitKeyframes()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302552">https://bugs.webkit.org/show_bug.cgi?id=302552</a>

Reviewed by Tim Nguyen.

`KeyframeEffectStack::hasEffectWithImplicitKeyframes()` does not have any call site
and `KeyframeEffect::hasImplicitKeyframes()` is only called from that method. They
can both be removed.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::hasImplicitKeyframes const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::hasEffectWithImplicitKeyframes const): Deleted.
* Source/WebCore/animation/KeyframeEffectStack.h:

Canonical link: <a href="https://commits.webkit.org/303069@main">https://commits.webkit.org/303069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bff600107f8d53d38a18d71b4816c495be08239

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82801 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/78f417c8-7415-45fd-9828-2cc74c04c31d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99877 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d957b62f-1eec-49e8-b0da-f15f6ab13061) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80583 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bff5ff5c-4a7d-40fa-82ad-edc0193897f5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2382 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/52 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81795 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110967 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35484 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141042 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3177 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108395 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2864 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108349 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2398 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113699 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56235 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20409 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3244 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32121 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66640 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3265 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->