### PR TITLE
BBQ stackmap should not write to try implicit slots

### DIFF
--- a/JSTests/wasm/stress/ipint-bbq-osr-check-try-implicit-slot-overlap.js
+++ b/JSTests/wasm/stress/ipint-bbq-osr-check-try-implicit-slot-overlap.js
@@ -1,0 +1,140 @@
+function instantiate(moduleBase64, importObject) {
+    let bytes = Uint8Array.fromBase64(moduleBase64);
+    return WebAssembly.instantiate(bytes, importObject);
+  }
+  const report = $.agent.report;
+  const isJIT = callerIsBBQOrOMGCompiled;
+const extra = {isJIT};
+(async function () {
+let memory0 = new WebAssembly.Memory({initial: 1850, shared: true, maximum: 2731});
+/**
+@param {I32} a0
+@param {F32} a1
+@returns {void}
+ */
+let fn0 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+};
+/**
+@returns {void}
+ */
+let fn1 = function () {
+};
+/**
+@param {I32} a0
+@param {F32} a1
+@returns {[I32, F32]}
+ */
+let fn2 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+return [36, 8.433544074882645e1];
+};
+/**
+@param {I32} a0
+@param {FuncRef} a1
+@returns {void}
+ */
+let fn3 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+};
+let tag5 = new WebAssembly.Tag({parameters: []});
+let tag6 = new WebAssembly.Tag({parameters: ['i32', 'f32']});
+let tag9 = new WebAssembly.Tag({parameters: []});
+let global0 = new WebAssembly.Global({value: 'i32', mutable: true}, 3721432472);
+let global1 = new WebAssembly.Global({value: 'f64', mutable: true}, 548636.1280581957);
+let global3 = new WebAssembly.Global({value: 'f32', mutable: true}, 52810.0658290932);
+let global4 = new WebAssembly.Global({value: 'i64', mutable: true}, 1872919390n);
+let global7 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, null);
+let global8 = new WebAssembly.Global({value: 'externref', mutable: true}, {});
+let table0 = new WebAssembly.Table({initial: 48, element: 'externref', maximum: 347});
+let table1 = new WebAssembly.Table({initial: 37, element: 'anyfunc'});
+let table2 = new WebAssembly.Table({initial: 51, element: 'externref', maximum: 276});
+let table3 = new WebAssembly.Table({initial: 77, element: 'externref'});
+let m2 = {fn3, global0, global2: global0, global7, memory0, tag5, tag6, tag9};
+let m1 = {fn0, fn1, fn2, global1, global6: global3, global8, table0, table1, table3, tag8: tag5, tag12: tag9};
+let m0 = {global3, global4, global5: global4, table2, table4: table3, tag7: tag5, tag10: tag9, tag11: tag6};
+let importObject0 = /** @type {Imports2} */ ({extra, m0, m1, m2});
+/*
+  (func (;5;) (param ) (result )
+    (local i32 i32)
+    loop ;; label = @1
+      local.get 1
+      i32.const 1
+      i32.add
+      local.tee 1
+      i32.const 43
+      i32.lt_u
+      br_if 0 (;@1;)
+      ;; BEGIN IMPORTANT
+        i32.const 1
+        i32.const 6
+        table.get 1
+        ;; BEGIN VERY IMPORTANT
+        loop (param i32 funcref) (result i32 funcref)  ;; label = @3
+          try (param i32 funcref) (result i32 funcref)  ;; label = @4
+            local.get 0
+            i32.const 1
+            i32.add
+            local.tee 0
+            i32.const 36
+            i32.lt_u
+            if (param i32 funcref) (result i32 funcref)  ;; label = @5
+              br 2 (;@3;)
+            end
+          end
+        end
+        ;; END VERY IMPORTANT
+        table.set 1
+      ;; END IMPORTANT
+    end
+    )
+  (func (;6;) (type 18) (param i32 f32)
+    call 5
+    return)
+
+*/
+let i0 = await instantiate(
+'AGFzbQEAAAABgAETYAABf2ACf3AJcH1/cHt9f3t9YAJ/cAJ/cGACf3AAYANvcHsAYANvcHsDb3B7YANvcHsAYAN7fn8De317YAN7fn8De35/YAN7fn8AYANwfnsDfXB/YANwfnsDcH57YANwfnsAYAAAYAAAYAAAYAJ/fQJ7f2ACf30Cf31gAn99AALnAhwCbTIHbWVtb3J5MAIDug6rFQJtMQNmbjAAEgJtMQNmbjEADQJtMQNmbjIAEQJtMgNmbjMAAwVleHRyYQVpc0pJVAAAAm0yBHRhZzUEAA4CbTIEdGFnNgQAEgJtMAR0YWc3BAAPAm0xBHRhZzgEAA0CbTIEdGFnOQQADgJtMAV0YWcxMAQADwJtMAV0YWcxMQQAEgJtMQV0YWcxMgQADwJtMgdnbG9iYWwwA38BAm0xB2dsb2JhbDEDfAECbTIHZ2xvYmFsMgN/AQJtMAdnbG9iYWwzA30BAm0wB2dsb2JhbDQDfgECbTAHZ2xvYmFsNQN+AQJtMQdnbG9iYWw2A30BAm0yB2dsb2JhbDcDcAECbTEHZ2xvYmFsOANvAQJtMQZ0YWJsZTABbwEw2wICbTEGdGFibGUxAXAAJQJtMAZ0YWJsZTIBbwEzlAICbTEGdGFibGUzAW8ATQJtMAZ0YWJsZTQBbwA7AwMCDRIEFgVvAFhvARTTBm8BE6kGcABObwFNygYNFwsADwAOAAYADQAOAAwADQAJAA0ABgANBl4KfQFDC0JCjAt8AUTD6W+dAQahrQt+AULEAAt/AUHfAAt8AESAU9orGbwSsgt/AUEBC30BQ0MnTH8LfgFC7ZHWnwwLfwFBxwALewH9DIFrswgU3AOrzNvkUWHqRLwLB74BFQR0YWczBAcIZ2xvYmFsMTYDEgR0YWcwBAIDZm41AAYEdGFnMgQGBnRhYmxlOAEIBnRhYmxlNwEHB21lbW9yeTECAAhnbG9iYWwxNQMRBHRhZzEEBQNmbjQABQhnbG9iYWwxMQMKBHRhZzQECghnbG9iYWwxMAMJBnRhYmxlNgEGCGdsb2JhbDE0AxAGdGFibGU5AQkHZ2xvYmFsOQMACGdsb2JhbDEzAwwGdGFibGU1AQUIZ2xvYmFsMTIDCwnyAQkDAE4BBQEDAgUCAwAFAwEGBAQDAwIGBgEAAwADAQEFBAEBBQYFBgUBAwYEAgQABgACBQYFBAYEAAIBBQYGBQIFAgYGAQADBgAFAgEGAQUGBQUBAFQAAwUCAQIFBgYAAgAABQYEBAMDAgADAgEABgEBBAIAAQQCAAQGAQAFAQICAwUEAAYBAgAEAAYFBAYDAwUABgUGBgEAAQEAAAMFBAQBAgYGAwMGBgMCAUEUCwARAwIFAwYABQIAAwIGAwYCBQUCAUEeCwACAAYCCEEMCwABAQIIQSILAAECAghBEgsAAQMCCEELCwABBAIBQQELAAEFCjgCMAECfwNAIAFBAWoiAUErSQ0AQQFBBiUBAwIGAiAAQQFqIgBBJEkEAgwCCwsLJgELCwUAEAUPCwsZAwEHnzQg5BrOxgBBiscACwSuJgPYAQKQxA=='
+    , importObject0);
+let {fn4, fn5, global9, global10, global11, global12, global13, global14, global15, global16, memory1, table5, table6, table7, table8, table9, tag0, tag1, tag2, tag3, tag4} = /**
+  @type {{
+fn4: (a0: FuncRef, a1: I64, a2: V128) => [FuncRef, I64, V128],
+fn5: (a0: I32, a1: F32) => void,
+global9: WebAssembly.Global,
+global10: WebAssembly.Global,
+global11: WebAssembly.Global,
+global12: WebAssembly.Global,
+global13: WebAssembly.Global,
+global14: WebAssembly.Global,
+global15: WebAssembly.Global,
+global16: WebAssembly.Global,
+memory1: WebAssembly.Memory,
+table5: WebAssembly.Table,
+table6: WebAssembly.Table,
+table7: WebAssembly.Table,
+table8: WebAssembly.Table,
+table9: WebAssembly.Table,
+tag0: WebAssembly.Tag,
+tag1: WebAssembly.Tag,
+tag2: WebAssembly.Tag,
+tag3: WebAssembly.Tag,
+tag4: WebAssembly.Tag
+  }} */ (i0.instance.exports);
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+    let zzz = fn5(global9.value, global3.value);
+    if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+})().then(() => {
+  report('after');
+}).catch(e => {
+  report('error');
+})
+

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1166,6 +1166,9 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe:
     const StackMap& stackMap = entryData.values();
     auto writeValueToRep = [&](uint64_t* bufferSlot, const OSREntryValue& value) {
         B3::Type type = value.type();
+        // Void signifies an unused exception slot in `try` (since we can't have an exception at that time)
+        if (type.kind() == B3::TypeKind::Void)
+            return;
         if (value.isGPR()) {
             ASSERT(!type.isFloat() && !type.isVector());
             context.gpr(value.gpr()) = *bufferSlot;


### PR DESCRIPTION
#### b107f7698299c89d7e3a5c93a7c4f0337ce985f4
<pre>
BBQ stackmap should not write to try implicit slots
<a href="https://bugs.webkit.org/show_bug.cgi?id=298196">https://bugs.webkit.org/show_bug.cgi?id=298196</a>
<a href="https://rdar.apple.com/159610745">rdar://159610745</a>

Reviewed by Yusuke Suzuki.

BBQ places the try block&apos;s implicit slot in the same Temp as the arguments. This
can lead to Debug assertions firing since it doesn&apos;t expect a real value at that
location. We should just not write to that slot when we parse the exception slot
reserved by IPInt&apos;s OSR.

* JSTests/wasm/stress/ipint-bbq-osr-check-try-implicit-slot-overlap.js: Added.
(instantiate):
(async let):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::ControlData::implicitSlots const):
(JSC::Wasm::BBQJITImpl::BBQJIT::makeStackMap):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Originally-landed-as: 297297.400@safari-7622-branch (d3b258b586e6). <a href="https://rdar.apple.com/164277028">rdar://164277028</a>
Canonical link: <a href="https://commits.webkit.org/303195@main">https://commits.webkit.org/303195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1206ed29b2f086311f947843449686bb75f6d9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82805 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/700d8694-8ade-4f40-ba4f-0392f9c2aa6a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67652 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11e4e303-46af-4ece-9a7c-45af9fdb9b1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80587 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dcd94780-4097-4f4f-8bea-d51db0887606) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/401 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81799 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123132 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111274 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35499 "Found 3 new test failures: inspector/animation/lifecycle-css-transition.html inspector/debugger/async-stack-trace-truncate.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141046 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129564 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3181 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108353 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2399 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56239 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20455 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3248 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32120 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162581 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66644 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40593 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3618 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3178 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->