### PR TITLE
Add test cases for array allocation sinking

### DIFF
--- a/JSTests/stress/array-allocation-sink-closure.js
+++ b/JSTests/stress/array-allocation-sink-closure.js
@@ -1,0 +1,11 @@
+for (let i = 0; i < testLoopCount; i++) {
+    function func(arg_array) {
+      let new_array = (() => new Array(8))();
+      new_array[0] = {};
+      arg_array[0] = new_array[0];
+      var obj = {'f': arg_array[1] ? new_array : 42};
+    }
+    for (let j = 0; j < 2; j++) {
+        func([1.1, 2.2]);
+    }
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-from-closure.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-from-closure.js
@@ -1,0 +1,25 @@
+function test(arg_array) {
+
+
+    let new_array = (() => {
+        let res = new Array(8);
+        res.length
+        return res;
+    })();
+    let o1 = {};
+    new_array[0] = o1;
+
+    let f;
+    if (arg_array[1]) {
+        new_array[0] = new_array.length;
+        f = new_array;
+    } else {
+        f = 42;
+    }
+
+    var obj = { 'f': f };
+}
+
+for (let j = 0; j < 1e5; j++) {
+    test([1.1, 2.2]);
+}


### PR DESCRIPTION
#### 20bb4e38db7e59e748a976a403c9eee750352ae4
<pre>
Add test cases for array allocation sinking
<a href="https://bugs.webkit.org/show_bug.cgi?id=298658">https://bugs.webkit.org/show_bug.cgi?id=298658</a>
<a href="https://rdar.apple.com/problem/160286715">rdar://problem/160286715</a>

Reviewed by Yijia Huang.

Add new tests from some bugs that we had to be merged back.

* JSTests/stress/array-allocation-sink-closure.js: Added.
(i.func):
* JSTests/stress/array-allocation-sink-escape-materialize-from-closure.js: Added.
(test):

Originally-landed-as: 297297.404@safari-7622-branch (930cbd46259f). <a href="https://rdar.apple.com/164214900">rdar://164214900</a>
Canonical link: <a href="https://commits.webkit.org/303196@main">https://commits.webkit.org/303196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/202f5baad39b730d763b007327fb82d2bcd4d29b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82807 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100375 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67647 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c78873b0-f398-412d-8faa-49f41e0ddd06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80589 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9acf7fe-b6a5-40a4-8d6b-39a62d756930) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2395 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/402 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81801 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123134 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111275 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141048 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129566 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3183 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108400 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108354 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2401 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113711 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56241 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20456 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3250 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32132 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162583 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3417 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40594 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->