### PR TITLE
AX: Crash can happen when the parent of a dynamically updated object is deleted

### DIFF
--- a/LayoutTests/accessibility/crash-deleting-dynamically-updated-text-input-expected.txt
+++ b/LayoutTests/accessibility/crash-deleting-dynamically-updated-text-input-expected.txt
@@ -1,0 +1,11 @@
+This test ensures we don't crash when deleting the parent of a text input that has had at least one value change.
+
+PASS: input.role === 'AXRole: AXTextField'
+PASS: accessibilityController.accessibleElementById('form').childAtIndex(0).role === 'AXRole: AXTextField'
+PASS: input.stringValue === 'AXValue: abc'
+PASS: input.role === 'AXRole: '
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/crash-deleting-dynamically-updated-text-input.html
+++ b/LayoutTests/accessibility/crash-deleting-dynamically-updated-text-input.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div role="group" id="form" aria-label="my form">
+    <input type="text" id="input">
+</div>
+<input id="checkbox" type="checkbox">
+
+<script>
+var output = "This test ensures we don't crash when deleting the parent of a text input that has had at least one value change.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var input = accessibilityController.accessibleElementById("input");
+    output += expect("input.role", "'AXRole: AXTextField'");
+    output += expect("accessibilityController.accessibleElementById('form').childAtIndex(0).role", "'AXRole: AXTextField'");
+
+    setTimeout(async function() {
+        // This will cause the isolated object to be fully replaced (at the time this comment was written).
+        document.getElementById("input").value = "abc";
+        output += await expectAsync("input.stringValue", "'AXValue: abc'");
+
+        // Delete the parent of the text input. When we process deletions, we'll iterate through all descendants (including
+        // the text input), deleting them too.
+        document.getElementById("form").remove();
+
+        // Check a checkbox, which will post a platform notification, forcing an immediate flush of queued isolated tree updates,
+        // including the removals we queued just above.
+        document.getElementById("checkbox").checked = true;
+
+        // Should not cause a crash. The actual role value returned doesn't really matter.
+        output += await expectAsync("input.role", "'AXRole: '");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4838,6 +4838,8 @@ webkit.org/b/299333 http/wpt/navigation-api/ [ Failure Pass ]
 webkit.org/b/302326 animations/animation-welcome-safari.html [ Failure Pass ]
 webkit.org/b/302326 fast/dom/rtl-scroll-to-leftmost-and-resize.html [ Failure Timeout Pass ]
 
+webkit.org/b/298463 accessibility/crash-deleting-dynamically-updated-text-input.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### 2ee2ba7e7a8f142872315fb5b5d8b510c9569f26
<pre>
AX: Crash can happen when the parent of a dynamically updated object is deleted
<a href="https://bugs.webkit.org/show_bug.cgi?id=298463">https://bugs.webkit.org/show_bug.cgi?id=298463</a>
<a href="https://rdar.apple.com/158287589">rdar://158287589</a>

Reviewed by Joshua Hoffman.

A crash can happen in this sequence:

  1. An object that is the child of another object in the isolated tree (it is contained within its m_children) receives
     a dynamic update from the DOM that will cause a full node update to run for it, creating a whole new AXIsolatedObject.
     An example of this is when the value changes for an input element. We do this for certain types of updates where
     the update affects so many properties, we don&apos;t bother trying to update them all individually.

  2. AXIsolatedTree::applyPendingChanges runs, and we replace the old object in AXIsolatedTree::m_readerThreadNodeMap
     with the new one. However, the &quot;old&quot; / stale object is still strong-referenced in the parent&apos;s m_children.

  3. The parent is deleted, and said deletion is queued up for processing the next time AXIsolatedTree::applyPendingChanges runs.

  4. An AT requests an attribute from the fully-updated, stale object. This calls -[WebAccessibilityObjectWrapperBase updateObjectBackingStore].
     We create a RefPtr to the fully-updated, stale object near the top of the method. Then we run AXIsolatedTree::applyPendingChanges.
     This deletes the parent object, and the parent deletes it&apos;s m_children too. This means the last strong reference
     to the stale object is in updateObjectBackingStore (remember the stale object was removed from m_readerThreadNodeMap in step 2).

  5. As the last step in updateObjectBackingStore, the wrapper returns self.axBackingObject, which is critically a raw pointer
     to the stale object.

  6. The RefPtr destructor runs as the last step in the method, deleting the stale object. But we&apos;ve already returned
     a pointer to it, and any subsequent use is an instant use-after-free.

This commit scopes the RefPtr in updateObjectBackingStore, preventing this issue from happening. A subsequent PR will
change full-node-updates to not re-create brand new AXIsolatedObject instances, just update all the properties of the
existing instance. This will prevent bugs stemming from the parent iterating over its children and using stale objects
while doing so.

* LayoutTests/accessibility/crash-deleting-dynamically-updated-text-input-expected.txt: Added.
* LayoutTests/accessibility/crash-deleting-dynamically-updated-text-input.html: Added.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase updateObjectBackingStore]):

Originally-landed-as: 297297.409@safari-7622-branch (0a56f1d9d362). <a href="https://rdar.apple.com/164214646">rdar://164214646</a>
Canonical link: <a href="https://commits.webkit.org/303297@main">https://commits.webkit.org/303297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/731d7b75bb08aeae218cf6a3f349f673d2d7c4e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139407 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/56b17859-2324-4b04-b207-d509c016f8f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100819 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/489161a2-2ffe-45d3-95b9-190da88f7cac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134841 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f1af2d1-085e-4306-b66c-e15c03f7fbcf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2983 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142051 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4057 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109191 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4138 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3554 "Found 1 new test failure: fast/webgpu/present-without-compute-pipeline.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109357 "Found 1 new API test failure: WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3083 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57278 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20516 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4110 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32811 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67557 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->