### PR TITLE
[WebKit][Main+SU] [bcdfa3892054a35c] ASAN_TRAP | WebCore::WebAnimationTime::approximatelyLessThan; WebCore::AnimationEffectTiming::getBasicTiming; WebCore::AnimationEffect::getBasicTiming

### DIFF
--- a/LayoutTests/webanimations/pause-after-switching-to-finite-timeline-expected.txt
+++ b/LayoutTests/webanimations/pause-after-switching-to-finite-timeline-expected.txt
@@ -1,0 +1,1 @@
+PASS if it does not crash.

--- a/LayoutTests/webanimations/pause-after-switching-to-finite-timeline.html
+++ b/LayoutTests/webanimations/pause-after-switching-to-finite-timeline.html
@@ -1,0 +1,25 @@
+<style>
+
+@keyframes anim { }
+
+frameset { animation: 10s anim }
+
+</style>
+<script>
+
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+
+window.addEventListener('DOMContentLoaded', async () => {
+    document.body.append(document.createElement('frameset'));
+    await frames.caches?.delete('');
+
+    const animation = document.getAnimations()[0];
+    animation.timeline = new ScrollTimeline({ axis: 'y' });
+    await animation.pause();
+
+    window.testRunner?.notifyDone();
+});
+
+</script>
+PASS if it does not crash.

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -382,6 +382,8 @@ void WebAnimation::setTimelineInternal(RefPtr<AnimationTimeline>&& timeline)
 
     if (m_effect)
         m_effect->animationTimelineDidChange(m_timeline.get());
+
+    m_pendingStartTime = std::nullopt;
 }
 
 void WebAnimation::effectTargetDidChange(const std::optional<const Styleable>& previousTarget, const std::optional<const Styleable>& newTarget)


### PR DESCRIPTION
#### 8a05c73a1d696f17d7713d7886713ed5b2d9bbde
<pre>
[WebKit][Main+SU] [bcdfa3892054a35c] ASAN_TRAP | WebCore::WebAnimationTime::approximatelyLessThan; WebCore::AnimationEffectTiming::getBasicTiming; WebCore::AnimationEffect::getBasicTiming
<a href="https://bugs.webkit.org/show_bug.cgi?id=298869">https://bugs.webkit.org/show_bug.cgi?id=298869</a>
<a href="https://rdar.apple.com/160116687">rdar://160116687</a>

Reviewed by Anne van Kesteren.

As part of 294049@main we started storing a &quot;pending start time&quot; for each animation which we would
set to be the start time when marking the animation as ready. When switching from a monotonic to a
progress-based timeline, we may be in a situation where that &quot;pending start time&quot; was recorded based
on the monotonic timeline, and if the animation is paused with a monotonic &quot;pending start time&quot; then
we will try to run some logic based on both monotonic and progress-based times in `WebAnimation::runPendingPauseTask()`.

To address this, we reset the &quot;pending start time&quot; when switching timelines, which makes sense regardless
of the type of timeline we&apos;re dealing with.

* LayoutTests/webanimations/pause-after-switching-to-finite-timeline-expected.txt: Added.
* LayoutTests/webanimations/pause-after-switching-to-finite-timeline.html: Added.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setTimelineInternal):

Originally-landed-as: 297297.417@safari-7622-branch (9a1fcd2847a2). <a href="https://rdar.apple.com/164214430">rdar://164214430</a>
Canonical link: <a href="https://commits.webkit.org/303264@main">https://commits.webkit.org/303264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5e623652a81fb0dc2ee93ef0d5a2b81bd8f5bd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83517 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a918664-3c27-4a7a-b519-e7e3eaf0b72b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100509 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68088 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a570f0e-88ff-4818-a4c0-d3c73df96126) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81319 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cddbbc9f-7caf-45da-86f1-7be1b17381a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2840 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/678 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82358 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141813 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3818 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108886 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109137 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2825 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114168 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57030 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20497 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3875 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32635 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67206 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->