### PR TITLE
Limit JSString length during Unicode operations to 1G characters

### DIFF
--- a/Source/WTF/wtf/unicode/icu/ICUHelpers.h
+++ b/Source/WTF/wtf/unicode/icu/ICUHelpers.h
@@ -61,6 +61,11 @@ constexpr bool needsToGrowToProduceCString(UErrorCode errorCode)
     return needsToGrowToProduceBuffer(errorCode) || errorCode == U_STRING_NOT_TERMINATED_WARNING;
 }
 
+constexpr bool isICUMemoryAllocationError(UErrorCode errorCode)
+{
+    return errorCode == U_MEMORY_ALLOCATION_ERROR;
+}
+
 namespace CallBufferProducingFunction {
 
 template<typename CharacterType, size_t inlineCapacity, typename ...ArgumentTypes> auto& findVector(Vector<CharacterType, inlineCapacity>& buffer, ArgumentTypes&&...)
@@ -128,4 +133,5 @@ WTF_EXPORT_PRIVATE unsigned minorVersion();
 using WTF::callBufferProducingFunction;
 using WTF::needsToGrowToProduceCString;
 using WTF::needsToGrowToProduceBuffer;
+using WTF::isICUMemoryAllocationError;
 using WTF::ICUDeleter;


### PR DESCRIPTION
#### 7a45348e0e20683eeade253712d4ea5dbff391c7
<pre>
Limit JSString length during Unicode operations to 1G characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=298232">https://bugs.webkit.org/show_bug.cgi?id=298232</a>
<a href="https://rdar.apple.com/159665462">rdar://159665462</a>

Reviewed by Yusuke Suzuki.

Unicode has some limits on string length, which can cause issues
when large strings are passed in. We should limit the max length
of strings to avoid hitting these limits, and raise an OOM if we
exceed this limit.

* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::normalize):

Originally-landed-as: 297297.419@safari-7622-branch (03c4ee731559). <a href="https://rdar.apple.com/164214304">rdar://164214304</a>
Canonical link: <a href="https://commits.webkit.org/303199@main">https://commits.webkit.org/303199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e83b2ec6ffb0f3345ea8466ae69813025e7649b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82816 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7dc50be-c92e-4576-bc10-2ac57c9be353) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99904 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67653 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80596 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2430 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/73 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81808 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123480 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111021 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35789 "Found 2 new test failures: inspector/animation/lifecycle-css-transition.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141055 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129573 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3190 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108742 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108361 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2407 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56718 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20458 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3257 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32133 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162590 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67003 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40598 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->