### PR TITLE
Perform parsing in SafeFontParser when requested.

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -73,3 +73,10 @@ cleanup = "rdar://161241477"
 symbols = [
     "CTFontGetUIFontType",
 ]
+
+[[temporary-usage]]
+request = "rdar://161402565"
+cleanup = "rdar://161402756"
+symbols = [
+    "FPFontCreateMemorySafeFontsFromData",
+]

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -251,6 +251,7 @@ CFBitVectorRef CTFontCopyColorGlyphCoverage(CTFontRef);
 
 #if HAVE(CTFONTMANAGER_CREATEMEMORYSAFEFONTDESCRIPTORFROMDATA)
 CTFontDescriptorRef CTFontManagerCreateMemorySafeFontDescriptorFromData(CFDataRef);
+CFArrayRef FPFontCreateMemorySafeFontsFromData(CFDataRef);
 #endif
 
 typedef const struct __FPFont* FPFontRef;

--- a/WebKitLibraries/SDKs/appletvos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/appletvos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [arm64-tvos, arm64e-tvos]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/appletvos26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/appletvos26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [arm64-tvos, arm64e-tvos]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/appletvsimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/appletvsimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [x86_64-tvos-simulator, arm64-tvos-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/appletvsimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/appletvsimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [x86_64-tvos-simulator, arm64-tvos-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/iphoneos26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/iphoneos26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [arm64-ios, arm64e-ios]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/iphonesimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [x86_64-ios-simulator, arm64-ios-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/watchos11.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/watchos11.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator11.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator11.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/xros2.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/xros2.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [arm64-xros, arm64e-xros]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/xros26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/xros26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [arm64-xros, arm64e-xros]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [x86_64-xros-simulator, arm64-xros-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...

--- a/WebKitLibraries/SDKs/xrsimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/xrsimulator26.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -5,5 +5,5 @@ install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontPa
 swift-abi-version: 7
 exports:
 -       targets: [x86_64-xros-simulator, arm64-xros-simulator]
-        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData, _FPFontCreateMemorySafeFontsFromData]
 ...


### PR DESCRIPTION
#### bf2bd2f72c62477542047d20e68383dbe6e9a0b4
<pre>
Perform parsing in SafeFontParser when requested.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299600">https://bugs.webkit.org/show_bug.cgi?id=299600</a>
<a href="https://rdar.apple.com/160955739">rdar://160955739</a>

Reviewed by Vitor Roriz and Brent Fulgham.

We currently use the memory safe variant of FontParser - SafeFontParser,
when requested (e.g. in Lockdown Mode or when force enabled). This uses
the memory safe SPI variant of FPFontCreateFontsFromData.

However, the actual font parsing itself still occurs via the regular
FontParser code, even on the memory safe path. This switches this
behaviour to now use the SafeFontParser for parsing as well.

* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::extractFontCustomPlatformDataShared):
(WebCore::extractFontCustomPlatformDataSystemParser):
(WebCore::extractFontCustomPlatformDataMemorySafe):
(WebCore::FontCustomPlatformData::create):
(WebCore::FontCustomPlatformData::createMemorySafe):
(WebCore::extractFontCustomPlatformData): Deleted.
* WebKitLibraries/SDKs/appletvos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:
* WebKitLibraries/SDKs/appletvsimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:
* WebKitLibraries/SDKs/watchos11.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:
* WebKitLibraries/SDKs/watchsimulator11.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:
* WebKitLibraries/SDKs/xros2.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:
* WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd:

Originally-landed-as: 297297.486@safari-7622-branch (bc123e1d6748). <a href="https://rdar.apple.com/164211967">rdar://164211967</a>
Canonical link: <a href="https://commits.webkit.org/304140@main">https://commits.webkit.org/304140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9f99759a7eae1d3031e10431d3a2d73c4351266

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86595 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3de957e1-65f1-4ec7-8fdd-ba6a90b34160) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102913 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70199 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f69f68ee-f139-4e84-9d08-fb96e64a9e69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83718 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/865d07f9-680a-4070-92ac-3e54f006a3b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5271 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2880 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2768 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144869 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39413 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111602 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5106 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116965 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60669 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6641 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6750 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->