### PR TITLE
Add user prompt before invoking ARQuickLook for 3D Asset Parsing

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -292,6 +292,9 @@
 /* Cancel displaying QuickLook Preview of 3D model */
 "Cancel (usdz QuickLook Preview)" = "Cancel";
 
+/* Cancel displaying QuickLook Preview of 3D object */
+"Cancel (QuickLook Preview)" = "Cancel";
+
 /* Title for Cancel button label in button bar */
 "Cancel button label in button bar" = "Cancel";
 
@@ -1755,6 +1758,15 @@
 
 /* View in AR? description */
 "You can view this object in 3D and place it in your surroundings using augmented reality." = "You can view this object in 3D and place it in your surroundings using augmented reality.";
+
+/* Allow displaying QuickLook Preview of 3D object */
+"View 3D Object (QuickLook Preview)" = "View 3D Object";
+
+/* View 3D Object? */
+"View 3D Object?" = "View 3D Object?";
+
+/* View 3D Object description */
+"You can see a preview of this object before viewing in 3D." = "You can see a preview of this object before viewing in 3D.";
 
 /* Title for View Spatial Photo action button */
 "View Spatial Photo" = "View Spatial Photo";

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -607,11 +607,9 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
 - (void)_didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:(const String&)suggestedFilename data:(NSData *)data
 {
     ASSERT(_customContentView);
-    [_customContentView web_setContentProviderData:data suggestedFilename:suggestedFilename.createNSString().get()];
-
-    // FIXME: It may make more sense for custom content providers to invoke this when they're ready,
-    // because there's no guarantee that all custom content providers will lay out synchronously.
-    _page->didLayoutForCustomContentProvider();
+    [_customContentView web_setContentProviderData:data suggestedFilename:suggestedFilename.createNSString().get() completionHandler:^{
+        _page->didLayoutForCustomContentProvider();
+    }];
 }
 
 - (void)_willInvokeUIScrollViewDelegateCallback

--- a/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProvider.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProvider.h
@@ -39,7 +39,7 @@ struct CGSize;
 @protocol WKWebViewContentProvider <NSObject>
 
 - (instancetype)web_initWithFrame:(CGRect)frame webView:(WKWebView *)webView mimeType:(NSString *)mimeType __attribute__((objc_method_family(init)));
-- (void)web_setContentProviderData:(NSData *)data suggestedFilename:(NSString *)filename;
+- (void)web_setContentProviderData:(NSData *)data suggestedFilename:(NSString *)filename completionHandler:(void (^)(void))completionHandler;
 - (void)web_setMinimumSize:(CGSize)size;
 - (void)web_setOverlaidAccessoryViewsInset:(CGSize)inset;
 - (void)web_computedContentInsetDidChange;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1196,6 +1196,7 @@
 		A17C48122C98E5C20023F3C7 /* try-text-select-with-disabled-text-interaction.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4952BE5C2578113900B0AEF1 /* try-text-select-with-disabled-text-interaction.html */; };
 		A17C48132C98E5C20023F3C7 /* two-paragraph-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4451C751EB8FD7C0020C5DA /* two-paragraph-contenteditable.html */; };
 		A17C48142C98E5C20023F3C7 /* UnitBox.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5229F733D300A7FB0F /* UnitBox.usdz */; };
+		A17C48141C98E5C20023F3C9 /* hab.reality in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5329F733D300A7FB2F /* hab.reality */; };
 		A17C48152C98E5C20023F3C7 /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
 		A17C48162C98E5C20023F3C7 /* web-audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD577798211CDE8F001B371E /* web-audio-only.html */; };
 		A17C48172C98E5C20023F3C7 /* web-authentication-get-assertion-hid-cancel.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DF22357E45D00E85E09 /* web-authentication-get-assertion-hid-cancel.html */; };
@@ -2035,6 +2036,7 @@
 				A17C46C02C98E54B0023F3C7 /* getUserMediaPermission.html in Copy Resources */,
 				A17C47772C98E5C20023F3C7 /* gif-and-file-input.html in Copy Resources */,
 				A17C47782C98E5C20023F3C7 /* green-400x400.webp in Copy Resources */,
+				A17C48141C98E5C20023F3C9 /* hab.reality in Copy Resources */,
 				A17C46762C98E4D20023F3C7 /* helloworld.webarchive in Copy Resources */,
 				A17C47792C98E5C20023F3C7 /* Helvetica_light.svg in Copy Resources */,
 				A17C46772C98E4D20023F3C7 /* HTMLCollectionNamedItem.html in Copy Resources */,
@@ -2748,6 +2750,7 @@
 		313C3A0121E5677A00DBA86E /* SystemPreviewBlobNaming.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SystemPreviewBlobNaming.html; sourceTree = "<group>"; };
 		31727A4A29F7338C00A7FB0F /* system-preview.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "system-preview.html"; sourceTree = "<group>"; };
 		31727A5229F733D300A7FB0F /* UnitBox.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = UnitBox.usdz; sourceTree = "<group>"; };
+		31727A5329F733D300A7FB2F /* hab.reality */ = {isa = PBXFileReference; lastKnownFileType = file; path = hab.reality; sourceTree = "<group>"; };
 		318210CD2C59AEFF00C334B4 /* CSSTokenizerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSTokenizerTests.cpp; sourceTree = "<group>"; };
 		31903C902764FE1400363472 /* color-scheme.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "color-scheme.html"; sourceTree = "<group>"; };
 		31B76E4223298E2B007FED2C /* SystemPreview.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemPreview.mm; sourceTree = "<group>"; };
@@ -5866,6 +5869,7 @@
 				467C565121B5ECDF0057516D /* GetSessionCookie.html */,
 				F47D30ED1ED28A6C000482E1 /* gif-and-file-input.html */,
 				F45C63FF28178AC40090DFAB /* green-400x400.webp */,
+				31727A5329F733D300A7FB2F /* hab.reality */,
 				1CC4C74C28890CE100A3B23D /* Helvetica_light.svg */,
 				EB230D3D245E722E00C66AD1 /* IDBCheckpointWAL.html */,
 				510477761D298E57009747EB /* IDBDeleteRecovery.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview.html
@@ -9,3 +9,9 @@
 <a id="bloblink" rel="ar" href="blob:foo">
     <img>
 </a>
+<a id="usdz-link" href="UnitBox.usdz"></a>
+<a id="reality-link" href="hab.reality"></a>
+<a id="reality-with-relar-link" rel="ar" href="hab.reality">
+    <img>
+</a>
+</body>


### PR DESCRIPTION
#### a44c7708f19cb62b72564acc2f81893c41a52563
<pre>
Add user prompt before invoking ARQuickLook for 3D Asset Parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=299065">https://bugs.webkit.org/show_bug.cgi?id=299065</a>
<a href="https://rdar.apple.com/159192457">rdar://159192457</a>

Reviewed by Mike Wyrzykowski and Abrar Rahman Protyasha.

Certain code flows allow 3D asset parsing outside of WebContent
without user prompts. This fix adds a user prompt for those flows and thus introduces
a user-in-the-loop mechanism to mitigate this attack surface.

These flows specifically are top level navigations to 3D assets
and &lt;a&gt; WITHOUT rel=ar. A new user prompt/message is needed because the
existing &quot;View in AR?&quot; prompt for &lt;a&gt; WITH rel=ar does not fit here. In the two flows here,
the user prompt precedes handing the file off to ARQL to generate a preview image.
The existing &quot;View in AR?&quot; prompt already has a user provided preview image,
and its prompt in contrast precedes ARQL launching into the camera and placing the asset into user surroundings.
As a result, our new prompt &quot;Display Model Preview?&quot; reflects the behavior appopriately to
the user.

Appropriate API tests are added to verify that alert shows up in all
3 flows (&lt;a&gt; WITH rel=ar, &lt;a&gt; WITHOUT rel=ar, and top level navigations) and for both usdz
and reality files. We also test to make sure that ARQL is only invoked when user presses allow action.
The RelARPrompt has its own testing logic because of its slightly different behavior
and the need to execute the cancel and allow action handlers separately due to std::exchange()
being used in SystemPreviewControllerCocoa.mm.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:data:]):
* Source/WebKit/UIProcess/Cocoa/WKWebViewContentProvider.h:
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView web_setContentProviderData:suggestedFilename:completionHandler:]):
(-[WKPDFView web_setContentProviderData:suggestedFilename:]): Deleted.
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:completionHandler:]):
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:]): Deleted.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(TestWebKitAPI::testModelPreviewPrompt):
(TestWebKitAPI::testRelARPrompt):
(TestWebKitAPI::TEST(WebKit, PromptUSDZTopLevelNavigation)):
(TestWebKitAPI::TEST(WebKit, PromptRealityTopLevelNavigation)):
(TestWebKitAPI::TEST(WebKit, PromptUSDZLinkWithoutRelAR)):
(TestWebKitAPI::TEST(WebKit, PromptRealityLinkWithoutRelAR)):
(TestWebKitAPI::TEST(WebKit, PromptUSDZLinkWithRelAR)):
(TestWebKitAPI::TEST(WebKit, PromptRealityLinkWithRelAR)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/hab.reality: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview.html:

Originally-landed-as: 297297.491@safari-7622-branch (053b792933f4). <a href="https://rdar.apple.com/164211773">rdar://164211773</a>
Canonical link: <a href="https://commits.webkit.org/304123@main">https://commits.webkit.org/304123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e34c5e96be1057cb475661f45501bc910ebce3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142164 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/893b5e37-948a-4e80-9e19-5c79854244b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6950 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/962ffa20-63b9-46d8-b7be-55c64633d8a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5399 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83710 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/918a31c9-bf10-4d10-be8a-d3aa1ac43d54) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5256 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2755 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144856 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6771 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39400 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111595 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5088 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60656 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6822 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35144 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->