### PR TITLE
[Safer CPP] Address remaining issues in several html/track classes

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -233,7 +233,6 @@ html/parser/HTMLTreeBuilder.cpp
 html/shadow/DateTimeNumericFieldElement.cpp
 html/shadow/DateTimeSymbolicFieldElement.cpp
 html/shadow/SliderThumbElement.cpp
-html/track/InbandGenericTextTrack.cpp
 html/track/InbandWebVTTTextTrack.cpp
 html/track/LoadableTextTrack.cpp
 html/track/TextTrackCue.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -461,11 +461,6 @@ html/parser/HTMLParserScheduler.cpp
 html/parser/HTMLScriptRunner.cpp
 html/parser/HTMLTreeBuilder.cpp
 html/shadow/MediaControlTextTrackContainerElement.cpp
-html/track/AudioTrack.cpp
-html/track/DataCue.cpp
-html/track/InbandDataTextTrack.cpp
-html/track/InbandGenericTextTrack.cpp
-html/track/InbandTextTrack.cpp
 html/track/InbandWebVTTTextTrack.cpp
 html/track/LoadableTextTrack.cpp
 html/track/TextTrack.cpp

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -60,6 +60,7 @@ public:
 
     size_t inbandTrackIndex() const;
 
+    Ref<AudioTrackPrivate> protectedPrivate() const;
     const AudioTrackPrivate& privateTrack() const { return m_private; }
     void setPrivate(AudioTrackPrivate&);
 

--- a/Source/WebCore/html/track/DataCue.cpp
+++ b/Source/WebCore/html/track/DataCue.cpp
@@ -104,12 +104,12 @@ DataCue::~DataCue() = default;
 RefPtr<ArrayBuffer> DataCue::data() const
 {
     if (m_platformValue)
-        return m_platformValue->data();
+        return protectedPlatformValue()->data();
 
     if (!m_data)
         return nullptr;
 
-    return ArrayBuffer::create(*m_data);
+    return ArrayBuffer::create(*RefPtr { m_data });
 }
 
 void DataCue::setData(ArrayBuffer& data)
@@ -125,13 +125,13 @@ bool DataCue::cueContentsMatch(const TextTrackCue& cue) const
     RefPtr<ArrayBuffer> otherData = dataCue->data();
     if ((otherData && !m_data) || (!otherData && m_data))
         return false;
-    if (m_data && m_data->data() && !equalSpans(m_data->span(), otherData->span()))
+    if (RefPtr thisData = m_data; thisData && thisData->data() && !equalSpans(thisData->span(), otherData->span()))
         return false;
 
     RefPtr otherPlatformValue = dataCue->platformValue();
     if ((otherPlatformValue && !m_platformValue) || (!otherPlatformValue && m_platformValue))
         return false;
-    if (m_platformValue && !m_platformValue->isEqual(*otherPlatformValue))
+    if (m_platformValue && !protectedPlatformValue()->isEqual(*otherPlatformValue))
         return false;
 
     JSC::JSValue thisValue = valueOrNull();
@@ -147,7 +147,7 @@ bool DataCue::cueContentsMatch(const TextTrackCue& cue) const
 JSC::JSValue DataCue::value(JSC::JSGlobalObject& state) const
 {
     if (m_platformValue)
-        return m_platformValue->deserialize(&state);
+        return protectedPlatformValue()->deserialize(&state);
 
     if (m_value)
         return m_value.get();

--- a/Source/WebCore/html/track/DataCue.h
+++ b/Source/WebCore/html/track/DataCue.h
@@ -57,6 +57,7 @@ public:
     void setData(JSC::ArrayBuffer&);
 
     const SerializedPlatformDataCue* platformValue() const { return m_platformValue.get(); }
+    RefPtr<const SerializedPlatformDataCue> protectedPlatformValue() const { return m_platformValue.get(); }
 
     JSC::JSValue value(JSC::JSGlobalObject&) const;
     void setValue(JSC::JSGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/html/track/InbandDataTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandDataTextTrack.cpp
@@ -94,7 +94,7 @@ void InbandDataTextTrack::addDataCue(const MediaTime& start, const MediaTime& en
 RefPtr<DataCue> InbandDataTextTrack::findIncompleteCue(const SerializedPlatformDataCue& cueToFind)
 {
     auto index = m_incompleteCueMap.findIf([&](const auto& cue) {
-        return cueToFind.isEqual(*cue->platformValue());
+        return cueToFind.isEqual(Ref { *cue->protectedPlatformValue() });
     });
 
     if (index == notFound)

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -83,7 +83,12 @@ void InbandTextTrack::setPrivate(InbandTextTrackPrivate& trackPrivate)
 
     setModeInternal(mode());
     updateKindFromPrivate();
-    setId(m_private->id());
+    setId(protectedPrivate()->id());
+}
+
+Ref<InbandTextTrackPrivate> InbandTextTrack::protectedPrivate() const
+{
+    return m_private;
 }
 
 void InbandTextTrack::setMode(Mode mode)
@@ -108,47 +113,47 @@ static inline InbandTextTrackPrivate::Mode toPrivate(TextTrack::Mode mode)
 
 void InbandTextTrack::setModeInternal(Mode mode)
 {
-    m_private->setMode(toPrivate(mode));
+    protectedPrivate()->setMode(toPrivate(mode));
 }
 
 bool InbandTextTrack::isClosedCaptions() const
 {
-    return m_private->isClosedCaptions();
+    return protectedPrivate()->isClosedCaptions();
 }
 
 bool InbandTextTrack::isSDH() const
 {
-    return m_private->isSDH();
+    return protectedPrivate()->isSDH();
 }
 
 bool InbandTextTrack::containsOnlyForcedSubtitles() const
 {
-    return m_private->containsOnlyForcedSubtitles();
+    return protectedPrivate()->containsOnlyForcedSubtitles();
 }
 
 bool InbandTextTrack::isMainProgramContent() const
 {
-    return m_private->isMainProgramContent();
+    return protectedPrivate()->isMainProgramContent();
 }
 
 bool InbandTextTrack::isEasyToRead() const
 {
-    return m_private->isEasyToRead();
+    return protectedPrivate()->isEasyToRead();
 }
 
 bool InbandTextTrack::isDefault() const
 {
-    return m_private->isDefault();
+    return protectedPrivate()->isDefault();
 }
 
 size_t InbandTextTrack::inbandTrackIndex()
 {
-    return m_private->trackIndex();
+    return protectedPrivate()->trackIndex();
 }
 
 String InbandTextTrack::inBandMetadataTrackDispatchType() const
 {
-    return m_private->inBandMetadataTrackDispatchType();
+    return protectedPrivate()->inBandMetadataTrackDispatchType();
 }
 
 void InbandTextTrack::idChanged(TrackID id)
@@ -175,7 +180,7 @@ void InbandTextTrack::willRemove()
 
 void InbandTextTrack::updateKindFromPrivate()
 {
-    switch (m_private->kind()) {
+    switch (protectedPrivate()->kind()) {
     case InbandTextTrackPrivate::Kind::Subtitles:
         setKind(Kind::Subtitles);
         return;
@@ -202,14 +207,14 @@ void InbandTextTrack::updateKindFromPrivate()
 
 MediaTime InbandTextTrack::startTimeVariance() const
 {
-    return m_private->startTimeVariance();
+    return protectedPrivate()->startTimeVariance();
 }
 
 #if !RELEASE_LOG_DISABLED
 void InbandTextTrack::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     TextTrack::setLogger(logger, logIdentifier);
-    m_private->setLogger(logger, this->logIdentifier());
+    protectedPrivate()->setLogger(logger, this->logIdentifier());
 }
 #endif
 

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -50,6 +50,7 @@ public:
     String inBandMetadataTrackDispatchType() const override;
 
     void setPrivate(InbandTextTrackPrivate&);
+    Ref<InbandTextTrackPrivate> protectedPrivate() const;
 #if !RELEASE_LOG_DISABLED
     void setLogger(const Logger&, uint64_t) final;
 #endif

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -81,6 +81,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     virtual void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
+    Ref<const Logger> protectedLogger() const { return logger(); }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 #endif


### PR DESCRIPTION
#### 6b5aa88ac433d9e407a2343d3b9d48b057f59930
<pre>
[Safer CPP] Address remaining issues in several html/track classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=302556">https://bugs.webkit.org/show_bug.cgi?id=302556</a>
<a href="https://rdar.apple.com/164758543">rdar://164758543</a>

Reviewed by Chris Dumez.

Address all remaining Safer CPP issues in several html/track classes.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::~AudioTrack):
(WebCore::AudioTrack::protectedPrivate const):
(WebCore::AudioTrack::setPrivate):
(WebCore::AudioTrack::setEnabled):
(WebCore::AudioTrack::inbandTrackIndex const):
(WebCore::AudioTrack::updateKindFromPrivate):
(WebCore::AudioTrack::setLogger):
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/DataCue.cpp:
(WebCore::DataCue::data const):
(WebCore::DataCue::cueContentsMatch const):
(WebCore::DataCue::value const):
* Source/WebCore/html/track/DataCue.h:
* Source/WebCore/html/track/InbandDataTextTrack.cpp:
(WebCore::InbandDataTextTrack::findIncompleteCue):
* Source/WebCore/html/track/InbandGenericTextTrack.cpp:
(WebCore::InbandGenericTextTrack::addGenericCue):
(WebCore::InbandGenericTextTrack::parser):
(WebCore::InbandGenericTextTrack::cueToExtend):
(WebCore::InbandGenericTextTrack::newRegionsParsed):
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::setPrivate):
(WebCore::InbandTextTrack::protectedPrivate const):
(WebCore::InbandTextTrack::setModeInternal):
(WebCore::InbandTextTrack::isClosedCaptions const):
(WebCore::InbandTextTrack::isSDH const):
(WebCore::InbandTextTrack::containsOnlyForcedSubtitles const):
(WebCore::InbandTextTrack::isMainProgramContent const):
(WebCore::InbandTextTrack::isEasyToRead const):
(WebCore::InbandTextTrack::isDefault const):
(WebCore::InbandTextTrack::inbandTrackIndex):
(WebCore::InbandTextTrack::inBandMetadataTrackDispatchType const):
(WebCore::InbandTextTrack::updateKindFromPrivate):
(WebCore::InbandTextTrack::startTimeVariance const):
(WebCore::InbandTextTrack::setLogger):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::protectedScriptExecutionContext const):
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TrackBase.h:
(WebCore::TrackBase::protectedLogger const):

Canonical link: <a href="https://commits.webkit.org/303176@main">https://commits.webkit.org/303176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d986bf2565a2023595e4e70d5fad0be1ef459ee7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42477 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139019 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83291 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/77d1fb85-80be-4486-b16d-5407697b7ff7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100405 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f483ba44-40d7-4865-934c-25f9ba1c1608) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5d8b9c17-587c-4d07-a308-1b36dea292ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82211 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141665 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3588 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108771 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2717 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56776 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3649 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32453 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3730 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->