### PR TITLE
Notify UIProcess of authentication view service presentation

### DIFF
--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -261,6 +261,10 @@ public:
     virtual void didEnterStandby(WebKit::WebPageProxy&) { }
     virtual void didExitStandby(WebKit::WebPageProxy&) { }
 #endif
+
+#if PLATFORM(VISION)
+    virtual void willPresentModalUI(WebKit::WebPageProxy&) { }
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -227,6 +227,9 @@ struct UIEdgeInsets;
 #if defined(TARGET_OS_VISION) && TARGET_OS_VISION
 - (void)_webView:(WKWebView *)webView setRecentlyAccessedGamepads:(BOOL)recentlyAccessedGamepads WK_API_AVAILABLE(visionos(2.0));
 - (void)_webView:(WKWebView *)webView gamepadsConnectedStateDidChange:(BOOL)gamepadsConnected WK_API_AVAILABLE(visionos(2.0));
+
+/// FIXME: Add modal type as parameter in rdar://163838660; currently it only supports WebAuthentication modal
+- (void)_webViewWillPresentModalUI:(WKWebView *)webView WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 #endif
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -215,6 +215,10 @@ private:
         void didExitStandby(WebPageProxy&) final;
 #endif
 
+#if PLATFORM(VISION)
+        void willPresentModalUI(WebPageProxy&) final;
+#endif
+
         id<WKUIDelegatePrivate> uiDelegatePrivate();
         RetainPtr<id<WKUIDelegatePrivate>> protectedUIDelegatePrivate();
 
@@ -333,6 +337,10 @@ private:
 #if PLATFORM(IOS_FAMILY)
         bool webViewDidEnterStandby : 1;
         bool webViewDidExitStandby : 1;
+#endif
+
+#if PLATFORM(VISION)
+        bool webViewWillPresentModalUI : 1;
 #endif
     } m_delegateMethods;
 };

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -261,6 +261,10 @@ void UIDelegate::setDelegate(id<WKUIDelegate> delegate)
     m_delegateMethods.webViewDidEnterStandby = [delegate respondsToSelector:@selector(_webViewDidEnterStandbyForTesting:)];
     m_delegateMethods.webViewDidExitStandby = [delegate respondsToSelector:@selector(_webViewDidExitStandbyForTesting:)];
 #endif
+
+#if PLATFORM(VISION)
+    m_delegateMethods.webViewWillPresentModalUI = [delegate respondsToSelector:@selector(_webViewWillPresentModalUI:)];
+#endif
 }
 
 #if ENABLE(CONTEXT_MENUS)
@@ -2314,5 +2318,23 @@ void UIDelegate::UIClient::didExitStandby(WebPageProxy&)
     [delegate _webViewDidExitStandbyForTesting:uiDelegate->m_webView.get().get()];
 }
 #endif // PLATFORM(IOS_FAMILY)
+
+#if PLATFORM(VISION)
+void UIDelegate::UIClient::willPresentModalUI(WebPageProxy& page)
+{
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
+        return;
+
+    if (!uiDelegate->m_delegateMethods.webViewWillPresentModalUI)
+        return;
+
+    RetainPtr delegate = uiDelegatePrivate();
+    if (!delegate)
+        return;
+
+    [delegate _webViewWillPresentModalUI:uiDelegate->m_webView.get().get()];
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -29,6 +29,7 @@
 #import "config.h"
 #import "WebAuthenticatorCoordinatorProxy.h"
 
+#import "APIUIClient.h"
 #import "ArgumentCoders.h"
 #import "LocalService.h"
 #import "Logging.h"
@@ -799,8 +800,12 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
     m_controller.get().delegate = (id<ASAuthorizationControllerDelegate>)m_delegate.get();
     if (requestData.mediation && *requestData.mediation == MediationRequirement::Conditional && std::holds_alternative<PublicKeyCredentialRequestOptions>(requestData.options))
         [m_controller performAutoFillAssistedRequests];
-    else
+    else {
+#if PLATFORM(VISION)
+        webPageProxy->uiClient().willPresentModalUI(*webPageProxy);
+#endif
         [m_controller performRequests];
+    }
 #endif
 }
 


### PR DESCRIPTION
#### 371a8b96982fe7c2ad75434942b0972478864ab4
<pre>
Notify UIProcess of authentication view service presentation
<a href="https://rdar.apple.com/164687201">rdar://164687201</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302557">https://bugs.webkit.org/show_bug.cgi?id=302557</a>

Reviewed by Pascoe.

Add a new WKUIDelegate method to notify clients when modal or view service will present on visionOS (Currently only supports WebAuthentication view service UI). This allows Safari to prepare its UI state when the modal appears.

The delegate method is called from WebAuthenticatorCoordinatorProxy when `m_isConditionalMediation` is false and the authentication UI will show. `m_isConditionalMediation` being true indicates it&apos;s an autofill request.

* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::willPresentModalUI):
Add willPresentModalUI to APIUIClient

* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
Add WKUIDelegate private method for visionOS. We should add modal type as parameter to tell client what modal will show / what modals are intentionally supported

* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::willPresentModalUI):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
Call delegate from WebAuthenticatorCoordinatorProxy when presenting UI

Canonical link: <a href="https://commits.webkit.org/303658@main">https://commits.webkit.org/303658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f110bf4299dd6fe4a1428854158ba005ba18d61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140780 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85272 "Failed to checkout and rebase branch from PR 53976") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5592 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/85272 "Failed to checkout and rebase branch from PR 53976") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136173 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82699 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113391 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5397 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38111 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110464 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4184 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115673 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59145 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5452 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34027 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68904 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->