### PR TITLE
[JSC] Cleaning up iterator related code

### DIFF
--- a/Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js
@@ -33,8 +33,8 @@ function next()
 
     var generator = @getIteratorHelperInternalField(this, @iteratorHelperFieldGenerator);
     var state = @getGeneratorInternalField(generator, @generatorFieldState);
-    if (state === @GeneratorStateCompleted)
-        return { value: @undefined, done: true };
+    if (state === @GeneratorStateExecuting)
+        @throwTypeError("Generator is executing");
 
     return @generatorResume(generator, state, @undefined, @GeneratorResumeModeNormal);
 }
@@ -59,8 +59,8 @@ function return()
         return { value: @undefined, done: true };
     }
 
-    if (state === @GeneratorStateCompleted)
-        return { value: @undefined, done: true };
+    if (state === @GeneratorStateExecuting)
+        @throwTypeError("Generator is executing");
 
     return @generatorResume(generator, state, @undefined, @GeneratorResumeModeReturn);
 }

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -180,7 +180,8 @@ static constexpr PropertyOffset donePropertyOffset = 1;
 
 Structure* createIteratorResultObjectStructure(VM& vm, JSGlobalObject& globalObject)
 {
-    Structure* iteratorResultStructure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), JSFinalObject::defaultInlineCapacity);
+    constexpr unsigned inlineCapacity = 2;
+    Structure* iteratorResultStructure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), inlineCapacity);
     PropertyOffset offset;
     iteratorResultStructure = Structure::addPropertyTransition(vm, iteratorResultStructure, vm.propertyNames->value, 0, offset);
     RELEASE_ASSERT(offset == valuePropertyOffset);


### PR DESCRIPTION
#### 2d66db3c081d49a7a22bee2bcb2ca41072932eee
<pre>
[JSC] Cleaning up iterator related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=302562">https://bugs.webkit.org/show_bug.cgi?id=302562</a>
<a href="https://rdar.apple.com/164768602">rdar://164768602</a>

Reviewed by Yijia Huang.

This is fixing a bug introduced in 302914@main.
JSIteratorHelperPrototype is using generator too, so it needs to be
changed too. This is caught by test262.
We also change iterator result object inlineCapacity to align it to the
JS generated ones.

* Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js:
(next):
(return):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::createIteratorResultObjectStructure):

Canonical link: <a href="https://commits.webkit.org/303065@main">https://commits.webkit.org/303065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/857609cb3a9c8fea4ba47d5430d12f7eb48e5546

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/131152 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138594 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dccea74e-ea7b-4a42-98ad-159ebd50836e) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3473 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 53980") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3323 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/89d8d07f-87b8-4a69-959d-0a595f6f3026) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/134098 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/3473 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 53980") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80621 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f668acd-c490-4cd3-9a67-e1c00e460e85) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/3473 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 53980") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/92 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81842 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123178 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/3473 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 53980") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141090 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129610 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3226 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108384 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2417 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56281 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20406 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/3289 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32163 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162622 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/3111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66697 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40602 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->