### PR TITLE
[Site isolation] Page and client coordinates of pointer events are always integers in cross-origin frames

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5521,10 +5521,10 @@ void Document::processApplicationManifest(const ApplicationManifest& application
 
 #endif // ENABLE(APPLICATION_MANIFEST)
 
-MouseEventWithHitTestResults Document::prepareMouseEvent(const HitTestRequest& request, const LayoutPoint& documentPoint, const PlatformMouseEvent& event)
+MouseEventWithHitTestResults Document::prepareMouseEvent(const HitTestRequest& request, const DoublePoint& documentPoint, const PlatformMouseEvent& event)
 {
     if (!hasLivingRenderTree())
-        return MouseEventWithHitTestResults(event, HitTestResult(LayoutPoint()));
+        return MouseEventWithHitTestResults(event, HitTestResult(DoublePoint()));
 
     HitTestResult result(documentPoint);
     hitTest(request, result);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -972,7 +972,7 @@ public:
     VisitedLinkState* visitedLinkStateIfExists() const { return m_visitedLinkState.get(); }
     inline VisitedLinkState& visitedLinkState() const;
 
-    MouseEventWithHitTestResults prepareMouseEvent(const HitTestRequest&, const LayoutPoint&, const PlatformMouseEvent&);
+    MouseEventWithHitTestResults prepareMouseEvent(const HitTestRequest&, const DoublePoint&, const PlatformMouseEvent&);
     // Returns whether focus was blocked. A true value does not necessarily mean the element was focused.
     // The element could have already been focused or may not be focusable (e.g. <input disabled>).
     WEBCORE_EXPORT bool setFocusedElement(Element*, BroadcastFocusedElement = BroadcastFocusedElement::Yes);

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -405,7 +405,7 @@ public:
     bool keyboardScrollRecursively(std::optional<ScrollDirection>, std::optional<ScrollGranularity>, Node*, bool isKeyRepeat);
     WEBCORE_EXPORT bool shouldUseSmoothKeyboardScrollingForFocusedScrollableArea();
 
-    std::optional<RemoteUserInputEventData> userInputEventDataForRemoteFrame(const RemoteFrame*, const IntPoint&);
+    std::optional<RemoteUserInputEventData> userInputEventDataForRemoteFrame(const RemoteFrame*, const DoublePoint&);
 
     WEBCORE_EXPORT void updateMouseEventTargetAfterLayoutIfNeeded();
     WEBCORE_EXPORT void scheduleMouseEventTargetUpdateAfterLayout();

--- a/Source/WebCore/page/RemoteUserInputEventData.h
+++ b/Source/WebCore/page/RemoteUserInputEventData.h
@@ -25,14 +25,14 @@
 
 #pragma once
 
+#include <WebCore/DoublePoint.h>
 #include <WebCore/FrameIdentifier.h>
-#include <WebCore/IntPoint.h>
 
 namespace WebCore {
 
 struct RemoteUserInputEventData {
     FrameIdentifier targetFrameID;
-    IntPoint transformedPoint;
+    DoublePoint transformedPoint;
 };
 
 }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -81,21 +81,33 @@ static inline void appendToNodeSet(const HitTestResult::NodeSet& source, HitTest
 
 HitTestResult::HitTestResult() = default;
 
+HitTestResult::HitTestResult(const IntPoint& point)
+    : m_hitTestLocation(point)
+    , m_doublePointInInnerNodeFrame(point)
+{
+}
+
 HitTestResult::HitTestResult(const LayoutPoint& point)
     : m_hitTestLocation(point)
-    , m_pointInInnerNodeFrame(point)
+    , m_doublePointInInnerNodeFrame(point)
+{
+}
+
+HitTestResult::HitTestResult(const DoublePoint& point)
+    : m_hitTestLocation(LayoutPoint(point))
+    , m_doublePointInInnerNodeFrame(point)
 {
 }
 
 HitTestResult::HitTestResult(const LayoutRect& rect)
     : m_hitTestLocation { rect }
-    , m_pointInInnerNodeFrame { rect.center() }
+    , m_doublePointInInnerNodeFrame { rect.center() }
 {
 }
 
 HitTestResult::HitTestResult(const HitTestLocation& other)
     : m_hitTestLocation(other)
-    , m_pointInInnerNodeFrame(m_hitTestLocation.point())
+    , m_doublePointInInnerNodeFrame(m_hitTestLocation.point())
 {
 }
 
@@ -103,7 +115,7 @@ HitTestResult::HitTestResult(const HitTestResult& other)
     : m_hitTestLocation(other.m_hitTestLocation)
     , m_innerNode(other.innerNode())
     , m_innerNonSharedNode(other.innerNonSharedNode())
-    , m_pointInInnerNodeFrame(other.m_pointInInnerNodeFrame)
+    , m_doublePointInInnerNodeFrame(other.m_doublePointInInnerNodeFrame)
     , m_localPoint(other.localPoint())
     , m_innerURLElement(other.URLElement())
     , m_scrollbar(other.scrollbar())
@@ -124,7 +136,7 @@ HitTestResult& HitTestResult::operator=(const HitTestResult& other)
     m_hitTestLocation = other.m_hitTestLocation;
     m_innerNode = other.innerNode();
     m_innerNonSharedNode = other.innerNonSharedNode();
-    m_pointInInnerNodeFrame = other.m_pointInInnerNodeFrame;
+    m_doublePointInInnerNodeFrame = other.m_doublePointInInnerNodeFrame;
     m_localPoint = other.localPoint();
     m_innerURLElement = other.URLElement();
     m_scrollbar = other.scrollbar();
@@ -837,7 +849,7 @@ void HitTestResult::append(const HitTestResult& other, const HitTestRequest& req
         m_innerNode = other.innerNode();
         m_innerNonSharedNode = other.innerNonSharedNode();
         m_localPoint = other.localPoint();
-        m_pointInInnerNodeFrame = other.m_pointInInnerNodeFrame;
+        m_doublePointInInnerNodeFrame = other.m_doublePointInInnerNodeFrame;
         m_innerURLElement = other.URLElement();
         m_scrollbar = other.scrollbar();
         m_isOverWidget = other.isOverWidget();

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <WebCore/DoublePoint.h>
 #include <WebCore/HitTestLocation.h>
 #include <WebCore/HitTestRequest.h>
 #include <WebCore/PseudoElementIdentifier.h>
@@ -48,7 +49,9 @@ public:
     using NodeSet = ListHashSet<Ref<Node>>;
 
     WEBCORE_EXPORT HitTestResult();
+    WEBCORE_EXPORT explicit HitTestResult(const IntPoint&);
     WEBCORE_EXPORT explicit HitTestResult(const LayoutPoint&);
+    WEBCORE_EXPORT explicit HitTestResult(const DoublePoint&);
 
     WEBCORE_EXPORT explicit HitTestResult(const LayoutRect&);
     WEBCORE_EXPORT explicit HitTestResult(const HitTestLocation&);
@@ -89,7 +92,8 @@ public:
     IntPoint roundedPointInMainFrame() const { return roundedIntPoint(pointInMainFrame()); }
 
     // The hit-tested point in the coordinates of the innerNode frame, the frame containing innerNode.
-    const LayoutPoint& pointInInnerNodeFrame() const { return m_pointInInnerNodeFrame; }
+    const LayoutPoint pointInInnerNodeFrame() const { return LayoutPoint(m_doublePointInInnerNodeFrame); }
+    const DoublePoint& doublePointInInnerNodeFrame() const { return m_doublePointInInnerNodeFrame; }
     IntPoint roundedPointInInnerNodeFrame() const { return roundedIntPoint(pointInInnerNodeFrame()); }
     WEBCORE_EXPORT LocalFrame* innerNodeFrame() const;
 
@@ -191,7 +195,7 @@ private:
 
     RefPtr<Node> m_innerNode;
     RefPtr<Node> m_innerNonSharedNode;
-    LayoutPoint m_pointInInnerNodeFrame; // The hit-tested point in innerNode frame coordinates.
+    DoublePoint m_doublePointInInnerNodeFrame; // The hit-tested point in innerNode frame coordinates.
     LayoutPoint m_localPoint; // A point in the local coordinate space of m_innerNonSharedNode's renderer. Allows us to efficiently
                               // determine where inside the renderer we hit on subsequent operations.
     RefPtr<Element> m_innerURLElement;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7275,7 +7275,7 @@ struct WebCore::PrewarmInformation {
 
 struct WebCore::RemoteUserInputEventData {
     WebCore::FrameIdentifier targetFrameID;
-    WebCore::IntPoint transformedPoint;
+    WebCore::DoublePoint transformedPoint;
 };
 
 struct WebCore::LinkDecorationFilteringData {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3866,7 +3866,7 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
             didPerformDragControllerAction(dragOperation, dragHandlingMethod, mouseIsOverFileInput, numberOfItemsToBeAccepted, insertionRect, editableElementRect);
             return;
         }
-        dragData.setClientPosition(remoteUserInputEventData->transformedPoint);
+        dragData.setClientPosition(roundedIntPoint(remoteUserInputEventData->transformedPoint));
         performDragControllerAction(action, dragData, remoteUserInputEventData->targetFrameID);
     };
 #if PLATFORM(GTK)
@@ -3928,7 +3928,7 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
             resetCurrentDragInformation();
             return;
         }
-        dragEnded(remoteUserInputEventData->transformedPoint, globalPosition, dragOperationMask, remoteUserInputEventData->targetFrameID);
+        dragEnded(roundedIntPoint(remoteUserInputEventData->transformedPoint), globalPosition, dragOperationMask, remoteUserInputEventData->targetFrameID);
     };
 
     sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::DragEnded(frameID, clientPosition, globalPosition, dragOperationMask), WTFMove(completionHandler));
@@ -4304,7 +4304,7 @@ void WebPageProxy::sendWheelEvent(WebCore::FrameIdentifier frameID, const WebWhe
                 return;
 
             if (remoteWheelEventData) {
-                wheelEvent.setPosition(remoteWheelEventData->transformedPoint);
+                wheelEvent.setPosition(roundedIntPoint(remoteWheelEventData->transformedPoint));
                 protectedThis->sendWheelEvent(remoteWheelEventData->targetFrameID, wheelEvent, processingSteps, rubberBandableEdges, willStartSwipe, wasHandledForScrolling);
                 return;
             }
@@ -14495,7 +14495,7 @@ void WebPageProxy::didPerformImmediateActionHitTest(IPC::Connection& connection,
 {
     if (protectedPreferences()->siteIsolationEnabled()) {
         if (result.remoteUserInputEventData) {
-            performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, result.remoteUserInputEventData->transformedPoint);
+            performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
             return;
         }
         if (auto parentFrameID = result.frameInfo->parentFrameID) {

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -846,7 +846,7 @@ void WebPageProxy::potentialTapAtPosition(std::optional<WebCore::FrameIdentifier
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protectedThis->potentialTapAtPosition(data->targetFrameID, data->transformedPoint, shouldRequestMagnificationInformation, requestID);
+        protectedThis->potentialTapAtPosition(data->targetFrameID, FloatPoint(data->transformedPoint), shouldRequestMagnificationInformation, requestID);
     } });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1399,10 +1399,9 @@ Awaitable<std::optional<WebCore::RemoteUserInputEventData>> WebPage::potentialTa
         if (RefPtr frameView = localFrame ? localFrame->view() : nullptr) {
             if (RefPtr remoteFrameView = remoteFrame->view()) {
                 RemoteFrameGeometryTransformer transformer(remoteFrameView.releaseNonNull(), frameView.releaseNonNull(), remoteFrame->frameID());
-                // FIXME: Use a different type with a FloatPoint to avoid rounding to an int.
                 co_return WebCore::RemoteUserInputEventData {
                     remoteFrame->frameID(),
-                    transformer.transformToRemoteFrameCoordinates(roundedIntPoint(position))
+                    transformer.transformToRemoteFrameCoordinates(position)
                 };
             }
         }


### PR DESCRIPTION
#### dd60c34a7e7e2903c7094117648311e314b10496
<pre>
[Site isolation] Page and client coordinates of pointer events are always integers in cross-origin frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=302550">https://bugs.webkit.org/show_bug.cgi?id=302550</a>
<a href="https://rdar.apple.com/164027526">rdar://164027526</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Update HitTestResult to store the point in the inner node frame as a DoublePoint
instead of a LayoutPoint, and update RemoteUserInputEventData to store the
transformed point as a DoublePoint instead of an IntPoint.

Tested on iOS by the following new layout tests:

iOSMouseSupport.FractionalCoordinatesInSimpleIFrameCrossOrigin
iOSMouseSupport.FractionalCoordinatesInRotatedIFrameCrossOrigin
iOSMouseSupport.FractionalCoordinatesInScaledIFrameCrossOrigin

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::prepareMouseEvent):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::documentPointForWindowPoint):
(WebCore::EventHandler::userInputEventDataForRemoteFrame):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::prepareMouseEvent):
(WebCore::EventHandler::handleWheelEventInternal):
(WebCore::EventHandler::dragSourceEndedAt):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/RemoteUserInputEventData.h:
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::HitTestResult):
(WebCore::HitTestResult::operator=):
(WebCore::HitTestResult::append):
* Source/WebCore/rendering/HitTestResult.h:
(WebCore::HitTestResult::pointInInnerNodeFrame const):
(WebCore::HitTestResult::doublePointInInnerNodeFrame const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::performDragControllerAction):
(WebKit::WebPageProxy::dragEnded):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::potentialTapAtPosition):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::potentialTapAtPosition):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(TEST_F(iOSMouseSupport, FractionalCoordinatesInSimpleIFrame)):
(TEST_F(iOSMouseSupport, FractionalCoordinatesInRotatedIFrame)):
(TEST_F(iOSMouseSupport, FractionalCoordinatesInScaledIFrame)):
(TEST_F(iOSMouseSupport, FractionalCoordinatesInSimpleIFrameCrossOrigin)):
(TEST_F(iOSMouseSupport, FractionalCoordinatesInRotatedIFrameCrossOrigin)):
(TEST_F(iOSMouseSupport, FractionalCoordinatesInScaledIFrameCrossOrigin)):

Canonical link: <a href="https://commits.webkit.org/303146@main">https://commits.webkit.org/303146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e3cc13d06d2c33d5ab6a38e346a714d75cc8c78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131441 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83209 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94c583ae-1a17-4368-bacf-9cd1d9c91218) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3613 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81158 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd2a6a65-c5cf-4ac7-b097-8964e5ab4934) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2651 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82139 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141592 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36299 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108959 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2670 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113986 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56702 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3578 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32399 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66986 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3600 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->