### PR TITLE
[text-wrap][pretty] Fix incorrect index in InlineContentConstrainer hyphenation fallback

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-4-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-4-expected.txt
@@ -1,0 +1,1 @@
+just some long long long long long long long long longlong long long long long long textAAAAAAAAAAAAAAAAAAAA This test passes if it doesn't crash.

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-4.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-4.html
@@ -1,0 +1,19 @@
+<style>
+div {
+  letter-spacing: 1em;
+  text-wrap: pretty;
+}
+html, div {
+  margin-right: 10000px;
+  display: table-header-group;
+}
+*:last-child {
+  font-family: system-ui;
+}
+</style>
+<script>
+   if (window.testRunner)
+       testRunner.dumpAsText();
+</script>
+<div contenteditable="true"><span>just some long long long long long long long long longlong long long long long long text</span>AAAAAAAAAAAAAAAAAAAA</div>
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-5-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-5-expected.txt
@@ -1,0 +1,1 @@
+#x13 { letter-spacing: 1em; text-wrap: pretty;direction: ltr;} *:first-child, style {margin-right: 999px; display: table-header-group;box-align: baseline;} *:last-child { font-family: system-ui;} A { Awebkit-align-self: AAAA;tab-size: 1em;-webkit-line-clamp: 16;-webkit-hyphenate-character: auto } AAAAAAAAAAAAAAAAAAAA This test passes if it doesn't crash.

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-5.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-5.html
@@ -1,0 +1,18 @@
+<style>
+   #x13 { letter-spacing: 1em; text-wrap: pretty;direction: ltr;}
+   *:first-child, style {margin-right: 999px; display: table-header-group;box-align: baseline;}
+   *:last-child { font-family: system-ui;}
+</style>
+<script>
+   function main() {
+   try { x21.appendChild(document.createTextNode("A { Awebkit-align-self: AAAA;tab-size: 1em;-webkit-line-clamp: 16;-webkit-hyphenate-character: auto }")); } catch (e) { }
+   }
+   if (window.testRunner)
+       testRunner.dumpAsText();
+</script>
+<body onload="main()">
+   <summary id="x13" contenteditable="true">
+   <style id="x21"></style>
+AAAAAAAAAAAAAAAAAAAA
+</body>
+This test passes if it doesn't crash.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -620,13 +620,24 @@ std::optional<Vector<LayoutUnit>> InlineContentConstrainer::prettifyRange(Inline
                 break;
             slidingWidth.advanceStartTo(breakOpportunities[firstStartIndex]);
         }
-        ASSERT(firstStartIndex < breakIndex);
+        ASSERT(firstStartIndex <= breakIndex);
 
         // If the start of our slidingWidth is past the last valid breaking point, we will not be able to find a valid solution.
         // Try to find a solution using hyphenation.
         if (firstStartIndex>lastValidStateIndex.value()) {
             // Perform a single line layout from lastValidStateIndex.value().
-            auto newEntry = layoutSingleLineForPretty({ state[lastValidStateIndex.value()].lineEnd.index, range.endIndex() }, idealLineWidth, state[lastValidStateIndex.value()], lastValidStateIndex.value());
+
+            // Sanity check indices before proceeding.
+            if (lastValidStateIndex.value() >= breakOpportunities.size()) {
+                ASSERT_NOT_REACHED_WITH_SECURITY_IMPLICATION();
+                return { };
+            }
+            if (lastValidStateIndex.value() >= state.size()) {
+                ASSERT_NOT_REACHED_WITH_SECURITY_IMPLICATION();
+                return { };
+            }
+
+            auto newEntry = layoutSingleLineForPretty({ breakOpportunities[lastValidStateIndex.value()], range.endIndex() }, idealLineWidth, state[lastValidStateIndex.value()], lastValidStateIndex.value());
             auto it = std::ranges::find(breakOpportunities, newEntry.lineEnd.index);
             // If hyphenation does not create a valid solution, we should return early.
             if (it == breakOpportunities.end())


### PR DESCRIPTION
#### 44bd78d54f85af0780656e0d1fd50e19586f89df
<pre>
[text-wrap][pretty] Fix incorrect index in InlineContentConstrainer hyphenation fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=302553">https://bugs.webkit.org/show_bug.cgi?id=302553</a>
&lt;<a href="https://rdar.apple.com/164680038">rdar://164680038</a>&gt;

Reviewed by Alan Baradlay.

This PR fixes a bug where the hyphenation fallback was using the wrong
starting inline item position. We should use:

breakOpportunities[lastValidStateIndex]

to correctly look up the actual inline item index from
the break opportunities array.

This PR also adds bounds checks before accessing the arrays.

Combined changes:
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-4-expected.txt: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-4.html: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-5-expected.txt: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-5.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::prettifyRange):

Canonical link: <a href="https://commits.webkit.org/303130@main">https://commits.webkit.org/303130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdce3c03a68bbdbc269cce09bc32fd2f750c83c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82855 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4b88775c-8456-43c4-a239-906e4f598763) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67683 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7fef9f7-8b1a-43cf-ae5e-6944d421208a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80626 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19979a4c-c4d4-49e7-aa5c-b4ec5a5fef1b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2404 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/93 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81844 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141093 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108446 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108388 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2419 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56284 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20425 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3292 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32164 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3114 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->