### PR TITLE
[Style] Remove GreaterThanOrSameSizeAsStyleRareInheritedData

### DIFF
--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -34,49 +34,6 @@
 
 namespace WebCore {
 
-struct GreaterThanOrSameSizeAsStyleRareInheritedData : public RefCounted<GreaterThanOrSameSizeAsStyleRareInheritedData> {
-    float firstFloat;
-    float secondFloat;
-    Style::ImageOrNone styleImage;
-    Style::WebkitTextStrokeWidth textStrokeWidth;
-    Style::Color firstColor;
-    Style::Color colors[10];
-    Style::ScrollbarColor scrollbarColor;
-    Style::DynamicRangeLimit dynamicRangeLimit;
-    void* ownPtrs[1];
-    AtomString atomStrings[5];
-    void* refPtrs[3];
-    float thirdFloat;
-    Style::TextEmphasisStyle textEmphasisStyle;
-    Style::TextIndent textIndent;
-    Style::TextUnderlineOffset offset;
-    Style::TextBoxEdge textBoxEdge;
-    Style::LineFitEdge lineFitEdge;
-    void* customPropertyDataRefs[1];
-    unsigned bitfields[7];
-    short pagedMediaShorts[2];
-    Style::TabSize tabSize;
-    short hyphenationShorts[3];
-
-#if ENABLE(TEXT_AUTOSIZING)
-    Style::TextSizeAdjust textSizeAdjust;
-#endif
-
-#if ENABLE(TOUCH_EVENTS)
-    Style::Color tapHighlightColor;
-#endif
-
-#if ENABLE(DARK_MODE_CSS)
-    Style::ColorScheme colorScheme;
-#endif
-    Style::ListStyleType listStyleType;
-    Style::BlockEllipsis blockEllipsis;
-    Style::MathDepth mathDepth;
-    uint64_t eventListenerRegionTypes;
-};
-
-static_assert(sizeof(StyleRareInheritedData) <= sizeof(GreaterThanOrSameSizeAsStyleRareInheritedData), "StyleRareInheritedData should bit pack");
-
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRareInheritedData);
 
 StyleRareInheritedData::StyleRareInheritedData()


### PR DESCRIPTION
#### 215c65a7bca6a66625d0ef13f9b1e17e981d7e00
<pre>
[Style] Remove GreaterThanOrSameSizeAsStyleRareInheritedData
<a href="https://bugs.webkit.org/show_bug.cgi?id=302573">https://bugs.webkit.org/show_bug.cgi?id=302573</a>

Reviewed by Darin Adler.

Removes GreaterThanOrSameSizeAsStyleRareInheritedData and the static assertion:

    `sizeof(StyleRareInheritedData) &lt;= sizeof(GreaterThanOrSameSizeAsStyleRareInheritedData)`

It is not worth the effort or hassle for a rare data object.

* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:

Canonical link: <a href="https://commits.webkit.org/303079@main">https://commits.webkit.org/303079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2265e8d9840d92172b2334e9c6f3b3d3925ea0e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138657 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99969 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80669 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2456 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81906 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141156 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27561 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2469 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56375 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32216 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66758 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->