### PR TITLE
[Style] Convert the 'text-transform' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3509,6 +3509,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/text/StyleTextAutospace.h
     style/values/text/StyleTextIndent.h
     style/values/text/StyleTextSpacingTrim.h
+    style/values/text/StyleTextTransform.h
     style/values/text/StyleWordSpacing.h
 
     style/values/text-decoration/StyleTextDecorationLine.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3341,6 +3341,7 @@ style/values/text/StyleLetterSpacing.cpp
 style/values/text/StyleTabSize.cpp
 style/values/text/StyleTextAutospace.cpp
 style/values/text/StyleTextIndent.cpp
+style/values/text/StyleTextTransform.cpp
 style/values/text/StyleWordSpacing.cpp
 style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp
 style/values/transforms/functions/StyleMatrixTransformFunction.cpp

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1591,7 +1591,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
         if (text.isEmpty())
             return;
 
-        if (textBox->style().textTransform().contains(TextTransform::FullSizeKana)) {
+        if (textBox->style().textTransform().contains(Style::TextTransformValue::FullSizeKana)) {
             // We don't want to serve transformed kana text to AT since it is a visual affordance.
             // Using the original text from the renderer provides the untransformed string.
             text = textBox->renderer().originalText().substring(textBox->start(), textBox->length());

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -51,6 +51,7 @@
 #include "StylePositionVisibility.h"
 #include "StyleScrollBehavior.h"
 #include "StyleTextDecorationLine.h"
+#include "StyleTextTransform.h"
 #include "StyleTouchAction.h"
 #include "StyleWebKitLineBoxContain.h"
 #include "StyleWebKitOverflowScrolling.h"
@@ -1279,8 +1280,8 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-#define TYPE TextTransform
-#define FOR_EACH(CASE) CASE(Capitalize) CASE(Uppercase) CASE(Lowercase) CASE(FullSizeKana) CASE(FullWidth) CASE(MathAuto)
+#define TYPE Style::TextTransformValue
+#define FOR_EACH(CASE) CASE(Capitalize) CASE(Uppercase) CASE(Lowercase) CASE(FullWidth) CASE(FullSizeKana) CASE(MathAuto)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7869,6 +7869,7 @@
             "inherited": true,
             "initial": "none",
             "values": [
+                "none",
                 "capitalize",
                 "uppercase",
                 "lowercase",
@@ -7876,15 +7877,15 @@
                 "full-width",
                 {
                     "value": "math-auto",
-                    "settings-flag": "cssTextTransformMathAutoEnabled"
-                },
-                "none"
+                    "settings-flag": "cssTextTransformMathAutoEnabled",
+                    "url": "https://w3c.github.io/mathml-core/#math-auto-transform"
+                }
             ],
             "codegen-properties": {
                 "aliases": [
                     "-epub-text-transform"
                 ],
-                "style-converter": "TextTransform",
+                "style-converter": "StyleType<TextTransform>",
                 "parser-grammar": "none | [ [ capitalize | uppercase | lowercase ] || full-width || full-size-kana ]@(no-single-item-opt) | math-auto@(settings-flag=cssTextTransformMathAutoEnabled)"
             },
             "specification": {

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1200,7 +1200,7 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
     ASSERT(textEndOffset >= 0);
     ASSERT(textStartOffset <= textEndOffset);
 
-    bool shouldIgnoreFullSizeKana = m_behaviors.contains(TextIteratorBehavior::IgnoresFullSizeKana) && renderer.style().textTransform().contains(TextTransform::FullSizeKana);
+    bool shouldIgnoreFullSizeKana = m_behaviors.contains(TextIteratorBehavior::IgnoresFullSizeKana) && renderer.style().textTransform().contains(Style::TextTransformValue::FullSizeKana);
 
     // FIXME: This probably yields the wrong offsets when text-transform: lowercase turns a single character into two characters.
     String string = m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || shouldIgnoreFullSizeKana ? renderer.originalText()

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -26,8 +26,9 @@
 #pragma once
 
 #include "FormattingContext.h"
-#include <WebCore/LayoutBoxGeometry.h>
-#include <WebCore/StyleZoomPrimitives.h>
+#include "LayoutBoxGeometry.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StyleZoomPrimitives.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -454,7 +454,7 @@ void RenderText::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
         needsResetText = true;
     }
 
-    auto oldTransform = oldStyle ? oldStyle->textTransform() : OptionSet<TextTransform> { };
+    auto oldTransform = oldStyle ? oldStyle->textTransform() : Style::TextTransform { CSS::Keyword::None { } };
     TextSecurity oldSecurity = oldStyle ? oldStyle->textSecurity() : TextSecurity::None;
     if (needsResetText || oldTransform != newStyle.textTransform() || oldSecurity != newStyle.textSecurity())
         RenderText::setText(originalText(), true);
@@ -1693,25 +1693,25 @@ String applyTextTransform(const RenderStyle& style, const String& text, Vector<c
 {
     auto transform = style.textTransform();
 
-    if (transform.isEmpty())
+    if (transform.isNone())
         return text;
 
     // https://w3c.github.io/csswg-drafts/css-text/#text-transform-order
     auto modified = text;
-    if (transform.contains(TextTransform::Capitalize))
+    if (transform.contains(Style::TextTransformValue::Capitalize))
         modified = capitalize(modified, previousCharacter); // FIXME: Need to take locale into account.
-    else if (transform.contains(TextTransform::Uppercase))
+    else if (transform.contains(Style::TextTransformValue::Uppercase))
         modified = modified.convertToUppercaseWithLocale(style.computedLocale());
-    else if (transform.contains(TextTransform::Lowercase))
+    else if (transform.contains(Style::TextTransformValue::Lowercase))
         modified = modified.convertToLowercaseWithLocale(style.computedLocale());
 
-    if (transform.contains(TextTransform::FullWidth))
+    if (transform.contains(Style::TextTransformValue::FullWidth))
         modified = transformToFullWidth(modified);
 
-    if (transform.contains(TextTransform::FullSizeKana))
+    if (transform.contains(Style::TextTransformValue::FullSizeKana))
         modified = convertToFullSizeKana(modified);
 
-    if (transform.contains(TextTransform::MathAuto))
+    if (transform.contains(Style::TextTransformValue::MathAuto))
         modified = convertToMathAuto(modified);
 
     return modified;
@@ -1729,7 +1729,7 @@ void RenderText::setRenderedText(const String& newText)
         m_text = makeStringByReplacingAll(m_text, '\\', yenSign);
     
     const auto& style = this->style();
-    if (!style.textTransform().isEmpty())
+    if (!style.textTransform().isNone())
         m_text = applyTextTransform(style, m_text, previousCharacter());
 
     // At rendering time, if certain fonts are used, these characters get swapped out with higher-quality PUA characters.
@@ -1871,7 +1871,7 @@ String RenderText::textWithoutConvertingBackslashToYenSymbol() const
     if (!m_useBackslashAsYenSymbol || style().textSecurity() != TextSecurity::None)
         return text();
 
-    if (style().textTransform().isEmpty())
+    if (style().textTransform().isNone())
         return originalText();
 
     return applyTextTransform(style(), originalText(), previousCharacter());

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -55,6 +55,8 @@
 #include "StyleResolver.h"
 #include "StyleScaleTransformFunction.h"
 #include "StyleSelfAlignmentData.h"
+#include "StyleTextDecorationLine.h"
+#include "StyleTextTransform.h"
 #include "StyleTreeResolver.h"
 #include "TransformOperationData.h"
 #include <algorithm>
@@ -108,7 +110,7 @@ static_assert(sizeof(RenderStyle) == sizeof(SameSizeAsRenderStyle), "RenderStyle
 
 static_assert(PublicPseudoIDBits == allPublicPseudoElementTypes.size());
 
-static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
+static_assert(!(static_cast<unsigned>(Style::maxTextTransformValue) >> TextTransformBits));
 
 // Value zero is used to indicate no pseudo-element.
 static_assert(!((enumToUnderlyingType(PseudoElementType::HighestEnumValue) + 1) >> PseudoElementTypeBits));
@@ -3612,7 +3614,7 @@ void RenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const NonIn
     LOG_IF_DIFFERENT(usesContainerUnits);
     LOG_IF_DIFFERENT(useTreeCountingFunctions);
 
-    LOG_IF_DIFFERENT_WITH_CAST(Style::TextDecorationLine, textDecorationLine);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::TextDecorationLine, textDecorationLine);
 
     LOG_IF_DIFFERENT(hasExplicitlyInheritedProperties);
     LOG_IF_DIFFERENT(disallowsFastPathInheritance);
@@ -3638,8 +3640,8 @@ void RenderStyle::InheritedFlags::dumpDifferences(TextStream& ts, const Inherite
     LOG_IF_DIFFERENT_WITH_CAST(TextAlignMode, textAlign);
     LOG_IF_DIFFERENT_WITH_CAST(TextWrapStyle, textWrapStyle);
 
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(OptionSet<TextTransform>, textTransform);
-    LOG_IF_DIFFERENT_WITH_CAST(Style::TextDecorationLine, textDecorationLineInEffect);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::TextTransform, textTransform);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::TextDecorationLine, textDecorationLineInEffect);
 
     LOG_IF_DIFFERENT_WITH_CAST(PointerEvents, pointerEvents);
     LOG_IF_DIFFERENT_WITH_CAST(Visibility, visibility);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -29,7 +29,6 @@
 #include <WebCore/BoxExtents.h>
 #include <WebCore/PseudoElementIdentifier.h>
 #include <WebCore/StylePrimitiveNumeric+Forward.h>
-#include <WebCore/StyleTextDecorationLine.h>
 #include <WebCore/WritingMode.h>
 #include <unicode/utypes.h>
 #include <wtf/CheckedRef.h>
@@ -357,11 +356,13 @@ struct TabSize;
 struct TextAutospace;
 struct TextBoxEdge;
 struct TextDecorationThickness;
+struct TextDecorationLine;
 struct TextEmphasisStyle;
 struct TextIndent;
 struct TextShadow;
 struct TextSizeAdjust;
 struct TextSpacingTrim;
+struct TextTransform;
 struct TextUnderlineOffset;
 struct TouchAction;
 struct Transform;
@@ -759,7 +760,7 @@ public:
     inline TextAlignMode textAlign() const { return static_cast<TextAlignMode>(m_inheritedFlags.textAlign); }
     inline TextAlignLast textAlignLast() const;
     inline TextGroupAlign textGroupAlign() const;
-    inline OptionSet<TextTransform> textTransform() const;
+    inline Style::TextTransform textTransform() const;
     inline Style::TextDecorationLine textDecorationLineInEffect() const;
     inline Style::TextDecorationLine textDecorationLine() const;
     inline TextDecorationStyle textDecorationStyle() const;
@@ -1410,7 +1411,7 @@ public:
     inline void setTextIndent(Style::TextIndent&&);
     inline void setTextUnderlinePosition(OptionSet<TextUnderlinePosition>);
     inline void setTextUnderlineOffset(Style::TextUnderlineOffset&&);
-    inline void setTextTransform(OptionSet<TextTransform>);
+    inline void setTextTransform(Style::TextTransform);
     bool setZoom(float);
     inline bool setUsedZoom(float);
     inline void setTextZoom(TextZoom);
@@ -2036,7 +2037,7 @@ public:
     static constexpr EmptyCell initialEmptyCells();
     static constexpr ListStylePosition initialListStylePosition();
     static inline Style::ListStyleType initialListStyleType();
-    static constexpr OptionSet<TextTransform> initialTextTransform();
+    static constexpr Style::TextTransform initialTextTransform();
     static inline Style::ViewTransitionClasses initialViewTransitionClasses();
     static inline Style::ViewTransitionName initialViewTransitionName();
     static constexpr Visibility initialVisibility();
@@ -2082,8 +2083,8 @@ public:
     static constexpr TextAlignMode initialTextAlign();
     static constexpr TextAlignLast initialTextAlignLast();
     static constexpr TextGroupAlign initialTextGroupAlign();
-    static inline Style::TextDecorationLine initialTextDecorationLine();
-    static inline Style::TextDecorationLine initialTextDecorationLineInEffect();
+    static constexpr Style::TextDecorationLine initialTextDecorationLine();
+    static constexpr Style::TextDecorationLine initialTextDecorationLineInEffect();
     static constexpr TextDecorationStyle initialTextDecorationStyle();
     static constexpr TextDecorationSkipInk initialTextDecorationSkipInk();
     static constexpr OptionSet<TextUnderlinePosition> initialTextUnderlinePosition();
@@ -2524,7 +2525,7 @@ private:
         PREFERRED_TYPE(bool) unsigned isLink : 1;
         PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
-        PREFERRED_TYPE(Style::TextDecorationLine) unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
+        unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element. PREFERRED_TYPE elided to avoid header inclusion.
 
         // If you add more style bits here, you will also need to update RenderStyle::NonInheritedFlags::copyNonInheritedFrom().
     };
@@ -2544,9 +2545,9 @@ private:
         PREFERRED_TYPE(TextWrapMode) unsigned char textWrapMode : 1;
         PREFERRED_TYPE(TextAlignMode) unsigned char textAlign : 4;
         PREFERRED_TYPE(TextWrapStyle) unsigned char textWrapStyle : 2;
-        PREFERRED_TYPE(OptionSet<TextTransform>) unsigned char textTransform : TextTransformBits;
+        unsigned char textTransform : TextTransformBits; // PREFERRED_TYPE elided to avoid header inclusion.
         unsigned char : 1; // byte alignment
-        PREFERRED_TYPE(Style::TextDecorationLine) unsigned char textDecorationLineInEffect : TextDecorationLineBits;
+        unsigned char textDecorationLineInEffect : TextDecorationLineBits; // PREFERRED_TYPE elided to avoid header inclusion.
 
         // Cursors and Visibility = 13 bits aligned onto 4 bits + 1 byte + 1 bit
         PREFERRED_TYPE(PointerEvents) unsigned char pointerEvents : 4;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1277,19 +1277,6 @@ TextStream& operator<<(TextStream& ts, TextSecurity textSecurity)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, TextTransform textTransform)
-{
-    switch (textTransform) {
-    case TextTransform::Capitalize: ts << "capitalize"_s; break;
-    case TextTransform::Uppercase: ts << "uppercase"_s; break;
-    case TextTransform::Lowercase: ts << "lowercase"_s; break;
-    case TextTransform::FullSizeKana: ts << "full-size-kana"_s; break;
-    case TextTransform::FullWidth: ts << "full-width"_s; break;
-    case TextTransform::MathAuto: ts << "math-auto"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, TextUnderlinePosition position)
 {
     switch (position) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -609,16 +609,6 @@ enum class TextAlignMode : uint8_t {
     End,
 };
 
-enum class TextTransform : uint8_t {
-    Capitalize    = 1 << 0,
-    Uppercase     = 1 << 1,
-    Lowercase     = 1 << 2,
-    FullSizeKana  = 1 << 3,
-    FullWidth     = 1 << 4,
-    MathAuto      = 1 << 5,
-};
-constexpr auto maxTextTransformValue = TextTransform::FullWidth;
-
 enum class TextDecorationStyle : uint8_t {
     Solid,
     Double,
@@ -1346,7 +1336,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, TextGroupAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, TextJustify);
 WTF::TextStream& operator<<(WTF::TextStream&, TextOverflow);
 WTF::TextStream& operator<<(WTF::TextStream&, TextSecurity);
-WTF::TextStream& operator<<(WTF::TextStream&, TextTransform);
 WTF::TextStream& operator<<(WTF::TextStream&, TextUnderlinePosition);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapStyle);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -68,7 +68,9 @@
 #include <WebCore/StyleRareNonInheritedData.h>
 #include <WebCore/StyleSurroundData.h>
 #include <WebCore/StyleTextAutospace.h>
+#include <WebCore/StyleTextDecorationLine.h>
 #include <WebCore/StyleTextSpacingTrim.h>
+#include <WebCore/StyleTextTransform.h>
 #include <WebCore/StyleTransformData.h>
 #include <WebCore/StyleVisitedLinkColorData.h>
 #include <WebCore/UnicodeBidi.h>
@@ -564,8 +566,8 @@ constexpr Style::TextBoxEdge RenderStyle::initialTextBoxEdge() { return CSS::Key
 constexpr Style::LineFitEdge RenderStyle::initialLineFitEdge() { return CSS::Keyword::Leading { }; }
 constexpr TextCombine RenderStyle::initialTextCombine() { return TextCombine::None; }
 inline Style::Color RenderStyle::initialTextDecorationColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::TextDecorationLine RenderStyle::initialTextDecorationLine() { return CSS::Keyword::None { }; }
-inline Style::TextDecorationLine RenderStyle::initialTextDecorationLineInEffect() { return initialTextDecorationLine(); }
+constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLine() { return CSS::Keyword::None { }; }
+constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLineInEffect() { return initialTextDecorationLine(); }
 constexpr TextDecorationSkipInk RenderStyle::initialTextDecorationSkipInk() { return TextDecorationSkipInk::Auto; }
 constexpr TextDecorationStyle RenderStyle::initialTextDecorationStyle() { return TextDecorationStyle::Solid; }
 inline Style::TextDecorationThickness RenderStyle::initialTextDecorationThickness() { return CSS::Keyword::Auto { }; }
@@ -583,7 +585,7 @@ constexpr TextSecurity RenderStyle::initialTextSecurity() { return TextSecurity:
 inline Style::TextShadows RenderStyle::initialTextShadow() { return CSS::Keyword::None { }; }
 inline Style::Color RenderStyle::initialTextStrokeColor() { return CSS::Keyword::Currentcolor { }; }
 constexpr Style::WebkitTextStrokeWidth RenderStyle::initialTextStrokeWidth() { return 0_css_px; }
-constexpr OptionSet<TextTransform> RenderStyle::initialTextTransform() { return { }; }
+constexpr Style::TextTransform RenderStyle::initialTextTransform() { return CSS::Keyword::None { }; }
 inline Style::TextUnderlineOffset RenderStyle::initialTextUnderlineOffset() { return CSS::Keyword::Auto { }; }
 constexpr OptionSet<TextUnderlinePosition> RenderStyle::initialTextUnderlinePosition() { return { }; }
 constexpr TextWrapMode RenderStyle::initialTextWrapMode() { return TextWrapMode::Wrap; }
@@ -808,11 +810,11 @@ inline Style::TextBoxEdge RenderStyle::textBoxEdge() const { return m_rareInheri
 inline Style::LineFitEdge RenderStyle::lineFitEdge() const { return m_rareInheritedData->lineFitEdge; }
 inline TextCombine RenderStyle::textCombine() const { return static_cast<TextCombine>(m_rareInheritedData->textCombine); }
 inline const Style::Color& RenderStyle::textDecorationColor() const { return m_nonInheritedData->rareData->textDecorationColor; }
-inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return m_nonInheritedFlags.textDecorationLine; }
+inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return Style::TextDecorationLine::fromRaw(m_nonInheritedFlags.textDecorationLine); }
 inline TextDecorationSkipInk RenderStyle::textDecorationSkipInk() const { return static_cast<TextDecorationSkipInk>(m_rareInheritedData->textDecorationSkipInk); }
 inline TextDecorationStyle RenderStyle::textDecorationStyle() const { return static_cast<TextDecorationStyle>(m_nonInheritedData->rareData->textDecorationStyle); }
 inline const Style::TextDecorationThickness& RenderStyle::textDecorationThickness() const { return m_nonInheritedData->rareData->textDecorationThickness; }
-inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return m_inheritedFlags.textDecorationLineInEffect; }
+inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return Style::TextDecorationLine::fromRaw(m_inheritedFlags.textDecorationLineInEffect); }
 inline const Style::Color& RenderStyle::textEmphasisColor() const { return m_rareInheritedData->textEmphasisColor; }
 inline const Style::TextEmphasisStyle& RenderStyle::textEmphasisStyle() const { return m_rareInheritedData->textEmphasisStyle; }
 inline OptionSet<TextEmphasisPosition> RenderStyle::textEmphasisPosition() const { return OptionSet<TextEmphasisPosition>::fromRaw(m_rareInheritedData->textEmphasisPosition); }
@@ -827,7 +829,7 @@ inline bool RenderStyle::hasTextShadow() const { return !textShadow().isNone(); 
 inline Style::TextSpacingTrim RenderStyle::textSpacingTrim() const { return fontDescription().textSpacingTrim(); }
 inline const Style::Color& RenderStyle::textStrokeColor() const { return m_rareInheritedData->textStrokeColor; }
 inline Style::WebkitTextStrokeWidth RenderStyle::textStrokeWidth() const { return m_rareInheritedData->textStrokeWidth; }
-inline OptionSet<TextTransform> RenderStyle::textTransform() const { return OptionSet<TextTransform>::fromRaw(m_inheritedFlags.textTransform); }
+inline Style::TextTransform RenderStyle::textTransform() const { return Style::TextTransform::fromRaw(m_inheritedFlags.textTransform); }
 inline const Style::TextUnderlineOffset& RenderStyle::textUnderlineOffset() const { return m_rareInheritedData->textUnderlineOffset; }
 inline OptionSet<TextUnderlinePosition> RenderStyle::textUnderlinePosition() const { return OptionSet<TextUnderlinePosition>::fromRaw(m_rareInheritedData->textUnderlinePosition); }
 inline TextZoom RenderStyle::textZoom() const { return static_cast<TextZoom>(m_rareInheritedData->textZoom); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -315,7 +315,7 @@ inline void RenderStyle::setTextSecurity(TextSecurity security) { SET(m_rareInhe
 inline void RenderStyle::setTextShadow(Style::TextShadows&& textShadow) { SET(m_rareInheritedData, textShadow, WTFMove(textShadow)); }
 inline void RenderStyle::setTextStrokeColor(Style::Color&& color) { SET(m_rareInheritedData, textStrokeColor, WTFMove(color)); }
 inline void RenderStyle::setTextStrokeWidth(Style::WebkitTextStrokeWidth width) { SET(m_rareInheritedData, textStrokeWidth, width); }
-inline void RenderStyle::setTextTransform(OptionSet<TextTransform> value) { m_inheritedFlags.textTransform = value.toRaw(); }
+inline void RenderStyle::setTextTransform(Style::TextTransform value) { m_inheritedFlags.textTransform = value.toRaw(); }
 inline void RenderStyle::setTextUnderlineOffset(Style::TextUnderlineOffset&& textUnderlineOffset) { SET(m_rareInheritedData, textUnderlineOffset, WTFMove(textUnderlineOffset)); }
 inline void RenderStyle::setTextUnderlinePosition(OptionSet<TextUnderlinePosition> position) { SET(m_rareInheritedData, textUnderlinePosition, static_cast<unsigned>(position.toRaw())); }
 inline void RenderStyle::setTextZoom(TextZoom zoom) { SET(m_rareInheritedData, textZoom, static_cast<unsigned>(zoom)); }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -113,7 +113,6 @@ class BuilderConverter {
 public:
     template<typename T, typename... Rest> static T convertStyleType(BuilderState&, const CSSValue&, Rest&&...);
 
-    static OptionSet<TextTransform> convertTextTransform(BuilderState&, const CSSValue&);
     template<CSSValueID> static AtomString convertCustomIdentAtomOrKeyword(BuilderState&, const CSSValue&);
 
     static OptionSet<TextEmphasisPosition> convertTextEmphasisPosition(BuilderState&, const CSSValue&);
@@ -139,19 +138,6 @@ public:
 template<typename T, typename... Rest> inline T BuilderConverter::convertStyleType(BuilderState& builderState, const CSSValue& value, Rest&&... rest)
 {
     return toStyleFromCSSValue<T>(builderState, value, std::forward<Rest>(rest)...);
-}
-
-inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(BuilderState&, const CSSValue& value)
-{
-    auto result = RenderStyle::initialTextTransform();
-    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
-        for (auto& currentValue : *list)
-            result.add(fromCSSValue<TextTransform>(currentValue));
-    } else if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->valueID() == CSSValueMathAuto)
-            result.add(TextTransform::MathAuto);
-    }
-    return result;
 }
 
 template<CSSValueID keyword> inline AtomString BuilderConverter::convertCustomIdentAtomOrKeyword(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -134,7 +134,6 @@ public:
     // MARK: Shared conversions
 
     static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const FixedVector<PositionTryFallback>&);
-    static Ref<CSSValue> convertTextTransform(ExtractorState&, OptionSet<TextTransform>);
     static Ref<CSSValue> convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition>);
     static Ref<CSSValue> convertTextEmphasisPosition(ExtractorState&, OptionSet<TextEmphasisPosition>);
     static Ref<CSSValue> convertSpeakAs(ExtractorState&, OptionSet<SpeakAs>);
@@ -271,32 +270,6 @@ inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorSt
     }
 
     return CSSValueList::createCommaSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertTextTransform(ExtractorState&, OptionSet<TextTransform> textTransform)
-{
-    CSSValueListBuilder list;
-    if (textTransform.contains(TextTransform::Capitalize))
-        list.append(CSSPrimitiveValue::create(CSSValueCapitalize));
-    else if (textTransform.contains(TextTransform::Uppercase))
-        list.append(CSSPrimitiveValue::create(CSSValueUppercase));
-    else if (textTransform.contains(TextTransform::Lowercase))
-        list.append(CSSPrimitiveValue::create(CSSValueLowercase));
-
-    if (textTransform.contains(TextTransform::FullWidth))
-        list.append(CSSPrimitiveValue::create(CSSValueFullWidth));
-
-    if (textTransform.contains(TextTransform::FullSizeKana))
-        list.append(CSSPrimitiveValue::create(CSSValueFullSizeKana));
-
-    if (textTransform.contains(TextTransform::MathAuto)) {
-        ASSERT(list.isEmpty());
-        list.append(CSSPrimitiveValue::create(CSSValueMathAuto));
-    }
-
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition> textUnderlinePosition)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -71,7 +71,6 @@ public:
     static void serializeSmoothScrolling(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, bool);
     static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<PositionTryFallback>&);
     static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
-    static void serializeTextTransform(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextTransform>);
     static void serializeTextUnderlinePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextUnderlinePosition>);
     static void serializeTextEmphasisPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextEmphasisPosition>);
     static void serializeSpeakAs(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<SpeakAs>);
@@ -217,43 +216,6 @@ inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& s
     }
 
     builder.append(CSSValueList::createCommaSeparated(WTFMove(list))->cssText(context));
-}
-
-inline void ExtractorSerializer::serializeTextTransform(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextTransform> textTransform)
-{
-    bool listEmpty = true;
-
-    if (textTransform.contains(TextTransform::Capitalize)) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Capitalize { });
-        listEmpty = false;
-    } else if (textTransform.contains(TextTransform::Uppercase)) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Uppercase { });
-        listEmpty = false;
-    } else if (textTransform.contains(TextTransform::Lowercase)) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Lowercase { });
-        listEmpty = false;
-    }
-
-    auto appendOption = [&](TextTransform test, CSSValueID value) {
-        if (textTransform.contains(test)) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(TextTransform::FullWidth, CSSValueFullWidth);
-    appendOption(TextTransform::FullSizeKana, CSSValueFullSizeKana);
-
-    if (textTransform.contains(TextTransform::MathAuto)) {
-        // math-auto can't be used in combination with other values, the parser already makes sure that is the case.
-        ASSERT(listEmpty);
-        serializationForCSS(builder, context, state.style, CSS::Keyword::MathAuto { });
-        listEmpty = false;
-    }
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
 }
 
 inline void ExtractorSerializer::serializeTextUnderlinePosition(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextUnderlinePosition> textUnderlinePosition)

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
@@ -79,79 +79,77 @@ struct TextDecorationLine {
     static constexpr uint8_t SingleValueSpellingError = static_cast<uint8_t>(Type::SingleValue) | static_cast<uint8_t>(SingleValue::SpellingError);
     static constexpr uint8_t SingleValueGrammarError  = static_cast<uint8_t>(Type::SingleValue) | static_cast<uint8_t>(SingleValue::GrammarError);
 
-    TextDecorationLine() = default;
+    constexpr TextDecorationLine() = default;
 
-    TextDecorationLine(uint8_t rawValue)
-        : m_packed(rawValue)
-    {
-    }
-
-    TextDecorationLine(CSS::Keyword::None)
+    constexpr TextDecorationLine(CSS::Keyword::None)
         : m_packed(SingleValueNone)
     {
     }
 
-    TextDecorationLine(CSS::Keyword::SpellingError)
+    constexpr TextDecorationLine(CSS::Keyword::SpellingError)
         : m_packed(SingleValueSpellingError)
     {
     }
 
-    TextDecorationLine(CSS::Keyword::GrammarError)
+    constexpr TextDecorationLine(CSS::Keyword::GrammarError)
         : m_packed(SingleValueGrammarError)
     {
     }
 
-    TextDecorationLine(OptionSet<TextDecorationLine::Flag> flags)
+    constexpr TextDecorationLine(OptionSet<TextDecorationLine::Flag> flags)
         : m_packed(flags.isEmpty() ? SingleValueNone : packFlags(flags))
     {
     }
 
-    TextDecorationLine(TextDecorationLine::Flag flag)
+    constexpr TextDecorationLine(TextDecorationLine::Flag flag)
         : TextDecorationLine(OptionSet<TextDecorationLine::Flag>(flag))
     {
     }
 
-    inline Type type() const { return static_cast<Type>(m_packed & TypeMask); }
-    bool isNone() const { return m_packed == SingleValueNone; }
-    bool isSpellingError() const { return m_packed == SingleValueSpellingError; }
-    bool isGrammarError() const { return m_packed == SingleValueGrammarError; }
-    bool isFlags() const { return type() == Type::Flags; }
+    static constexpr TextDecorationLine fromRaw(uint8_t rawValue) { return TextDecorationLine(rawValue); }
+    constexpr uint8_t toRaw() const { return m_packed; }
 
-    bool hasUnderline() const
+    constexpr Type type() const { return static_cast<Type>(m_packed & TypeMask); }
+    constexpr bool isNone() const { return m_packed == SingleValueNone; }
+    constexpr bool isSpellingError() const { return m_packed == SingleValueSpellingError; }
+    constexpr bool isGrammarError() const { return m_packed == SingleValueGrammarError; }
+    constexpr bool isFlags() const { return type() == Type::Flags; }
+
+    constexpr bool hasUnderline() const
     {
         return (isFlags()) && (m_packed & UnderlineBit);
     }
 
-    bool hasOverline() const
+    constexpr bool hasOverline() const
     {
         return (isFlags()) && (m_packed & OverlineBit);
     }
 
-    bool hasLineThrough() const
+    constexpr bool hasLineThrough() const
     {
         return (isFlags()) && (m_packed & LineThroughBit);
     }
 
-    bool hasBlink() const
+    constexpr bool hasBlink() const
     {
         return (isFlags()) && (m_packed & BlinkBit);
     }
 
-    bool containsAny(OptionSet<TextDecorationLine::Flag> options) const
+    constexpr bool containsAny(OptionSet<TextDecorationLine::Flag> options) const
     {
         if (!isFlags())
             return false;
         return (m_packed & packFlags(options));
     }
 
-    bool contains(TextDecorationLine::Flag option) const
+    constexpr bool contains(TextDecorationLine::Flag option) const
     {
         if (!isFlags())
             return false;
         return (m_packed & packFlagValue(option));
     }
 
-    void remove(TextDecorationLine::Flag option)
+    constexpr void remove(TextDecorationLine::Flag option)
     {
         if (type() == Type::Flags) {
             m_packed &= ~packFlagValue(option);
@@ -161,9 +159,9 @@ struct TextDecorationLine {
         }
     }
 
-    uint8_t addOrReplaceIfNotNone(const TextDecorationLine& value);
+    uint8_t addOrReplaceIfNotNone(const TextDecorationLine&);
 
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
@@ -183,10 +181,10 @@ struct TextDecorationLine {
         return visitor(CSS::Keyword::None { });
     }
 
-    void setNone() { m_packed = SingleValueNone; }
-    void setSpellingError() { m_packed = SingleValueSpellingError; }
-    void setGrammarError() { m_packed = SingleValueGrammarError; }
-    void setFlags(OptionSet<TextDecorationLine::Flag> flags)
+    constexpr void setNone() { m_packed = SingleValueNone; }
+    constexpr void setSpellingError() { m_packed = SingleValueSpellingError; }
+    constexpr void setGrammarError() { m_packed = SingleValueGrammarError; }
+    constexpr void setFlags(OptionSet<TextDecorationLine::Flag> flags)
     {
         if (isFlags())
             m_packed |= packFlags(flags);
@@ -194,10 +192,9 @@ struct TextDecorationLine {
             m_packed = packFlags(flags);
     }
 
-    operator bool() const { return !isNone(); }
-    bool operator==(const TextDecorationLine& other) const { return m_packed == other.m_packed; }
+    constexpr operator bool() const { return !isNone(); }
+    constexpr bool operator==(const TextDecorationLine&) const = default;
 
-    uint8_t toRaw() const { return m_packed; }
     static constexpr uint8_t packFlags(OptionSet<TextDecorationLine::Flag> flags)
     {
         uint8_t result = static_cast<uint8_t>(Type::Flags);
@@ -213,8 +210,13 @@ struct TextDecorationLine {
     }
 
 private:
+    constexpr TextDecorationLine(uint8_t rawValue)
+        : m_packed(rawValue)
+    {
+    }
+
     // Returns only the value bits, not to be confused with "toRaw", which returns the whole packed raw representation
-    inline uint8_t rawValue() const { return m_packed & ValuesMask; }
+    constexpr uint8_t rawValue() const { return m_packed & ValuesMask; }
 
     // Note that this function packs only the 'Value' bit, ignoring the Type. This is useful for bitwise operations.
     static constexpr uint8_t packFlagValue(TextDecorationLine::Flag flag)
@@ -233,7 +235,7 @@ private:
         return 0;
     }
 
-    OptionSet<TextDecorationLine::Flag> unpackFlags() const
+    constexpr OptionSet<TextDecorationLine::Flag> unpackFlags() const
     {
         ASSERT(isFlags());
         OptionSet<TextDecorationLine::Flag> flags;

--- a/Source/WebCore/style/values/text/StyleTextTransform.cpp
+++ b/Source/WebCore/style/values/text/StyleTextTransform.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleTextTransform.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<TextTransform>::operator()(BuilderState& state, const CSSValue& value) -> TextTransform
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        case CSSValueCapitalize:
+            return { TextTransformValue::Capitalize };
+        case CSSValueUppercase:
+            return { TextTransformValue::Uppercase };
+        case CSSValueLowercase:
+            return { TextTransformValue::Lowercase };
+        case CSSValueFullWidth:
+            return { TextTransformValue::FullWidth };
+        case CSSValueFullSizeKana:
+            return { TextTransformValue::FullSizeKana };
+        case CSSValueMathAuto:
+            return { TextTransformValue::MathAuto };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return CSS::Keyword::None { };
+
+    TextTransformValueEnumSet result;
+    for (Ref item : *list) {
+        switch (item->valueID()) {
+        case CSSValueCapitalize:
+            if (result.containsAny({ TextTransformValue::Uppercase, TextTransformValue::Lowercase })) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::None { };
+            }
+            result.value.add(TextTransformValue::Capitalize);
+            break;
+        case CSSValueUppercase:
+            if (result.containsAny({ TextTransformValue::Capitalize, TextTransformValue::Lowercase })) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::None { };
+            }
+            result.value.add(TextTransformValue::Uppercase);
+            break;
+        case CSSValueLowercase:
+            if (result.containsAny({ TextTransformValue::Capitalize, TextTransformValue::Uppercase })) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::None { };
+            }
+            result.value.add(TextTransformValue::Lowercase);
+            break;
+        case CSSValueFullWidth:
+            result.value.add(TextTransformValue::FullWidth);
+            break;
+        case CSSValueFullSizeKana:
+            result.value.add(TextTransformValue::FullSizeKana);
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+    return result;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/text/StyleTextTransform.h
+++ b/Source/WebCore/style/values/text/StyleTextTransform.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'text-transform'> = none | [ capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto
+// https://drafts.csswg.org/css-text/#propdef-text-transform
+// Additional value `math-auto` added by MathML
+// https://w3c.github.io/mathml-core/#math-auto-transform
+
+enum class TextTransformValue : uint8_t {
+    Capitalize,
+    Uppercase,
+    Lowercase,
+    FullWidth,
+    FullSizeKana,
+    MathAuto,
+};
+constexpr auto maxTextTransformValue = TextTransformValue::MathAuto;
+
+using TextTransformValueEnumSet = SpaceSeparatedEnumSet<TextTransformValue>;
+
+// FIXME: This could be packed in to 5 bits if we didn't use an EnumSet.
+struct TextTransform {
+    using EnumSet = TextTransformValueEnumSet;
+    using value_type = TextTransformValueEnumSet::value_type;
+
+    constexpr TextTransform(CSS::Keyword::None) : m_value { } { }
+    constexpr TextTransform(EnumSet&& set) : m_value { WTFMove(set) } { }
+    constexpr TextTransform(value_type value) : TextTransform { EnumSet { value } } { }
+    constexpr TextTransform(std::initializer_list<value_type> initializerList) : TextTransform { EnumSet { initializerList } } { }
+
+    static constexpr TextTransform fromRaw(EnumSet::StorageType rawValue) { return EnumSet::fromRaw(rawValue); }
+    constexpr EnumSet::StorageType toRaw() const { return m_value.toRaw(); }
+
+    constexpr bool contains(TextTransformValue e) const { return m_value.contains(e); }
+    constexpr bool containsAny(EnumSet other) const { return m_value.containsAny(other.value); }
+    constexpr bool containsAll(EnumSet other) const { return m_value.containsAll(other.value); }
+    constexpr bool containsOnly(EnumSet other) const { return m_value.containsOnly(other.value); }
+
+    constexpr bool isNone() const { return m_value.isEmpty(); }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isNone())
+            return visitor(CSS::Keyword::None { });
+
+        return visitor(m_value);
+    }
+
+    constexpr bool operator==(const TextTransform&) const = default;
+
+private:
+    EnumSet m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<TextTransform> { auto operator()(BuilderState&, const CSSValue&) -> TextTransform; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextTransform)


### PR DESCRIPTION
#### 62f525a389ac857ceb2d1077084d8a765f018b5d
<pre>
[Style] Convert the &apos;text-transform&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302576">https://bugs.webkit.org/show_bug.cgi?id=302576</a>

Reviewed by Darin Adler.

Converts the &apos;text-transform&apos; property to use strong style types.

Also removes StyleTextDecorationLine.h from RenderStyle.h and makes it constexpr.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/editing/TextIterator.cpp:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h:
* Source/WebCore/style/values/text/StyleTextTransform.cpp: Added.
* Source/WebCore/style/values/text/StyleTextTransform.h: Added.

Canonical link: <a href="https://commits.webkit.org/303094@main">https://commits.webkit.org/303094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bab8b12806675409b05bdb6609a879a186a858f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100030 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67780 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134229 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80731 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81978 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141228 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3358 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2532 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56507 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3420 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66828 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3442 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->