### PR TITLE
[AutoFill Debugging] Add support for `aria-(labeled|labelled|described)by` DOM attributes

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -9,14 +9,23 @@ root
                 link,uid=…,events=[click],url='https://example.com/','Section 2',[…]
     role='main'
         section,aria-label='Interactive Elements'
-            button,uid=…,events=[click],aria-label='Test button','Click Me',[…]
-            '        \nThis button does nothing\n\n        ',[…]
+            button,uid=…,events=[click],aria-describedby='This button does nothing',aria-label='Test button','Click Me',[…]
+            'This button does nothing',[…]
             input,'text',uid=…,placeholder='Enter text here'
             uid=…,role='button',events=[click,keyboard],'Clickable Div',[…]
+        section,aria-label='ARIA Labeling Examples'
+            'Name Field\n\n        \nDescription',[…]
+            input,'text',uid=…,aria-labelledby='Name Field',placeholder='Your name'
+            role='region',aria-labelledby='Description','This region is labeled by another element.',[…]
+            input,'text',uid=…,aria-labelledby='Name Field',placeholder='Full name'
+            'User Profile',[…]
+            role='group',aria-labelledby='User Profile'
+                'Username:',[…]
+                input,'text',uid=…,[…],label='Username:'
         section,aria-label='Content with Roles'
-            article,role='article','            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.\n\n\n        ',[…]
+            article,role='article','Article Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.',[…]
             role='complementary',aria-label='Related information'
-                '            \nRelated Links\n\n\n            ',[…]
+                'Related Links',[…]
                 list
                     list-item
                         link,uid=…,events=[hover],url='https://webkit.org/','Example Link',[…]
@@ -28,14 +37,14 @@ root
             aria-label='Figure 1'
                 canvas,uid=…,[…]
             textarea,uid=…,'This is a text box',[…]
-            '        Price: $11',[…]
+            'Price: $11',[…]
             superscript,'99',[…]
-            '        Link to ',[…]
+            'Link to',[…]
             subscript
                 'WebKit home page:',[…]
                 link,uid=…,url='https://webkit.org/'
     role='contentinfo'
-        '    \nFooter content with ',[…]
+        'Footer content with',[…]
         role='img',aria-label='copyright symbol','©',[…]
-        ' 2024',[…]
+        '2024',[…]
 version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -36,6 +36,10 @@ canvas {
     border: 1px dashed gray;
     padding: 1em;
 }
+
+#error-text {
+    display: none;
+}
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
@@ -56,7 +60,22 @@ canvas {
         <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
         <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
     </section>
-    <section id="section2" aria-label="Content with Roles">
+    <section id="section2" aria-label="ARIA Labeling Examples">
+        <div id="label1">Name Field</div>
+        <div id="label2">Description</div>
+        <input type="text" aria-labelledby="label1" placeholder="Your name" />
+        <div aria-labelledby="label2" role="region">
+            <p>This region is labeled by another element.</p>
+        </div>
+        <div id="error-text">Name not found.</div>
+        <input type="text" aria-labelledby="label1" aria-describedby="error-text" placeholder="Full name" />
+        <div id="title-label">User Profile</div>
+        <div role="group" aria-labelledby="title-label">
+            <label for="username">Username:</label>
+            <input type="text" id="username" />
+        </div>
+    </section>
+    <section id="section3" aria-label="Content with Roles">
         <article role="article">
             <header>
                 <h3>Article Title</h3>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -9,14 +9,14 @@ root
                 link,'Section 2'
     role='main'
         section,aria-label='Interactive Elements'
-            button,aria-label='Test button','Click Me'
-            '        \nThis button does nothing\n\n        '
+            button,aria-describedby='This button does nothing',aria-label='Test button','Click Me'
+            'This button does nothing'
             input,'text',uid=…,placeholder='Enter text here'
             role='button','Clickable Div'
         section,aria-label='Content with Roles'
-            article,role='article','            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.\n\n\n        '
+            article,role='article','Article Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.'
             role='complementary',aria-label='Related information'
-                '            \nRelated Links\n\n\n            '
+                'Related Links'
                 list
                     list-item
                         link,'Example Link'
@@ -31,7 +31,7 @@ root
                     'WebKit home page:'
                     link
     role='contentinfo'
-        '    \nFooter content with '
+        'Footer content with'
         role='img',aria-label='copyright symbol','©'
-        ' 2024'
+        '2024'
 version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -1,26 +1,26 @@
 root
-    '    \nWelcome to Test Page'
+    'Welcome to Test Page'
     navigation
         list
             list-item
                 link,'Section 1'
             list-item
                 link,'Section 2'
-    '    \nHere’s to the crazy ones…\n\n\n    '
+    'Here’s to the crazy ones…'
     section
         button,'Click Me'
-        '        \nThis button does nothing\n\n        '
+        'This button does nothing'
         input,'text',placeholder='Enter text here'
-        '        \nClickable Div\n\n    '
+        'Clickable Div'
     section
-        article,'            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content…\n\n\n        '
-        '        \n\n            \nRelated Links\n\n\n            '
+        article,'Article Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content…'
+        'Related Links'
         list
             list-item
                 link,'Example Link'
             list-item
                 link,'Test Link'
-        '        \n\n        \n\n            \nReady\n\n            '
+        'Ready'
         button,'Update Status'
-    '    \nThe quick brown fox jumped…\n\n\n\n\n    \nFooter content with © 2024'
+    'The quick brown fox jumped…\n\n\n\n\n    \nFooter content with © 2024'
 version=2

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -296,12 +296,8 @@ static void addPartsForText(const TextExtraction::TextItemData& textItem, Vector
                 return;
             }
 
-            auto isNewline = [](UChar character) {
-                return character == '\n' || character == '\r';
-            };
-
             auto startIndex = filteredText.find([&](auto character) {
-                return !isNewline(character);
+                return !isASCIIWhitespace(character);
             });
 
             if (startIndex == notFound) {
@@ -310,7 +306,7 @@ static void addPartsForText(const TextExtraction::TextItemData& textItem, Vector
             } else {
                 size_t endIndex = filteredText.length() - 1;
                 for (size_t i = filteredText.length(); i > 0; --i) {
-                    if (!isNewline(filteredText.characterAt(i - 1))) {
+                    if (!isASCIIWhitespace(filteredText.characterAt(i - 1))) {
                         endIndex = i - 1;
                         break;
                     }


### PR DESCRIPTION
#### f6c59e7e6cb6f5cf6cbf406af1e7e38187fed8fa
<pre>
[AutoFill Debugging] Add support for `aria-(labeled|labelled|described)by` DOM attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=302578">https://bugs.webkit.org/show_bug.cgi?id=302578</a>
<a href="https://rdar.apple.com/164800859">rdar://164800859</a>

Reviewed by Abrar Rahman Protyasha.

Make a couple of enhancements to debug text extraction:

-   Add support for 3 more accessibility attributes which reference other elements in the DOM:
    `aria-labeledby`, `aria-labelledby`, and `aria-describedby`. However, rather that surface the
    DOM attribute values themselves (which are `id` attributes referencing other elements in the
    DOM), we surface the visible text inside those referenced elements.

-   Additionally trim all whitespace characters (not just newlines) around visible text.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::normalizeText):

Move this helper method to the top of the file.

(WebCore::TextExtraction::extractRecursive):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForText):

Canonical link: <a href="https://commits.webkit.org/303086@main">https://commits.webkit.org/303086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9ad6a6958d7db552ef52e7d5c86a743fc532b0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138666 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82937 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c12ef443-695f-47d5-9104-17197a230f0e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99978 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7936c8bd-3242-4c51-a74d-b0b28a1b3563) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/acafbdda-83c6-4a9c-a4b0-a9a34cef7a51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2465 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/176 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81916 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141165 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3298 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108498 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3343 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2948 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108441 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27568 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2478 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56396 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3360 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32222 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3382 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->