### PR TITLE
Simplify creating the WebCore::IOSurface

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -146,11 +146,13 @@ public:
     };
 
     WEBCORE_EXPORT static std::unique_ptr<IOSurface> create(IOSurfacePool*, IntSize, const DestinationColorSpace&, Name = Name::Default, Format = Format::BGRA, UseLosslessCompression = UseLosslessCompression::No);
-    WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromImage(IOSurfacePool*, CGImageRef);
+    WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromPool(IOSurfacePool&, IntSize, const DestinationColorSpace&, Name = Name::Default, Format = Format::BGRA, UseLosslessCompression = UseLosslessCompression::No);
 
-    WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromSendRight(const WTF::MachSendRight&&);
     // If the colorSpace argument is non-null, it replaces any colorspace metadata on the surface.
     WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromSurface(IOSurfaceRef, std::optional<DestinationColorSpace>&&);
+    WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromSendRight(const WTF::MachSendRight&&);
+
+    WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromImage(IOSurfacePool*, CGImageRef);
 
     WEBCORE_EXPORT static void moveToPool(std::unique_ptr<IOSurface>&&, IOSurfacePool*);
 
@@ -242,8 +244,7 @@ public:
     RetainPtr<CGContextRef> createCompatibleBitmap(unsigned width, unsigned height);
 
 private:
-    IOSurface(IntSize, const DestinationColorSpace&, Name, Format, UseLosslessCompression, bool& success);
-    IOSurface(IOSurfaceRef, std::optional<DestinationColorSpace>&&);
+    IOSurface(IntSize, std::optional<DestinationColorSpace>&&, Name, std::optional<UsedFormat>&&, RetainPtr<IOSurfaceRef>&&);
 
     void setColorSpaceProperty();
     void ensureColorSpace();
@@ -258,21 +259,18 @@ private:
 
     BitmapConfiguration bitmapConfiguration() const;
 
-    std::optional<UsedFormat> m_format;
-    std::optional<DestinationColorSpace> m_colorSpace;
     IntSize m_size;
-    size_t m_totalBytes;
+    std::optional<DestinationColorSpace> m_colorSpace;
+    Name m_name { Name::Default };
+    std::optional<UsedFormat> m_format;
+    RetainPtr<IOSurfaceRef> m_surface;
+
+    size_t m_totalBytes { 0 };
 #if HAVE(SUPPORT_HDR_DISPLAY)
     std::optional<float> m_contentEDRHeadroom;
 #endif
-
     ProcessIdentity m_resourceOwner;
-
-    RetainPtr<IOSurfaceRef> m_surface;
-
     static std::optional<IntSize> s_maximumSize;
-
-    Name m_name;
 
     WEBCORE_EXPORT friend WTF::TextStream& operator<<(WTF::TextStream&, const WebCore::IOSurface&);
 };

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,6 @@
 #import "IOSurfacePool.h"
 #import "ImageBufferBackend.h"
 #import "Logging.h"
-#import "PlatformScreen.h"
 #import "ProcessCapabilities.h"
 #import "ProcessIdentity.h"
 #import "SharedMemory.h"
@@ -84,68 +83,46 @@ static RetainPtr<NSString> surfaceNameToNSString(IOSurface::Name name)
     }
 }
 
-std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, const DestinationColorSpace& colorSpace, IOSurface::Name name, Format pixelFormat, UseLosslessCompression useLosslessCompression)
+static std::optional<IOSurface::UsedFormat> formatFromSurface(IOSurfaceRef surface)
 {
-    ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
+    unsigned pixelFormat = IOSurfaceGetPixelFormat(surface);
+    if (pixelFormat == kCVPixelFormatType_32BGRA)
+        return IOSurface::UsedFormat { IOSurface::Format::BGRA, UseLosslessCompression::No };
 
-    if (pool) {
-        if (auto cachedSurface = pool->takeSurface(size, colorSpace, pixelFormat, useLosslessCompression)) {
-            LOG_WITH_STREAM(IOSurface, stream << "IOSurface::create took from pool: " << *cachedSurface);
-            if (cachedSurface->name() != name) {
-                IOSurfaceSetValue(cachedSurface->protectedSurface().get(), kIOSurfaceName, surfaceNameToNSString(name).get());
-                cachedSurface->setName(name);
-            }
-            return cachedSurface;
-        }
-    }
+    if (pixelFormat == kCVPixelFormatType_Lossless_32BGRA)
+        return IOSurface::UsedFormat { IOSurface::Format::BGRA, UseLosslessCompression::Yes };
 
-    bool success = false;
-    auto surface = std::unique_ptr<IOSurface>(new IOSurface(size, colorSpace, name, pixelFormat, useLosslessCompression, success));
-    if (!success) {
-        LOG(IOSurface, "IOSurface::create failed to create %dx%d surface", size.width(), size.height());
-        return nullptr;
-    }
+    if (pixelFormat == kCVPixelFormatType_422YpCbCr8BiPlanarFullRange)
+        return IOSurface::UsedFormat { IOSurface::Format::YUV422, UseLosslessCompression::No };
 
-    LOG_WITH_STREAM(IOSurface, stream << "IOSurface::create created " << *surface);
-    return surface;
-}
+    if (pixelFormat == kCVPixelFormatType_32RGBA)
+        return IOSurface::UsedFormat { IOSurface::Format::RGBA, UseLosslessCompression::No };
 
-std::unique_ptr<IOSurface> IOSurface::createFromSendRight(const MachSendRight&& sendRight)
-{
-    ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
+#if ENABLE(PIXEL_FORMAT_RGB10)
+    if (pixelFormat == kCVPixelFormatType_30RGBLEPackedWideGamut)
+        return IOSurface::UsedFormat { IOSurface::Format::RGB10, UseLosslessCompression::No };
 
-    auto surface = adoptCF(IOSurfaceLookupFromMachPort(sendRight.sendRight()));
-    return IOSurface::createFromSurface(surface.get(), { });
-}
+    if (pixelFormat == kCVPixelFormatType_AGX_30RGBLEPackedWideGamut)
+        return IOSurface::UsedFormat { IOSurface::Format::RGB10, UseLosslessCompression::Yes };
+#endif
 
-std::unique_ptr<IOSurface> IOSurface::createFromSurface(IOSurfaceRef surface, std::optional<DestinationColorSpace>&& colorSpace)
-{
-    if (!surface)
-        return nullptr;
+#if ENABLE(PIXEL_FORMAT_RGB10A8)
+    if (pixelFormat == kCVPixelFormatType_30RGBLE_8A_BiPlanar)
+        return IOSurface::UsedFormat { IOSurface::Format::RGB10A8, UseLosslessCompression::No };
 
-    return std::unique_ptr<IOSurface>(new IOSurface(surface, WTFMove(colorSpace)));
-}
+    if (pixelFormat == kCVPixelFormatType_AGX_30RGBLE_8A_BiPlanar)
+        return IOSurface::UsedFormat { IOSurface::Format::RGB10A8, UseLosslessCompression::Yes };
+#endif
 
-std::unique_ptr<IOSurface> IOSurface::createFromImage(IOSurfacePool* pool, CGImageRef image)
-{
-    if (!image)
-        return nullptr;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (pixelFormat == kCVPixelFormatType_64RGBAHalf)
+        return IOSurface::UsedFormat { IOSurface::Format::RGBA16F, UseLosslessCompression::No };
 
-    size_t width = CGImageGetWidth(image);
-    size_t height = CGImageGetHeight(image);
+    if (pixelFormat == kCVPixelFormatType_Lossless_64RGBAHalf)
+        return IOSurface::UsedFormat { IOSurface::Format::RGBA16F, UseLosslessCompression::Yes };
+#endif
 
-    auto surface = IOSurface::create(pool, IntSize(width, height), DestinationColorSpace { CGImageGetColorSpace(image) }, Name::ImageBuffer);
-    if (!surface)
-        return nullptr;
-    auto context = surface->createPlatformContext();
-    CGContextDrawImage(context.get(), CGRectMake(0, 0, width, height), image);
-    return surface;
-}
-
-void IOSurface::moveToPool(std::unique_ptr<IOSurface>&& surface, IOSurfacePool* pool)
-{
-    if (pool)
-        pool->addSurface(WTFMove(surface));
+    return { };
 }
 
 // MARK: -
@@ -214,6 +191,8 @@ static RetainPtr<IOSurfaceRef> createSurfaceViaCoreVideo(IntSize size, IOSurface
     RetainPtr cvBuffer = adoptCF(rawPixelBuffer);
     return CVPixelBufferGetIOSurface(cvBuffer.get());
 }
+
+// MARK: -
 
 static NSDictionary *optionsForBiplanarSurface(IntSize size, unsigned pixelFormat, size_t firstPlaneBytesPerPixel, size_t secondPlaneBytesPerPixel, IOSurface::Name name)
 {
@@ -338,14 +317,13 @@ static RetainPtr<IOSurfaceRef> createSurface(IntSize size, IOSurface::Name name,
 
 // MARK: -
 
-IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, IOSurface::Name name, Format format, UseLosslessCompression useLosslessCompression, bool& success)
-    : m_format({ format, useLosslessCompression })
-    , m_colorSpace(colorSpace)
-    , m_size(size)
-    , m_name(name)
+std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, const DestinationColorSpace& colorSpace, IOSurface::Name name, Format format, UseLosslessCompression useLosslessCompression)
 {
-    ASSERT(!success);
     ASSERT(!size.isEmpty());
+    ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
+
+    if (auto cachedSurface = pool ? createFromPool(*pool, size, colorSpace, name, format, useLosslessCompression) : nullptr)
+        return cachedSurface;
 
 #if !HAVE(COREVIDEO_COMPRESSED_PIXEL_FORMAT_TYPES)
     useLosslessCompression = UseLosslessCompression::No;
@@ -357,79 +335,96 @@ IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, IOSu
         useLosslessCompression = UseLosslessCompression::No;
 #endif
 
+    RetainPtr<IOSurfaceRef> surface;
     if (useLosslessCompression == UseLosslessCompression::Yes) {
         // We could allocate more formats via CoreVideo in future.
-        m_surface = createSurfaceViaCoreVideo(size, name, format, useLosslessCompression);
-        if (!m_surface)
-            m_format = { format, UseLosslessCompression::No };
+        surface = createSurfaceViaCoreVideo(size, name, format, useLosslessCompression);
+        if (!surface)
+            useLosslessCompression = UseLosslessCompression::No;
     }
 
-    if (!m_surface)
-        m_surface = createSurface(size, name, format);
+    if (!surface)
+        surface = createSurface(size, name, format);
 
-    success = !!m_surface;
-    if (success) {
-        setColorSpaceProperty();
-        m_totalBytes = IOSurfaceGetAllocSize(m_surface.get());
-    } else
-        RELEASE_LOG_ERROR(Layers, "IOSurface creation failed for size: (%d %d) and format: (%d)", size.width(), size.height(), enumToUnderlyingType(format));
+    if (!surface) {
+        LOG(IOSurface, "IOSurface::create failed to create %dx%d surface", size.width(), size.height());
+        return nullptr;
+    }
+
+    auto result = std::unique_ptr<IOSurface>(new IOSurface(size, colorSpace, name, UsedFormat { format, useLosslessCompression }, WTFMove(surface)));
+    LOG_WITH_STREAM(IOSurface, stream << "IOSurface::create created " << *result);
+    return result;
 }
 
-static std::optional<IOSurface::UsedFormat> formatFromSurface(IOSurfaceRef surface)
+std::unique_ptr<IOSurface> IOSurface::createFromPool(IOSurfacePool& pool, IntSize size, const DestinationColorSpace& colorSpace, IOSurface::Name name, Format pixelFormat, UseLosslessCompression useLosslessCompression)
 {
-    unsigned pixelFormat = IOSurfaceGetPixelFormat(surface);
-    if (pixelFormat == kCVPixelFormatType_32BGRA)
-        return IOSurface::UsedFormat { IOSurface::Format::BGRA, UseLosslessCompression::No };
+    auto cachedSurface = pool.takeSurface(size, colorSpace, pixelFormat, useLosslessCompression);
+    if (!cachedSurface)
+        return nullptr;
 
-    if (pixelFormat == kCVPixelFormatType_Lossless_32BGRA)
-        return IOSurface::UsedFormat { IOSurface::Format::BGRA, UseLosslessCompression::Yes };
+    LOG_WITH_STREAM(IOSurface, stream << "IOSurface::create took from pool: " << *cachedSurface);
 
-    if (pixelFormat == kCVPixelFormatType_422YpCbCr8BiPlanarFullRange)
-        return IOSurface::UsedFormat { IOSurface::Format::YUV422, UseLosslessCompression::No };
+    if (cachedSurface->name() == name)
+        return cachedSurface;
 
-    if (pixelFormat == kCVPixelFormatType_32RGBA)
-        return IOSurface::UsedFormat { IOSurface::Format::RGBA, UseLosslessCompression::No };
-
-#if ENABLE(PIXEL_FORMAT_RGB10)
-    if (pixelFormat == kCVPixelFormatType_30RGBLEPackedWideGamut)
-        return IOSurface::UsedFormat { IOSurface::Format::RGB10, UseLosslessCompression::No };
-
-    if (pixelFormat == kCVPixelFormatType_AGX_30RGBLEPackedWideGamut)
-        return IOSurface::UsedFormat { IOSurface::Format::RGB10, UseLosslessCompression::Yes };
-#endif
-
-#if ENABLE(PIXEL_FORMAT_RGB10A8)
-    if (pixelFormat == kCVPixelFormatType_30RGBLE_8A_BiPlanar)
-        return IOSurface::UsedFormat { IOSurface::Format::RGB10A8, UseLosslessCompression::No };
-
-    if (pixelFormat == kCVPixelFormatType_AGX_30RGBLE_8A_BiPlanar)
-        return IOSurface::UsedFormat { IOSurface::Format::RGB10A8, UseLosslessCompression::Yes };
-#endif
-
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (pixelFormat == kCVPixelFormatType_64RGBAHalf)
-        return IOSurface::UsedFormat { IOSurface::Format::RGBA16F, UseLosslessCompression::No };
-
-    if (pixelFormat == kCVPixelFormatType_Lossless_64RGBAHalf)
-        return IOSurface::UsedFormat { IOSurface::Format::RGBA16F, UseLosslessCompression::Yes };
-#endif
-
-    return { };
+    IOSurfaceSetValue(cachedSurface->protectedSurface().get(), kIOSurfaceName, surfaceNameToNSString(name).get());
+    cachedSurface->setName(name);
+    return cachedSurface;
 }
 
-IOSurface::IOSurface(IOSurfaceRef surface, std::optional<DestinationColorSpace>&& colorSpace)
-    : m_format(formatFromSurface(surface))
+std::unique_ptr<IOSurface> IOSurface::createFromSurface(IOSurfaceRef surface, std::optional<DestinationColorSpace>&& colorSpace)
+{
+    if (!surface)
+        return nullptr;
+
+    auto size = IntSize(IOSurfaceGetWidth(surface), IOSurfaceGetHeight(surface));
+    return std::unique_ptr<IOSurface>(new IOSurface(size, WTFMove(colorSpace), Name::Default, formatFromSurface(surface), surface));
+}
+
+std::unique_ptr<IOSurface> IOSurface::createFromSendRight(const MachSendRight&& sendRight)
+{
+    ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
+
+    auto surface = adoptCF(IOSurfaceLookupFromMachPort(sendRight.sendRight()));
+    return IOSurface::createFromSurface(surface.get(), { });
+}
+
+std::unique_ptr<IOSurface> IOSurface::createFromImage(IOSurfacePool* pool, CGImageRef image)
+{
+    if (!image)
+        return nullptr;
+
+    auto size = IntSize(CGImageGetWidth(image), CGImageGetHeight(image));
+    auto surface = IOSurface::create(pool, size, DestinationColorSpace::SRGB(), Name::ImageBuffer);
+    if (!surface)
+        return nullptr;
+
+    auto context = surface->createPlatformContext();
+    CGContextDrawImage(context.get(), CGRectMake(0, 0, size.width(), size.height()), image);
+    return surface;
+}
+
+// MARK: -
+
+IOSurface::IOSurface(IntSize size, std::optional<DestinationColorSpace>&& colorSpace, IOSurface::Name name, std::optional<UsedFormat>&& format, RetainPtr<IOSurfaceRef>&& surface)
+    : m_size(size)
     , m_colorSpace(WTFMove(colorSpace))
-    , m_surface(surface)
+    , m_name(name)
+    , m_format(WTFMove(format))
+    , m_surface(WTFMove(surface))
 {
-    m_size = IntSize(IOSurfaceGetWidth(surface), IOSurfaceGetHeight(surface));
-    m_totalBytes = IOSurfaceGetAllocSize(surface);
-
+    m_totalBytes = IOSurfaceGetAllocSize(m_surface.get());
     if (m_colorSpace)
         setColorSpaceProperty();
 }
 
 IOSurface::~IOSurface() = default;
+
+void IOSurface::moveToPool(std::unique_ptr<IOSurface>&& surface, IOSurfacePool* pool)
+{
+    if (pool)
+        pool->addSurface(WTFMove(surface));
+}
 
 static constexpr IntSize fallbackMaxSurfaceDimension()
 {


### PR DESCRIPTION
#### 340761431136c5455fd8352f5486011f45712758
<pre>
Simplify creating the WebCore::IOSurface
<a href="https://bugs.webkit.org/show_bug.cgi?id=302579">https://bugs.webkit.org/show_bug.cgi?id=302579</a>
<a href="https://rdar.apple.com/164802650">rdar://164802650</a>

Reviewed by NOBODY (OOPS!).

Simplify creating the WebCore::IOSurface by having only one constructor and multiple
create methods. These create methods will ensure the system IOSurface is created
before passing it to the constructor. The constructor should not decide whether
it was created successfully or not. It should only fills its members with valid
created arguments.

* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::formatFromSurface):
(WebCore::IOSurface::create):
(WebCore::IOSurface::createFromPool):
(WebCore::IOSurface::createFromSurface):
(WebCore::IOSurface::createFromSendRight):
(WebCore::IOSurface::createFromImage):
(WebCore::IOSurface::IOSurface):
(WebCore::IOSurface::moveToPool):
(WebCore::m_name): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/340761431136c5455fd8352f5486011f45712758

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82942 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4138daf8-68fb-4af2-968b-ea9174ca9e6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67727 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d4180ed-2562-4232-891c-62408fac9854) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80680 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c5bba853-0242-41a1-96c5-28d9a2a4b753) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2468 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81919 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141168 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3301 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108500 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2953 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108443 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2482 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113802 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56400 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3363 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32226 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3293 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->