### PR TITLE
[CMake] Use imported target in the libhyphen find-module

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -71,7 +71,6 @@ list(APPEND WebCore_LIBRARIES
     ${ENCHANT_LIBRARIES}
     ${LIBSECRET_LIBRARIES}
     ${LIBTASN1_LIBRARIES}
-    ${HYPHEN_LIBRARIES}
     ${UPOWERGLIB_LIBRARIES}
     ${X11_X11_LIB}
     Cairo::Cairo
@@ -188,4 +187,8 @@ if (USE_GBM)
     list(APPEND WebCore_LIBRARIES GBM::GBM)
 elseif (USE_LIBDRM)
     list(APPEND WebCore_LIBRARIES LibDRM::LibDRM)
+endif ()
+
+if (USE_LIBHYPHEN)
+    list(APPEND WebCore_PRIVATE_LIBRARIES Hyphen::Hyphen)
 endif ()

--- a/Source/cmake/FindHyphen.cmake
+++ b/Source/cmake/FindHyphen.cmake
@@ -6,7 +6,7 @@
 #  HYPHEN_LIBRARY - libraries required to link against libhyphen.
 #
 # Copyright (C) 2012 Intel Corporation. All rights reserved.
-# Copyright (C) 2015 Igalia S.L.
+# Copyright (C) 2015, 2025 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,18 +29,50 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[=======================================================================[.rst:
+FindHyphen
+----------
 
-find_path(HYPHEN_INCLUDE_DIR NAMES hyphen.h)
-find_library(HYPHEN_LIBRARIES NAMES hyphen hnj)
+Find libhyphen header and library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``Hyphen::Hyphen``
+  The libhyphen library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``Hyphen_FOUND``
+  true if libhyphen is available.
+
+#]=======================================================================]
+
+find_path(Hyphen_INCLUDE_DIR NAMES hyphen.h)
+find_library(Hyphen_LIBRARY NAMES hyphen hnj)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Hyphen REQUIRED_VARS HYPHEN_INCLUDE_DIR HYPHEN_LIBRARIES
-                                  FOUND_VAR HYPHEN_FOUND)
+find_package_handle_standard_args(Hyphen
+    REQUIRED_VARS Hyphen_LIBRARY Hyphen_INCLUDE_DIR
+)
 
-if (HYPHEN_INCLUDE_DIR AND HYPHEN_LIBRARIES)
-    set(HYPHEN_FOUND 1)
-else ()
-    set(HYPHEN_FOUND 0)
+if (Hyphen_FOUND AND NOT TARGET Hyphen::Hyphen)
+    add_library(Hyphen::Hyphen UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(Hyphen::Hyphen PROPERTIES
+        IMPORTED_LOCATION "${Hyphen_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Hyphen_INCLUDE_DIR}"
+    )
 endif ()
 
-mark_as_advanced(HYPHEN_INCLUDE_DIR HYPHEN_LIBRARIES HYPHEN_FOUND)
+mark_as_advanced(
+    Hyphen_INCLUDE_DIR
+    Hyphen_LIBRARY
+)
+
+if (Hyphen_FOUND)
+    set(Hyphen_LIBRARIES ${Hyphen_LIBRARY})
+    set(Hyphen_INCLUDE_DIRS ${Hyphen_INCLUDE_DIR})
+endif ()

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -375,7 +375,7 @@ endif ()
 
 if (USE_LIBHYPHEN)
     find_package(Hyphen)
-    if (NOT HYPHEN_FOUND)
+    if (NOT Hyphen_FOUND)
        message(FATAL_ERROR "libhyphen is needed for USE_LIBHYPHEN.")
     endif ()
 endif ()


### PR DESCRIPTION
#### bfadf7e860f6a5f633112fc480814e3c59f0dd3c
<pre>
[CMake] Use imported target in the libhyphen find-module
<a href="https://bugs.webkit.org/show_bug.cgi?id=302580">https://bugs.webkit.org/show_bug.cgi?id=302580</a>

Reviewed by Fujii Hironori.

* Source/WebCore/PlatformGTK.cmake:
* Source/cmake/FindHyphen.cmake:
* Source/cmake/OptionsGTK.cmake:

Canonical link: <a href="https://commits.webkit.org/303127@main">https://commits.webkit.org/303127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db71ea37325930dfa2fa2ae5d37afbde5828cf1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3531 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67841 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134305 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2695 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2611 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82054 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123381 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141539 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129813 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36226 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108703 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108919 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27599 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2595 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3496 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32335 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162830 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66904 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->