### PR TITLE
Address safer CPP warnings in JSONValues.h

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -15,6 +15,8 @@ dfg/DFGFinalizer.h
 dfg/DFGLazyJSValue.h
 dfg/DFGNode.h
 dfg/DFGPropertyTypeKey.h
+dfg/DFGSpeculativeJIT.h
+ftl/FTLLowerDFGToB3.cpp
 ftl/FTLOSRExitHandle.h
 heap/Heap.h
 heap/HeapSnapshotBuilder.h

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -342,7 +342,7 @@ std::optional<double> BackendDispatcher::getDouble(JSON::Object* params, const S
 String BackendDispatcher::getString(JSON::Object* params, const String& name, bool required)
 {
     // FIXME: <http://webkit.org/b/179847> simplify this when legacy InspectorObject symbols are no longer needed.
-    String (JSON::Value::*asString)() const = &JSON::Value::asString;
+    const String& (JSON::Value::*asString)() const = &JSON::Value::asString;
     return getPropertyValue<String>(params, name, required, asString, "String"_s);
 }
 

--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,1 +1,0 @@
-wtf/JSONValues.h

--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -2909,6 +2909,7 @@ template<class T, class... Types> constexpr add_pointer_t<const T> get_if(const 
 
 namespace WTF {
 template<typename... Ts> using Variant = mpark::variant<Ts...>;
+template<size_t I, class T> using variant_alternative_t = typename mpark::variant_alternative<I, T>::type;
 template<typename T> constexpr mpark::in_place_type_t<T> InPlaceType { };
 template<typename T> using InPlaceTypeT = mpark::in_place_type_t<T>;
 template<size_t I> constexpr mpark::in_place_index_t<I> InPlaceIndex { };

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -63,7 +63,7 @@ static std::optional<Vector<RefPtr<KeyHandle>>> parseLicenseFormat(const JSON::O
         return std::nullopt;
 
     // Retrieve the keys array.
-    auto keysArray = it->value->asArray();
+    auto keysArray = Ref { it->value }->asArray();
     if (!keysArray)
         return std::nullopt;
 
@@ -111,7 +111,7 @@ static bool parseLicenseReleaseAcknowledgementFormat(const JSON::Object& root)
         return false;
 
     // Retrieve the kids array.
-    auto kidsArray = it->value->asArray();
+    auto kidsArray = Ref { it->value }->asArray();
     if (!kidsArray)
         return false;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -302,7 +302,7 @@ bool WebExtension::parseManifest(StringView manifestString)
 RefPtr<const JSON::Object> WebExtension::manifestObject()
 {
     if (m_parsedManifest)
-        return m_manifestJSON->asObject();
+        return Ref { m_manifestJSON }->asObject();
 
     m_parsedManifest = true;
 
@@ -315,7 +315,7 @@ RefPtr<const JSON::Object> WebExtension::manifestObject()
     if (!parseManifest(manifestStringResult.value()))
         return nullptr;
 
-    return m_manifestJSON->asObject();
+    return Ref { m_manifestJSON }->asObject();
 }
 
 bool WebExtension::manifestParsedSuccessfully()


### PR DESCRIPTION
#### 27cec92205acf7c53239aff1dddada9657936d84
<pre>
Address safer CPP warnings in JSONValues.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302584">https://bugs.webkit.org/show_bug.cgi?id=302584</a>

Reviewed by Geoffrey Garen.

Warning was about raw StringImpl data member in JSSONValue.
This tested as performance neutral on the benchmarks we track.

* Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::getString):
* Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::visitDerived):
(WTF::JSONImpl::Value::asBoolean const):
(WTF::JSONImpl::Value::asDouble const):
(WTF::JSONImpl::Value::asInteger const):
(WTF::JSONImpl::Value::asString const):
(WTF::JSONImpl::Value::dump const):
(WTF::JSONImpl::Value::writeJSONImpl const):
(WTF::JSONImpl::Value::memoryCostImpl const):
(WTF::JSONImpl::ObjectBase::ObjectBase):
(WTF::JSONImpl::ArrayBase::ArrayBase):
* Source/WTF/wtf/JSONValues.h:
(WTF::JSONImpl::Value::asObject):
(WTF::JSONImpl::Value::asObject const):
(WTF::JSONImpl::Value::asArray):
* Source/WTF/wtf/Variant.h:
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::parseLicenseFormat):
(WebCore::parseLicenseReleaseAcknowledgementFormat):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::manifestObject):

Canonical link: <a href="https://commits.webkit.org/303098@main">https://commits.webkit.org/303098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93c6ae723f8d149557eaa879cfc4dcfbb0c092f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131295 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1cb01151-db49-4e32-a8c5-a5e0b015775a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3467 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f1576b7-842e-4b91-8bbb-e72b32e62de6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134241 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/117534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80745 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b47c5de4-f21a-4904-8ee4-f612f42736d9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81990 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123317 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111139 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141240 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129749 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3370 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36177 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3416 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27579 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2545 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56525 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3432 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162766 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66840 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3362 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->