### PR TITLE
CMSampleBuffer serialiser doesn't handle when kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms contains more than one key

### DIFF
--- a/Source/WebCore/platform/TrackInfo.cpp
+++ b/Source/WebCore/platform/TrackInfo.cpp
@@ -56,27 +56,4 @@ Ref<TrackInfo> TrackInfo::fromVariant(Variant<Ref<AudioInfo>, Ref<VideoInfo>> va
     }), WTFMove(variant));
 }
 
-#if PLATFORM(COCOA)
-FourCC VideoInfo::computeBoxType() const
-{
-    if (boxType.value)
-        return boxType;
-
-    switch (codecName.value) {
-    case kCMVideoCodecType_VP9:
-    case 'vp08':
-        return 'vpcC';
-    case kCMVideoCodecType_H264:
-        return 'avcC';
-    case kCMVideoCodecType_HEVC:
-        return 'hvcC';
-    case kCMVideoCodecType_AV1:
-        return 'av1C';
-    default:
-        ASSERT_NOT_REACHED();
-        return 'baad';
-    }
-}
-#endif
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -69,6 +69,8 @@ WEBCORE_EXPORT void attachColorSpaceToPixelBuffer(const PlatformVideoColorSpace&
 WEBCORE_EXPORT Vector<Ref<SharedBuffer>> getKeyIDs(CMFormatDescriptionRef);
 #endif
 
+WEBCORE_EXPORT FourCC computeBoxType(FourCC);
+
 class PacketDurationParser final {
     WTF_MAKE_TZONE_ALLOCATED(PacketDurationParser);
 public:

--- a/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
@@ -24,6 +24,7 @@
  */
 
 #import "config.h"
+#import "CMUtilities.h"
 #import "H264UtilitiesCocoa.h"
 
 #import "BitReader.h"
@@ -114,7 +115,7 @@ RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t> avcc)
     info->codecName = kCMVideoCodecType_H264;
     info->size = { static_cast<float>(dimensions.width), static_cast<float>(dimensions.height) };
     info->displaySize = { static_cast<float>(presentationDimensions.width), static_cast<float>(presentationDimensions.height) };
-    info->atomData = SharedBuffer::create(avcc);
+    info->extensionAtoms = { 1 , { computeBoxType(kCMVideoCodecType_H264), SharedBuffer::create(avcc) } };
 
     return info;
 }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(VP9) && PLATFORM(COCOA)
 
+#import "CMUtilities.h"
 #import "FourCC.h"
 #import "LibWebRTCProvider.h"
 #import "MediaCapabilitiesInfo.h"
@@ -533,9 +534,9 @@ static Ref<VideoInfo> createVideoInfoFromVPCodecConfigurationRecord(const VPCode
     auto videoInfo = VideoInfo::create();
     videoInfo->size = size;
     videoInfo->displaySize = displaySize;
-    videoInfo->atomData = SharedBuffer::create(vpcCFromVPCodecConfigurationRecord(record));
-    videoInfo->colorSpace = colorSpaceFromVPCodecConfigurationRecord(record);
     videoInfo->codecName = record.codecName == "vp09"_s ? 'vp09' : 'vp08';
+    videoInfo->extensionAtoms = { 1, { computeBoxType(videoInfo->codecName), SharedBuffer::create(vpcCFromVPCodecConfigurationRecord(record)) } };
+    videoInfo->colorSpace = colorSpaceFromVPCodecConfigurationRecord(record);
     videoInfo->codecString = createVPCodecParametersString(record);
     return videoInfo;
 }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -668,7 +668,7 @@ void MediaRecorderPrivateEncoder::processVideoEncoderActiveConfiguration(const V
     else
         videoInfo->displaySize = { static_cast<float>(config.width), static_cast<float>(config.height) };
     if (configuration.description)
-        videoInfo->atomData = SharedBuffer::create(*configuration.description);
+        videoInfo->extensionAtoms = { 1, { computeBoxType(m_videoCodec), SharedBuffer::create(*configuration.description) } };
     if (configuration.colorSpace)
         videoInfo->colorSpace = *configuration.colorSpace;
     videoInfo->codecName = m_videoCodec;

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
@@ -127,8 +127,10 @@ public:
         auto* videoTrack = downcast<mkvmuxer::VideoTrack>(m_segment.GetTrackByNumber(trackIndex));
         ASSERT(videoTrack);
         videoTrack->set_codec_id(mkvCodeIcForMediaVideoCodecId(info.codecName));
-        if (RefPtr atomData = info.atomData; atomData && atomData->span().size())
+        if (info.extensionAtoms.size()) {
+            Ref atomData = info.extensionAtoms[0].second;
             videoTrack->SetCodecPrivate(atomData->span().data(), atomData->span().size());
+        }
         return trackIndex;
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8840,8 +8840,7 @@ header: <WebCore/TrackInfo.h>
     WebCore::FloatSize displaySize;
     uint8_t bitDepth;
     WebCore::PlatformVideoColorSpace colorSpace;
-    WebCore::FourCC boxType;
-    RefPtr<WebCore::SharedBuffer> atomData;
+    Vector<std::pair<WebCore::FourCC, Ref<WebCore::SharedBuffer>>> extensionAtoms
 };
 
 [RefCounted, CreateUsing=fromVariant] struct WebCore::TrackInfo {


### PR DESCRIPTION
#### 05d2e2c1d5404a545b04cc31198a333f7d8694f2
<pre>
CMSampleBuffer serialiser doesn&apos;t handle when kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms contains more than one key
<a href="https://bugs.webkit.org/show_bug.cgi?id=302585">https://bugs.webkit.org/show_bug.cgi?id=302585</a>
<a href="https://rdar.apple.com/164817308">rdar://164817308</a>

Reviewed by Youenn Fablet.

When serialising a CMSampleBuffer to be transferred over IPC we first convert
it to a MediaSampleBlock and its TrackInfo.
The file loaded by the test `LayoutTests/media/media-source/media-managedmse-webvtt-track.html `
causes a decoding error when MediaSourceUseRemoteAudioVideoRenderer is enabled.

The reason is that the file content/bip-bop-webvtt-frag.mp4&apos;s `avc1` box
contains two keys: that standard `avcC` and a `btrt` one.

The code to convert the CMFormatDescriptionRef to a VideoInfo createVideoInfoFromFormatDescription
assumed that the required data to decode the video when two keys were present
was the first one. But that&apos;s not always the case.
For future-proofing we now use the entire content of the CMFormatDescription&apos;s
kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms and store it
in VideoInfo structure. This removes most potential conversion error for
unexpected values.

Covered by existing tests.
* Source/WebCore/platform/TrackInfo.cpp:
(WebCore::VideoInfo::computeBoxType const): Deleted.
* Source/WebCore/platform/TrackInfo.h:
(WebCore::VideoInfo::create):
(WebCore::VideoInfo::VideoInfo):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::createFormatDescriptionFromTrackInfo):
(WebCore::createVideoInfoFromFormatDescription):
(WebCore::computeBoxType):
* Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm:
(WebCore::createVideoInfoFromAVCC):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::createVideoInfoFromVPCodecConfigurationRecord):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::processVideoEncoderActiveConfiguration):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addVideoTrack):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303154@main">https://commits.webkit.org/303154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9081144a68266061948f9fcf3114ca22276df97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82984 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100007 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67753 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80707 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/210 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81951 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141201 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3331 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27619 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2511 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56450 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3393 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32251 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3415 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->