### PR TITLE
[JSC] Align `Intl.Locale.prototype.getWeekInfo ( )` with ECMA-402

### DIFF
--- a/JSTests/stress/intl-locale-info.js
+++ b/JSTests/stress/intl-locale-info.js
@@ -19,14 +19,14 @@ function shouldBeOneOf(actual, expectedArray) {
 
 {
     let he = new Intl.Locale("he")
-    shouldBe(JSON.stringify(he.getWeekInfo()), `{"firstDay":7,"weekend":[5,6],"minimalDays":1}`);
+    shouldBe(JSON.stringify(he.getWeekInfo()), `{"firstDay":7,"weekend":[5,6]}`);
     let af = new Intl.Locale("af")
-    shouldBe(JSON.stringify(af.getWeekInfo()), `{"firstDay":7,"weekend":[6,7],"minimalDays":1}`);
+    shouldBe(JSON.stringify(af.getWeekInfo()), `{"firstDay":7,"weekend":[6,7]}`);
     let enGB = new Intl.Locale("en-GB")
-    shouldBe(JSON.stringify(enGB.getWeekInfo()), `{"firstDay":1,"weekend":[6,7],"minimalDays":4}`);
+    shouldBe(JSON.stringify(enGB.getWeekInfo()), `{"firstDay":1,"weekend":[6,7]}`);
     let msBN = new Intl.Locale("ms-BN");
     // "weekend" should be [5,7]. But currently ICU/CLDR does not support representing non-contiguous weekend.
-    shouldBe(JSON.stringify(msBN.getWeekInfo()), `{"firstDay":1,"weekend":[6,7],"minimalDays":1}`);
+    shouldBe(JSON.stringify(msBN.getWeekInfo()), `{"firstDay":1,"weekend":[6,7]}`);
 }
 {
     let l = new Intl.Locale("ar")

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -538,9 +538,6 @@ test/intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js:
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
-test/intl402/Locale/prototype/getWeekInfo/output-object-keys.js:
-  default: 'Test262Error: Actual [firstDay, weekend, minimalDays] and expected [firstDay, weekend] should have the same contents. '
-  strict mode: 'Test262Error: Actual [firstDay, weekend, minimalDays] and expected [firstDay, weekend] should have the same contents. '
 test/intl402/NumberFormat/currency-digits-nonstandard-notation.js:
   default: "Test262Error: Didn't get correct maximumFractionDigits for JPY in engineering notation. Expected SameValue(«0», «3») to be true"
   strict mode: "Test262Error: Didn't get correct maximumFractionDigits for JPY in engineering notation. Expected SameValue(«0», «3») to be true"

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -893,7 +893,6 @@ JSObject* IntlLocale::weekInfo(JSGlobalObject* globalObject)
     }
 
     int32_t firstDayOfWeek = ucal_getAttribute(calendar.get(), UCAL_FIRST_DAY_OF_WEEK);
-    int32_t minimalDays = ucal_getAttribute(calendar.get(), UCAL_MINIMAL_DAYS_IN_FIRST_WEEK);
 
     auto canonicalizeDayOfWeekType = [](UCalendarWeekdayType type) {
         switch (type) {
@@ -961,7 +960,6 @@ JSObject* IntlLocale::weekInfo(JSGlobalObject* globalObject)
     JSObject* result = constructEmptyObject(globalObject);
     result->putDirect(vm, Identifier::fromString(vm, "firstDay"_s), jsNumber(convertUCalendarDaysOfWeekToMondayBasedDay(firstDayOfWeek)));
     result->putDirect(vm, Identifier::fromString(vm, "weekend"_s), weekendArray);
-    result->putDirect(vm, Identifier::fromString(vm, "minimalDays"_s), jsNumber(minimalDays));
     return result;
 }
 


### PR DESCRIPTION
#### 4d2a14f6f159ee907cb97fd4489e6dd694c4d352
<pre>
[JSC] Align `Intl.Locale.prototype.getWeekInfo ( )` with ECMA-402
<a href="https://bugs.webkit.org/show_bug.cgi?id=302587">https://bugs.webkit.org/show_bug.cgi?id=302587</a>

Reviewed by Yusuke Suzuki.

This patch removes `minimalDays` from `Intl.Locale.prototype.getWeekInfo()`
to comformant to ECMA-402 spec[1].

[1]: <a href="https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo">https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo</a>

* JSTests/stress/intl-locale-info.js:
(throw.new.Error):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::IntlLocale::weekInfo):

Canonical link: <a href="https://commits.webkit.org/303287@main">https://commits.webkit.org/303287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d103cb98881b31ab2c001b5e340665c4739737f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100010 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67756 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81954 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123281 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141204 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129713 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108528 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108473 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2510 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113826 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56453 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20511 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3396 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32250 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162730 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66804 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42404 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->