### PR TITLE
Introduce customelementregistry content attribute and avoid changing null registry when inserting a node

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry-exceptions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry-exceptions.html
@@ -7,8 +7,6 @@
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-<div id="host-window"><template shadowrootmode="open"><a-b></a-b></template></div>
-<div id="host-null"><template shadowrootmode="open" shadowrootcustomelementregistry=""><a-b></a-b></template></div>
 <script>
 
 setup({allow_uncaught_exception : true});

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry.html
@@ -41,7 +41,7 @@ test((t) => {
     const clone = document.getElementById('host-null').cloneNode(true);
     const ab = clone.shadowRoot.querySelector('a-b');
     document.body.appendChild(ab);
-    assert_equals(ab.customElementRegistry, window.customElements);
+    assert_equals(ab.customElementRegistry, null);
 
     const frame = document.createElement('iframe');
     t.add_cleanup(() => frame.remove());

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
@@ -3,7 +3,6 @@ PASS A newly attached disconnected ShadowRoot should use the global registry by 
 PASS A newly attached connected ShadowRoot should use the global registry by default
 PASS A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
 PASS A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
-PASS attachShadow() should use the global registry when customElementRegistry is null
-FAIL attachShadow() should use the shadow host's registry when customElementRegistry is null assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS attachShadow() should use null registry when customElementRegistry is null
 PASS attachShadow() should use the null registry when the shadow host uses null registry and customElementRegistry is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
@@ -36,15 +36,8 @@ test(() => {
 test(() => {
     const host = document.body.appendChild(document.createElement('div'));
     const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
-    assert_equals(shadowRoot.customElementRegistry, window.customElements);
-}, 'attachShadow() should use the global registry when customElementRegistry is null');
-
-test(() => {
-    const registry = new CustomElementRegistry;
-    const host = document.body.appendChild(document.createElement('div', {customElementRegistry: registry}));
-    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
-    assert_equals(shadowRoot.customElementRegistry, registry);
-}, 'attachShadow() should use the shadow host\'s registry when customElementRegistry is null');
+    assert_equals(shadowRoot.customElementRegistry, null);
+}, 'attachShadow() should use null registry when customElementRegistry is null');
 
 test(() => {
     const registry = new CustomElementRegistry;

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-expected.txt
@@ -1,0 +1,18 @@
+
+PASS HTML parser should create a builtin element with null registry if customelementregistry is set
+PASS document.createElement should create a builtin element with null registry if customElement is set to null
+PASS attchShadow on a builtin element with null customElementRegistry should create a ShadowRoot with null registry
+PASS Setting customelementregistry content attribute after a builtin element had finishsed parsing should not set null registry
+PASS Cloning a builtin element with null regsitry should create an element with null registry
+PASS HTML parser should create a custom element candidate with null registry if customelementregistry is set
+PASS document.createElement should create a custom element candidate with null registry if customElement is set to null
+PASS attchShadow on a custom element candidate with null customElementRegistry should create a ShadowRoot with null registry
+PASS Setting customelementregistry content attribute after a custom element candidate had finishsed parsing should not set null registry
+PASS Cloning a custom element candidate with null regsitry should create an element with null registry
+PASS HTML parser should create a custom element with null registry if customelementregistry is set
+PASS document.createElement should create a custom element with null registry if customElement is set to null
+PASS attchShadow on a custom element with null customElementRegistry should create a ShadowRoot with null registry
+PASS Setting customelementregistry content attribute after a custom element had finishsed parsing should not set null registry
+PASS Cloning a custom element with null regsitry should create an element with null registry
+PASS Setting customelementregistry content attribute during constructor should not make it use null registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml-expected.txt
@@ -1,0 +1,6 @@
+
+PASS XHTML parser should create a custom element candidate with null registry if customelementregistry is set
+PASS XHTML parser should create a defined custom element with null registry if customelementregistry is set
+PASS XHTML fragment parser should create a custom element candidate with null registry if customelementregistry is set
+PASS XHTML fragment parser should create a defined custom element with null registry if customelementregistry is set
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-initialize"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+<![CDATA[
+
+customElements.define('c-d', class ABElement extends HTMLElement { });
+
+]]>
+</script>
+<div id="container"><a-b customelementregistry=""></a-b><c-d customelementregistry=""></c-d></div>
+<script>
+<![CDATA[
+
+const container = document.getElementById('container');
+test((test) => {
+    assert_equals(container.querySelector('a-b').customElementRegistry, null);
+}, `XHTML parser should create a custom element candidate with null registry if customelementregistry is set`);
+
+test((test) => {
+    assert_equals(container.querySelector('c-d').customElementRegistry, null);
+}, `XHTML parser should create a defined custom element with null registry if customelementregistry is set`);
+
+test((test) => {
+    container.setHTMLUnsafe(`<a-b customelementregistry></a-b>`);
+    assert_equals(container.querySelector('a-b').customElementRegistry, null);
+}, `XHTML fragment parser should create a custom element candidate with null registry if customelementregistry is set`);
+
+test((test) => {
+    container.setHTMLUnsafe(`<c-d></c-d>`);
+    assert_equals(container.querySelector('c-d').customElementRegistry, window.customElements);
+    container.setHTMLUnsafe(`<c-d customelementregistry></c-d>`);
+    assert_equals(container.querySelector('c-d').customElementRegistry, null);
+}, `XHTML fragment parser should create a defined custom element with null registry if customelementregistry is set`);
+
+]]>
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-initialize">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+function makeIframe(test) {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    test.add_cleanup(() => iframe.remove());
+    return [iframe.contentDocument, iframe.contentWindow];
+}
+
+function makeIframeWithABElement(test) {
+    const [doc, win] = makeIframe(test);
+    win.customElements.define('a-b', class ABElement extends win.HTMLElement { });
+    return [doc, win];
+}
+
+function runBasicTests(makeIframe, elementName, elementDescription) {
+    test((test) => {
+        const [doc, win] = makeIframe(test);
+        doc.documentElement.setHTMLUnsafe(`<${elementName} customelementregistry></${elementName}>`);
+        assert_equals(doc.querySelector(elementName).customElementRegistry, null);
+    }, `HTML parser should create a ${elementDescription} with null registry if customelementregistry is set`);
+
+    test((test) => {
+        const [doc, win] = makeIframe(test);
+        assert_equals(doc.createElement(elementName, {customElementRegistry: null}).customElementRegistry, null);
+        assert_equals(doc.createElementNS('http://www.w3.org/1999/xhtml', 'div', {customElementRegistry: null}).customElementRegistry, null);
+    }, `document.createElement should create a ${elementDescription} with null registry if customElement is set to null`);
+
+    test((test) => {
+        const [doc, win] = makeIframe(test);
+        const host = doc.createElement(elementName);
+        const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null})
+        assert_equals(shadowRoot.customElementRegistry, null);
+    }, `attchShadow on a ${elementDescription} with null customElementRegistry should create a ShadowRoot with null registry`);
+
+    test((test) => {
+        const [doc, win] = makeIframe(test);
+        const element = doc.createElement(elementName);
+        assert_equals(element.customElementRegistry, win.customElements);
+        element.setAttribute('customelementregistry', '');
+        assert_equals(element.customElementRegistry, win.customElements);
+    }, `Setting customelementregistry content attribute after a ${elementDescription} had finishsed parsing should not set null registry`);
+
+    test((test) => {
+        const [doc, win] = makeIframe(test);
+        const element = doc.createElement(elementName, {customElementRegistry: null});
+        assert_equals(element.customElementRegistry, null);
+        assert_equals(element.cloneNode(false).customElementRegistry, null);
+
+        doc.documentElement.setHTMLUnsafe(`<${elementName} customelementregistry></${elementName}>`);
+        assert_equals(doc.querySelector(elementName).customElementRegistry, null);
+        assert_equals(doc.querySelector(elementName).cloneNode(true).customElementRegistry, null);
+    }, `Cloning a ${elementDescription} with null regsitry should create an element with null registry`);
+}
+
+runBasicTests(makeIframe, 'div', 'builtin element');
+runBasicTests(makeIframe, 'a-b', 'custom element candidate');
+runBasicTests(makeIframeWithABElement, 'a-b', 'custom element');
+
+test((test) => {
+    const [doc, win] = makeIframe(test);
+
+    const upgradeCandidate = doc.createElement('a-b');
+    assert_equals(upgradeCandidate.customElementRegistry, win.customElements);
+
+    doc.body.setHTMLUnsafe('<a-b></a-b>');
+    assert_equals(doc.querySelector('a-b').customElementRegistry, win.customElements);
+
+    assert_equals(upgradeCandidate.customElementRegistry, win.customElements);
+    let customElementRegistryDuringConstruction = null;
+    win.customElements.define('a-b', class ABElement extends win.HTMLElement {
+        constructor() {
+            super();
+            this.setAttribute('customelementregistry', '');
+            customElementRegistryDuringConstruction = this.customElementRegistry;
+            this.removeAttribute('customelementregistry', '');
+        }
+    });
+    assert_equals(customElementRegistryDuringConstruction, win.customElements);
+    assert_equals(doc.querySelector('a-b').customElementRegistry, win.customElements);
+
+    const element = doc.createElement('a-b');
+    assert_equals(customElementRegistryDuringConstruction, win.customElements);
+    assert_equals(element.customElementRegistry, win.customElements);
+
+    doc.body.setHTMLUnsafe('<a-b></a-b>');
+    assert_equals(customElementRegistryDuringConstruction, win.customElements);
+    assert_equals(element.customElementRegistry, win.customElements);
+
+    win.customElements.upgrade(upgradeCandidate);
+    assert_equals(customElementRegistryDuringConstruction, win.customElements);
+    assert_equals(element.customElementRegistry, win.customElements);
+}, `Setting customelementregistry content attribute during constructor should not make it use null registry`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade-expected.txt
@@ -1,0 +1,8 @@
+
+PASS customElementRegistry of an upgrade candidate created in a document without a browsing context uses null regsitry by default
+PASS Connecting a custom element candiate in a shadow root with a scoped custom element registry has null registry by default
+PASS Connecting a custom element candiate with null registry does not set the registry
+PASS Connecting a custom element candiate with a scoped custom element registry does not change the registry
+PASS Inserting a custom element candiate with null registry does not change the registry
+PASS Inserting the shadow host of a shadow root with a scoped custom element registry does not change the registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+test(() => {
+    assert_equals((new Document).createElement('a-b').customElementRegistry, null);
+    assert_equals(document.implementation.createHTMLDocument().createElement('a-b').customElementRegistry, null);
+    assert_equals(document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null).createElement('a-b').customElementRegistry, null);
+}, 'customElementRegistry of an upgrade candidate created in a document without a browsing context uses null regsitry by default');
+
+function makeIframe(test) {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    test.add_cleanup(() => iframe.remove());
+    return [iframe.contentDocument, iframe.contentWindow];
+}
+
+test((test) => {
+    const [doc, win] = makeIframe(test);
+    doc.documentElement.setHTMLUnsafe('<div id="host"><template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelementregistry><a-b></a-b></template></div>');
+    const hostClone = doc.getElementById('host').cloneNode(true);
+    assert_equals(hostClone.shadowRoot.customElementRegistry, null);
+    assert_equals(hostClone.shadowRoot.querySelector('a-b').customElementRegistry, null);
+}, 'Connecting a custom element candiate in a shadow root with a scoped custom element registry has null registry by default');
+
+test((test) => {
+    const [doc, win] = makeIframe(test);
+    doc.documentElement.setHTMLUnsafe('<div id="host"><template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelementregistry><a-b></a-b></template></div>');
+    win.customElements.define('a-b', class ABElement extends win.HTMLElement { });
+    const hostClone = doc.getElementById('host').cloneNode(true);
+    assert_equals(hostClone.shadowRoot.customElementRegistry, null);
+    const candidate = hostClone.shadowRoot.querySelector('a-b');
+    assert_equals(candidate.customElementRegistry, null);
+    doc.body.appendChild(candidate);
+    assert_equals(candidate.customElementRegistry, null);
+}, 'Connecting a custom element candiate with null registry does not set the registry');
+
+test((test) => {
+    const [doc, win] = makeIframe(test);
+    doc.documentElement.setHTMLUnsafe('<div id="host"><template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelementregistry><a-b></a-b></template></div>');
+    win.customElements.define('a-b', class ABElement extends win.HTMLElement { });
+    const hostClone = doc.getElementById('host').cloneNode(true);
+    const candidate = hostClone.shadowRoot.querySelector('a-b');
+    const registry = new CustomElementRegistry;
+    assert_equals(candidate.customElementRegistry, null);
+    registry.initialize(hostClone.shadowRoot);
+    assert_equals(candidate.customElementRegistry, registry);
+    doc.body.appendChild(candidate);
+    assert_equals(candidate.customElementRegistry, registry);
+
+    const element = doc.createElement('host', {customElementRegistry: registry});
+    assert_equals(element.customElementRegistry, registry);
+    doc.body.appendChild(element);
+    assert_equals(element.customElementRegistry, registry);
+}, 'Connecting a custom element candiate with a scoped custom element registry does not change the registry');
+
+test((test) => {
+    const [doc, win] = makeIframe(test);
+    doc.documentElement.setHTMLUnsafe('<div id="host1"><template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelementregistry><a-b></a-b></template></div>'
+        + '<div id="host2"><template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelementregistry><c-d></c-d></template></div>');
+    win.customElements.define('a-b', class ABElement extends win.HTMLElement { });
+    const clone1 = doc.getElementById('host1').cloneNode(true);
+    const clone2 = doc.getElementById('host2').cloneNode(true);
+    const candidate = clone1.shadowRoot.querySelector('a-b');
+    assert_equals(candidate.customElementRegistry, null);
+    assert_equals(clone2.shadowRoot.querySelector('c-d').customElementRegistry, null);
+    const registry = new CustomElementRegistry;
+    registry.initialize(clone2.shadowRoot);
+    assert_equals(clone2.shadowRoot.querySelector('c-d').customElementRegistry, registry);
+    clone2.shadowRoot.appendChild(candidate);
+    assert_equals(candidate.customElementRegistry, null);
+}, 'Inserting a custom element candiate with null registry does not change the registry');
+
+test((test) => {
+    const [doc, win] = makeIframe(test);
+    const registry = new CustomElementRegistry;
+    const host = doc.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: registry});
+    assert_equals(shadowRoot.customElementRegistry, registry);
+    doc.body.appendChild(host);
+    assert_equals(shadowRoot.customElementRegistry, registry);
+}, 'Inserting the shadow host of a shadow root with a scoped custom element registry does not change the registry');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria-expected.txt
@@ -4,7 +4,7 @@ PASS Adding definition to global registry should affect shadow roots also using 
 PASS Adding definition to scoped registry should affect all associated shadow roots
 PASS Adding definition to scoped registry should not affect document tree scope
 PASS Adding definition to scoped registry should not affect shadow roots using other registries
-PASS Adding definition to global registry should not upgrade nodes no longer using the registry
+PASS Adding definition to global registry should not upgrade nodes no longer using a scoped registry
 PASS Adding definition to scoped registry should not upgrade nodes no longer using the registry
 PASS Adding definition to scoped registry affects associated shadow roots in all iframes
 PASS Adding definition to scoped registry affects associated shadow roots in other frame trees

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
@@ -38,7 +38,7 @@ test(t => {
 
   const registry = new CustomElementRegistry;
   const shadow = attachShadowForTest(t, registry);
-  shadow.appendChild(document.createElement(name));
+  shadow.appendChild(document.createElement(name, {customElementRegistry: registry}));
 
   class TestElement extends HTMLElement {};
   customElements.define(name, TestElement);
@@ -68,10 +68,10 @@ test(t => {
 
   const registry = new CustomElementRegistry;
   const shadow1 = attachShadowForTest(t, registry);
-  shadow1.appendChild(document.createElement(name));
+  shadow1.appendChild(document.createElement(name, {customElementRegistry: registry}));
 
   const shadow2 = attachShadowForTest(t, registry);
-  shadow2.appendChild(document.createElement(name));
+  shadow2.appendChild(document.createElement(name, {customElementRegistry: registry}));
 
   class TestElement extends HTMLElement {};
   registry.define(name, TestElement);
@@ -86,7 +86,7 @@ test(t => {
 
   const registry = new CustomElementRegistry;
   const shadow = attachShadowForTest(t, registry);
-  shadow.appendChild(document.createElement(name));
+  shadow.appendChild(document.createElement(name, {customElementRegistry: registry}));
 
   class TestElement extends HTMLElement {};
   registry.define(name, TestElement);
@@ -100,10 +100,11 @@ test(t => {
 
   const registry = new CustomElementRegistry;
   const shadow1 = attachShadowForTest(t, registry);
-  shadow1.appendChild(document.createElement(name));
+  shadow1.appendChild(document.createElement(name, {customElementRegistry: registry}));
 
-  const shadow2 = attachShadowForTest(t, new CustomElementRegistry);
-  shadow2.appendChild(document.createElement(name));
+  const registry2 = new CustomElementRegistry;
+  const shadow2 = attachShadowForTest(t, registry2);
+  shadow2.appendChild(document.createElement(name, {customElementRegistry: registry2}));
 
   const shadow3 = attachShadowForTest(t);
   shadow3.appendChild(document.createElement(name));
@@ -118,9 +119,8 @@ test(t => {
 
 test(t => {
   const name = nextCustomElementName();
-  const node = document.body.appendChild(document.createElement(name));
-
   const registry = new CustomElementRegistry;
+  const node = document.body.appendChild(document.createElement(name, {customElementRegistry: registry}));
   const shadow = attachShadowForTest(t, registry);
   shadow.appendChild(node);
 
@@ -128,7 +128,7 @@ test(t => {
   customElements.define(name, TestElement);
 
   assert_false(node instanceof TestElement);
-}, 'Adding definition to global registry should not upgrade nodes no longer using the registry');
+}, 'Adding definition to global registry should not upgrade nodes no longer using a scoped registry');
 
 test(t => {
   const name = nextCustomElementName();
@@ -151,12 +151,12 @@ test(t => {
 
   const registry = new CustomElementRegistry;
   const shadow1 = attachShadowForTest(t, registry);
-  const node1 = shadow1.appendChild(document.createElement(name));
+  const node1 = shadow1.appendChild(document.createElement(name, {customElementRegistry: registry}));
 
   const iframe = createIFrameForTest(t);
   const host2 = iframe.contentDocument.createElement('div');
   const shadow2 = host2.attachShadow({mode: 'open', customElementRegistry: registry});
-  const node2 = shadow2.appendChild(iframe.contentDocument.createElement(name));
+  const node2 = shadow2.appendChild(iframe.contentDocument.createElement(name, {customElementRegistry: registry}));
   iframe.contentDocument.body.appendChild(host2);
 
   class TestElement extends HTMLElement {};
@@ -176,7 +176,7 @@ test(t => {
 
   const host = newWindow.document.createElement('div');
   const shadow = host.attachShadow({mode: 'open', customElementRegistry: registry});
-  const node = shadow.appendChild(newWindow.document.createElement(name));
+  const node = shadow.appendChild(newWindow.document.createElement(name, {customElementRegistry: registry}));
   newWindow.document.body.appendChild(host);
 
   class TestElement extends HTMLElement {};

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -76,6 +76,8 @@ Ref<Element> JSCustomElementInterface::constructElementWithFallback(Document& do
     auto element = HTMLUnknownElement::create(QualifiedName(nullAtom(), localName, HTMLNames::xhtmlNamespaceURI), document);
     element->setIsCustomElementUpgradeCandidate();
     element->setIsFailedCustomElement();
+    if (registry.isScoped())
+        CustomElementRegistry::addToScopedCustomElementRegistryMap(element, registry);
 
     return element;
 }
@@ -91,6 +93,8 @@ Ref<Element> JSCustomElementInterface::constructElementWithFallback(Document& do
     auto element = HTMLUnknownElement::create(name, document);
     element->setIsCustomElementUpgradeCandidate();
     element->setIsFailedCustomElement();
+    if (registry.isScoped())
+        CustomElementRegistry::addToScopedCustomElementRegistryMap(element, registry);
 
     return element;
 }

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -81,7 +81,7 @@ void CustomElementRegistry::didAssociateWithDocument(Document& document)
 static void enqueueUpgradeInShadowIncludingTreeOrder(ContainerNode& node, JSCustomElementInterface& elementInterface, CustomElementRegistry& registry)
 {
     for (RefPtr element = ElementTraversal::firstWithin(node); element; element = ElementTraversal::next(*element)) {
-        if (element->isCustomElementUpgradeCandidate() && element->treeScope().customElementRegistry() == &registry && element->tagQName().matches(elementInterface.name()))
+        if (element->isCustomElementUpgradeCandidate() && CustomElementRegistry::registryForElement(*element) == &registry && element->tagQName().matches(elementInterface.name()))
             element->enqueueToUpgrade(elementInterface);
         if (RefPtr shadowRoot = element->shadowRoot()) {
             if (shadowRoot->mode() != ShadowRootMode::UserAgent)

--- a/Source/WebCore/dom/ElementCreationOptions.h
+++ b/Source/WebCore/dom/ElementCreationOptions.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 struct ElementCreationOptions {
-    RefPtr<CustomElementRegistry> customElementRegistry;
+    std::optional<RefPtr<CustomElementRegistry>> customElementRegistry;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ElementCreationOptions.idl
+++ b/Source/WebCore/dom/ElementCreationOptions.idl
@@ -24,5 +24,5 @@
  */
 
 dictionary ElementCreationOptions {
-    CustomElementRegistry customElementRegistry;
+    CustomElementRegistry? customElementRegistry;
 };

--- a/Source/WebCore/dom/ShadowRootInit.h
+++ b/Source/WebCore/dom/ShadowRootInit.h
@@ -38,7 +38,7 @@ struct ShadowRootInit {
     bool clonable { false };
     bool serializable { false };
     SlotAssignmentMode slotAssignment { SlotAssignmentMode::Named };
-    RefPtr<CustomElementRegistry> customElementRegistry;
+    std::optional<RefPtr<CustomElementRegistry>> customElementRegistry;
     String referenceTarget;
 };
 

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -31,6 +31,6 @@ dictionary ShadowRootInit {
     boolean clonable = false;
     boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry? customElementRegistry = null;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry? customElementRegistry;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled] DOMString referenceTarget;
 };

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -119,6 +119,7 @@ coords
 crossorigin
 cue
 cuebackground
+customelementregistry
 data
 datetime
 declare


### PR DESCRIPTION
#### 30db0392404836cdf3341bbe233d3e55e5886017
<pre>
Introduce customelementregistry content attribute and avoid changing null registry when inserting a node
<a href="https://bugs.webkit.org/show_bug.cgi?id=302583">https://bugs.webkit.org/show_bug.cgi?id=302583</a>

Reviewed by Chris Dumez.

This PR introduces customelementregistry content attribute on element which sets the custom element registry of an element to null,
It also adds the support for specifying `null` in `customElementRegistry` to use null custom element registry in `document.createElement`,
`document.createElementNS`, and `element.attachShadow`.

In addition, this PR changes the semantics of inserting a node so that inserting an element with null custom element registry will not
update its custom element registry to that of the new parent.

These behavior changes were discussed during TPAC as explained in: <a href="https://github.com/whatwg/dom/issues/1413#issuecomment-3530198733">https://github.com/whatwg/dom/issues/1413#issuecomment-3530198733</a>

Test: imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html
      imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml
      imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry-exceptions.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria.html:
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::constructElementWithFallback): Add the element to scoped custom element registry map if needed.
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::enqueueUpgradeInShadowIncludingTreeOrder): Fixed the bug that this code wasn&apos;t accounting for null custom element registry.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createElementForBindings): Respect `null` being specified in Init dictionary.
(WebCore::Document::createElementNS): Ditto.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributeChanged): Mark the element as it uses null custom element registry if parser sets customelementregistry content attribute.
(WebCore::Element::insertedIntoAncestor): Rewrote the logic to update the custom element registry map.
* Source/WebCore/dom/ElementCreationOptions.h:
* Source/WebCore/dom/ElementCreationOptions.idl:
* Source/WebCore/dom/Node.cpp:
(WebCore::adoptCustomElementRegistryIfNotExplicitlySet): Added.
(WebCore::Node::moveShadowTreeToNewDocumentFastCase): Set the custom element registry if a given adopted node uses null registry.
(WebCore::Node::moveShadowTreeToNewDocumentSlowCase): Ditto.
(WebCore::Node::moveNodeToNewDocumentFastCase): Ditto.
(WebCore::Node::moveNodeToNewDocumentSlowCase): Ditto.
* Source/WebCore/dom/ShadowRootInit.h:
* Source/WebCore/dom/ShadowRootInit.idl:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface): Handle customelementregistry content attribute.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::handleNamespaceAttributes):
(WebCore::handleElementAttributes):
(WebCore::XMLDocumentParser::startElementNs): Handle customelementregistry content attribute.

Canonical link: <a href="https://commits.webkit.org/303300@main">https://commits.webkit.org/303300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee073bd0a6510a73787fe107c3726338b4863713

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83771 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5967a5f-3fc5-4865-9660-66e1aefedab2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100807 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/83e82a88-8639-475c-8511-959479c440ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134829 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81597 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/878691fe-8539-446f-a454-1f75c1018509) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2971 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/827 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82615 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142039 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4044 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36821 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109181 "Found 1 new test failure: fast/scrolling/rtl-scrollbars-sticky-document.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4125 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3543 "Found 2 new test failures: fast/images/individual-animation-toggle.html http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109347 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3074 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57266 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32798 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67545 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->