### PR TITLE
[Style] Convert the 'text-*-position' properties to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3517,9 +3517,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/text-decoration/StyleTextDecorationLine.h
     style/values/text-decoration/StyleTextDecorationThickness.h
+    style/values/text-decoration/StyleTextEmphasisPosition.h
     style/values/text-decoration/StyleTextEmphasisStyle.h
     style/values/text-decoration/StyleTextShadow.h
     style/values/text-decoration/StyleTextUnderlineOffset.h
+    style/values/text-decoration/StyleTextUnderlinePosition.h
 
     style/values/transforms/functions/StyleTransformFunctionWrapper.h
     style/values/transforms/functions/StyleMatrix3DTransformFunction.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3337,9 +3337,11 @@ style/values/svg/StyleSVGStrokeDasharray.cpp
 style/values/svg/StyleSVGStrokeDashoffset.cpp
 style/values/text-decoration/StyleTextDecorationLine.cpp
 style/values/text-decoration/StyleTextDecorationThickness.cpp
+style/values/text-decoration/StyleTextEmphasisPosition.cpp
 style/values/text-decoration/StyleTextEmphasisStyle.cpp
 style/values/text-decoration/StyleTextShadow.cpp
 style/values/text-decoration/StyleTextUnderlineOffset.cpp
+style/values/text-decoration/StyleTextUnderlinePosition.cpp
 style/values/text/StyleHangingPunctuation.cpp
 style/values/text/StyleLetterSpacing.cpp
 style/values/text/StyleTabSize.cpp

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -52,7 +52,9 @@
 #include "StylePositionVisibility.h"
 #include "StyleScrollBehavior.h"
 #include "StyleTextDecorationLine.h"
+#include "StyleTextEmphasisPosition.h"
 #include "StyleTextTransform.h"
+#include "StyleTextUnderlinePosition.h"
 #include "StyleTouchAction.h"
 #include "StyleWebKitLineBoxContain.h"
 #include "StyleWebKitOverflowScrolling.h"
@@ -1265,6 +1267,18 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 
 #define TYPE TextDecorationStyle
 #define FOR_EACH(CASE) CASE(Solid) CASE(Double) CASE(Dotted) CASE(Dashed) CASE(Wavy)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE Style::TextEmphasisPositionValue
+#define FOR_EACH(CASE) CASE(Over) CASE(Under) CASE(Left) CASE(Right)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE Style::TextUnderlinePositionValue
+#define FOR_EACH(CASE) CASE(FromFont) CASE(Under) CASE(Left) CASE(Right)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10842,8 +10842,8 @@
                 "aliases": [
                     "-webkit-text-underline-position"
                 ],
-                "style-converter": "TextUnderlinePosition",
-                "parser-grammar": "auto | [ [ under | from-font ] || [ left | right ]@(settings-flag=cssTextUnderlinePositionLeftRightEnabled) ]@(type=CSSValuePair)"
+                "style-converter": "StyleType<TextUnderlinePosition>",
+                "parser-grammar": "auto | [ [ under | from-font ] || [ left | right ]@(settings-flag=cssTextUnderlinePositionLeftRightEnabled) ]@(no-single-item-opt)"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -10951,7 +10951,7 @@
                 "aliases": [
                     "-webkit-text-emphasis-position"
                 ],
-                "style-converter": "TextEmphasisPosition",
+                "style-converter": "StyleType<TextEmphasisPosition>",
                 "parser-grammar": "[ [ over | under ] && [ right | left ]? ]@(no-single-item-opt)"
             },
             "specification": {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -563,10 +563,10 @@ std::pair<InlineLayoutUnit, InlineLayoutUnit> InlineFormattingUtils::textEmphasi
     auto hasAboveTextEmphasis = false;
     auto hasUnderTextEmphasis = false;
     if (style.writingMode().isVerticalTypographic()) {
-        hasAboveTextEmphasis = !emphasisPosition.contains(TextEmphasisPosition::Left);
+        hasAboveTextEmphasis = !emphasisPosition.contains(Style::TextEmphasisPositionValue::Left);
         hasUnderTextEmphasis = !hasAboveTextEmphasis;
     } else {
-        hasAboveTextEmphasis = !emphasisPosition.contains(TextEmphasisPosition::Under);
+        hasAboveTextEmphasis = !emphasisPosition.contains(Style::TextEmphasisPositionValue::Under);
         hasUnderTextEmphasis = !hasAboveTextEmphasis;
     }
 

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -114,7 +114,7 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
         bool hasMarkers = false;
         if (auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*child))
             hasMarkers = textBox->hasMarkers();
-        if (childStyle->usedLetterSpacing() < 0 || childStyle->hasTextShadow() || !childStyle->textEmphasisStyle().isNone() || childStyle->hasPositiveStrokeWidth() || hasMarkers || !childStyle->textUnderlineOffset().isAuto() || !childStyle->textDecorationThickness().isAuto() || !childStyle->textUnderlinePosition().isEmpty())
+        if (childStyle->usedLetterSpacing() < 0 || childStyle->hasTextShadow() || !childStyle->textEmphasisStyle().isNone() || childStyle->hasPositiveStrokeWidth() || hasMarkers || !childStyle->textUnderlineOffset().isAuto() || !childStyle->textDecorationThickness().isAuto() || !childStyle->textUnderlinePosition().isAuto())
             child->clearKnownToHaveNoOverflow();
     } else if (child->boxModelObject()->hasSelfPaintingLayer())
         child->clearKnownToHaveNoOverflow();

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -70,9 +70,9 @@ static std::optional<bool> emphasisMarkExistsAndIsAbove(const RenderText& render
         return { };
 
     auto emphasisPosition = style.textEmphasisPosition();
-    bool isAbove = !emphasisPosition.contains(TextEmphasisPosition::Under);
+    bool isAbove = !emphasisPosition.contains(Style::TextEmphasisPositionValue::Under);
     if (style.writingMode().isVerticalTypographic())
-        isAbove = !emphasisPosition.contains(TextEmphasisPosition::Left);
+        isAbove = !emphasisPosition.contains(Style::TextEmphasisPositionValue::Left);
 
     auto findRubyAnnotation = [&]() -> RenderBlockFlow* {
         for (auto* baseCandidate = renderer.parent(); baseCandidate; baseCandidate = baseCandidate->parent()) {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -181,14 +181,12 @@ enum class TextBoxTrim : uint8_t;
 enum class TextCombine : bool;
 enum class TextDecorationSkipInk : uint8_t;
 enum class TextDecorationStyle : uint8_t;
-enum class TextEmphasisPosition : uint8_t;
 enum class TextGroupAlign : uint8_t;
 enum class TextJustify : uint8_t;
 enum class TextOverflow : bool;
 enum class TextRenderingMode : uint8_t;
 enum class TextSecurity : uint8_t;
 enum class TextTransform : uint8_t;
-enum class TextUnderlinePosition : uint8_t;
 enum class TextWrapMode : bool;
 enum class TextWrapStyle : uint8_t;
 enum class TextZoom : bool;
@@ -356,8 +354,9 @@ struct StrokeWidth;
 struct TabSize;
 struct TextAutospace;
 struct TextBoxEdge;
-struct TextDecorationThickness;
 struct TextDecorationLine;
+struct TextDecorationThickness;
+struct TextEmphasisPosition;
 struct TextEmphasisStyle;
 struct TextIndent;
 struct TextShadow;
@@ -365,6 +364,7 @@ struct TextSizeAdjust;
 struct TextSpacingTrim;
 struct TextTransform;
 struct TextUnderlineOffset;
+struct TextUnderlinePosition;
 struct TouchAction;
 struct Transform;
 struct TransformOrigin;
@@ -766,7 +766,7 @@ public:
     inline Style::TextDecorationLine textDecorationLine() const;
     inline TextDecorationStyle textDecorationStyle() const;
     inline TextDecorationSkipInk textDecorationSkipInk() const;
-    inline OptionSet<TextUnderlinePosition> textUnderlinePosition() const;
+    inline Style::TextUnderlinePosition textUnderlinePosition() const;
     inline const Style::TextUnderlineOffset& textUnderlineOffset() const;
     inline const Style::TextDecorationThickness& textDecorationThickness() const;
 
@@ -1041,7 +1041,7 @@ public:
     inline bool affectsTransform() const;
 
     inline const Style::TextEmphasisStyle& textEmphasisStyle() const;
-    inline OptionSet<TextEmphasisPosition> textEmphasisPosition() const;
+    inline Style::TextEmphasisPosition textEmphasisPosition() const;
 
     inline RubyPosition rubyPosition() const;
     inline bool isInterCharacterRubyPosition() const;
@@ -1411,7 +1411,7 @@ public:
     inline void setTextDecorationSkipInk(TextDecorationSkipInk);
     inline void setTextDecorationThickness(Style::TextDecorationThickness&&);
     inline void setTextIndent(Style::TextIndent&&);
-    inline void setTextUnderlinePosition(OptionSet<TextUnderlinePosition>);
+    inline void setTextUnderlinePosition(Style::TextUnderlinePosition);
     inline void setTextUnderlineOffset(Style::TextUnderlineOffset&&);
     inline void setTextTransform(Style::TextTransform);
     bool setZoom(float);
@@ -1623,7 +1623,7 @@ public:
     inline void setTextDecorationColor(Style::Color&&);
     inline void setTextEmphasisColor(Style::Color&&);
     inline void setTextEmphasisStyle(Style::TextEmphasisStyle&&);
-    inline void setTextEmphasisPosition(OptionSet<TextEmphasisPosition>);
+    inline void setTextEmphasisPosition(Style::TextEmphasisPosition);
 
     inline void setObjectFit(ObjectFit);
     inline void setObjectPosition(Style::ObjectPosition&&);
@@ -2090,7 +2090,7 @@ public:
     static constexpr Style::TextDecorationLine initialTextDecorationLineInEffect();
     static constexpr TextDecorationStyle initialTextDecorationStyle();
     static constexpr TextDecorationSkipInk initialTextDecorationSkipInk();
-    static constexpr OptionSet<TextUnderlinePosition> initialTextUnderlinePosition();
+    static constexpr Style::TextUnderlinePosition initialTextUnderlinePosition();
     static inline Style::TextUnderlineOffset initialTextUnderlineOffset();
     static inline Style::TextDecorationThickness initialTextDecorationThickness();
     static constexpr Style::ZIndex initialSpecifiedZIndex();
@@ -2183,7 +2183,7 @@ public:
     static inline Style::Color initialBackgroundColor();
     static inline Style::Color initialTextEmphasisColor();
     static inline Style::TextEmphasisStyle initialTextEmphasisStyle();
-    static constexpr OptionSet<TextEmphasisPosition> initialTextEmphasisPosition();
+    static constexpr Style::TextEmphasisPosition initialTextEmphasisPosition();
     static constexpr RubyPosition initialRubyPosition();
     static constexpr RubyAlign initialRubyAlign();
     static constexpr RubyOverhang initialRubyOverhang();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1209,17 +1209,6 @@ TextStream& operator<<(TextStream& ts, TextEmphasisMark mark)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, TextEmphasisPosition position)
-{
-    switch (position) {
-    case TextEmphasisPosition::Over: ts << "Over"_s; break;
-    case TextEmphasisPosition::Under: ts << "Under"_s; break;
-    case TextEmphasisPosition::Left: ts << "Left"_s; break;
-    case TextEmphasisPosition::Right: ts << "Right"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, TextGroupAlign textGroupAlign)
 {
     switch (textGroupAlign) {
@@ -1262,17 +1251,6 @@ TextStream& operator<<(TextStream& ts, TextSecurity textSecurity)
     case TextSecurity::Disc: ts << "disc"_s; break;
     case TextSecurity::Circle: ts << "circle"_s; break;
     case TextSecurity::Square: ts << "square"_s; break;
-    }
-    return ts;
-}
-
-TextStream& operator<<(TextStream& ts, TextUnderlinePosition position)
-{
-    switch (position) {
-    case TextUnderlinePosition::FromFont: ts << "from-font"_s; break;
-    case TextUnderlinePosition::Under: ts << "under"_s; break;
-    case TextUnderlinePosition::Left: ts << "left"_s; break;
-    case TextUnderlinePosition::Right: ts << "right"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -873,20 +873,6 @@ enum class TextEmphasisMark : uint8_t {
     Sesame
 };
 
-enum class TextEmphasisPosition : uint8_t {
-    Over  = 1 << 0,
-    Under = 1 << 1,
-    Left  = 1 << 2,
-    Right = 1 << 3
-};
-
-enum class TextUnderlinePosition : uint8_t {
-    Under    = 1 << 0,
-    FromFont = 1 << 1,
-    Left     = 1 << 2,
-    Right    = 1 << 3
-};
-
 enum class TextOverflow : bool {
     Clip,
     Ellipsis
@@ -1323,12 +1309,10 @@ WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationSkipInk);
 WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisFill);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisMark);
-WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisPosition);
 WTF::TextStream& operator<<(WTF::TextStream&, TextGroupAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, TextJustify);
 WTF::TextStream& operator<<(WTF::TextStream&, TextOverflow);
 WTF::TextStream& operator<<(WTF::TextStream&, TextSecurity);
-WTF::TextStream& operator<<(WTF::TextStream&, TextUnderlinePosition);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextBoxTrim);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -575,7 +575,7 @@ constexpr TextDecorationStyle RenderStyle::initialTextDecorationStyle() { return
 inline Style::TextDecorationThickness RenderStyle::initialTextDecorationThickness() { return CSS::Keyword::Auto { }; }
 inline Style::Color RenderStyle::initialTextEmphasisColor() { return CSS::Keyword::Currentcolor { }; }
 inline Style::TextEmphasisStyle RenderStyle::initialTextEmphasisStyle() { return CSS::Keyword::None { }; }
-constexpr OptionSet<TextEmphasisPosition> RenderStyle::initialTextEmphasisPosition() { return { TextEmphasisPosition::Over, TextEmphasisPosition::Right }; }
+constexpr Style::TextEmphasisPosition RenderStyle::initialTextEmphasisPosition() { return { Style::TextEmphasisPositionValue::Over, Style::TextEmphasisPositionValue::Right }; }
 inline Style::Color RenderStyle::initialTextFillColor() { return CSS::Keyword::Currentcolor { }; }
 inline bool RenderStyle::hasExplicitlySetColor() const { return m_inheritedFlags.hasExplicitlySetColor; }
 constexpr TextGroupAlign RenderStyle::initialTextGroupAlign() { return TextGroupAlign::None; }
@@ -589,7 +589,7 @@ inline Style::Color RenderStyle::initialTextStrokeColor() { return CSS::Keyword:
 constexpr Style::WebkitTextStrokeWidth RenderStyle::initialTextStrokeWidth() { return 0_css_px; }
 constexpr Style::TextTransform RenderStyle::initialTextTransform() { return CSS::Keyword::None { }; }
 inline Style::TextUnderlineOffset RenderStyle::initialTextUnderlineOffset() { return CSS::Keyword::Auto { }; }
-constexpr OptionSet<TextUnderlinePosition> RenderStyle::initialTextUnderlinePosition() { return { }; }
+constexpr Style::TextUnderlinePosition RenderStyle::initialTextUnderlinePosition() { return CSS::Keyword::Auto { }; }
 constexpr TextWrapMode RenderStyle::initialTextWrapMode() { return TextWrapMode::Wrap; }
 constexpr TextWrapStyle RenderStyle::initialTextWrapStyle() { return TextWrapStyle::Auto; }
 constexpr TextZoom RenderStyle::initialTextZoom() { return TextZoom::Normal; }
@@ -821,7 +821,7 @@ inline const Style::TextDecorationThickness& RenderStyle::textDecorationThicknes
 inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return Style::TextDecorationLine::fromRaw(m_inheritedFlags.textDecorationLineInEffect); }
 inline const Style::Color& RenderStyle::textEmphasisColor() const { return m_rareInheritedData->textEmphasisColor; }
 inline const Style::TextEmphasisStyle& RenderStyle::textEmphasisStyle() const { return m_rareInheritedData->textEmphasisStyle; }
-inline OptionSet<TextEmphasisPosition> RenderStyle::textEmphasisPosition() const { return OptionSet<TextEmphasisPosition>::fromRaw(m_rareInheritedData->textEmphasisPosition); }
+inline Style::TextEmphasisPosition RenderStyle::textEmphasisPosition() const { return Style::TextEmphasisPosition::fromRaw(m_rareInheritedData->textEmphasisPosition); }
 inline const Style::Color& RenderStyle::textFillColor() const { return m_rareInheritedData->textFillColor; }
 inline TextGroupAlign RenderStyle::textGroupAlign() const { return static_cast<TextGroupAlign>(m_nonInheritedData->rareData->textGroupAlign); }
 inline const Style::TextIndent& RenderStyle::textIndent() const { return m_rareInheritedData->textIndent; }
@@ -835,7 +835,7 @@ inline const Style::Color& RenderStyle::textStrokeColor() const { return m_rareI
 inline Style::WebkitTextStrokeWidth RenderStyle::textStrokeWidth() const { return m_rareInheritedData->textStrokeWidth; }
 inline Style::TextTransform RenderStyle::textTransform() const { return Style::TextTransform::fromRaw(m_inheritedFlags.textTransform); }
 inline const Style::TextUnderlineOffset& RenderStyle::textUnderlineOffset() const { return m_rareInheritedData->textUnderlineOffset; }
-inline OptionSet<TextUnderlinePosition> RenderStyle::textUnderlinePosition() const { return OptionSet<TextUnderlinePosition>::fromRaw(m_rareInheritedData->textUnderlinePosition); }
+inline Style::TextUnderlinePosition RenderStyle::textUnderlinePosition() const { return Style::TextUnderlinePosition::fromRaw(m_rareInheritedData->textUnderlinePosition); }
 inline TextZoom RenderStyle::textZoom() const { return static_cast<TextZoom>(m_rareInheritedData->textZoom); }
 inline const Style::InsetEdge& RenderStyle::top() const { return m_nonInheritedData->surroundData->inset.top(); }
 inline Style::TouchAction RenderStyle::touchAction() const { return m_nonInheritedData->rareData->touchAction; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -304,7 +304,7 @@ inline void RenderStyle::setTextDecorationThickness(Style::TextDecorationThickne
 inline void RenderStyle::setTextDecorationLineInEffect(Style::TextDecorationLine&& value) { m_inheritedFlags.textDecorationLineInEffect = value.toRaw(); }
 inline void RenderStyle::setTextEmphasisColor(Style::Color&& c) { SET(m_rareInheritedData, textEmphasisColor, WTFMove(c)); }
 inline void RenderStyle::setTextEmphasisStyle(Style::TextEmphasisStyle&& style) { SET(m_rareInheritedData, textEmphasisStyle, style); }
-inline void RenderStyle::setTextEmphasisPosition(OptionSet<TextEmphasisPosition> position) { SET(m_rareInheritedData, textEmphasisPosition, static_cast<unsigned>(position.toRaw())); }
+inline void RenderStyle::setTextEmphasisPosition(Style::TextEmphasisPosition position) { SET(m_rareInheritedData, textEmphasisPosition, position.toRaw()); }
 inline void RenderStyle::setTextFillColor(Style::Color&& color) { SET(m_rareInheritedData, textFillColor, WTFMove(color)); }
 inline void RenderStyle::setHasExplicitlySetColor(bool value) { m_inheritedFlags.hasExplicitlySetColor = value; }
 inline void RenderStyle::setTableLayout(TableLayoutType value) { SET_NESTED(m_nonInheritedData, miscData, tableLayout, static_cast<unsigned>(value)); }
@@ -318,7 +318,7 @@ inline void RenderStyle::setTextStrokeColor(Style::Color&& color) { SET(m_rareIn
 inline void RenderStyle::setTextStrokeWidth(Style::WebkitTextStrokeWidth width) { SET(m_rareInheritedData, textStrokeWidth, width); }
 inline void RenderStyle::setTextTransform(Style::TextTransform value) { m_inheritedFlags.textTransform = value.toRaw(); }
 inline void RenderStyle::setTextUnderlineOffset(Style::TextUnderlineOffset&& textUnderlineOffset) { SET(m_rareInheritedData, textUnderlineOffset, WTFMove(textUnderlineOffset)); }
-inline void RenderStyle::setTextUnderlinePosition(OptionSet<TextUnderlinePosition> position) { SET(m_rareInheritedData, textUnderlinePosition, static_cast<unsigned>(position.toRaw())); }
+inline void RenderStyle::setTextUnderlinePosition(Style::TextUnderlinePosition position) { SET(m_rareInheritedData, textUnderlinePosition, position.toRaw()); }
 inline void RenderStyle::setTextZoom(TextZoom zoom) { SET(m_rareInheritedData, textZoom, static_cast<unsigned>(zoom)); }
 inline void RenderStyle::setTop(Style::InsetEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, inset.top(), WTFMove(edge)); }
 inline void RenderStyle::setTouchAction(Style::TouchAction touchAction) { SET_NESTED(m_nonInheritedData, rareData, touchAction, touchAction); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -429,8 +429,8 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
 
     LOG_IF_DIFFERENT_WITH_CAST(Hyphens, hyphens);
     LOG_IF_DIFFERENT_WITH_CAST(TextCombine, textCombine);
-    LOG_IF_DIFFERENT_WITH_CAST(TextEmphasisPosition, textEmphasisPosition);
-    LOG_IF_DIFFERENT_WITH_CAST(TextUnderlinePosition, textUnderlinePosition);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::TextEmphasisPosition, textEmphasisPosition);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::TextUnderlinePosition, textUnderlinePosition);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::WebkitLineBoxContain, lineBoxContain);
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -49,10 +49,12 @@
 #include <WebCore/StyleStrokeWidth.h>
 #include <WebCore/StyleTabSize.h>
 #include <WebCore/StyleTextBoxEdge.h>
+#include <WebCore/StyleTextEmphasisPosition.h>
 #include <WebCore/StyleTextEmphasisStyle.h>
 #include <WebCore/StyleTextIndent.h>
 #include <WebCore/StyleTextShadow.h>
 #include <WebCore/StyleTextUnderlineOffset.h>
+#include <WebCore/StyleTextUnderlinePosition.h>
 #include <WebCore/StyleTouchAction.h>
 #include <WebCore/StyleWebKitLineBoxContain.h>
 #include <WebCore/StyleWebKitLineGrid.h>
@@ -187,8 +189,8 @@ public:
     PREFERRED_TYPE(OptionSet<SpeakAs>) unsigned speakAs : 4 { 0 };
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
-    PREFERRED_TYPE(TextEmphasisPosition) unsigned textEmphasisPosition : 4;
-    PREFERRED_TYPE(TextUnderlinePosition) unsigned textUnderlinePosition : 4;
+    PREFERRED_TYPE(Style::TextEmphasisPosition) unsigned textEmphasisPosition : 4;
+    PREFERRED_TYPE(Style::TextUnderlinePosition) unsigned textUnderlinePosition : 4;
     PREFERRED_TYPE(Style::WebkitLineBoxContain) unsigned lineBoxContain: 7;
     PREFERRED_TYPE(Style::ImageOrientation) unsigned imageOrientation : 1;
     PREFERRED_TYPE(ImageRendering) unsigned imageRendering : 3;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -115,11 +115,9 @@ public:
 
     template<CSSValueID> static AtomString convertCustomIdentAtomOrKeyword(BuilderState&, const CSSValue&);
 
-    static OptionSet<TextEmphasisPosition> convertTextEmphasisPosition(BuilderState&, const CSSValue&);
     static TextAlignMode convertTextAlign(BuilderState&, const CSSValue&);
     static TextAlignLast convertTextAlignLast(BuilderState&, const CSSValue&);
     static Resize convertResize(BuilderState&, const CSSValue&);
-    static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
 
     static OptionSet<SpeakAs> convertSpeakAs(BuilderState&, const CSSValue&);
 
@@ -147,42 +145,6 @@ template<CSSValueID keyword> inline AtomString BuilderConverter::convertCustomId
     if (primitiveValue->valueID() == keyword)
         return nullAtom();
     return AtomString { primitiveValue->stringValue() };
-}
-
-inline static OptionSet<TextEmphasisPosition> valueToEmphasisPosition(const CSSPrimitiveValue& primitiveValue)
-{
-    ASSERT(primitiveValue.isValueID());
-
-    switch (primitiveValue.valueID()) {
-    case CSSValueOver:
-        return TextEmphasisPosition::Over;
-    case CSSValueUnder:
-        return TextEmphasisPosition::Under;
-    case CSSValueLeft:
-        return TextEmphasisPosition::Left;
-    case CSSValueRight:
-        return TextEmphasisPosition::Right;
-    default:
-        break;
-    }
-
-    ASSERT_NOT_REACHED();
-    return RenderStyle::initialTextEmphasisPosition();
-}
-
-inline OptionSet<TextEmphasisPosition> BuilderConverter::convertTextEmphasisPosition(BuilderState& builderState, const CSSValue& value)
-{
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
-        return valueToEmphasisPosition(*primitiveValue);
-
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    OptionSet<TextEmphasisPosition> position;
-    for (auto& currentValue : *list)
-        position.add(valueToEmphasisPosition(currentValue));
-    return position;
 }
 
 inline TextAlignMode BuilderConverter::convertTextAlign(BuilderState& builderState, const CSSValue& value)
@@ -251,43 +213,6 @@ inline Resize BuilderConverter::convertResize(BuilderState& builderState, const 
         resize = fromCSSValue<Resize>(value);
 
     return resize;
-}
-
-inline static OptionSet<TextUnderlinePosition> valueToUnderlinePosition(const CSSPrimitiveValue& primitiveValue)
-{
-    ASSERT(primitiveValue.isValueID());
-
-    switch (primitiveValue.valueID()) {
-    case CSSValueFromFont:
-        return TextUnderlinePosition::FromFont;
-    case CSSValueUnder:
-        return TextUnderlinePosition::Under;
-    case CSSValueLeft:
-        return TextUnderlinePosition::Left;
-    case CSSValueRight:
-        return TextUnderlinePosition::Right;
-    case CSSValueAuto:
-        return RenderStyle::initialTextUnderlinePosition();
-    default:
-        break;
-    }
-
-    ASSERT_NOT_REACHED();
-    return RenderStyle::initialTextUnderlinePosition();
-}
-
-inline OptionSet<TextUnderlinePosition> BuilderConverter::convertTextUnderlinePosition(BuilderState& builderState, const CSSValue& value)
-{
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
-        return valueToUnderlinePosition(*primitiveValue);
-
-    auto pair = requiredPairDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!pair)
-        return { };
-
-    auto position = valueToUnderlinePosition(pair->first);
-    position.add(valueToUnderlinePosition(pair->second));
-    return position;
 }
 
 inline float zoomWithTextZoomFactor(BuilderState& builderState)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -134,8 +134,6 @@ public:
     // MARK: Shared conversions
 
     static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const FixedVector<PositionTryFallback>&);
-    static Ref<CSSValue> convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition>);
-    static Ref<CSSValue> convertTextEmphasisPosition(ExtractorState&, OptionSet<TextEmphasisPosition>);
     static Ref<CSSValue> convertSpeakAs(ExtractorState&, OptionSet<SpeakAs>);
     static Ref<CSSValue> convertPositionAnchor(ExtractorState&, const std::optional<ScopedName>&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
@@ -269,43 +267,6 @@ inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorSt
     }
 
     return CSSValueList::createCommaSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition> textUnderlinePosition)
-{
-    ASSERT(!((textUnderlinePosition & TextUnderlinePosition::FromFont) && (textUnderlinePosition & TextUnderlinePosition::Under)));
-    ASSERT(!((textUnderlinePosition & TextUnderlinePosition::Left) && (textUnderlinePosition & TextUnderlinePosition::Right)));
-
-    if (textUnderlinePosition.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAuto);
-    bool isFromFont = textUnderlinePosition.contains(TextUnderlinePosition::FromFont);
-    bool isUnder = textUnderlinePosition.contains(TextUnderlinePosition::Under);
-    bool isLeft = textUnderlinePosition.contains(TextUnderlinePosition::Left);
-    bool isRight = textUnderlinePosition.contains(TextUnderlinePosition::Right);
-
-    auto metric = isUnder ? CSSValueUnder : CSSValueFromFont;
-    auto side = isLeft ? CSSValueLeft : CSSValueRight;
-    if (!isFromFont && !isUnder)
-        return CSSPrimitiveValue::create(side);
-    if (!isLeft && !isRight)
-        return CSSPrimitiveValue::create(metric);
-    return CSSValuePair::create(CSSPrimitiveValue::create(metric), CSSPrimitiveValue::create(side));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertTextEmphasisPosition(ExtractorState&, OptionSet<TextEmphasisPosition> textEmphasisPosition)
-{
-    ASSERT(!((textEmphasisPosition & TextEmphasisPosition::Over) && (textEmphasisPosition & TextEmphasisPosition::Under)));
-    ASSERT(!((textEmphasisPosition & TextEmphasisPosition::Left) && (textEmphasisPosition & TextEmphasisPosition::Right)));
-    ASSERT((textEmphasisPosition & TextEmphasisPosition::Over) || (textEmphasisPosition & TextEmphasisPosition::Under));
-
-    CSSValueListBuilder list;
-    if (textEmphasisPosition & TextEmphasisPosition::Over)
-        list.append(CSSPrimitiveValue::create(CSSValueOver));
-    if (textEmphasisPosition & TextEmphasisPosition::Under)
-        list.append(CSSPrimitiveValue::create(CSSValueUnder));
-    if (textEmphasisPosition & TextEmphasisPosition::Left)
-        list.append(CSSPrimitiveValue::create(CSSValueLeft));
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertSpeakAs(ExtractorState&, OptionSet<SpeakAs> speakAs)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -71,8 +71,6 @@ public:
     static void serializeSmoothScrolling(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, bool);
     static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<PositionTryFallback>&);
     static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
-    static void serializeTextUnderlinePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextUnderlinePosition>);
-    static void serializeTextEmphasisPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextEmphasisPosition>);
     static void serializeSpeakAs(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<SpeakAs>);
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
@@ -215,55 +213,6 @@ inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& s
     }
 
     builder.append(CSSValueList::createCommaSeparated(WTFMove(list))->cssText(context));
-}
-
-inline void ExtractorSerializer::serializeTextUnderlinePosition(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextUnderlinePosition> textUnderlinePosition)
-{
-    ASSERT(!((textUnderlinePosition & TextUnderlinePosition::FromFont) && (textUnderlinePosition & TextUnderlinePosition::Under)));
-    ASSERT(!((textUnderlinePosition & TextUnderlinePosition::Left) && (textUnderlinePosition & TextUnderlinePosition::Right)));
-
-    if (textUnderlinePosition.isEmpty()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Auto { });
-        return;
-    }
-
-    bool isFromFont = textUnderlinePosition.contains(TextUnderlinePosition::FromFont);
-    bool isUnder = textUnderlinePosition.contains(TextUnderlinePosition::Under);
-    bool isLeft = textUnderlinePosition.contains(TextUnderlinePosition::Left);
-    bool isRight = textUnderlinePosition.contains(TextUnderlinePosition::Right);
-
-    auto metric = isUnder ? CSSValueUnder : CSSValueFromFont;
-    auto side = isLeft ? CSSValueLeft : CSSValueRight;
-    if (!isFromFont && !isUnder) {
-        builder.append(nameLiteralForSerialization(side));
-        return;
-    }
-    if (!isLeft && !isRight) {
-        builder.append(nameLiteralForSerialization(metric));
-        return;
-    }
-
-    builder.append(nameLiteralForSerialization(metric), ' ', nameLiteralForSerialization(side));
-}
-
-inline void ExtractorSerializer::serializeTextEmphasisPosition(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext&, OptionSet<TextEmphasisPosition> textEmphasisPosition)
-{
-    ASSERT(!((textEmphasisPosition & TextEmphasisPosition::Over) && (textEmphasisPosition & TextEmphasisPosition::Under)));
-    ASSERT(!((textEmphasisPosition & TextEmphasisPosition::Left) && (textEmphasisPosition & TextEmphasisPosition::Right)));
-    ASSERT((textEmphasisPosition & TextEmphasisPosition::Over) || (textEmphasisPosition & TextEmphasisPosition::Under));
-
-    bool listEmpty = true;
-    auto appendOption = [&](TextEmphasisPosition test, CSSValueID value) {
-        if (textEmphasisPosition &  test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(TextEmphasisPosition::Over, CSSValueOver);
-    appendOption(TextEmphasisPosition::Under, CSSValueUnder);
-    appendOption(TextEmphasisPosition::Left, CSSValueLeft);
 }
 
 inline void ExtractorSerializer::serializeSpeakAs(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<SpeakAs> speakAs)

--- a/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleTextEmphasisPosition.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<TextEmphasisPosition>::operator()(BuilderState& state, const CSSValue& value) -> TextEmphasisPosition
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueOver:
+            return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+        case CSSValueUnder:
+            return { TextEmphasisPositionValue::Under, TextEmphasisPositionValue::Right };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+
+    TextEmphasisPositionValueEnumSet result;
+    for (Ref item : *list) {
+        switch (item->valueID()) {
+        case CSSValueOver:
+            if (result.contains(TextEmphasisPositionValue::Under)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+            }
+            result.value.add(TextEmphasisPositionValue::Over);
+            break;
+        case CSSValueUnder:
+            if (result.contains(TextEmphasisPositionValue::Over)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+            }
+            result.value.add(TextEmphasisPositionValue::Under);
+            break;
+        case CSSValueLeft:
+            if (result.contains(TextEmphasisPositionValue::Right)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+            }
+            result.value.add(TextEmphasisPositionValue::Left);
+            break;
+        case CSSValueRight:
+            if (result.contains(TextEmphasisPositionValue::Left)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+            }
+            result.value.add(TextEmphasisPositionValue::Right);
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+        }
+    }
+
+    // Result must contain either `over` or `under`.
+    if (!result.containsAny({ TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Under })) {
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+    }
+
+    // If neither `left` nor `right` has been specified, `right` is added as the default.
+    if (!result.containsAny({ TextEmphasisPositionValue::Left, TextEmphasisPositionValue::Right }))
+        result.value.add(TextEmphasisPositionValue::Right);
+
+    return result;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'text-emphasis-position'> = [ over | under ] && [ right | left ]?@(default=right)
+// https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position
+
+enum class TextEmphasisPositionValue : uint8_t {
+    Over,
+    Under,
+    Left,
+    Right,
+};
+
+using TextEmphasisPositionValueEnumSet = SpaceSeparatedEnumSet<TextEmphasisPositionValue>;
+
+// FIXME: This could be packed into 2 bits if we didn't use an EnumSet.
+struct TextEmphasisPosition {
+    using EnumSet = TextEmphasisPositionValueEnumSet;
+    using value_type = TextEmphasisPositionValueEnumSet::value_type;
+
+    constexpr TextEmphasisPosition(EnumSet&& set) : m_value { WTFMove(set) } { }
+    constexpr TextEmphasisPosition(value_type value) : TextEmphasisPosition { EnumSet { value } } { }
+    constexpr TextEmphasisPosition(std::initializer_list<value_type> initializerList) : TextEmphasisPosition { EnumSet { initializerList } } { }
+
+    static constexpr TextEmphasisPosition fromRaw(EnumSet::StorageType rawValue) { return EnumSet::fromRaw(rawValue); }
+    constexpr EnumSet::StorageType toRaw() const { return m_value.toRaw(); }
+
+    constexpr bool contains(TextEmphasisPositionValue e) const { return m_value.contains(e); }
+    constexpr bool containsAny(EnumSet other) const { return m_value.containsAny(other.value); }
+    constexpr bool containsAll(EnumSet other) const { return m_value.containsAll(other.value); }
+    constexpr bool containsOnly(EnumSet other) const { return m_value.containsOnly(other.value); }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (contains(TextEmphasisPositionValue::Over)) {
+            if (contains(TextEmphasisPositionValue::Left))
+                return visitor(SpaceSeparatedTuple { CSS::Keyword::Over { }, CSS::Keyword::Left { } });
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Over { } });
+        } else {
+            if (contains(TextEmphasisPositionValue::Left))
+                return visitor(SpaceSeparatedTuple { CSS::Keyword::Under { }, CSS::Keyword::Left { } });
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Under { } });
+        }
+    }
+
+    constexpr bool operator==(const TextEmphasisPosition&) const = default;
+
+private:
+    EnumSet m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<TextEmphasisPosition> { auto operator()(BuilderState&, const CSSValue&) -> TextEmphasisPosition; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextEmphasisPosition)

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleTextUnderlinePosition.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<TextUnderlinePosition>::operator()(BuilderState& state, const CSSValue& value) -> TextUnderlinePosition
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        case CSSValueFromFont:
+            return { TextUnderlinePositionValue::FromFont };
+        case CSSValueUnder:
+            return { TextUnderlinePositionValue::Under };
+        case CSSValueLeft:
+            return { TextUnderlinePositionValue::Left };
+        case CSSValueRight:
+            return { TextUnderlinePositionValue::Right };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Auto { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return CSS::Keyword::Auto { };
+
+    TextUnderlinePositionValueEnumSet result;
+    for (Ref item : *list) {
+        switch (item->valueID()) {
+        case CSSValueFromFont:
+            if (result.contains(TextUnderlinePositionValue::Under)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Auto { };
+            }
+            result.value.add(TextUnderlinePositionValue::FromFont);
+            break;
+        case CSSValueUnder:
+            if (result.contains(TextUnderlinePositionValue::FromFont)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Auto { };
+            }
+            result.value.add(TextUnderlinePositionValue::Under);
+            break;
+        case CSSValueLeft:
+            if (result.contains(TextUnderlinePositionValue::Right)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Auto { };
+            }
+            result.value.add(TextUnderlinePositionValue::Left);
+            break;
+        case CSSValueRight:
+            if (result.contains(TextUnderlinePositionValue::Left)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Auto { };
+            }
+            result.value.add(TextUnderlinePositionValue::Right);
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Auto { };
+        }
+    }
+    return result;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'text-underline-position'> = auto | [ from-font | under ] || [ left | right ]
+// https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-position
+
+enum class TextUnderlinePositionValue : uint8_t {
+    FromFont,
+    Under,
+    Left,
+    Right,
+};
+
+using TextUnderlinePositionValueEnumSet = SpaceSeparatedEnumSet<TextUnderlinePositionValue>;
+
+struct TextUnderlinePosition {
+    using EnumSet = TextUnderlinePositionValueEnumSet;
+    using value_type = TextUnderlinePositionValueEnumSet::value_type;
+
+    enum class Side : uint8_t { NoPreference, Left, Right };
+
+    constexpr TextUnderlinePosition(CSS::Keyword::Auto) : m_value { } { }
+    constexpr TextUnderlinePosition(EnumSet&& set) : m_value { WTFMove(set) } { }
+    constexpr TextUnderlinePosition(value_type value) : TextUnderlinePosition { EnumSet { value } } { }
+    constexpr TextUnderlinePosition(std::initializer_list<value_type> initializerList) : TextUnderlinePosition { EnumSet { initializerList } } { }
+
+    static constexpr TextUnderlinePosition fromRaw(EnumSet::StorageType rawValue) { return EnumSet::fromRaw(rawValue); }
+    constexpr EnumSet::StorageType toRaw() const { return m_value.toRaw(); }
+
+    constexpr bool contains(TextUnderlinePositionValue e) const { return m_value.contains(e); }
+    constexpr bool containsAny(EnumSet other) const { return m_value.containsAny(other.value); }
+    constexpr bool containsAll(EnumSet other) const { return m_value.containsAll(other.value); }
+    constexpr bool containsOnly(EnumSet other) const { return m_value.containsOnly(other.value); }
+
+    constexpr bool isAuto() const { return m_value.isEmpty(); }
+    constexpr bool isFromFont() const { return contains(TextUnderlinePositionValue::FromFont); }
+    constexpr bool isUnder() const { return contains(TextUnderlinePositionValue::Under); }
+
+    constexpr Side verticalTypographySide() const
+    {
+        if (contains(TextUnderlinePositionValue::Left))
+            return Side::Left;
+        if (contains(TextUnderlinePositionValue::Right))
+            return Side::Right;
+        return Side::NoPreference;
+    }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isAuto())
+            return visitor(CSS::Keyword::Auto { });
+        return visitor(m_value);
+    }
+
+    constexpr bool operator==(const TextUnderlinePosition&) const = default;
+
+private:
+    EnumSet m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<TextUnderlinePosition> { auto operator()(BuilderState&, const CSSValue&) -> TextUnderlinePosition; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextUnderlinePosition)


### PR DESCRIPTION
#### 7e36c93813bd2d82a82152dc8393b962feb68023
<pre>
[Style] Convert the &apos;text-*-position&apos; properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302591">https://bugs.webkit.org/show_bug.cgi?id=302591</a>

Reviewed by Darin Adler.

Converts the &apos;text-emphasis-position&apos; and &apos;text-underline-position&apos; properties
to use strong style types.

Additionally, changes the parsing for the two to match, allowing the code-generator
to pick which data structure to use rather than specifying CSSValuePair explicitly.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/InlineTextBoxStyle.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp: Added.
* Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.h: Added.
* Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.cpp: Added.
* Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.h: Added.

Canonical link: <a href="https://commits.webkit.org/303263@main">https://commits.webkit.org/303263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/339ada0e1c5857c7f136e319d585888cce81880f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131626 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100492 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2829 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/680 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108864 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27690 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2808 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56912 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3763 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32546 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3590 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67174 "Built successfully") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3936 "Failed to checkout and rebase branch from PR 54007") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->