### PR TITLE
[Swift in WebKit] WebGPU should not disable various verifiers and checkers

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -239,9 +239,11 @@ WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndStackDepth(const char*, i
 WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
 #ifdef __cplusplus
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, const char*);
+#if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
 WTF_EXPORT_PRIVATE void WTFPrintBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, std::span<void* const> stack, const char* prefix);
 WTF_EXPORT_PRIVATE void WTFPrintBacktrace(std::span<void* const> stack);
 #endif
+#endif // __cplusplus
 
 WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 

--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -121,7 +121,7 @@ WK_SWIFT_OBJC_INTEROP_MODE_ENABLE_WEBGPU_SWIFT = objcxx;
 // SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES
 
 // FIXME: broaden SafeInteropWrappers to all of WebKit; rdar://159439903
-OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp -Xcc -std=c++2b -Xcc -D__WEBGPU__ -Xcc -DUCHAR_TYPE=char16_t -enable-experimental-feature SafeInteropWrappers -Xcc -fvisibility=hidden -no-verify-emitted-module-interface;
+OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp -Xcc -std=c++2b -Xcc -D__WEBGPU__ -Xcc -DUCHAR_TYPE=char16_t -enable-experimental-feature SafeInteropWrappers -Xcc -fvisibility=hidden;
 
 SWIFT_OPTIMIZATION_LEVEL = -O;
 SWIFT_OPTIMIZATION_LEVEL[config=Debug] = -Onone;
@@ -131,7 +131,6 @@ EXCLUDED_SOURCE_FILE_NAMES_ENABLE_WEBGPU_SWIFT =;
 EXCLUDED_SOURCE_FILE_NAMES_ = *.swift;
 
 BUILD_LIBRARY_FOR_DISTRIBUTION = YES; // This is required for all frameworks in the OS.
-RUN_SWIFT_ABI_CHECKER_TOOL = NO;
 
 // When back-deploying for STP and downlevel builds, force Xcode to embed any
 // compatibility runtimes alongside WebKit.framework.


### PR DESCRIPTION
#### f751eada332bab4a650b7e511591e6a9a73354bd
<pre>
[Swift in WebKit] WebGPU should not disable various verifiers and checkers
<a href="https://bugs.webkit.org/show_bug.cgi?id=302595">https://bugs.webkit.org/show_bug.cgi?id=302595</a>
<a href="https://rdar.apple.com/164839737">rdar://164839737</a>

Reviewed by NOBODY (OOPS!).

Since verifying and checking things is a good thing to do, stop using ` -no-verify-emitted-module-interface` and
`RUN_SWIFT_ABI_CHECKER_TOOL` in WebGPU. These were only used because the WTF module is incorrect (which itself was not caught
because WTF is a library, which do not support module verification).

Since `Assertions.h` in WTF is unique in that it requires either C, or C++20 and greater, fix by wrapping the parts that need
C++20 or higher in the correct compiler guards.

* Source/WTF/wtf/Assertions.h:
* Source/WebGPU/Configurations/WebGPU.xcconfig:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f751eada332bab4a650b7e511591e6a9a73354bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131286 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3616 "Hash f751eada for PR 54008 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e490561e-fd03-4a58-82d5-02861fcf63fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3627 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3458 "Hash f751eada for PR 54008 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100033 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67784 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/47626222-51ff-4996-bd0d-6e692ee4854b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80734 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b4d0fb4-6e72-4fb2-a1bf-d00de40e6892) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2529 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81981 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123308 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141231 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129740 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3361 "Hash f751eada for PR 54008 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108551 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3407 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/3458 "Hash f751eada for PR 54008 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108496 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2536 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56511 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3423 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32278 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3245 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66831 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42405 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->