### PR TITLE
Let RenderAttachment handle the rendering of the selected state

### DIFF
--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-expected.html
@@ -1,0 +1,12 @@
+<html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!-- This test is intentionally in quirks mode, to access extra CSS system colors used in Attachment shadow trees. -->
+<head>
+</head>
+<body>
+<div class="attachment" title="Title.pdf" progress="0.75"></div>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+AugmentAttachmentClassElementsWithAttachmentTree();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-alone-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-alone-expected.html
@@ -1,0 +1,13 @@
+<html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!-- This test is intentionally in quirks mode, to access extra CSS system colors used in Attachment shadow trees. -->
+<head>
+</head>
+<body>
+<div id="a" class="attachment" title="Title.pdf" progress="0.75"></div>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+AugmentAttachmentClassElementsWithAttachmentTree();
+document.getElementById("a-attachment-container").classList.add("attachment-has-selection");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-alone.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-alone.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<head>
+</head>
+<body>
+<attachment id="a" title="Title.pdf" progress="0.75"></attachment>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+window.getSelection().setBaseAndExtent(a.previousSibling, a.previousSibling.length, a.nextSibling, 0);
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-expected.html
@@ -1,0 +1,14 @@
+<html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!-- This test is intentionally in quirks mode, to access extra CSS system colors used in Attachment shadow trees. -->
+<head>
+</head>
+<body>
+<span id="before" style="vertical-align: top;">before</span><div id="a" class="attachment" title="Title.pdf" progress="0.75"></div><span id="after" style="vertical-align: top;">after</span>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+AugmentAttachmentClassElementsWithAttachmentTree();
+window.getSelection().setBaseAndExtent(before.lastChild, before.lastChild.length - 3, after.firstChild, 3);
+document.getElementById("a-attachment-container").classList.add("attachment-has-selection", "attachment-selection-continues-left", "attachment-selection-continues-right");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-left-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-left-expected.html
@@ -1,0 +1,14 @@
+<html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!-- This test is intentionally in quirks mode, to access extra CSS system colors used in Attachment shadow trees. -->
+<head>
+</head>
+<body>
+<span id="before" style="vertical-align: top;">before</span><div id="a" class="attachment" title="Title.pdf" progress="0.75"></div>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+AugmentAttachmentClassElementsWithAttachmentTree();
+window.getSelection().setBaseAndExtent(before.lastChild, before.lastChild.length - 3, a.nextSibling, 0);
+document.getElementById("a-attachment-container").classList.add("attachment-has-selection", "attachment-selection-continues-left");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-left.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-left.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<head>
+<meta name="fuzzy" content="maxDifference=0-123;totalPixels=0-299" /> <!-- Tolerance for gap between text/span and attachment -->
+<style>span { vertical-align: top; }</style> <!-- Disregard baselines -->
+</head>
+<body>
+<span id="before">before</span><attachment id="a" title="Title.pdf" progress="0.75"></attachment>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+window.getSelection().setBaseAndExtent(before.lastChild, before.lastChild.length - 3, a.nextSibling, 0);
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-right-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-right-expected.html
@@ -1,0 +1,14 @@
+<html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!-- This test is intentionally in quirks mode, to access extra CSS system colors used in Attachment shadow trees. -->
+<head>
+</head>
+<body>
+<div id="a" class="attachment" title="Title.pdf" progress="0.75"></div><span id="after" style="vertical-align: top;">after</span>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+AugmentAttachmentClassElementsWithAttachmentTree();
+window.getSelection().setBaseAndExtent(a.previousSibling, a.previousSibling.length, after.firstChild, 3);
+document.getElementById("a-attachment-container").classList.add("attachment-has-selection", "attachment-selection-continues-right");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-right.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-right.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<head>
+<meta name="fuzzy" content="maxDifference=0-76;totalPixels=0-299" /> <!-- Tolerance for gap between text/span and attachment -->
+<style>span { vertical-align: top; }</style> <!-- Disregard baselines -->
+</head>
+<body>
+<attachment id="a" title="Title.pdf" progress="0.75"></attachment><span id="after">after</span>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+window.getSelection().setBaseAndExtent(a.previousSibling, a.previousSibling.length, after.firstChild, 3);
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<head>
+<meta name="fuzzy" content="maxDifference=0-123;totalPixels=0-159" /> <!-- Tolerance for gap between text/span and attachment -->
+<style>span { vertical-align: top; }</style> <!-- Disregard baselines -->
+</head>
+<body>
+<span id="before">before</span><attachment id="a" title="Title.pdf" progress="0.75"></attachment><span id="after">after</span>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+window.getSelection().setBaseAndExtent(before.lastChild, before.lastChild.length - 3, after.firstChild, 3);
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<head>
+</head>
+<body>
+<attachment title="Title.pdf" progress="0.75"></attachment>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/resources/attachment-test-utils.js
+++ b/LayoutTests/fast/attachment/resources/attachment-test-utils.js
@@ -1,12 +1,29 @@
+function assertInAttachmentTest(successOrExpressionString, expressionString) {
+    if (!expressionString) {
+        expressionString = successOrExpressionString;
+        successOrExpressionString = eval(successOrExpressionString);
+    }
+    console.assert(successOrExpressionString, expressionString);
+    if (!successOrExpressionString) {
+        const d = document.body.appendChild(document.createElement("div"));
+        d.style.border = "2px solid red";
+        const error = "ASSERTION FAILURE: " + expressionString;
+        d.innerText = error;
+        document.documentElement.classList.remove("reftest-wait");
+        throw new Error(error);
+    }
+}
+
 function takeScreenshot() {
+    assertInAttachmentTest('document.documentElement.classList.contains("reftest-wait")');
     document.documentElement.classList.remove("reftest-wait");
 }
 
 function takeScreenshotWhenAttachmentsSettled(message) {
-    console.assert(document.documentElement.classList.contains("reftest-wait"));
+    assertInAttachmentTest('document.documentElement.classList.contains("reftest-wait")');
 
     const attachments = [...document.getElementsByTagName("attachment")];
-    console.assert(attachments.length);
+    assertInAttachmentTest(attachments.length, "attachments.length");
     if (!attachments.length)
         return takeScreenshot();
 
@@ -43,4 +60,100 @@ function takeActualScreenshotWhenAttachmentsSettled() {
 
 function takeExpectedScreenshotWhenAttachmentsSettled() {
     takeScreenshotWhenAttachmentsSettled("expected");
+}
+
+function AugmentDivWithAttachmentTree() {
+    const isIOSFamily = window.testRunner && window.testRunner.isIOSFamily;
+    const isVision = isIOSFamily && window.testRunner.isVision;
+
+    let style = "div.attachment { display: inline-block; margin: 1px; } ";
+    if (window.internals) {
+        style += window.internals.attachmentElementShadowUserAgentStyleSheet();
+
+        style = style.replaceAll("#attachment-", ".attachment-");
+        // Hard-coded values because these -apple-xxx colors are only available in UA style sheets.
+        style = style.replaceAll("-apple-system-tertiary-fill", isIOSFamily ? (isVision ? "rgb(118 118 128 / 0.24)" : "rgb(118 118 128 / 0.12)") : "rgb(0 0 0 / 0.047)");
+        style = style.replaceAll("-apple-system-quaternary-fill", isIOSFamily ? (isVision ? "rgb(118 118 128 / 0.18)" : "rgb(116 116 128 / 0.08)") : "rgb(0 0 0 / 0.03)");
+    }
+
+    let styleElement = document.createElement("style");
+    styleElement.innerHTML = style;
+    document.head.appendChild(styleElement);
+
+    const iconSize = isIOSFamily ? (isVision ? 40 : 72) : 52;
+
+    const attachments = [...document.getElementsByClassName("attachment")];
+    for (attachment of attachments) {
+        function addChild(parent, type, className, innerText)
+        {
+            let child = document.createElement(type);
+            if (attachment.id) {
+                child.id = attachment.id + "-" + className;
+            }
+            child.className = className;
+            child.style = style;
+            if (innerText !== undefined) {
+                child.innerText = innerText;
+            }
+            parent.appendChild(child);
+            return child;
+        }
+
+        let action = "";
+        let title = "";
+        let subtitle = "";
+        let progress = "0";
+        for (const attr of attachment.attributes) {
+            switch (attr.name) {
+            case "action": action = attr.value; break;
+            case "title": title = attr.value; break;
+            case "subtitle": subtitle = attr.value; break;
+            case "progress": progress = attr.value; break;
+            }
+        }
+
+        // Same tree structure as created in HTMLAttachmentElement::ensureWideLayoutShadowTree().
+        let container = addChild(attachment, "div", "attachment-container");
+        container.style = `--icon-size: ${iconSize}px`;
+        {
+            let background = addChild(container, "div", "attachment-background");
+            {
+                let previewArea = addChild(background, "div", "attachment-preview-area");
+                {
+                    let image = addChild(previewArea, "img", "attachment-icon");
+                    let placeholder = addChild(previewArea, "div", "attachment-placeholder");
+                    let progressElement = addChild(previewArea, "div", "attachment-progress");
+
+                    // FIXME: Handle non-progress with fake icon.
+                    if (progress == "0") {
+                        image.style = "display: none";
+                        progressElement.style = "display: none";
+                    } else {
+                        image.style = "display: none";
+                        placeholder.style = "display: none";
+                        progressElement.style = "--progress: " + progress;
+                    }
+                }
+
+                let informationArea = addChild(background, "div", "attachment-information-area");
+                {
+                    let informationBlock = addChild(informationArea, "div", "attachment-information-block");
+                    {
+                        let actionText = addChild(informationBlock, "div", "attachment-action", action);
+                        let titleText = addChild(informationBlock, "div", "attachment-title", title);
+                        let subtitleText = addChild(informationBlock, "div", "attachment-subtitle", subtitle);
+                        // FIXME: Implement save button.
+                    }
+                }
+            }
+        }
+    }
+}
+
+function AugmentAttachmentClassElementsWithAttachmentTree()
+{
+    const attachments = [...document.getElementsByClassName("attachment")];
+    for (attachment of attachments) {
+        AugmentDivWithAttachmentTree(attachment);
+    }
 }

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -96,6 +96,16 @@ public:
     bool isWideLayout() const { return m_implementation == Implementation::WideLayout; }
     HTMLElement* wideLayoutShadowContainer() const { return m_containerElement.get(); }
     HTMLElement* wideLayoutImageElement() const;
+    WEBCORE_EXPORT static String shadowUserAgentStyleSheetText();
+
+    enum class HighlightState : uint8_t {
+        None, // The object is not selected.
+        Start, // The object either contains the start of a selection run or is the start of a run
+        Inside, // The object is fully encompassed by a selection run
+        End, // The object either contains the end of a selection run or is the end of a run
+        Both // The object contains an entire run or is the sole selected object in that run
+    };
+    void addSelectionClasses(HighlightState);
 
 private:
     friend class AttachmentSaveEventListener;

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -54,6 +54,20 @@ div#attachment-container {
     display: flex;
 }
 
+div#attachment-container.attachment-has-selection {
+    background-color: -apple-system-selected-text-background;
+}
+
+div#attachment-container.attachment-selection-continues-left {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+}
+
+div#attachment-container.attachment-selection-continues-right {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+}
+
 /* This div is needed to blend the transparent background color *over* the opaque container above. */
 div#attachment-background {
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
@@ -62,7 +76,7 @@ div#attachment-background {
     background-color: -apple-system-tertiary-fill;
 #endif
     width: 100%;
-    border-radius: inherit;
+    border-radius: 8px;
     display: flex;
 }
 

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -110,6 +110,19 @@ bool RenderAttachment::shouldDrawBorder() const
     return m_shouldDrawBorder;
 }
 
+void RenderAttachment::setSelectionState(HighlightState state)
+{
+    RenderReplaced::setSelectionState(state);
+
+    // HTMLAttachmentElement::HighlightState is duck-typed to match these RenderObject::HighlightState underlying values.
+    static_assert(uint8_t(HTMLAttachmentElement::HighlightState::None) == uint8_t(RenderObject::HighlightState::None));
+    static_assert(uint8_t(HTMLAttachmentElement::HighlightState::Start) == uint8_t(RenderObject::HighlightState::Start));
+    static_assert(uint8_t(HTMLAttachmentElement::HighlightState::Inside) == uint8_t(RenderObject::HighlightState::Inside));
+    static_assert(uint8_t(HTMLAttachmentElement::HighlightState::End) == uint8_t(RenderObject::HighlightState::End));
+    static_assert(uint8_t(HTMLAttachmentElement::HighlightState::Both) == uint8_t(RenderObject::HighlightState::Both));
+    attachmentElement().addSelectionClasses(HTMLAttachmentElement::HighlightState(uint8_t(state)));
+}
+
 void RenderAttachment::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& offset)
 {
     ASSERT(!isSkippedContentRoot(*this));

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -59,7 +59,8 @@ private:
     LayoutSize layoutWideLayoutAttachmentOnly();
     void layoutShadowContent(const LayoutSize&) override;
 
-    bool shouldDrawSelectionTint() const override { return isWideLayout(); }
+    bool shouldDrawSelectionTint() const final { return false; }
+    void setSelectionState(HighlightState) final;
     void paintReplaced(PaintInfo&, const LayoutPoint& offset) final;
 
     void layout() override;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7618,12 +7618,19 @@ void Internals::setContentSizeCategory(Internals::ContentSizeCategory category)
 #endif
 }
 
-#if ENABLE(ATTACHMENT_ELEMENT) && ENABLE(SERVICE_CONTROLS)
+#if ENABLE(ATTACHMENT_ELEMENT)
+#if ENABLE(SERVICE_CONTROLS)
 bool Internals::hasImageControls(const HTMLImageElement& element) const
 {
     return ImageControlsMac::hasImageControls(element);
 }
-#endif // ENABLE(ATTACHMENT_ELEMENT) && ENABLE(SERVICE_CONTROLS)
+#endif // ENABLE(SERVICE_CONTROLS)
+
+String Internals::attachmentElementShadowUserAgentStyleSheet() const
+{
+    return HTMLAttachmentElement::shadowUserAgentStyleSheetText();
+}
+#endif // ENABLE(ATTACHMENT_ELEMENT)
 
 #if ENABLE(MEDIA_SESSION)
 ExceptionOr<double> Internals::currentMediaSessionPosition(const MediaSession& session)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1533,9 +1533,12 @@ public:
     enum class ContentSizeCategory { L, XXXL };
     void setContentSizeCategory(ContentSizeCategory);
 
-#if ENABLE(ATTACHMENT_ELEMENT) && ENABLE(SERVICE_CONTROLS)
+#if ENABLE(ATTACHMENT_ELEMENT)
+#if ENABLE(SERVICE_CONTROLS)
     bool hasImageControls(const HTMLImageElement&) const;
-#endif // ENABLE(ATTACHMENT_ELEMENT) && ENABLE(SERVICE_CONTROLS)
+#endif // ENABLE(SERVICE_CONTROLS)
+    String attachmentElementShadowUserAgentStyleSheet() const;
+#endif // ENABLE(ATTACHMENT_ELEMENT)
 
 #if ENABLE(MEDIA_SESSION)
     ExceptionOr<double> currentMediaSessionPosition(const MediaSession&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1414,6 +1414,7 @@ enum ContentsFormat {
     undefined setContentSizeCategory(ContentSizeCategory category);
 
     [Conditional=ATTACHMENT_ELEMENT, Conditional=SERVICE_CONTROLS] boolean hasImageControls(HTMLImageElement element);
+    [Conditional=ATTACHMENT_ELEMENT] DOMString attachmentElementShadowUserAgentStyleSheet();
 
     [Conditional=MEDIA_SESSION] double currentMediaSessionPosition(MediaSession session);
     [Conditional=MEDIA_SESSION] undefined sendMediaSessionAction(MediaSession session, MediaSessionActionDetails actionDetails);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -26,6 +26,7 @@
 interface TestRunner {
     readonly attribute boolean isWebKit2;
     readonly attribute boolean isIOSFamily;
+    readonly attribute boolean isVision;
     readonly attribute boolean isMac;
     readonly attribute boolean isKeyboardImmediatelyAvailable;
     readonly attribute boolean keyboardAppearsOverContent;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -57,6 +57,15 @@ public:
 #endif
     }
 
+    bool isVision() const
+    {
+#if PLATFORM(VISION)
+        return true;
+#else
+        return false;
+#endif
+    }
+
     bool isMac() const
     {
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 0b0286ed2a676c84ff1ef81d26ed2b37e0ce7f84
<pre>
Let RenderAttachment handle the rendering of the selected state
<a href="https://bugs.webkit.org/show_bug.cgi?id=304374">https://bugs.webkit.org/show_bug.cgi?id=304374</a>
<a href="https://rdar.apple.com/111200272">rdar://111200272</a>

Reviewed by Cameron McCormack.

Instead of the default tinted transparent overlay (which modifies all
colors), attachments now handle the selected state by only modifying the
main brick background color, similar to how selected text only changes
its background-color.

When the renderer&apos;s selection state changes, CSS classes are added or
removed to control the eventual painting.

Bonus: The selection state also specifies if the selection ends at the
element or continues outside, so the border radius can be removed when
the selection continues outside of the element, otherwise gaps would be
visible at the corners.

This patch also adds a new type of reference tests, where the actual
attachment brick (with its shadow tree) is compared to a made-up pure
HTML DOM tree with the same styling, but where sub-elements can be
individually tweaked to match test expectations.

* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-expected.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-alone-expected.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-alone.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-expected.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-left-expected.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-left.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-right-expected.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended-right.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075-selected-extended.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-ref-progress-075.html: Added.
* LayoutTests/fast/attachment/resources/attachment-test-utils.js:
(assertInAttachmentTest): Actually surface script assertion failures
(takeScreenshot):
(takeScreenshotWhenAttachmentsSettled):
(AugmentDivWithAttachmentTree.addChild):
(AugmentDivWithAttachmentTree):
(AugmentAttachmentClassElementsWithAttachmentTree):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::shadowUserAgentStyleSheetText):
(WebCore::HTMLAttachmentElement::ensureWideLayoutShadowTree):
(WebCore::attachmentClassHasSelection):
(WebCore::attachmentClassSelectionContinuesLeft):
(WebCore::attachmentClassSelectionContinuesRight):
(WebCore::HTMLAttachmentElement::addSelectionClasses):
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container.attachment-has-selection):
(div#attachment-container.attachment-selection-continues-left):
(div#attachment-container.attachment-selection-continues-right):
(div#attachment-background):
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::setSelectionState):
* Source/WebCore/rendering/RenderAttachment.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::attachmentElementShadowUserAgentStyleSheet const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::isVision const):

Canonical link: <a href="https://commits.webkit.org/304918@main">https://commits.webkit.org/304918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58a0d4ccec460f4f54142ad18fa464ef34af870a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89839 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/623ad3a1-feff-4bf0-a9b6-77de598b5465) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104657 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/05bbfb11-ffb5-4815-8172-7d6e5f6436f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/410ca228-894e-46ca-af44-16c263c3c6f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6905 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4597 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5190 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8909 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113015 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6824 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118910 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63098 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8957 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36964 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8749 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->