### PR TITLE
Remove raw pointer hash table from WebGPU::Sampler

### DIFF
--- a/Source/WebGPU/WebGPU/Sampler.mm
+++ b/Source/WebGPU/WebGPU/Sampler.mm
@@ -176,8 +176,7 @@ static Sampler::UniqueSamplerIdentifier computeDescriptorHash(MTLSamplerDescript
     auto floatToUint32 = ^(float f) {
         return *reinterpret_cast<uint32_t*>(&f);
     };
-    std::array<uint32_t, 4> uintData = { miscHash(descriptor), floatToUint32(descriptor.lodMinClamp), floatToUint32(descriptor.lodMaxClamp), floatToUint32(descriptor.maxAnisotropy) };
-    return base64EncodeToString(asByteSpan(std::span { uintData }));
+    return std::array<uint32_t, 4> { miscHash(descriptor), floatToUint32(descriptor.lodMinClamp), floatToUint32(descriptor.lodMaxClamp), floatToUint32(descriptor.maxAnisotropy) };
 }
 
 static MTLSamplerDescriptor *createMetalDescriptorFromDescriptor(const WGPUSamplerDescriptor &descriptor)
@@ -241,7 +240,7 @@ Sampler::~Sampler()
 
     Locker locker { samplerStateLock };
     if (auto it = retainedSamplerStates->find(*m_samplerIdentifier); it != retainedSamplerStates->end()) {
-        it->value.apiSamplerList.remove(this);
+        it->value.apiSamplerList.remove(*m_samplerIdentifier);
         if (!it->value.apiSamplerList.size())
             retainedSamplerStates->remove(it);
     }
@@ -276,7 +275,7 @@ id<MTLSamplerState> Sampler::samplerState() const
     auto samplerIdentifier = *m_samplerIdentifier;
     if (auto it = retainedSamplerStates->find(samplerIdentifier); it != retainedSamplerStates->end()) {
         samplerState = it->value.samplerState.get();
-        it->value.apiSamplerList.add(this);
+        it->value.apiSamplerList.add(samplerIdentifier);
         lastAccessedKeys->appendOrMoveToLast(samplerIdentifier);
         if ((m_cachedSamplerState = samplerState))
             return samplerState;
@@ -307,7 +306,7 @@ id<MTLSamplerState> Sampler::samplerState() const
         .samplerState = samplerState,
         .apiSamplerList = { }
     });
-    addResult.iterator->value.apiSamplerList.add(this);
+    addResult.iterator->value.apiSamplerList.add(samplerIdentifier);
     lastAccessedKeys->appendOrMoveToLast(samplerIdentifier);
 
     m_cachedSamplerState = samplerState;


### PR DESCRIPTION
#### 1a66fec098c4c0729d840980ce992f834cb20533
<pre>
Remove raw pointer hash table from WebGPU::Sampler
<a href="https://bugs.webkit.org/show_bug.cgi?id=302598">https://bugs.webkit.org/show_bug.cgi?id=302598</a>
<a href="https://rdar.apple.com/164843430">rdar://164843430</a>

Reviewed by Chris Dumez.

As required by the SaferCPP bot.

Replaced Sampler* with UniqueSamplerIdentifier.

Also changed UniqueSamplerIdentifier from String to std::array&lt;uint32_t, 4&gt;.
We store UniqueSamplerIdentifier in cross-thread hash tables, so String is not
a great choice.

Canonical link: <a href="https://commits.webkit.org/303099@main">https://commits.webkit.org/303099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd511bcddd589e924d3d5ba8c179f5215ed129a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83033 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/86ec292e-2611-49bc-8e10-32888408560c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100038 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67791 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d6760363-ef94-4680-ba51-cd22ad6857a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80739 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8597db3b-6ae0-4914-b6e7-6d666ed2a28c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/247 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81987 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111138 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141237 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108556 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3413 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3009 "Found 1 new test failure: fast/images/individual-animation-toggle.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108501 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2540 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56521 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20416 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3429 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32284 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66837 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3451 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->