### PR TITLE
[GTK][WPE] Remove hybrid mode from SkiaPaintingEngine

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -45,28 +45,16 @@ class SkiaPaintingEngine {
     WTF_MAKE_TZONE_ALLOCATED(SkiaPaintingEngine);
     WTF_MAKE_NONCOPYABLE(SkiaPaintingEngine);
 public:
-    SkiaPaintingEngine(unsigned numberOfCPUThreads, unsigned numberOfGPUThreads);
+    SkiaPaintingEngine();
     ~SkiaPaintingEngine();
 
     static std::unique_ptr<SkiaPaintingEngine> create();
 
-    enum class HybridPaintingStrategy {
-        PreferCPUIfIdle,
-        PreferGPUIfIdle,
-        PreferGPUAboveMinimumArea,
-        MinimumFractionOfTasksUsingGPU,
-        CPUAffineRendering,
-        GPUAffineRendering
-    };
-
     static unsigned numberOfCPUPaintingThreads();
     static unsigned numberOfGPUPaintingThreads();
-    static unsigned minimumAreaForGPUPainting();
-    static float minimumFractionOfTasksUsingGPUPainting();
-    static HybridPaintingStrategy hybridPaintingStrategy();
     static bool shouldUseLinearTileTextures();
 
-    bool useThreadedRendering() const { return m_cpuWorkerPool || m_gpuWorkerPool; }
+    bool useThreadedRendering() const { return m_workerPool; }
 
     Ref<CoordinatedTileBuffer> paint(const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
     Ref<SkiaRecordingResult> record(const GraphicsLayer&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);
@@ -76,11 +64,7 @@ private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
 
-    bool isHybridMode() const;
-    RenderingMode decideHybridRenderingMode(const IntRect& dirtyRect, float contentsScale) const;
-
-    RefPtr<WorkerPool> m_cpuWorkerPool;
-    RefPtr<WorkerPool> m_gpuWorkerPool;
+    RefPtr<WorkerPool> m_workerPool;
     std::unique_ptr<BitmapTexturePool> m_texturePool;
 };
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -373,13 +373,11 @@ static String threadedRenderingInfo(const RenderProcessInfo& info)
     if (!info.cpuPaintingThreadsCount && !info.gpuPaintingThreadsCount)
         return "Disabled"_s;
 
-    if (!info.gpuPaintingThreadsCount)
+    if (info.cpuPaintingThreadsCount)
         return makeString("CPU ("_s, info.cpuPaintingThreadsCount, " threads)"_s);
 
-    if (!info.cpuPaintingThreadsCount)
-        return makeString("GPU ("_s, info.gpuPaintingThreadsCount, " threads)"_s);
-
-    return makeString("GPU ("_s, info.gpuPaintingThreadsCount, " threads), CPU ("_s, info.cpuPaintingThreadsCount, " threads)"_s);
+    ASSERT(info.gpuPaintingThreadsCount);
+    return makeString("GPU ("_s, info.gpuPaintingThreadsCount, " threads)"_s);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -44,6 +44,7 @@
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/PageOverlayController.h>
+#include <WebCore/ProcessCapabilities.h>
 #include <WebCore/RenderLayerBacking.h>
 #include <WebCore/RenderView.h>
 #include <WebCore/ScrollingThread.h>
@@ -621,8 +622,10 @@ void LayerTreeHost::foreachRegionInDamageHistoryForTesting(Function<void(const R
 void LayerTreeHost::fillGLInformation(RenderProcessInfo&& info, CompletionHandler<void(RenderProcessInfo&&)>&& completionHandler)
 {
 #if USE(SKIA)
-    info.cpuPaintingThreadsCount = SkiaPaintingEngine::numberOfCPUPaintingThreads();
-    info.gpuPaintingThreadsCount = SkiaPaintingEngine::numberOfGPUPaintingThreads();
+    if (ProcessCapabilities::canUseAcceleratedBuffers())
+        info.gpuPaintingThreadsCount = SkiaPaintingEngine::numberOfGPUPaintingThreads();
+    else
+        info.cpuPaintingThreadsCount = SkiaPaintingEngine::numberOfCPUPaintingThreads();
 #endif
     m_compositor->fillGLInformation(WTFMove(info), WTFMove(completionHandler));
 }

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
@@ -67,15 +67,6 @@ class WPEMiniBrowserSkiaCPUDriver(WPEMiniBrowserDriver):
         self._test_environ['WEBKIT_SKIA_ENABLE_CPU_RENDERING'] = '1'
 
 
-class WPEMiniBrowserNoHybridDriver(WPEMiniBrowserDriver):
-    browser_name = 'minibrowser-wpe-nohybrid'
-
-    def prepare_env(self, config):
-        super().prepare_env(config)
-        # Disabling CPU rendering threads disables hybrid mode.
-        self._test_environ['WEBKIT_SKIA_CPU_PAINTING_THREADS'] = '0'
-
-
 class WPEMiniBrowserLegacyAPIDriver(WPEMiniBrowserBaseDriver):
     browser_name = 'minibrowser-wpe-legacy'
 

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -95,8 +95,6 @@ class GtkPort(GLibPort):
             else:
                 _log.warning("Can't find Gallium llvmpipe driver. Try to run update-webkitgtk-libs")
 
-        # Gtk uses hybrid painting mode by default (preferring GPU) -- for deterministic tests we always want to use the GPU for Gtk.
-        environment['WEBKIT_SKIA_CPU_PAINTING_THREADS'] = '0'
         return environment
 
     def _generate_all_test_configurations(self):


### PR DESCRIPTION
#### eef9d9306ae6a89a062a23dbd3e1b44c2badac79
<pre>
[GTK][WPE] Remove hybrid mode from SkiaPaintingEngine
<a href="https://bugs.webkit.org/show_bug.cgi?id=302601">https://bugs.webkit.org/show_bug.cgi?id=302601</a>

Reviewed by Carlos Garcia Campos.

Remove the hybrid mode from SkiaPaintingEngine, revert to either
always use the GPU or CPU for rendering. After tuning the tile sizes
specifically for GPU rendering, there is no performance benefit left
justifying the complexity of the hybrid mode - get rid of it.

Covered by existing tests.

* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::SkiaPaintingEngine):
(WebCore::SkiaPaintingEngine::create):
(WebCore::SkiaPaintingEngine::record):
(WebCore::SkiaPaintingEngine::replay):
(WebCore::SkiaPaintingEngine::isHybridMode const): Deleted.
(WebCore::SkiaPaintingEngine::decideHybridRenderingMode const): Deleted.
(WebCore::SkiaPaintingEngine::minimumAreaForGPUPainting): Deleted.
(WebCore::SkiaPaintingEngine::minimumFractionOfTasksUsingGPUPainting): Deleted.
(WebCore::SkiaPaintingEngine::hybridPaintingStrategy): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
(WebCore::SkiaPaintingEngine::useThreadedRendering const):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::threadedRenderingInfo):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::fillGLInformation):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py:
(WPEMiniBrowserSkiaCPUDriver.prepare_env):
(WPEMiniBrowserNoHybridDriver): Deleted.
(WPEMiniBrowserNoHybridDriver.prepare_env): Deleted.
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/303171@main">https://commits.webkit.org/303171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c124e3d4cf01c4201934b0e59f49114e7cc71acf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139069 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134507 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81245 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/130909 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82261 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3637 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3685 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109048 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27629 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2755 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3698 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32491 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67109 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->