### PR TITLE
Reduce use of raw pointers in vectors in WebKit/

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/CDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.cpp
@@ -52,8 +52,8 @@ namespace WebCore {
 
 bool CDM::supportsKeySystem(const String& keySystem)
 {
-    for (auto* factory : CDMFactory::registeredFactories()) {
-        if (factory->supportsKeySystem(keySystem))
+    for (auto& weakFactory : CDMFactory::registeredFactories()) {
+        if (Ref { weakFactory.get() }->supportsKeySystem(keySystem))
             return true;
     }
     return false;
@@ -74,7 +74,8 @@ CDM::CDM(Document& document, const String& keySystem, const String& mediaKeysHas
     , m_mediaKeysHashSalt { mediaKeysHashSalt }
 {
     ASSERT(supportsKeySystem(keySystem));
-    for (auto* factory : CDMFactory::registeredFactories()) {
+    for (auto& weakFactory : CDMFactory::registeredFactories()) {
+        Ref factory = weakFactory.get();
         if (factory->supportsKeySystem(keySystem)) {
             m_private = factory->createCDM(keySystem, m_mediaKeysHashSalt, *this);
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/encryptedmedia/CDMFactory.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMFactory.cpp
@@ -38,9 +38,9 @@
 
 namespace WebCore {
 
-Vector<CDMFactory*>& CDMFactory::registeredFactories()
+Vector<WeakRef<CDMFactory>>& CDMFactory::registeredFactories()
 {
-    static NeverDestroyed<Vector<CDMFactory*>> factories;
+    static NeverDestroyed<Vector<WeakRef<CDMFactory>>> factories;
     static std::once_flag once;
     std::call_once(once, [&] {
         platformRegisterFactories(factories);
@@ -51,18 +51,18 @@ Vector<CDMFactory*>& CDMFactory::registeredFactories()
 
 void CDMFactory::registerFactory(CDMFactory& factory)
 {
-    ASSERT(!registeredFactories().contains(&factory));
-    registeredFactories().append(&factory);
+    ASSERT(!registeredFactories().containsIf([&](auto& item) { return item.ptr() == &factory; }));
+    registeredFactories().append(factory);
 }
 
 void CDMFactory::unregisterFactory(CDMFactory& factory)
 {
-    ASSERT(registeredFactories().contains(&factory));
-    registeredFactories().removeAll(&factory);
+    ASSERT(registeredFactories().containsIf([&](auto& item) { return item.ptr() == &factory; }));
+    registeredFactories().removeAllMatching([&](auto& item) { return item.ptr() == &factory; });
 }
 
 #if !USE(GSTREAMER) && !USE(AVFOUNDATION)
-void CDMFactory::platformRegisterFactories(Vector<CDMFactory*>&)
+void CDMFactory::platformRegisterFactories(Vector<WeakRef<CDMFactory>>&)
 {
 }
 #endif

--- a/Source/WebCore/platform/encryptedmedia/CDMFactory.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMFactory.h
@@ -30,6 +30,8 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include <memory>
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 
 #if !RELEASE_LOG_DISABLED
@@ -43,19 +45,19 @@ namespace WebCore {
 class CDMPrivate;
 class CDMPrivateClient;
 
-class CDMFactory {
+class CDMFactory : public AbstractRefCountedAndCanMakeWeakPtr<CDMFactory> {
 public:
     virtual ~CDMFactory() { };
     virtual std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) = 0;
     virtual bool supportsKeySystem(const String&) = 0;
 
-    WEBCORE_EXPORT static Vector<CDMFactory*>& registeredFactories();
+    WEBCORE_EXPORT static Vector<WeakRef<CDMFactory>>& registeredFactories();
     WEBCORE_EXPORT static void registerFactory(CDMFactory&);
     WEBCORE_EXPORT static void unregisterFactory(CDMFactory&);
 
     // Platform-specific function that's called when the list of
     // registered CDMFactory objects is queried for the first time.
-    WEBCORE_EXPORT static void platformRegisterFactories(Vector<CDMFactory*>&);
+    WEBCORE_EXPORT static void platformRegisterFactories(Vector<WeakRef<CDMFactory>>&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
@@ -60,6 +60,10 @@ public:
 
     virtual ~CDMFactoryClearKey();
 
+    // Do nothing since this is a singleton object.
+    void ref() const final { }
+    void deref() const final { }
+
     std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) final;
     bool supportsKeySystem(const String&) final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -271,10 +271,10 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& validInitDataT
     return validTypes;
 }
 
-void CDMFactory::platformRegisterFactories(Vector<CDMFactory*>& factories)
+void CDMFactory::platformRegisterFactories(Vector<WeakRef<CDMFactory>>& factories)
 {
-    factories.append(&CDMFactoryClearKey::singleton());
-    factories.append(&CDMFactoryFairPlayStreaming::singleton());
+    factories.append(CDMFactoryClearKey::singleton());
+    factories.append(CDMFactoryFairPlayStreaming::singleton());
 
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
@@ -44,6 +44,10 @@ public:
 
     virtual ~CDMFactoryFairPlayStreaming();
 
+    // Do nothing since this is a singleton object.
+    void ref() const final { }
+    void deref() const final { }
+
     std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) override;
     bool supportsKeySystem(const String&) override;
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMFactoryGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMFactoryGStreamer.cpp
@@ -39,10 +39,10 @@
 
 namespace WebCore {
 
-void CDMFactory::platformRegisterFactories(Vector<CDMFactory*>& factories)
+void CDMFactory::platformRegisterFactories(Vector<WeakRef<CDMFactory>>& factories)
 {
 #if ENABLE(THUNDER)
-    factories.append(&CDMFactoryThunder::singleton());
+    factories.append(CDMFactoryThunder::singleton());
 #else
     UNUSED_PARAM(factories);
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -60,6 +60,10 @@ public:
 
     virtual ~CDMFactoryThunder() = default;
 
+    // Do nothing since this is a singleton object.
+    void ref() const final { }
+    void deref() const final { }
+
     std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) final;
     RefPtr<CDMProxy> createCDMProxy(const String&) final;
     bool supportsKeySystem(const String&) final;

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -51,10 +51,13 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MockCDM> : s
 
 namespace WebCore {
 
-class MockCDMFactory : public RefCountedAndCanMakeWeakPtr<MockCDMFactory>, private CDMFactory {
+class MockCDMFactory : public RefCounted<MockCDMFactory>, public CDMFactory {
 public:
     static Ref<MockCDMFactory> create() { return adoptRef(*new MockCDMFactory); }
     ~MockCDMFactory();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     const Vector<AtomString>& supportedDataTypes() const { return m_supportedDataTypes; }
     void setSupportedDataTypes(Vector<String>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -63,12 +63,12 @@ static CDMFactory* factoryForKeySystem(const String& keySystem)
     auto foundIndex = factories.findIf([&] (auto& factory) { return factory->supportsKeySystem(keySystem); });
     if (foundIndex == notFound)
         return nullptr;
-    return factories[foundIndex];
+    return factories[foundIndex].ptr();
 }
 
 void RemoteCDMFactoryProxy::createCDM(const String& keySystem, const String& mediaKeysHashSalt, CompletionHandler<void(std::optional<RemoteCDMIdentifier>&&, RemoteCDMConfiguration&&)>&& completion)
 {
-    auto factory = factoryForKeySystem(keySystem);
+    RefPtr factory = factoryForKeySystem(keySystem);
     if (!factory) {
         completion(std::nullopt, { });
         return;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -366,14 +366,14 @@ void WebNotificationManagerProxy::providerDidRemoveNotificationPolicies(API::Arr
 
 void WebNotificationManagerProxy::getNotifications(const URL& url, const String& tag, PAL::SessionID sessionID, CompletionHandler<void(Vector<NotificationData>&&)>&& callback)
 {
-    Vector<WebNotification*> notifications;
+    Vector<Ref<WebNotification>> notifications;
     for (auto& notification : m_notifications.values()) {
         auto& data = notification->data();
         if (data.serviceWorkerRegistrationURL != url || data.sourceSession != sessionID)
             continue;
         if (!tag.isEmpty() && data.tag != tag)
             continue;
-        notifications.append(notification.ptr());
+        notifications.append(notification.copyRef());
     }
     // Let's sort as per https://notifications.spec.whatwg.org/#dom-serviceworkerregistration-getnotifications.
     std::ranges::sort(notifications, [](auto& a, auto& b) {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -59,9 +59,9 @@ void RemoteCDMFactory::deref() const
     return m_webProcess->deref();
 }
 
-void RemoteCDMFactory::registerFactory(Vector<CDMFactory*>& factories)
+void RemoteCDMFactory::registerFactory(Vector<WeakRef<CDMFactory>>& factories)
 {
-    factories.append(this);
+    factories.append(*this);
 }
 
 ASCIILiteral RemoteCDMFactory::supplementName()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -54,21 +54,20 @@ class WebProcess;
 
 class RemoteCDMFactory final
     : public WebCore::CDMFactory
-    , public WebProcessSupplement
-    , public CanMakeWeakPtr<RemoteCDMFactory> {
+    , public WebProcessSupplement {
     WTF_MAKE_TZONE_ALLOCATED(RemoteCDMFactory);
 public:
     explicit RemoteCDMFactory(WebProcess&);
     virtual ~RemoteCDMFactory();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
 
     GPUProcessConnection& gpuProcessConnection();
 
-    void registerFactory(Vector<WebCore::CDMFactory*>&);
+    void registerFactory(Vector<WeakRef<WebCore::CDMFactory>>&);
 
     void didReceiveSessionMessage(IPC::Connection&, IPC::Decoder&);
 


### PR DESCRIPTION
#### 6bcb5d2437c060e86e0e5f8511d20377a0664e89
<pre>
Reduce use of raw pointers in vectors in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=302602">https://bugs.webkit.org/show_bug.cgi?id=302602</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/encryptedmedia/CDM.cpp:
(WebCore::CDM::supportsKeySystem):
* Source/WebCore/platform/encryptedmedia/CDMFactory.cpp:
(WebCore::CDMFactory::registeredFactories):
(WebCore::CDMFactory::registerFactory):
(WebCore::CDMFactory::unregisterFactory):
(WebCore::CDMFactory::platformRegisterFactories):
(): Deleted.
* Source/WebCore/platform/encryptedmedia/CDMFactory.h:
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h:
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMFactory::platformRegisterFactories):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h:
* Source/WebCore/platform/graphics/gstreamer/eme/CDMFactoryGStreamer.cpp:
(WebCore::CDMFactory::platformRegisterFactories):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h:
* Source/WebCore/testing/MockCDMFactory.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::factoryForKeySystem):
(WebKit::RemoteCDMFactoryProxy::createCDM):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::getNotifications):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::registerFactory):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:

Canonical link: <a href="https://commits.webkit.org/303138@main">https://commits.webkit.org/303138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c4b8efa56b724987de62668e99e88f8b638d7d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131314 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83062 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d9b6427-16c9-4971-bb32-6337040e3171) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100054 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67815 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa05ee33-997a-4c68-8840-139f57231dd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80756 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3501470-c7e8-47f2-a511-33e8cabb4c24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2556 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82009 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141259 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3389 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108572 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108517 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2556 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56549 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3451 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32301 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3381 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->