### PR TITLE
Correct fast/multicol/vertical-rl/image-inside-nested-blocks-with-border.html

### DIFF
--- a/LayoutTests/fast/multicol/image-inside-nested-blocks-with-border-expected.txt
+++ b/LayoutTests/fast/multicol/image-inside-nested-blocks-with-border-expected.txt
@@ -1,1 +1,11 @@
-PASS
+Test that getBoundingClientRect works as expected on a float in the second column
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result.left is 300
+PASS result.top is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/multicol/image-inside-nested-blocks-with-border.html
+++ b/LayoutTests/fast/multicol/image-inside-nested-blocks-with-border.html
@@ -1,44 +1,25 @@
-<html>
-<body>
-<div id="tests" style="-webkit-column-count:2; -webkit-column-gap:0; -webkit-column-fill:auto; column-count:2; column-gap:0; column-fill:auto; height:300px; width:600px;">
-<div style="height:280px"></div>
-<div id="f1" style="border:5px solid black; float:left">
-<img style="display:block;width:140px;height:80px;">
-</div>
-</div>
-<div id="result"></div>
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
 <script>
+    description("Test that getBoundingClientRect works as expected on a float in the second column");
+</script>
+<body>
+    <div id="multicol" style="column-count:2; column-gap:0; column-fill:auto; height:300px; width:600px;">
+        <div style="height:280px;"></div>
+        <div id="f1" style="border:5px solid black; float:left;">
+            <img style="display:block; width:140px; height:80px;">
+        </div>
+    </div>
+    <script>
     function floatOffset(float)
     {
-        var parentRect = document.getElementById('tests').getBoundingClientRect();
+        var parentRect = document.getElementById("multicol").getBoundingClientRect();
         var rect = float.getBoundingClientRect();
-        return { width: rect.left - parentRect.left, height: rect.top - parentRect.top  };
+        return { left: rect.left - parentRect.left, top: rect.top - parentRect.top  };
     }
 
-    var tests = [
-        ["f1", 300, 0]
-    ];
-
-    var test;
-    var failures = 0;
-    while (test = tests.shift()) {
-        var float = document.getElementById(test[0]);
-        var result = floatOffset(float);
-        var passed = result.width === test[1] && result.height === test[2]
-        float.style.backgroundColor = passed ? "green" : "red";
-        if (!passed)
-            failures++
-    }
-
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        document.getElementById("tests").style.display = "none";
-    }
-
-    document.getElementById("result").innerText = failures ? "FAIL: " + failures + " cases failed" : "PASS";
-</script>
-
-
-
+    var result = floatOffset(document.getElementById("f1"));
+    shouldBe("result.left", "300");
+    shouldBe("result.top", "0");
+    </script>
 </body>
-</html>

--- a/LayoutTests/fast/multicol/vertical-lr/image-inside-nested-blocks-with-border-expected.txt
+++ b/LayoutTests/fast/multicol/vertical-lr/image-inside-nested-blocks-with-border-expected.txt
@@ -1,1 +1,11 @@
-PASS
+Test that getBoundingClientRect works as expected on a float in the second column - writing-mode is vertical-lr.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result.left is 0
+PASS result.top is 300
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/multicol/vertical-lr/image-inside-nested-blocks-with-border.html
+++ b/LayoutTests/fast/multicol/vertical-lr/image-inside-nested-blocks-with-border.html
@@ -1,44 +1,25 @@
-<html>
-<body style="-webkit-writing-mode: vertical-lr">
-<div id="tests" style="-webkit-column-count:2; -webkit-column-gap:0; -webkit-column-fill:auto; column-count:2; column-gap:0; column-fill:auto; width:300px; height:600px;">
-<div style="width:280px"></div>
-<div id="f1" style="border:5px solid black; float:left">
-<img style="display:block;height:140px;width:80px;">
-</div>
-</div>
-<div id="result"></div>
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
 <script>
+    description("Test that getBoundingClientRect works as expected on a float in the second column - writing-mode is vertical-lr.");
+</script>
+<body style="writing-mode:vertical-lr;">
+    <div id="multicol" style="column-count:2; column-gap:0; column-fill:auto; width:300px; height:600px;">
+        <div style="width:280px;"></div>
+        <div id="f1" style="border:5px solid black; float:left;">
+            <img style="display:block; height:140px; width:80px;">
+        </div>
+    </div>
+    <script>
     function floatOffset(float)
     {
-        var parentRect = document.getElementById('tests').getBoundingClientRect();
+        var parentRect = document.getElementById("multicol").getBoundingClientRect();
         var rect = float.getBoundingClientRect();
-        return { width: rect.left - parentRect.left, height: rect.top - parentRect.top  };
+        return { left: rect.left - parentRect.left, top: rect.top - parentRect.top  };
     }
 
-    var tests = [
-        ["f1", 0, 300]
-    ];
-
-    var test;
-    var failures = 0;
-    while (test = tests.shift()) {
-        var float = document.getElementById(test[0]);
-        var result = floatOffset(float);
-        var passed = result.width === test[1] && result.height === test[2]
-        float.style.backgroundColor = passed ? "green" : "red";
-        if (!passed)
-            failures++
-    }
-
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        document.getElementById("tests").style.display = "none";
-    }
-
-    document.getElementById("result").innerText = failures ? "FAIL: " + failures + " cases failed" : "PASS";
-</script>
-
-
-
+    var result = floatOffset(document.getElementById("f1"));
+    shouldBe("result.left", "0");
+    shouldBe("result.top", "300");
+    </script>
 </body>
-</html>

--- a/LayoutTests/fast/multicol/vertical-rl/image-inside-nested-blocks-with-border-expected.txt
+++ b/LayoutTests/fast/multicol/vertical-rl/image-inside-nested-blocks-with-border-expected.txt
@@ -1,2 +1,11 @@
-ALERT: 210 300
-FAIL: 1 cases failed
+Test that getBoundingClientRect works as expected on a float in the second column - writing-mode is vertical-rl.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result.left is 210
+PASS result.top is 300
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/multicol/vertical-rl/image-inside-nested-blocks-with-border.html
+++ b/LayoutTests/fast/multicol/vertical-rl/image-inside-nested-blocks-with-border.html
@@ -1,46 +1,26 @@
-<html>
-<body style="-webkit-writing-mode: vertical-rl">
-<div id="tests" style="-webkit-column-count:2; -webkit-column-gap:0; -webkit-column-fill:auto; column-count:2; column-gap:0; column-fill:auto; width:300px; height:600px;">
-<div style="width:280px"></div>
-<div id="f1" style="border:5px solid black; float:left">
-<img style="display:block;height:140px;width:80px;">
-</div>
-</div>
-<div id="result"></div>
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
 <script>
+    description("Test that getBoundingClientRect works as expected on a float in the second column - writing-mode is vertical-rl.");
+</script>
+<body style="writing-mode:vertical-rl;">
+    <div id="multicol" style="column-count:2; column-gap:0; column-fill:auto; width:300px; height:600px;">
+        <div style="width:280px;"></div>
+        <div id="f1" style="border:5px solid black; float:left;">
+            <img style="display:block; height:140px; width:80px;">
+        </div>
+    </div>
+    <script>
     function floatOffset(float)
     {
-        var parentRect = document.getElementById('tests').getBoundingClientRect();
+        var parentRect = document.getElementById("multicol").getBoundingClientRect();
         var rect = float.getBoundingClientRect();
-        return { width: rect.left - parentRect.left, height: rect.top - parentRect.top  };
+        return { left: rect.left - parentRect.left, top: rect.top - parentRect.top  };
     }
 
-    var tests = [
-        ["f1", 0, 300]
-    ];
-
-    var test;
-    var failures = 0;
-    while (test = tests.shift()) {
-        var float = document.getElementById(test[0]);
-        var result = floatOffset(float);
-        var passed = result.width === test[1] && result.height === test[2]
-        float.style.backgroundColor = passed ? "green" : "red";
-        if (!passed) {
-            failures++
-            alert(result.width + " " + result.height)
-        }
-    }
-
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        document.getElementById("tests").style.display = "none";
-    }
-
-    document.getElementById("result").innerText = failures ? "FAIL: " + failures + " cases failed" : "PASS";
-</script>
-
-
-
+    var result = floatOffset(document.getElementById("f1"));
+    shouldBe("result.left", "210");
+    shouldBe("result.top", "300");
+    </script>
 </body>
-</html>
+


### PR DESCRIPTION
#### b19437c8434527c76901df42c8cc950db5e19cc1
<pre>
Correct fast/multicol/vertical-rl/image-inside-nested-blocks-with-border.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=302606">https://bugs.webkit.org/show_bug.cgi?id=302606</a>
<a href="https://rdar.apple.com/164849032">rdar://164849032</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/c7376a0255a90880df56c2151697a8447116452e">https://chromium.googlesource.com/chromium/src.git/+/c7376a0255a90880df56c2151697a8447116452e</a>

We have a float at the beginning of the second column. The test wanted the
float to have its left edge flush with the left edge of the multicol container,
but this is vertical-rl writing mode, so it will instead have its right edge
flush with the right edge of the multicol container, since that&apos;s where columns
start in the block progression direction. So the test &quot;failed&quot; and was stored
as such in the expectation file. But both the layout engine and the behavior of
getBoundingClientRect were correct all along.

Corrected the test, and removed a bunch of boilerplate and turned it into
something using js-test.js instead. In order to be consistent, this also cleans
up the vertical-lr and horiontal-tb (default) variants in the same way as well.

* LayoutTests/fast/multicol/image-inside-nested-blocks-with-border-expected.txt:
* LayoutTests/fast/multicol/image-inside-nested-blocks-with-border.html:
* LayoutTests/fast/multicol/vertical-lr/image-inside-nested-blocks-with-border-expected.txt:
* LayoutTests/fast/multicol/vertical-lr/image-inside-nested-blocks-with-border.html:
* LayoutTests/fast/multicol/vertical-rl/image-inside-nested-blocks-with-border-expected.txt:
* LayoutTests/fast/multicol/vertical-rl/image-inside-nested-blocks-with-border.html:

Canonical link: <a href="https://commits.webkit.org/303103@main">https://commits.webkit.org/303103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3a358792ad737b3bb083d88acd503a8c1fc287a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83049 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cfdf7650-9f3d-4137-93ad-54aeab5d69b5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100049 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67803 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7027bfef-67b1-44cf-ae93-67cde5fa2eff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80751 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bf6b444e-99da-4cd1-a7a3-037787d199ce) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/276 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81999 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141249 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3379 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108567 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27582 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2552 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56538 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3441 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32294 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3263 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3463 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->