### PR TITLE
Stop storing `Connection::SyncMessageState` as a raw pointer inside a HashMap

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -651,9 +651,7 @@ private:
     SerialFunctionDispatcher& dispatcher();
 
     class SyncMessageState;
-    struct SyncMessageStateRelease {
-        void operator()(SyncMessageState*) const;
-    };
+    RefPtr<SyncMessageState> protectedSyncState() const;
 
     void addAsyncReplyHandler(AsyncReplyHandler&&);
     void addAsyncReplyHandlerWithDispatcher(AsyncReplyHandlerWithDispatcher&&);
@@ -682,7 +680,7 @@ private:
     };
 
     CheckedPtr<Client> m_client;
-    std::unique_ptr<SyncMessageState, SyncMessageStateRelease> m_syncState;
+    RefPtr<SyncMessageState> m_syncState;
     UniqueID m_uniqueID;
     bool m_isServer;
     std::atomic<bool> m_isValid { true };


### PR DESCRIPTION
#### 18ce3a5fb18350ddef137659855acf961be40c22
<pre>
Stop storing `Connection::SyncMessageState` as a raw pointer inside a HashMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=302607">https://bugs.webkit.org/show_bug.cgi?id=302607</a>

Reviewed by Darin Adler.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::getOrCreate):
(IPC::Connection::SyncMessageState::~SyncMessageState):
(IPC::Connection::enqueueMatchingMessagesToMessageReceiveQueue):
(IPC::Connection::open):
(IPC::Connection::waitForMessage):
(IPC::Connection::waitForSyncReply):
(IPC::Connection::processIncomingSyncReply):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::connectionDidClose):
(IPC::Connection::dispatchSyncMessage):
(IPC::Connection::dispatcher):
(IPC::Connection::dispatchSyncStateMessages):
(IPC::Connection::protectedSyncState const):
(IPC::Connection::SyncMessageState::dispatcher): Deleted.
(IPC::Connection::SyncMessageState::wakeUpClientRunLoop): Deleted.
(IPC::Connection::SyncMessageState::wait): Deleted.
(IPC::Connection::SyncMessageState::SyncMessageState): Deleted.
(IPC::Connection::SyncMessageState::ConnectionAndIncomingMessage::dispatch): Deleted.
(IPC::Connection::SyncMessageState::WTF_GUARDED_BY_LOCK): Deleted.
(IPC::Connection::SyncMessageState::get):
(IPC::Connection::SyncMessageStateRelease::operator() const): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:

Canonical link: <a href="https://commits.webkit.org/303164@main">https://commits.webkit.org/303164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee7c214c153677804dd0a51268214735ad652a25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139011 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a4df0c4f-7ab6-49d4-ba01-7a908e261964) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3676 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7a098e4-1fcd-4d7d-b550-52a2dab6280a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134450 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81195 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef2772d9-901c-4781-8f53-7c77a3f33f85) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82203 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141657 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3580 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36350 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3628 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3189 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2710 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114037 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56768 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32443 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3466 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67052 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->