### PR TITLE
[JSC] Remove stale assertion in VMManager::notifyVMStop()

### DIFF
--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -418,9 +418,6 @@ void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
     }
 
     m_numberOfStoppedVMs.exchangeSub(1);
-
-    // If we get here, we're either transitioning to RunOne or Running mode.
-    RELEASE_ASSERT(!m_targetVM || m_targetVM == &vm);
 }
 
 void VMManager::notifyVMConstruction(VM& vm)


### PR DESCRIPTION
#### 494a0858c52afce4086a385c8cc556328832a193
<pre>
[JSC] Remove stale assertion in VMManager::notifyVMStop()
<a href="https://bugs.webkit.org/show_bug.cgi?id=302608">https://bugs.webkit.org/show_bug.cgi?id=302608</a>
<a href="https://rdar.apple.com/164849609">rdar://164849609</a>

Reviewed by NOBODY (OOPS!).

The assertion RELEASE_ASSERT(!m_targetVM || m_targetVM == &amp;vm) at the end of
notifyVMStop() was incorrect for multi-VM WebAssembly debugging scenarios.

The race occurred when:
1. A stop-the-world completes and resumeTheWorld() is called, waking all VMs
2. The target VM (A) exits notifyVMStop() first and immediately hits another
    breakpoint, re-entering notifyVMStop()
3. VM A sets m_targetVM = A (becoming the new target for the new stop request)
4. Other VMs (B, C) are still exiting from the PREVIOUS resumeTheWorld request
5. VMs B and C execute the assertion and see m_targetVM = A but vm = B (or C)
6. The assertion fails

This is expected behavior: after a stop-the-world completes and VMs resume,
any VM can immediately hit a new breakpoint and become the new target while
other VMs are still exiting from the previous resume. The invariant
&quot;!m_targetVM || m_targetVM == &amp;vm&quot; only holds within the critical section
while servicing a stop request - it cannot be maintained after exiting
because new stop requests can legitimately designate a different target VM.

Another assertion inside the critical section already provides sufficient
validation of the targetVM state machine. The post-exit assertion was
attempting to enforce an invariant that does not hold at that point.

Tests: Multi-VM WebAssembly debugger stress tests will be added in a follow-up patch.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/494a0858c52afce4086a385c8cc556328832a193

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83054 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0a868f01-3202-4962-966b-e1df14a94e82) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/3712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67804 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6da51d77-d7fa-42f0-b31a-9536b3fcadb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134254 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2639 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80752 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/65eeabe6-2e63-49e4-a091-86b96602111d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82003 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123330 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141253 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129762 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108568 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3429 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3025 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108513 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2554 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56543 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3445 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32298 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162779 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66853 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->