### PR TITLE
[Swift in WebKit] Work towards proper WebGPU modularization (part 2)

### DIFF
--- a/Source/WebGPU/WebGPU/DDMesh.mm
+++ b/Source/WebGPU/WebGPU/DDMesh.mm
@@ -206,14 +206,14 @@ static DDBridgeSemantic convert(WGPUDDSemantic semantic)
 {
     switch (semantic) {
     case WGPUDDSemantic::Color:
-        return DDBridgeSemantic::kColor;
+        return DDBridgeSemanticColor;
     case WGPUDDSemantic::Vector:
-        return DDBridgeSemantic::kVector;
+        return DDBridgeSemanticVector;
     case WGPUDDSemantic::Scalar:
-        return DDBridgeSemantic::kScalar;
+        return DDBridgeSemanticScalar;
     case WGPUDDSemantic::Unknown:
     default:
-        return DDBridgeSemantic::kUnknown;
+        return DDBridgeSemanticUnknown;
     }
 }
 
@@ -235,55 +235,55 @@ static DDBridgeDataType convert(WGPUDDDataType type)
 {
     switch (type) {
     case WGPUDDDataType::kBool:
-        return DDBridgeDataType::kBool;
+        return DDBridgeDataTypeBool;
     case WGPUDDDataType::kInt:
-        return DDBridgeDataType::kInt;
+        return DDBridgeDataTypeInt;
     case WGPUDDDataType::kInt2:
-        return DDBridgeDataType::kInt2;
+        return DDBridgeDataTypeInt2;
     case WGPUDDDataType::kInt3:
-        return DDBridgeDataType::kInt3;
+        return DDBridgeDataTypeInt3;
     case WGPUDDDataType::kInt4:
-        return DDBridgeDataType::kInt4;
+        return DDBridgeDataTypeInt4;
     case WGPUDDDataType::kFloat:
-        return DDBridgeDataType::kFloat;
+        return DDBridgeDataTypeFloat;
     case WGPUDDDataType::kColor3f:
-        return DDBridgeDataType::kColor3f;
+        return DDBridgeDataTypeColor3f;
     case WGPUDDDataType::kColor3h:
-        return DDBridgeDataType::kColor3h;
+        return DDBridgeDataTypeColor3h;
     case WGPUDDDataType::kColor4f:
-        return DDBridgeDataType::kColor4f;
+        return DDBridgeDataTypeColor4f;
     case WGPUDDDataType::kColor4h:
-        return DDBridgeDataType::kColor4h;
+        return DDBridgeDataTypeColor4h;
     case WGPUDDDataType::kFloat2:
-        return DDBridgeDataType::kFloat2;
+        return DDBridgeDataTypeFloat2;
     case WGPUDDDataType::kFloat3:
-        return DDBridgeDataType::kFloat3;
+        return DDBridgeDataTypeFloat3;
     case WGPUDDDataType::kFloat4:
-        return DDBridgeDataType::kFloat4;
+        return DDBridgeDataTypeFloat4;
     case WGPUDDDataType::kHalf:
-        return DDBridgeDataType::kHalf;
+        return DDBridgeDataTypeHalf;
     case WGPUDDDataType::kHalf2:
-        return DDBridgeDataType::kHalf2;
+        return DDBridgeDataTypeHalf2;
     case WGPUDDDataType::kHalf3:
-        return DDBridgeDataType::kHalf3;
+        return DDBridgeDataTypeHalf3;
     case WGPUDDDataType::kHalf4:
-        return DDBridgeDataType::kHalf4;
+        return DDBridgeDataTypeHalf4;
     case WGPUDDDataType::kMatrix2f:
-        return DDBridgeDataType::kMatrix2f;
+        return DDBridgeDataTypeMatrix2f;
     case WGPUDDDataType::kMatrix3f:
-        return DDBridgeDataType::kMatrix3f;
+        return DDBridgeDataTypeMatrix3f;
     case WGPUDDDataType::kMatrix4f:
-        return DDBridgeDataType::kMatrix4f;
+        return DDBridgeDataTypeMatrix4f;
     case WGPUDDDataType::kSurfaceShader:
-        return DDBridgeDataType::kSurfaceShader;
+        return DDBridgeDataTypeSurfaceShader;
     case WGPUDDDataType::kGeometryModifier:
-        return DDBridgeDataType::kGeometryModifier;
+        return DDBridgeDataTypeGeometryModifier;
     case WGPUDDDataType::kString:
-        return DDBridgeDataType::kString;
+        return DDBridgeDataTypeString;
     case WGPUDDDataType::kToken:
-        return DDBridgeDataType::kToken;
+        return DDBridgeDataTypeToken;
     case WGPUDDDataType::kAsset:
-        return DDBridgeDataType::kAsset;
+        return DDBridgeDataTypeAsset;
     }
 }
 
@@ -313,13 +313,13 @@ static DDBridgeNodeType convert(WGPUDDNodeType bridgeNodeType)
 {
     switch (bridgeNodeType) {
     case WGPUDDNodeType::Builtin:
-        return DDBridgeNodeType::kBuiltin;
+        return DDBridgeNodeTypeBuiltin;
     case WGPUDDNodeType::Constant:
-        return DDBridgeNodeType::kConstant;
+        return DDBridgeNodeTypeConstant;
     case WGPUDDNodeType::Arguments:
-        return DDBridgeNodeType::kArguments;
+        return DDBridgeNodeTypeArguments;
     case WGPUDDNodeType::Results:
-        return DDBridgeNodeType::kResults;
+        return DDBridgeNodeTypeResults;
     }
 }
 
@@ -327,83 +327,83 @@ static DDBridgeConstant convert(const WGPUDDConstant constant)
 {
     switch (constant) {
     case WGPUDDConstant::kBool:
-        return DDBridgeConstant::kBool;
+        return DDBridgeConstantBool;
     case WGPUDDConstant::kUchar:
-        return DDBridgeConstant::kUchar;
+        return DDBridgeConstantUchar;
     case WGPUDDConstant::kInt:
-        return DDBridgeConstant::kInt;
+        return DDBridgeConstantInt;
     case WGPUDDConstant::kUint:
-        return DDBridgeConstant::kUint;
+        return DDBridgeConstantUint;
     case WGPUDDConstant::kHalf:
-        return DDBridgeConstant::kHalf;
+        return DDBridgeConstantHalf;
     case WGPUDDConstant::kFloat:
-        return DDBridgeConstant::kFloat;
+        return DDBridgeConstantFloat;
     case WGPUDDConstant::kTimecode:
-        return DDBridgeConstant::kTimecode;
+        return DDBridgeConstantTimecode;
     case WGPUDDConstant::kString:
-        return DDBridgeConstant::kString;
+        return DDBridgeConstantString;
     case WGPUDDConstant::kToken:
-        return DDBridgeConstant::kToken;
+        return DDBridgeConstantToken;
     case WGPUDDConstant::kAsset:
-        return DDBridgeConstant::kAsset;
+        return DDBridgeConstantAsset;
     case WGPUDDConstant::kMatrix2f:
-        return DDBridgeConstant::kMatrix2f;
+        return DDBridgeConstantMatrix2f;
     case WGPUDDConstant::kMatrix3f:
-        return DDBridgeConstant::kMatrix3f;
+        return DDBridgeConstantMatrix3f;
     case WGPUDDConstant::kMatrix4f:
-        return DDBridgeConstant::kMatrix4f;
+        return DDBridgeConstantMatrix4f;
     case WGPUDDConstant::kQuatf:
-        return DDBridgeConstant::kQuatf;
+        return DDBridgeConstantQuatf;
     case WGPUDDConstant::kQuath:
-        return DDBridgeConstant::kQuath;
+        return DDBridgeConstantQuath;
     case WGPUDDConstant::kFloat2:
-        return DDBridgeConstant::kFloat2;
+        return DDBridgeConstantFloat2;
     case WGPUDDConstant::kHalf2:
-        return DDBridgeConstant::kHalf2;
+        return DDBridgeConstantHalf2;
     case WGPUDDConstant::kInt2:
-        return DDBridgeConstant::kInt2;
+        return DDBridgeConstantInt2;
     case WGPUDDConstant::kFloat3:
-        return DDBridgeConstant::kFloat3;
+        return DDBridgeConstantFloat3;
     case WGPUDDConstant::kHalf3:
-        return DDBridgeConstant::kHalf3;
+        return DDBridgeConstantHalf3;
     case WGPUDDConstant::kInt3:
-        return DDBridgeConstant::kInt3;
+        return DDBridgeConstantInt3;
     case WGPUDDConstant::kFloat4:
-        return DDBridgeConstant::kFloat4;
+        return DDBridgeConstantFloat4;
     case WGPUDDConstant::kHalf4:
-        return DDBridgeConstant::kHalf4;
+        return DDBridgeConstantHalf4;
     case WGPUDDConstant::kInt4:
-        return DDBridgeConstant::kInt4;
+        return DDBridgeConstantInt4;
 
     // semantic:
     case WGPUDDConstant::kPoint3f:
-        return DDBridgeConstant::kPoint3f;
+        return DDBridgeConstantPoint3f;
     case WGPUDDConstant::kPoint3h:
-        return DDBridgeConstant::kPoint3h;
+        return DDBridgeConstantPoint3h;
     case WGPUDDConstant::kNormal3f:
-        return DDBridgeConstant::kNormal3f;
+        return DDBridgeConstantNormal3f;
     case WGPUDDConstant::kNormal3h:
-        return DDBridgeConstant::kNormal3h;
+        return DDBridgeConstantNormal3h;
     case WGPUDDConstant::kVector3f:
-        return DDBridgeConstant::kVector3f;
+        return DDBridgeConstantVector3f;
     case WGPUDDConstant::kVector3h:
-        return DDBridgeConstant::kVector3h;
+        return DDBridgeConstantVector3h;
     case WGPUDDConstant::kColor3f:
-        return DDBridgeConstant::kColor3f;
+        return DDBridgeConstantColor3f;
     case WGPUDDConstant::kColor3h:
-        return DDBridgeConstant::kColor3h;
+        return DDBridgeConstantColor3h;
     case WGPUDDConstant::kColor4f:
-        return DDBridgeConstant::kColor4f;
+        return DDBridgeConstantColor4f;
     case WGPUDDConstant::kColor4h:
-        return DDBridgeConstant::kColor4h;
+        return DDBridgeConstantColor4h;
     case WGPUDDConstant::kTexCoord2h:
-        return DDBridgeConstant::kTexCoord2h;
+        return DDBridgeConstantTexCoord2h;
     case WGPUDDConstant::kTexCoord2f:
-        return DDBridgeConstant::kTexCoord2f;
+        return DDBridgeConstantTexCoord2f;
     case WGPUDDConstant::kTexCoord3h:
-        return DDBridgeConstant::kTexCoord3h;
+        return DDBridgeConstantTexCoord3h;
     case WGPUDDConstant::kTexCoord3f:
-        return DDBridgeConstant::kTexCoord3f;
+        return DDBridgeConstantTexCoord3f;
     }
 }
 

--- a/Source/WebGPU/WebGPU/DDModelTypes.h
+++ b/Source/WebGPU/WebGPU/DDModelTypes.h
@@ -158,24 +158,24 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @end
 
-enum class DDBridgeSemantic {
-    kColor,
-    kVector,
-    kScalar,
-    kUnknown
+typedef NS_ENUM(NSInteger, DDBridgeSemantic) {
+    DDBridgeSemanticColor,
+    DDBridgeSemanticVector,
+    DDBridgeSemanticScalar,
+    DDBridgeSemanticUnknown
 };
 
 @interface DDBridgeImageAsset : NSObject
 
 @property (nonatomic, nullable, strong, readonly) NSData *data;
-@property (nonatomic, readonly) NSUInteger width;
-@property (nonatomic, readonly) NSUInteger height;
-@property (nonatomic, readonly) NSUInteger bytesPerPixel;
+@property (nonatomic, readonly) unsigned long width;
+@property (nonatomic, readonly) unsigned long height;
+@property (nonatomic, readonly) unsigned long bytesPerPixel;
 @property (nonatomic, readonly) DDBridgeSemantic semantic;
 @property (nonatomic, readonly, strong) NSString *path;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithData:(nullable NSData *)data width:(NSUInteger)width height:(NSUInteger)height bytesPerPixel:(NSUInteger)bytesPerPixel semantic:(DDBridgeSemantic)semantic path:(NSString *)path NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithData:(nullable NSData *)data width:(unsigned long)width height:(unsigned long)height bytesPerPixel:(unsigned long)bytesPerPixel semantic:(DDBridgeSemantic)semantic path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -212,42 +212,42 @@ enum class DDBridgeSemantic {
 
 @end
 
-enum class DDBridgeDataType {
-    kBool,
-    kInt,
-    kInt2,
-    kInt3,
-    kInt4,
-    kFloat,
-    kColor3f,
-    kColor3h,
-    kColor4f,
-    kColor4h,
-    kFloat2,
-    kFloat3,
-    kFloat4,
-    kHalf,
-    kHalf2,
-    kHalf3,
-    kHalf4,
-    kMatrix2f,
-    kMatrix3f,
-    kMatrix4f,
-    kSurfaceShader,
-    kGeometryModifier,
-    kString,
-    kToken,
-    kAsset
+typedef NS_ENUM(NSInteger, DDBridgeDataType) {
+    DDBridgeDataTypeBool,
+    DDBridgeDataTypeInt,
+    DDBridgeDataTypeInt2,
+    DDBridgeDataTypeInt3,
+    DDBridgeDataTypeInt4,
+    DDBridgeDataTypeFloat,
+    DDBridgeDataTypeColor3f,
+    DDBridgeDataTypeColor3h,
+    DDBridgeDataTypeColor4f,
+    DDBridgeDataTypeColor4h,
+    DDBridgeDataTypeFloat2,
+    DDBridgeDataTypeFloat3,
+    DDBridgeDataTypeFloat4,
+    DDBridgeDataTypeHalf,
+    DDBridgeDataTypeHalf2,
+    DDBridgeDataTypeHalf3,
+    DDBridgeDataTypeHalf4,
+    DDBridgeDataTypeMatrix2f,
+    DDBridgeDataTypeMatrix3f,
+    DDBridgeDataTypeMatrix4f,
+    DDBridgeDataTypeSurfaceShader,
+    DDBridgeDataTypeGeometryModifier,
+    DDBridgeDataTypeString,
+    DDBridgeDataTypeToken,
+    DDBridgeDataTypeAsset
 };
 
 @interface DDBridgePrimvar : NSObject
 
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *referencedGeomPropName;
-@property (nonatomic, readonly) NSUInteger attributeFormat;
+@property (nonatomic, readonly) unsigned long attributeFormat;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithName:(NSString *)name referencedGeomPropName:(NSString *)referencedGeomPropName attributeFormat:(NSUInteger)attributeFormat NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(NSString *)name referencedGeomPropName:(NSString *)referencedGeomPropName attributeFormat:(unsigned long)attributeFormat NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -261,54 +261,54 @@ enum class DDBridgeDataType {
 
 @end
 
-enum class DDBridgeConstant {
-    kBool,
-    kUchar,
-    kInt,
-    kUint,
-    kHalf,
-    kFloat,
-    kTimecode,
-    kString,
-    kToken,
-    kAsset,
-    kMatrix2f,
-    kMatrix3f,
-    kMatrix4f,
-    kQuatf,
-    kQuath,
-    kFloat2,
-    kHalf2,
-    kInt2,
-    kFloat3,
-    kHalf3,
-    kInt3,
-    kFloat4,
-    kHalf4,
-    kInt4,
+typedef NS_ENUM(NSInteger, DDBridgeConstant) {
+    DDBridgeConstantBool,
+    DDBridgeConstantUchar,
+    DDBridgeConstantInt,
+    DDBridgeConstantUint,
+    DDBridgeConstantHalf,
+    DDBridgeConstantFloat,
+    DDBridgeConstantTimecode,
+    DDBridgeConstantString,
+    DDBridgeConstantToken,
+    DDBridgeConstantAsset,
+    DDBridgeConstantMatrix2f,
+    DDBridgeConstantMatrix3f,
+    DDBridgeConstantMatrix4f,
+    DDBridgeConstantQuatf,
+    DDBridgeConstantQuath,
+    DDBridgeConstantFloat2,
+    DDBridgeConstantHalf2,
+    DDBridgeConstantInt2,
+    DDBridgeConstantFloat3,
+    DDBridgeConstantHalf3,
+    DDBridgeConstantInt3,
+    DDBridgeConstantFloat4,
+    DDBridgeConstantHalf4,
+    DDBridgeConstantInt4,
 
     // semantic types
-    kPoint3f,
-    kPoint3h,
-    kNormal3f,
-    kNormal3h,
-    kVector3f,
-    kVector3h,
-    kColor3f,
-    kColor3h,
-    kColor4f,
-    kColor4h,
-    kTexCoord2h,
-    kTexCoord2f,
-    kTexCoord3h,
-    kTexCoord3f
+    DDBridgeConstantPoint3f,
+    DDBridgeConstantPoint3h,
+    DDBridgeConstantNormal3f,
+    DDBridgeConstantNormal3h,
+    DDBridgeConstantVector3f,
+    DDBridgeConstantVector3h,
+    DDBridgeConstantColor3f,
+    DDBridgeConstantColor3h,
+    DDBridgeConstantColor4f,
+    DDBridgeConstantColor4h,
+    DDBridgeConstantTexCoord2h,
+    DDBridgeConstantTexCoord2f,
+    DDBridgeConstantTexCoord3h,
+    DDBridgeConstantTexCoord3f
 };
 
-enum class DDBridgeNodeType {
-    kBuiltin,
-    kConstant,
-    kArguments,
-    kResults
+typedef NS_ENUM(NSInteger, DDBridgeNodeType) {
+    DDBridgeNodeTypeBuiltin,
+    DDBridgeNodeTypeConstant,
+    DDBridgeNodeTypeArguments,
+    DDBridgeNodeTypeResults
 };
 
 @interface DDValueString : NSObject

--- a/Source/WebGPU/WebGPU/Internal/module.modulemap
+++ b/Source/WebGPU/WebGPU/Internal/module.modulemap
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-module WebGPU_Internal {
+module WebGPU_Internal [system] {
     umbrella header "WebGPUSwiftInternal.h"
     module * {
         export *


### PR DESCRIPTION
#### dbc483b29505781771b9c8335cdea707bf301b6d
<pre>
[Swift in WebKit] Work towards proper WebGPU modularization (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=302613">https://bugs.webkit.org/show_bug.cgi?id=302613</a>
<a href="https://rdar.apple.com/164853644">rdar://164853644</a>

Reviewed by Mike Wyrzykowski.

- All modules should have the `[system]` attribute. In this mode, `NSUInteger` is translated to Swift as `Int`.
Consequently, update some properties in `DDModelTypes` to stop using NSUInteger; for properties that just need
&quot;some reasonably large limited&quot; number, they should just use `NSInteger`, and properties that require a specific
width integer type should just use that type directly.

- All declarations in `DDModelTypes.h` are Objective-C, except for the enum declarations which are nonsensically
C++ enums instead of Objective C enums. Convert them to Objective C enums to be more consistent and substantially
easier to use in Swift.

* Source/WebGPU/WebGPU/DDMesh.mm:
(WebGPU::convert):
* Source/WebGPU/WebGPU/DDModelTypes.h:
* Source/WebGPU/WebGPU/Internal/module.modulemap:

Canonical link: <a href="https://commits.webkit.org/303258@main">https://commits.webkit.org/303258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2096e353cb48f61d46f56be2fad018c77e2ea5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83582 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e3d5eab-7974-44d4-8004-308c8d0b25cc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100687 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68119 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/949941b1-9761-4fcf-b669-f94f055d782a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134663 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81463 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/91c0c1c9-dcab-46b0-b7e1-c6909dd45efb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82448 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111661 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141872 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36684 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3427 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2955 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114261 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57088 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3932 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32675 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3764 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->