### PR TITLE
AVTrackPrivateAVFObjCImpl.mm has incorrect threading assumptions

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -121,8 +121,6 @@ void AVTrackPrivateAVFObjCImpl::initializationCompleted()
 
 bool AVTrackPrivateAVFObjCImpl::enabled() const
 {
-    assertIsMainThread();
-
     if (m_playerItemTrack)
         return [m_playerItemTrack isEnabled];
     if (RefPtr mediaSelectionOption = m_mediaSelectionOption)
@@ -133,8 +131,6 @@ bool AVTrackPrivateAVFObjCImpl::enabled() const
 
 void AVTrackPrivateAVFObjCImpl::setEnabled(bool enabled)
 {
-    assertIsMainThread();
-
     if (m_playerItemTrack)
         [m_playerItemTrack setEnabled:enabled];
     else if (RefPtr mediaSelectionOption = m_mediaSelectionOption)
@@ -145,8 +141,6 @@ void AVTrackPrivateAVFObjCImpl::setEnabled(bool enabled)
 
 AudioTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::audioKind() const
 {
-    assertIsMainThread();
-
     if (m_assetTrack) {
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicIsAuxiliaryContent])
             return AudioTrackPrivate::Kind::Alternative;
@@ -174,8 +168,6 @@ AudioTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::audioKind() const
 
 VideoTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::videoKind() const
 {
-    assertIsMainThread();
-
     if (m_assetTrack) {
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicDescribesVideoForAccessibility])
             return VideoTrackPrivate::Kind::Sign;
@@ -207,8 +199,6 @@ VideoTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::videoKind() const
 
 InbandTextTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::textKindForAVAssetTrack(const AVAssetTrack *track)
 {
-    assertIsMainThread();
-
     RetainPtr mediaType = [track mediaType];
     if ([mediaType isEqualToString:AVMediaTypeClosedCaption])
         return InbandTextTrackPrivate::Kind::Captions;
@@ -239,8 +229,6 @@ InbandTextTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::textKindForAVAssetTrack(
 
 InbandTextTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::textKindForAVMediaSelectionOption(const AVMediaSelectionOption *option)
 {
-    assertIsMainThread();
-
     RetainPtr mediaType = [option mediaType];
     if ([mediaType isEqualToString:AVMediaTypeClosedCaption])
         return InbandTextTrackPrivate::Kind::Captions;
@@ -264,8 +252,6 @@ InbandTextTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::textKindForAVMediaSelect
 
 InbandTextTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::textKind() const
 {
-    assertIsMainThread();
-
     if (m_assetTrack)
         return textKindForAVAssetTrack(m_assetTrack.get());
 
@@ -277,8 +263,6 @@ InbandTextTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::textKind() const
 
 int AVTrackPrivateAVFObjCImpl::index() const
 {
-    assertIsMainThread();
-
     if (m_assetTrack)
         return [[[m_assetTrack asset] tracks] indexOfObject:m_assetTrack.get()];
     if (RefPtr mediaSelectionOption = m_mediaSelectionOption)
@@ -289,8 +273,6 @@ int AVTrackPrivateAVFObjCImpl::index() const
 
 TrackID AVTrackPrivateAVFObjCImpl::id() const
 {
-    assertIsMainThread();
-
     if (m_assetTrack)
         return [m_assetTrack trackID];
     if (m_mediaSelectionOption)
@@ -301,8 +283,6 @@ TrackID AVTrackPrivateAVFObjCImpl::id() const
 
 String AVTrackPrivateAVFObjCImpl::label() const
 {
-    assertIsMainThread();
-
     ASSERT(m_assetTrack || m_mediaSelectionOption);
 
     RetainPtr<NSArray> commonMetadata = nil;
@@ -324,8 +304,6 @@ String AVTrackPrivateAVFObjCImpl::label() const
 
 String AVTrackPrivateAVFObjCImpl::language() const
 {
-    assertIsMainThread();
-
     if (m_assetTrack) {
         auto language = languageForAVAssetTrack(m_assetTrack.get());
         if (!language.isEmpty())
@@ -343,8 +321,6 @@ String AVTrackPrivateAVFObjCImpl::language() const
 
 String AVTrackPrivateAVFObjCImpl::languageForAVAssetTrack(const AVAssetTrack *track)
 {
-    assertIsMainThread();
-
     RetainPtr language = [track extendedLanguageTag];
 
     // If the language code is stored as a QuickTime 5-bit packed code there aren't enough bits for a full
@@ -362,8 +338,6 @@ String AVTrackPrivateAVFObjCImpl::languageForAVAssetTrack(const AVAssetTrack *tr
 
 String AVTrackPrivateAVFObjCImpl::languageForAVMediaSelectionOption(const AVMediaSelectionOption *option)
 {
-    assertIsMainThread();
-
     RetainPtr language = [option extendedLanguageTag];
 
     // If the language code is stored as a QuickTime 5-bit packed code there aren't enough bits for a full
@@ -419,8 +393,6 @@ void AVTrackPrivateAVFObjCImpl::setAudioTrackConfigurationObserver(AudioTrackCon
 
 static RetainPtr<CMFormatDescriptionRef> formatDescriptionFor(const AVTrackPrivateAVFObjCImpl& impl)
 {
-    assertIsMainThread();
-
     auto assetTrack = assetTrackFor(impl);
     if (!assetTrack || [assetTrack statusOfValueForKey:@"formatDescriptions" error:nil] != AVKeyValueStatusLoaded)
         return nullptr;
@@ -435,8 +407,6 @@ String AVTrackPrivateAVFObjCImpl::codec() const
 
 uint32_t AVTrackPrivateAVFObjCImpl::width() const
 {
-    assertIsMainThread();
-
     if (auto assetTrack = assetTrackFor(*this))
         return assetTrack.naturalSize.width;
     ASSERT_NOT_REACHED();
@@ -445,8 +415,6 @@ uint32_t AVTrackPrivateAVFObjCImpl::width() const
 
 uint32_t AVTrackPrivateAVFObjCImpl::height() const
 {
-    assertIsMainThread();
-
     if (auto assetTrack = assetTrackFor(*this))
         return assetTrack.naturalSize.height;
     ASSERT_NOT_REACHED();
@@ -455,8 +423,6 @@ uint32_t AVTrackPrivateAVFObjCImpl::height() const
 
 PlatformVideoColorSpace AVTrackPrivateAVFObjCImpl::colorSpace() const
 {
-    assertIsMainThread();
-
     if (auto colorSpace = colorSpaceFromFormatDescription(formatDescriptionFor(*this).get()))
         return *colorSpace;
     return { };
@@ -464,8 +430,6 @@ PlatformVideoColorSpace AVTrackPrivateAVFObjCImpl::colorSpace() const
 
 double AVTrackPrivateAVFObjCImpl::framerate() const
 {
-    assertIsMainThread();
-
     auto assetTrack = assetTrackFor(*this);
     if (!assetTrack)
         return 0;
@@ -476,8 +440,6 @@ double AVTrackPrivateAVFObjCImpl::framerate() const
 
 uint32_t AVTrackPrivateAVFObjCImpl::sampleRate() const
 {
-    assertIsMainThread();
-
     auto formatDescription = formatDescriptionFor(*this);
     if (!formatDescription)
         return 0;
@@ -491,8 +453,6 @@ uint32_t AVTrackPrivateAVFObjCImpl::sampleRate() const
 
 uint32_t AVTrackPrivateAVFObjCImpl::numberOfChannels() const
 {
-    assertIsMainThread();
-
     auto formatDescription = formatDescriptionFor(*this);
     if (!formatDescription)
         return 0;
@@ -506,8 +466,6 @@ uint32_t AVTrackPrivateAVFObjCImpl::numberOfChannels() const
 
 uint64_t AVTrackPrivateAVFObjCImpl::bitrate() const
 {
-    assertIsMainThread();
-
     auto assetTrack = assetTrackFor(*this);
     if (!assetTrack)
         return 0;


### PR DESCRIPTION
#### fb8d83cd86b76b267a6cfa13dbd4cf2cc3fba39f
<pre>
AVTrackPrivateAVFObjCImpl.mm has incorrect threading assumptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=302622">https://bugs.webkit.org/show_bug.cgi?id=302622</a>
<a href="https://rdar.apple.com/164860959">rdar://164860959</a>

Reviewed by Jer Noble and Eric Carlson.

AVTrackPrivateAVFObjCImpl is created with immutable AVAssetTrack when
using with an AVStreamDataParser ; as such, the code is actually thread-safe.
When used over MSE and following webkit.org/b/302054 where we will move the
SourceBufferPrivate to a dedicated workqueue, those threading assumptions
are no longer valid.
We remove them.

* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::enabled const):
(WebCore::AVTrackPrivateAVFObjCImpl::setEnabled):
(WebCore::AVTrackPrivateAVFObjCImpl::audioKind const):
(WebCore::AVTrackPrivateAVFObjCImpl::videoKind const):
(WebCore::AVTrackPrivateAVFObjCImpl::textKindForAVAssetTrack):
(WebCore::AVTrackPrivateAVFObjCImpl::textKindForAVMediaSelectionOption):
(WebCore::AVTrackPrivateAVFObjCImpl::textKind const):
(WebCore::AVTrackPrivateAVFObjCImpl::index const):
(WebCore::AVTrackPrivateAVFObjCImpl::id const):
(WebCore::AVTrackPrivateAVFObjCImpl::label const):
(WebCore::AVTrackPrivateAVFObjCImpl::language const):
(WebCore::AVTrackPrivateAVFObjCImpl::languageForAVAssetTrack):
(WebCore::AVTrackPrivateAVFObjCImpl::languageForAVMediaSelectionOption):
(WebCore::formatDescriptionFor):
(WebCore::AVTrackPrivateAVFObjCImpl::width const):
(WebCore::AVTrackPrivateAVFObjCImpl::height const):
(WebCore::AVTrackPrivateAVFObjCImpl::colorSpace const):
(WebCore::AVTrackPrivateAVFObjCImpl::framerate const):
(WebCore::AVTrackPrivateAVFObjCImpl::sampleRate const):
(WebCore::AVTrackPrivateAVFObjCImpl::numberOfChannels const):
(WebCore::AVTrackPrivateAVFObjCImpl::bitrate const):

Canonical link: <a href="https://commits.webkit.org/303160@main">https://commits.webkit.org/303160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11f20eb8ed03723cb71cb2b03002c0bfc0e155f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139030 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c086c88-8677-4732-924c-dfa4e3cd8f81) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3695 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/99e6cd64-03f8-4459-b948-b7aff4c3305e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81212 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a65dc17-e717-414d-85e1-9e8d489ec42a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82223 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141677 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3599 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3647 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27620 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/2726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114057 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/56787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3660 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32461 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67071 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->