### PR TITLE
[blocks-in-inline] Lines with blocks are contentful

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-block-only-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-block-only-expected.html
@@ -1,0 +1,7 @@
+<div style="width:100px; height:100px;background:red;">
+  <span>
+    <div style="height:50px; background:green;"></div>
+  </span>
+  <div style="height:50px; background:green;"></div>
+</div>
+

--- a/LayoutTests/fast/inline/blocks-in-inline-block-only.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-block-only.html
@@ -1,0 +1,8 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<div style="width:100px; height:100px;background:red;">
+  <span>
+    <div style="height:50px; background:green;"></div>
+  </span>
+  <div style="height:50px; background:green;"></div>
+</div>
+

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -66,6 +66,7 @@ LineBox LineBoxBuilder::build(size_t lineIndex)
         // Since we don't need to position and align block content inside the line, we don't need to create any boxes for this block content.
         auto lineBoxLogicalHeight = formattingContext().geometryForBox(runs[0].layoutBox()).marginBoxHeight();
         lineBox.setLogicalRect({ lineLayoutResult.lineGeometry.logicalTopLeft, lineLayoutResult.lineGeometry.logicalWidth, lineBoxLogicalHeight });
+        lineBox.setHasContent(true);
         setVerticalPropertiesForInlineLevelBox(lineBox, lineBox.rootInlineBox());
     } else {
         constructInlineLevelBoxes(lineBox);


### PR DESCRIPTION
#### 092ce66e3878982b2f020d791f0c1ce04e14e2d5
<pre>
[blocks-in-inline] Lines with blocks are contentful
<a href="https://bugs.webkit.org/show_bug.cgi?id=302627">https://bugs.webkit.org/show_bug.cgi?id=302627</a>
<a href="https://rdar.apple.com/problem/164876133">rdar://problem/164876133</a>

Reviewed by NOBODY (OOPS!).

Test: fast/inline/blocks-in-inline-block-only.html
* LayoutTests/fast/inline/blocks-in-inline-block-only-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-block-only.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::build):

We miscompute in LineLayout::contentLogicalHeight because we ignore the child lines that
have block content if they are the first or the last line.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/092ce66e3878982b2f020d791f0c1ce04e14e2d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83156 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/97d676a2-2b48-4bc6-8639-9bfd07df4af9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3560 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d0d61a7-2170-4ee1-b364-53b45677eb90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134334 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2696 "Found 1 new test failure: http/tests/site-isolation/history/navigate-same-site-iframe-into-new-process-and-go-back.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80968 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6cd9245c-ef3d-42c8-b57f-70884e7f39e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/345 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82086 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111221 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141478 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3463 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36248 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3094 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/108872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2617 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113935 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56638 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3525 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32356 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66933 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->