### PR TITLE
[WPE] WPE Platform: add getters to WPEClipboardContent

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
@@ -193,10 +193,10 @@ gint64 wpe_clipboard_get_change_count(WPEClipboard* clipboard)
  * wpe_clipboard_get_formats:
  * @clipboard: a #WPEClipoard
  *
- * Get the formats that clipboard can provide
+ * Get the MIME type formats that clipboard can provide
  *
  * Returns: (array zero-terminated=1) (element-type utf8) (transfer none): A %NULL-terminated
- *    array of formats, or %NULL if clipboard is empty.
+ *    array of MIME type formats, or %NULL if clipboard is empty.
  */
 const char* const* wpe_clipboard_get_formats(WPEClipboard* clipboard)
 {
@@ -257,9 +257,9 @@ WPEClipboardContent* wpe_clipboard_get_content(WPEClipboard* clipboard)
 /**
  * wpe_clipboard_read_bytes:
  * @clipboard: a #WPEClipoard
- * @format: the format of the text to read
+ * @format: the MIME type format of the text to read
  *
- * Get the contents of @clipboard for the given @format as bytes.
+ * Get the contents of @clipboard for the given MIME type @format as bytes.
  *
  * Returns: (transfer full) (nullable): a new #GBytes, or %NULL
  */
@@ -295,10 +295,10 @@ GBytes* wpe_clipboard_read_bytes(WPEClipboard* clipboard, const char* format)
 /**
  * wpe_clipboard_read_text:
  * @clipboard: a #WPEClipoard
- * @format: the format of the text to read
+ * @format: the MIME type format of the text to read
  * @size: (out) (optional): location to return size of returned text.
  *
- * Get the contents of @clipboard for the given @format as text.
+ * Get the contents of @clipboard for the given MIME type @format as text.
  *
  * Returns: (transfer full) (nullable): a new allocated string.
  */
@@ -382,12 +382,27 @@ void wpe_clipboard_content_set_text(WPEClipboardContent* content, const char* te
 }
 
 /**
+ * wpe_clipboard_content_get_text:
+ * @content: a #WPEClipboardContent
+ *
+ * Get the text on @content.
+ *
+ * Returns: (transfer none) (nullable): the text on @content or %NULL
+ */
+const char* wpe_clipboard_content_get_text(WPEClipboardContent* content)
+{
+    g_return_val_if_fail(content, nullptr);
+
+    return content->text ? content->text->data() : nullptr;
+}
+
+/**
  * wpe_clipboard_content_set_bytes:
  * @content: a #WPEClipboardContent
- * @format: a format
+ * @format: a MIME type format
  * @bytes: a #GBytes with the data to set
  *
- * Set @bytes data on @content for @format.
+ * Set @bytes data on @content for MIME type @format.
  */
 void wpe_clipboard_content_set_bytes(WPEClipboardContent* content, const char* format, GBytes* bytes)
 {
@@ -400,12 +415,32 @@ void wpe_clipboard_content_set_bytes(WPEClipboardContent* content, const char* f
 }
 
 /**
+ * wpe_clipboard_content_get_bytes:
+ * @content: a #WPEClipboardContent
+ * @format: a MIME type format
+ *
+ * Get a #GBytes with data on @content for MIME type @format.
+ *
+ * Returns: (transfer none) (nullable): the bytes on @content for MIME type @format or %NULL
+ */
+GBytes* wpe_clipboard_content_get_bytes(WPEClipboardContent* content, const char* format)
+{
+    g_return_val_if_fail(content, nullptr);
+    g_return_val_if_fail(format && *format, nullptr);
+
+    if (!content->buffers)
+        return nullptr;
+
+    return content->buffers->get(g_intern_string(format));
+}
+
+/**
  * wpe_clipboard_content_serialize:
  * @content: a #WPEClipboardContent
- * @format: a format
+ * @format: a MIME type format
  * @stream: a #GOutputStream
  *
- * Serialize @content for @format in @stream.
+ * Serialize @content for MIME type @format in @stream.
  *
  * Returns: %TRUE if content was correctly serialized, or %FALSE otherwise
  */

--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
@@ -77,9 +77,12 @@ WPE_API WPEClipboardContent *wpe_clipboard_content_ref        (WPEClipboardConte
 WPE_API void                 wpe_clipboard_content_unref      (WPEClipboardContent *content);
 WPE_API void                 wpe_clipboard_content_set_text   (WPEClipboardContent *content,
                                                                const char          *text);
+WPE_API const char          *wpe_clipboard_content_get_text   (WPEClipboardContent *content);
 WPE_API void                 wpe_clipboard_content_set_bytes  (WPEClipboardContent *content,
                                                                const char          *format,
                                                                GBytes              *bytes);
+WPE_API GBytes              *wpe_clipboard_content_get_bytes  (WPEClipboardContent *content,
+                                                               const char          *format);
 WPE_API gboolean             wpe_clipboard_content_serialize  (WPEClipboardContent *content,
                                                                const char          *format,
                                                                GOutputStream       *stream);


### PR DESCRIPTION
#### 7fced2ae3591f5f3c92e2e5e812b78bdf6e56be0
<pre>
[WPE] WPE Platform: add getters to WPEClipboardContent
<a href="https://bugs.webkit.org/show_bug.cgi?id=302629">https://bugs.webkit.org/show_bug.cgi?id=302629</a>

Reviewed by Adrian Perez de Castro.

Make it possible to get the text or bytes in a WPEClipboardContent.

Canonical link: <a href="https://commits.webkit.org/303381@main">https://commits.webkit.org/303381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5efad7d787d3266db812cd94f116624a8a55fec1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131368 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3698 "Hash 5efad7d7 for PR 54037 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83125 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3718 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3540 "Hash 5efad7d7 for PR 54037 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100331 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67846 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2596 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111204 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141572 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3489 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/3540 "Hash 5efad7d7 for PR 54037 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108939 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2600 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113920 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56612 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20547 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3505 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32342 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66913 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->