### PR TITLE
[CoordinatedGraphics] Rename flushLayers as updateRendering in LayerTreeHost

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -179,14 +179,12 @@ enum TracePointCode {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     GTKWPEPortRange = 20000,
 
-    FlushPendingLayerChangesStart,
-    FlushPendingLayerChangesEnd,
+    UpdateRenderingStart,
+    UpdateRenderingEnd,
     WaitForCompositionCompletionStart,
     WaitForCompositionCompletionEnd,
     RenderLayerTreeStart,
     RenderLayerTreeEnd,
-    LayerFlushStart,
-    LayerFlushEnd,
     UpdateLayerContentBuffersStart,
     UpdateLayerContentBuffersEnd,
 #endif

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -145,8 +145,7 @@ public:
         case BuildTransactionStart:
         case WaitForCompositionCompletionStart:
         case RenderLayerTreeStart:
-        case FlushPendingLayerChangesStart:
-        case LayerFlushStart:
+        case UpdateRenderingStart:
         case SyncMessageStart:
         case SyncTouchEventStart:
         case InitializeWebProcessStart:
@@ -209,8 +208,7 @@ public:
         case BackingStoreFlushEnd:
         case WaitForCompositionCompletionEnd:
         case RenderLayerTreeEnd:
-        case FlushPendingLayerChangesEnd:
-        case LayerFlushEnd:
+        case UpdateRenderingEnd:
         case BuildTransactionEnd:
         case SyncMessageEnd:
         case SyncTouchEventEnd:
@@ -497,18 +495,15 @@ private:
         case WakeUpAndApplyDisplayListEnd:
             return "WakeUpAndApplyDisplayList"_s;
 
-        case FlushPendingLayerChangesStart:
-        case FlushPendingLayerChangesEnd:
-            return "FlushPendingLayerChanges"_s;
+        case UpdateRenderingStart:
+        case UpdateRenderingEnd:
+            return "UpdateRendering"_s;
         case WaitForCompositionCompletionStart:
         case WaitForCompositionCompletionEnd:
             return "WaitForCompositionCompletion"_s;
         case RenderLayerTreeStart:
         case RenderLayerTreeEnd:
             return "RenderLayerTree"_s;
-        case LayerFlushStart:
-        case LayerFlushEnd:
-            return "LayerFlush"_s;
 
         case WTFRange:
         case JavaScriptRange:

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -169,7 +169,7 @@ void DrawingAreaCoordinatedGraphics::updateRenderingWithForcedRepaint()
     }
 
     if (!m_layerTreeStateIsFrozen)
-        m_layerTreeHost->forceRepaint();
+        m_layerTreeHost->updateRenderingWithForcedRepaint();
 }
 
 void DrawingAreaCoordinatedGraphics::updateRenderingWithForcedRepaintAsync(WebPage& page, CompletionHandler<void()>&& completionHandler)
@@ -182,7 +182,7 @@ void DrawingAreaCoordinatedGraphics::updateRenderingWithForcedRepaintAsync(WebPa
     if (m_layerTreeStateIsFrozen)
         return completionHandler();
 
-    m_layerTreeHost->forceRepaintAsync(WTFMove(completionHandler));
+    m_layerTreeHost->updateRenderingWithForcedRepaintAsync(WTFMove(completionHandler));
 }
 
 void DrawingAreaCoordinatedGraphics::setLayerTreeStateIsFrozen(bool isFrozen)
@@ -327,7 +327,7 @@ void DrawingAreaCoordinatedGraphics::triggerRenderingUpdate()
         return;
 
     if (m_layerTreeHost)
-        m_layerTreeHost->scheduleLayerFlush();
+        m_layerTreeHost->scheduleRenderingUpdate();
     else
         scheduleDisplay();
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -82,13 +82,12 @@ public:
     const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
     void setLayerTreeStateIsFrozen(bool);
 
-    void scheduleLayerFlush();
-    void cancelPendingLayerFlush();
     void setRootCompositingLayer(WebCore::GraphicsLayer*);
     void setViewOverlayRootLayer(WebCore::GraphicsLayer*);
 
-    void forceRepaint();
-    void forceRepaintAsync(CompletionHandler<void()>&&);
+    void scheduleRenderingUpdate();
+    void updateRenderingWithForcedRepaint();
+    void updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&&);
     void sizeDidChange();
 
     void pauseRendering();
@@ -123,8 +122,11 @@ public:
 private:
     void updateRootLayer();
     WebCore::FloatRect visibleContentsRect() const;
-    void layerFlushRunLoopObserverFired();
-    void flushLayers();
+
+    void scheduleRenderingUpdateRunLoopObserver();
+    void invalidateRenderingUpdateRunLoopObserver();
+    void renderingUpdateRunLoopObserverFired();
+    void updateRendering();
     void commitSceneState();
 
     // CoordinatedPlatformLayer::Client
@@ -161,7 +163,7 @@ private:
     bool m_layerTreeStateIsFrozen { false };
     bool m_pendingResize { false };
     bool m_pendingForceRepaint { false };
-    bool m_isFlushingLayers { false };
+    bool m_isUpdatingRendering { false };
     bool m_waitUntilPaintingComplete { false };
     bool m_isSuspended { false };
     bool m_isWaitingForRenderer { false };
@@ -176,7 +178,7 @@ private:
         CompletionHandler<void()> callback;
         std::optional<uint32_t> compositionRequestID;
     } m_forceRepaintAsync;
-    std::unique_ptr<WebCore::RunLoopObserver> m_layerFlushRunLoopObserver;
+    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
 #if USE(CAIRO)
     std::unique_ptr<WebCore::Cairo::PaintingEngine> m_paintingEngine;
 #elif USE(SKIA)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
@@ -95,13 +95,13 @@ public:
     const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
     void setLayerTreeStateIsFrozen(bool);
 
-    void scheduleLayerFlush();
-    void cancelPendingLayerFlush();
+    void scheduleRenderingUpdate();
+    void cancelRenderingUpdate();
     void setRootCompositingLayer(WebCore::GraphicsLayer*);
     void setViewOverlayRootLayer(WebCore::GraphicsLayer*);
 
-    void forceRepaint();
-    void forceRepaintAsync(CompletionHandler<void()>&&);
+    void updateRenderingWithForcedRepaint();
+    void updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&&);
     void sizeDidChange();
 
     void pauseRendering();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -141,7 +141,7 @@ void LayerTreeHost::setLayerTreeStateIsFrozen(bool)
 {
 }
 
-void LayerTreeHost::scheduleLayerFlush()
+void LayerTreeHost::scheduleRenderingUpdate()
 {
     if (!enabled())
         return;
@@ -150,11 +150,6 @@ void LayerTreeHost::scheduleLayerFlush()
         return;
 
     m_layerFlushTimer.startOneShot(0_s);
-}
-
-void LayerTreeHost::cancelPendingLayerFlush()
-{
-    m_layerFlushTimer.stop();
 }
 
 void LayerTreeHost::setRootCompositingLayer(WebCore::GraphicsLayer* graphicsLayer)
@@ -188,7 +183,7 @@ void LayerTreeHost::setNonCompositedContentsNeedDisplay(const WebCore::IntRect& 
     if (!enabled())
         return;
     m_rootLayer->setNeedsDisplayInRect(rect);
-    scheduleLayerFlush();
+    scheduleRenderingUpdate();
 }
 
 void LayerTreeHost::scrollNonCompositedContents(const WebCore::IntRect& scrollRect)
@@ -212,12 +207,12 @@ void LayerTreeHost::flushAndRenderLayers()
     compositeLayersToContext();
 }
 
-void LayerTreeHost::forceRepaint()
+void LayerTreeHost::updateRenderingWithForcedRepaint()
 {
     flushAndRenderLayers();
 }
 
-void LayerTreeHost::forceRepaintAsync(CompletionHandler<void()>&& completionHandler)
+void LayerTreeHost::updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&& completionHandler)
 {
     completionHandler();
 }
@@ -233,7 +228,7 @@ void LayerTreeHost::sizeDidChange()
     m_rootLayer->setSize(newSize);
     applyDeviceScaleFactor();
 
-    scheduleLayerFlush();
+    scheduleRenderingUpdate();
 }
 
 void LayerTreeHost::pauseRendering()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
@@ -62,14 +62,13 @@ public:
     const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
     void setLayerTreeStateIsFrozen(bool);
     void setShouldNotifyAfterNextScheduledLayerFlush(bool);
-    void scheduleLayerFlush();
-    void cancelPendingLayerFlush();
+    void scheduleRenderingUpdate();
     void setRootCompositingLayer(WebCore::GraphicsLayer*);
     void setViewOverlayRootLayer(WebCore::GraphicsLayer*);
     void setNonCompositedContentsNeedDisplay(const WebCore::IntRect&);
     void scrollNonCompositedContents(const WebCore::IntRect&);
-    void forceRepaint();
-    void forceRepaintAsync(CompletionHandler<void()>&&);
+    void updateRenderingWithForcedRepaint();
+    void updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&&);
     void sizeDidChange();
     void pauseRendering();
     void resumeRendering();


### PR DESCRIPTION
#### f2693824bc0991cd20d10d6419710313b1766d18
<pre>
[CoordinatedGraphics] Rename flushLayers as updateRendering in LayerTreeHost
<a href="https://bugs.webkit.org/show_bug.cgi?id=302632">https://bugs.webkit.org/show_bug.cgi?id=302632</a>

Reviewed by Miguel Gomez and Nikolas Zimmermann.

Layer flushing is just one part of the rendering update, so better use
render update which is more accurate and consistent with other ports and
DrawingArea API.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::updateRenderingWithForcedRepaint):
(WebKit::DrawingAreaCoordinatedGraphics::updateRenderingWithForcedRepaintAsync):
(WebKit::DrawingAreaCoordinatedGraphics::triggerRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::~LayerTreeHost):
(WebKit::LayerTreeHost::setLayerTreeStateIsFrozen):
(WebKit::LayerTreeHost::scheduleRenderingUpdate):
(WebKit::LayerTreeHost::scheduleRenderingUpdateRunLoopObserver):
(WebKit::LayerTreeHost::invalidateRenderingUpdateRunLoopObserver):
(WebKit::LayerTreeHost::updateRendering):
(WebKit::LayerTreeHost::renderingUpdateRunLoopObserverFired):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaint):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaintAsync):
(WebKit::LayerTreeHost::ensureDrawing):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::resumeRendering):
(WebKit::LayerTreeHost::didComposite):
(WebKit::LayerTreeHost::scheduleLayerFlush): Deleted.
(WebKit::LayerTreeHost::cancelPendingLayerFlush): Deleted.
(WebKit::LayerTreeHost::flushLayers): Deleted.
(WebKit::LayerTreeHost::layerFlushRunLoopObserverFired): Deleted.
(WebKit::LayerTreeHost::forceRepaint): Deleted.
(WebKit::LayerTreeHost::forceRepaintAsync): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::~LayerTreeHost):
(WebKit::LayerTreeHost::setLayerTreeStateIsFrozen):
(WebKit::LayerTreeHost::scheduleRenderingUpdate):
(WebKit::LayerTreeHost::cancelRenderingUpdate):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaint):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaintAsync):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::resumeRendering):
(WebKit::LayerTreeHost::requestDisplayRefreshMonitorUpdate):
(WebKit::LayerTreeHost::didComposite):
(WebKit::LayerTreeHost::scheduleLayerFlush): Deleted.
(WebKit::LayerTreeHost::cancelPendingLayerFlush): Deleted.
(WebKit::LayerTreeHost::forceRepaint): Deleted.
(WebKit::LayerTreeHost::forceRepaintAsync): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
(WebKit::LayerTreeHost::scheduleRenderingUpdate):
(WebKit::LayerTreeHost::setNonCompositedContentsNeedDisplay):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaint):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaintAsync):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::scheduleLayerFlush): Deleted.
(WebKit::LayerTreeHost::cancelPendingLayerFlush): Deleted.
(WebKit::LayerTreeHost::forceRepaint): Deleted.
(WebKit::LayerTreeHost::forceRepaintAsync): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:

Canonical link: <a href="https://commits.webkit.org/303174@main">https://commits.webkit.org/303174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef3c66a12bc0668e8fb06088eada64aab6c85e70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83151 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67873 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2617 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/347 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82089 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123413 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141561 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129845 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3466 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108716 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108933 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2624 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56641 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20445 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3528 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32358 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162862 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3350 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66936 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->