### PR TITLE
[blocks-in-inline] Stop updating block render tree positions LineLayout::updateRenderTreePositions

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float-expected.html
@@ -1,5 +1,5 @@
 <style>
-.case { border: 2px solid blue; margin: 20px; }
+.case { border: 2px solid blue; }
 .topMargin { height: 20px; margin-top: 20px; border: 2px solid green; }
 .bottomMargin { height: 20px; margin-bottom: 20px; border: 2px solid green; }
 .float { float:left; background: teal; }

--- a/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
 <style>
-.case { border: 2px solid blue; margin: 20px; }
+.case { border: 2px solid blue;}
 .topMargin { height: 20px; margin-top: 20px; border: 2px solid green; }
 .bottomMargin { height: 20px; margin-bottom: 20px; border: 2px solid green; }
 .float { float:left; background: teal; }

--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-widows-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-widows-expected.html
@@ -1,0 +1,30 @@
+<style>
+.columns {
+  columns: 3;
+  column-fill: auto;
+  line-height: 1;
+  height: 5em;
+  orphans: 3;
+  widows: 3;
+}
+</style>
+<body>
+  <div class="columns">
+    <div>
+      p1l1<br>
+      p1l2<br>
+      p1l3<br>
+    </div>
+    <span>
+      <div>
+        p2l1<br>
+        p2l2<br>
+        p2l3<br>
+        p2l4<br>
+        p2l5<br>
+        p2l6<br>
+        p2l7<br>
+      </div>
+    </span>
+  </div>
+</body>

--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-widows.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-widows.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<style>
+.columns {
+  columns: 3;
+  column-fill: auto;
+  line-height: 1;
+  height: 5em;
+  orphans: 3;
+  widows: 3;
+}
+</style>
+<body>
+  <div class="columns">
+    <div>
+      p1l1<br>
+      p1l2<br>
+      p1l3<br>
+    </div>
+    <span>
+      <div>
+        p2l1<br>
+        p2l2<br>
+        p2l3<br>
+        p2l4<br>
+        p2l5<br>
+        p2l6<br>
+        p2l7<br>
+      </div>
+    </span>
+  </div>
+</body>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -593,13 +593,6 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
                 continue;
 
             auto& layoutBox = box.layoutBox();
-
-            if (layoutBox.isBlockLevelBox() && layoutBox.isInFlow()) {
-                auto& renderer = downcast<RenderBox>(*box.layoutBox().rendererForIntegration());
-                renderer.setLocation(Layout::toLayoutPoint(box.visualRectIgnoringBlockDirection().location()));
-                continue;
-            }
-
             if (!layoutBox.isAtomicInlineBox())
                 continue;
 


### PR DESCRIPTION
#### 2da497c2bd9564a6af07c9583ae489c7eda04078
<pre>
[blocks-in-inline] Stop updating block render tree positions LineLayout::updateRenderTreePositions
<a href="https://bugs.webkit.org/show_bug.cgi?id=302633">https://bugs.webkit.org/show_bug.cgi?id=302633</a>
<a href="https://rdar.apple.com/164875829">rdar://164875829</a>

Reviewed by Alan Baradlay.

We compute the positions during nested layout. Another round of positioning is just chance to get things
wrong and hide bugs.

Test: fast/inline/blocks-in-inline-multicol-widows.html
* LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float-expected.html:
* LayoutTests/fast/inline/blocks-in-inline-margin-collapse-float.html:

There was a hidden bug with this test. Update the test to not hit it for now as we will implement
proper margin collapsing separately.

* LayoutTests/fast/inline/blocks-in-inline-multicol-widows-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-multicol-widows.html: Added.

Here we got position right and then updateRenderTreePositions moved the box to a wrong place.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):

Stop updating block positions.

Canonical link: <a href="https://commits.webkit.org/303117@main">https://commits.webkit.org/303117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f8056628b1cc9e1c20b09ef0fc4fea6be4612c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83146 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc78fa3e-7b22-48f6-91a5-c4ea81726359) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3559 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3416ffac-d543-427c-a38c-9aa0ef1c6e91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134333 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117604 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/81077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3a8e1625-04c5-4ffc-ac6f-95c0e411ac45) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/344 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82085 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141474 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3462 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36247 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3093 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/108871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2623 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56637 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3524 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32355 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->