### PR TITLE
Reuse RTCEncodedSourceProducer in RTCRtpScriptTransformer

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
@@ -130,11 +130,12 @@ ExceptionOr<RTCEncodedStreams> RTCRtpReceiver::createEncodedStreams(ScriptExecut
         return Exception { ExceptionCode::InvalidStateError };
 
     if (!m_encodedStreamProducer) {
-        auto producerOrException = RTCEncodedStreamProducer::create(context, m_backend->rtcRtpTransformBackend(), m_track->isVideo());
+        auto producerOrException = RTCEncodedStreamProducer::create(context);
         if (producerOrException.hasException())
             return producerOrException.releaseException();
 
         lazyInitialize(m_encodedStreamProducer, producerOrException.releaseReturnValue());
+        m_encodedStreamProducer->start(m_backend->rtcRtpTransformBackend(), m_track->isVideo());
     }
 
     return m_encodedStreamProducer->streams();

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -31,19 +31,10 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DedicatedWorkerGlobalScope.h"
 #include "EventLoop.h"
-#include "FrameRateMonitor.h"
 #include "JSDOMPromiseDeferred.h"
-#include "JSRTCEncodedAudioFrame.h"
-#include "JSRTCEncodedVideoFrame.h"
-#include "Logging.h"
 #include "MessageWithMessagePorts.h"
-#include "RTCRtpTransformableFrame.h"
-#include "ReadableStream.h"
-#include "ReadableStreamSource.h"
-#include "SerializedScriptValue.h"
+#include "RTCEncodedStreamProducer.h"
 #include "WorkerThread.h"
-#include "WritableStream.h"
-#include "WritableStreamSink.h"
 
 namespace WebCore {
 
@@ -54,149 +45,49 @@ ExceptionOr<Ref<RTCRtpScriptTransformer>> RTCRtpScriptTransformer::create(Script
 
     auto& globalObject = *JSC::jsCast<JSDOMGlobalObject*>(context.globalObject());
     JSC::JSLockHolder lock(globalObject.vm());
-    auto readableSource = SimpleReadableStreamSource::create();
-    auto readable = ReadableStream::create(globalObject, readableSource.copyRef());
-    if (readable.hasException())
-        return readable.releaseException();
+
+    auto producerOrException = RTCEncodedStreamProducer::create(context);
+    if (producerOrException.hasException())
+        return producerOrException.releaseException();
     if (!options.message)
         return Exception { ExceptionCode::InvalidStateError };
 
     auto ports = MessagePort::entanglePorts(context, WTFMove(options.transferredPorts));
-    auto transformer = adoptRef(*new RTCRtpScriptTransformer(context, options.message.releaseNonNull(), WTFMove(ports), readable.releaseReturnValue(), WTFMove(readableSource)));
+    auto transformer = adoptRef(*new RTCRtpScriptTransformer(context, options.message.releaseNonNull(), WTFMove(ports), producerOrException.releaseReturnValue()));
     transformer->suspendIfNeeded();
     return transformer;
 }
 
-RTCRtpScriptTransformer::RTCRtpScriptTransformer(ScriptExecutionContext& context, Ref<SerializedScriptValue>&& options, Vector<Ref<MessagePort>>&& ports, Ref<ReadableStream>&& readable, Ref<SimpleReadableStreamSource>&& readableSource)
+RTCRtpScriptTransformer::RTCRtpScriptTransformer(ScriptExecutionContext& context, Ref<SerializedScriptValue>&& options, Vector<Ref<MessagePort>>&& ports, Ref<RTCEncodedStreamProducer>&& streamProducer)
     : ActiveDOMObject(&context)
     , m_options(WTFMove(options))
     , m_ports(WTFMove(ports))
-    , m_readableSource(WTFMove(readableSource))
-    , m_readable(WTFMove(readable))
-#if !RELEASE_LOG_DISABLED
-    , m_enableAdditionalLogging(context.settingsValues().webRTCMediaPipelineAdditionalLoggingEnabled)
-    , m_identifier(RTCRtpScriptTransformerIdentifier::generate())
-#endif
+    , m_streamProducer(WTFMove(streamProducer))
 {
 }
 
 RTCRtpScriptTransformer::~RTCRtpScriptTransformer() = default;
 
-ExceptionOr<Ref<WritableStream>> RTCRtpScriptTransformer::writable()
+ReadableStream& RTCRtpScriptTransformer::readable()
 {
-    if (!m_writable) {
-        RefPtr context = downcast<WorkerGlobalScope>(scriptExecutionContext());
-        if (!context || !context->globalObject())
-            return Exception { ExceptionCode::InvalidStateError };
+    return m_streamProducer->readable();
+}
 
-        auto& globalObject = *JSC::jsCast<JSDOMGlobalObject*>(context->globalObject());
-        auto writableOrException = WritableStream::create(globalObject, SimpleWritableStreamSink::create([transformer = Ref { *this }](auto& context, auto value) -> ExceptionOr<void> {
-            if (!transformer->m_backend)
-                return Exception { ExceptionCode::InvalidStateError };
-
-            auto& globalObject = *context.globalObject();
-            Ref vm = globalObject.vm();
-            auto scope = DECLARE_THROW_SCOPE(vm);
-
-            auto frameConversionResult = convert<IDLUnion<IDLInterface<RTCEncodedAudioFrame>, IDLInterface<RTCEncodedVideoFrame>>>(globalObject, value);
-            if (frameConversionResult.hasException(scope)) [[unlikely]]
-                return Exception { ExceptionCode::ExistingExceptionError };
-
-            auto frame = frameConversionResult.releaseReturnValue();
-            auto rtcFrame = WTF::switchOn(frame, [&](RefPtr<RTCEncodedAudioFrame>& value) {
-                return value->rtcFrame(vm);
-            }, [&](RefPtr<RTCEncodedVideoFrame>& value) {
-                return value->rtcFrame(vm);
-            });
-
-            if (!rtcFrame->isFromTransformer(transformer.get())) {
-                RELEASE_LOG_ERROR(WebRTC, "Trying to enqueue a foreign frame");
-                return { };
-            }
-
-            // If no data, skip the frame since there is nothing to packetize or decode.
-            if (rtcFrame->data().data()) {
-#if !RELEASE_LOG_DISABLED
-                if (transformer->m_enableAdditionalLogging && transformer->m_backend->mediaType() == RTCRtpTransformBackend::MediaType::Video) {
-                    if (!transformer->m_writableFrameRateMonitor) {
-                        transformer->m_writableFrameRateMonitor = makeUnique<FrameRateMonitor>([identifier = transformer->m_identifier](auto info) {
-                            RELEASE_LOG(WebRTC, "RTCRtpScriptTransformer writable %" PRIu64 ", frame at %f, previous frame was at %f, observed frame rate is %f, delay since last frame is %f ms, frame count is %lu", identifier.toUInt64(), info.frameTime.secondsSinceEpoch().value(), info.lastFrameTime.secondsSinceEpoch().value(), info.observedFrameRate, ((info.frameTime - info.lastFrameTime) * 1000).value(), info.frameCount);
-                        });
-                    }
-                    transformer->m_writableFrameRateMonitor->update();
-                }
-#endif
-                transformer->m_backend->processTransformedFrame(rtcFrame.get());
-            }
-            return { };
-        }));
-        if (writableOrException.hasException())
-            return writableOrException;
-        m_writable = writableOrException.releaseReturnValue();
-    }
-    return Ref { *m_writable };
+WritableStream& RTCRtpScriptTransformer::writable()
+{
+    return m_streamProducer->writable();
 }
 
 void RTCRtpScriptTransformer::start(Ref<RTCRtpTransformBackend>&& backend)
 {
-    m_isVideo = backend->mediaType() == RTCRtpTransformBackend::MediaType::Video;
     m_isSender = backend->side() == RTCRtpTransformBackend::Side::Sender;
-
-    Ref context = downcast<WorkerGlobalScope>(*scriptExecutionContext());
-    backend->setTransformableFrameCallback([weakThis = WeakPtr { *this }, thread = Ref { context->thread() }](Ref<RTCRtpTransformableFrame>&& frame) mutable {
-        thread->runLoop().postTaskForMode([weakThis, frame = WTFMove(frame)](auto& context) mutable {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-
-            frame->setTransformer(*protectedThis);
-            protectedThis->enqueueFrame(context, WTFMove(frame));
-        }, WorkerRunLoop::defaultMode());
-    });
-
-    m_backend = WTFMove(backend);
+    m_streamProducer->start(WTFMove(backend), backend->mediaType() == RTCRtpTransformBackend::MediaType::Video);
 }
 
 void RTCRtpScriptTransformer::clear(ClearCallback clearCallback)
 {
-    RefPtr backend = std::exchange(m_backend, { });
-    if (backend && clearCallback == ClearCallback::Yes)
-        backend->clearTransformableFrameCallback();
-    m_backend = nullptr;
+    m_streamProducer->clear(clearCallback == ClearCallback::Yes);
     stopPendingActivity();
-}
-
-void RTCRtpScriptTransformer::enqueueFrame(ScriptExecutionContext& context, Ref<RTCRtpTransformableFrame>&& frame)
-{
-    if (!m_backend)
-        return;
-
-    auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context.globalObject());
-    if (!globalObject)
-        return;
-
-    Ref vm = globalObject->vm();
-    JSC::JSLockHolder lock(vm);
-
-    if (m_isVideo && !m_pendingKeyFramePromises.isEmpty() && frame->isKeyFrame()) {
-        // FIXME: We should take into account rids to resolve promises.
-        for (Ref promise : std::exchange(m_pendingKeyFramePromises, { }))
-            promise->resolve<IDLUnsignedLongLong>(frame->timestamp());
-    }
-
-#if !RELEASE_LOG_DISABLED
-    if (m_enableAdditionalLogging && m_isVideo) {
-        if (!m_readableFrameRateMonitor) {
-            m_readableFrameRateMonitor = makeUnique<FrameRateMonitor>([identifier = m_identifier](auto info) {
-                RELEASE_LOG(WebRTC, "RTCRtpScriptTransformer readable %" PRIu64 ", frame at %f, previous frame was at %f, observed frame rate is %f, delay since last frame is %f ms, frame count is %lu", identifier.toUInt64(), info.frameTime.secondsSinceEpoch().value(), info.lastFrameTime.secondsSinceEpoch().value(), info.observedFrameRate, ((info.frameTime - info.lastFrameTime) * 1000).value(), info.frameCount);
-            });
-        }
-        m_readableFrameRateMonitor->update();
-    }
-#endif
-
-    auto value = m_isVideo ? toJS(globalObject, globalObject, RTCEncodedVideoFrame::create(WTFMove(frame))) : toJS(globalObject, globalObject, RTCEncodedAudioFrame::create(WTFMove(frame)));
-    m_readableSource->enqueue(value);
 }
 
 static std::optional<Exception> validateRid(const String& rid)
@@ -223,7 +114,7 @@ static std::optional<Exception> validateRid(const String& rid)
 void RTCRtpScriptTransformer::generateKeyFrame(const String& rid, Ref<DeferredPromise>&& promise)
 {
     RefPtr context = scriptExecutionContext();
-    if (!context || !m_isVideo || !m_isSender) {
+    if (!context || !m_streamProducer->isVideo() || !m_isSender) {
         promise->reject(Exception { ExceptionCode::InvalidStateError, "Not attached to a valid video sender"_s });
         return;
     }
@@ -233,35 +124,20 @@ void RTCRtpScriptTransformer::generateKeyFrame(const String& rid, Ref<DeferredPr
         return;
     }
 
-    RefPtr backend = m_backend;
-    if (!backend)
-        return;
-
-    if (!m_backend->requestKeyFrame(rid)) {
-        context->eventLoop().queueTask(TaskSource::Networking, [promise = WTFMove(promise)]() mutable {
-            promise->reject(Exception { ExceptionCode::NotFoundError, "rid was not found or is empty"_s });
-        });
-        return;
-    }
-
-    m_pendingKeyFramePromises.append(WTFMove(promise));
+    m_streamProducer->generateKeyFrame(*context, rid, WTFMove(promise));
 }
 
 void RTCRtpScriptTransformer::sendKeyFrameRequest(Ref<DeferredPromise>&& promise)
 {
     RefPtr context = scriptExecutionContext();
-    if (!context || !m_isVideo || m_isSender) {
+    if (!context || !m_streamProducer->isVideo() || m_isSender) {
         promise->reject(Exception { ExceptionCode::InvalidStateError, "Not attached to a valid video receiver"_s });
         return;
     }
 
-    RefPtr backend = m_backend;
-    if (!backend)
-        return;
+    m_streamProducer->sendKeyFrameRequest();
 
     // FIXME: We should be able to know when the FIR request is sent to resolve the promise at this exact time.
-    backend->requestKeyFrame({ });
-
     context->eventLoop().queueTask(TaskSource::Networking, [promise = WTFMove(promise)]() mutable {
         promise->resolve();
     });

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -40,19 +40,16 @@ namespace WebCore {
 
 class FrameRateMonitor;
 class MessagePort;
+class RTCEncodedStreamProducer;
+class RTCRtpTransformBackend;
 class ReadableStream;
 class ScriptExecutionContext;
-class RTCRtpTransformBackend;
 class SerializedScriptValue;
-class SimpleReadableStreamSource;
 class WritableStream;
 
 struct MessageWithMessagePorts;
 
 template<typename> class ExceptionOr;
-
-enum class RTCRtpScriptTransformerIdentifierType { };
-using RTCRtpScriptTransformerIdentifier = AtomicObjectIdentifier<RTCRtpScriptTransformerIdentifierType>;
 
 class RTCRtpScriptTransformer
     : public RefCounted<RTCRtpScriptTransformer>
@@ -65,8 +62,8 @@ public:
     static ExceptionOr<Ref<RTCRtpScriptTransformer>> create(ScriptExecutionContext&, MessageWithMessagePorts&&);
     ~RTCRtpScriptTransformer();
 
-    ReadableStream& readable() { return m_readable; }
-    ExceptionOr<Ref<WritableStream>> writable();
+    ReadableStream& readable();
+    WritableStream& writable();
     JSC::JSValue options(JSC::JSGlobalObject&);
 
     void generateKeyFrame(const String&, Ref<DeferredPromise>&&);
@@ -79,7 +76,7 @@ public:
     void clear(ClearCallback);
 
 private:
-    RTCRtpScriptTransformer(ScriptExecutionContext&, Ref<SerializedScriptValue>&&, Vector<Ref<MessagePort>>&&, Ref<ReadableStream>&&, Ref<SimpleReadableStreamSource>&&);
+    RTCRtpScriptTransformer(ScriptExecutionContext&, Ref<SerializedScriptValue>&&, Vector<Ref<MessagePort>>&&, Ref<RTCEncodedStreamProducer>&&);
 
     // ActiveDOMObject.
     void stop() final { stopPendingActivity(); }
@@ -91,23 +88,12 @@ private:
     const Ref<SerializedScriptValue> m_options;
     Vector<Ref<MessagePort>> m_ports;
 
-    const Ref<SimpleReadableStreamSource> m_readableSource;
-    const Ref<ReadableStream> m_readable;
-    RefPtr<WritableStream> m_writable;
+    const Ref<RTCEncodedStreamProducer> m_streamProducer;
 
     RefPtr<RTCRtpTransformBackend> m_backend;
     RefPtr<PendingActivity<RTCRtpScriptTransformer>> m_pendingActivity;
 
-    Deque<Ref<DeferredPromise>> m_pendingKeyFramePromises;
-    bool m_isVideo { false };
     bool m_isSender { false };
-
-#if !RELEASE_LOG_DISABLED
-    bool m_enableAdditionalLogging { false };
-    RTCRtpScriptTransformerIdentifier m_identifier;
-    std::unique_ptr<FrameRateMonitor> m_readableFrameRateMonitor;
-    std::unique_ptr<FrameRateMonitor> m_writableFrameRateMonitor;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -264,11 +264,12 @@ ExceptionOr<RTCEncodedStreams> RTCRtpSender::createEncodedStreams(ScriptExecutio
         return Exception { ExceptionCode::InvalidStateError };
 
     if (!m_encodedStreamProducer) {
-        auto producerOrException = RTCEncodedStreamProducer::create(context, m_backend->rtcRtpTransformBackend(), m_trackKind == "video"_s);
+        auto producerOrException = RTCEncodedStreamProducer::create(context);
         if (producerOrException.hasException())
             return producerOrException.releaseException();
 
         lazyInitialize(m_encodedStreamProducer, producerOrException.releaseReturnValue());
+        m_encodedStreamProducer->start(m_backend->rtcRtpTransformBackend(), m_trackKind == "video"_s);
     }
 
     return m_encodedStreamProducer->streams();

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -22,7 +22,6 @@ Modules/mediastream/RTCEncodedFrame.cpp
 Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/RTCRtpReceiver.cpp
 Modules/mediastream/RTCRtpSFrameTransform.cpp
-Modules/mediastream/RTCRtpScriptTransformer.cpp
 Modules/mediastream/RTCRtpSender.cpp
 Modules/mediastream/RTCRtpTransform.cpp
 Modules/mediastream/UserMediaRequest.cpp

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -195,7 +195,7 @@ template: enum class WebCore::MainThreadPermissionObserverIdentifierType
 template: enum class WebCore::OpaqueOriginIdentifierType
 template: enum class WebCore::PortIdentifierType
 template: enum class WebCore::RTCDataChannelLocalIdentifierType
-template: enum class WebCore::RTCRtpScriptTransformerIdentifierType
+template: enum class WebCore::RTCEncodedStreamProducerIdentifierType
 template: struct WebCore::RenderingResourceIdentifierType
 template: struct WebCore::ResourceLoaderIdentifierType
 template: struct WebCore::SamplesRendererTrackIdentifierType


### PR DESCRIPTION
#### fc07c80ec38e0558f2b89431b185d4c4b5468796
<pre>
Reuse RTCEncodedSourceProducer in RTCRtpScriptTransformer
<a href="https://rdar.apple.com/164876812">rdar://164876812</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302635">https://bugs.webkit.org/show_bug.cgi?id=302635</a>

Reviewed by Jean-Yves Avenard.

We do a refactoring to share more code between RTCEncodedSourceProducer and RTCRtpScriptTransformer.
Both were creating readable and writable streams to expose audio/video encoded frames.
With the patch, RTCRtpScriptTransformer is now using RTCEncodedSourceProducer to create/manager readable and writable streams.
We update RTCEncodedSourceProducer to handle key frame generation and logging previously done in RTCRtpScriptTransformer.

Canonical link: <a href="https://commits.webkit.org/303238@main">https://commits.webkit.org/303238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e98322e723bbb14faccc64cb48e75774ddae246

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a95a27b6-62b3-4041-9d09-45c8930ab6bc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100480 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68053 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2f531e55-a022-4203-9be7-4e852a1bcc15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81288 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a321834a-a3c9-4904-be13-846d5de6779d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2761 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/511 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82315 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141769 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3691 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108854 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3739 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3271 "Too many flaky failures: fast/images/individual-animation-toggle.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-text-fragment.html, imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https.html, imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html, imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html, imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90.html, imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex.html, imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html, imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html, imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2797 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56892 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3752 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32534 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->