### PR TITLE
Unify mechanism for serializing Installed Fonts across CoreIPC.

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -209,23 +209,13 @@ struct WEBCORE_EXPORT AttributedString {
         Color color;
     };
 
-    struct FontWrapper {
-        Ref<Font> font;
-
-        String postScriptName() const;
-        double pointSize() const;
-        CTFontDescriptorOptions fontDescriptorOptions() const;
-        std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes() const;
-        static std::optional<FontWrapper> createFromIPCData(const String& postScriptName, double pointSize, const CTFontDescriptorOptions&, const std::optional<WebCore::FontPlatformSerializedAttributes>&);
-    };
-
     struct AttributeValue {
 
         using AttributeType = Variant<
             double,
             String,
             URL,
-            FontWrapper,
+            InstalledFont,
             Vector<String>,
             Vector<double>,
             ParagraphStyle,

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -84,6 +84,8 @@ enum class FontVisibility : bool { Visible, Invisible };
 enum class FontIsOrientationFallback : bool { No, Yes };
 
 #if USE(CORE_TEXT)
+using IPCFontData = Variant<WebCore::InstalledFont, WebCore::CustomFontCreationData>;
+
 bool fontHasEitherTable(CTFontRef, unsigned tableTag1, unsigned tableTag2);
 bool supportsOpenTypeFeature(CTFontRef, CFStringRef featureTag);
 #endif
@@ -259,7 +261,11 @@ public:
     std::optional<BitVector> findOTSVGGlyphs(std::span<const GlyphBufferGlyph>) const;
 
     bool hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph>) const;
-
+#if USE(CORE_TEXT)
+    WEBCORE_EXPORT static std::optional<Ref<Font>> fromIPCData(IPCFontData&&);
+    WEBCORE_EXPORT IPCFontData toSerializableFont() const;
+    WEBCORE_EXPORT std::optional<InstalledFont> toSerializableInstalledFont() const;
+#endif
 #if PLATFORM(WIN)
     SCRIPT_CACHE* scriptCache() const { return &m_scriptCache; }
 #endif

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -147,7 +147,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 
             return std::nullopt;
         },
-        [&] (FontPlatformSerializedCreationData& d) -> std::optional<FontPlatformData> {
+        [&] (CustomFontCreationData& d) -> std::optional<FontPlatformData> {
             auto fontFaceData = SharedBuffer::create(WTFMove(d.fontFaceData));
             if (RefPtr fontCustomPlatformData = FontCustomPlatformData::create(fontFaceData, d.itemInCollection))
                 return FontPlatformData(size, WTFMove(orientation), WTFMove(widthVariant), WTFMove(textRenderingMode), syntheticBold, syntheticOblique, WTFMove(fontCustomPlatformData));
@@ -160,7 +160,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 FontPlatformData::IPCData FontPlatformData::toIPCData() const
 {
     if (auto* data = creationData())
-        return FontPlatformSerializedCreationData { { data->fontFaceData->span() }, data->itemInCollection };
+        return CustomFontCreationData { { data->fontFaceData->span() }, data->itemInCollection };
 
     return FontPlatformSerializedData { m_font.getTypeface()->serialize() };
 }

--- a/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
@@ -88,7 +88,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 
             return std::nullopt;
         },
-        [&] (FontPlatformSerializedCreationData& d) -> std::optional<FontPlatformData> {
+        [&] (CustomFontCreationData& d) -> std::optional<FontPlatformData> {
             auto fontFaceData = SharedBuffer::create(WTFMove(d.fontFaceData));
             if (RefPtr fontCustomPlatformData = FontCustomPlatformData::create(fontFaceData, d.itemInCollection))
                 return FontPlatformData(size, syntheticBold, syntheticOblique, WTFMove(orientation), WTFMove(widthVariant), WTFMove(textRenderingMode), fontCustomPlatformData.get());
@@ -101,7 +101,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOr
 FontPlatformData::IPCData FontPlatformData::toIPCData() const
 {
     if (auto* data = creationData())
-        return FontPlatformSerializedCreationData { { data->fontFaceData->span() }, data->itemInCollection };
+        return CustomFontCreationData { { data->fontFaceData->span() }, data->itemInCollection };
 
     LOGFONT logFont;
     GetObject(hfont(), sizeof logFont, &logFont);

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -180,24 +180,16 @@ header: <WebCore/AttributedString.h>
     Vector<WebCore::TextTab> textTabs;
 }
 
-[Nested, CreateUsing=createFromIPCData] struct WebCore::AttributedString::FontWrapper {
-    String postScriptName();
-    double pointSize();
-    CTFontDescriptorOptions fontDescriptorOptions();
-    std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes();
-}
-
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
 [Nested] struct WebCore::AttributedString::AttributeValue {
-    Variant<double, String, URL, WebCore::AttributedString::FontWrapper, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::MultiRepresentationHEICAttachmentData, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+    Variant<double, String, URL, WebCore::InstalledFont, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::MultiRepresentationHEICAttachmentData, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
 }
 #endif
 #if !ENABLE(MULTI_REPRESENTATION_HEIC)
 [Nested] struct WebCore::AttributedString::AttributeValue {
-    Variant<double, String, URL, WebCore::AttributedString::FontWrapper, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+    Variant<double, String, URL, WebCore::InstalledFont, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
 }
 #endif
-
 
 [Nested] struct WebCore::AttributedString::ColorFromPlatformColor {
     WebCore::Color color

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -136,3 +136,86 @@ using WebCore::ScrollOffset = WebCore::IntPoint;
     bool enclosingLayerUsesContentsLayer;
 #endif
 };
+
+[Nested] enum class WebCore::FontAttributes::SubscriptOrSuperscript : uint8_t {
+    None,
+    Subscript,
+    Superscript
+};
+
+[Nested] enum class WebCore::FontAttributes::HorizontalAlignment : uint8_t {
+    Left,
+    Center,
+    Right,
+    Justify,
+    Natural
+};
+
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType::NoneData {
+};
+
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType::StringData {
+    AtomString identifier;
+};
+
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType::CounterStyleData {
+    AtomString identifier;
+};
+
+header: <WebCore/StyleListStyleType.h>
+[CustomHeader, Nested] struct WebCore::Style::ListStyleType {
+    Variant<WebCore::Style::ListStyleType::NoneData, WebCore::Style::ListStyleType::StringData, WebCore::Style::ListStyleType::CounterStyleData> ipcData()
+};
+
+header: <WebCore/FontAttributes.h>
+[CustomHeader] struct WebCore::TextList {
+    WebCore::Style::ListStyleType styleType;
+    int startingItemNumber
+    bool ordered
+};
+
+struct WebCore::FontShadow {
+    WebCore::Color color;
+    WebCore::FloatSize offset;
+    double blurRadius;
+};
+
+[CustomHeader] struct WebCore::FontAttributes {
+    RefPtr<WebCore::Font> font
+    WebCore::Color backgroundColor
+    WebCore::Color foregroundColor
+    WebCore::FontShadow fontShadow
+    WebCore::FontAttributes::SubscriptOrSuperscript subscriptOrSuperscript
+    WebCore::FontAttributes::HorizontalAlignment horizontalAlignment
+    Vector<WebCore::TextList> textLists
+    bool hasUnderline
+    bool hasStrikeThrough
+    bool hasMultipleFonts
+};
+
+header: <WebCore/FontAttributeChanges.h>
+enum class WebCore::VerticalAlignChange : uint8_t {
+    Superscript,
+    Baseline,
+    Subscript
+};
+
+header: <WebCore/FontAttributeChanges.h>
+[CustomHeader] class WebCore::FontChanges {
+    String m_fontName;
+    String m_fontFamily;
+    std::optional<double> m_fontSize;
+    [Validator='!*m_fontSize || !*m_fontSizeDelta'] std::optional<double> m_fontSizeDelta;
+    std::optional<bool> m_bold;
+    std::optional<bool> m_italic;
+};
+
+class WebCore::FontAttributeChanges {
+    std::optional<WebCore::VerticalAlignChange> m_verticalAlign;
+    std::optional<WebCore::Color> m_backgroundColor;
+    std::optional<WebCore::Color> m_foregroundColor;
+    std::optional<WebCore::FontShadow> m_shadow;
+    std::optional<bool> m_strikeThrough;
+    std::optional<bool> m_underline;
+    WebCore::FontChanges m_fontChanges;
+};

--- a/Source/WebKit/Shared/PlatformPopupMenuData.h
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.h
@@ -34,8 +34,7 @@ namespace WebKit {
 
 struct PlatformPopupMenuData {
 #if PLATFORM(COCOA)
-    String postScriptName;
-    double pointSize { 0.0 };
+    WebCore::InstalledFont font;
     bool shouldPopOver { false };
     bool hideArrows { false };
     WebCore::PopupMenuStyle::Size menuSize { WebCore::PopupMenuStyle::Size::Normal };

--- a/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
@@ -22,8 +22,7 @@
 
 struct WebKit::PlatformPopupMenuData {
 #if PLATFORM(COCOA)
-    String postScriptName;
-    double pointSize;
+    WebCore::InstalledFont font;
     bool shouldPopOver;
     bool hideArrows;
     WebCore::PopupMenuStyle::Size menuSize;

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -51,7 +51,8 @@ enum class WebCore::TextRenderingMode : uint8_t {
     GeometricPrecision
 };
 
-using WebCore::FontPlatformData::IPCData = Variant<WebCore::FontPlatformSerializedData, WebCore::FontPlatformSerializedCreationData>;
+#if !USE(CORE_TEXT)
+using WebCore::FontPlatformData::IPCData = Variant<WebCore::FontPlatformSerializedData, WebCore::CustomFontCreationData>;
 
 [CreateUsing=fromIPCData] class WebCore::FontPlatformData {
     float size();
@@ -62,6 +63,7 @@ using WebCore::FontPlatformData::IPCData = Variant<WebCore::FontPlatformSerializ
     bool syntheticOblique();
     WebCore::FontPlatformData::IPCData toIPCData();
 }
+#endif
 
 header: <WebCore/FontPlatformData.h>
 [CustomHeader] struct WebCore::FontPlatformDataAttributes {
@@ -149,104 +151,43 @@ header: <WebCore/FontPlatformData.h>
 #endif
 };
 
-[CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
+[CustomHeader] struct WebCore::CustomFontCreationData {
+    WebCore::FontMetadata metadata;
     Vector<uint8_t> fontFaceData;
     std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
     String itemInCollection;
 };
 
-[CustomHeader] struct WebCore::FontPlatformSerializedData {
-    CTFontDescriptorOptions options;
-    RetainPtr<CFStringRef> referenceURL;
-    RetainPtr<CFStringRef> postScriptName;
-    std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
-};
+[CustomHeader] struct WebCore::FontMetadata {
+    double pointSize;
+    WebCore::FontOrientation orientation;
+    WebCore::FontWidthVariant widthVariant;
+    WebCore::TextRenderingMode textRenderingMode;
+    bool syntheticBold;
+    bool syntheticOblique;
+}
+
+[CustomHeader, Nested] struct WebCore::InstalledFont::PostScriptFont {
+    String postScriptName;
+    CTFontDescriptorOptions fontDescriptorOptions;
+    std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes
+}
+
+[CustomHeader] struct WebCore::InstalledFont {
+    Variant<WebCore::InstalledFont::PostScriptFont> font;
+    WebCore::FontMetadata metadata;
+}
+
+
+[RefCounted, CreateUsing=fromIPCData] class WebCore::Font {
+    Variant<WebCore::InstalledFont, WebCore::CustomFontCreationData> toSerializableFont();
+}
+
 #endif // USE(CORE_TEXT)
 
+#if !USE(CORE_TEXT)
 [RefCounted] class WebCore::Font {
     WebCore::FontInternalAttributes attributes();
     WebCore::FontPlatformData platformData();
 }
-
-[Nested] enum class WebCore::FontAttributes::SubscriptOrSuperscript : uint8_t {
-    None,
-    Subscript,
-    Superscript
-};
-
-[Nested] enum class WebCore::FontAttributes::HorizontalAlignment : uint8_t {
-    Left,
-    Center,
-    Right,
-    Justify,
-    Natural
-};
-
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType::NoneData {
-};
-
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType::StringData {
-    AtomString identifier;
-};
-
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType::CounterStyleData {
-    AtomString identifier;
-};
-
-header: <WebCore/StyleListStyleType.h>
-[CustomHeader, Nested] struct WebCore::Style::ListStyleType {
-    Variant<WebCore::Style::ListStyleType::NoneData, WebCore::Style::ListStyleType::StringData, WebCore::Style::ListStyleType::CounterStyleData> ipcData()
-};
-
-header: <WebCore/FontAttributes.h>
-[CustomHeader] struct WebCore::TextList {
-    WebCore::Style::ListStyleType styleType;
-    int startingItemNumber
-    bool ordered
-};
-
-struct WebCore::FontShadow {
-    WebCore::Color color;
-    WebCore::FloatSize offset;
-    double blurRadius;
-};
-
-[CustomHeader] struct WebCore::FontAttributes {
-    RefPtr<WebCore::Font> font
-    WebCore::Color backgroundColor
-    WebCore::Color foregroundColor
-    WebCore::FontShadow fontShadow
-    WebCore::FontAttributes::SubscriptOrSuperscript subscriptOrSuperscript
-    WebCore::FontAttributes::HorizontalAlignment horizontalAlignment
-    Vector<WebCore::TextList> textLists
-    bool hasUnderline
-    bool hasStrikeThrough
-    bool hasMultipleFonts
-};
-
-header: <WebCore/FontAttributeChanges.h>
-enum class WebCore::VerticalAlignChange : uint8_t {
-    Superscript,
-    Baseline,
-    Subscript
-};
-
-header: <WebCore/FontAttributeChanges.h>
-[CustomHeader] class WebCore::FontChanges {
-    String m_fontName;
-    String m_fontFamily;
-    std::optional<double> m_fontSize;
-    [Validator='!*m_fontSize || !*m_fontSizeDelta'] std::optional<double> m_fontSizeDelta;
-    std::optional<bool> m_bold;
-    std::optional<bool> m_italic;
-};
-
-class WebCore::FontAttributeChanges {
-    std::optional<WebCore::VerticalAlignChange> m_verticalAlign;
-    std::optional<WebCore::Color> m_backgroundColor;
-    std::optional<WebCore::Color> m_foregroundColor;
-    std::optional<WebCore::FontShadow> m_shadow;
-    std::optional<bool> m_strikeThrough;
-    std::optional<bool> m_underline;
-    WebCore::FontChanges m_fontChanges;
-};
+#endif

--- a/Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in
+++ b/Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in
@@ -30,7 +30,7 @@ headers: "CoreIPCLOGFONT.h"
 #endif
 
 header: <WebCore/FontPlatformData.h>
-[CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
+[CustomHeader] struct WebCore::CustomFontCreationData {
     Vector<uint8_t> fontFaceData;
     String itemInCollection;
 };

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
@@ -23,7 +23,7 @@
 #if USE(SKIA)
 
 header: <WebCore/FontPlatformData.h>
-[CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
+[CustomHeader] struct WebCore::CustomFontCreationData {
     Vector<uint8_t> fontFaceData;
     String itemInCollection;
 };

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -110,15 +110,10 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    auto scaledFontSize = data.pointSize * pageScaleFactor;
-    
-    RetainPtr descriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(data.postScriptName.createCFString().get(), scaledFontSize));
-    RetainPtr matched = adoptCF(CTFontDescriptorCreateMatchingFontDescriptorsWithOptions(descriptor.get(), NULL, kCTFontDescriptorMatchingOptionIncludeHiddenFonts));
-
-    if (matched && CFArrayGetCount(matched.get())) {
-        RetainPtr matchedDescriptor = dynamic_cf_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(matched.get(), 0));
-        font = adoptCF(CTFontCreateWithFontDescriptor(matchedDescriptor.get(), scaledFontSize, NULL));
-    }
+    PlatformPopupMenuData mutableData = data;
+    auto scaledFontSize = mutableData.font.metadata.pointSize * pageScaleFactor;
+    mutableData.font.metadata.pointSize = scaledFontSize;
+    font = mutableData.font.toCTFont();
 
     // font will be nil when using a custom font. However, we should still
     // honor the font size, matching other browsers.


### PR DESCRIPTION
#### 8689b06fff023110e53618bea3f90e558f3ad8fe
<pre>
Unify mechanism for serializing Installed Fonts across CoreIPC.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302637">https://bugs.webkit.org/show_bug.cgi?id=302637</a>
<a href="https://rdar.apple.com/164878071">rdar://164878071</a>

Reviewed by Vitor Roriz.

Unifies the serialization of InstalledFonts for both WebCore::Font
and standalone usages (AttributedString, PopupMenu).

* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSObject):
(WebCore::extractValue):
(WebCore::AttributedString::FontWrapper::createFromIPCData): Deleted.
(WebCore::AttributedString::FontWrapper::postScriptName const): Deleted.
(WebCore::AttributedString::FontWrapper::pointSize const): Deleted.
(WebCore::AttributedString::FontWrapper::fontDescriptorOptions const): Deleted.
(WebCore::AttributedString::FontWrapper::fontSerializedAttributes const): Deleted.
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::fromIPCData):
(WebCore::Font::toSerializableInstalledFont const):
(WebCore::Font::toSerializableFont const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::toIPCData const):
(WebCore::InstalledFont::PostScriptFont::toCTFont const):
(WebCore::InstalledFont::toCTFont const):
(WebCore::InstalledFont::toFont const):
(WebCore::FontPlatformData::fromIPCData): Deleted.
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::toIPCData const):
* Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp:
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::toIPCData const):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/Shared/PlatformPopupMenuData.h:
* Source/WebKit/Shared/PlatformPopupMenuData.serialization.in:
* Source/WebKit/Shared/WebCoreFont.serialization.in:
* Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in:
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in:
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::showPopupMenu):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm:
(WebKit::WebPopupMenu::setUpPlatformData):

Canonical link: <a href="https://commits.webkit.org/303318@main">https://commits.webkit.org/303318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f226ae3cdb29de5f9714e1d0af8d2931e83877b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83394 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a41e3737-8e65-459a-b83f-28a04baa5581) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100468 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68044 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b278a40-9043-41a0-9ac5-c3f0bc88f084) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81277 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b9af043-77b1-4b9e-a090-9b793fb21749) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2879 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/520 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82302 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141756 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108841 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2781 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114121 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56877 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3739 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32523 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3669 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->