### PR TITLE
Upgrade ReadableByteStreamFetchSourceEnabled to preview

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -668,6 +668,8 @@ imported/w3c/web-platform-tests/background-fetch/fetch-uploads.https.window.html
 imported/w3c/web-platform-tests/background-fetch/update-ui.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/background-fetch/fetch.https.window.html [ Skip ]
 
+webkit.org/b/303084 imported/w3c/web-platform-tests/fetch/api/response/response-body-read-task-handling.html [ Pass Failure ]
+
 # Skip some reporting tests that now timeout
 imported/w3c/web-platform-tests/reporting/cross-origin-same-site-credentials.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/reporting/document-reporting-bypass-report-to.https.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ ReadableByteStreamFetchSourceEnabled=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.serviceworker.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ ReadableByteStreamFetchSourceEnabled=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.sharedworker.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ ReadableByteStreamFetchSourceEnabled=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-consume-stream.any.worker.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ ReadableByteStreamFetchSourceEnabled=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6450,7 +6450,7 @@ ReadableByteStreamAPIEnabled:
 
 ReadableByteStreamFetchSourceEnabled:
   type: bool
-  status: unstable
+  status: preview
   category: dom
   humanReadableName: "ReadableByteStream for fetch API"
   humanReadableDescription: "Enable Readable Byte Streams for fetch API"


### PR DESCRIPTION
#### 268e0aff0f0d02dba86fa6f1f4c8af932cfe42c6
<pre>
Upgrade ReadableByteStreamFetchSourceEnabled to preview
<a href="https://rdar.apple.com/164882296">rdar://164882296</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302639">https://bugs.webkit.org/show_bug.cgi?id=302639</a>

Reviewed by Chris Dumez.

We mark WPT fetch/api/response/response-body-read-task-handling.html as flaky.
We sometimes drain the microtask queue when exiting from C++ call sites while we should probably not.
This will be investigated as part of <a href="https://bugs.webkit.org/show_bug.cgi?id=303084.">https://bugs.webkit.org/show_bug.cgi?id=303084.</a>

Canonical link: <a href="https://commits.webkit.org/303529@main">https://commits.webkit.org/303529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3984732e8505b42cea5aa556946644371f5b1674

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140255 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d97b877b-5c73-4892-8a05-af8ef7d0c7a6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101470 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/222882a8-7cdd-4f7a-9b11-4d130aa84b0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135672 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82263 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/30e310bd-edab-4436-9075-04d1ebfeff61) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83489 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124796 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142911 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131234 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4891 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109846 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4973 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110023 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3730 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115170 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58373 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4945 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33517 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164201 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68396 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42640 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/omg-tail-call-clobber-scratch-register.js.default (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->