### PR TITLE
[masonry] Import WPT css-masonry folder

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -98,6 +98,7 @@
     "web-platform-tests/css/css-lists": "import",
     "web-platform-tests/css/css-logical": "import",
     "web-platform-tests/css/css-masking": "import",
+    "web-platform-tests/css/css-masonry": "import",
     "web-platform-tests/css/css-mixins": "import",
     "web-platform-tests/css/css-multicol": "import",
     "web-platform-tests/css/css-namespaces": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: masonry
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-computed-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Property item-tolerance value 'normal'
+PASS Property item-tolerance value 'infinite'
+PASS Property item-tolerance value '10px'
+PASS Property item-tolerance value '20%'
+PASS Property item-tolerance value 'calc(20% + 10px)'
+PASS Property item-tolerance value 'calc(-0.5em + 10px)'
+PASS Property item-tolerance value 'calc(0.5em + 10px)'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-computed.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masonry: item-tolerance getComputedStyle()</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<link rel="author" title="Sam Davis Omekara Jr." href="mailto:samomekarajr@microsoft.com">
+<meta name="assert" content="item-tolerance computed value is as specified.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+<script>
+test_computed_value("item-tolerance", "normal");
+test_computed_value("item-tolerance", "infinite");
+
+test_computed_value("item-tolerance", "10px");
+test_computed_value("item-tolerance", "20%");
+test_computed_value("item-tolerance", "calc(20% + 10px)");
+
+test_computed_value("item-tolerance", "calc(-0.5em + 10px)", "0px");
+test_computed_value("item-tolerance", "calc(0.5em + 10px)", "30px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-invalid-expected.txt
@@ -1,0 +1,14 @@
+
+PASS e.style['item-tolerance'] = "auto" should not set the property value
+PASS e.style['item-tolerance'] = "10" should not set the property value
+PASS e.style['item-tolerance'] = "10px 20px" should not set the property value
+PASS e.style['item-tolerance'] = "1fr" should not set the property value
+FAIL e.style['item-tolerance'] = "-1px" should not set the property value assert_equals: expected "" but got "-1px"
+FAIL e.style['item-tolerance'] = "-10%" should not set the property value assert_equals: expected "" but got "-10%"
+PASS e.style['item-tolerance'] = "normal 10px" should not set the property value
+PASS e.style['item-tolerance'] = "infinite 10px" should not set the property value
+PASS e.style['item-tolerance'] = "10px normal" should not set the property value
+PASS e.style['item-tolerance'] = "10px infinite" should not set the property value
+PASS e.style['item-tolerance'] = "normal infinite" should not set the property value
+PASS e.style['item-tolerance'] = "infinite normal" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-invalid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masonry: item-tolerance parsing</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<link rel="author" title="Sam Davis Omekara Jr." href="mailto:samomekarajr@microsoft.com">
+<meta name="assert" content="item-tolerance supports only the grammar 'normal | <length-percentage>'.">
+<meta name="assert" content="item-tolerance rejects negative <length-percentage>.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("item-tolerance", "auto");
+
+test_invalid_value("item-tolerance", "10");
+test_invalid_value("item-tolerance", "10px 20px");
+test_invalid_value("item-tolerance", "1fr");
+test_invalid_value("item-tolerance", "-1px");
+test_invalid_value("item-tolerance", "-10%");
+test_invalid_value("item-tolerance", "normal 10px");
+test_invalid_value("item-tolerance", "infinite 10px");
+test_invalid_value("item-tolerance", "10px normal");
+test_invalid_value("item-tolerance", "10px infinite");
+test_invalid_value("item-tolerance", "normal infinite");
+test_invalid_value("item-tolerance", "infinite normal");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-valid-expected.txt
@@ -1,0 +1,10 @@
+
+PASS e.style['item-tolerance'] = "normal" should set the property value
+PASS e.style['item-tolerance'] = "infinite" should set the property value
+PASS e.style['item-tolerance'] = "initial" should set the property value
+PASS e.style['item-tolerance'] = "0" should set the property value
+PASS e.style['item-tolerance'] = "1px" should set the property value
+PASS e.style['item-tolerance'] = "calc(2em + 3ex)" should set the property value
+PASS e.style['item-tolerance'] = "4%" should set the property value
+PASS e.style['item-tolerance'] = "5vmin" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-valid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masonry: item-tolerance parsing</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<link rel="author" title="Sam Davis Omekara Jr." href="mailto:samomekarajr@microsoft.com">
+<meta name="assert" content="item-tolerance supports the full grammar 'normal | <length-percentage>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("item-tolerance", "normal");
+test_valid_value("item-tolerance", "infinite");
+test_valid_value("item-tolerance", "initial");
+
+test_valid_value("item-tolerance", "0", "0px");
+test_valid_value("item-tolerance", "1px");
+test_valid_value("item-tolerance", "calc(2em + 3ex)");
+test_valid_value("item-tolerance", "4%");
+test_valid_value("item-tolerance", "5vmin");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-computed-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL Property masonry-direction value 'row' assert_true: masonry-direction doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-direction value 'column' assert_true: masonry-direction doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-direction value 'row-reverse' assert_true: masonry-direction doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-direction value 'column-reverse' assert_true: masonry-direction doesn't seem to be supported in the computed style expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-computed.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: masonry-direction getComputedStyle()</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/computed-testcommon.js"></script>
+  <script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  </div>
+  <script>
+    test_computed_value("masonry-direction", "row");
+    test_computed_value("masonry-direction", "column");
+    test_computed_value("masonry-direction", "row-reverse");
+    test_computed_value("masonry-direction", "column-reverse");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-invalid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['masonry-direction'] = "auto" should not set the property value
+PASS e.style['masonry-direction'] = "column row-reverse" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-invalid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: parsing masonry-direction with invalid values</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <meta name="assert" content="masonry-direction supports only the grammar 'row | row-reverse | column | column-reverse'.">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  </div>
+  <script>
+    test_invalid_value("masonry-direction", "auto");
+    test_invalid_value("masonry-direction", "column row-reverse");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-valid-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL e.style['masonry-direction'] = "row" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-direction'] = "row-reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-direction'] = "column" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-direction'] = "column-reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-valid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: parsing masonry-direction with valid values</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <meta name="assert" content="masonry-direction supports the full grammar 'row | row-reverse | column | column-reverse'.">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  <script>
+    test_valid_value("masonry-direction", "row");
+    test_valid_value("masonry-direction", "row-reverse");
+    test_valid_value("masonry-direction", "column");
+    test_valid_value("masonry-direction", "column-reverse");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-computed-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Property masonry-fill value 'normal' assert_true: masonry-fill doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-fill value 'reverse' assert_true: masonry-fill doesn't seem to be supported in the computed style expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-computed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: masonry-fill getComputedStyle()</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/computed-testcommon.js"></script>
+  <script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  </div>
+  <script>
+    test_computed_value("masonry-fill", "normal");
+    test_computed_value("masonry-fill", "reverse");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-invalid-expected.txt
@@ -1,0 +1,7 @@
+
+PASS e.style['masonry-fill'] = "10" should not set the property value
+PASS e.style['masonry-fill'] = "true" should not set the property value
+PASS e.style['masonry-fill'] = "default" should not set the property value
+PASS e.style['masonry-fill'] = "set" should not set the property value
+PASS e.style['masonry-fill'] = "before, after" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-invalid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: parsing masonry-fill with invalid values</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  <script>
+    test_invalid_value('masonry-fill', '10');
+    test_invalid_value('masonry-fill', 'true');
+    test_invalid_value('masonry-fill', 'default');
+    test_invalid_value('masonry-fill', 'set');
+    test_invalid_value('masonry-fill', 'before, after');
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-valid-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL e.style['masonry-fill'] = "normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-fill'] = "reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-valid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: parsing masonry-fill with valid values</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  <script>
+    test_valid_value('masonry-fill', 'normal');
+    test_valid_value('masonry-fill', 'reverse');
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-computed-expected.txt
@@ -1,0 +1,10 @@
+
+FAIL Property masonry-flow value 'column normal' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-flow value 'column reverse' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-flow value 'row normal' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-flow value 'row reverse' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-flow value 'column-reverse normal' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-flow value 'column-reverse reverse' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-flow value 'row-reverse normal' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry-flow value 'row-reverse reverse' assert_true: masonry-flow doesn't seem to be supported in the computed style expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-computed.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Masonry: masonry-flow getComputedStyle()</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/computed-testcommon.js"></script>
+  <script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  <script>
+    test_computed_value("masonry-flow", "column normal");
+    test_computed_value("masonry-flow", "column reverse");
+
+    test_computed_value("masonry-flow", "row normal");
+    test_computed_value("masonry-flow", "row reverse");
+
+    test_computed_value("masonry-flow", "column-reverse normal");
+    test_computed_value("masonry-flow", "column-reverse reverse");
+
+    test_computed_value("masonry-flow", "row-reverse normal");
+    test_computed_value("masonry-flow", "row-reverse reverse");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-invalid-expected.txt
@@ -1,0 +1,9 @@
+
+PASS e.style['masonry-flow'] = "nowrap row nowrap" should not set the property value
+PASS e.style['masonry-flow'] = "column wrap column" should not set the property value
+PASS e.style['masonry-flow'] = "reverse-column column" should not set the property value
+PASS e.style['masonry-flow'] = "reverse-row, row" should not set the property value
+PASS e.style['masonry-flow'] = "normal row-reverse" should not set the property value
+PASS e.style['masonry-flow'] = "reverse column" should not set the property value
+PASS e.style['masonry-flow'] = "auto, auto" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-invalid.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: masonry-flow parsing</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+  <script>
+    test_invalid_value("masonry-flow", "nowrap row nowrap");
+    test_invalid_value("masonry-flow", "column wrap column");
+    test_invalid_value("masonry-flow", "reverse-column column");
+    test_invalid_value("masonry-flow", "reverse-row, row");
+    test_invalid_value("masonry-flow", "normal row-reverse");
+    test_invalid_value("masonry-flow", "reverse column");
+    test_invalid_value("masonry-flow", "auto, auto");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-valid-expected.txt
@@ -1,0 +1,34 @@
+
+FAIL e.style['masonry-flow'] = "column normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "column reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "column normal" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "column" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column normal" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column normal" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry-flow'] = "column reverse" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "column" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column reverse" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column reverse" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry-flow'] = "row normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "row reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "row normal" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "row" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row normal" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row normal" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry-flow'] = "row reverse" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "row" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row reverse" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row reverse" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry-flow'] = "column-reverse normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "column-reverse reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "column-reverse normal" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "column-reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column-reverse normal" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column-reverse normal" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry-flow'] = "column-reverse reverse" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "column-reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column-reverse reverse" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "column-reverse reverse" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry-flow'] = "row-reverse normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "row-reverse reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry-flow'] = "row-reverse normal" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "row-reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row-reverse normal" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row-reverse normal" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry-flow'] = "row-reverse reverse" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "row-reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row-reverse reverse" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "reverse" but got (undefined) undefined
+FAIL e.style['masonry-flow'] = "row-reverse reverse" should not set unrelated longhands assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-valid.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: parsing masonry-flow with valid values</title>
+  <link rel="author" title="Celeste Pan" href="mailto:celestepan@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/parsing-testcommon.js"></script>
+  <script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+  <script>
+    test_valid_value("masonry-flow", "column normal");
+    test_valid_value("masonry-flow", "column reverse");
+    test_shorthand_value('masonry-flow', 'column normal', {
+      'masonry-direction': 'column',
+      'masonry-fill': 'normal'
+    });
+    test_shorthand_value('masonry-flow', 'column reverse', {
+      'masonry-direction': 'column',
+      'masonry-fill': 'reverse'
+    });
+
+    test_valid_value("masonry-flow", "row normal");
+    test_valid_value("masonry-flow", "row reverse");
+    test_shorthand_value('masonry-flow', 'row normal', {
+      'masonry-direction': 'row',
+      'masonry-fill': 'normal'
+    });
+    test_shorthand_value('masonry-flow', 'row reverse', {
+      'masonry-direction': 'row',
+      'masonry-fill': 'reverse'
+    });
+
+    test_valid_value("masonry-flow", "column-reverse normal");
+    test_valid_value("masonry-flow", "column-reverse reverse");
+    test_shorthand_value('masonry-flow', 'column-reverse normal', {
+      'masonry-direction': 'column-reverse',
+      'masonry-fill': 'normal'
+    });
+    test_shorthand_value('masonry-flow', 'column-reverse reverse', {
+      'masonry-direction': 'column-reverse',
+      'masonry-fill': 'reverse'
+    });
+
+    test_valid_value("masonry-flow", "row-reverse normal");
+    test_valid_value("masonry-flow", "row-reverse reverse");
+    test_shorthand_value('masonry-flow', 'row-reverse normal', {
+      'masonry-direction': 'row-reverse',
+      'masonry-fill': 'normal'
+    });
+    test_shorthand_value('masonry-flow', 'row-reverse reverse', {
+      'masonry-direction': 'row-reverse',
+      'masonry-fill': 'reverse'
+    });
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-computed-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL Property masonry value '"a b" 1fr 2fr row normal' assert_true: masonry doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry value '8px column normal' assert_true: masonry doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry value '"a b c" 10% 20% 30% row-reverse' assert_true: masonry doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry value '"a b" 10px 20px column-reverse reverse' assert_true: masonry doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry value 'min-content row' assert_true: masonry doesn't seem to be supported in the computed style expected true got false
+FAIL Property masonry value 'repeat(5, auto) reverse' assert_true: masonry doesn't seem to be supported in the computed style expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-computed.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Masonry: masonry getComputedStyle()</title>
+  <link rel="author" title="Yanling Wang" href="mailto:yanlingwang@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/computed-testcommon.js"></script>
+  <script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+  <div id="target"></div>
+  <script>
+    test_computed_value("masonry", '"a b" 1fr 2fr row normal');
+    test_computed_value("masonry", "8px column normal");
+    test_computed_value("masonry", '"a b c" 10% 20% 30% row-reverse', '"a b c" 10% 20% 30% row-reverse normal');
+    test_computed_value("masonry", '"a b" 10px 20px column-reverse reverse');
+    test_computed_value("masonry", 'min-content row', 'min-content row normal');
+    test_computed_value("masonry", 'repeat(5, auto) reverse', 'repeat(5, auto) column reverse');
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-invalid-expected.txt
@@ -1,0 +1,14 @@
+
+PASS e.style['masonry'] = "\"a a\" 1fr row normal extra" should not set the property value
+PASS e.style['masonry'] = "\"a a a\" \"b b b\" 1fr 1fr 1fr column normal" should not set the property value
+PASS e.style['masonry'] = "row normal \"a a\" 1fr" should not set the property value
+PASS e.style['masonry'] = "\"a a\" 1fr invalid normal" should not set the property value
+PASS e.style['masonry'] = "10px reverse invalid" should not set the property value
+PASS e.style['masonry'] = "fit-content(-10px)" should not set the property value
+PASS e.style['masonry'] = "[] normal" should not set the property value
+PASS e.style['masonry'] = "[] repeat(auto-fill, 10px) \"a\" row-reverse" should not set the property value
+PASS e.style['masonry'] = "[one] 10px [two] [three]" should not set the property value
+PASS e.style['masonry'] = "[auto] 1px" should not set the property value
+PASS e.style['masonry'] = "20% 40% column, reverse" should not set the property value
+PASS e.style['masonry'] = "none auto column-reverse reverse" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-invalid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: parsing masonry with invalid values</title>
+  <link rel="author" title="Yanling Wang" href="mailto:yanlingwang@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+  <script>
+    test_invalid_value("masonry", '"a a" 1fr row normal extra');
+    test_invalid_value("masonry", '"a a a" "b b b" 1fr 1fr 1fr column normal');
+    test_invalid_value("masonry", 'row normal "a a" 1fr');
+    test_invalid_value("masonry", '"a a" 1fr invalid normal');
+    test_invalid_value("masonry", '10px reverse invalid');
+    test_invalid_value("masonry", 'fit-content(-10px)');
+    test_invalid_value("masonry", '[] normal');
+    test_invalid_value("masonry", '[] repeat(auto-fill, 10px) "a" row-reverse');
+    test_invalid_value("masonry", '[one] 10px [two] [three]');
+    test_invalid_value("masonry", '[auto] 1px');
+    test_invalid_value("masonry", '20% 40% column, reverse');
+    test_invalid_value("masonry", 'none auto column-reverse reverse');
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-serialization-expected.txt
@@ -1,0 +1,37 @@
+
+FAIL grid-template-rows: none,
+      grid-template-columns: none,
+      grid-template-areas: none,
+      masonry-direction: column,
+      masonry-fill: normal should be valid. assert_equals: expected (string) "none column normal" but got (undefined) undefined
+FAIL grid-template-rows: 10px,
+      grid-template-columns: none,
+      grid-template-areas: none,
+      masonry-direction: column,
+      masonry-fill: reverse should be valid. assert_equals: expected (string) "none column reverse" but got (undefined) undefined
+FAIL grid-template-rows: 10px 20px,
+      grid-template-columns: 10% 20%,
+      grid-template-areas: none,
+      masonry-direction: row,
+      masonry-fill: normal should be valid. assert_equals: expected (string) "10px 20px row normal" but got (undefined) undefined
+FAIL grid-template-rows: none,
+      grid-template-columns: 1fr 1fr 3fr,
+      grid-template-areas: "a a b",
+      masonry-direction: column,
+      masonry-fill: reverse should be valid. assert_equals: expected (string) "\"a a b\" 1fr 1fr 3fr column reverse" but got (undefined) undefined
+FAIL grid-template-rows: 20% 40%,
+      grid-template-columns: none,
+      grid-template-areas: "b" "a",
+      masonry-direction: row,
+      masonry-fill: normal should be valid. assert_equals: expected (string) "\"b a\" 20% 40% row normal" but got (undefined) undefined
+FAIL grid-template-rows: none,
+      grid-template-columns: fit-content(calc(0.5em + 10px)),
+      grid-template-areas: none,
+      masonry-direction: column-reverse,
+      masonry-fill: normal should be valid. assert_equals: expected (string) "fit-content(calc(0.5em + 10px)) column-reverse normal" but got (undefined) undefined
+FAIL grid-template-rows: 10% 20% 40%,
+      grid-template-columns: none,
+      grid-template-areas: "a" "b" "c",
+      masonry-direction: row-reverse,
+      masonry-fill: normal should be valid. assert_equals: expected (string) "\"a b c\" 10% 20% 40% row-reverse normal" but got (undefined) undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-serialization.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Masonry: masonry serializes properly when longhands are set</title>
+  <link rel="author" title="Yanling Wang" href="mailto:yanlingwang@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <script>
+    function testValidMasonry(gridTemplateRowsValue, gridTemplateColumnsValue, gridTemplateAreasValue, masonryDirectionValue, masonryFillValue, serializedMasonryValue) {
+    test(()=>{
+      const root = document.documentElement;
+    const properties = [
+      ["gridTemplateRows", gridTemplateRowsValue],
+      ["gridTemplateColumns", gridTemplateColumnsValue],
+      ["gridTemplateAreas", gridTemplateAreasValue],
+      ["masonryDirection", masonryDirectionValue],
+      ["masonryFill", masonryFillValue],
+    ];
+    for (const [property, value] of properties) {
+      root.style[property] = "";
+      root.style[property] = value;
+    }
+    assert_equals(root.style.masonry, serializedMasonryValue);
+  }, `grid-template-rows: ${gridTemplateRowsValue},
+      grid-template-columns: ${gridTemplateColumnsValue},
+      grid-template-areas: ${gridTemplateAreasValue},
+      masonry-direction: ${masonryDirectionValue},
+      masonry-fill: ${masonryFillValue} should be valid.`);
+}
+
+  testValidMasonry("none", "none", "none", "column", "normal", "none column normal");
+  testValidMasonry("10px", "none", "none", "column", "reverse", "none column reverse");
+  testValidMasonry("10px 20px", "10% 20%", "none", "row", "normal", "10px 20px row normal");
+  testValidMasonry("none", "1fr 1fr 3fr", '"a a b"', 'column', 'reverse','"a a b" 1fr 1fr 3fr column reverse');
+  testValidMasonry("20% 40%", "none", '"b" "a"', 'row', 'normal', '"b a" 20% 40% row normal');
+  testValidMasonry("none", "fit-content(calc(0.5em + 10px))", "none", "column-reverse", "normal", "fit-content(calc(0.5em + 10px)) column-reverse normal");
+  testValidMasonry("10% 20% 40%", "none", '"a" "b" "c"', "row-reverse", "normal", '"a b c" 10% 20% 40% row-reverse normal');
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-valid-expected.txt
@@ -1,0 +1,36 @@
+
+FAIL masonry followed by !important assert_equals: expected (string) "\"test\" max-content row normal" but got (undefined) undefined
+FAIL e.style['masonry'] = "\"a\" calc(10px) column-reverse normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry'] = "minmax(calc(30% + 40vw), 10px)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL masonry: minmax(10px, 20px) row should be valid. assert_not_equals: property should be set got disallowed value ""
+FAIL masonry: 1px 2px should be valid. assert_not_equals: property should be set got disallowed value ""
+FAIL masonry: "a" 10px reverse should be valid. assert_not_equals: property should be set got disallowed value ""
+FAIL masonry: "a b" 10px 20px row normal should be valid. assert_not_equals: property should be set got disallowed value ""
+FAIL masonry: "a b c" 10% 20% 30% row-reverse should be valid. assert_not_equals: property should be set got disallowed value ""
+FAIL masonry: repeat(5, auto) row reverse should be valid. assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['masonry'] = "none" should set grid-template-areas assert_equals: grid-template-areas should be canonical expected "none" but got ""
+FAIL e.style['masonry'] = "none" should set grid-template-columns assert_equals: grid-template-columns should be canonical expected "none" but got ""
+FAIL e.style['masonry'] = "none" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "column" but got (undefined) undefined
+FAIL e.style['masonry'] = "none" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry'] = "none" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry'] = "10px reverse" should set grid-template-areas assert_equals: grid-template-areas should be canonical expected "none" but got ""
+FAIL e.style['masonry'] = "10px reverse" should set grid-template-columns assert_equals: grid-template-columns should be canonical expected "10px" but got ""
+FAIL e.style['masonry'] = "10px reverse" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "column" but got (undefined) undefined
+FAIL e.style['masonry'] = "10px reverse" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "reverse" but got (undefined) undefined
+FAIL e.style['masonry'] = "10px reverse" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry'] = "\"b a\" 20% 40% column normal" should set grid-template-areas assert_equals: grid-template-areas should be canonical expected "\"b a\"" but got ""
+FAIL e.style['masonry'] = "\"b a\" 20% 40% column normal" should set grid-template-columns assert_equals: grid-template-columns should be canonical expected "20% 40%" but got ""
+FAIL e.style['masonry'] = "\"b a\" 20% 40% column normal" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "column" but got (undefined) undefined
+FAIL e.style['masonry'] = "\"b a\" 20% 40% column normal" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry'] = "\"b a\" 20% 40% column normal" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry'] = "\"b b a\" 1fr 2fr 3fr row" should set grid-template-areas assert_equals: grid-template-areas should be canonical expected "\"b\" \"b\" \"a\"" but got ""
+FAIL e.style['masonry'] = "\"b b a\" 1fr 2fr 3fr row" should set grid-template-rows assert_equals: grid-template-rows should be canonical expected "1fr 2fr 3fr" but got ""
+FAIL e.style['masonry'] = "\"b b a\" 1fr 2fr 3fr row" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "row" but got (undefined) undefined
+FAIL e.style['masonry'] = "\"b b a\" 1fr 2fr 3fr row" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry'] = "\"b b a\" 1fr 2fr 3fr row" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['masonry'] = "repeat(2, auto) row-reverse" should set grid-template-areas assert_equals: grid-template-areas should be canonical expected "none" but got ""
+FAIL e.style['masonry'] = "repeat(2, auto) row-reverse" should set grid-template-rows assert_equals: grid-template-rows should be canonical expected "repeat(2, auto)" but got ""
+FAIL e.style['masonry'] = "repeat(2, auto) row-reverse" should set masonry-direction assert_equals: masonry-direction should be canonical expected (string) "row-reverse" but got (undefined) undefined
+FAIL e.style['masonry'] = "repeat(2, auto) row-reverse" should set masonry-fill assert_equals: masonry-fill should be canonical expected (string) "normal" but got (undefined) undefined
+FAIL e.style['masonry'] = "repeat(2, auto) row-reverse" should not set unrelated longhands assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-valid.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Masonry: parsing masonry with valid values</title>
+  <link rel="author" title="Yanling Wang" href="mailto:yanlingwang@microsoft.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/css/support/parsing-testcommon.js"></script>
+  <script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<style>
+  #div {
+    masonry: "test" max-content row !important;
+  }
+</style>
+<body>
+  <div id=div></div>
+  <div id=testDiv></div>
+  <script>
+    test(() => {
+      assert_equals(getComputedStyle(div).masonry, '"test" max-content row normal');
+    }, 'masonry followed by !important');
+
+    function test_valid_masonry_value(property, value, serializedValue) {
+      if (arguments.length < 3)
+        serializedValue = value;
+      var stringifiedValue = JSON.stringify(value);
+      test(()=>{
+        var testDiv = document.getElementById('testDiv');
+        testDiv.style[property] = "";
+        testDiv.style[property] = value;
+        var readValue = getComputedStyle(testDiv).getPropertyValue(property);
+        assert_not_equals(readValue, "", "property should be set");
+        assert_equals(readValue, serializedValue, "serialization should be canonical");
+      }, `masonry: ${value} should be valid.`);
+    }
+
+    test_valid_value("masonry", '"a" calc(10px) column-reverse normal');
+    test_valid_value("masonry", 'minmax(calc(30% + 40vw), 10px)', 'minmax(calc(30% + 40vw), 10px) column normal');
+    test_valid_masonry_value("masonry", 'minmax(10px, 20px) row', 'minmax(10px, 20px) row normal');
+    test_valid_masonry_value("masonry", '1px 2px', '1px 2px column normal');
+    test_valid_masonry_value("masonry", '"a" 10px reverse', '"a" 10px column reverse');
+    test_valid_masonry_value("masonry", '"a b" 10px 20px row normal');
+    test_valid_masonry_value("masonry", '"a b c" 10% 20% 30% row-reverse', '"a b c" 10% 20% 30% row-reverse normal');
+    test_valid_masonry_value("masonry", 'repeat(5, auto) row reverse');
+    test_shorthand_value('masonry', 'none', {
+      'grid-template-columns': 'none',
+      'grid-template-areas': 'none',
+      'masonry-direction': 'column',
+      'masonry-fill': 'normal'
+    });
+    test_shorthand_value('masonry', '10px reverse', {
+      'grid-template-columns': '10px',
+      'grid-template-areas': 'none',
+      'masonry-direction': 'column',
+      'masonry-fill': 'reverse'
+    });
+    test_shorthand_value('masonry', '"b a" 20% 40% column normal', {
+      'grid-template-columns': '20% 40%',
+      'grid-template-areas': '"b a"',
+      'masonry-direction': 'column',
+      'masonry-fill': 'normal'
+    });
+    test_shorthand_value('masonry', '"b b a" 1fr 2fr 3fr row', {
+      'grid-template-rows': '1fr 2fr 3fr',
+      'grid-template-areas': '"b" "b" "a"',
+      'masonry-direction': 'row',
+      'masonry-fill': 'normal'
+    });
+    test_shorthand_value('masonry', 'repeat(2, auto) row-reverse', {
+      'grid-template-rows': 'repeat(2, auto)',
+      'grid-template-areas': 'none',
+      'masonry-direction': 'row-reverse',
+      'masonry-fill': 'normal'
+    });
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/w3c-import.log
@@ -1,0 +1,32 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-serialization.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-valid.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/WEB_FEATURES.yml


### PR DESCRIPTION
#### af451a50c413a9f9ef7e2cdcb99f977b1a16dcb7
<pre>
[masonry] Import WPT css-masonry folder
<a href="https://bugs.webkit.org/show_bug.cgi?id=302640">https://bugs.webkit.org/show_bug.cgi?id=302640</a>
<a href="https://rdar.apple.com/problem/164882874">rdar://problem/164882874</a>

Reviewed by Sammy Gill.

Import css/css-masonry-folder
Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/6c213479a8cb49a88133a9c500b35a8b56e8def3">https://github.com/web-platform-tests/wpt/commit/6c213479a8cb49a88133a9c500b35a8b56e8def3</a>

* LayoutTests/imported/w3c/resources/import-expectations.json
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/WEB_FEATURES.yml
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-computed-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-computed.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-invalid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-invalid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-valid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/item-tolerance-valid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-computed-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-computed.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-invalid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-invalid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-valid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-direction-valid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-computed-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-computed.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-invalid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-invalid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-valid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-fill-valid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-computed-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-computed.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-invalid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-invalid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-valid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-flow-valid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-computed-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-computed.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-invalid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-invalid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-serialization-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-serialization.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-valid-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/masonry-shorthand-valid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/tentative/parsing/w3c-import.log
* LayoutTests/imported/w3c/web-platform-tests/css/css-masonry/w3c-import.log

Canonical link: <a href="https://commits.webkit.org/303129@main">https://commits.webkit.org/303129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f779db41e3ff94465111acf953ca19d73e97037

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83168 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5be89c7a-fd0e-4278-a31f-f8582a5e9b61) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3577 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8d34c894-80aa-4362-9c74-821129b7a96c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81141 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/50be5665-3caf-47ee-8b04-3ee8dd1b5eef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2627 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82103 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141554 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3480 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36264 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108927 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27601 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/2639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113951 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56657 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3542 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32372 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3564 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->