### PR TITLE
Ref count various WebKit types within Swift

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -57,6 +57,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/RunLoop.h>
 #include <wtf/ThreadAssertions.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -849,7 +850,7 @@ private:
 #endif
 
     friend class StreamClientConnection;
-};
+} SWIFT_SHARED_REFERENCE(refConnection, derefConnection);
 
 template<typename T>
 Error Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
@@ -1158,3 +1159,13 @@ inline void markCurrentlyDispatchedMessageAsInvalid(const RefPtr<Connection>& co
 
 
 } // namespace IPC
+
+inline void refConnection(IPC::Connection* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefConnection(IPC::Connection* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -29,6 +29,7 @@
 #include "APIObject.h"
 #include <ranges>
 #include <wtf/Forward.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/Vector.h>
 
 namespace API {
@@ -89,8 +90,18 @@ private:
     }
 
     Vector<RefPtr<Object>> m_elements;
-};
+} SWIFT_SHARED_REFERENCE(refArray, derefArray);
 
 } // namespace API
+
+inline void refArray(API::Array* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefArray(API::Array* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}
 
 SPECIALIZE_TYPE_TRAITS_API_OBJECT(Array);

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -30,6 +30,7 @@
 #include <wtf/Platform.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 #if PLATFORM(COCOA)
@@ -284,7 +285,7 @@ private:
 
     CFTypeRef m_wrapper;
 #endif // DELEGATE_REF_COUNTING_TO_COCOA
-};
+} SWIFT_SHARED_REFERENCE(refObject, derefObject);
 
 template <Object::Type ArgumentType>
 class ObjectImpl : public Object {
@@ -317,6 +318,24 @@ inline API::Object* Object::unwrap(void* object)
 #endif
 
 } // namespace API
+
+inline void refObject(API::Object* WTF_NONNULL obj)
+{
+#if DELEGATE_REF_COUNTING_TO_COCOA
+    obj->ref();
+#else
+    WTF::ref(obj);
+#endif
+}
+
+inline void derefObject(API::Object* WTF_NONNULL obj)
+{
+#if DELEGATE_REF_COUNTING_TO_COCOA
+    obj->deref();
+#else
+    WTF::deref(obj);
+#endif
+}
 
 #undef DELEGATE_REF_COUNTING_TO_COCOA
 

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -36,6 +36,7 @@
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/RefCounted.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/RunLoop.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -142,7 +143,7 @@ private:
     );
 
     Vector<AtomString> m_documentState;
-};
+} SWIFT_SHARED_REFERENCE(refFrameState, derefFrameState);
 
 struct BackForwardListState {
     Vector<Ref<FrameState>> items;
@@ -161,3 +162,13 @@ struct SessionState {
 };
 
 } // namespace WebKit
+
+inline void refFrameState(WebKit::FrameState* obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefFrameState(WebKit::FrameState* obj)
+{
+    WTF::deref(obj);
+}

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -29,6 +29,7 @@
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RetainReleaseSwift.h>
 
 namespace WebKit {
 
@@ -85,6 +86,17 @@ private:
     Ref<FrameState> m_frameState;
     WeakPtr<WebBackForwardListFrameItem> m_parent;
     Vector<Ref<WebBackForwardListFrameItem>> m_children;
-};
+
+} SWIFT_SHARED_REFERENCE(refWebBackForwardListFrameItem, derefWebBackForwardListFrameItem);
 
 } // namespace WebKit
+
+inline void refWebBackForwardListFrameItem(WebKit::WebBackForwardListFrameItem* obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefWebBackForwardListFrameItem(WebKit::WebBackForwardListFrameItem* obj)
+{
+    WTF::deref(obj);
+}

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -31,6 +31,7 @@
 #include "WebsiteDataStore.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -123,11 +124,21 @@ private:
     RefPtr<ViewSnapshot> m_snapshot;
 #endif
     bool m_isRemoteFrameNavigation { false };
-};
+} SWIFT_SHARED_REFERENCE(refBackForwardListItem, derefBackForwardListItem);
 
 typedef Vector<Ref<WebBackForwardListItem>> BackForwardListItemVector;
 
 } // namespace WebKit
+
+inline void refBackForwardListItem(WebKit::WebBackForwardListItem* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefBackForwardListItem(WebKit::WebBackForwardListItem* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebBackForwardListItem)
 static bool isType(const API::Object& object) { return object.type() == API::Object::Type::BackForwardListItem; }

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -37,6 +37,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/ProcessID.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/Seconds.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMalloc.h>
@@ -334,7 +335,7 @@ private:
 #endif
     HashMap<Vector<uint8_t>, std::pair<unsigned, std::unique_ptr<IPC::Encoder>>> m_messagesToSendOnResume;
     unsigned m_messagesToSendOnResumeIndex { 0 };
-};
+} SWIFT_SHARED_REFERENCE(refAuxiliaryProcessProxy, derefAuxiliaryProcessProxy);
 
 template<typename T>
 bool AuxiliaryProcessProxy::send(T&& message, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions)
@@ -398,3 +399,13 @@ inline AuxiliaryProcessProxy::State AuxiliaryProcessProxy::state() const
 }
 
 } // namespace WebKit
+
+inline void refAuxiliaryProcessProxy(WebKit::AuxiliaryProcessProxy* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefAuxiliaryProcessProxy(WebKit::AuxiliaryProcessProxy* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -28,6 +28,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <pal/SessionID.h>
 #include <wtf/Forward.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -77,6 +78,16 @@ private:
     WeakRef<WebProcessPool> m_processPool;
     unsigned m_capacity { 0 };
     WeakListHashSet<WebBackForwardListItem> m_itemsWithCachedPage;
-};
+} SWIFT_SHARED_REFERENCE(refWebBackForwardCache, derefWebBackForwardCache);
 
 } // namespace WebKit
+
+inline void refWebBackForwardCache(WebKit::WebBackForwardCache* WTF_NONNULL obj)
+{
+    obj->ref();
+}
+
+inline void derefWebBackForwardCache(WebKit::WebBackForwardCache* WTF_NONNULL obj)
+{
+    obj->deref();
+}

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -40,6 +40,7 @@
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/ProcessID.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -317,9 +318,19 @@ private:
     WebCore::SandboxFlags m_effectiveSandboxFlags;
     WebCore::ReferrerPolicy m_effectiveReferrerPolicy { WebCore::ReferrerPolicy::EmptyString };
     WebCore::ScrollbarMode m_scrollingMode;
-};
+} SWIFT_SHARED_REFERENCE(refWebFrameProxy, derefWebFrameProxy);
 
 } // namespace WebKit
+
+inline void refWebFrameProxy(WebKit::WebFrameProxy* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefWebFrameProxy(WebKit::WebFrameProxy* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebFrameProxy)
     static bool isType(const API::Object& object) { return object.type() == API::Object::Type::Frame; }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -35,6 +35,7 @@
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
 #include <wtf/ProcessID.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/RunLoop.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
@@ -4054,9 +4055,19 @@ private:
     bool m_statusBarIsVisible { true };
     bool m_menuBarIsVisible { true };
     bool m_toolbarsAreVisible { true };
-};
+} SWIFT_SHARED_REFERENCE(refWebPageProxy, derefWebPageProxy);
 
 } // namespace WebKit
+
+inline void refWebPageProxy(WebKit::WebPageProxy* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefWebPageProxy(WebKit::WebPageProxy* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebPageProxy)
     static bool isType(const API::Object& object) { return object.type() == API::Object::Type::Page; }

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -30,6 +30,7 @@
 #include "WebPreferencesDefinitions.h"
 #include "WebPreferencesStore.h"
 #include <wtf/RefPtr.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -151,9 +152,19 @@ private:
     bool m_needUpdateAfterBatch { false };
 
     FOR_EACH_WEBKIT_PREFERENCE_WITH_INSPECTOR_OVERRIDE(DECLARE_INSPECTOR_OVERRIDE_STORE)
-};
+} SWIFT_SHARED_REFERENCE(refPrefs, derefPrefs);
 
 } // namespace WebKit
+
+inline void refPrefs(WebKit::WebPreferences* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefPrefs(WebKit::WebPreferences* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebPreferences)
 static bool isType(const API::Object& object) { return object.type() == API::Object::Type::Preferences; }

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -60,6 +60,7 @@
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
@@ -934,11 +935,21 @@ private:
 
     bool m_didReceiveLogsDuringLaunchForTesting { false };
 #endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-};
+} SWIFT_SHARED_REFERENCE(refWebProcessProxy, derefWebProcessProxy);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const WebProcessProxy&);
 
 } // namespace WebKit
+
+inline void refWebProcessProxy(WebKit::WebProcessProxy* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefWebProcessProxy(WebKit::WebProcessProxy* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebProcessProxy)
 static bool isType(const WebKit::AuxiliaryProcessProxy& process) { return process.type() == WebKit::AuxiliaryProcessProxy::Type::WebContent; }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -48,6 +48,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefCounter.h>
 #include <wtf/RefPtr.h>
+#include <wtf/RetainReleaseSwift.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -679,8 +680,18 @@ private:
 
     RemoveDataTaskCounter m_removeDataTaskCounter;
     uint64_t m_cookiesVersion { 0 };
-};
+} SWIFT_SHARED_REFERENCE(refDataStore, derefDataStore);
 
+}
+
+inline void refDataStore(WebKit::WebsiteDataStore* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefDataStore(WebKit::WebsiteDataStore* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebsiteDataStore)

--- a/Tools/TestWebKitAPI/Configurations/Base.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/Base.xcconfig
@@ -81,7 +81,7 @@ CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 GCC_WARN_64_TO_32_BIT_CONVERSION[arch=arm64*] = NO;
 GCC_WARN_64_TO_32_BIT_CONVERSION[arch=x86_64] = NO;
-WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wthread-safety;
+WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wthread-safety -Wno-nullability-completeness;
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 WK_FIXME_WARNING_CFLAGS = -Wno-unused-parameter -Wno-undef;


### PR DESCRIPTION
#### 85b8b03d430589e9a39c93e69983ef393e17fc8a
<pre>
Ref count various WebKit types within Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=302644">https://bugs.webkit.org/show_bug.cgi?id=302644</a>
<a href="https://rdar.apple.com/164888628">rdar://164888628</a>

Reviewed by Geoffrey Garen.

This informs Swift that some C++ types should be treated as Swift reference
types (i.e. reference-counted) rather than value types. It teaches Swift
how to manipulate the reference counts for these types.

This is a temporary solution. In due course, we&apos;ll be able to inform
Swift that the base WTF::RefCounted type is the ancestor of all reference
counted types, and it won&apos;t be necessary to make these changes to
individual classes.

That&apos;s enabled by either of these changes:
<a href="https://rdar.apple.com/131065240">rdar://131065240</a> - allow templated types to be ref counted
<a href="https://rdar.apple.com/160696723">rdar://160696723</a> - allow method calls for ref and deref
We can&apos;t currently use this functionality in WebKit because we need
to support older compilers, and also due to a compiler
bug <a href="https://rdar.apple.com/162195228">rdar://162195228</a>. So for now, we will annotate just those
specific types which are required for upcoming CoreIPC message handler
work.

To avoid warnings/errors, these functions need to have their parameters
marked as _Nonnull, or specifically to adopt the WTF macro WTF_NONNULL.
That currently causes problems with -Wnullability-completeness, which
complains that other functions in the same headers are not duly
annotated. WebKit has switched off this warning for its whole codebase
but had overlooked TestWebKitAPI, which does not inherit warning flags
from the rest of the .xcconfig system. Add this warning flag there too
in order to prevent these compile errors when TestWebKitAPI indirectly
includes IPC/Connection.h

Canonical link: <a href="https://commits.webkit.org/303461@main">https://commits.webkit.org/303461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49337756612d9141c84e9d3d96eabccb3cf669a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83980 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0c1d04b-cbd9-4cb3-aef2-9143293baf93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100957 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68315 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4363c9c5-6ff9-4938-ac6d-03127f0b1c38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a0661a02-fbed-4499-be7d-9249c767694e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3104 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1100 "Found 2 new API test failures: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer, TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82803 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142230 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4231 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109327 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3211 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57467 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4285 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32962 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4116 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4376 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4244 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->