### PR TITLE
[WKCI] git checkout commands should run with --progress flag enabled

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -287,7 +287,7 @@ class CheckOutSpecificRevision(shell.ShellCommand):
         return not self.doStepIf(step)
 
     def run(self):
-        self.command = ['git', 'checkout', self.getProperty('user_provided_git_hash')]
+        self.command = ['git', 'checkout', '--progress', self.getProperty('user_provided_git_hash')]
         return super().run()
 
 

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -870,7 +870,7 @@ class CheckOutSpecificRevision(shell.ShellCommand):
         return result
 
     def run(self):
-        self.command = ['git', 'checkout', self.getProperty('ews_revision')]
+        self.command = ['git', 'checkout', '--progress', self.getProperty('ews_revision')]
         return super().run()
 
 
@@ -1083,9 +1083,9 @@ class UpdateWorkingDirectory(steps.ShellSequence, ShellMixin):
         base = self.getProperty('github.base.ref', DEFAULT_BRANCH)
 
         commands = [
-            ['git', 'checkout', 'remotes/{}/{}'.format(remote, base), '-f'],
+            ['git', 'checkout', '--progress', 'remotes/{}/{}'.format(remote, base), '-f'],
             self.shell_command('git branch -D {} || {}'.format(base, self.shell_exit_0())),
-            ['git', 'checkout', '-b', base],
+            ['git', 'checkout', '--progress', '-b', base],
         ]
         if base != DEFAULT_BRANCH:
             commands.append(self.shell_command('git branch -D {} || {}'.format(DEFAULT_BRANCH, self.shell_exit_0())))
@@ -1199,7 +1199,7 @@ class CheckOutPullRequest(steps.ShellSequence, ShellMixin):
             self.shell_command(f'git remote add {remote} {GITHUB_URL}{project}.git || {self.shell_exit_0()}'),
             ['git', 'remote', 'set-url', remote, f'{GITHUB_URL}{project}.git'],
             ['git', 'fetch', remote, pr_branch],
-            ['git', 'checkout', '-b', pr_branch],
+            ['git', 'checkout', '--progress', '-b', pr_branch],
             ['git', 'cherry-pick', '--allow-empty', f'HEAD..remotes/{remote}/{pr_branch}'],
         ]
 
@@ -2905,7 +2905,7 @@ class RevertAppliedChanges(steps.ShellSequence):
             exclude_patterns.extend(('-e', pattern))
         for command in [
             ['git', 'clean', '-f', '-d'] + exclude_patterns,
-            ['git', 'checkout', self.getProperty('ews_revision') or self.getProperty('got_revision')],
+            ['git', 'checkout', '--progress', self.getProperty('ews_revision') or self.getProperty('got_revision')],
         ]:
             self.commands.append(util.ShellArg(command=command, logname='stdio'))
 
@@ -6208,7 +6208,7 @@ class CleanGitRepo(steps.ShellSequence, ShellMixin):
             self.shell_command('git am --abort || {}'.format(self.shell_exit_0())),
             self.shell_command('git cherry-pick --abort || {}'.format(self.shell_exit_0())),
             ['git', 'clean', '-f', '-d'],  # Remove any left-over layout test results, added files, etc.
-            ['git', 'checkout', '{}/{}'.format(self.git_remote, self.default_branch), '-f'],  # Checkout branch from specific remote
+            ['git', 'checkout', '--progress', '{}/{}'.format(self.git_remote, self.default_branch), '-f'],  # Checkout branch from specific remote
             ['git', 'branch', '-D', self.default_branch],  # Delete any local cache of the specified branch
             ['git', 'branch', self.default_branch],  # Create local instance of branch from remote, but don't track it
             self.shell_command("git branch | grep -v ' {}$' | grep -v 'HEAD detached at' | xargs git branch -D || {}".format(self.default_branch, self.shell_exit_0())),
@@ -6912,7 +6912,7 @@ class Canonicalize(steps.ShellSequence, ShellMixin, AddToLogMixin):
             commands += [['git', 'pull', remote, base_ref, '--rebase']]
             if head_ref:
                 commands += [['git', 'branch', '-f', base_ref, head_ref]]
-            commands += [['git', 'checkout', base_ref]]
+            commands += [['git', 'checkout', '--progress', base_ref]]
         commands.append(['python3', 'Tools/Scripts/git-webkit', 'canonicalize', '-n', str(self.number_commits_to_canonicalize())])
 
         if self.getProperty('github.number', ''):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -3508,7 +3508,7 @@ class TestCheckOutSpecificRevision(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=1200,
                         log_environ=False,
-                        command=['git', 'checkout', '1a3425cb92dbcbca12a10aa9514f1b77c76dc26'],
+                        command=['git', 'checkout', '--progress', '1a3425cb92dbcbca12a10aa9514f1b77c76dc26'],
                         )
             .exit(0),
         )
@@ -3523,7 +3523,7 @@ class TestCheckOutSpecificRevision(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=1200,
                         log_environ=False,
-                        command=['git', 'checkout', '1a3425cb92dbcbca12a10aa9514f1b77c76dc26'],
+                        command=['git', 'checkout', '--progress', '1a3425cb92dbcbca12a10aa9514f1b77c76dc26'],
                         )
             .log('stdio', stdout='Unexpected failure')
             .exit(2),
@@ -3599,7 +3599,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(
                 workdir='wkdir',
                 log_environ=False,
-                command=['git', 'checkout', 'remotes/origin/main', '-f'],
+                command=['git', 'checkout', '--progress', 'remotes/origin/main', '-f'],
             ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -3607,7 +3607,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
                         ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
-                        command=['git', 'checkout', '-b', 'main'],
+                        command=['git', 'checkout', '--progress', '-b', 'main'],
                         ).exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Updated working directory')
@@ -3620,7 +3620,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(
                 workdir='wkdir',
                 log_environ=False,
-                command=['git', 'checkout', 'remotes/origin/safari-xxx-branch', '-f'],
+                command=['git', 'checkout', '--progress', 'remotes/origin/safari-xxx-branch', '-f'],
             ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -3628,7 +3628,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
                         ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
-                        command=['git', 'checkout', '-b', 'safari-xxx-branch'],
+                        command=['git', 'checkout', '--progress', '-b', 'safari-xxx-branch'],
                         ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -3649,7 +3649,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(
                 workdir='wkdir',
                 log_environ=False,
-                command=['git', 'checkout', 'remotes/security/main', '-f'],
+                command=['git', 'checkout', '--progress', 'remotes/security/main', '-f'],
             ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -3657,7 +3657,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
                         ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
-                        command=['git', 'checkout', '-b', 'main'],
+                        command=['git', 'checkout', '--progress', '-b', 'main'],
                         ).exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Updated working directory')
@@ -3671,7 +3671,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(
                 workdir='wkdir',
                 log_environ=False,
-                command=['git', 'checkout', 'remotes/security/safari-xxx-branch', '-f'],
+                command=['git', 'checkout', '--progress', 'remotes/security/safari-xxx-branch', '-f'],
             ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -3679,7 +3679,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
                         ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
-                        command=['git', 'checkout', '-b', 'safari-xxx-branch'],
+                        command=['git', 'checkout', '--progress', '-b', 'safari-xxx-branch'],
                         ).exit(0),
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -3698,7 +3698,7 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         log_environ=False,
-                        command=['git', 'checkout', 'remotes/origin/main', '-f'],
+                        command=['git', 'checkout', '--progress', 'remotes/origin/main', '-f'],
                         )
             .log('stdio', stdout='Unexpected failure.')
             .exit(2),
@@ -3948,7 +3948,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', '-b', 'eng/pull-request-branch'],
+                command=['git', 'checkout', '--progress', '-b', 'eng/pull-request-branch'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -4005,7 +4005,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', '-b', 'eng/pull-request-branch'],
+                command=['git', 'checkout', '--progress', '-b', 'eng/pull-request-branch'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -4062,7 +4062,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', '-b', 'integration/ci/1234'],
+                command=['git', 'checkout', '--progress', '-b', 'integration/ci/1234'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -4119,7 +4119,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', '-b', 'eng/pull-request-branch'],
+                command=['git', 'checkout', '--progress', '-b', 'eng/pull-request-branch'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -4198,7 +4198,7 @@ class TestRevertAppliedChanges(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=5 * 60,
-                command=['git', 'checkout', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
+                command=['git', 'checkout', '--progress', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
             ).exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Reverted applied changes')
@@ -4220,7 +4220,7 @@ class TestRevertAppliedChanges(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=5 * 60,
-                command=['git', 'checkout', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
+                command=['git', 'checkout', '--progress', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
             ).exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Reverted applied changes')
@@ -4242,7 +4242,7 @@ class TestRevertAppliedChanges(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=5 * 60,
-                command=['git', 'checkout', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
+                command=['git', 'checkout', '--progress', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
             )
             .log('stdio', stdout='Unexpected failure.').exit(2),
         )
@@ -4264,7 +4264,7 @@ class TestRevertAppliedChanges(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=5 * 60,
-                command=['git', 'checkout', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
+                command=['git', 'checkout', '--progress', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
             ).exit(0),
         )
         self.expect_outcome(result=SUCCESS, state_string='Reverted applied changes')
@@ -4288,7 +4288,7 @@ class TestRevertAppliedChanges(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=5 * 60,
-                command=['git', 'checkout', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
+                command=['git', 'checkout', '--progress', 'b2db8d1da7b74b5ddf075e301370e64d914eef7c'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -6064,7 +6064,7 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='You are in detached HEAD state.'),
             ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
@@ -6096,7 +6096,7 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='You are in detached HEAD state.'),
             ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
@@ -6127,7 +6127,7 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', 'origin/master', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'checkout', '--progress', 'origin/master', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='You are in detached HEAD state.'),
             ExpectShell(command=['git', 'branch', '-D', 'master'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='Deleted branch master (was 57015967fef9).'),
@@ -6158,7 +6158,7 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(128)
+            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(128)
             .log('stdio', stdout='You are in detached HEAD state.'),
             ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
@@ -6190,7 +6190,7 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='You are in detached HEAD state.'),
             ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
@@ -8605,7 +8605,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', 'main'],
+                command=['git', 'checkout', '--progress', 'main'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -8668,7 +8668,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', 'main'],
+                command=['git', 'checkout', '--progress', 'main'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -8732,7 +8732,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', 'main'],
+                command=['git', 'checkout', '--progress', 'main'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -8795,7 +8795,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', 'safari-000-branch'],
+                command=['git', 'checkout', '--progress', 'safari-000-branch'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',
@@ -8895,7 +8895,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 log_environ=False,
                 env=self.ENV,
-                command=['git', 'checkout', 'main'],
+                command=['git', 'checkout', '--progress', 'main'],
             ).exit(0),
             ExpectShell(
                 workdir='wkdir',


### PR DESCRIPTION
#### 8f26e204263c2bbf2ea1db09dfc6d28e6ccc4dc0
<pre>
[WKCI] git checkout commands should run with --progress flag enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=302646">https://bugs.webkit.org/show_bug.cgi?id=302646</a>

Reviewed by Nikolas Zimmermann.

git checkout only reports the progress to stderr by default when
running inside a terminal, so it happens that on buildbot steps
the git checkout command is silent by default (no TTY attached).

And that can cause the command to be killed meanwhile is working
because it can reach the deadline of 300 seconds without output.

Fix that by explicitly enabling progress reporting.

* Tools/CISupport/build-webkit-org/steps.py:
(CheckOutSpecificRevision.run):
* Tools/CISupport/ews-build/steps.py:
(CheckOutSpecificRevision.run):
(UpdateWorkingDirectory.run):
(CheckOutPullRequest.getCommandList):
(RevertAppliedChanges.run):
(CleanGitRepo.run):
(Canonicalize.run):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestCheckOutSpecificRevision.test_success):
(TestCheckOutSpecificRevision.test_failure):
(TestUpdateWorkingDirectory.test_success):
(TestUpdateWorkingDirectory.test_success_branch):
(TestUpdateWorkingDirectory.test_success_remote):
(TestUpdateWorkingDirectory.test_success_remote_branch):
(TestUpdateWorkingDirectory.test_failure):
(TestCheckOutPullRequest.test_success):
(TestCheckOutPullRequest.test_success_apple):
(TestCheckOutPullRequest.test_success_integration_remote):
(TestCheckOutPullRequest.test_success_win):
(TestRevertAppliedChanges.test_success):
(TestRevertAppliedChanges.test_success_exclude):
(TestRevertAppliedChanges.test_failure):
(TestRevertAppliedChanges.test_patch):
(TestRevertAppliedChanges.test_glib_cleanup):

Canonical link: <a href="https://commits.webkit.org/303126@main">https://commits.webkit.org/303126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d719be040e1397392413649d9f4589ce7045dc44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138936 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3604 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134378 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81149 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82130 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141580 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3507 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36291 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130860 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3553 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/108948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2664 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113978 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56693 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20424 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3569 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->