### PR TITLE
[threaded-animations] timelines contained within iframes don't get uploaded to the remote layer tree

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html
+++ b/LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+#target {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+
+    background-color: green;
+    opacity: 0;
+}
+
+</style>
+
+<div id="target"></div>
+
+</body>

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS The timeline current time updates as its source is scrolled with a root scroller within an iframe
+

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<body>
+    
+<style>
+    
+iframe {
+    position: absolute;
+    
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+
+    border: none;
+}    
+
+</style>
+    
+<iframe src="resources/scroll-timeline-in-iframe-content.html"></iframe>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const iframe = document.querySelector("iframe");
+
+const target = () => iframe.contentDocument.getElementById("target");
+
+const scrollAndCheckTimeline = async (scroller, progress) => {
+    const maxScrollTop = scroller.scrollHeight - iframe.contentWindow.innerHeight;
+    const scrollTop = progress * maxScrollTop;
+
+    iframe.contentWindow.scrollTo(0, scrollTop);
+    await UIHelper.renderingUpdate();
+
+    const expectedTimelineTime = `${(progress * 100).toFixed(2)}%`;
+
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target());
+    assert_equals(remoteAnimationStack.animations.length, 1);
+    const timelineTime = remoteAnimationStack.animations[0].timeline.currentTime;
+    assert_equals(timelineTime, expectedTimelineTime, `After scrolling to ${scrollTop}, the timeline time is ${expectedTimelineTime}`);
+};
+
+promise_test(async t => {
+    if (!target())
+        await new Promise(resolve => iframe.contentWindow.addEventListener("DOMContentLoaded", resolve));
+
+    const scroller = iframe.contentDocument.documentElement;
+
+    const timeline = new ScrollTimeline({ source : scroller });
+    const animation = target().animate({ opacity: 1 }, { timeline });
+
+    await animationAcceleration(animation);
+
+    await scrollAndCheckTimeline(scroller, 0);
+    await scrollAndCheckTimeline(scroller, 0.5);
+    await scrollAndCheckTimeline(scroller, 1);
+    await scrollAndCheckTimeline(scroller, 0.25);
+    await scrollAndCheckTimeline(scroller, 0.75);
+}, "The timeline current time updates as its source is scrolled with a root scroller within an iframe");
+
+</script>
+</body>


### PR DESCRIPTION
#### 62b90babf8ba020b69a887fa629bdccc970837be
<pre>
[threaded-animations] timelines contained within iframes don&apos;t get uploaded to the remote layer tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=302647">https://bugs.webkit.org/show_bug.cgi?id=302647</a>
<a href="https://rdar.apple.com/164892610">rdar://164892610</a>

Reviewed by Simon Fraser.

When we added support for uploading timelines through the remote layer tree transaction in 301942@main
we only ever looked for timelines in the top-level document of any given page. We now iterate through
all of a page&apos;s documents and make a union of all timelines found.

Test: webanimations/threaded-animations/scroll-timeline-in-iframe.html

* LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html: Added.
* LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html: Added.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitLayerTree):

Canonical link: <a href="https://commits.webkit.org/303169@main">https://commits.webkit.org/303169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08680e5f82a329e67e1e01ff3a4202316871fcc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83212 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/314d5bb9-d791-43e9-8812-779f6a5b85ec) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100372 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67912 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7179cc8c-7303-417a-93cc-be40053240ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81159 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d67c4385-4c03-40e7-9df4-e15d6681fa67) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82142 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141595 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3519 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108958 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2674 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56705 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20441 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3581 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32402 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->