### PR TITLE
Max triangles per draw call limit is a bit low

### DIFF
--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -257,24 +257,12 @@ static uint32_t computeMaxCountForDevice(id<MTLDevice> device)
 {
 #if HAVE(METAL_FAMILY_9)
     if ([device supportsFamily:MTLGPUFamilyApple9])
-        return 300 * MB;
+        return 3 * GB;
 #endif
-#if HAVE(METAL_FAMILY_8)
-    if ([device supportsFamily:MTLGPUFamilyApple8])
-        return 275 * MB;
-#endif
-    if ([device supportsFamily:MTLGPUFamilyApple7])
-        return 250 * MB;
-    if ([device supportsFamily:MTLGPUFamilyApple6])
-        return 225 * MB;
-    if ([device supportsFamily:MTLGPUFamilyApple5])
-        return 200 * MB;
-    if ([device supportsFamily:MTLGPUFamilyApple4])
-        return 200 * MB;
     if ([device supportsFamily:MTLGPUFamilyMac2])
-        return 300 * MB;
+        return 3 * GB;
 
-    return 200 * MB;
+    return 2 * GB;
 }
 
 static uint32_t computeAppleGPUFamily(id<MTLDevice> device)
@@ -808,7 +796,7 @@ id<MTLRenderPipelineState> Device::indexedIndirectBufferClampPipeline(NSUInteger
     {
         device MTLDrawPrimitivesIndirectArguments& output = wkoutput.args;
         device MTLDrawIndexedPrimitivesIndirectArguments& indexedOutput = wkindexedOutput.args;
-        bool lostCondition = input.indexCount > %u || input.instanceCount > %u || input.indexCount * input.instanceCount > %u;
+        bool lostCondition = input.indexCount > %u || input.instanceCount > %u || madsat(input.indexCount, input.instanceCount, 0u) > %u;
         bool condition = lostCondition
             || input.indexCount + input.indexStart > indexBufferCount[0]
             || input.indexStart >= indexBufferCount[0]
@@ -877,7 +865,7 @@ id<MTLRenderPipelineState> Device::indirectBufferClampPipeline(NSUInteger raster
     [[vertex]] void vsIndirect(device const MTLDrawPrimitivesIndirectArguments& input [[buffer(0)]], device WebKitMTLDrawPrimitivesIndirectArguments& wkoutput [[buffer(1)]], const constant uint* minCounts [[buffer(2)]])
     {
         device MTLDrawPrimitivesIndirectArguments& output = wkoutput.args;
-        bool lostCondition = input.vertexCount > %u || input.instanceCount > %u || input.vertexCount * input.instanceCount > %u;
+        bool lostCondition = input.vertexCount > %u || input.instanceCount > %u || madsat(input.vertexCount, input.instanceCount, 0u) > %u;
         bool vertexCondition = lostCondition
             || input.vertexCount + input.vertexStart > minCounts[0]
             || input.vertexStart >= minCounts[0];


### PR DESCRIPTION
#### 7f28b7d8367413221eb43cc0be8b01976856593d
<pre>
Max triangles per draw call limit is a bit low
<a href="https://bugs.webkit.org/show_bug.cgi?id=302650">https://bugs.webkit.org/show_bug.cgi?id=302650</a>
<a href="https://rdar.apple.com/164894555">rdar://164894555</a>

Reviewed by Dan Glastonbury.

We received a report that a developer had to split
up draw calls due to running into an arbitrary limit
we choose to limit command buffer errors on iOS.

I tried the site, <a href="https://sebbbi.github.io/LimitedDetail/">https://sebbbi.github.io/LimitedDetail/</a>, which
seems fine on my iPhone so it seems like the limit is too low.

Sites may still run into errors with complex functions or outputs,
but this is already achievable with smaller draw call counts so it
seems like we limit real use cases with the earlier limit.

* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::computeMaxCountForDevice):

Canonical link: <a href="https://commits.webkit.org/303233@main">https://commits.webkit.org/303233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dea36965753e3832d639513278cc4edd41bfd136

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83196 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/88b0dfdf-7743-464f-9446-ad6ccfa2ed05) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100360 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67893 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4ba6e01f-44b2-4b5f-be65-971bdc181a5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81144 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e28535b9-6288-4b66-98af-61a5828df040) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/385 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82127 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111256 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141575 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3504 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108723 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27670 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2661 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56690 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3566 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32388 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3588 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->