### PR TITLE
[Style] Convert the 'hanging-punctuation' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3502,6 +3502,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/svg/StyleSVGStrokeDasharray.h
     style/values/svg/StyleSVGStrokeDashoffset.h
 
+    style/values/text/StyleHangingPunctuation.h
     style/values/text/StyleHyphenateCharacter.h
     style/values/text/StyleHyphenateLimitEdge.h
     style/values/text/StyleHyphenateLimitLines.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3338,6 +3338,7 @@ style/values/text-decoration/StyleTextDecorationThickness.cpp
 style/values/text-decoration/StyleTextEmphasisStyle.cpp
 style/values/text-decoration/StyleTextShadow.cpp
 style/values/text-decoration/StyleTextUnderlineOffset.cpp
+style/values/text/StyleHangingPunctuation.cpp
 style/values/text/StyleLetterSpacing.cpp
 style/values/text/StyleTabSize.cpp
 style/values/text/StyleTextAutospace.cpp

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -46,6 +46,7 @@
 #include "ScrollAxis.h"
 #include "ScrollTypes.h"
 #include "StyleContain.h"
+#include "StyleHangingPunctuation.h"
 #include "StyleImageOrientation.h"
 #include "StyleMarginTrim.h"
 #include "StylePositionVisibility.h"
@@ -924,8 +925,8 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-#define TYPE HangingPunctuation
-#define FOR_EACH(CASE) CASE(First) CASE(Last) CASE(AllowEnd) CASE(ForceEnd)
+#define TYPE Style::HangingPunctuationValue
+#define FOR_EACH(CASE) CASE(First) CASE(ForceEnd) CASE(AllowEnd) CASE(Last)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4517,7 +4517,7 @@
                 "last"
             ],
             "codegen-properties": {
-                "style-converter": "HangingPunctuation",
+                "style-converter": "StyleType<HangingPunctuation>",
                 "parser-grammar": "none | [ first || [ force-end | allow-end ] || last ]@(preserve-order no-single-item-opt)"
             },
             "specification": {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -460,7 +460,7 @@ void Line::appendText(const InlineTextItem& inlineTextItem, const RenderStyle& s
             return;
         }
         if (TextUtil::hasHangableStopOrCommaEnd(inlineTextItem, style)) {
-            auto isConditionalHanging = style.hangingPunctuation().contains(HangingPunctuation::AllowEnd);
+            auto isConditionalHanging = style.hangingPunctuation().contains(Style::HangingPunctuationValue::AllowEnd);
             m_hangingContent.setTrailingStopOrComma(TextUtil::hangableStopOrCommaEndWidth(inlineTextItem, style), isConditionalHanging);
             return;
         }

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -509,7 +509,7 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedInlineLayoutByStyle(const
             return false;
         if (style.boxDecorationBreak() == BoxDecorationBreak::Clone)
             return false;
-        if (!style.hangingPunctuation().isEmpty())
+        if (!style.hangingPunctuation().isNone())
             return false;
         if (!style.hyphenateLimitLines().isNoLimit())
             return false;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -630,7 +630,7 @@ InlineLayoutUnit TextUtil::hyphenWidth(const RenderStyle& style)
 
 bool TextUtil::hasHangablePunctuationStart(const InlineTextItem& inlineTextItem, const RenderStyle& style)
 {
-    if (!inlineTextItem.length() || !style.hangingPunctuation().contains(HangingPunctuation::First))
+    if (!inlineTextItem.length() || !style.hangingPunctuation().contains(Style::HangingPunctuationValue::First))
         return false;
     auto leadingCharacter = inlineTextItem.inlineTextBox().content()[inlineTextItem.start()];
     return U_GET_GC_MASK(leadingCharacter) & (U_GC_PS_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
@@ -647,7 +647,7 @@ float TextUtil::hangablePunctuationStartWidth(const InlineTextItem& inlineTextIt
 
 bool TextUtil::hasHangablePunctuationEnd(const InlineTextItem& inlineTextItem, const RenderStyle& style)
 {
-    if (!inlineTextItem.length() || !style.hangingPunctuation().contains(HangingPunctuation::Last))
+    if (!inlineTextItem.length() || !style.hangingPunctuation().contains(Style::HangingPunctuationValue::Last))
         return false;
     auto trailingCharacter = inlineTextItem.inlineTextBox().content()[inlineTextItem.end() - 1];
     return U_GET_GC_MASK(trailingCharacter) & (U_GC_PE_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
@@ -664,7 +664,7 @@ float TextUtil::hangablePunctuationEndWidth(const InlineTextItem& inlineTextItem
 
 bool TextUtil::hasHangableStopOrCommaEnd(const InlineTextItem& inlineTextItem, const RenderStyle& style)
 {
-    if (!inlineTextItem.length() || !style.hangingPunctuation().containsAny({ HangingPunctuation::AllowEnd, HangingPunctuation::ForceEnd }))
+    if (!inlineTextItem.length() || !style.hangingPunctuation().containsAny({ Style::HangingPunctuationValue::AllowEnd, Style::HangingPunctuationValue::ForceEnd }))
         return false;
     auto trailingPosition = inlineTextItem.end() - 1;
     auto trailingCharacter = inlineTextItem.inlineTextBox().content()[trailingPosition];

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4709,8 +4709,8 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
     CheckedPtr<RenderBox> previousFloat;
     bool isPrevChildInlineFlow = false;
     bool shouldBreakLineAfterText = false;
-    bool canHangPunctuationAtStart = styleToUse.hangingPunctuation().contains(HangingPunctuation::First);
-    bool canHangPunctuationAtEnd = styleToUse.hangingPunctuation().contains(HangingPunctuation::Last);
+    bool canHangPunctuationAtStart = styleToUse.hangingPunctuation().contains(Style::HangingPunctuationValue::First);
+    bool canHangPunctuationAtEnd = styleToUse.hangingPunctuation().contains(Style::HangingPunctuationValue::Last);
     RenderText* lastText = nullptr;
     struct RubyBaseContent {
         float minimumWidth { 0.f };

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -345,9 +345,9 @@ inline bool BreakingContext::handleText()
 
     const RenderStyle& style = lineStyle(renderer, m_lineInfo);
     const FontCascade& font = style.fontCascade();
-    bool canHangPunctuationAtStart = style.hangingPunctuation().contains(HangingPunctuation::First);
-    bool canHangPunctuationAtEnd = style.hangingPunctuation().contains(HangingPunctuation::Last);
-    bool canHangStopOrCommaAtLineEnd = style.hangingPunctuation().contains(HangingPunctuation::AllowEnd);
+    bool canHangPunctuationAtStart = style.hangingPunctuation().contains(Style::HangingPunctuationValue::First);
+    bool canHangPunctuationAtEnd = style.hangingPunctuation().contains(Style::HangingPunctuationValue::Last);
+    bool canHangStopOrCommaAtLineEnd = style.hangingPunctuation().contains(Style::HangingPunctuationValue::AllowEnd);
     int endPunctuationIndex = canHangPunctuationAtEnd && m_collapseWhiteSpace ? renderer.lastCharacterIndexStrippingSpaces() : renderer.text().length() - 1;
 
     float wrapWidthOffset = m_width.uncommittedWidth() + inlineLogicalWidth(renderer, !m_appliedStartWidth, true);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -128,7 +128,6 @@ enum class FontSynthesisLonghandValue : bool;
 enum class FontVariantCaps : uint8_t;
 enum class FontVariantEmoji : uint8_t;
 enum class FontVariantPosition : uint8_t;
-enum class HangingPunctuation : uint8_t;
 enum class Hyphens : uint8_t;
 enum class ImageRendering : uint8_t;
 enum class InputSecurity : bool;
@@ -280,6 +279,7 @@ struct GridPosition;
 struct GridTemplateAreas;
 struct GridTemplateList;
 struct GridTrackSizes;
+struct HangingPunctuation;
 struct HyphenateCharacter;
 struct HyphenateLimitEdge;
 struct HyphenateLimitLines;
@@ -890,7 +890,7 @@ public:
     inline BreakBetween breakBefore() const;
     inline BreakBetween breakAfter() const;
 
-    OptionSet<HangingPunctuation> hangingPunctuation() const;
+    inline Style::HangingPunctuation hangingPunctuation() const;
 
     inline Style::WebkitTextStrokeWidth textStrokeWidth() const;
 
@@ -1650,7 +1650,7 @@ public:
     inline void setBreakAfter(BreakBetween);
     inline void setBreakInside(BreakInside);
     
-    inline void setHangingPunctuation(OptionSet<HangingPunctuation>);
+    inline void setHangingPunctuation(Style::HangingPunctuation);
 
     inline void setLineGrid(Style::WebkitLineGrid&&);
     inline void setLineSnap(LineSnap);
@@ -2022,7 +2022,7 @@ public:
     static constexpr Style::TextSpacingTrim initialTextSpacingTrim();
     static constexpr BreakBetween initialBreakBetween();
     static constexpr BreakInside initialBreakInside();
-    static constexpr OptionSet<HangingPunctuation> initialHangingPunctuation();
+    static constexpr Style::HangingPunctuation initialHangingPunctuation();
     static constexpr TableLayoutType initialTableLayout();
     static constexpr BorderCollapse initialBorderCollapse();
     static constexpr BorderStyle initialBorderStyle();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -657,17 +657,6 @@ TextStream& operator<<(TextStream& ts, UsedFloat floating)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, HangingPunctuation punctuation)
-{
-    switch (punctuation) {
-    case HangingPunctuation::First: ts << "first"_s; break;
-    case HangingPunctuation::Last: ts << "last"_s; break;
-    case HangingPunctuation::AllowEnd: ts << "allow-end"_s; break;
-    case HangingPunctuation::ForceEnd: ts << "force-end"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, Hyphens hyphens)
 {
     switch (hyphens) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -697,13 +697,6 @@ enum class BreakInside : uint8_t {
     AvoidPage
 };
 
-enum class HangingPunctuation : uint8_t {
-    First     = 1 << 0,
-    Last      = 1 << 1,
-    AllowEnd  = 1 << 2,
-    ForceEnd  = 1 << 3
-};
-
 enum class EmptyCell : bool {
     Show,
     Hide
@@ -1283,7 +1276,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, FlexDirection);
 WTF::TextStream& operator<<(WTF::TextStream&, FlexWrap);
 WTF::TextStream& operator<<(WTF::TextStream&, Float);
 WTF::TextStream& operator<<(WTF::TextStream&, UsedFloat);
-WTF::TextStream& operator<<(WTF::TextStream&, HangingPunctuation);
 WTF::TextStream& operator<<(WTF::TextStream&, Hyphens);
 WTF::TextStream& operator<<(WTF::TextStream&, ImageRendering);
 WTF::TextStream& operator<<(WTF::TextStream&, InsideLink);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -264,7 +264,7 @@ inline const Style::GridPosition& RenderStyle::gridItemStart(Style::GridTrackSiz
 inline const Style::GridTemplateList& RenderStyle::gridTemplateRows() const { return m_nonInheritedData->rareData->grid->m_gridTemplateRows; }
 inline const Style::GridTemplateList& RenderStyle::gridTemplateList(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridTemplateColumns() : gridTemplateRows(); }
 inline const Style::GridTemplateAreas& RenderStyle::gridTemplateAreas() const { return m_nonInheritedData->rareData->grid->m_gridTemplateAreas; }
-inline OptionSet<HangingPunctuation> RenderStyle::hangingPunctuation() const { return OptionSet<HangingPunctuation>::fromRaw(m_rareInheritedData->hangingPunctuation); }
+inline Style::HangingPunctuation RenderStyle::hangingPunctuation() const { return Style::HangingPunctuation::fromRaw(m_rareInheritedData->hangingPunctuation); }
 inline bool RenderStyle::hasAnimations() const { return !animations().isInitial(); }
 inline bool RenderStyle::hasAnimationsOrTransitions() const { return hasAnimations() || hasTransitions(); }
 inline bool RenderStyle::hasAnyPublicPseudoStyles() const { return m_nonInheritedFlags.hasAnyPublicPseudoStyles(); }
@@ -452,7 +452,7 @@ inline Style::GridPosition RenderStyle::initialGridItemRowStart() { return CSS::
 inline Style::GridTemplateList RenderStyle::initialGridTemplateColumns() { return CSS::Keyword::None { }; }
 inline Style::GridTemplateList RenderStyle::initialGridTemplateRows() { return CSS::Keyword::None { }; }
 inline Style::GridTemplateAreas RenderStyle::initialGridTemplateAreas() { return CSS::Keyword::None { }; }
-constexpr OptionSet<HangingPunctuation> RenderStyle::initialHangingPunctuation() { return { }; }
+constexpr Style::HangingPunctuation RenderStyle::initialHangingPunctuation() { return CSS::Keyword::None { }; }
 constexpr Style::HyphenateLimitEdge RenderStyle::initialHyphenateLimitAfter() { return CSS::Keyword::Auto { }; }
 constexpr Style::HyphenateLimitEdge RenderStyle::initialHyphenateLimitBefore() { return CSS::Keyword::Auto { }; }
 constexpr Style::HyphenateLimitLines RenderStyle::initialHyphenateLimitLines() { return CSS::Keyword::NoLimit { }; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -162,7 +162,7 @@ inline void RenderStyle::setGridItemColumnStart(Style::GridPosition&& columnStar
 inline void RenderStyle::setGridItemRowEnd(Style::GridPosition&& rowEndPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridRowEnd, WTFMove(rowEndPosition)); }
 inline void RenderStyle::setGridItemRowStart(Style::GridPosition&& rowStartPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridRowStart, WTFMove(rowStartPosition)); }
 inline void RenderStyle::setGridTemplateAreas(Style::GridTemplateAreas&& areas) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridTemplateAreas, WTFMove(areas)); }
-inline void RenderStyle::setHangingPunctuation(OptionSet<HangingPunctuation> punctuation) { SET(m_rareInheritedData, hangingPunctuation, punctuation.toRaw()); }
+inline void RenderStyle::setHangingPunctuation(Style::HangingPunctuation punctuation) { SET(m_rareInheritedData, hangingPunctuation, punctuation.toRaw()); }
 inline void RenderStyle::setHasAttrContent() { SET_NESTED(m_nonInheritedData, miscData, hasAttrContent, true); }
 inline void RenderStyle::setHasAutoCaretColor() { SET_PAIR(m_rareInheritedData, hasAutoCaretColor, true, caretColor, Style::Color::currentColor()); }
 inline void RenderStyle::setHasDisplayAffectedByAnimations() { SET_NESTED(m_nonInheritedData, miscData, hasDisplayAffectedByAnimations, true); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -457,7 +457,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(Style::WebkitTouchCallout, webkitTouchCallout);
 #endif
 
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(OptionSet<HangingPunctuation>, hangingPunctuation);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::HangingPunctuation, hangingPunctuation);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::SVGPaintOrder, paintOrder);
     LOG_IF_DIFFERENT_WITH_CAST(LineCap, capStyle);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -32,6 +32,7 @@
 #include <WebCore/StyleCursor.h>
 #include <WebCore/StyleCustomPropertyData.h>
 #include <WebCore/StyleDynamicRangeLimit.h>
+#include <WebCore/StyleHangingPunctuation.h>
 #include <WebCore/StyleHyphenateCharacter.h>
 #include <WebCore/StyleHyphenateLimitEdge.h>
 #include <WebCore/StyleHyphenateLimitLines.h>
@@ -208,7 +209,7 @@ public:
 #if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
     PREFERRED_TYPE(Style::WebkitTouchCallout) unsigned webkitTouchCallout : 1;
 #endif
-    PREFERRED_TYPE(OptionSet<HangingPunctuation>) unsigned hangingPunctuation : 4;
+    PREFERRED_TYPE(Style::HangingPunctuation) unsigned hangingPunctuation : 4;
     PREFERRED_TYPE(Style::SVGPaintOrder::Type) unsigned paintOrder : 3;
     PREFERRED_TYPE(LineCap) unsigned capStyle : 2;
     PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -121,8 +121,6 @@ public:
     static Resize convertResize(BuilderState&, const CSSValue&);
     static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
 
-    static OptionSet<HangingPunctuation> convertHangingPunctuation(BuilderState&, const CSSValue&);
-
     static OptionSet<SpeakAs> convertSpeakAs(BuilderState&, const CSSValue&);
 
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
@@ -310,16 +308,6 @@ inline OptionSet<SpeakAs> BuilderConverter::convertSpeakAs(BuilderState&, const 
             if (!isValueID(currentValue, CSSValueNormal))
                 result.add(fromCSSValue<SpeakAs>(currentValue));
         }
-    }
-    return result;
-}
-
-inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation(BuilderState&, const CSSValue& value)
-{
-    auto result = RenderStyle::initialHangingPunctuation();
-    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
-        for (auto& currentValue : *list)
-            result.add(fromCSSValue<HangingPunctuation>(currentValue));
     }
     return result;
 }

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -137,7 +137,6 @@ public:
     static Ref<CSSValue> convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition>);
     static Ref<CSSValue> convertTextEmphasisPosition(ExtractorState&, OptionSet<TextEmphasisPosition>);
     static Ref<CSSValue> convertSpeakAs(ExtractorState&, OptionSet<SpeakAs>);
-    static Ref<CSSValue> convertHangingPunctuation(ExtractorState&, OptionSet<HangingPunctuation>);
     static Ref<CSSValue> convertPositionAnchor(ExtractorState&, const std::optional<ScopedName>&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const std::optional<PositionArea>&);
@@ -322,22 +321,6 @@ inline Ref<CSSValue> ExtractorConverter::convertSpeakAs(ExtractorState&, OptionS
         list.append(CSSPrimitiveValue::create(CSSValueNoPunctuation));
     if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNormal);
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertHangingPunctuation(ExtractorState&, OptionSet<HangingPunctuation> hangingPunctuation)
-{
-    CSSValueListBuilder list;
-    if (hangingPunctuation & HangingPunctuation::First)
-        list.append(CSSPrimitiveValue::create(CSSValueFirst));
-    if (hangingPunctuation & HangingPunctuation::AllowEnd)
-        list.append(CSSPrimitiveValue::create(CSSValueAllowEnd));
-    if (hangingPunctuation & HangingPunctuation::ForceEnd)
-        list.append(CSSPrimitiveValue::create(CSSValueForceEnd));
-    if (hangingPunctuation & HangingPunctuation::Last)
-        list.append(CSSPrimitiveValue::create(CSSValueLast));
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -74,7 +74,6 @@ public:
     static void serializeTextUnderlinePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextUnderlinePosition>);
     static void serializeTextEmphasisPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextEmphasisPosition>);
     static void serializeSpeakAs(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<SpeakAs>);
-    static void serializeHangingPunctuation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<HangingPunctuation>);
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
     static void serializeNameScope(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const NameScope&);
@@ -285,26 +284,6 @@ inline void ExtractorSerializer::serializeSpeakAs(ExtractorState& state, StringB
 
     if (listEmpty)
         serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
-}
-
-inline void ExtractorSerializer::serializeHangingPunctuation(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<HangingPunctuation> hangingPunctuation)
-{
-    bool listEmpty = true;
-    auto appendOption = [&](HangingPunctuation test, CSSValueID value) {
-        if (hangingPunctuation &  test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(HangingPunctuation::First, CSSValueFirst);
-    appendOption(HangingPunctuation::AllowEnd, CSSValueAllowEnd);
-    appendOption(HangingPunctuation::ForceEnd, CSSValueForceEnd);
-    appendOption(HangingPunctuation::Last, CSSValueLast);
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
 }
 
 inline void ExtractorSerializer::serializePositionAnchor(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const std::optional<ScopedName>& positionAnchor)

--- a/Source/WebCore/style/values/text/StyleHangingPunctuation.cpp
+++ b/Source/WebCore/style/values/text/StyleHangingPunctuation.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleHangingPunctuation.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<HangingPunctuation>::operator()(BuilderState& state, const CSSValue& value) -> HangingPunctuation
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        case CSSValueFirst:
+            return { HangingPunctuationValue::First };
+        case CSSValueForceEnd:
+            return { HangingPunctuationValue::ForceEnd };
+        case CSSValueAllowEnd:
+            return { HangingPunctuationValue::AllowEnd };
+        case CSSValueLast:
+            return { HangingPunctuationValue::Last };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return CSS::Keyword::None { };
+
+    HangingPunctuationValueEnumSet result;
+    for (Ref item : *list) {
+        switch (item->valueID()) {
+        case CSSValueFirst:
+            result.value.add(HangingPunctuationValue::First);
+            break;
+        case CSSValueForceEnd:
+            if (result.contains(HangingPunctuationValue::AllowEnd)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::None { };
+            }
+            result.value.add(HangingPunctuationValue::ForceEnd);
+            break;
+        case CSSValueAllowEnd:
+            if (result.contains(HangingPunctuationValue::ForceEnd)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::None { };
+            }
+            result.value.add(HangingPunctuationValue::AllowEnd);
+            break;
+        case CSSValueLast:
+            result.value.add(HangingPunctuationValue::Last);
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+    return result;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/text/StyleHangingPunctuation.h
+++ b/Source/WebCore/style/values/text/StyleHangingPunctuation.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'hanging-punctuation'> = none | [ first || [ force-end | allow-end ] || last ]
+// https://drafts.csswg.org/css-text/#propdef-hanging-punctuation
+
+enum class HangingPunctuationValue : uint8_t {
+    First,
+    ForceEnd,
+    AllowEnd,
+    Last,
+};
+
+using HangingPunctuationValueEnumSet = SpaceSeparatedEnumSet<HangingPunctuationValue>;
+
+struct HangingPunctuation {
+    using EnumSet = HangingPunctuationValueEnumSet;
+    using value_type = HangingPunctuationValueEnumSet::value_type;
+
+    constexpr HangingPunctuation(CSS::Keyword::None) : m_value { } { }
+    constexpr HangingPunctuation(EnumSet&& set) : m_value { WTFMove(set) } { }
+    constexpr HangingPunctuation(value_type value) : HangingPunctuation { EnumSet { value } } { }
+    constexpr HangingPunctuation(std::initializer_list<value_type> initializerList) : HangingPunctuation { EnumSet { initializerList } } { }
+
+    static constexpr HangingPunctuation fromRaw(EnumSet::StorageType rawValue) { return EnumSet::fromRaw(rawValue); }
+    constexpr EnumSet::StorageType toRaw() const { return m_value.toRaw(); }
+
+    constexpr bool contains(HangingPunctuationValue e) const { return m_value.contains(e); }
+    constexpr bool containsAny(EnumSet other) const { return m_value.containsAny(other.value); }
+    constexpr bool containsAll(EnumSet other) const { return m_value.containsAll(other.value); }
+    constexpr bool containsOnly(EnumSet other) const { return m_value.containsOnly(other.value); }
+
+    constexpr bool isNone() const { return m_value.isEmpty(); }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isNone())
+            return visitor(CSS::Keyword::None { });
+        return visitor(m_value);
+    }
+
+    constexpr bool operator==(const HangingPunctuation&) const = default;
+
+private:
+    EnumSet m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<HangingPunctuation> { auto operator()(BuilderState&, const CSSValue&) -> HangingPunctuation; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::HangingPunctuation)


### PR DESCRIPTION
#### dd8e16a05b689346e199a5ec5babdbed5159d458
<pre>
[Style] Convert the &apos;hanging-punctuation&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302657">https://bugs.webkit.org/show_bug.cgi?id=302657</a>

Reviewed by Darin Adler.

Converts the &apos;hanging-punctuation&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/line/BreakingContext.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/text/StyleHangingPunctuation.cpp: Added.
* Source/WebCore/style/values/text/StyleHangingPunctuation.h: Added.

Canonical link: <a href="https://commits.webkit.org/303150@main">https://commits.webkit.org/303150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29aa217a8a7b2dee86c469f56cb5f1fb00d4248f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131449 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3621 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2654 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82147 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141600 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3524 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36305 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108968 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2677 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113992 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56710 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32408 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66994 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->