### PR TITLE
Resync `resources` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resources/example.pdf
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/example.pdf
@@ -1,0 +1,50 @@
+%PDF-1.7
+% ò¤ô
+1 0 obj <<
+  /Type /Catalog
+  /Pages 2 0 R
+>>
+endobj
+2 0 obj <<
+  /Type /Pages
+  /MediaBox [ 0 0 200 300 ]
+  /Count 1
+  /Kids [ 3 0 R ]
+>>
+endobj
+3 0 obj <<
+  /Type /Page
+  /Parent 2 0 R
+  /Contents 4 0 R
+>>
+endobj
+4 0 obj <<
+>>
+stream
+q
+0 0 0 rg
+0 290 10 10 re B*
+10 150 50 30 re B*
+0 0 1 rg
+190 290 10 10 re B*
+70 232 50 30 re B*
+0 1 0 rg
+190 0 10 10 re B*
+130 150 50 30 re B*
+1 0 0 rg
+0 0 10 10 re B*
+70 67 50 30 re B*
+Q
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000068 00000 n 
+0000000161 00000 n 
+0000000230 00000 n 
+trailer<< /Root 1 0 R /Size 5 >>
+startxref
+456
+%%EOF

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js
@@ -1398,7 +1398,7 @@ IdlInterface.prototype.default_to_json_operation = function() {
         if (I.has_default_to_json_regular_operation()) {
             isDefault = true;
             for (const m of I.members) {
-                if (m.special !== "static" && m.type == "attribute" && I.array.is_json_type(m.idlType)) {
+                if (!m.untested && m.special !== "static" && m.type == "attribute" && I.array.is_json_type(m.idlType)) {
                     map.set(m.name, m.idlType);
                 }
             }

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tox.ini
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py39,py310,py311,py312,py313,py314
 skipsdist=True
 
 [testenv]

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-actions.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-actions.js
@@ -252,7 +252,7 @@
      */
     addTick: function(duration) {
       this.tickIdx += 1;
-      if (duration) {
+      if (duration !== undefined && duration !== null) {
         this.pause(duration);
       }
       return this;
@@ -279,6 +279,10 @@
     /**
      * Create a keyDown event for the current default key source
      *
+     * To send special keys, send the respective key's codepoint,
+     * as defined by `WebDriver
+     * <https://w3c.github.io/webdriver/#keyboard-actions>`_.
+     *
      * @param {String} key - Key to press
      * @param {String?} sourceName - Named key source to use or null for the default key source
      * @returns {Actions}
@@ -291,6 +295,10 @@
 
     /**
      * Create a keyUp event for the current default key source
+     *
+     * To send special keys, send the respective key's codepoint,
+     * as defined by `WebDriver
+     * <https://w3c.github.io/webdriver/#keyboard-actions>`_.
      *
      * @param {String} key - Key to release
      * @param {String?} sourceName - Named key source to use or null for the default key source
@@ -536,7 +544,7 @@
         tick = actions.addTick().tickIdx;
       }
       let moveAction = {type: "pointerMove", x, y, origin};
-      if (duration) {
+      if (duration !== undefined && duration !== null) {
         moveAction.duration = duration;
       }
       let actionProperties = setPointerProperties(moveAction, width, height, pressure,
@@ -581,7 +589,7 @@
         tick = actions.addTick().tickIdx;
       }
       this.actions.set(tick, {type: "scroll", x, y, deltaX, deltaY, origin});
-      if (duration) {
+      if (duration !== undefined && duration !== null) {
         this.actions.get(tick).duration = duration;
       }
     },

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver.js
@@ -23,6 +23,14 @@
         }
     }
 
+    function assertTestIsTentative(){
+        const testPath = location.pathname;
+        const tentative = testPath.includes('.tentative.') || testPath.includes('/tentative/');
+        if (!tentative) {
+            throw new Error("Method in testdriver.js intended for tentative tests used in non-tentative test");
+        }
+    }
+
     function getInViewCenterPoint(rect) {
         var left = Math.max(0, rect.left);
         var right = Math.min(window.innerWidth, rect.right);
@@ -770,6 +778,78 @@
                 }
             },
             /**
+             * `speculation <https://wicg.github.io/nav-speculation/prefetch.html>`_ module.
+             */
+            speculation: {
+                /**
+                 * `speculation.PrefetchStatusUpdated <https://wicg.github.io/nav-speculation/prefetch.html#speculation-prefetchstatusupdated-event>`_
+                 * event.
+                 */
+                prefetch_status_updated: {
+                    /**
+                     * @typedef {object} PrefetchStatusUpdated
+                     * `speculation.PrefetchStatusUpdatedParameters <https://wicg.github.io/nav-speculation/prefetch.html#cddl-type-speculationprefetchstatusupdatedparameters>`_
+                     * event.
+                     */
+
+                    /**
+                     * Subscribes to the event. Events will be emitted only if
+                     * there is a subscription for the event. This method does
+                     * not add actual listeners. To listen to the event, use the
+                     * `on` or `once` methods. The buffered events will be
+                     * emitted before the command promise is resolved.
+                     *
+                     * @param {object} [params] Parameters for the subscription.
+                     * @param {null|Array.<(Context)>} [params.contexts] The
+                     * optional contexts parameter specifies which browsing
+                     * contexts to subscribe to the event on. It should be
+                     * either an array of Context objects, or null. If null, the
+                     * event will be subscribed to globally. If omitted, the
+                     * event will be subscribed to on the current browsing
+                     * context.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
+                     */
+                    subscribe: async function(params = {}) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.speculation
+                            .prefetch_status_updated.subscribe(params);
+                    },
+                    /**
+                     * Adds an event listener for the event.
+                     *
+                     * @param {function(PrefetchStatusUpdated): void} callback The
+                     * callback to be called when the event is emitted. The
+                     * callback is called with the event object as a parameter.
+                     * @returns {function(): void} A function that removes the
+                     * added event listener when called.
+                     */
+                    on: function(callback) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.speculation
+                            .prefetch_status_updated.on(callback);
+                    },
+                    /**
+                     * Adds an event listener for the event that is only called
+                     * once and removed afterward.
+                     *
+                     * @return {Promise<PrefetchStatusUpdated>} The promise which
+                     * is resolved with the event object when the event is emitted.
+                     */
+                    once: function() {
+                        assertBidiIsEnabled();
+                        return new Promise(resolve => {
+                            const remove_handler =
+                                window.test_driver_internal.bidi.speculation
+                                    .prefetch_status_updated.on(event => {
+                                    resolve(event);
+                                    remove_handler();
+                                });
+                        });
+                    }
+                }
+            },
+            /**
              * `emulation <https://www.w3.org/TR/webdriver-bidi/#module-emulation>`_ module.
              */
             emulation: {
@@ -882,6 +962,61 @@
                     return window.test_driver_internal.bidi.emulation.set_screen_orientation_override(
                         params);
                 },
+                /**
+                 * Overrides the touch configuration for the specified browsing
+                 * contexts.
+                 * Matches the `emulation.setTouchOverride
+                 * <https://w3c.github.io/webdriver-bidi/#command-emulation-setTouchOverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_touch_override({
+                 *     maxTouchPoints: 5
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|number} params.maxTouchPoints - The
+                 * maximum number of simultaneous touch points to support.
+                 * If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the touch override on. It should be either an array of
+                 * Context objects (window or browsing context id), or null. If
+                 * null or omitted, the override will be set on the current
+                 * browsing context.
+                 * @returns {Promise<void>} Resolves when the touch
+                 * override is successfully set.
+                 */
+                set_touch_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_touch_override(
+                        params);
+                },
+            },
+            /**
+             * `user_agent_client_hints <https://wicg.github.io/ua-client-hints/#automation>`_ module.
+             */
+            user_agent_client_hints: {
+                /**
+                 * Overrides the user agent client hints configuration for the specified browsing
+                 * contexts. Matches the `userAgentClientHints.setClientHintsOverride
+                 * <https://wicg.github.io/ua-client-hints/#emulation-setclienthintsoverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|object} params.clientHints - The client hints to override.
+                 * Matches the `userAgentClientHints.ClientHints` type.
+                 * If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the override on.
+                 * @returns {Promise<void>} Resolves when the override is successfully set.
+                 */
+                set_client_hints_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.user_agent_client_hints.set_client_hints_override(
+                        params);
+                }
             },
             /**
              * `log <https://www.w3.org/TR/webdriver-bidi/#module-log>`_ module.
@@ -973,9 +1108,12 @@
                  * @param {PermissionState} params.state - a `PermissionState
                  *                          <https://w3c.github.io/permissions/#dom-permissionstate>`_
                  *                          value.
-                 * @param {string} [params.origin] - an optional `origin` string to set the
+                 * @param {string} [params.origin] - an optional top-level `origin` string to set the
                  *                 permission for. If omitted, the permission is set for the
                  *                 current window's origin.
+                 * @param {string} [params.embeddedOrigin] - an optional embedded `origin` string to set the
+                 *                 permission for. If omitted, the top-level `origin` is used as the
+                 *                 embedded origin.
                  * @returns {Promise} fulfilled after the permission is set, or rejected if setting
                  *                    the permission fails.
                  */
@@ -1189,6 +1327,34 @@
         get_computed_role: async function(element) {
             let role = await window.test_driver_internal.get_computed_role(element);
             return role;
+        },
+
+        /**
+         * Get accessibility properties for a DOM element.
+         *
+         * @param {Element} element
+         * @returns {Promise} fulfilled after the accessibility properties are
+         *                    returned, or rejected in the cases the WebDriver
+         *                    command errors
+         */
+        get_accessibility_properties_for_element: async function(element) {
+            assertTestIsTentative();
+            let acc = await window.test_driver_internal.get_accessibility_properties_for_element(element);
+            return acc;
+        },
+
+        /**
+         * Get properties for an accessibility node.
+         *
+         * @param {String} accId
+         * @returns {Promise} fulfilled after the accessibility properties are
+         *                    returned, or rejected in the cases the WebDriver
+         *                    command errors
+         */
+        get_accessibility_properties_for_accessibility_node: async function(accId) {
+            assertTestIsTentative();
+            let acc = await window.test_driver_internal.get_accessibility_properties_for_accessibility_node(accId);
+            return acc;
         },
 
         /**
@@ -2169,6 +2335,69 @@
          */
         clear_display_features: function(context=null) {
             return window.test_driver_internal.clear_display_features(context);
+        },
+
+        /**
+         * Gets the current globally-applied privacy control status
+         *
+         * @returns {Promise} Fulfils with an object with boolean property `gpc`
+         *                    that encodes the current "do not sell or share"
+         *                    signal the browser is configured to convey.
+         */
+        get_global_privacy_control: function() {
+            return window.test_driver_internal.get_global_privacy_control();
+        },
+
+        /**
+         * Gets the current globally-applied privacy control status
+         *
+         * @param {bool} newValue - The a boolean that is true if the browers
+         *                          should convey a "do not sell or share" signal
+         *                          and false otherwise
+         *
+         * @returns {Promise} Fulfils with an object with boolean property `gpc`
+         *                    that encodes the new "do not sell or share"
+         *                    after applying the new value.
+         */
+        set_global_privacy_control: function(newValue) {
+            return window.test_driver_internal.set_global_privacy_control(newValue);
+        },
+
+        /**
+         * Installs a WebExtension.
+         *
+         * Matches the `Install WebExtension
+         * <https://github.com/w3c/webextensions/blob/main/specification/webdriver-classic.bs>`_
+         * WebDriver command.
+         *
+         * @param {Object} params - Parameters for loading the extension.
+         * @param {String} params.type - A type such as "path", "archivePath", or "base64".
+         *
+         * @param {String} params.path - The path to the extension's resources if type "path" or "archivePath" is specified.
+         *
+         * @param {String} params.value - The base64 encoded value of the extension's resources if type "base64" is specified.
+         *
+         * @returns {Promise} Returns the extension identifier as defined in the spec.
+         *                    Rejected if the extension fails to load.
+         */
+        install_web_extension: function(params) {
+            return window.test_driver_internal.install_web_extension(params);
+        },
+
+        /**
+         * Uninstalls a WebExtension.
+         *
+         * Matches the `Uninstall WebExtension
+         * <https://github.com/w3c/webextensions/blob/main/specification/webdriver-classic.bs>`_
+         * WebDriver command.
+         *
+         * @param {String} extension_id - The extension identifier.
+         *
+         * @returns {Promise} Fulfilled after the extension has been removed.
+         *                    Rejected in case the WebDriver command errors out.
+         */
+        uninstall_web_extension: function(extension_id) {
+            return window.test_driver_internal.uninstall_web_extension(extension_id);
         }
     };
 
@@ -2252,6 +2481,16 @@
                 set_screen_orientation_override: function (params) {
                     throw new Error(
                         "bidi.emulation.set_screen_orientation_override is not implemented by testdriver-vendor.js");
+                },
+                set_touch_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_touch_override is not implemented by testdriver-vendor.js");
+                }
+            },
+            user_agent_client_hints: {
+                set_client_hints_override: function (params) {
+                    throw new Error(
+                        "bidi.user_agent_client_hints.set_client_hints_override is not implemented by testdriver-vendor.js");
                 }
             },
             log: {
@@ -2271,6 +2510,18 @@
                     throw new Error(
                         "bidi.permissions.set_permission() is not implemented by testdriver-vendor.js");
                 }
+            },
+            speculation: {
+                prefetch_status_updated: {
+                    async subscribe() {
+                        throw new Error(
+                            'bidi.speculation.prefetch_status_updated.subscribe is not implemented by testdriver-vendor.js');
+                    },
+                    on() {
+                        throw new Error(
+                            'bidi.speculation.prefetch_status_updated.on is not implemented by testdriver-vendor.js');
+                    }
+                },
             }
         },
 
@@ -2302,6 +2553,14 @@
 
         async get_computed_name(element) {
             throw new Error("get_computed_name is a testdriver.js function which cannot be run in this context.");
+        },
+
+        async get_accessibility_properties_for_element(element) {
+            throw new Error("get_accessibility_properties_for_element is a testdriver.js function which cannot be run in this context.");
+        },
+
+        async get_accessibility_properties_for_accessibility_node(accId) {
+            throw new Error("get_accessibility_properties_for_accessibility_node is a testdriver.js function which cannot be run in this context.");
         },
 
         async send_keys(element, keys) {
@@ -2486,6 +2745,14 @@
 
         async clear_display_features(context=null) {
             throw new Error("clear_display_features() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_global_privacy_control(newValue) {
+            throw new Error("set_global_privacy_control() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_global_privacy_control() {
+            throw new Error("get_global_privacy_control() is not implemented by testdriver-vendor.js");
         }
     };
 })();

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js
@@ -867,6 +867,54 @@
             });
     }
 
+/**
+     * Assert that a `Promise` is rejected with a `QuotaExceededError` with the
+     * expected values.
+     *
+     * For the remaining arguments, there are two ways of calling
+     * `promise_rejects_quotaexceedederror`:
+     *
+     * 1) If the `QuotaExceededError` is expected to come from the
+     *    current global, the second argument should be the promise
+     *    expected to reject, the third and a fourth the expected
+     *    `requested` and `quota` property values, and the fifth,
+     *    optional, argument is the assertion description.
+     *
+     * 2) If the `QuotaExceededError` is expected to come from some
+     *    other global, the second argument should be the
+     *    `QuotaExceededError` constructor from that global, the third
+     *    argument should be the promise expected to reject, the fourth
+     *    and fifth the expected `requested` and `quota` property
+     *    values, and the sixth, optional, argument is the assertion
+     *    description.
+     *
+     */
+    function promise_rejects_quotaexceedederror(test, promiseOrConstructor, requestedOrPromise, quotaOrRequested, descriptionOrQuota, maybeDescription)
+    {
+        let constructor, promise, requested, quota, description;
+        if (typeof promiseOrConstructor === "function" &&
+            promiseOrConstructor.name === "QuotaExceededError") {
+            constructor = promiseOrConstructor;
+            promise = requestedOrPromise;
+            requested = quotaOrRequested;
+            quota = descriptionOrQuota;
+            description = maybeDescription;
+        } else {
+            constructor = self.QuotaExceededError;
+            promise = promiseOrConstructor;
+            requested = requestedOrPromise;
+            quota = quotaOrRequested;
+            description = descriptionOrQuota;
+            assert(maybeDescription === undefined,
+                   "Too many args passed to no-constructor version of promise_rejects_quotaexceedederror");
+        }
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func("Should have rejected: " + description))
+            .catch(function(e) {
+                assert_throws_quotaexceedederror_impl(function() { throw e; }, requested, quota, description, "promise_rejects_quotaexceedederror", constructor);
+            });
+    }
+
     /**
      * Assert that a Promise is rejected with the provided value.
      *
@@ -1240,6 +1288,7 @@
     expose(promise_test, 'promise_test');
     expose(promise_rejects_js, 'promise_rejects_js');
     expose(promise_rejects_dom, 'promise_rejects_dom');
+    expose(promise_rejects_quotaexceedederror, 'promise_rejects_quotaexceedederror');
     expose(promise_rejects_exactly, 'promise_rejects_exactly');
     expose(generate_tests, 'generate_tests');
     expose(setup, 'setup');
@@ -2296,7 +2345,6 @@
                 NETWORK_ERR: 'NetworkError',
                 ABORT_ERR: 'AbortError',
                 URL_MISMATCH_ERR: 'URLMismatchError',
-                QUOTA_EXCEEDED_ERR: 'QuotaExceededError',
                 TIMEOUT_ERR: 'TimeoutError',
                 INVALID_NODE_TYPE_ERR: 'InvalidNodeTypeError',
                 DATA_CLONE_ERR: 'DataCloneError'
@@ -2321,7 +2369,6 @@
                 NetworkError: 19,
                 AbortError: 20,
                 URLMismatchError: 21,
-                QuotaExceededError: 22,
                 TimeoutError: 23,
                 InvalidNodeTypeError: 24,
                 DataCloneError: 25,
@@ -2352,12 +2399,19 @@
             if (typeof type === "number") {
                 if (type === 0) {
                     throw new AssertionError('Test bug: ambiguous DOMException code 0 passed to assert_throws_dom()');
-                } else if (!(type in code_name_map)) {
+                }
+                if (type === 22) {
+                    throw new AssertionError('Test bug: QuotaExceededError needs to be tested for using assert_throws_quotaexceedederror()');
+                }
+                if (!(type in code_name_map)) {
                     throw new AssertionError('Test bug: unrecognized DOMException code "' + type + '" passed to assert_throws_dom()');
                 }
                 name = code_name_map[type];
                 required_props.code = type;
             } else if (typeof type === "string") {
+                if (name === "QuotaExceededError") {
+                    throw new AssertionError('Test bug: QuotaExceededError needs to be tested for using assert_throws_quotaexceedederror()');
+                }
                 name = type in codename_name_map ? codename_name_map[type] : type;
                 if (!(name in name_code_map)) {
                     throw new AssertionError('Test bug: unrecognized DOMException code name or name "' + type + '" passed to assert_throws_dom()');
@@ -2389,6 +2443,137 @@
                    "${func} threw an exception from the wrong global",
                    {func});
 
+        }
+    }
+
+    /**
+     * Assert a `QuotaExceededError` with the expected values is thrown.
+     *
+     * There are two ways of calling `assert_throws_quotaexceedederror`:
+     *
+     * 1) If the `QuotaExceededError` is expected to come from the
+     *    current global, the first argument should be the function
+     *    expected to throw, the second and a third the expected
+     *    `requested` and `quota` property values, and the fourth,
+     *    optional, argument is the assertion description.
+     *
+     * 2) If the `QuotaExceededError` is expected to come from some
+     *    other global, the first argument should be the
+     *    `QuotaExceededError` constructor from that global, the second
+     *    argument should be the function expected to throw, the third
+     *    and fourth the expected `requested` and `quota` property
+     *    values, and the fifth, optional, argument is the assertion
+     *    description.
+     *
+     * For the `requested` and `quota` values, instead of `null` or a
+     * number, the caller can provide a function which determines
+     * whether the value is acceptable by returning a boolean.
+     *
+     */
+    function assert_throws_quotaexceedederror(funcOrConstructor, requestedOrFunc, quotaOrRequested, descriptionOrQuota, maybeDescription)
+    {
+        let constructor, func, requested, quota, description;
+        if (funcOrConstructor.name === "QuotaExceededError") {
+            constructor = funcOrConstructor;
+            func = requestedOrFunc;
+            requested = quotaOrRequested;
+            quota = descriptionOrQuota;
+            description = maybeDescription;
+        } else {
+            constructor = self.QuotaExceededError;
+            func = funcOrConstructor;
+            requested = requestedOrFunc;
+            quota = quotaOrRequested;
+            description = descriptionOrQuota;
+            assert(maybeDescription === undefined,
+                   "Too many args passed to no-constructor version of assert_throws_quotaexceedederror");
+        }
+        assert_throws_quotaexceedederror_impl(func, requested, quota, description, "assert_throws_quotaexceedederror", constructor);
+    }
+    expose_assert(assert_throws_quotaexceedederror, "assert_throws_quotaexceedederror");
+
+    /**
+     * Similar to `assert_throws_quotaexceedederror` but allows
+     * specifying the assertion type
+     * (`"assert_throws_quotaexceedederror"` or
+     * `"promise_rejects_quotaexceedederror"`, in practice). The
+     * `constructor` argument must be the `QuotaExceededError`
+     * constructor from the global we expect the exception to come from.
+     */
+    function assert_throws_quotaexceedederror_impl(func, requested, quota, description, assertion_type, constructor)
+    {
+        try {
+            func.call(this);
+            assert(false, assertion_type, description, "${func} did not throw",
+                   {func});
+        } catch (e) {
+            if (e instanceof AssertionError) {
+                throw e;
+            }
+
+            // Basic sanity-checks on the thrown exception.
+            assert(typeof e === "object",
+                   assertion_type, description,
+                   "${func} threw ${e} with type ${type}, not an object",
+                   {func, e, type:typeof e});
+
+            assert(e !== null,
+                   assertion_type, description,
+                   "${func} threw null, not an object",
+                   {func});
+
+            // Sanity-check our requested and quota.
+            assert(requested === null ||
+                   typeof requested === "number" ||
+                   typeof requested === "function",
+                   assertion_type, description,
+                   "${requested} is not null, a number, or a function",
+                   {requested});
+            assert(quota === null ||
+                   typeof quota === "number" ||
+                   typeof quota === "function",
+                   assertion_type, description,
+                   "${quota} is not null or a number",
+                   {quota});
+
+            const required_props = {
+                code: 22,
+                name: "QuotaExceededError"
+            };
+            if (typeof requested !== "function") {
+                required_props.requested = requested;
+            }
+            if (typeof quota !== "function") {
+                required_props.quota = quota;
+            }
+
+            for (const [prop, expected] of Object.entries(required_props)) {
+                assert(prop in e && e[prop] == expected,
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: property ${prop} is equal to ${actual}, expected ${expected}",
+                       {func, e, prop, actual:e[prop], expected});
+            }
+
+            if (typeof requested === "function") {
+                assert(requested(e.requested),
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: requested value ${requested} did not pass the requested predicate",
+                       {func, e, requested});
+            }
+            if (typeof quota === "function") {
+                assert(quota(e.quota),
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: quota value ${quota} did not pass the quota predicate",
+                       {func, e, quota});
+            }
+
+            // Check that the exception is from the right global.  This check is last
+            // so more specific, and more informative, checks on the properties can
+            // happen in case a totally incorrect exception is thrown.
+            assert(e.constructor === constructor,
+                   assertion_type, description,
+                   "${func} threw an exception from the wrong global",
+                   {func});
         }
     }
 
@@ -4959,7 +5144,7 @@ table#results.assertions > tbody > tr > td:last-child {\
     width:35%;\
 }\
 \
-table#results > thead > > tr > th {\
+table#results > thead > tr > th {\
     padding:0;\
     padding-bottom:0.5em;\
     border-bottom:medium solid black;\

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/w3c-import.log
@@ -21,6 +21,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/resources/blank.html
 /LayoutTests/imported/w3c/web-platform-tests/resources/channel.sub.js
 /LayoutTests/imported/w3c/web-platform-tests/resources/check-layout-th.js
+/LayoutTests/imported/w3c/web-platform-tests/resources/example.pdf
 /LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js
 /LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/resources/out-of-scope-test.js
@@ -43,3 +44,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/resources/testharnessreport.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/resources/web-bluetooth-bidi-test.js
+/LayoutTests/imported/w3c/web-platform-tests/resources/web-extensions-helper.js

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/web-extensions-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/web-extensions-helper.js
@@ -1,0 +1,40 @@
+// testharness file with WebExtensions utilities
+
+/**
+ * Loads the WebExtension at the path specified and runs the tests defined in the extension's resources.
+ * Listens to messages sent from the user agent and converts the `browser.test` assertions
+ * into testharness.js assertions.
+ *
+ * @param {string} extensionPath - a path to the extension's resources.
+ */
+
+setup({ explicit_done: true })
+globalThis.runTestsWithWebExtension = function(extensionPath) {
+    test_driver.install_web_extension({
+        type: "path",
+        path: extensionPath
+    })
+    .then((result) => {
+        let test;
+        browser.test.onTestStarted.addListener((data) => {
+            test = async_test(data.testName)
+        })
+
+        browser.test.onTestFinished.addListener((data) => {
+            test.step(() => {
+                let description = data.message ? `${data.assertionDescription}. ${data.message}` : data.assertionDescription
+                assert_true(data.result, description)
+            })
+
+            test.done()
+
+            if (!data.result) {
+                test.set_status(test.FAIL)
+            }
+
+            if (!data.remainingTests) {
+                test_driver.uninstall_web_extension(result.extension).then(() => { done() })
+            }
+        })
+    })
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/webidl2/lib/VERSION.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/webidl2/lib/VERSION.md
@@ -1,1 +1,1 @@
-Currently using webidl2.js@6889aee6fc7d65915ab1267825248157dbc50486.
+Currently using webidl2.js@e6d8ab852ec4e76596f6e308eb7f2efc8b613bfd.

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5459,21 +5459,6 @@
     "imported/w3c/web-platform-tests/resource-timing/workerStart-tao-protected.https.html": [
         "slow"
     ],
-    "imported/w3c/web-platform-tests/resources/test/tests/unit/exceptional-cases-timeouts.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/resources/test/tests/unit/exceptional-cases.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/resources/test/tests/unit/promise_setup-timeout.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/resources/test/tests/unit/single_test.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/resources/test/tests/unit/throwing-assertions.html": [
-        "slow"
-    ],
     "imported/w3c/web-platform-tests/screen-orientation/hidden_document.html": [
         "slow"
     ],


### PR DESCRIPTION
#### af0a52765978395b82ef69f634cfcda5d6b21548
<pre>
Resync `resources` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=306173">https://bugs.webkit.org/show_bug.cgi?id=306173</a>
<a href="https://rdar.apple.com/168822984">rdar://168822984</a>

Reviewed by NOBODY (OOPS!).

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d61231d9ceef372cc66d64ac19c467c2506a8814">https://github.com/web-platform-tests/wpt/commit/d61231d9ceef372cc66d64ac19c467c2506a8814</a>

* LayoutTests/imported/w3c/web-platform-tests/resources/example.pdf: Added.
* LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js:
(IdlInterface.prototype.default_to_json_operation):
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tox.ini:
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-actions.js:
(Actions.prototype.addTick):
(PointerSource.prototype.pointerMove):
(WheelSource.prototype.scroll):
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver.js:
(assertTestIsTentative):
(window.test_driver.bidi.):
(window.test_driver):
* LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js:
(promise_rejects_quotaexceedederror):
* LayoutTests/imported/w3c/web-platform-tests/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/resources/web-extensions-helper.js: Added.
(globalThis.runTestsWithWebExtension):
* LayoutTests/imported/w3c/web-platform-tests/resources/webidl2/lib/VERSION.md:
* LayoutTests/imported/w3c/web-platform-tests/resources/webidl2/lib/webidl2.js:
(return.):
* LayoutTests/tests-options.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af0a52765978395b82ef69f634cfcda5d6b21548

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106600 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44ea0017-510e-4caa-9e8e-d83e3b673800) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26229 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118381 "Found 19 new test failures: http/wpt/cache-storage/cache-quota-add.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.worker.html imported/w3c/web-platform-tests/compression/idlharness.https.any.html imported/w3c/web-platform-tests/compression/idlharness.https.any.worker.html imported/w3c/web-platform-tests/encoding/idlharness.any.html imported/w3c/web-platform-tests/encoding/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.worker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83826 "6 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f55864a1-0471-476e-ac8f-3d13039e03f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156101 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20622 "Found 1 new test failure: http/wpt/cache-storage/cache-quota-add.any.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99094 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74b385c5-481c-48b7-9942-734350ddca26) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19696 "Found 22 new test failures: imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.worker.html imported/w3c/web-platform-tests/compression/idlharness.https.any.html imported/w3c/web-platform-tests/compression/idlharness.https.any.worker.html imported/w3c/web-platform-tests/encoding/idlharness.any.html imported/w3c/web-platform-tests/encoding/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.worker.html imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.html imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.worker.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17638 "2 api tests failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9722 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164360 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16947 "Found 20 new test failures: http/wpt/cache-storage/cache-quota-add.any.html http/wpt/cache-storage/cache-quota-after-restart.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.worker.html imported/w3c/web-platform-tests/compression/idlharness.https.any.html imported/w3c/web-platform-tests/compression/idlharness.https.any.worker.html imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.html imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.worker.html imported/w3c/web-platform-tests/fs/idlharness.https.any.html imported/w3c/web-platform-tests/fs/idlharness.https.any.worker.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126441 "Found 19 new test failures: http/wpt/cache-storage/cache-quota-add.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.worker.html imported/w3c/web-platform-tests/compression/idlharness.https.any.html imported/w3c/web-platform-tests/compression/idlharness.https.any.worker.html imported/w3c/web-platform-tests/encoding/idlharness.any.html imported/w3c/web-platform-tests/encoding/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.worker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25721 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21673 "Found 24 new test failures: http/wpt/cache-storage/cache-quota-add.any.html http/wpt/cache-storage/cache-quota-after-restart.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.worker.html imported/w3c/web-platform-tests/compression/idlharness.https.any.html imported/w3c/web-platform-tests/compression/idlharness.https.any.worker.html imported/w3c/web-platform-tests/encoding/idlharness.any.html imported/w3c/web-platform-tests/encoding/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/encoding/idlharness.any.worker.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126599 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82386 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21551 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13928 "Found 20 new test failures: http/wpt/cache-storage/cache-quota-add.any.html http/wpt/cache-storage/cache-quota-after-restart.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.html imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues.any.worker.html imported/w3c/web-platform-tests/compression/idlharness.https.any.html imported/w3c/web-platform-tests/compression/idlharness.https.any.worker.html imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.html imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.worker.html imported/w3c/web-platform-tests/fs/idlharness.https.any.html imported/w3c/web-platform-tests/fs/idlharness.https.any.worker.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25339 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25032 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->