### PR TITLE
[Style] Convert the 'speak-as' property to strong style types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -242,6 +242,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/shapes"
     "${WEBCORE_DIR}/style/values/size-adjust"
     "${WEBCORE_DIR}/style/values/sizing"
+    "${WEBCORE_DIR}/style/values/speech"
     "${WEBCORE_DIR}/style/values/svg"
     "${WEBCORE_DIR}/style/values/text"
     "${WEBCORE_DIR}/style/values/text-decoration"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3489,6 +3489,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/sizing/StyleMinimumSize.h
     style/values/sizing/StylePreferredSize.h
 
+    style/values/speech/StyleSpeakAs.h
+
     style/values/svg/StyleSVGBaselineShift.h
     style/values/svg/StyleSVGCenterCoordinateComponent.h
     style/values/svg/StyleSVGCoordinateComponent.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3327,6 +3327,7 @@ style/values/size-adjust/StyleTextSizeAdjust.cpp
 style/values/sizing/StyleAspectRatio.cpp
 style/values/sizing/StyleContainIntrinsicSize.cpp
 style/values/sizing/StylePreferredSize.cpp
+style/values/speech/StyleSpeakAs.cpp
 style/values/svg/StyleSVGBaselineShift.cpp
 style/values/svg/StyleSVGGlyphOrientationHorizontal.cpp
 style/values/svg/StyleSVGGlyphOrientationVertical.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -112,6 +112,10 @@ struct ScrollRectToVisibleOptions;
 struct ModelPlayerAccessibilityChildren;
 #endif
 
+namespace Style {
+struct SpeakAs;
+}
+
 enum class ClickHandlerFilter : bool {
     ExcludeBody,
     IncludeBody,
@@ -1214,7 +1218,7 @@ public:
 #if PLATFORM(COCOA)
     virtual bool preventKeyboardDOMEventDispatch() const = 0;
     virtual void setPreventKeyboardDOMEventDispatch(bool) = 0;
-    virtual OptionSet<SpeakAs> speakAs() const = 0;
+    virtual Style::SpeakAs speakAs() const = 0;
     String speechHint() const;
     String descriptionAttributeValue() const;
     String helpTextAttributeValue() const;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -781,7 +781,7 @@ public:
 #if PLATFORM(COCOA)
     bool preventKeyboardDOMEventDispatch() const final;
     void setPreventKeyboardDOMEventDispatch(bool) final;
-    OptionSet<SpeakAs> speakAs() const final;
+    Style::SpeakAs speakAs() const final;
     bool hasApplePDFAnnotationAttribute() const final { return hasAttribute(HTMLNames::x_apple_pdf_annotationAttr); }
 #endif
 

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -67,12 +67,12 @@ String AXCoreObject::speechHint() const
     auto speakAs = this->speakAs();
 
     StringBuilder builder;
-    builder.append((speakAs & SpeakAs::SpellOut) ? "spell-out"_s : "normal"_s);
-    if (speakAs & SpeakAs::Digits)
+    builder.append(speakAs.contains(Style::SpeakAsValue::SpellOut) ? "spell-out"_s : "normal"_s);
+    if (speakAs.contains(Style::SpeakAsValue::Digits))
         builder.append(" digits"_s);
-    if (speakAs & SpeakAs::LiteralPunctuation)
+    if (speakAs.contains(Style::SpeakAsValue::LiteralPunctuation))
         builder.append(" literal-punctuation"_s);
-    if (speakAs & SpeakAs::NoPunctuation)
+    if (speakAs.contains(Style::SpeakAsValue::NoPunctuation))
         builder.append(" no-punctuation"_s);
 
     return builder.toString();

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -36,11 +36,11 @@
 
 namespace WebCore {
 
-OptionSet<SpeakAs> AccessibilityObject::speakAs() const
+Style::SpeakAs AccessibilityObject::speakAs() const
 {
     if (auto* style = this->style())
         return style->speakAs();
-    return { };
+    return CSS::Keyword::Normal { };
 }
 
 FloatPoint AccessibilityObject::screenRelativePosition() const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -185,11 +185,11 @@ bool isDefaultValue(AXProperty property, AXPropertyValueVariant& value)
         [](FontOrientation typedValue) { return typedValue == FontOrientation::Horizontal; },
         [](AXTextRunLineID typedValue) { return !typedValue; },
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
-        [] (WallTime& time) { return !time; },
-        [] (ElementName& name) { return name == ElementName::Unknown; },
-        [] (DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },
-        [] (AccessibilityOrientation) { return false; },
-        [] (OptionSet<SpeakAs>& typedValue) { return typedValue.isEmpty(); },
+        [](WallTime& time) { return !time; },
+        [](ElementName& name) { return name == ElementName::Unknown; },
+        [](DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },
+        [](AccessibilityOrientation) { return false; },
+        [](Style::SpeakAs& typedValue) { return typedValue.isNormal(); },
         [](auto&) {
             ASSERT_NOT_REACHED();
             return false;
@@ -643,16 +643,15 @@ Vector<T> AXIsolatedObject::vectorAttributeValue(AXProperty property) const
     );
 }
 
-template<typename T>
-OptionSet<T> AXIsolatedObject::optionSetAttributeValue(AXProperty property) const
+Style::SpeakAs AXIsolatedObject::speakAsAttributeValue(AXProperty property) const
 {
     size_t index = indexOfProperty(property);
     if (index == notFound)
-        return OptionSet<T>();
+        return CSS::Keyword::Normal { };
 
     return WTF::switchOn(m_properties[index].second,
-        [] (const OptionSet<T>& typedValue) -> OptionSet<T> { return typedValue; },
-        [] (auto&) { return OptionSet<T>(); }
+        [](const Style::SpeakAs& typedValue) -> Style::SpeakAs { return typedValue; },
+        [](auto&) -> Style::SpeakAs { return CSS::Keyword::Normal { }; }
     );
 }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -184,10 +184,10 @@ private:
     URL urlAttributeValue(AXProperty) const;
     uint64_t uint64AttributeValue(AXProperty) const;
     Path pathAttributeValue(AXProperty) const;
+    Style::SpeakAs speakAsAttributeValue(AXProperty) const;
     std::pair<unsigned, unsigned> indexRangePairAttributeValue(AXProperty) const;
     template<typename T> T rectAttributeValue(AXProperty) const;
     template<typename T> Vector<T> vectorAttributeValue(AXProperty) const;
-    template<typename T> OptionSet<T> optionSetAttributeValue(AXProperty) const;
     template<typename T> std::optional<T> optionalAttributeValue(AXProperty) const;
     template<typename T> T propertyValue(AXProperty) const;
 
@@ -398,7 +398,7 @@ private:
     void mathPrescripts(AccessibilityMathMultiscriptPairs&) final;
     void mathPostscripts(AccessibilityMathMultiscriptPairs&) final;
 #if PLATFORM(COCOA)
-    OptionSet<SpeakAs> speakAs() const final { return optionSetAttributeValue<SpeakAs>(AXProperty::SpeakAs); }
+    Style::SpeakAs speakAs() const final { return speakAsAttributeValue(AXProperty::SpeakAs); }
 #endif
 #if PLATFORM(MAC)
     bool caretBrowsingEnabled() const final { return boolAttributeValue(AXProperty::CaretBrowsingEnabled); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -36,6 +36,7 @@
 #include <WebCore/ColorHash.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleSpeakAs.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
@@ -328,7 +329,7 @@ using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, b
     , RetainPtr<NSAttributedString>
     , RetainPtr<NSView>
     , RetainPtr<id>
-    , OptionSet<SpeakAs>
+    , Style::SpeakAs
 #endif // PLATFORM(COCOA)
 #if ENABLE(AX_THREAD_TEXT_APIS)
     , RetainPtr<CTFontRef>

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -51,6 +51,7 @@
 #include "StyleMarginTrim.h"
 #include "StylePositionVisibility.h"
 #include "StyleScrollBehavior.h"
+#include "StyleSpeakAs.h"
 #include "StyleTextDecorationLine.h"
 #include "StyleTextEmphasisPosition.h"
 #include "StyleTextTransform.h"
@@ -1819,7 +1820,7 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-#define TYPE SpeakAs
+#define TYPE Style::SpeakAsValue
 #define FOR_EACH(CASE) CASE(SpellOut) CASE(Digits) CASE(LiteralPunctuation) CASE(NoPunctuation)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7651,7 +7651,7 @@
                 }
             ],
             "codegen-properties": {
-                "style-converter": "SpeakAs",
+                "style-converter": "StyleType<SpeakAs>",
                 "parser-grammar": "none | [ [ normal | spell-out ] || digits || [ literal-punctuation | no-punctuation ] ]@(no-single-item-opt)",
                 "parser-grammar-comment": "Current spec grammar is 'normal | [ spell-out || digits || [ literal-punctuation | no-punctuation ] ]'."
             },

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -169,7 +169,6 @@ enum class RubyAlign : uint8_t;
 enum class RubyOverhang : bool;
 enum class ScrollAxis : uint8_t;
 enum class ScrollSnapStop : bool;
-enum class SpeakAs : uint8_t;
 enum class StyleAppearance : uint8_t;
 enum class StyleColorOptions : uint8_t;
 enum class StyleDifference : uint8_t;
@@ -349,6 +348,7 @@ struct ScrollbarGutter;
 struct ScrollbarWidth;
 struct ShapeMargin;
 struct ShapeOutside;
+struct SpeakAs;
 struct StrokeMiterlimit;
 struct StrokeWidth;
 struct TabSize;
@@ -1220,7 +1220,7 @@ public:
     inline Style::ImageOrientation imageOrientation() const;
     inline ImageRendering imageRendering() const;
 
-    inline OptionSet<SpeakAs> speakAs() const;
+    inline Style::SpeakAs speakAs() const;
 
     inline const Style::Filter& filter() const;
     inline bool hasFilter() const;
@@ -1618,7 +1618,7 @@ public:
     inline void setScale(Style::Scale&&);
     inline void setTranslate(Style::Translate&&);
 
-    inline void setSpeakAs(OptionSet<SpeakAs>);
+    inline void setSpeakAs(Style::SpeakAs);
     inline void setTextCombine(TextCombine);
     inline void setTextDecorationColor(Style::Color&&);
     inline void setTextEmphasisColor(Style::Color&&);
@@ -2137,7 +2137,7 @@ public:
     static constexpr OverflowWrap initialOverflowWrap();
     static constexpr NBSPMode initialNBSPMode();
     static constexpr LineBreak initialLineBreak();
-    static constexpr OptionSet<SpeakAs> initialSpeakAs();
+    static constexpr Style::SpeakAs initialSpeakAs();
     static constexpr Hyphens initialHyphens();
     static constexpr Style::HyphenateLimitEdge initialHyphenateLimitBefore();
     static constexpr Style::HyphenateLimitEdge initialHyphenateLimitAfter();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1089,17 +1089,6 @@ TextStream& operator<<(TextStream& ts, Scroller scroller)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, SpeakAs speakAs)
-{
-    switch (speakAs) {
-    case SpeakAs::SpellOut: ts << "spell-out"_s; break;
-    case SpeakAs::Digits: ts << "digits"_s; break;
-    case SpeakAs::LiteralPunctuation: ts << "literal-punctuation"_s; break;
-    case SpeakAs::NoPunctuation: ts << "no-punctuation"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, StyleDifference diff)
 {
     switch (diff) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -853,13 +853,6 @@ enum class Hyphens : uint8_t {
     Auto
 };
 
-enum class SpeakAs : uint8_t {
-    SpellOut           = 1 << 0,
-    Digits             = 1 << 1,
-    LiteralPunctuation = 1 << 2,
-    NoPunctuation      = 1 << 3
-};
-
 enum class TextEmphasisFill : bool {
     Filled,
     Open
@@ -1298,7 +1291,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapAxisAlignType);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStop);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStrictness);
 WTF::TextStream& operator<<(WTF::TextStream&, Scroller);
-WTF::TextStream& operator<<(WTF::TextStream&, SpeakAs);
 WTF::TextStream& operator<<(WTF::TextStream&, StyleDifference);
 WTF::TextStream& operator<<(WTF::TextStream&, StyleDifferenceContextSensitiveProperty);
 WTF::TextStream& operator<<(WTF::TextStream&, TableLayoutType);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -554,7 +554,7 @@ constexpr Style::ShapeImageThreshold RenderStyle::initialShapeImageThreshold() {
 inline Style::ShapeMargin RenderStyle::initialShapeMargin() { return 0_css_px; }
 inline Style::ShapeOutside RenderStyle::initialShapeOutside() { return CSS::Keyword::None { }; }
 inline Style::PreferredSize RenderStyle::initialSize() { return CSS::Keyword::Auto { }; }
-constexpr OptionSet<SpeakAs> RenderStyle::initialSpeakAs() { return { }; }
+constexpr Style::SpeakAs RenderStyle::initialSpeakAs() { return CSS::Keyword::Normal { }; }
 constexpr Style::ZIndex RenderStyle::initialSpecifiedZIndex() { return CSS::Keyword::Auto { }; }
 inline Style::Color RenderStyle::initialStrokeColor() { return { Color::transparentBlack }; }
 constexpr Style::StrokeMiterlimit RenderStyle::initialStrokeMiterLimit() { return 4_css_number; }
@@ -793,7 +793,7 @@ inline const Style::ShapeMargin& RenderStyle::shapeMargin() const { return m_non
 inline const Style::ShapeOutside& RenderStyle::shapeOutside() const { return m_nonInheritedData->rareData->shapeOutside; }
 inline ContentVisibility RenderStyle::usedContentVisibility() const { return static_cast<ContentVisibility>(m_rareInheritedData->usedContentVisibility); }
 inline bool RenderStyle::isSkippedRootOrSkippedContent() const { return usedContentVisibility() != ContentVisibility::Visible; }
-inline OptionSet<SpeakAs> RenderStyle::speakAs() const { return OptionSet<SpeakAs>::fromRaw(m_rareInheritedData->speakAs); }
+inline Style::SpeakAs RenderStyle::speakAs() const { return Style::SpeakAs::fromRaw(m_rareInheritedData->speakAs); }
 inline Style::ZIndex RenderStyle::specifiedZIndex() const { return m_nonInheritedData->boxData->specifiedZIndex(); }
 inline bool RenderStyle::specifiesColumns() const { return !columnCount().isAuto() || !columnWidth().isAuto() || !hasInlineColumnAxis(); }
 inline const Style::Color& RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -285,7 +285,7 @@ inline void RenderStyle::setShapeImageThreshold(Style::ShapeImageThreshold shape
 inline void RenderStyle::setShapeMargin(Style::ShapeMargin&& shapeMargin) { SET_NESTED(m_nonInheritedData, rareData, shapeMargin, WTFMove(shapeMargin)); }
 inline void RenderStyle::setShapeOutside(Style::ShapeOutside&& shapeOutside) { SET_NESTED(m_nonInheritedData, rareData, shapeOutside, WTFMove(shapeOutside)); }
 inline void RenderStyle::setUsedContentVisibility(ContentVisibility usedContentVisibility) { SET(m_rareInheritedData, usedContentVisibility, static_cast<unsigned>(usedContentVisibility)); }
-inline void RenderStyle::setSpeakAs(OptionSet<SpeakAs> style) { SET(m_rareInheritedData, speakAs, style.toRaw()); }
+inline void RenderStyle::setSpeakAs(Style::SpeakAs speakAs) { SET(m_rareInheritedData, speakAs, speakAs.toRaw()); }
 inline void RenderStyle::setSpecifiedZIndex(Style::ZIndex index) { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoSpecifiedZIndex, static_cast<uint8_t>(index.m_isAuto), m_specifiedZIndexValue, index.m_value); }
 inline void RenderStyle::setStrokeColor(Style::Color&& color) { SET(m_rareInheritedData, strokeColor, WTFMove(color)); }
 inline void RenderStyle::setStrokeMiterLimit(Style::StrokeMiterlimit value) { SET(m_rareInheritedData, miterLimit, value); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -95,6 +95,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
     , userSelect(static_cast<unsigned>(RenderStyle::initialUserSelect()))
+    , speakAs(RenderStyle::initialSpeakAs().toRaw())
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(RenderStyle::initialTextCombine()))
     , textEmphasisPosition(static_cast<unsigned>(RenderStyle::initialTextEmphasisPosition().toRaw()))
@@ -425,7 +426,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
     LOG_IF_DIFFERENT_WITH_CAST(ColorSpace, colorSpace);
 
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(OptionSet<SpeakAs>, speakAs);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::SpeakAs, speakAs);
 
     LOG_IF_DIFFERENT_WITH_CAST(Hyphens, hyphens);
     LOG_IF_DIFFERENT_WITH_CAST(TextCombine, textCombine);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -45,6 +45,7 @@
 #include <WebCore/StyleQuotes.h>
 #include <WebCore/StyleSVGPaintOrder.h>
 #include <WebCore/StyleScrollbarColor.h>
+#include <WebCore/StyleSpeakAs.h>
 #include <WebCore/StyleStrokeMiterlimit.h>
 #include <WebCore/StyleStrokeWidth.h>
 #include <WebCore/StyleTabSize.h>
@@ -186,7 +187,7 @@ public:
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
     PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
     PREFERRED_TYPE(ColorSpace) unsigned colorSpace : 1;
-    PREFERRED_TYPE(OptionSet<SpeakAs>) unsigned speakAs : 4 { 0 };
+    PREFERRED_TYPE(Style::SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
     PREFERRED_TYPE(Style::TextEmphasisPosition) unsigned textEmphasisPosition : 4;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -119,8 +119,6 @@ public:
     static TextAlignLast convertTextAlignLast(BuilderState&, const CSSValue&);
     static Resize convertResize(BuilderState&, const CSSValue&);
 
-    static OptionSet<SpeakAs> convertSpeakAs(BuilderState&, const CSSValue&);
-
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
     static std::optional<PositionArea> convertPositionArea(BuilderState&, const CSSValue&);
 
@@ -223,18 +221,6 @@ inline float zoomWithTextZoomFactor(BuilderState& builderState)
         return usedZoom * textZoomFactor;
     }
     return builderState.cssToLengthConversionData().zoom();
-}
-
-inline OptionSet<SpeakAs> BuilderConverter::convertSpeakAs(BuilderState&, const CSSValue& value)
-{
-    auto result = RenderStyle::initialSpeakAs();
-    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
-        for (auto& currentValue : *list) {
-            if (!isValueID(currentValue, CSSValueNormal))
-                result.add(fromCSSValue<SpeakAs>(currentValue));
-        }
-    }
-    return result;
 }
 
 inline std::optional<ScopedName> BuilderConverter::convertPositionAnchor(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -134,7 +134,6 @@ public:
     // MARK: Shared conversions
 
     static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const FixedVector<PositionTryFallback>&);
-    static Ref<CSSValue> convertSpeakAs(ExtractorState&, OptionSet<SpeakAs>);
     static Ref<CSSValue> convertPositionAnchor(ExtractorState&, const std::optional<ScopedName>&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const std::optional<PositionArea>&);
@@ -267,22 +266,6 @@ inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorSt
     }
 
     return CSSValueList::createCommaSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertSpeakAs(ExtractorState&, OptionSet<SpeakAs> speakAs)
-{
-    CSSValueListBuilder list;
-    if (speakAs & SpeakAs::SpellOut)
-        list.append(CSSPrimitiveValue::create(CSSValueSpellOut));
-    if (speakAs & SpeakAs::Digits)
-        list.append(CSSPrimitiveValue::create(CSSValueDigits));
-    if (speakAs & SpeakAs::LiteralPunctuation)
-        list.append(CSSPrimitiveValue::create(CSSValueLiteralPunctuation));
-    if (speakAs & SpeakAs::NoPunctuation)
-        list.append(CSSPrimitiveValue::create(CSSValueNoPunctuation));
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNormal);
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertPositionAnchor(ExtractorState& state, const std::optional<ScopedName>& positionAnchor)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -68,10 +68,7 @@ public:
 
     // MARK: Shared serializations
 
-    static void serializeSmoothScrolling(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, bool);
     static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<PositionTryFallback>&);
-    static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
-    static void serializeSpeakAs(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<SpeakAs>);
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
     static void serializeNameScope(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const NameScope&);
@@ -213,26 +210,6 @@ inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& s
     }
 
     builder.append(CSSValueList::createCommaSeparated(WTFMove(list))->cssText(context));
-}
-
-inline void ExtractorSerializer::serializeSpeakAs(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<SpeakAs> speakAs)
-{
-    bool listEmpty = true;
-    auto appendOption = [&](SpeakAs test, CSSValueID value) {
-        if (speakAs &  test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(SpeakAs::SpellOut, CSSValueSpellOut);
-    appendOption(SpeakAs::Digits, CSSValueDigits);
-    appendOption(SpeakAs::LiteralPunctuation, CSSValueLiteralPunctuation);
-    appendOption(SpeakAs::NoPunctuation, CSSValueNoPunctuation);
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
 }
 
 inline void ExtractorSerializer::serializePositionAnchor(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const std::optional<ScopedName>& positionAnchor)

--- a/Source/WebCore/style/values/speech/StyleSpeakAs.cpp
+++ b/Source/WebCore/style/values/speech/StyleSpeakAs.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSpeakAs.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<SpeakAs>::operator()(BuilderState& state, const CSSValue& value) -> SpeakAs
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+        case CSSValueNormal:
+            return CSS::Keyword::Normal { };
+        case CSSValueSpellOut:
+            return { SpeakAsValue::SpellOut };
+        case CSSValueDigits:
+            return { SpeakAsValue::Digits };
+        case CSSValueLiteralPunctuation:
+            return { SpeakAsValue::LiteralPunctuation };
+        case CSSValueNoPunctuation:
+            return { SpeakAsValue::NoPunctuation };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Normal { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return CSS::Keyword::Normal { };
+
+    SpeakAsValueEnumSet result;
+    for (Ref item : *list) {
+        switch (item->valueID()) {
+        case CSSValueSpellOut:
+            result.value.add(SpeakAsValue::SpellOut);
+            break;
+        case CSSValueDigits:
+            result.value.add(SpeakAsValue::Digits);
+            break;
+        case CSSValueLiteralPunctuation:
+            if (result.contains(SpeakAsValue::NoPunctuation)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Normal { };
+            }
+            result.value.add(SpeakAsValue::LiteralPunctuation);
+            break;
+        case CSSValueNoPunctuation:
+            if (result.contains(SpeakAsValue::LiteralPunctuation)) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Normal { };
+            }
+            result.value.add(SpeakAsValue::NoPunctuation);
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Normal { };
+        }
+    }
+    return result;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/speech/StyleSpeakAs.h
+++ b/Source/WebCore/style/values/speech/StyleSpeakAs.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'speak-as'> = none | normal | spell-out || digits || [ literal-punctuation | no-punctuation ]
+// FIXME: `none` is non-standard and computes to `normal`
+// https://drafts.csswg.org/css-speech-1/#propdef-speak-as
+
+enum class SpeakAsValue : uint8_t {
+    SpellOut,
+    Digits,
+    LiteralPunctuation,
+    NoPunctuation,
+};
+
+using SpeakAsValueEnumSet = SpaceSeparatedEnumSet<SpeakAsValue>;
+
+struct SpeakAs {
+    using EnumSet = SpeakAsValueEnumSet;
+    using value_type = SpeakAsValueEnumSet::value_type;
+
+    constexpr SpeakAs(CSS::Keyword::Normal) : m_value { } { }
+    constexpr SpeakAs(EnumSet&& set) : m_value { WTFMove(set) } { }
+    constexpr SpeakAs(value_type value) : SpeakAs { EnumSet { value } } { }
+    constexpr SpeakAs(std::initializer_list<value_type> initializerList) : SpeakAs { EnumSet { initializerList } } { }
+
+    static constexpr SpeakAs fromRaw(EnumSet::StorageType rawValue) { return EnumSet::fromRaw(rawValue); }
+    constexpr EnumSet::StorageType toRaw() const { return m_value.toRaw(); }
+
+    constexpr bool contains(SpeakAsValue e) const { return m_value.contains(e); }
+    constexpr bool containsAny(EnumSet other) const { return m_value.containsAny(other.value); }
+    constexpr bool containsAll(EnumSet other) const { return m_value.containsAll(other.value); }
+    constexpr bool containsOnly(EnumSet other) const { return m_value.containsOnly(other.value); }
+
+    constexpr bool isNormal() const { return m_value.isEmpty(); }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isNormal())
+            return visitor(CSS::Keyword::Normal { });
+        return visitor(m_value);
+    }
+
+    constexpr bool operator==(const SpeakAs&) const = default;
+
+private:
+    EnumSet m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<SpeakAs> { auto operator()(BuilderState&, const CSSValue&) -> SpeakAs; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SpeakAs)


### PR DESCRIPTION
#### d0edfce225e5c42603d8eb69bcbb5fa4605782d2
<pre>
[Style] Convert the &apos;speak-as&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=302658">https://bugs.webkit.org/show_bug.cgi?id=302658</a>

Reviewed by Darin Adler.

Converts the &apos;speak-as&apos; property to use strong style types.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/speech/StyleSpeakAs.cpp: Added.
* Source/WebCore/style/values/speech/StyleSpeakAs.h: Added.

Canonical link: <a href="https://commits.webkit.org/303271@main">https://commits.webkit.org/303271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30383123a5299beb148590e660f9bea348133604

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131886 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139398 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4140 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100812 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134832 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81602 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82618 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4048 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36824 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4129 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/109355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27694 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114401 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57269 "Failed to checkout and rebase branch from PR 54063") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4101 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32801 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3933 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->