### PR TITLE
[GFC][Debug] Crash under WTF::CanMakeCheckedPtr

### DIFF
--- a/LayoutTests/fast/layoutformattingcontext/grid-simple-debug-crash-expected.txt
+++ b/LayoutTests/fast/layoutformattingcontext/grid-simple-debug-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if there is no crash in debug.
+
+

--- a/LayoutTests/fast/layoutformattingcontext/grid-simple-debug-crash.html
+++ b/LayoutTests/fast/layoutformattingcontext/grid-simple-debug-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>
+<style>
+.grid {
+  display: grid;
+  width: 100px;
+  height: 100px;
+  grid-template-columns: 100px;
+  grid-template-rows: 100px;
+  align-items: start;
+  justify-items: start;
+}
+.item {
+  width: 10px;
+  height: 10px;
+  min-width: 0;
+  min-height: 0;
+  grid-column: 1/2;
+  grid-row: 1/2;
+}
+</style>
+</head>
+<p>PASS if there is no crash in debug.</p>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</html>

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -42,9 +42,8 @@ class UnplacedGridItem;
 struct GridAreaLines;
 struct UnplacedGridItems;
 
-class GridFormattingContext : public CanMakeCheckedPtr<GridFormattingContext> {
+class GridFormattingContext {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GridFormattingContext);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GridFormattingContext);
 public:
 
     struct GridLayoutConstraints {

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -356,7 +356,7 @@ std::pair<GridLayout::UsedInlineSizes, GridLayout::UsedBlockSizes> GridLayout::l
 
 const ElementBox& GridLayout::gridContainer() const
 {
-    return m_gridFormattingContext->root();
+    return m_gridFormattingContext.root();
 }
 
 const RenderStyle& GridLayout::gridContainerStyle() const

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -84,12 +84,12 @@ private:
     static BorderBoxPositions performInlineAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
     static BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
 
-    const GridFormattingContext& formattingContext() const { return m_gridFormattingContext.get(); }
+    const GridFormattingContext& formattingContext() const { return m_gridFormattingContext; }
 
     const ElementBox& gridContainer() const;
     const RenderStyle& gridContainerStyle() const;
 
-    const CheckedRef<const GridFormattingContext> m_gridFormattingContext;
+    const GridFormattingContext& m_gridFormattingContext;
 };
 
 }


### PR DESCRIPTION
#### d023813644970ed8e2f21f847562ac00f3e8d3e7
<pre>
[GFC][Debug] Crash under WTF::CanMakeCheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=302661">https://bugs.webkit.org/show_bug.cgi?id=302661</a>
<a href="https://rdar.apple.com/164903170">rdar://164903170</a>

Reviewed by Alan Baradlay.

GridFormattingContext is never heap allocated so we
currently hit an ASSERT in debug builds that was introduced in
302223@main. Since this object just lives on the stack we can
remove CanMakeCheckedPtr for it and add it back if we ever
decide it needs to be long lived for some reason.

Canonical link: <a href="https://commits.webkit.org/303141@main">https://commits.webkit.org/303141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c02d06cade97d886a0262316aa55e5f7ba59a97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138961 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8bdc99b9-25bd-403d-8447-e122413125f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3627 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/344f1e76-2861-4657-8cf4-e1c1c13c59ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134401 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117669 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81165 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ed31341-e55b-465e-9bcb-6818a577a154) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82153 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141606 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3530 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36310 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108963 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2675 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56716 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3592 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32413 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3614 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->