### PR TITLE
[libpas] Implement Retag-on-Scavenge for segregated objects

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -248,7 +248,7 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_finish_all
     pas_bitfit_page_testing_verify(page);
 
     PAS_PROFILE(BITFIT_ALLOCATION, &page_config, begin, size, allocation_mode);
-    PAS_MTE_HANDLE(BITFIT_ALLOCATION, &page_config, begin, size, allocation_mode);
+    PAS_MTE_HANDLE(BITFIT_ALLOCATION, page_config, begin, size, allocation_mode);
 
     return pas_bitfit_allocation_result_create_success(begin);
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
@@ -33,6 +33,7 @@
 #include "pas_heap_lock.h"
 #include "pas_immortal_heap.h"
 #include "pas_lock.h"
+#include "pas_mte.h"
 #include <stdio.h>
 
 PAS_BEGIN_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -919,7 +919,7 @@ pas_local_allocator_try_allocate_in_primordial_partial_view(
 
     if (result.did_succeed) {
         PAS_PROFILE(PRIMORDIAL_BUMP_ALLOCATION, &page_config, result.begin, allocator->object_size, allocation_mode);
-        PAS_MTE_HANDLE(PRIMORDIAL_BUMP_ALLOCATION, &page_config, result.begin, allocator->object_size, allocation_mode);
+        PAS_MTE_HANDLE(PRIMORDIAL_BUMP_ALLOCATION, page_config, result.begin, allocator->object_size, allocation_mode);
     }
 
     pas_lock_switch(&held_lock, NULL);
@@ -1519,7 +1519,7 @@ pas_local_allocator_try_allocate_with_free_bits(
     }
 
     PAS_PROFILE(LOCAL_FREEBITS_ALLOCATION, &page_config, result, allocator, allocation_mode);
-    PAS_MTE_HANDLE(LOCAL_FREEBITS_ALLOCATION, &page_config, result, allocator, allocation_mode);
+    PAS_MTE_HANDLE(LOCAL_FREEBITS_ALLOCATION, page_config, result, allocator, allocation_mode);
     
     return pas_allocation_result_create_success(result);
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_page_granule_use_count.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_granule_use_count.h
@@ -47,6 +47,7 @@ static PAS_ALWAYS_INLINE void pas_page_granule_get_indices(
     PAS_ASSERT(*index_of_last_granule < page_size / granule_size);
 }
 
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static PAS_ALWAYS_INLINE void pas_page_granule_for_each_use_in_range(
     pas_page_granule_use_count* use_counts,
     uintptr_t begin,
@@ -71,6 +72,7 @@ static PAS_ALWAYS_INLINE void pas_page_granule_for_each_use_in_range(
          ++granule_index)
         action(use_counts + granule_index, arg);
 }
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static PAS_ALWAYS_INLINE void pas_page_granule_use_count_increment(
     pas_page_granule_use_count* use_count_ptr,


### PR DESCRIPTION
#### 0de9a179e544a6932f063d2b00c6781de4b5700a
<pre>
[libpas] Implement Retag-on-Scavenge for segregated objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=302663">https://bugs.webkit.org/show_bug.cgi?id=302663</a>
<a href="https://rdar.apple.com/164906028">rdar://164906028</a>

Reviewed by Dan Hecht.

The original implementation of retag-on-scavenge was insufficient,
but at the time its problems were masked by other bugs (mainly
the performance bug wherein we allocated all pages with backing
MTE memory, even when they were intended only for allocating
compact objects). Secondly, they were also masked by recently-
modified page configurations which ensured that certain allocation
paths were not reached in practice in those places where the feature
was enabled. This patch goes over and fixes those issues for segregated
objects in particular, thus enabling the feature in privileged
processes.
The main issues:
 - The way we were previously checking whether or not an allocation
   should be re- tagged relied on the page configuration. However, that
   does not always work because the local-allocator can also decide to
   use a tagged page-config to ultimately allocate *untagged* memory.
   Since the metadata used to make this decision is not accessible on
   the deallocation path, we instead determine it &apos;experimentally&apos; by
   executing an LDG instruction on the page. Since libpas makes sure to
   never explicitly zero-tag an allocation inside of an MTE-backed page,
   if we get a zero-tag back that means the object is canonically tagged
   -- i.e., has no backing MTE tag memory.
 - Bitfit heaps, unlike segregated heaps, can allocate objects of
   different sizes in the same memory location. This complicates both
   the process of determining the size of an object being freed as well
   as making it impossible to elide re-tagging an object on allocation,
   as the deallocation path cannot know the size of the next object to
   be allocated in a given slot. This patch thus disables the bitfit
   retag-on-scavenge path for the time being, pending future work.

As part of the above work, this patch also refactors some components to
use always-inline functions instead of macros, as part of a general
intent to move away from the heavily macro-ified and indirect approach
that was an artifact of how libpas MTE was developed on a side-tree prior
to the announcement of MIE.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
(pas_bitfit_page_finish_allocation):
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_try_allocate_in_primordial_partial_view):
(pas_local_allocator_try_allocate_with_free_bits):
* Source/bmalloc/libpas/src/libpas/pas_mte.h:
(pas_mte_maybe_tag_allocated_region):
(pas_mte_retag_freed_region_if_tagged):
* Source/bmalloc/libpas/src/libpas/pas_mte_config.h:
* Source/bmalloc/libpas/src/libpas/pas_page_granule_use_count.h:
* Source/bmalloc/libpas/src/libpas/pas_zero_memory.h:
(pas_zero_memory):

Canonical link: <a href="https://commits.webkit.org/303396@main">https://commits.webkit.org/303396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2857f697563a67c6a4f4c8beb5fe43d7bfe1e181

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132173 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84094 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101031 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68365 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/671e3d07-994e-4fef-ace6-8cfed0802f99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135119 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81824 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c0938ee-6eaf-4b1e-a421-1b547730830a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82908 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124236 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142335 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130680 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4416 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3762 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109586 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3290 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4389 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33043 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163647 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4221 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42528 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4480 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4348 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->