### PR TITLE
imported/w3c/web-platform-tests/svg/render/reftests/blending-001.svg has constant failures. Fuziness

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/blending-001.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/blending-001.svg
@@ -11,7 +11,7 @@
     <html:link rel="help"
           href="https://www.w3.org/TR/SVG2/render.html#PaintersModel"/>
     <html:link rel="match"  href="blending-001-ref.svg" />
-    <html:meta name="fuzzy" content="0-1;0-11" />
+    <html:meta name="fuzzy" content="maxDifference=0-127; totalPixels=0-1220" />
   </g>
 
   <style id="test-font" type="text/css">


### PR DESCRIPTION
#### b4acdd7f48b90951d27f3856d5b1059e59eb7dce
<pre>
imported/w3c/web-platform-tests/svg/render/reftests/blending-001.svg has constant failures. Fuziness
<a href="https://bugs.webkit.org/show_bug.cgi?id=206369">https://bugs.webkit.org/show_bug.cgi?id=206369</a>
<a href="https://rdar.apple.com/164915998">rdar://164915998</a>

Reviewed by Said Abou-Hallawa.

This test is failing not because of the test itself, but because of
fuziness blur at the top in WebKit.

* LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/blending-001.svg:

Canonical link: <a href="https://commits.webkit.org/303170@main">https://commits.webkit.org/303170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/771ed8f366fc6237164781f3efe0e59ffae62919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83307 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e323c3b1-8ddd-42b8-a44b-440eb1abb94a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d32ca758-f3a7-4429-8ebb-2cba262270b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81180 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d99099c-8b5d-4906-8736-7a0cfee0f0c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2681 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/423 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141632 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3555 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108757 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108982 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2693 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114016 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56743 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20442 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3616 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32427 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3441 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3642 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->