### PR TITLE
[AppKit Gestures] Pan gesture driven wheel inputs should support momentum scrolling

### DIFF
--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -83,6 +83,7 @@ public:
 #if PLATFORM(COCOA)
     MonotonicTime ioHIDEventTimestamp() const { return m_ioHIDEventTimestamp; }
     std::optional<WebCore::FloatSize> rawPlatformDelta() const { return m_rawPlatformDelta; }
+    void setRawPlatformDelta(std::optional<WebCore::FloatSize>&& delta) { m_rawPlatformDelta = WTFMove(delta); }
     uint32_t scrollCount() const { return m_scrollCount; }
     const WebCore::FloatSize& unacceleratedScrollingDelta() const { return m_unacceleratedScrollingDelta; }
 #endif

--- a/Source/WebKit/UIProcess/mac/WKPanGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKPanGestureController.mm
@@ -30,6 +30,7 @@
 
 #import "AppKitSPI.h"
 #import "NativeWebWheelEvent.h"
+#import "ScrollingAccelerationCurve.h"
 #import "WKWebView.h"
 #import "WebEventModifier.h"
 #import "WebEventType.h"
@@ -47,6 +48,8 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/UUID.h>
 #import <wtf/WeakPtr.h>
+
+#define WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG(pageID, fmt, ...) RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] %s: " fmt, pageID, std::source_location::current().function_name(), ##__VA_ARGS__)
 
 static WebCore::FloatSize translationInView(NSPanGestureRecognizer *gesture, WKWebView *view)
 {
@@ -76,10 +79,24 @@ static WebKit::WebWheelEvent::Phase toWheelEventPhase(NSGestureRecognizerState s
     }
 }
 
+static WebCore::FloatSize velocityInView(NSPanGestureRecognizer *gesture, WKWebView *view)
+{
+    return WebCore::toFloatSize(WebCore::FloatPoint { [gesture velocityInView:view] });
+}
+
+static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
+{
+    // rawPlatformDelta uses IOHIDEvent coordinate conventions, which have the opposite
+    // sign from WebKit's delta field. This matches WebEventFactory.mm which negates
+    // IOHIDEventFieldScrollX/Y values when extracting rawPlatformDelta from real events.
+    return -delta;
+}
+
 @implementation WKPanGestureController {
     WeakPtr<WebKit::WebPageProxy> _page;
     WeakPtr<WebKit::WebViewImpl> _viewImpl;
     RetainPtr<NSPanGestureRecognizer> _panGestureRecognizer;
+    bool _isMomentumActive;
 }
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKPanGestureControllerAdditions.mm>)
@@ -110,7 +127,45 @@ static WebKit::WebWheelEvent::Phase toWheelEventPhase(NSGestureRecognizerState s
     return self;
 }
 
+#pragma mark - Gesture Recognition
+
 - (void)panGestureRecognized:(NSGestureRecognizer *)gesture
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG(page->identifier().toUInt64(), "%@", gesture);
+
+    RetainPtr panGesture = dynamic_objc_cast<NSPanGestureRecognizer>(gesture);
+    if (!panGesture || _panGestureRecognizer != panGesture)
+        return;
+
+    if (viewImpl->ignoresAllEvents()) {
+        WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG(page->identifier().toUInt64(), "Ignored gesture");
+        return;
+    }
+
+    if ([panGesture state] == NSGestureRecognizerStateBegan)
+        viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
+
+    // FIXME: Need to supply a real event here.
+    if (viewImpl->allowsBackForwardNavigationGestures() && viewImpl->ensureProtectedGestureController()->handleScrollWheelEvent(nil)) {
+        WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG(page->identifier().toUInt64(), "View gesture controller handled gesture");
+        return;
+    }
+
+    [self sendWheelEventForGesture:panGesture.get()];
+    [self startMomentumIfNeededForGesture:panGesture.get()];
+}
+
+#pragma mark - Wheel Event Handling
+
+- (void)sendWheelEventForGesture:(NSPanGestureRecognizer *)gesture
 {
     CheckedPtr viewImpl = _viewImpl.get();
     if (!viewImpl)
@@ -121,39 +176,19 @@ static WebKit::WebWheelEvent::Phase toWheelEventPhase(NSGestureRecognizerState s
         return;
 
     RefPtr page = _page.get();
-    RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] panGestureRecognized: %@", page->identifier().toUInt64(), gesture);
-
-    RetainPtr panGesture = dynamic_objc_cast<NSPanGestureRecognizer>(gesture);
-    if (!panGesture || _panGestureRecognizer != panGesture)
+    if (!page)
         return;
 
-    if (viewImpl->ignoresAllEvents()) {
-        RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] panGestureRecognized: ignored gesture", page->identifier().toUInt64());
-        return;
-    }
-
-    auto gestureState = [panGesture state];
-    if (gestureState == NSGestureRecognizerStateBegan)
-        viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
-
-    // FIXME: Need to supply a real event here.
-    if (viewImpl->allowsBackForwardNavigationGestures() && viewImpl->ensureProtectedGestureController()->handleScrollWheelEvent(nil)) {
-        RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] panGestureRecognized: View gesture controller handled gesture", page->identifier().toUInt64());
-        return;
-    }
-
-    auto timestamp = MonotonicTime::fromRawSeconds([panGesture timestamp]);
+    auto timestamp = MonotonicTime::fromRawSeconds([gesture timestamp]);
     WebCore::IntPoint position { [gesture locationInView:webView.get()] };
-    auto globalPosition { WebCore::globalPoint([panGesture locationInView:nil], [webView window]) };
-    auto gestureDelta { translationInView(panGesture.get(), webView.get()) };
+    auto globalPosition { WebCore::globalPoint([gesture locationInView:nil], [webView window]) };
+    auto gestureDelta { translationInView(gesture, webView.get()) };
     auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
     auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
     bool directionInvertedFromDevice = false;
-    auto phase = toWheelEventPhase(gestureState);
+    auto phase = toWheelEventPhase(gesture.state);
     auto momentumPhase = WebKit::WebWheelEvent::Phase::None;
     bool hasPreciseScrollingDeltas = true;
-
-    // FIXME: These are placeholder values.
     uint32_t scrollCount = 1;
     auto unacceleratedScrollingDelta = gestureDelta;
     auto ioHIDEventTimestamp = timestamp;
@@ -177,9 +212,111 @@ static WebKit::WebWheelEvent::Phase toWheelEventPhase(NSGestureRecognizerState s
         rawPlatformDelta,
         momentumEndType
     };
+
     page->handleNativeWheelEvent(WebKit::NativeWebWheelEvent { wheelEvent });
 }
 
+#pragma mark - Momentum Handling
+
+- (void)startMomentumIfNeededForGesture:(NSPanGestureRecognizer *)gesture
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    if (gesture.state != NSGestureRecognizerStateEnded)
+        return;
+
+    auto velocity = velocityInView(gesture, webView.get());
+    auto velocityMagnitude = std::max(std::abs(velocity.width()), std::abs(velocity.height()));
+    static constexpr float minimumVelocityForMomentum = 20;
+    if (velocityMagnitude < minimumVelocityForMomentum)
+        return;
+
+    auto timestamp = MonotonicTime::fromRawSeconds([gesture timestamp]);
+    WebCore::IntPoint position { [gesture locationInView:webView.get()] };
+    auto globalPosition = WebCore::globalPoint([gesture locationInView:nil], [webView window]);
+
+    WebKit::WebWheelEvent momentumEvent {
+        { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
+        position,
+        WebCore::IntPoint { globalPosition },
+        WebCore::FloatSize { },
+        WebCore::FloatSize { },
+        WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
+        false,
+        WebKit::WebWheelEvent::Phase::None,
+        WebKit::WebWheelEvent::Phase::Began,
+        true,
+        1,
+        WebCore::FloatSize { },
+        timestamp,
+        std::nullopt,
+        WebKit::WebWheelEvent::MomentumEndType::Unknown
+    };
+    WebKit::NativeWebWheelEvent nativeMomentumEvent { momentumEvent };
+
+    nativeMomentumEvent.setRawPlatformDelta([&nativeMomentumEvent, velocity] {
+        static constexpr WebCore::FramesPerSecond fallbackMomentumFrameRate { 60 };
+        auto momentumFrameRate = WebKit::ScrollingAccelerationCurve::fromNativeWheelEvent(nativeMomentumEvent)
+            .or_else([] {
+                return WebKit::ScrollingAccelerationCurve::fallbackCurve();
+            }).transform([](const auto& curve) {
+                return curve.frameRate();
+            }).value_or(fallbackMomentumFrameRate);
+        auto initialMomentumDelta = velocity / momentumFrameRate;
+        return toRawPlatformDelta(initialMomentumDelta);
+    }());
+
+    page->handleNativeWheelEvent(nativeMomentumEvent);
+    _isMomentumActive = true;
+
+    WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG(page->identifier().toUInt64(), "Started momentum scrolling with velocity %.2f pts/s", velocityMagnitude);
+}
+
+- (void)interruptMomentumIfNeeded
+{
+    if (!std::exchange(_isMomentumActive, false))
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    auto timestamp = MonotonicTime::now();
+
+    WebKit::WebWheelEvent cancelEvent {
+        { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
+        WebCore::IntPoint { },
+        WebCore::IntPoint { },
+        WebCore::FloatSize { },
+        WebCore::FloatSize { },
+        WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
+        false,
+        WebKit::WebWheelEvent::Phase::Cancelled,
+        WebKit::WebWheelEvent::Phase::None,
+        true,
+        1,
+        WebCore::FloatSize { },
+        timestamp,
+        std::nullopt,
+        WebKit::WebWheelEvent::MomentumEndType::Interrupted
+    };
+
+    page->handleNativeWheelEvent(WebKit::NativeWebWheelEvent { cancelEvent });
+    WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG(page->identifier().toUInt64(), "Interrupted momentum scrolling");
+}
+
 @end
+
+#undef WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7319,8 +7319,6 @@ void WebViewImpl::configurePanGestureRecognizerIfNeeded()
     Ref page = m_page.get();
     if (!page->protectedPreferences()->useAppKitGestures())
         return;
-
-    RetainPtr view = m_view.get();
     m_panGestureController = adoptNS([[WKPanGestureController alloc] initWithPage:page viewImpl:*this]);
 }
 


### PR DESCRIPTION
#### ac3d35def7ee6b9a6bdb085e947f5766086f74ac
<pre>
[AppKit Gestures] Pan gesture driven wheel inputs should support momentum scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=302655">https://bugs.webkit.org/show_bug.cgi?id=302655</a>
<a href="https://rdar.apple.com/162040854">rdar://162040854</a>

Reviewed by Wenson Hsieh.

303084@main introduced general pan gesture --&gt; wheel input support, but
did not hook all the necessary event handling to drive the momentum
phases of scrolling.

In this patch, we teach WKPanGestureController how to prod the momentum
event dispatcher by sending a `Momentum:=Phase::Began` wheel event
with the appropriate velocity at the end of a recognized gesture. This
leads to synthetic momentum events generation using the acceleration
curve. Moreover, we introduce some state to facilitate catching or
interruption of an ongoing momentum scroll. Again, we simply teach
WKPanGestureController to prod the momentum event dispatcher by sending
a wheel event with `MomentumEndType:=Interrupted`.

* Source/WebKit/Shared/WebWheelEvent.h:
(WebKit::WebWheelEvent::setRawPlatformDelta):
  Add a setter so the raw delta can be computed after event creation,
  since the event itself may be required to fetch an associated scrolling
  acceleration curve.
* Source/WebKit/UIProcess/mac/WKPanGestureController.mm:
(velocityInView):
(toRawPlatformDelta):
(-[WKPanGestureController panGestureRecognized:]):
  Small refactor to avoid unnecessary bloat in the gesture recognition
  method.
(-[WKPanGestureController sendWheelEventForGesture:]):
(-[WKPanGestureController startMomentumIfNeededForGesture:]):
(-[WKPanGestureController interruptMomentumIfNeeded]):
  Introduce three smaller wheel event handling helper methods.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm: Removed unused variable.
(WebKit::WebViewImpl::configurePanGestureRecognizerIfNeeded):

Canonical link: <a href="https://commits.webkit.org/303172@main">https://commits.webkit.org/303172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd328cdd5615b097771123fa722562f8d0da9abd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83312 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/91861108-b3c6-4e1b-9cd2-7562cae044c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7210b3a1-d2be-4d3f-b66a-d6b685ec55dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81220 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9415e6fc-418c-465d-ab6f-31a455b291e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2703 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82231 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111322 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141685 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3607 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36377 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108783 "Found 3 new test failures: imported/w3c/web-platform-tests/encoding/legacy-mb-korean/euc-kr/euckr-decode-csksc56011987.html?8001-9000 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framesize.html imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109022 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2735 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56795 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20443 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3668 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32468 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3499 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67079 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->