### PR TITLE
Re-land: Remove raw pointer hash table from WebGPU::Sampler

### DIFF
--- a/Source/WebGPU/WebGPU/Sampler.h
+++ b/Source/WebGPU/WebGPU/Sampler.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #import <wtf/FastMalloc.h>
+#import <wtf/GenericHashKey.h>
+#import <wtf/Hasher.h>
 #import <wtf/ListHashSet.h>
 #import <wtf/Lock.h>
 #import <wtf/Ref.h>
@@ -44,7 +46,13 @@ class Device;
 class Sampler : public WGPUSamplerImpl, public RefCounted<Sampler> {
     WTF_MAKE_TZONE_ALLOCATED(Sampler);
 public:
-    using UniqueSamplerIdentifier = String;
+    using UniqueSamplerIdentifier = std::array<uint32_t, 4>;
+
+    inline void add(Hasher& hasher, const UniqueSamplerIdentifier& input)
+    {
+        for (auto value : input)
+            WTF::add(hasher, value);
+    }
 
     static Ref<Sampler> create(UniqueSamplerIdentifier&& samplerIdentifier, const WGPUSamplerDescriptor& descriptor, Device& device)
     {
@@ -79,13 +87,13 @@ private:
     const Ref<Device> m_device;
     // static is intentional here as the limit is per process
     static Lock samplerStateLock;
-    using CachedSamplerStateContainer = HashMap<UniqueSamplerIdentifier, WeakObjCPtr<id<MTLSamplerState>>>;
+    using CachedSamplerStateContainer = HashMap<GenericHashKey<UniqueSamplerIdentifier>, WeakObjCPtr<id<MTLSamplerState>>>;
     struct SamplerStateWithReferences {
         RetainPtr<id<MTLSamplerState>> samplerState;
-        HashSet<const Sampler*> apiSamplerList;
+        HashSet<uintptr_t> apiSamplerList;
     };
-    using RetainedSamplerStateContainer = HashMap<UniqueSamplerIdentifier, SamplerStateWithReferences>;
-    using CachedKeyContainer = ListHashSet<UniqueSamplerIdentifier>;
+    using RetainedSamplerStateContainer = HashMap<GenericHashKey<UniqueSamplerIdentifier>, SamplerStateWithReferences>;
+    using CachedKeyContainer = ListHashSet<GenericHashKey<UniqueSamplerIdentifier>>;
     static std::unique_ptr<CachedSamplerStateContainer> cachedSamplerStates WTF_GUARDED_BY_LOCK(samplerStateLock);
     static std::unique_ptr<RetainedSamplerStateContainer> retainedSamplerStates WTF_GUARDED_BY_LOCK(samplerStateLock);
     static std::unique_ptr<CachedKeyContainer> lastAccessedKeys;


### PR DESCRIPTION
#### 03305adad597630b82105daa651db9e52256b6b4
<pre>
Re-land: Remove raw pointer hash table from WebGPU::Sampler
<a href="https://bugs.webkit.org/show_bug.cgi?id=302667">https://bugs.webkit.org/show_bug.cgi?id=302667</a>
<a href="https://rdar.apple.com/164916940">rdar://164916940</a>

Reviewed by Mike Wyrzykowski.

Fixed the potential nullptr sampler access by restoring the Sampler&apos;s pointer as
the hash set key.

We never dereference the pointers in the set, so we can make this verifiably
memory safe by casting to pointer to integer and storing integer. (Bounds safety
works the same: pointer difference =&gt; scalar is safe; scalar =&gt; pointer
difference is not safe.)

Canonical link: <a href="https://commits.webkit.org/303143@main">https://commits.webkit.org/303143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7c06f034806f2273b21c8b86b71865fd2907831

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138989 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa5ba0ff-2142-43a4-818f-076795ee24d2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3654 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e13f22a-a809-42b0-8215-6db94a422bbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134428 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/117696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7fc2b54a-3958-41f9-a147-95e78bd44696) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82181 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3558 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3606 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108984 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2696 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114024 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56746 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20431 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3619 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67030 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->