### PR TITLE
[Style] Avoid redundant LayoutUnit conversion in LineWidth evaluation

### DIFF
--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -100,7 +100,7 @@ void Serialize<LineWidth>::operator()(StringBuilder& builder, const CSS::Seriali
     if (auto minimumLineWidth = 1.0f / deviceScaleFactor; result > 0.0f && result < minimumLineWidth)
         result = minimumLineWidth;
 
-    result = floorToDevicePixel(result, deviceScaleFactor);
+    result = std::floor(result * deviceScaleFactor) / deviceScaleFactor;
 
     CSS::serializationForCSS(builder, context, CSS::LengthRaw<> { CSS::LengthUnit::Px, result });
 }

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/StylePrimitiveNumeric.h>
 #include <WebCore/StyleZoomPrimitives.h>
+#include <cmath>
 
 namespace WebCore {
 
@@ -77,7 +78,12 @@ template<typename Result> struct Evaluation<LineWidth, Result> {
         if (auto minimumLineWidth = 1.0f / zoom.deviceScaleFactor; result > 0.0f && result < minimumLineWidth)
             return Result(minimumLineWidth);
 
-        return Result(floorToDevicePixel(result, zoom.deviceScaleFactor));
+        float snapped = std::floor(result * zoom.deviceScaleFactor) / zoom.deviceScaleFactor;
+
+        if constexpr (std::is_same_v<Result, LayoutUnit>)
+            return LayoutUnit::fromRawValue(clampToInteger(snapped * kFixedPointDenominator));
+        else
+            return Result(snapped);
     }
 };
 


### PR DESCRIPTION
#### 0f6e74d7d5d25c1cdc313a1714ce796cf186bb57
<pre>
[Style] Avoid redundant LayoutUnit conversion in LineWidth evaluation
<a href="https://bugs.webkit.org/show_bug.cgi?id=302668">https://bugs.webkit.org/show_bug.cgi?id=302668</a>
<a href="https://rdar.apple.com/164917570">rdar://164917570</a>

Reviewed by Brent Fulgham and Alan Baradlay.

This fix performs device pixel snapping math directly, avoiding the
intermediate LayoutUnit conversion.

Previously, when evaluating LineWidth values, the Evaluation template
called floorToDevicePixel, which internally converted to LayoutUnit.
The caller then converted the result to LayoutUnit again, causing
two constructor calls with full bounds validation for every
border width query during layout.

Tested on Speedometer 3 with eval-time zoom enabled:
- Before: Evaluation&lt;LineWidth, LayoutUnit&gt; showed ~392 samples in traces
- After: ~169 samples (~57% fewer, ~223 saved)

* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
(WebCore::Style::Serialize&lt;LineWidth&gt;::operator):
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:

Canonical link: <a href="https://commits.webkit.org/303290@main">https://commits.webkit.org/303290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/559b3f94c497f552f1ab50a02ce352432cc19983

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139396 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7dcbdae4-69d0-46de-8efe-28d1fb03d27f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100808 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43d40cf3-d16a-4191-89f1-b3b7e23c1f7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134830 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81598 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3476c6a4-6d32-40ec-99ae-399835f5c06b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82616 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142040 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4045 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109182 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4126 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3541 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27706 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3075 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57267 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4099 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32799 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3931 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4059 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->