### PR TITLE
[webkitcorepy] Fix stdin in mock popen

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py
@@ -167,7 +167,7 @@ class Popen(PopenBase):
 
         self.text_mode = encoding or errors or text or universal_newlines
 
-        if self.stdin is not None and self.text_mode:
+        if self.stdin is not None and text:
             self.stdin = io.TextIOWrapper(self.stdin, write_through=True, line_buffering=(bufsize == 1), encoding=encoding, errors=errors)
         if self.stdout is not None and self.text_mode:
             self.stdout = io.TextIOWrapper(self.stdout, encoding=encoding, errors=errors)
@@ -181,7 +181,9 @@ class Popen(PopenBase):
             raise ValueError('Cannot send input after starting communication')
 
         self._communication_started = True
-        if input:
+        if input and isinstance(self.stdin, io.TextIOWrapper):
+            self.stdin.write(input)
+        elif input:
             self.stdin.write(string_utils.encode(input))
         self.wait(timeout=timeout)
         return self.stdout.read() if self.stdout else None, self.stderr.read() if self.stderr else None

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/subprocess_utils_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/subprocess_utils_unittest.py
@@ -24,7 +24,7 @@ import sys
 import time
 import unittest
 
-from webkitcorepy import OutputCapture, run, TimeoutExpired, Timeout, Thread
+from webkitcorepy import mocks, OutputCapture, run, TimeoutExpired, Timeout, Thread
 
 
 class SubprocessUtils(unittest.TestCase):
@@ -81,3 +81,23 @@ class SubprocessUtils(unittest.TestCase):
         with OutputCapture(), self.assertRaises(TimeoutExpired):
             with Timeout(1):
                 run([sys.executable, '-c', 'import time;time.sleep(2)'])
+
+    def test_input(self):
+        def callback(*args, **kwargs):
+            print(kwargs['input'])
+            return mocks.ProcessCompletion(returncode=0)
+
+        with OutputCapture() as captured, mocks.Subprocess('command', generator=callback):
+            run(['command'], input=b'stdin content')
+
+        self.assertEqual(captured.stdout.getvalue(), "b'stdin content'\n")
+
+    def test_input_text(self):
+        def callback(*args, **kwargs):
+            print(kwargs['input'])
+            return mocks.ProcessCompletion(returncode=0)
+
+        with OutputCapture() as captured, mocks.Subprocess('command', generator=callback):
+            run(['command'], input='stdin content', text=True)
+
+        self.assertEqual(captured.stdout.getvalue(), "stdin content\n")


### PR DESCRIPTION
#### f8964b7a8d6c1c2af172d6eb86ccbd12d42a483f
<pre>
[webkitcorepy] Fix stdin in mock popen
<a href="https://bugs.webkit.org/show_bug.cgi?id=302671">https://bugs.webkit.org/show_bug.cgi?id=302671</a>
<a href="https://rdar.apple.com/164920281">rdar://164920281</a>

Reviewed by Elliott Williams and Ryan Haddad.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py:
(Popen.__init__): self.stdin should be set as io.TextIOWrapper if text=True.
(Popen.communicate): Pass input directly to self.stdin, if that object is a io.TextIOWrapper.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/subprocess_utils_unittest.py:
(SubprocessUtils.test_input):
(SubprocessUtils.test_input_text):

Canonical link: <a href="https://commits.webkit.org/303203@main">https://commits.webkit.org/303203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8764c43dc3ff74456bd6980c24ef58156abdae8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83278 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5eb7c89-820b-41c3-a134-6b3312e4a710) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/67956 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81192 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e0991fa-0782-411d-9eaf-b439a134fa9b) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/130848 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2687 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/430 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82199 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141653 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108765 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130928 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108995 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2704 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56764 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3637 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32441 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3462 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3567 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->