### PR TITLE
Prepare for -Wunsafe-buffer-usage-in-unique-ptr-array-access

### DIFF
--- a/Source/JavaScriptCore/tools/HeapVerifier.h
+++ b/Source/JavaScriptCore/tools/HeapVerifier.h
@@ -88,7 +88,12 @@ private:
     };
 
     void incrementCycle() { m_currentCycle = (m_currentCycle + 1) % m_numberOfCycles; }
-    GCCycle& currentCycle() { return m_cycles[m_currentCycle]; }
+    GCCycle& currentCycle()
+    {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        return m_cycles[m_currentCycle];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    }
     GCCycle& cycleForIndex(int cycleIndex)
     {
         ASSERT(cycleIndex <= 0 && cycleIndex > -m_numberOfCycles);
@@ -96,7 +101,9 @@ private:
         if (cycleIndex < 0)
             cycleIndex += m_numberOfCycles;
         ASSERT(cycleIndex < m_numberOfCycles);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return m_cycles[cycleIndex];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     CellList* cellListForGathering(Phase);

--- a/Source/WTF/wtf/StackShot.h
+++ b/Source/WTF/wtf/StackShot.h
@@ -59,8 +59,10 @@ public:
     StackShot& operator=(const StackShot& other)
     {
         auto newArray = makeUniqueArray<void*>(other.m_size);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         for (size_t i = other.m_size; i--;)
             newArray[i] = other.m_array[i];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         m_size = other.m_size;
         m_array = WTFMove(newArray);
         return *this;
@@ -82,22 +84,26 @@ public:
     {
         if (m_size != other.m_size)
             return false;
-        
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         for (size_t i = m_size; i--;) {
             if (m_array[i] != other.m_array[i])
                 return false;
         }
-        
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
         return true;
     }
     
     unsigned hash() const
     {
         unsigned result = m_size;
-        
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         for (size_t i = m_size; i--;)
             result ^= PtrHash<void*>::hash(m_array[i]);
-        
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
         return result;
     }
     

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -43,8 +43,10 @@ CSSSelectorList::CSSSelectorList(const CSSSelectorList& other)
         return;
 
     m_selectorArray = makeUniqueArray<CSSSelector>(otherComponentCount);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (unsigned i = 0; i < otherComponentCount; ++i)
         new (NotNull, &m_selectorArray[i]) CSSSelector(other.m_selectorArray[i]);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
@@ -59,6 +61,7 @@ CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
     ASSERT(flattenedSize);
     m_selectorArray = makeUniqueArray<CSSSelector>(flattenedSize);
     size_t arrayIndex = 0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (size_t i = 0; i < selectorVector.size(); ++i) {
         auto* last = selectorVector[i].get();
         auto* current = last;
@@ -66,9 +69,7 @@ CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
             {
                 // Move item from the parser selector vector into m_selectorArray without invoking destructor (Ugh.)
                 auto* currentSelector = current->releaseSelector().release();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                 memcpy(static_cast<void*>(&m_selectorArray[arrayIndex]), static_cast<void*>(currentSelector), sizeof(CSSSelector));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
                 // Free the underlying memory without invoking the destructor.
                 operator delete (currentSelector);
@@ -85,16 +86,19 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     ASSERT(flattenedSize == arrayIndex);
     m_selectorArray[arrayIndex - 1].m_isLastInSelectorList = true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 CSSSelectorList CSSSelectorList::makeCopyingSimpleSelector(const CSSSelector& simpleSelector)
 {
     auto selectorArray = makeUniqueArray<CSSSelector>(1);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     new (NotNull, &selectorArray[0]) CSSSelector(simpleSelector);
     selectorArray[0].m_isFirstInComplexSelector = true;
     selectorArray[0].m_isLastInComplexSelector = true;
     selectorArray[0].m_isLastInSelectorList = true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return CSSSelectorList { WTFMove(selectorArray) };
 }
@@ -107,10 +111,12 @@ CSSSelectorList CSSSelectorList::makeCopyingComplexSelector(const CSSSelector& c
 
     auto selectorArray = makeUniqueArray<CSSSelector>(length);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     size_t i = 0;
     for (auto* selector = &complexSelector; selector; selector = selector->precedingInComplexSelector(), ++i)
         new (NotNull, &selectorArray[i]) CSSSelector(*selector);
     selectorArray[length - 1].m_isLastInSelectorList = true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return CSSSelectorList { WTFMove(selectorArray) };
 }
@@ -127,6 +133,7 @@ CSSSelectorList CSSSelectorList::makeJoining(const CSSSelectorList& a, const CSS
 
     auto selectorArray = makeUniqueArray<CSSSelector>(aComponentCount + bComponentCount);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (size_t i = 0; i < aComponentCount; ++i)
         new (NotNull, &selectorArray[i]) CSSSelector(a.m_selectorArray[i]);
     for (size_t i = 0; i < bComponentCount; ++i)
@@ -134,6 +141,7 @@ CSSSelectorList CSSSelectorList::makeJoining(const CSSSelectorList& a, const CSS
 
     selectorArray[aComponentCount - 1].m_isLastInSelectorList = false;
     selectorArray[aComponentCount + bComponentCount - 1].m_isLastInSelectorList = true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return CSSSelectorList { WTFMove(selectorArray) };
 }
@@ -149,6 +157,7 @@ CSSSelectorList CSSSelectorList::makeJoining(const Vector<const CSSSelectorList*
 
     auto selectorArray = makeUniqueArray<CSSSelector>(totalComponentCount);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     size_t componentIndex = 0;
     for (auto list : lists) {
         auto count = list->componentCount();
@@ -159,6 +168,7 @@ CSSSelectorList CSSSelectorList::makeJoining(const Vector<const CSSSelectorList*
 
     ASSERT(componentIndex == totalComponentCount);
     selectorArray[componentIndex - 1].m_isLastInSelectorList = true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return CSSSelectorList { WTFMove(selectorArray) };
 }

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -53,7 +53,12 @@ public:
 
     bool isEmpty() const { return !m_selectorArray; }
     const CSSSelector* first() const { return m_selectorArray.get(); }
-    const CSSSelector* selectorAt(size_t index) const { return &m_selectorArray[index]; }
+    const CSSSelector* selectorAt(size_t index) const
+    {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        return &m_selectorArray[index];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    }
 
     size_t indexOfNextSelectorAfter(size_t index) const
     {

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -334,9 +334,11 @@ Ref<StyleRule> StyleRule::createForSplitting(const Vector<const CSSSelector*>& s
 {
     ASSERT_WITH_SECURITY_IMPLICATION(!selectors.isEmpty());
     auto selectorListArray = makeUniqueArray<CSSSelector>(selectors.size());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (unsigned i = 0; i < selectors.size(); ++i)
         new (NotNull, &selectorListArray[i]) CSSSelector(*selectors.at(i));
     selectorListArray[selectors.size() - 1].setLastInSelectorList();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     auto styleRule = StyleRule::create(WTFMove(properties), hasDocumentSecurityOrigin, CSSSelectorList(WTFMove(selectorListArray)));
     styleRule->markAsSplitRule();
     return styleRule;

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -520,7 +520,9 @@ inline CompiledSelector& StyleRule::compiledSelectorForListIndex(unsigned index)
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(index < listSize);
         m_compiledSelectors = makeUniqueArray<CompiledSelector>(listSize);
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return m_compiledSelectors[index];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #endif

--- a/Source/WebCore/platform/audio/DynamicsCompressor.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressor.cpp
@@ -108,6 +108,7 @@ void DynamicsCompressor::process(const AudioBus& sourceBus, AudioBus& destinatio
 
     switch (numberOfChannels) {
     case 2: // stereo
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         m_sourceChannels[0] = sourceBus.channel(0)->span();
 
         if (numberOfSourceChannels > 1)
@@ -115,6 +116,7 @@ void DynamicsCompressor::process(const AudioBus& sourceBus, AudioBus& destinatio
         else
             // Simply duplicate mono channel input data to right channel for stereo processing.
             m_sourceChannels[1] = m_sourceChannels[0];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         break;
     default:
@@ -124,8 +126,10 @@ void DynamicsCompressor::process(const AudioBus& sourceBus, AudioBus& destinatio
         return;
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (unsigned i = 0; i < numberOfChannels; ++i)
         m_destinationChannels[i] = destinationBus.channel(i)->mutableSpan();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     float dbThreshold = parameterValue(ParamThreshold);
     float dbKnee = parameterValue(ParamKnee);


### PR DESCRIPTION
#### 129b0c617014dd7d65ffc0ce6ef960595d4b0dbd
<pre>
Prepare for -Wunsafe-buffer-usage-in-unique-ptr-array-access
<a href="https://bugs.webkit.org/show_bug.cgi?id=302672">https://bugs.webkit.org/show_bug.cgi?id=302672</a>
<a href="https://rdar.apple.com/164920989">rdar://164920989</a>

Reviewed by Chris Dumez and David Kilzer.

This is a new warning, so skip existing failures for now; we can burn them
down later.

* Source/JavaScriptCore/tools/HeapVerifier.h:
(JSC::HeapVerifier::currentCycle):
(JSC::HeapVerifier::cycleForIndex):
* Source/WTF/wtf/StackShot.h:
(WTF::StackShot::operator=):
(WTF::StackShot::operator== const):
(WTF::StackShot::hash const):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::makeCopyingSimpleSelector):
(WebCore::CSSSelectorList::makeCopyingComplexSelector):
(WebCore::CSSSelectorList::makeJoining):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::selectorAt const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::createForSplitting):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRule::compiledSelectorForListIndex const):
* Source/WebCore/platform/audio/DynamicsCompressor.cpp:
(WebCore::DynamicsCompressor::process):

Canonical link: <a href="https://commits.webkit.org/303153@main">https://commits.webkit.org/303153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b8ac7aa093d94c9e934b00ed7393635115bd5f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131503 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139010 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b049ebb-b8e6-4d08-92d3-1e4db7177769) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3675 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ce09995d-2012-48d3-8c01-ac299097cd1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134449 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81197 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/911a4aa4-e9d7-4895-9789-ea6135c4cbb9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82202 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123528 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141656 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129957 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3579 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36352 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3627 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109001 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2715 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56767 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20436 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3640 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32445 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162974 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67051 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->