### PR TITLE
[iOS] `viewport-fit: auto` is not honored when navigating from a page with `viewport-fit: cover`

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -641,6 +641,7 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
     _findInteractionEnabled = NO;
     _needsToPresentLockdownModeMessage = YES;
     _allowsMagnification = YES;
+    _avoidsUnsafeArea = YES;
 
     auto fastClickingEnabled = []() {
         if (NSNumber *enabledValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitFastClickingDisabled"])

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -251,8 +251,6 @@ struct PerWebProcessState {
     BOOL hasScheduledVisibleRectUpdate { NO };
     BOOL commitDidRestoreScrollPosition { NO };
 
-    BOOL avoidsUnsafeArea { YES };
-
     BOOL viewportMetaTagWidthWasExplicit { NO };
     BOOL viewportMetaTagCameFromImageDocument { NO };
     BOOL lastTransactionWasInStableState { NO };
@@ -375,6 +373,7 @@ struct PerWebProcessState {
 #if PLATFORM(IOS_FAMILY)
     BOOL _forcesInitialScaleFactor;
     BOOL _automaticallyAdjustsViewLayoutSizesWithObscuredInset;
+    BOOL _avoidsUnsafeArea;
 #endif
     CGRect _inputViewBoundsInWindow;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3617,10 +3617,10 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
 
 - (void)_setAvoidsUnsafeArea:(BOOL)avoidsUnsafeArea
 {
-    if (_perProcessState.avoidsUnsafeArea == avoidsUnsafeArea)
+    if (_avoidsUnsafeArea == avoidsUnsafeArea)
         return;
 
-    _perProcessState.avoidsUnsafeArea = avoidsUnsafeArea;
+    _avoidsUnsafeArea = avoidsUnsafeArea;
 
     if ([self _updateScrollViewContentInsetsIfNecessary] && !self._shouldDeferGeometryUpdates && !_overriddenLayoutParameters)
         [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
@@ -4377,7 +4377,7 @@ static bool isLockdownModeWarningNeeded()
 {
     if (![self usesStandardContentView])
         return NO;
-    return _perProcessState.avoidsUnsafeArea;
+    return _avoidsUnsafeArea;
 }
 
 - (UIView *)_enclosingViewForExposedRectComputation

--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.h
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.h
@@ -49,6 +49,11 @@ void instantiateUIApplicationIfNeeded(Class customApplicationClass = nil);
 #define EXPECT_NS_EQUAL(expected, actual) \
     EXPECT_PRED_FORMAT2(TestWebKitAPI::Util::assertNSObjectsAreEqual, expected, actual)
 
+#if PLATFORM(IOS_FAMILY)
+std::ostream& operator<<(std::ostream&, const UIEdgeInsets&);
+bool operator==(const UIEdgeInsets&, const UIEdgeInsets&);
+#endif
+
 #if USE(CG)
 
 std::ostream& operator<<(std::ostream&, const CGPoint&);

--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
@@ -84,6 +84,16 @@ bool operator==(const CGRect& a, const CGRect& b)
 
 #if PLATFORM(IOS_FAMILY)
 
+std::ostream& operator<<(std::ostream& os, const UIEdgeInsets& insets)
+{
+    return os << "(top = " << insets.top << ", left = " << insets.left << ", bottom = " << insets.bottom << ", right = " << insets.right << ")";
+}
+
+bool operator==(const UIEdgeInsets& a, const UIEdgeInsets& b)
+{
+    return UIEdgeInsetsEqualToEdgeInsets(a, b);
+}
+
 void TestWebKitAPI::Util::instantiateUIApplicationIfNeeded(Class customApplicationClass)
 {
     if (UIApplication.sharedApplication)


### PR DESCRIPTION
#### be2067342cce44336c3e59d9217d6e7af47cecb2
<pre>
[iOS] `viewport-fit: auto` is not honored when navigating from a page with `viewport-fit: cover`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302676">https://bugs.webkit.org/show_bug.cgi?id=302676</a>
<a href="https://rdar.apple.com/164923783">rdar://164923783</a>

Reviewed by Abrar Rahman Protyasha.

`viewport-fit: cover` works by setting the content inset adjustment behavior on
`WKScrollView` to `UIScrollViewContentInsetAdjustmentNever`. When the value of
viewport-fit changes, the scroll view&apos;s content inset adjustment behavior must
also be changed. This is normally done in `-[WKWebView _setAvoidsUnsafeArea:]`.
However, that method has an early return if `_perProcessState.avoidsUnsafeArea`
is equal to the input parameter. Due to process-swap-on-navigation,
`_perProcessState` is reset (to true) when navigating from a page with
`viewport-fit: auto` to `viewport-fit: cover`. `-[WKWebView _setAvoidsUnsafeArea:]`
is only called on the next layer tree transaction. Consequently,
`-[WKWebView _setAvoidsUnsafeArea:]` is a no-op, as `viewport-fit: auto` wants
&quot;avoids unsafe area&quot; to be true, and the `_perProcessState` already has it as such.

Fix by moving `avoidsUnsafeArea` out of per-process-state, and making it an
instance variable on `WKWebView`. There is no need to reset this variable on
process-swap or exit. If it needs to be updated, it will be on the next layer
tree transaction.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setAvoidsUnsafeArea:]):
(-[WKWebView _safeAreaShouldAffectObscuredInsets]):
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, ContentInsetAdjustmentBehaviorChangeAfterViewportFitChange)):
* Tools/TestWebKitAPI/cocoa/TestCocoa.h:
* Tools/TestWebKitAPI/cocoa/TestCocoa.mm:
(operator&lt;&lt;):
(operator==):

Canonical link: <a href="https://commits.webkit.org/303187@main">https://commits.webkit.org/303187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5975a1d5e4e2be7b73c68cde7b0298578156282f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83294 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100406 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d86154f-dbe8-49dd-9730-79146f4c8697) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81234 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9091bf62-ded9-4571-a8b9-bbcfa8e2e13b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2692 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/438 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82215 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141668 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108773 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3639 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3198 "Found 1 new test failure: fast/images/individual-animation-toggle.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109008 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2719 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56779 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20449 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3652 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32457 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3582 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->