### PR TITLE
[Site Isolation] Prevent didStartProvisionalLoad from being called twice on browsing context switches

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -144,7 +144,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
         else
             m_mainFrame->frameLoadState().didStartProvisionalLoad(URL { m_request.url() });
         page.didReceiveServerRedirectForProvisionalLoadForFrameShared(WTFMove(process), m_mainFrame->frameID(), m_navigationID, WTFMove(m_request), { });
-    } else if (previousMainFrame && !previousMainFrame->provisionalURL().isEmpty()) {
+    } else if (previousMainFrame && !previousMainFrame->provisionalURL().isEmpty() && !m_isProcessSwappingForNewWindow) {
         // In case of a process swap after response policy, the didStartProvisionalLoad already happened but the new main frame doesn't know about it
         // so we need to tell it so it can update its provisional URL.
         protectedMainFrame()->didStartProvisionalLoad(URL { previousMainFrame->provisionalURL() });


### PR DESCRIPTION
#### 24039354222e5203965d41a72ecdcab56f7fe5f3
<pre>
[Site Isolation] Prevent didStartProvisionalLoad from being called twice on browsing context switches
<a href="https://bugs.webkit.org/show_bug.cgi?id=302678">https://bugs.webkit.org/show_bug.cgi?id=302678</a>
<a href="https://rdar.apple.com/164680770">rdar://164680770</a>

Reviewed by Alex Christensen.

When a cross-origin document is opened with window.open(), there is a scenario
where `FrameLoadState::didStartProvisionalLoad` can be called twice with the
same URL and trigger the ASSERT in `FrameLoadState::didStartProvisionalLoad`
which checks that the provisional url for that frame is empty.

This scenario can happen when a cross origin document is opened and a browsing
context switch is triggered due to the new document&apos;s incompatible Cross Origin
Opener Policy (COOP). The first calls of `FrameLoadState::didStartProvisionalLoad`
is during the initial load of the page. The second call happens when the browsing
context switch happens due to the incompatible COOP policy of the new document.
For the second call, the call stack is:
`WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation` -&gt;
`WebPageProxy::continueNavigationInNewProcess` -&gt;
`ProvisionalPageProxy` constructor -&gt;
`didStartProvisionalLoad`.

This ASSERT was also hit by the LayoutTest
&quot;imported/w3c/web-platform-tests/html/cross-origin-opener-policy/javascript-url.https.html&quot;
with Site Isolation (which this patch fixes).

This patch doesn&apos;t call `FrameLoadState::didStartProvisionalLoad` when
`m_isProcessSwappingForNewWindow` is true. Earlier in the ProvisionalPageProxy
constructor, `m_mainFrame` is set to `page.mainFrame()` (which is the previous
frame). In this case, the current main frame points to the previous main frame
which has already had `didStartProvisionalLoad` called for it.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, BrowsingContextGroupSwitchForIncompatibleCrossOriginOpenerPolicy)):

Canonical link: <a href="https://commits.webkit.org/303420@main">https://commits.webkit.org/303420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8405ee22b6af97cc414a8e4d7d727f0a6aeab879

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84027 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/097611ec-173d-4a63-b8e0-759e83e3ebaf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100991 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68332 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6ca4f141-d14d-4f1d-ae17-ccbabef062dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81782 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/da525f11-89dd-40c1-9353-bf930b2e594b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1024 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142273 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4274 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109365 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109540 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3243 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114606 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57518 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20561 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4328 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32999 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4419 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4287 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->