### PR TITLE
Adopt C++20 Concepts in JavaScriptCore/dfg

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCFG.h
+++ b/Source/JavaScriptCore/dfg/DFGCFG.h
@@ -96,17 +96,29 @@ public:
 
 using SSACFG = CFG;
 
-template <typename T, typename = typename std::enable_if<std::is_same<T, CPSCFG>::value>::type>
-CPSCFG& selectCFG(Graph& graph)
-{
-    return graph.ensureCPSCFG();
-}
+template<typename> struct CFGSelection;
 
-template <typename T, typename = typename std::enable_if<std::is_same<T, SSACFG>::value>::type>
-SSACFG& selectCFG(Graph& graph)
+template<>
+struct CFGSelection<CPSCFG> {
+    static CPSCFG& select(Graph& graph)
+    {
+        return graph.ensureCPSCFG();
+    }
+};
+
+template<>
+struct CFGSelection<SSACFG> {
+    static SSACFG& select(Graph& graph)
+    {
+        RELEASE_ASSERT(graph.m_ssaCFG);
+        return *graph.m_ssaCFG;
+    }
+};
+
+template<typename T>
+auto& selectCFG(Graph& graph)
 {
-    RELEASE_ASSERT(graph.m_ssaCFG);
-    return *graph.m_ssaCFG;
+    return CFGSelection<T>::select(graph);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGDominators.h
+++ b/Source/JavaScriptCore/dfg/DFGDominators.h
@@ -51,16 +51,28 @@ WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL(template<typename CFGKind>, D
 using SSADominators = Dominators<SSACFG>;
 using CPSDominators = Dominators<CPSCFG>;
 
-template <typename T, typename = typename std::enable_if<std::is_same<T, CPSCFG>::value>::type>
-CPSDominators& ensureDominatorsForCFG(Graph& graph)
-{
-    return graph.ensureCPSDominators();
-}
+template<typename> struct DominatorsSelection;
 
-template <typename T, typename = typename std::enable_if<std::is_same<T, SSACFG>::value>::type>
-SSADominators& ensureDominatorsForCFG(Graph& graph)
+template<>
+struct DominatorsSelection<CPSCFG> {
+    static CPSDominators& select(Graph& graph)
+    {
+        return graph.ensureCPSDominators();
+    }
+};
+
+template<>
+struct DominatorsSelection<SSACFG> {
+    static SSADominators& select(Graph& graph)
+    {
+        return graph.ensureSSADominators();
+    }
+};
+
+template<typename T>
+auto& ensureDominatorsForCFG(Graph& graph)
 {
-    return graph.ensureSSADominators();
+    return DominatorsSelection<T>::select(graph);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1659,7 +1659,7 @@ public:
 
     JSType queriedType()
     {
-        static_assert(std::is_same<uint8_t, std::underlying_type<JSType>::type>::value, "Ensure that uint8_t is the underlying type for JSType.");
+        static_assert(std::same_as<uint8_t, std::underlying_type_t<JSType>>);
         return static_cast<JSType>(m_opInfo.as<uint32_t>());
     }
 
@@ -3922,23 +3922,27 @@ private:
             u.int64 = std::bit_cast<uint64_t>(newArrayBufferData);
             return *this;
         }
-        template <typename T>
-        ALWAYS_INLINE auto as() const -> typename std::enable_if<std::is_pointer<T>::value && !std::is_const<typename std::remove_pointer<T>::type>::value, T>::type
+        template<typename T>
+            requires (std::is_pointer_v<T> && !std::is_const_v<std::remove_pointer_t<T>>)
+        ALWAYS_INLINE T as() const
         {
             return static_cast<T>(u.pointer);
         }
-        template <typename T>
-        ALWAYS_INLINE auto as() const -> typename std::enable_if<std::is_pointer<T>::value && std::is_const<typename std::remove_pointer<T>::type>::value, T>::type
+        template<typename T>
+            requires (std::is_pointer_v<T> && std::is_const_v<std::remove_pointer_t<T>>)
+        ALWAYS_INLINE T as() const
         {
             return static_cast<T>(u.constPointer);
         }
-        template <typename T>
-        ALWAYS_INLINE auto as() const -> typename std::enable_if<(std::is_integral<T>::value || std::is_enum<T>::value) && sizeof(T) <= 4, T>::type
+        template<typename T>
+            requires ((std::integral<T> || std::is_enum_v<T>) && sizeof(T) <= 4)
+        ALWAYS_INLINE T as() const
         {
             return static_cast<T>(u.int32);
         }
-        template <typename T>
-        ALWAYS_INLINE auto as() const -> typename std::enable_if<(std::is_integral<T>::value || std::is_enum<T>::value) && sizeof(T) == 8, T>::type
+        template<typename T>
+            requires ((std::integral<T> || std::is_enum_v<T>) && sizeof(T) == 8)
+        ALWAYS_INLINE T as() const
         {
             return static_cast<T>(u.int64);
         }

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -119,7 +119,7 @@ void OSRExit::emitRestoreArguments(CCallHelpers& jit, VM& vm, const Operands<Val
                 GPRInfo::regT1);
         }
 
-        static_assert(std::is_same<decltype(operationCreateDirectArgumentsDuringExit), decltype(operationCreateClonedArgumentsDuringExit)>::value, "We assume these functions have the same signature below.");
+        static_assert(std::same_as<decltype(operationCreateDirectArgumentsDuringExit), decltype(operationCreateClonedArgumentsDuringExit)>, "We assume these functions have the same signature below.");
         jit.setupArguments<decltype(operationCreateDirectArgumentsDuringExit)>(
             AssemblyHelpers::TrustedImmPtr(&vm), AssemblyHelpers::TrustedImmPtr(inlineCallFrame), GPRInfo::regT0, GPRInfo::regT1);
         jit.prepareCallOperation(vm);

--- a/Source/JavaScriptCore/dfg/DFGOpInfo.h
+++ b/Source/JavaScriptCore/dfg/DFGOpInfo.h
@@ -41,9 +41,8 @@ namespace JSC { namespace DFG {
 // a constant index, argument, or identifier) from a Node*.
 struct OpInfo {
     OpInfo() : m_value(0) { }
-    template<
-        typename IntegralType,
-        typename Constraint = typename std::enable_if<(std::is_integral<IntegralType>::value || std::is_enum<IntegralType>::value) && sizeof(IntegralType) <= sizeof(uint64_t)>::type>
+    template<typename IntegralType>
+        requires ((std::integral<IntegralType> || std::is_enum_v<IntegralType>) && sizeof(IntegralType) <= sizeof(uint64_t))
     explicit OpInfo(IntegralType value)
         : m_value(static_cast<uint64_t>(value)) { }
     explicit OpInfo(RegisteredStructure structure) : m_value(static_cast<uint64_t>(std::bit_cast<uintptr_t>(structure))) { }

--- a/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
@@ -208,7 +208,7 @@ protected:
                 jit->exceptionCheck(CCallHelpers::operationExceptionRegister<typename FunctionTraits<FunctionType>::ResultType>());
         }
 
-        if constexpr (!std::is_same_v<ResultType, NoResultTag>)
+        if constexpr (!std::same_as<ResultType, NoResultTag>)
             jit->setupResults(extractResult(this->m_result));
 
         if (m_spillMode == NeedToSpill)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1085,14 +1085,14 @@ public:
 
         if (exceptionReg != InvalidGPRReg) {
             RegisterSetBuilder spilledRegs = spilledRegsForSilentSpillPlans(plans);
-            if constexpr (std::is_same_v<GPRReg, ResultRegType> || std::is_same_v<JSValueRegs, ResultRegType>) {
+            if constexpr (std::same_as<GPRReg, ResultRegType> || std::same_as<JSValueRegs, ResultRegType>) {
                 spilledRegs.add(GPRInfo::returnValueGPR, IgnoreVectors);
                 spilledRegs.add(result, IgnoreVectors);
             }
 
             if constexpr (sizeof...(OtherSpilledRegTypes) > 0) {
                 constexpr auto addRegIfNeeded = [](auto& spilledRegs, auto& reg) ALWAYS_INLINE_LAMBDA {
-                    static_assert(std::is_same_v<GPRReg, std::decay_t<decltype(reg)>> || std::is_same_v<JSValueRegs, std::decay_t<decltype(reg)>>);
+                    static_assert(std::same_as<GPRReg, std::decay_t<decltype(reg)>> || std::same_as<JSValueRegs, std::decay_t<decltype(reg)>>);
                     spilledRegs.add(reg, IgnoreVectors);
                 };
                 (addRegIfNeeded(spilledRegs, otherSpilledRegs), ...);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -2452,7 +2452,7 @@ void SpeculativeJIT::emitBranch(Node* node)
 template<typename MapOrSet>
 void SpeculativeJIT::compileMapGetImpl(Node* node)
 {
-    constexpr bool isMapObjectUse = std::is_same<MapOrSet, JSMap>::value;
+    constexpr bool isMapObjectUse = std::same_as<MapOrSet, JSMap>;
 
     SpeculateCellOperand map(this, node->child1());
     JSValueOperand key(this, node->child2(), ManualOperandSpeculation);
@@ -2614,7 +2614,7 @@ void SpeculativeJIT::compileMapGetImpl(Node* node)
     if (!slowPathCases.empty()) {
         JIT_COMMENT(*this, "The slow path should call the operation.");
         slowPathCases.link(this);
-        auto operation = std::is_same<MapOrSet, JSMap>::value ? operationMapGet : operationSetGet;
+        auto operation = std::same_as<MapOrSet, JSMap> ? operationMapGet : operationSetGet;
         callOperationWithSilentSpill(operation, entryKeySlotGPR, LinkableConstant::globalObject(*this, node), mapGPR, keyGPR, hashGPR);
         done.append(jump());
     }


### PR DESCRIPTION
#### 56ff086f9da348f91908594db9e741485c043863
<pre>
Adopt C++20 Concepts in JavaScriptCore/dfg
<a href="https://bugs.webkit.org/show_bug.cgi?id=302683">https://bugs.webkit.org/show_bug.cgi?id=302683</a>
<a href="https://rdar.apple.com/164931352">rdar://164931352</a>

Reviewed by Darin Adler and Sam Weinig.

* Source/JavaScriptCore/dfg/DFGCFG.h:
* Source/JavaScriptCore/dfg/DFGDominators.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::queriedType):
(JSC::DFG::Node::OpInfoWrapper::as const):
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::emitRestoreArguments):
* Source/JavaScriptCore/dfg/DFGOpInfo.h:
* Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h:
(JSC::DFG::CallSlowPathGenerator::tearDown):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::tryHandleOrGetExceptionUnderSilentSpill):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileMapGetImpl):

Canonical link: <a href="https://commits.webkit.org/303328@main">https://commits.webkit.org/303328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e39e9aa104770f5d410e7638e288d2386e95a3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100877 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3038 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82705 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124036 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142131 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130480 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109248 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109418 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3128 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4188 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32868 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163447 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67635 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42504 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->