### PR TITLE
Reduce use of raw pointers in containers in WebCore/

### DIFF
--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -192,9 +192,9 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
     return create(context, url, Vector<String> { 1, protocol });
 }
 
-HashSet<WebSocket*>& WebSocket::allActiveWebSockets()
+HashSet<CheckedPtr<WebSocket>>& WebSocket::allActiveWebSockets()
 {
-    static NeverDestroyed<HashSet<WebSocket*>> activeWebSockets;
+    static NeverDestroyed<HashSet<CheckedPtr<WebSocket>>> activeWebSockets;
     return activeWebSockets;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -33,6 +33,7 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "WebSocketChannelClient.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/URL.h>
@@ -48,8 +49,9 @@ class Blob;
 class ThreadableWebSocketChannel;
 template<typename> class ExceptionOr;
 
-class WebSocket final : public RefCounted<WebSocket>, public EventTarget, public ActiveDOMObject, private WebSocketChannelClient {
+class WebSocket final : public RefCounted<WebSocket>, public EventTarget, public ActiveDOMObject, public CanMakeThreadSafeCheckedPtr<WebSocket>, private WebSocketChannelClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebSocket);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSocket);
 public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
@@ -61,7 +63,7 @@ public:
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols);
     virtual ~WebSocket();
 
-    static HashSet<WebSocket*>& allActiveWebSockets() WTF_REQUIRES_LOCK(s_allActiveWebSocketsLock);
+    static HashSet<CheckedPtr<WebSocket>>& allActiveWebSockets() WTF_REQUIRES_LOCK(s_allActiveWebSocketsLock);
     static Lock& allActiveWebSocketsLock() WTF_RETURNS_LOCK(s_allActiveWebSocketsLock);
 
     enum State {

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -99,6 +99,7 @@ class ResourceRequest;
 class ServiceWorker;
 class ServiceWorkerContainer;
 class SocketProvider;
+class WeakPtrImplWithEventTargetData;
 class WebCoreOpaqueRoot;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class CrossOriginMode : bool;
@@ -340,7 +341,7 @@ public:
 
     void registerServiceWorker(ServiceWorker&);
     void unregisterServiceWorker(ServiceWorker&);
-    inline ServiceWorker* serviceWorker(ServiceWorkerIdentifier); // Defined in ScriptExecutionContextInlines.h.
+    inline ServiceWorker* serviceWorker(ServiceWorkerIdentifier); // Defined in ServiceWorker.h.
 
     ServiceWorkerContainer* serviceWorkerContainer();
     ServiceWorkerContainer* ensureServiceWorkerContainer();
@@ -420,7 +421,7 @@ private:
     void checkConsistency() const;
     WEBCORE_EXPORT GuaranteedSerialFunctionDispatcher& nativePromiseDispatcher();
 
-    HashSet<MessagePort*> m_messagePorts;
+    WeakHashSet<MessagePort, WeakPtrImplWithEventTargetData> m_messagePorts;
     HashSet<ContextDestructionObserver*> m_destructionObservers;
     HashSet<ActiveDOMObject*> m_activeDOMObjects;
 
@@ -444,7 +445,7 @@ private:
 #endif
 
     RefPtr<ServiceWorker> m_activeServiceWorker;
-    HashMap<ServiceWorkerIdentifier, ServiceWorker*> m_serviceWorkers;
+    HashMap<ServiceWorkerIdentifier, WeakRef<ServiceWorker, WeakPtrImplWithEventTargetData>> m_serviceWorkers;
 
     String m_domainForCachePartition;
     mutable ScriptExecutionContextIdentifier m_identifier;

--- a/Source/WebCore/dom/ScriptExecutionContextInlines.h
+++ b/Source/WebCore/dom/ScriptExecutionContextInlines.h
@@ -28,7 +28,6 @@
 #include <WebCore/DOMTimer.h>
 #include <WebCore/EventLoop.h>
 #include <WebCore/ScriptExecutionContext.h>
-#include <WebCore/ServiceWorkerIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CrossThreadTask.h>
 #include <wtf/NativePromise.h>
@@ -48,11 +47,6 @@ inline RefPtr<DOMTimer> ScriptExecutionContext::takeTimeout(int timeoutId)
 inline DOMTimer* ScriptExecutionContext::findTimeout(int timeoutId)
 {
     return m_timeouts.get(timeoutId);
-}
-
-inline ServiceWorker* ScriptExecutionContext::serviceWorker(ServiceWorkerIdentifier identifier)
-{
-    return m_serviceWorkers.get(identifier);
 }
 
 inline CheckedRef<EventLoopTaskGroup> ScriptExecutionContext::checkedEventLoop()

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -143,7 +143,7 @@ protected:
 
     virtual Inspector::Protocol::Network::LoaderId loaderIdentifier(DocumentLoader*) = 0;
     virtual Inspector::Protocol::Network::FrameId frameIdentifier(DocumentLoader*) = 0;
-    virtual Vector<WebSocket*> activeWebSockets() WTF_REQUIRES_LOCK(WebSocket::allActiveWebSocketsLock()) = 0;
+    virtual Vector<Ref<WebSocket>> activeWebSockets() WTF_REQUIRES_LOCK(WebSocket::allActiveWebSocketsLock()) = 0;
     virtual void setResourceCachingDisabledInternal(bool) = 0;
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     virtual bool setEmulatedConditionsInternal(std::optional<int>&& bytesPerSecondLimit) = 0;
@@ -159,7 +159,7 @@ private:
     void continuePendingRequests();
     void continuePendingResponses();
 
-    WebSocket* webSocketForRequestId(const Inspector::Protocol::Network::RequestId&);
+    RefPtr<WebSocket> webSocketForRequestId(const Inspector::Protocol::Network::RequestId&);
 
     Ref<Inspector::Protocol::Network::Initiator> buildInitiatorObject(Document*, const ResourceRequest* = nullptr);
     Ref<Inspector::Protocol::Network::ResourceTiming> buildObjectForTiming(const NetworkLoadMetrics&, ResourceLoader&);

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -76,11 +76,11 @@ Inspector::Protocol::Network::FrameId PageNetworkAgent::frameIdentifier(Document
     return { };
 }
 
-Vector<WebSocket*> PageNetworkAgent::activeWebSockets()
+Vector<Ref<WebSocket>> PageNetworkAgent::activeWebSockets()
 {
-    Vector<WebSocket*> webSockets;
+    Vector<Ref<WebSocket>> webSockets;
 
-    for (auto* webSocket : WebSocket::allActiveWebSockets()) {
+    for (CheckedPtr webSocket : WebSocket::allActiveWebSockets()) {
         RefPtr channel = webSocket->channel();
         if (!channel)
             continue;
@@ -96,7 +96,7 @@ Vector<WebSocket*> PageNetworkAgent::activeWebSockets()
         if (document->page() != m_inspectedPage.ptr())
             continue;
 
-        webSockets.append(webSocket);
+        webSockets.append(*webSocket);
     }
 
     return webSockets;

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
@@ -43,7 +43,7 @@ public:
 private:
     Inspector::Protocol::Network::LoaderId loaderIdentifier(DocumentLoader*);
     Inspector::Protocol::Network::FrameId frameIdentifier(DocumentLoader*);
-    Vector<WebSocket*> activeWebSockets() WTF_REQUIRES_LOCK(WebSocket::allActiveWebSocketsLock());
+    Vector<Ref<WebSocket>> activeWebSockets() WTF_REQUIRES_LOCK(WebSocket::allActiveWebSocketsLock());
     void setResourceCachingDisabledInternal(bool);
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     bool setEmulatedConditionsInternal(std::optional<int>&& bytesPerSecondLimit);

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
@@ -57,7 +57,7 @@ Inspector::Protocol::Network::FrameId WorkerNetworkAgent::frameIdentifier(Docume
     return { };
 }
 
-Vector<WebSocket*> WorkerNetworkAgent::activeWebSockets()
+Vector<Ref<WebSocket>> WorkerNetworkAgent::activeWebSockets()
 {
     // FIXME: <https://webkit.org/b/168475> Web Inspector: Correctly display worker's WebSockets
     return { };

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h
@@ -40,7 +40,7 @@ public:
 private:
     Inspector::Protocol::Network::LoaderId loaderIdentifier(DocumentLoader*);
     Inspector::Protocol::Network::FrameId frameIdentifier(DocumentLoader*);
-    Vector<WebSocket*> activeWebSockets() WTF_REQUIRES_LOCK(WebSocket::allActiveWebSocketsLock());
+    Vector<Ref<WebSocket>> activeWebSockets() WTF_REQUIRES_LOCK(WebSocket::allActiveWebSocketsLock());
     void setResourceCachingDisabledInternal(bool);
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     bool setEmulatedConditionsInternal(std::optional<int>&& bytesPerSecondLimit);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -169,15 +169,15 @@ static void setAllDefersLoading(const ResourceLoaderMap& loaders, bool defers)
         loader->setDefersLoading(defers);
 }
 
-static HashMap<ScriptExecutionContextIdentifier, DocumentLoader*>& scriptExecutionContextIdentifierToLoaderMap()
+static HashMap<ScriptExecutionContextIdentifier, SingleThreadWeakPtr<DocumentLoader>>& scriptExecutionContextIdentifierToLoaderMap()
 {
-    static NeverDestroyed<HashMap<ScriptExecutionContextIdentifier, DocumentLoader*>> map;
+    static MainThreadNeverDestroyed<HashMap<ScriptExecutionContextIdentifier, SingleThreadWeakPtr<DocumentLoader>>> map;
     return map.get();
 }
 
 DocumentLoader* DocumentLoader::fromScriptExecutionContextIdentifier(ScriptExecutionContextIdentifier identifier)
 {
-    return scriptExecutionContextIdentifierToLoaderMap().get(identifier);
+    return scriptExecutionContextIdentifierToLoaderMap().get(identifier).get();
 }
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
@@ -2259,7 +2259,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
 
         m_resultingClientId = ScriptExecutionContextIdentifier::generate();
         ASSERT(!scriptExecutionContextIdentifierToLoaderMap().contains(*m_resultingClientId));
-        scriptExecutionContextIdentifierToLoaderMap().add(*m_resultingClientId, this);
+        scriptExecutionContextIdentifierToLoaderMap().add(*m_resultingClientId, *this);
         mainResourceLoadOptions.resultingClientIdentifier = m_resultingClientId->object();
     }
 

--- a/Source/WebCore/loader/archive/Archive.cpp
+++ b/Source/WebCore/loader/archive/Archive.cpp
@@ -38,12 +38,12 @@ Archive::~Archive() = default;
 
 void Archive::clearAllSubframeArchives()
 {
-    HashSet<Archive*> clearedArchives;
+    HashSet<RefPtr<Archive>> clearedArchives;
     clearedArchives.add(this);
     clearAllSubframeArchives(clearedArchives);
 }
 
-void Archive::clearAllSubframeArchives(HashSet<Archive*>& clearedArchives)
+void Archive::clearAllSubframeArchives(HashSet<RefPtr<Archive>>& clearedArchives)
 {
     ASSERT(clearedArchives.contains(this));
     for (auto& archive : m_subframeArchives) {

--- a/Source/WebCore/loader/archive/Archive.h
+++ b/Source/WebCore/loader/archive/Archive.h
@@ -59,7 +59,7 @@ protected:
     void clearAllSubframeArchives();
 
 private:
-    void clearAllSubframeArchives(HashSet<Archive*>&);
+    void clearAllSubframeArchives(HashSet<RefPtr<Archive>>&);
 
     RefPtr<ArchiveResource> m_mainResource;
     Vector<Ref<ArchiveResource>> m_subresources;

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
+#include "ScriptExecutionContext.h"
 #include "ServiceWorkerData.h"
 #include <JavaScriptCore/Strong.h>
 #include <wtf/RefCounted.h>
@@ -90,5 +91,10 @@ private:
     bool m_isStopped { false };
     RefPtr<PendingActivity<ServiceWorker>> m_pendingActivityForEventDispatch;
 };
+
+inline ServiceWorker* ScriptExecutionContext::serviceWorker(ServiceWorkerIdentifier identifier)
+{
+    return m_serviceWorkers.get(identifier);
+}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 80254cf0d73f6dc98199ff70bc0769f4e801add4
<pre>
Reduce use of raw pointers in containers in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=302690">https://bugs.webkit.org/show_bug.cgi?id=302690</a>

Reviewed by Darin Adler and Geoffrey Garen.

* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::allActiveWebSockets):
(): Deleted.
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::ScriptExecutionContext::regenerateIdentifier):
(WebCore::ScriptExecutionContext::addToContextsMap):
(WebCore::ScriptExecutionContext::checkConsistency const):
(WebCore::ScriptExecutionContext::dispatchMessagePortEvents):
(WebCore::ScriptExecutionContext::createdMessagePort):
(WebCore::ScriptExecutionContext::destroyedMessagePort):
(WebCore::ScriptExecutionContext::registerServiceWorker):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContextInlines.h:
(WebCore::ScriptExecutionContext::serviceWorker): Deleted.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::enable):
(WebCore::InspectorNetworkAgent::webSocketForRequestId):
(WebCore::webSocketAsScriptValue):
(WebCore::InspectorNetworkAgent::resolveWebSocket):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
(WebCore::PageNetworkAgent::activeWebSockets):
(): Deleted.
* Source/WebCore/inspector/agents/page/PageNetworkAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp:
(WebCore::WorkerNetworkAgent::activeWebSockets):
(): Deleted.
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::scriptExecutionContextIdentifierToLoaderMap):
(WebCore::DocumentLoader::fromScriptExecutionContextIdentifier):
(WebCore::DocumentLoader::loadMainResource):
(): Deleted.
* Source/WebCore/loader/archive/Archive.cpp:
(WebCore::Archive::clearAllSubframeArchives):
* Source/WebCore/loader/archive/Archive.h:
* Source/WebCore/page/PageGroup.cpp:
(WebCore::pageGroups):
(WebCore::PageGroup::pageGroup):
* Source/WebCore/workers/service/ServiceWorker.h:
(WebCore::ScriptExecutionContext::serviceWorker):

Canonical link: <a href="https://commits.webkit.org/303210@main">https://commits.webkit.org/303210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/898c27449411b4e0ebe3f9a9066263d94eb02736

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83345 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e452f1be-ebec-4a50-9549-bd086a5d4234) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/afe685a5-72e6-4c02-abe9-e1151f3e2c42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81246 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/32f1c0f6-fbad-408f-bf34-2554ba2d3e07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/473 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82260 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141714 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3636 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108804 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3684 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3237 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109049 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2754 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114086 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56830 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3697 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32490 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3779 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->