### PR TITLE
wip

### DIFF
--- a/JSTests/wasm/debugger/lib/core/base.py
+++ b/JSTests/wasm/debugger/lib/core/base.py
@@ -254,6 +254,9 @@ class BaseTestCase:
 
         cmd = [jsc_path, f"--wasm-debugger={self.current_port}"]
 
+        if self._verbose_wasm_debugger:
+            cmd.append("--verboseWasmDebugger=1")
+
         cmd.append(test_file)
 
         self.logger.verbose(f"Starting debugger on port {self.current_port}")
@@ -272,6 +275,9 @@ class BaseTestCase:
                 # Update the command to use just the filename
                 test_filename = os.path.basename(test_file)
                 cmd = [jsc_path, f"--wasm-debugger={self.current_port}"]
+
+                if self._verbose_wasm_debugger:
+                    cmd.append("--verboseWasmDebugger=1")
 
                 cmd.append(test_filename)
             else:
@@ -488,7 +494,7 @@ class BaseTestCase:
             return result
 
     def send_lldb_command_or_raise(
-        self, command: str, patterns=None, mode=PatternMatchMode.ALL, timeout=5.0
+        self, command: str, patterns=None, mode=PatternMatchMode.ALL, timeout=20.0
     ):
         """Send LLDB command with patterns and raise exception on failure"""
         result = self.send_lldb_command_with_patterns(command, patterns, mode, timeout)
@@ -650,7 +656,7 @@ class BaseTestCase:
 
                     if UtilsLogger._verbose:
                         print(
-                            f"{Colors.DIM}🔍 [{process_name}][{stream_name.upper()}] {line}{Colors.RESET}"
+                            f"{Colors.DIM}🔍 [{self.name}][{process_name}][{stream_name.upper()}] {line}{Colors.RESET}"
                         )
 
             except Exception as e:

--- a/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-different-funcs.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-different-funcs.js
@@ -1,0 +1,111 @@
+// Multi-VM WebAssembly Debugger Test - Different Functions
+// This test creates multiple VMs running different functions from the SAME WebAssembly module
+// to verify that the debugger properly handles different VMs executing different functions
+
+// WASM module with 3 different functions
+// Compiled from multi-funcs.wat using wat2wasm
+const wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [])
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 3 functions (all type 0)
+    0x03, 0x04, 0x03, 0x00, 0x00, 0x00,
+
+    // [0x14] Export section: export 3 functions
+    0x07, 0x19, 0x03,
+    // Export function 0 as "func1"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x31, 0x00, 0x00,
+    // Export function 1 as "func2"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x32, 0x00, 0x01,
+    // Export function 2 as "func3"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x33, 0x00, 0x02,
+
+    // [0x30] Code section
+    0x0a,                   // section id=10
+    0x22,                   // section size=34
+    0x03,                   // 3 functions
+
+    // Function 0: func1 (body size=10)
+    0x0a,                   // body size
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x35] nop
+    0x41, 0x0a,             // [0x36] i32.const 10
+    0x1a,                   // [0x38] drop
+    0x01,                   // [0x39] nop
+    0x41, 0x14,             // [0x3a] i32.const 20
+    0x1a,                   // [0x3c] drop
+    0x0b,                   // [0x3d] end
+
+    // Function 1: func2 (body size=10)
+    0x0a,                   // body size
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x40] nop
+    0x41, 0x1e,             // [0x41] i32.const 30
+    0x1a,                   // [0x43] drop
+    0x01,                   // [0x44] nop
+    0x41, 0x28,             // [0x45] i32.const 40
+    0x1a,                   // [0x47] drop
+    0x0b,                   // [0x48] end
+
+    // Function 2: func3 (body size=10)
+    0x0a,                   // body size
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x4b] nop
+    0x41, 0x32,             // [0x4c] i32.const 50
+    0x1a,                   // [0x4e] drop
+    0x01,                   // [0x4f] nop
+    0x41, 0x3c,             // [0x50] i32.const 60
+    0x1a,                   // [0x52] drop
+    0x0b                    // [0x53] end
+]);
+
+const NUM_WORKERS = 2;
+const PRINT_INTERVAL = 1e7;
+
+print("=== Multi-VM Different Functions Test ===");
+print(`Creating ${NUM_WORKERS} workers + main thread (${NUM_WORKERS + 1} VMs total)`);
+print("Each VM runs a DIFFERENT function from the same WASM module");
+print("");
+
+// Worker script: each worker runs a specific function
+const workerScript = (workerId, funcName) => `
+    const wasmBytes = new Uint8Array([${Array.from(wasm).join(',')}]);
+    const wasmModule = new WebAssembly.Module(wasmBytes);
+    const wasmInstance = new WebAssembly.Instance(wasmModule, {});
+
+    // Run a specific wasm function in an infinite loop
+    const func = wasmInstance.exports.${funcName};
+    let iteration = 0;
+    for (; ;) {
+        func();
+        iteration += 1;
+        if (iteration % ${PRINT_INTERVAL} == 0)
+            print("Worker ${workerId} (${funcName}) iteration=", iteration);
+    }
+`;
+
+// Start workers, each running a different function
+const functions = ['func2', 'func3'];
+for (let i = 0; i < NUM_WORKERS; i++) {
+    $.agent.start(workerScript(i + 1, functions[i]));
+    print(`Started worker ${i + 1}/${NUM_WORKERS} running ${functions[i]}`);
+}
+
+// Main thread runs func1
+print("Main thread starting func1 execution...");
+print("");
+const mainModule = new WebAssembly.Module(wasm);
+const mainInstance = new WebAssembly.Instance(mainModule, {});
+const func1 = mainInstance.exports.func1;
+
+let iteration = 0;
+for (; ;) {
+    func1();
+    iteration += 1;
+    if (iteration % PRINT_INTERVAL == 0)
+        print("Main (func1) iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-same-func.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-same-func.js
@@ -1,0 +1,77 @@
+// Multi-VM WebAssembly Debugger Test
+// This test creates multiple VMs (main thread + 2 workers) running WebAssembly code concurrently
+// to verify that the debugger properly handles cross-VM/instance scenarios
+
+// Simple WASM module: (func [] -> [])
+const wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [])
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x12] Export section: export function 0 as "compute"
+    0x07, 0x0b, 0x01, 0x07, 0x63, 0x6f, 0x6d, 0x70, 0x75, 0x74, 0x65, 0x00, 0x00,
+
+    // [0x1f] Code section
+    0x0a,                   // section id=10
+    0x09,                   // section size=9
+    0x01,                   // 1 function
+    0x07,                   // function body size=7
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x24] nop
+    0x41, 0x2a,             // [0x25] i32.const 42
+    0x1a,                   // [0x27] drop
+    0x01,                   // [0x28] nop
+    0x0b                    // [0x29] end function
+]);
+
+const NUM_WORKERS = 2;
+const PRINT_INTERVAL = 1e7;
+
+print("=== Multi-VM WebAssembly Debugger Test ===");
+print(`Creating ${NUM_WORKERS} workers + main thread (${NUM_WORKERS + 1} VMs total)`);
+print("Each VM will run in an infinite loop - attach debugger to test");
+print("");
+
+// Worker script: each worker instantiates the wasm module and calls it in an infinite loop
+const workerScript = (workerId) => `
+    const wasmBytes = new Uint8Array([${Array.from(wasm).join(',')}]);
+    const wasmModule = new WebAssembly.Module(wasmBytes);
+    const wasmInstance = new WebAssembly.Instance(wasmModule, {});
+
+    // Run the wasm function in an infinite loop
+    const compute = wasmInstance.exports.compute;
+    let iteration = 0;
+    for (; ;) {
+        compute();
+        iteration += 1;
+        if (iteration % ${PRINT_INTERVAL} == 0)
+            print("Worker ${workerId} iteration=", iteration);
+    }
+`;
+
+// Start workers
+for (let i = 0; i < NUM_WORKERS; i++) {
+    $.agent.start(workerScript(i + 1));
+    print(`Started worker ${i + 1}/${NUM_WORKERS}`);
+}
+
+// Main thread also runs WebAssembly in an infinite loop
+print("Main thread starting WebAssembly execution...");
+print("");
+const mainModule = new WebAssembly.Module(wasm);
+const mainInstance = new WebAssembly.Instance(mainModule, {});
+const mainCompute = mainInstance.exports.compute;
+
+let iteration = 0;
+for (; ;) {
+    mainCompute();
+    iteration += 1;
+    if (iteration % PRINT_INTERVAL == 0)
+        print("Main iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/system-call.js
+++ b/JSTests/wasm/debugger/resources/wasm/system-call.js
@@ -1,0 +1,6 @@
+let iteration = 0;
+for (; ;) {
+    iteration += 1;
+    if (iteration % 1e8 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/test-wasm-debugger.py
+++ b/JSTests/wasm/debugger/test-wasm-debugger.py
@@ -48,13 +48,13 @@ def calculate_smart_workers(test_count, requested_workers=None):
 
 
 def create_test_runner(
-    verbose=False, build_config=None, parallel=False, workers=None, test_names=None
+    verbose=False, build_config=None, parallel=False, workers=None, test_names=None, verbose_wasm_debugger=False
 ):
     """Create test runner with auto-discovered test cases and smart worker calculation"""
     if parallel:
         # First create a temporary runner to get test count
         temp_runner = create_auto_registered_runner(
-            build_config=build_config, verbose_wasm_debugger=False
+            build_config=build_config, verbose_wasm_debugger=verbose_wasm_debugger
         )
 
         # Calculate test count
@@ -79,7 +79,7 @@ def create_test_runner(
 
         runner = ParallelWebAssemblyDebuggerTestRunner(
             build_config=build_config,
-            verbose_wasm_debugger=False,
+            verbose_wasm_debugger=verbose_wasm_debugger,
             max_workers=smart_workers,
             verbose_parallel=verbose,
         )
@@ -87,7 +87,7 @@ def create_test_runner(
         discovery.auto_register_tests(runner.registry)
     else:
         runner = create_auto_registered_runner(
-            build_config=build_config, verbose_wasm_debugger=False
+            build_config=build_config, verbose_wasm_debugger=verbose_wasm_debugger
         )
     return runner
 
@@ -97,6 +97,9 @@ def main():
     parser = argparse.ArgumentParser(description="WebAssembly Debugger Test Framework")
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose logging"
+    )
+    parser.add_argument(
+        "--verbose-wasm-debugger", action="store_true", help="Enable verbose WebAssembly debugger logging (--verboseWasmDebugger=1)"
     )
     parser.add_argument(
         "--pid-tid", action="store_true", help="Enable PID/TID prefixes"
@@ -128,6 +131,9 @@ def main():
     # Use -1 as sentinel for auto-detect, otherwise use specified value
     workers = None if args.parallel == -1 else args.parallel
 
+    if args.verbose_wasm_debugger:
+        args.verbose = True
+
     if args.verbose:
         Logger.set_verbose(True)
 
@@ -135,7 +141,7 @@ def main():
         Logger.set_pid_tid_logging(True)
 
     runner = create_test_runner(
-        args.verbose, build_config, parallel, workers, args.test
+        args.verbose, build_config, parallel, workers, args.test, args.verbose_wasm_debugger
     )
 
     if args.list:

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -357,7 +357,7 @@ class SwiftWasmTestCase(BaseTestCase):
     def stepTest(self):
         self.send_lldb_command_or_raise("b processNumber")
 
-        # TODO: Step over - Current Swift LLDB is problematic with step over
+        # FIXME: Step over - Current Swift LLDB is problematic with step over
 
         # Step Into
         self.send_lldb_command_or_raise(
@@ -1427,3 +1427,75 @@ class TryTableTestCase(BaseTestCase):
         self.send_lldb_command_or_raise(
             "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
         )
+
+
+class SystemCallTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/system-call.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Try table test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("si", patterns=[])
+        self.send_lldb_command_or_raise("process interrupt")
+
+        self.send_lldb_command_or_raise("s", patterns=[])
+        self.send_lldb_command_or_raise("process interrupt")
+
+        self.send_lldb_command_or_raise("n", patterns=[])
+        self.send_lldb_command_or_raise("process interrupt")
+
+        # FIXME: `dis` hangs LLDB when stop in the system call.
+
+
+class MultiVMSameModuleSameFunctionTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise(
+            "resources/wasm/multi-vm-same-module-same-func.js"
+        )
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Try table test failed: {e}")
+
+    def stepTest(self):
+        # FIXME: Add tests when thread select is full supported
+        return
+
+
+class MultiVMSameModuleDifferentFunctionsTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise(
+            "resources/wasm/multi-vm-same-module-different-funcs.js"
+        )
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Try table test failed: {e}")
+
+    def stepTest(self):
+        # FIXME: Add tests when thread select is full supported
+        return

--- a/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
+++ b/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
@@ -800,9 +800,9 @@ static int test()
     dataLogLn("");
     dataLogLn("Starting VMManager StopTheWorld Test");
 
-    auto* originalWasmDebugger = g_jscConfig.wasmDebuggerStopTheWorld;
+    auto* originalWasmDebugger = g_jscConfig.wasmDebuggerOnStop;
     auto* originalMemoryDebugger = g_jscConfig.memoryDebuggerStopTheWorld;
-    VMManager::setWasmDebuggerCallback(wasmDebuggerTestCallback);
+    VMManager::setWasmDebuggerOnStop(wasmDebuggerTestCallback);
     VMManager::setMemoryDebuggerCallback(memoryDebuggerTestCallback);
 
     // FIXME: for now, VMTraps doesn't completely work on JIT runs yet. Once we fix that, we'll need
@@ -813,7 +813,7 @@ static int test()
 
     auto resetSettings = makeScopeExit([&] {
         Options::setOptions(savedOptionsBuilder.toString().ascii().data());
-        VMManager::setWasmDebuggerCallback(originalWasmDebugger);
+        VMManager::setWasmDebuggerOnStop(originalWasmDebugger);
         VMManager::setMemoryDebuggerCallback(originalMemoryDebugger);
     });
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2281,8 +2281,11 @@
 		FFD49E742E276CA10083E383 /* WasmMemoryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5E2E276CA10083E383 /* WasmMemoryHandler.h */; };
 		FFE21FE52CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */; };
 		FFE31BDB2E6212CD006FE0B7 /* WasmVirtualAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = FFE31BDA2E6212CD006FE0B7 /* WasmVirtualAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */; };
 		FFF3373F2BCDF1240070D04B /* JSCBytecodeCacheVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFF4D5A32CE304CD006EA634 /* DeferredWorkTimerInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFFAF8CB2EC97B2B00042238 /* TestScripts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */; };
+		FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -6347,9 +6350,15 @@
 		FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGLoopUnrollingPhase.h; path = dfg/DFGLoopUnrollingPhase.h; sourceTree = "<group>"; };
 		FFE21FE42CC1BE1800DEC268 /* DFGLoopUnrollingPhase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGLoopUnrollingPhase.cpp; path = dfg/DFGLoopUnrollingPhase.cpp; sourceTree = "<group>"; };
 		FFE31BDA2E6212CD006FE0B7 /* WasmVirtualAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmVirtualAddress.h; sourceTree = "<group>"; };
+		FFE88B9C2EC96CA700C9F5E2 /* ExecutionHandlerTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerTest.h; sourceTree = "<group>"; };
+		FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionHandlerTest.cpp; sourceTree = "<group>"; };
 		FFF3373D2BCDF1240070D04B /* JSCBytecodeCacheVersion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSCBytecodeCacheVersion.cpp; sourceTree = "<group>"; };
 		FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSCBytecodeCacheVersion.h; sourceTree = "<group>"; };
 		FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeferredWorkTimerInlines.h; sourceTree = "<group>"; };
+		FFFAF8C92EC97B2B00042238 /* TestScripts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestScripts.h; sourceTree = "<group>"; };
+		FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestScripts.cpp; sourceTree = "<group>"; };
+		FFFAF8CC2EC9A7C000042238 /* ExecutionHandlerTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerTestSupport.h; sourceTree = "<group>"; };
+		FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionHandlerTestSupport.cpp; sourceTree = "<group>"; };
 		FFFAFBE02E6ABDCB006BFA2E /* WasmVirtualAddress.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmVirtualAddress.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -10534,9 +10543,15 @@
 			children = (
 				FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */,
 				FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */,
+				FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */,
+				FFE88B9C2EC96CA700C9F5E2 /* ExecutionHandlerTest.h */,
+				FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */,
+				FFFAF8CC2EC9A7C000042238 /* ExecutionHandlerTestSupport.h */,
 				FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */,
 				FFA2E0232EA16F37006661A3 /* MemoryTests.cpp */,
 				FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */,
+				FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */,
+				FFFAF8C92EC97B2B00042238 /* TestScripts.h */,
 				FF18EBC42EA5C73E00185CFA /* TestUtilities.cpp */,
 				FFA2E0252EA16F37006661A3 /* TestUtilities.h */,
 				FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */,
@@ -13782,9 +13797,12 @@
 			files = (
 				FFA2E02D2EA16F37006661A3 /* BinaryTests.cpp in Sources */,
 				FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */,
+				FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */,
+				FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */,
 				FF1344662EB3F2A600940C00 /* ExtGCTests.cpp in Sources */,
 				FFA2E02E2EA16F37006661A3 /* MemoryTests.cpp in Sources */,
 				FFA2E02C2EA16F37006661A3 /* SpecialTests.cpp in Sources */,
+				FFFAF8CB2EC97B2B00042238 /* TestScripts.cpp in Sources */,
 				FF18EBC52EA5C73E00185CFA /* TestUtilities.cpp in Sources */,
 				FF0F569A2E3348CA002A232A /* testwasmdebugger.cpp in Sources */,
 				FFA2E02F2EA16F37006661A3 /* UnaryTests.cpp in Sources */,

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4403,7 +4403,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
 
 #if ENABLE(WEBASSEMBLY)
             if (Options::enableWasmDebugger()) [[unlikely]]
-                Wasm::DebugServer::singleton().start(&vm);
+                Wasm::DebugServer::singleton().start();
 #endif
 
             func(vm, globalObject, success);

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -40,8 +40,10 @@
 #include "Options.h"
 #include "StructureAlignedMemoryAllocator.h"
 #include "SuperSampler.h"
+#include "VMManager.h"
 #include "VMTraps.h"
 #include "WasmCapabilities.h"
+#include "WasmExecutionHandler.h"
 #include "WasmFaultSignalHandler.h"
 #include "WasmThunks.h"
 #include <mutex>
@@ -142,8 +144,13 @@ void initializeWithOptionsCustomization(const ScopedLambda<void()>& optionsCusto
         if (Wasm::isSupported() || !Options::usePollingTraps()) {
             if (!Options::usePollingTraps())
                 VMTraps::initializeSignals();
-            if (Wasm::isSupported())
+            if (Wasm::isSupported()) {
                 Wasm::prepareSignalingMemory();
+#if ENABLE(WEBASSEMBLY)
+                VMManager::setWasmDebuggerOnStop(Wasm::wasmDebuggerOnStopCallback);
+                VMManager::setWasmDebuggerOnResume(Wasm::wasmDebuggerOnResumeCallback);
+#endif
+            }
         }
 
         assertInvariants();

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -106,7 +106,9 @@ struct Config {
     using ShellTimeoutCheckCallback = void (*)(VM&);
     ShellTimeoutCheckCallback JSC_CONFIG_METHOD(shellTimeoutCheckCallback);
 
-    StopTheWorldCallback JSC_CONFIG_METHOD(wasmDebuggerStopTheWorld);
+    StopTheWorldCallback JSC_CONFIG_METHOD(wasmDebuggerOnStop);
+    using PostResumeCallback = void (*)();
+    PostResumeCallback JSC_CONFIG_METHOD(wasmDebuggerOnResume);
     StopTheWorldCallback JSC_CONFIG_METHOD(memoryDebuggerStopTheWorld);
 
     struct {

--- a/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
+++ b/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
@@ -47,6 +47,8 @@ enum class StopTheWorldEvent : uint8_t {
     VMCreated,
     VMActivated,
     VMStopped,
+    BreakpointHit,
+    StepIntoSiteReached,
 };
 
 // The VMManager Stop the World (STW) mechanism will call handlers of this shape once the world
@@ -73,5 +75,6 @@ enum class StopTheWorldEvent : uint8_t {
 // RunAll or RunOne mode).
 
 using StopTheWorldCallback = StopTheWorldStatus (*)(VM&, StopTheWorldEvent);
+using PostResumeCallback = void (*)();
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -132,6 +132,7 @@
 #include "VMManager.h"
 #include "VariableEnvironment.h"
 #include "WaiterListManager.h"
+#include "WasmDebugServerUtilities.h"
 #include "WasmWorklist.h"
 #include "Watchdog.h"
 #include "WeakGCMapInlines.h"
@@ -1884,5 +1885,16 @@ void VM::DrainMicrotaskDelayScope::decrement()
         m_vm->drainMicrotasks();
     }
 }
+
+#if ENABLE(WEBASSEMBLY)
+
+Wasm::DebugState* VM::debugState()
+{
+    if (!m_debugState)
+        m_debugState = makeUnique<Wasm::DebugState>();
+    return m_debugState.get();
+}
+
+#endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -178,6 +178,14 @@ namespace DOMJIT {
 class Signature;
 }
 
+#if ENABLE(WEBASSEMBLY)
+class JSWebAssemblyInstance;
+namespace Wasm {
+class IPIntCallee;
+struct DebugState;
+}
+#endif
+
 struct EntryFrame;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VM);
@@ -1108,14 +1116,8 @@ public:
     void notifyDebuggerHookInjected() { m_isDebuggerHookInjected = true; }
     bool isDebuggerHookInjected() const { return m_isDebuggerHookInjected; }
 
-    bool isWasmStopWorldActive() { return m_isWasmStopWorldActive; }
-    void setIsWasmStopWorldActive(bool isWasmStopWorldActive) { m_isWasmStopWorldActive = isWasmStopWorldActive; }
-
 #if ENABLE(WEBASSEMBLY)
-    bool takeStepIntoWasmCall() { return m_stepIntoEvent.take(Wasm::StepIntoEvent::StepIntoCall); }
-    void setStepIntoWasmCall() { m_stepIntoEvent.set(Wasm::StepIntoEvent::StepIntoCall); }
-    bool takeStepIntoWasmThrow() { return m_stepIntoEvent.take(Wasm::StepIntoEvent::StepIntoThrow); }
-    void setStepIntoWasmThrow() { m_stepIntoEvent.set(Wasm::StepIntoEvent::StepIntoThrow); }
+    JS_EXPORT_PRIVATE Wasm::DebugState* debugState();
 #endif
 
 private:
@@ -1240,10 +1242,9 @@ private:
     bool m_executionForbidden { false };
     bool m_executionForbiddenOnTermination { false };
     bool m_isDebuggerHookInjected { false };
-    bool m_isWasmStopWorldActive { false };
 
 #if ENABLE(WEBASSEMBLY)
-    Wasm::StepIntoEvent m_stepIntoEvent;
+    std::unique_ptr<Wasm::DebugState> m_debugState;
 #endif
 
     Lock m_loopHintExecutionCountLock;

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -88,9 +88,12 @@ if (DEVELOPER_MODE)
 
         ../wasm/debugger/tests/BinaryTests.cpp
         ../wasm/debugger/tests/ControlFlowTests.cpp
+        ../wasm/debugger/tests/ExecutionHandlerTest.cpp
+        ../wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
         ../wasm/debugger/tests/ExtGCTests.cpp
         ../wasm/debugger/tests/MemoryTests.cpp
         ../wasm/debugger/tests/SpecialTests.cpp
+        ../wasm/debugger/tests/TestScripts.cpp
         ../wasm/debugger/tests/TestUtilities.cpp
         ../wasm/debugger/tests/UnaryTests.cpp
     )

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -44,6 +44,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmCallee.h"
 #include "WasmCallingConvention.h"
 #include "WasmDebugServer.h"
+#include "WasmExecutionHandler.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmModuleInformation.h"
 #include "WasmOSREntryPlan.h"
@@ -70,16 +71,22 @@ namespace JSC { namespace IPInt {
 
 // Sets a breakpoint at the callee entry when stepping into a call.
 // Should Call this before WASM_CALL_RETURN in prepare_call* functions.
-#define IPINT_HANDLE_STEP_INTO_CALL(vmValue, boxedCalleeValue, targetInstanceValue) do { \
-        if (Options::enableWasmDebugger()) [[unlikely]] \
-            Wasm::DebugServer::singleton().setStepIntoBreakpointForCall((vmValue), (boxedCalleeValue), (targetInstanceValue)); \
+#define IPINT_HANDLE_STEP_INTO_CALL(callerVM, boxedCallee, calleeInstance) do { \
+        if (Options::enableWasmDebugger()) [[unlikely]] { \
+            Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton(); \
+            if (debugServer.isConnected()) \
+                debugServer.execution().setStepIntoBreakpointForCall((callerVM), (boxedCallee), (calleeInstance)); \
+        } \
     } while (false)
 
 // Sets a breakpoint at the exception handler when stepping into a throw.
 // Should Call this after genericUnwind() in throw/rethrow/throw_ref functions.
-#define IPINT_HANDLE_STEP_INTO_THROW(vm, instance) do { \
-        if (Options::enableWasmDebugger()) [[unlikely]] \
-            Wasm::DebugServer::singleton().setStepIntoBreakpointForThrow((vm), (instance)); \
+#define IPINT_HANDLE_STEP_INTO_THROW(throwVM) do { \
+        if (Options::enableWasmDebugger()) [[unlikely]] { \
+            Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton(); \
+            if (debugServer.isConnected()) \
+                debugServer.execution().setStepIntoBreakpointForThrow((throwVM)); \
+        } \
     } while (false)
 
 
@@ -453,7 +460,7 @@ WASM_IPINT_EXTERN_CPP_DECL(throw_exception, CallFrame* callFrame, IPIntStackEntr
     ASSERT(!!vm.callFrameForCatch);
     ASSERT(!!vm.targetMachinePCForThrow);
 
-    IPINT_HANDLE_STEP_INTO_THROW(vm, instance);
+    IPINT_HANDLE_STEP_INTO_THROW(vm);
     WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
 }
 
@@ -479,7 +486,7 @@ WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, IPIntStackEn
     ASSERT(!!vm.callFrameForCatch);
     ASSERT(!!vm.targetMachinePCForThrow);
 
-    IPINT_HANDLE_STEP_INTO_THROW(vm, instance);
+    IPINT_HANDLE_STEP_INTO_THROW(vm);
     WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
 }
 
@@ -499,7 +506,7 @@ WASM_IPINT_EXTERN_CPP_DECL(throw_ref, CallFrame* callFrame, EncodedJSValue exnre
     ASSERT(!!vm.callFrameForCatch);
     ASSERT(!!vm.targetMachinePCForThrow);
 
-    IPINT_HANDLE_STEP_INTO_THROW(vm, instance);
+    IPINT_HANDLE_STEP_INTO_THROW(vm);
     WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
 }
 
@@ -1183,20 +1190,20 @@ extern "C" UGPRPair SYSV_ABI slow_path_wasm_popcountll(const void* pc, uint64_t 
 WASM_IPINT_EXTERN_CPP_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee* callee)
 {
     VM& vm = instance->vm();
-    if (vm.traps().handleTrapsIfNeeded()) {
+
+    if (Options::enableWasmDebugger()) [[unlikely]]
+        vm.debugState()->setPrologueStopData(instance, callee);
+    bool handledTraps = vm.traps().handleTrapsIfNeeded();
+
+    if (handledTraps) {
         if (vm.hasPendingTerminationException())
             IPINT_THROW(Wasm::ExceptionType::Termination);
         ASSERT(!vm.exceptionForInspection());
     }
 
     // Redo stack check because we may really have gotten here due to an imminent StackOverflow.
-    if (vm.softStackLimit() <= candidateNewStackPointer) {
-        if (Options::enableWasmDebugger()) [[unlikely]] {
-            if (vm.isWasmStopWorldActive())
-                Wasm::DebugServer::singleton().setInterruptBreakpoint(instance, callee);
-        }
+    if (vm.softStackLimit() <= candidateNewStackPointer)
         IPINT_RETURN(encodedJSValue()); // No stack overflow. Carry on.
-    }
 
     IPINT_THROW(Wasm::ExceptionType::StackOverflow);
 }
@@ -1244,7 +1251,7 @@ WASM_IPINT_EXTERN_CPP_DECL(unreachable_breakpoint_handler, CallFrame* callFrame,
             IPIntStackEntry* stackPointer = reinterpret_cast<IPIntStackEntry*>(sp + 4);
             if (Options::verboseWasmDebugger())
                 displayWasmDebugState(instance, callee, stackPointer, pl);
-            breakpointHandled = debugServer.stopCode(callFrame, instance, callee, pc, mc, pl, stackPointer);
+            breakpointHandled = debugServer.execution().hitBreakpoint(callFrame, instance, callee, pc, mc, pl, stackPointer);
         }
     }
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][unreachable] Done with breakpointHandled=", breakpointHandled);

--- a/Source/JavaScriptCore/wasm/debugger/Debugger-Mutator-Protocol.md
+++ b/Source/JavaScriptCore/wasm/debugger/Debugger-Mutator-Protocol.md
@@ -1,0 +1,239 @@
+# Debugger-Mutator Communication Protocol
+
+**ExecutionHandler Thread Synchronization in WebAssembly Debugging**
+
+This document describes the thread communication protocol used in `WasmExecutionHandler.cpp` to coordinate between the debugger thread (LLDB commands) and mutator threads (WebAssembly execution), along with VMManager coordination for stop-the-world operations.
+
+---
+
+## Thread Actors
+
+### 1. **Debugger Thread**
+
+- Runs on the debug server's WorkQueue thread
+- Processes LLDB commands: continue, step, interrupt, thread selection
+- Initiates debugging operations
+- Thread ID: `m_debugServerThreadId`
+
+### 2. **Mutator Thread(s)**
+
+- Runs WebAssembly bytecode execution
+- One per VM (main thread + worker threads)
+- Responds to debugging commands
+- Thread ID: `VM::ownerThread()->uid()`
+
+### 3. **VMManager** (Coordinator)
+
+- Singleton managing all VMs in the process
+- Implements stop-the-world coordination
+- Calls `wasmDebuggerOnStop()` and `wasmDebuggerOnResume()` callbacks
+- Ensures all VMs stopped before debugger accesses state
+
+---
+
+## Synchronization Primitives
+
+### Key State Variables
+
+```cpp
+m_mutatorContinue             // Debugger signals mutator to continue
+m_debuggerContinue            // Mutator signals debugger to continue
+
+m_debuggerState               // Current debugger operation state
+m_vm                          // Target VM being debugged
+m_awaitingResumeNotification  // Resume barrier flag
+```
+
+### Debugger States
+
+```cpp
+enum class DebuggerState {
+    Replied,              // Idle, ready for next command
+    InterruptRequested,   // Async interrupt in progress
+    ContinueRequested,    // Resume all VMs
+    StepRequested,        // Single-step with breakpoints
+    SwitchRequested       // VM context switch
+};
+```
+
+---
+
+## Protocol Flow Diagrams
+
+### 1. **Continue Operation** (Resume All VMs)
+
+```
+Debugger Thread                         Mutator Thread (Target)                                    Other Thread(s)
+==================       ==========================================================================================================================
+                                      ExecutionHandler::stopCode()                            VMManager::notifyVMStop()
+                                   ┌──>├─ wait(mutatorCV)                            ┌────────>├─ wait(worldCV)
+resumeImpl()                       │   │                                             │         └─ Other VMs exiting notifyVMStop()                    
+  ├─ Set state = ContinueRequested │   │                                             │ 
+  ├─ notifyOne(mutator) ───────────┘   │                                             │ 
+  ├─ wait(debuggerCV) <──┐             │                                             │ 
+  │                      │             │                                             │ 
+  │                      │             ├─ Check state -> ContinueRequested           │                
+  │                      │             ├─ Set m_awaitingResumeNotification = true    │ 
+  │                      │             └─ Return ResumeMode::All                     │ 
+  │                      │                └─ VMManager::resumeAll() ─────────────────┘ 
+  │                      │                    └─ Target VM exiting notifyVMStop()            
+  │                      │                                                                Some VMs May exit notifyVMStop() early and hit breakpoints
+  │                      │                                                                 ├─ stopTheWorld()
+  │                      │                                                            ┌───>├─ wait(mutatorCV) on m_awaitingResumeNotification
+  │                      │ Last VM exiting notifyVMStop() ─> wasmDebuggerOnResume()   │    │
+  │                      │                                   ├─ handlePostResume()    │    │  
+  │                      │                                   ├─ Set m_awaitingResumeNotification = false
+  │                      └───────────────────────────────────├─ notifyOne(debuggerCV) │    │  
+  │                                                          └─ notifyAll(mutator) ───┘    │ 
+  └─ Debugger resumes                                                                      └─ notifyVMStop() and send stop reply to debugger
+```
+
+**Key Points:**
+
+- Debugger waits for **post-resume** confirmation to prevent interrupt() race
+- `m_awaitingResumeNotification` acts as resume barrier
+- VMManager ensures all VMs actually resumed before callback
+
+---
+
+### 2. **Interrupt Operation** (Async Stop Request)
+
+```
+Debugger Thread                                               All Thread(s)
+==================         ===========================================================================================
+                                                            [Running Wasm]
+interrupt()
+  ├─ Set state = InterruptRequested
+  ├─ VMManager::requestStopAll() ──────────────────-----───> VMTraps fire 
+  ├─ wait(debuggerCV) <──┐              notifyVMStop()                    notifyVMStop()
+  │                      │               ├─                               └─ Other VMs wait(worldCV)
+  │                      │               ├─ One VM picked as target
+  │                      │               ├─ stopCode()      
+  │                      │               ├─ setStopped()
+  │                      │               ├─ Check state -> InterruptRequested
+  │                      └───────────────┼─ notifyOne(debuggerCV)
+  │                                      └─ wait(mutatorCV)
+  │                      
+  └─ sendStopReply()
+```
+
+**Key Points:**
+
+- **Asynchronous**: Debugger initiates trap via VMManager
+- All VMs stopped via trap mechanism (no direct wait/notify initially)
+- Once target VM stops, it notifies debugger
+- Multiple VMs coordinate through VMManager stop-the-world
+
+---
+
+### 3. **Single Step Operation**
+
+```
+Debugger Thread                         Mutator Thread (Target)                                    Other Thread(s)
+==================       ==========================================================================================================================
+                                      ExecutionHandler::stopCode()                            VMManager::notifyVMStop()
+                                   ┌──>├─ wait(mutatorCV)                                      └─ wait(worldCV)
+step()                             │   │                                        
+  ├─ stepAtBreakpoint()            │   │                                    
+  │   └─ Set one-time breakpoints  │   │                                    
+  ├─ Set state = StepRequested     │   │                                    
+  ├─ notifyOne(mutator) ───────────┘   │                                    
+  ├─ wait(debuggerCV) <──┐             │                                    
+  │                      │             ├─ Check state -> StepRequested      
+  │                      │             └─ Return ResumeMode::One            
+  │                      │                └─ VMManager::resumeOne(targetVM) 
+  │                      │                    └─ Target VM exiting notifyVMStop() (others stay stopped)
+  │                      │                        ├─ Target VM executes
+  │                      │                        ├─ Hits one-time breakpoint
+  │                      │                        └─ stopTheWorld()
+  │                      │                            └─ notifyVMStop()
+  │                      │                                └─ stopCode()
+  │                      │                                    ├─ setStopped()
+  │                      │                                    ├─ Check state -> StepRequested
+  │                      └────────────────────────────────────┼─ notifyOne(debuggerCV)
+  │                                                           └─ wait(mutatorCV)
+  └─ sendStopReply()
+```
+
+**Key Points:**
+
+- One-time breakpoints set before resume
+- Only target VM runs (RunOne mode)
+- All other VMs remain stopped
+- Breakpoint hit triggers another stop-the-world
+
+---
+
+### 4. **Step-Into (Call/Throw)** - Two-Phase Protocol
+
+```
+Debugger Thread                         Mutator Thread (Target)                                    Other Thread(s)
+==================       ==========================================================================================================================
+                                      ExecutionHandler::stopCode()                            VMManager::notifyVMStop()
+                                   ┌──>├─ wait(mutatorCV)                                      └─ wait(worldCV)
+step()                             │   │                                          
+  └─ stepAtBreakpoint()            │   │                                 
+      ├─ Detect call/throw         │   │                                 
+      ├─ Set hasStepIntoEvent flag │   │                                 
+      ├─ notifyOne(mutator) ───────┘   │                                 
+      ├─ wait(debuggerCV) <──┐         │                                 
+      │                      │         ├─ Wakes up, executes call/throw  
+      │                      │         └─ setStepIntoBreakpointForCall/Throw()             
+      │                      │             ├─ Set breakpoint at callee or exception handler   
+      │                      │             └─ stopTheWorld()           
+      │                      │                 └─ notifyVMStop()
+      │                      │                     ├─ stopCode(StepIntoSiteReached)
+      │                      │                     ├─ Check state -> StepRequested                 
+      │                      └─────────────────────┼─ notifyOne(debuggerCV)
+      │                           ┌──────────────> ├─ wait(mutatorCV)
+      │                           │                │
+      │                           │                │
+      ├─ notifyOne(mutator) ──────┘                │
+      ├─ wait(debuggerCV) <┐                       │
+      │                    │                       ├─ Wakes up, runs to step-into breakpoint
+      │                    │                       ├─ Breakpoint hit -> stopCode()
+      │                    │                       ├─ setStopped()
+      │                    │                       ├─ Check state -> StepRequested
+      │                    └───────────────────────┼─ notifyOne(debuggerCV)
+      │                                            └─ wait(mutatorCV)
+      └─ sendStopReply()
+```
+
+**Key Points:**
+
+- **Two-phase handshake**:
+  1. Execute call/throw and register breakpoint
+  2. Resume and hit step-into breakpoint
+- Breakpoint set dynamically at call/throw site
+
+---
+
+### 5. **VM Context Switch**
+
+```
+Debugger Thread                    Old Mutator Thread (Old Target)         New Mutator Thread (New Target)              Other Thread(s)
+==================           ========================================    ==================================        ========================
+                               ExecutionHandler::stopCode()               VMManager::notifyVMStop()                 VMManager::notifyVMStop()
+                          ┌─────>├─ wait(mutatorCV)                     ┌──>├─ wait(worldCV)                         └─ wait(worldCV)
+switchTarget(threadId)    │      │                                      │   │                                
+  ├─ m_vm = newTargetVM   │      │                                      │   │
+  ├─ Set state = SwitchRequested │                                      │   │
+  ├─ notifyOne(mutator)───┘      │                                      │   │
+  ├─ wait(debuggerCV) <────┐     │                                      │   │
+  │                        │     ├─ Check state -> SwitchRequested      │   │
+  │                        │     └─ Return ResumeMode::Switch           │   │
+  │                        │         └─ VMManager switch context ───────┘   │
+  │                        │             └─ wait(worldCV)                   │
+  │                        │                                                └─ wasmDebuggerOnStop() 
+  │                        │                                                    └─ handleStopTheWorld() -> stopCode()    
+  │                        │                                                        ├─ setStopped() 
+  │                        │                                                        ├─ Check state -> SwitchRequested
+  │                        └────────────────────────────────────────────────────────┼─ notifyOne(debuggerCV)
+  │                                                                                 └─ wait(mutatorCV)
+  └── sendStopReply()
+```
+
+**Key Points:**
+
+- Switch debugging target between VMs
+- VMManager coordinates transition

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -5,6 +5,7 @@ A comprehensive debugging solution that enables LLDB debugging of WebAssembly co
 > **Related Documentation:**
 > - **This document**: JSC debug server implementation (both Standalone and RWI modes)
 > - **[RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md)**: WebKit integration architecture (RWI mode details)
+> - **[Debugger-Mutator-Protocol.md](./Debugger-Mutator-Protocol.md)**: Thread synchronization protocol and control flow diagrams
 
 ## What is this project?
 
@@ -188,11 +189,6 @@ See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions
 
 ## Known Issues and Future Improvements
 
-### Multi-VM Debugging Support
-
-- **Issue**: Current implementation only stops a single VM when hitting breakpoints
-- **Location**: `WasmExecutionHandler.cpp:65-66`
-- **Solution**: When ANY VM hits a WebAssembly breakpoint, stop ALL execution across ALL VMs in the process for comprehensive debugging
 
 ### WASM Stack Value Type Support
 
@@ -225,6 +221,11 @@ See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions
 - **Issue**: LLDB is not notified when new modules are loaded or unloaded
 - **Location**: `WasmDebugServer.cpp:472, 484`
 - **Solution**: Implement proper LLDB notifications for dynamic module loading/unloading
+
+### Multi-Thread Display in LLDB
+
+- **Issue**: Thread select and stop reply protocol handlers need improvement to correctly display multi-VM data in LLDB
+- **Current Status**: Multi-VM stop-the-world is implemented, but thread information may not display correctly in LLDB UI
 
 ## Protocol References
 

--- a/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
+++ b/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
@@ -213,12 +213,8 @@ Unlike Web Inspector which initializes/tears down controllers per page, WebAssem
 
 ### Stop-the-World Design
 
-WebAssembly debugging is designed with a **stop-the-world** pause model:
-- When LLDB hits a Wasm breakpoint, the VM that hit the breakpoint pauses execution
-- **Design Intent**: Stop ALL VMs in the process (main thread + all worker threads) for comprehensive debugging
-- **Current Implementation**: Only stops the single VM that hit the breakpoint (multi-VM support not yet implemented)
-- This matches standard native debugging behavior (LLDB/GDB debugging C++ code)
-- Provides consistent state inspection guarantees during pause
+WebAssembly debugging uses a **stop-the-world** pause model:
+- When LLDB requests an interrupt or hits a breakpoint, ALL VMs in the process stop execution (main thread + all worker threads)
 
 ### Asymmetric Interaction with JavaScript Debugger
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -35,6 +35,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSWebAssemblyModule.h"
 #include "Options.h"
 #include "VM.h"
+#include "VMManager.h"
 #include "WasmBreakpointManager.h"
 #include "WasmExecutionHandler.h"
 #include "WasmIPIntSlowPaths.h"
@@ -67,24 +68,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace JSC {
 namespace Wasm {
 
-static inline StringView getErrorReply(ProtocolError error)
-{
-    switch (error) {
-    case ProtocolError::InvalidPacket:
-        return "E01"_s;
-    case ProtocolError::InvalidAddress:
-        return "E02"_s;
-    case ProtocolError::InvalidRegister:
-        return "E03"_s;
-    case ProtocolError::MemoryError:
-        return "E04"_s;
-    case ProtocolError::UnknownCommand:
-        return "E05"_s;
-    default:
-        return "E00"_s;
-    }
-}
-
 DebugServer& DebugServer::singleton()
 {
     static NeverDestroyed<DebugServer> instance;
@@ -97,7 +80,7 @@ DebugServer::DebugServer()
 {
 }
 
-bool DebugServer::start(VM* vm)
+bool DebugServer::start()
 {
     if (isState(State::Running) || isState(State::Starting)) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Server already running or is starting");
@@ -111,10 +94,8 @@ bool DebugServer::start(VM* vm)
 
     RELEASE_ASSERT(isSocketValid(m_serverSocket));
 
-    m_vm = vm;
-    m_moduleManager = makeUnique<ModuleManager>(*vm);
-    m_breakpointManager = makeUnique<BreakpointManager>();
-    m_executionHandler = makeUnique<ExecutionHandler>(*this, *m_moduleManager, *m_breakpointManager);
+    m_moduleManager = makeUnique<ModuleManager>();
+    m_executionHandler = makeUnique<ExecutionHandler>(*this, *m_moduleManager);
 
     startAcceptThread();
 
@@ -123,7 +104,7 @@ bool DebugServer::start(VM* vm)
 }
 
 #if ENABLE(REMOTE_INSPECTOR)
-bool DebugServer::startRWI(VM* vm, Function<bool(const String&)>&& rwiResponseHandler)
+bool DebugServer::startRWI(Function<bool(const String&)>&& rwiResponseHandler)
 {
     if (isState(State::Running) || isState(State::Starting)) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Server already running or is starting");
@@ -132,10 +113,8 @@ bool DebugServer::startRWI(VM* vm, Function<bool(const String&)>&& rwiResponseHa
 
     setState(State::Starting);
 
-    m_vm = vm;
-    m_moduleManager = makeUnique<ModuleManager>(*vm);
-    m_breakpointManager = makeUnique<BreakpointManager>();
-    m_executionHandler = makeUnique<ExecutionHandler>(*this, *m_moduleManager, *m_breakpointManager);
+    m_moduleManager = makeUnique<ModuleManager>();
+    m_executionHandler = makeUnique<ExecutionHandler>(*this, *m_moduleManager);
     m_rwiResponseHandler = WTFMove(rwiResponseHandler);
 
     // RWI mode: No thread creation needed!
@@ -212,16 +191,12 @@ void DebugServer::resetAll()
     closeSocket(m_clientSocket);
     m_acceptThread = nullptr;
 
-    m_vm = nullptr;
-    m_debugServerThreadId = std::nullopt;
-
     m_noAckMode = false;
     m_queryHandler = nullptr;
     m_memoryHandler = nullptr;
     m_executionHandler = nullptr;
 
     m_moduleManager = nullptr;
-    m_breakpointManager = nullptr;
 
 #if ENABLE(REMOTE_INSPECTOR)
     m_rwiResponseHandler = nullptr;
@@ -230,7 +205,7 @@ void DebugServer::resetAll()
 
 bool DebugServer::needToHandleBreakpoints() const
 {
-    return isConnected() && m_breakpointManager && m_breakpointManager->hasBreakpoints();
+    return isConnected() && execution().hasBreakpoints();
 }
 
 union SocketAddress {
@@ -293,7 +268,7 @@ bool DebugServer::createAndBindServerSocket()
 void DebugServer::startAcceptThread()
 {
     m_acceptThread = WTF::Thread::create("WasmDebugServer", [this]() {
-        m_debugServerThreadId = Thread::currentSingleton().uid();
+        m_executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());
 
         while (isState(State::Running)) {
             dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Waiting for client connections...");
@@ -327,7 +302,6 @@ void DebugServer::reset()
 {
     // Reset to the init state without stopping the debug server.
     m_executionHandler->reset();
-    m_breakpointManager->clearAllBreakpoints();
     closeSocket(m_clientSocket);
     m_noAckMode = false;
 }
@@ -367,7 +341,7 @@ void DebugServer::handleRawPacket(StringView rawPacket)
 
 #if ENABLE(REMOTE_INSPECTOR)
     if (isRWIMode())
-        m_debugServerThreadId = Thread::currentSingleton().uid();
+        m_executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());
 #endif
 
     // Handle single-byte control characters
@@ -453,12 +427,7 @@ void DebugServer::handlePacket(StringView packet)
     case 'k':
     case 'D':
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Kill/detach request");
-#if ENABLE(REMOTE_INSPECTOR)
-        if (isRWIMode())
-            reset();
-        else
-#endif
-            closeSocket(m_clientSocket);
+        reset();
         break;
     default:
         sendReplyNotSupported(packet);
@@ -511,26 +480,25 @@ void DebugServer::handleThreadManagement(StringView packet)
     char operation = packet[1];
     StringView threadSpec = packet.substring(2);
 
-    auto reply = [&]() {
-        if (threadSpec == "-1" || threadSpec == "0" || threadSpec == "1") {
-            // -1 = all threads, 0 = any thread, 1 = thread 1
-            // All are valid for our single-threaded WebAssembly context
-            sendReplyOK();
-        } else
-            sendErrorReply(ProtocolError::InvalidAddress);
-    };
-
     switch (operation) {
     case 'c': {
         // Hc<thread-id>: Set thread for step and continue operations
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Hc (set continue thread): ", threadSpec);
-        reply();
+
+        if (threadSpec == "-1" || threadSpec == "0") {
+            // -1 = all threads, 0 = any thread, 1 = thread 1
+            // All are valid for our single-threaded WebAssembly context
+            sendReplyOK();
+        } else {
+            execution().switchTarget(parseHex(threadSpec));
+            sendReplyOK();
+        }
         break;
     }
     case 'g': {
         // Hg<thread-id>: Set thread for other operations (register access, etc.)
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Hg (set general thread): ", threadSpec);
-        reply();
+        sendErrorReply(ProtocolError::InvalidAddress);
         break;
     }
     default:
@@ -551,6 +519,14 @@ void DebugServer::trackInstance(JSWebAssemblyInstance* instance)
     }
 }
 
+void DebugServer::untrackInstance(JSWebAssemblyInstance* instance)
+{
+    if (!m_moduleManager)
+        return;
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Untracking WebAssembly instance: ", RawPointer(instance));
+    m_moduleManager->unregisterInstance(instance);
+}
+
 void DebugServer::trackModule(Module& module)
 {
     if (!m_moduleManager)
@@ -569,56 +545,6 @@ void DebugServer::untrackModule(Module& module)
         return;
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Untracking WebAssembly module: ", RawPointer(&module));
     m_moduleManager->unregisterModule(module);
-}
-
-bool DebugServer::stopCode(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack) { return m_executionHandler->stopCode(callFrame, instance, callee, pc, mc, locals, stack); }
-
-void DebugServer::setInterruptBreakpoint(JSWebAssemblyInstance* instance, IPIntCallee* callee) { return m_executionHandler->setBreakpointAtEntry(instance, callee, Breakpoint::Type::Interrupt); }
-
-void DebugServer::setStepIntoBreakpointForCall(VM& vm, CalleeBits boxedCallee, JSWebAssemblyInstance* instance)
-{
-    if (!vm.takeStepIntoWasmCall())
-        return;
-
-    if (!instance)
-        return;
-    if (!boxedCallee.isNativeCallee())
-        return;
-    RefPtr wasmCallee = uncheckedDowncast<Wasm::Callee>(boxedCallee.asNativeCallee());
-    if (wasmCallee->compilationMode() != Wasm::CompilationMode::IPIntMode)
-        return;
-
-    m_executionHandler->setBreakpointAtEntry(instance, uncheckedDowncast<IPIntCallee>(wasmCallee.get()), Breakpoint::Type::Step);
-}
-
-void DebugServer::setStepIntoBreakpointForThrow(VM& vm, JSWebAssemblyInstance* instance)
-{
-    RELEASE_ASSERT(instance);
-
-    if (!vm.takeStepIntoWasmThrow())
-        return;
-
-    if (!vm.callFrameForCatch)
-        return;
-    if (!vm.callFrameForCatch->callee().isNativeCallee())
-        return;
-    RefPtr wasmCallee = uncheckedDowncast<Wasm::Callee>(vm.callFrameForCatch->callee().asNativeCallee());
-    if (wasmCallee->compilationMode() != Wasm::CompilationMode::IPIntMode)
-        return;
-
-    RefPtr catchCallee = uncheckedDowncast<IPIntCallee>(wasmCallee.get());
-    ASSERT(std::holds_alternative<uintptr_t>(vm.targetInterpreterPCForThrow));
-    uintptr_t handlerOffset = std::get<uintptr_t>(vm.targetInterpreterPCForThrow);
-    const uint8_t* handlerPC = catchCallee->bytecode() + handlerOffset;
-
-    if (*handlerPC == static_cast<uint8_t>(Wasm::OpType::TryTable) && vm.targetInterpreterMetadataPCForThrow) {
-        const uint8_t* metadataPtr = catchCallee->metadata() + vm.targetInterpreterMetadataPCForThrow;
-        metadataPtr += sizeof(IPInt::CatchMetadata);
-        const IPInt::BlockMetadata* blockMetadata = reinterpret_cast<const IPInt::BlockMetadata*>(metadataPtr);
-        handlerPC = handlerPC + blockMetadata->deltaPC;
-    }
-
-    m_executionHandler->setBreakpointAtPC(instance, catchCallee->functionIndex(), Breakpoint::Type::Step, handlerPC);
 }
 
 bool DebugServer::isConnected() const

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -35,6 +35,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <atomic>
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/Threading.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -44,7 +45,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
-class CalleeBits;
 class VM;
 class CallFrame;
 class JSWebAssemblyInstance;
@@ -91,24 +91,8 @@ public:
 
     DebugServer();
     ~DebugServer() = default;
-    VM* vm() const { return m_vm; }
 
-    uint64_t mutatorThreadId() const
-    {
-        // Dynamically get the owner thread from the VM instead of caching it
-        // since the VM's owner can change over time.
-        RELEASE_ASSERT(m_vm);
-        auto ownerThread = m_vm->ownerThread();
-        RELEASE_ASSERT(ownerThread && *ownerThread);
-        return (*ownerThread)->uid();
-    }
-    uint64_t debugServerThreadId() const
-    {
-        RELEASE_ASSERT(m_debugServerThreadId.has_value());
-        return *m_debugServerThreadId;
-    }
-
-    JS_EXPORT_PRIVATE bool start(VM*);
+    JS_EXPORT_PRIVATE bool start();
     JS_EXPORT_PRIVATE void stop();
 
 #if ENABLE(REMOTE_INSPECTOR)
@@ -116,17 +100,13 @@ public:
     // 1. Direct TCP socket mode (JSC shell debugging)
     // 2. Remote Web Inspector integration mode (WebKit debugging)
     bool isRWIMode() const { return !!m_rwiResponseHandler; }
-    JS_EXPORT_PRIVATE bool startRWI(VM*, Function<bool(const String&)>&& rwiResponseHandler);
+    JS_EXPORT_PRIVATE bool startRWI(Function<bool(const String&)>&& rwiResponseHandler);
 #endif
 
     void trackInstance(JSWebAssemblyInstance*);
+    void untrackInstance(JSWebAssemblyInstance*);
     void trackModule(Module&);
     void untrackModule(Module&);
-
-    void setInterruptBreakpoint(JSWebAssemblyInstance*, IPIntCallee*);
-    void setStepIntoBreakpointForCall(VM&, CalleeBits, JSWebAssemblyInstance*);
-    void setStepIntoBreakpointForThrow(VM&, JSWebAssemblyInstance*);
-    bool stopCode(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*);
 
     void setPort(uint64_t port) { m_port = port; }
     bool needToHandleBreakpoints() const;
@@ -134,6 +114,18 @@ public:
     JS_EXPORT_PRIVATE bool isConnected() const;
 
     JS_EXPORT_PRIVATE void handleRawPacket(StringView rawPacket);
+
+    ExecutionHandler& execution() const
+    {
+        RELEASE_ASSERT(m_executionHandler);
+        return *m_executionHandler;
+    }
+
+    JS_EXPORT_PRIVATE ModuleManager& moduleManager() const
+    {
+        RELEASE_ASSERT(m_moduleManager);
+        return *m_moduleManager;
+    }
 
 private:
     void reset();
@@ -177,23 +169,20 @@ private:
     SocketType m_clientSocket { invalidSocketValue };
     RefPtr<Thread> m_acceptThread;
 
-    VM* m_vm { nullptr };
-    std::optional<uint64_t> m_debugServerThreadId;
-
     bool m_noAckMode { false };
     std::unique_ptr<QueryHandler> m_queryHandler;
     std::unique_ptr<MemoryHandler> m_memoryHandler;
     std::unique_ptr<ExecutionHandler> m_executionHandler;
 
     std::unique_ptr<ModuleManager> m_moduleManager;
-    std::unique_ptr<BreakpointManager> m_breakpointManager;
 
 #if ENABLE(REMOTE_INSPECTOR)
     Function<bool(const String&)> m_rwiResponseHandler;
 #endif
 };
-} // namespace JSC
+
 } // namespace Wasm
+} // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -29,7 +29,11 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
+#include <JavaScriptCore/WasmVirtualAddress.h>
+#include <memory>
 #include <wtf/HexNumber.h>
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringView.h>
 
@@ -40,11 +44,13 @@ class JSWebAssemblyInstance;
 
 namespace IPInt {
 struct IPIntLocal;
-} // namespace IPInt
+struct IPIntStackEntry;
+}
 
 namespace Wasm {
 
 class VirtualAddress;
+class IPIntCallee;
 enum class TypeKind : int8_t;
 struct Type;
 
@@ -127,6 +133,98 @@ struct Breakpoint {
     uint8_t originalBytecode { 0 };
 };
 
+// Immutable snapshot of VM state when stopped at a debugging event (interrupt/breakpoint/step).
+// Captures stop reason, location, PC/MC, and execution state for debugger inspection.
+struct StopData {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(StopData);
+
+    // GDB Remote Protocol stop reason codes mapped to GDB Remote Protocol semantics
+    // Reference: https://sourceware.org/gdb/onlinedocs/gdb/Stop-Reply-Packets.html
+    enum class Code : uint8_t {
+        Unknown = 0,
+        Stop, // SIGSTOP - Debugger interrupt (uncatchable stop) - reason:signal
+        Trace, // SIGTRAP - Single step/trace completion - reason:trace
+        Breakpoint // SIGTRAP - Breakpoint hit - reason:breakpoint (distinct from trace)
+    };
+
+    enum class Location : uint8_t {
+        Prologue = 0,
+        Breakpoint
+    };
+
+    StopData(Breakpoint::Type, VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
+
+    StopData(IPIntCallee*, JSWebAssemblyInstance*);
+
+    ~StopData();
+
+    void setCode(Breakpoint::Type);
+    void dump(PrintStream&) const;
+
+    Code code { Code::Unknown };
+    Location location;
+    VirtualAddress address;
+    uint8_t originalBytecode { 0 };
+    uint8_t* pc { nullptr };
+    uint8_t* mc { nullptr };
+    IPInt::IPIntLocal* locals { nullptr };
+    IPInt::IPIntStackEntry* stack { nullptr };
+    RefPtr<IPIntCallee> callee;
+    JSWebAssemblyInstance* instance { nullptr };
+    CallFrame* callFrame { nullptr };
+};
+
+// Per-VM debugging state machine (Running/Stopped) with current stop information.
+// Owns stopData snapshot while stopped, tracks step-into events across function boundaries.
+// Created on-demand via VM::debugState(), accessed only when VM is stopped.
+struct DebugState {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(DebugState);
+
+    enum class State : uint8_t {
+        Running,
+        Stopped,
+    };
+
+    DebugState() = default;
+
+    void setPrologueStopData(JSWebAssemblyInstance* instance, IPIntCallee* callee)
+    {
+        stopData = makeUnique<StopData>(callee, instance);
+    }
+
+    void setBreakpointStopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
+    {
+        stopData = makeUnique<StopData>(type, address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
+    }
+
+    bool atSystemCall() const { return !stopData; }
+    bool atPrologue() const { return !!stopData && stopData->location == StopData::Location::Prologue; }
+    bool atBreakpoint() const { return !!stopData && stopData->location == StopData::Location::Breakpoint; }
+
+    void clearStop()
+    {
+        state = State::Running;
+        stopData = nullptr;
+    }
+
+    void setStopped() { state = State::Stopped; }
+    bool isStopped() const { return state == State::Stopped; }
+    void setRunning() { state = State::Running; }
+    bool isRunning() const { return state == State::Running; }
+
+    bool hasStepIntoEvent() { return stepIntoEvent.hasAny(); }
+    void setStepIntoCall() { stepIntoEvent.set(StepIntoEvent::StepIntoCall); }
+    bool takeStepIntoCall() { return stepIntoEvent.take(StepIntoEvent::StepIntoCall); }
+    void setStepIntoThrow() { stepIntoEvent.set(StepIntoEvent::StepIntoThrow); }
+    bool takeStepIntoThrow() { return stepIntoEvent.take(StepIntoEvent::StepIntoThrow); }
+
+    State state { State::Running };
+    std::unique_ptr<const StopData> stopData { nullptr };
+
+    // Step-into tracking (for step debugging behavior)
+    StepIntoEvent stepIntoEvent { };
+};
+
 template<typename T>
 inline String toNativeEndianHex(const T& value)
 {
@@ -151,6 +249,24 @@ uint32_t parseDecimal(StringView, uint32_t defaultValue = 0);
 Vector<StringView> splitWithDelimiters(StringView packet, StringView delimiters);
 
 bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress& virtualReturnPC);
+
+inline StringView getErrorReply(ProtocolError error)
+{
+    switch (error) {
+    case ProtocolError::InvalidPacket:
+        return "E01"_s;
+    case ProtocolError::InvalidAddress:
+        return "E02"_s;
+    case ProtocolError::InvalidRegister:
+        return "E03"_s;
+    case ProtocolError::MemoryError:
+        return "E04"_s;
+    case ProtocolError::UnknownCommand:
+        return "E05"_s;
+    default:
+        return "E00"_s;
+    }
+}
 
 } // namespace Wasm
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -35,6 +35,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "Options.h"
 #include "SubspaceInlines.h"
 #include "VM.h"
+#include "VMManager.h"
 #include "WasmBreakpointManager.h"
 #include "WasmCallee.h"
 #include "WasmDebugServer.h"
@@ -54,6 +55,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/WTFString.h>
 
@@ -62,55 +64,25 @@ namespace Wasm {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ExecutionHandler);
 
-// FIXME: This current implementation only stops a single VM. In real-world browser debugging,
-// when ANY VM hits a WASM breakpoint, we should stop ALL execution across ALL VMs in the process.
-//
-// COMPREHENSIVE STOP-THE-WORLD APPROACH:
-// - Single VM with WASM: Current implementation works (but should be consistent)
-// - TODO: Multiple VMs, only one running WASM: Stop ALL VMs (WASM + non-WASM mutators)
-// - TODO: Multiple VMs, multiple running WASM: Stop ALL VMs (all WASM + all non-WASM mutators)
-class StopWorld {
-public:
-    explicit StopWorld(VM& vm)
-        : m_vm(vm)
-    {
-    }
-
-    ~StopWorld()
-    {
-        if (m_vm.isWasmStopWorldActive())
-            deactivateStopWorld();
-    }
-
-    void activateStopWorld()
-    {
-        m_vm.traps().requestStop();
-        m_vm.setIsWasmStopWorldActive(true);
-    }
-
-    void deactivateStopWorld()
-    {
-        m_vm.traps().cancelStop();
-        m_vm.setIsWasmStopWorldActive(false);
-    }
-
-private:
-    VM& m_vm;
-};
-
 struct StopReasonInfo {
     String reasonString;
     StringView reasonSuffix;
 };
 
-static inline StopReasonInfo stopReasonCodeToInfo(ExecutionHandler::StopReason::Code code)
+static inline StopReasonInfo stopReasonCodeToInfo(StopData::Code code)
 {
     switch (code) {
-    case ExecutionHandler::StopReason::Code::Signal:
-        return { "T02"_s, "signal"_s }; // SIGINT - Interrupt signal
-    case ExecutionHandler::StopReason::Code::Trace:
+    case StopData::Code::Stop:
+#if OS(DARWIN)
+        return { "T11"_s, "signal"_s }; // SIGSTOP on macOS (17 decimal = 0x11 hex)
+#elif OS(LINUX)
+        return { "T13"_s, "signal"_s }; // SIGSTOP on Linux (19 decimal = 0x13 hex)
+#else
+        return { "T11"_s, "signal"_s }; // Default: SIGSTOP (most common value)
+#endif
+    case StopData::Code::Trace:
         return { "T05"_s, "trace"_s }; // SIGTRAP - Trace/single step
-    case ExecutionHandler::StopReason::Code::Breakpoint:
+    case StopData::Code::Breakpoint:
         return { "T05"_s, "breakpoint"_s }; // SIGTRAP - Breakpoint hit
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -118,77 +90,294 @@ static inline StopReasonInfo stopReasonCodeToInfo(ExecutionHandler::StopReason::
     }
 }
 
-ExecutionHandler::ExecutionHandler(DebugServer& debugServer, ModuleManager& moduleManager, BreakpointManager& breakpointManager)
+ExecutionHandler::ExecutionHandler(DebugServer& debugServer, ModuleManager& instanceManager)
     : m_debugServer(debugServer)
-    , m_moduleManager(moduleManager)
-    , m_breakpointManager(breakpointManager)
+    , m_moduleManager(instanceManager)
+    , m_breakpointManager(makeUnique<BreakpointManager>())
 {
 }
 
-void ExecutionHandler::stopImpl(StopReason&& stopReason)
+void ExecutionHandler::stopTheWorld(VM& targetVM, StopTheWorldEvent event)
 {
-    RELEASE_ASSERT(Thread::currentSingleton().uid() == m_debugServer.mutatorThreadId());
+    auto info = VMManager::info();
+    dataLogLnIf(Options::verboseWasmDebugger(), "[stopTheWorld] targetVM:", RawPointer(&targetVM), " event:", event, " ", info);
 
-    Locker locker { m_lock };
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop][Breakpoint] Start");
+    {
+        Locker locker { m_lock };
 
-    m_stopReason = stopReason;
-    m_mutatorState = MutatorState::Stopped;
-    m_breakpointManager.clearAllOneTimeBreakpoints();
+        switch (event) {
+        case StopTheWorldEvent::StepIntoSiteReached:
+            RELEASE_ASSERT(Thread::currentSingleton().uid() == mutatorThreadId(*m_vm));
+            RELEASE_ASSERT(m_vm == info.targetVM && info.worldMode == VMManager::Mode::RunOne);
+            break;
+        case StopTheWorldEvent::BreakpointHit:
+            RELEASE_ASSERT(info.worldMode != VMManager::Mode::Stopped);
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
 
-    if (m_debuggerState == DebuggerState::ContinueRequested) {
-        sendStopReply(locker);
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop][Breakpoint] Currently in continue. Sent a stop reply and waiting...");
-    } else {
-        RELEASE_ASSERT(m_debuggerState == DebuggerState::StopRequested);
-        m_debuggerContinue.notifyOne();
+        // Wait for previous resume all to prevent reenter notifyVMStop.
+        while (m_awaitingResumeNotification)
+            m_mutatorContinue.wait(m_lock);
+        m_vm = &targetVM;
     }
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop][Breakpoint] Updated stop reason and waiting...");
-    m_mutatorContinue.wait(locker);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop][Breakpoint] Unblocked and running...");
-
-    m_stopReason.reset();
-    m_mutatorState = MutatorState::Running;
-    if (m_debuggerState == DebuggerState::ContinueRequested)
-        m_debuggerContinue.notifyOne();
+    VMManager::requestStopAll(VMManager::StopReason::WasmDebugger);
+    VMManager::singleton().notifyVMStop(targetVM, event);
 }
 
-bool ExecutionHandler::stopCode(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
+bool ExecutionHandler::hitBreakpoint(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
 {
-    RELEASE_ASSERT(Thread::currentSingleton().uid() == m_debugServer.mutatorThreadId());
-
     VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
-    if (auto* breakpoint = m_breakpointManager.findBreakpoint(address)) {
-        StopReason stopReason(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop] Going to stop at ", *breakpoint, " with ", stopReason);
-        stopImpl(WTFMove(stopReason));
+    if (auto* breakpoint = m_breakpointManager->findBreakpoint(address)) {
+        VM& targetVM = instance->vm();
+        targetVM.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Code][hitBreakpoint] Going to stop at ", *breakpoint, " with ", *targetVM.debugState()->stopData);
+        stopTheWorld(targetVM, StopTheWorldEvent::BreakpointHit);
         return true;
     }
     return false;
 }
 
-void ExecutionHandler::resume()
+ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, StopTheWorldEvent event)
+{
+    RELEASE_ASSERT(Thread::currentSingleton().uid() == mutatorThreadId(*m_vm));
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop] Start with event:", event);
+
+    targetState()->setStopped();
+
+    auto notifyDebuggerOfStop = [&]() WTF_REQUIRES_LOCK(m_lock) {
+        if (m_debuggerState == DebuggerState::ContinueRequested) {
+            sendStopReply(locker);
+            dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop] Sent a stop reply and waiting...");
+        } else {
+            RELEASE_ASSERT(requiresStopConfirmation());
+            m_debuggerContinue.notifyOne(); // Notify debugger that code stopped.
+        }
+    };
+
+    // Handle stop event and notify debugger
+    switch (event) {
+    case StopTheWorldEvent::VMStopped:
+    case StopTheWorldEvent::VMCreated:
+    case StopTheWorldEvent::VMActivated:
+        RELEASE_ASSERT(m_debuggerState == DebuggerState::InterruptRequested
+            || m_debuggerState == DebuggerState::SwitchRequested);
+        notifyDebuggerOfStop();
+        break;
+    case StopTheWorldEvent::BreakpointHit:
+        RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested
+            || m_debuggerState == DebuggerState::ContinueRequested
+            || m_debuggerState == DebuggerState::SwitchRequested);
+        m_breakpointManager->clearAllOneTimeBreakpoints();
+        notifyDebuggerOfStop();
+        break;
+    case StopTheWorldEvent::StepIntoSiteReached:
+        RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
+        m_debuggerContinue.notifyOne(); // Notify that breakpoint is set.
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    // Wait for debugger command
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop] Waiting for debugger command...");
+    m_mutatorContinue.wait(locker); // Wait for resume mode to be set.
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop] Unblocked and running...");
+
+    // Determine resume mode
+    if (m_debuggerState == DebuggerState::SwitchRequested)
+        return ResumeMode::Switch;
+
+    targetState()->clearStop();
+
+    // Defer debugger notification until after VMs resume to prevent interrupt() race.
+    if (m_debuggerState == DebuggerState::ContinueRequested)
+        m_awaitingResumeNotification = true;
+
+    return (m_debuggerState == DebuggerState::StepRequested) ? ResumeMode::One : ResumeMode::All;
+}
+
+StopTheWorldStatus ExecutionHandler::handleStopTheWorld(VM& stopTheWorldTargetVM, StopTheWorldEvent event)
 {
     Locker locker { m_lock };
 
+    selectTargetVMIfNeeded(stopTheWorldTargetVM);
+    RELEASE_ASSERT(m_vm);
+
+    // If target differs from triggering VM, switch to target.
+    if (m_vm != &stopTheWorldTargetVM) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[STW] Context switch to target VM");
+        return STW_CONTEXT_SWITCH(m_vm);
+    }
+
+    // Mark VMs' states (target running, others stopped).
+    markVMStates(m_vm);
+
+    // Stop the code and let debugger decide resume mode.
+    ExecutionHandler::ResumeMode mode = stopCode(locker, event);
+    switch (mode) {
+    case ExecutionHandler::ResumeMode::One:
+        RELEASE_ASSERT(m_vm->debugState()->isRunning());
+        return STW_RESUME_ONE(m_vm);
+    case ExecutionHandler::ResumeMode::All:
+        RELEASE_ASSERT(m_vm->debugState()->isRunning());
+        clearOtherVMStopData(m_vm);
+        return STW_RESUME_ALL();
+    case ExecutionHandler::ResumeMode::Switch:
+        RELEASE_ASSERT(m_vm != &stopTheWorldTargetVM);
+        RELEASE_ASSERT(stopTheWorldTargetVM.debugState()->isStopped());
+        RELEASE_ASSERT(m_vm->debugState()->isStopped());
+        stopTheWorldTargetVM.debugState()->setRunning();
+        m_vm->debugState()->setRunning();
+        return STW_CONTEXT_SWITCH(m_vm);
+    }
+    return STW_RESUME_ALL();
+}
+
+void ExecutionHandler::selectTargetVMIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(m_lock)
+{
+    if (m_vm)
+        return;
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[STW] No target VM, selecting one");
+
+    // Prefer VM at prologue, otherwise use the triggered VM
+    VM* selectedVM = nullptr;
+    VMManager::forEachVM([&](VM& vm) {
+        if (vm.debugState()->atPrologue()) {
+            selectedVM = &vm;
+            return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    });
+
+    m_vm = selectedVM ? selectedVM : &fallbackVM;
+}
+
+void ExecutionHandler::markVMStates(VM* targetVM) WTF_REQUIRES_LOCK(m_lock)
+{
+    VMManager::forEachVM([&](VM& vm) {
+        if (&vm == targetVM)
+            vm.debugState()->setRunning();
+        else
+            vm.debugState()->setStopped();
+        return IterationStatus::Continue;
+    });
+}
+
+void ExecutionHandler::clearOtherVMStopData(VM* targetVM) WTF_REQUIRES_LOCK(m_lock)
+{
+    VMManager::forEachVM([&](VM& vm) {
+        if (&vm != targetVM) {
+            RELEASE_ASSERT(vm.debugState()->isStopped());
+            vm.debugState()->clearStop();
+        }
+        return IterationStatus::Continue;
+    });
+}
+
+// Called by VMManager when ALL VMs are stopped at safe points.
+// Returns resume mode (ResumeOne/ResumeAll/ContextSwitch) to coordinate execution.
+StopTheWorldStatus wasmDebuggerOnStopCallback(VM& stopTheWorldTargetVM, StopTheWorldEvent event)
+{
+    auto& server = DebugServer::singleton();
+    if (!server.isConnected()) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[STW] Not connected, resuming all");
+        return STW_RESUME_ALL();
+    }
+
+    return server.execution().handleStopTheWorld(stopTheWorldTargetVM, event);
+}
+
+void ExecutionHandler::handlePostResume()
+{
+    Locker locker { m_lock };
+
+    if (takeAwaitingResumeNotification()) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[PostResume] Notify debugger to continue");
+        m_debuggerContinue.notifyOne(); // Notify that resume is complete.
+        m_mutatorContinue.notifyAll(); // Release resume barrier for VMs blocked in stopTheWorld().
+    }
+}
+
+// Called by VMManager after ALL VMs have resumed (when m_numberOfStoppedVMs reaches 0).
+// This is the safe point to notify debugger that resume is complete and release barriers in stopTheWorld().
+void wasmDebuggerOnResumeCallback()
+{
+    auto& server = DebugServer::singleton();
+    if (!server.isConnected()) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[STW][PostResume] Not connected, resuming all");
+        return;
+    }
+
+    server.execution().handlePostResume();
+}
+
+void ExecutionHandler::resume()
+{
+    Locker locker { m_lock };
+    resumeImpl(locker);
+}
+
+void ExecutionHandler::resumeImpl(Locker<Lock>& locker)
+{
+    RELEASE_ASSERT(Thread::currentSingleton().uid() == debugServerThreadId());
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Continue] Start");
 
-    RELEASE_ASSERT(Thread::currentSingleton().uid() == m_debugServer.debugServerThreadId());
-    RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && m_mutatorState == MutatorState::Stopped);
-    m_mutatorContinue.notifyOne();
+    RELEASE_ASSERT(targetState()->isStopped());
+    m_debuggerState = DebuggerState::ContinueRequested;
+    m_mutatorContinue.notifyOne(); // Notify target VM with resume all command.
 
     // This is to simplify implementation. If we don't wait here, we may have a race condition that
     // after above notification, interrupt() may acquire the locker first.
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Continue] Notified code to continue and waiting...");
-    m_debuggerState = DebuggerState::ContinueRequested;
-    m_debuggerContinue.wait(m_lock);
+    m_debuggerContinue.wait(locker); // Wait for resume to complete.
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Continue] Confirmed that code is running...");
+}
+
+static inline VM* findVM(uint64_t threadId)
+{
+    VM* result = nullptr;
+    VMManager::forEachVM([&](VM& vm) {
+        if (threadId == ExecutionHandler::mutatorThreadId(vm)) {
+            result = &vm;
+            return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    });
+    return result;
+}
+
+void ExecutionHandler::switchTarget(uint64_t threadId)
+{
+    RELEASE_ASSERT(Thread::currentSingleton().uid() == debugServerThreadId());
+
+    Locker locker { m_lock };
+
+    VM* newTargetVM = findVM(threadId);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][SwitchVM] current target VM=", RawPointer(m_vm), " new target VM=", RawPointer(newTargetVM));
+
+    if (m_vm == newTargetVM)
+        return;
+
+    RELEASE_ASSERT(targetState()->isStopped());
+    m_vm = newTargetVM;
+    m_debuggerState = DebuggerState::SwitchRequested;
+    m_mutatorContinue.notifyOne(); // Notify to switch VM context.
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][SwitchVM] Notified code to continue and switch VM, waiting...");
+    m_debuggerContinue.wait(locker); // Wait for new target VM to stop.
+    RELEASE_ASSERT(targetState()->isStopped());
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][SwitchVM] Code is stopped");
 }
 
 void ExecutionHandler::interrupt()
 {
-    RELEASE_ASSERT(Thread::currentSingleton().uid() == m_debugServer.debugServerThreadId());
+    RELEASE_ASSERT(Thread::currentSingleton().uid() == debugServerThreadId());
 
     Locker locker { m_lock };
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Interrupt] Start");
@@ -197,67 +386,101 @@ void ExecutionHandler::interrupt()
     // no matter how many Ctrl+C the user types, LLDB will not send additional interrupt packets
     // until it receives a stop reply. This prevents packet flooding and ensures clean protocol behavior.
     // Our WebKit implementation handles each interrupt request by activating StopWorld via VM traps.
-    StopWorld stopWorld(*m_debugServer.vm());
 
-    {
-        RELEASE_ASSERT(m_mutatorState == MutatorState::Running);
-        m_debuggerState = DebuggerState::StopRequested;
-        stopWorld.activateStopWorld();
+    bool mutatorIsStopped = m_vm && targetState()->isStopped();
+    bool interruptRequested = m_debuggerState == DebuggerState::InterruptRequested;
+    if (mutatorIsStopped || interruptRequested) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Interrupt] mutatorIsStopped:", mutatorIsStopped, " interruptRequested:", interruptRequested, " then return!");
+        return;
     }
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Interrupt] Notified code to stop and waiting...");
-    m_debuggerContinue.wait(m_lock);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Interrupt] Confirmed that code is stoped");
-
     {
-        stopWorld.deactivateStopWorld();
-        sendStopReply(locker);
+        RELEASE_ASSERT(!m_vm || targetState()->isRunning());
+        m_debuggerState = DebuggerState::InterruptRequested;
+        VMManager::singleton().requestStopAll(VMManager::StopReason::WasmDebugger);
     }
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Interrupt] Notified code to stop, waiting...");
+    m_debuggerContinue.wait(locker); // Wait for target VM to stop.
+    sendStopReply(locker);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Interrupt] Code is stopped and debugger replied");
 }
 
 void ExecutionHandler::step()
 {
-    RELEASE_ASSERT(Thread::currentSingleton().uid() == m_debugServer.debugServerThreadId());
+    RELEASE_ASSERT(Thread::currentSingleton().uid() == debugServerThreadId());
 
     Locker locker { m_lock };
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Start with ", m_stopReason);
+    auto* state = targetState();
+    RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && state->isStopped());
 
-    uint8_t* currentPC = m_stopReason.pc;
+    bool resumeAll = false;
+    if (state->atSystemCall())
+        resumeAll = true;
+    else if (state->atBreakpoint())
+        resumeAll = stepAtBreakpoint(locker, state);
+    else {
+        RELEASE_ASSERT(state->atPrologue());
+        setBreakpointAtEntry(state->stopData->instance, state->stopData->callee.get(), Breakpoint::Type::Step);
+    }
+
+    if (resumeAll) {
+        resumeImpl(locker);
+        return;
+    }
+
+    RELEASE_ASSERT(m_breakpointManager->hasOneTimeBreakpoints());
+    m_debuggerState = DebuggerState::StepRequested;
+    m_mutatorContinue.notifyOne(); // Notify to resume until next breakpoint.
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Notified code to continue and expected a stop, waiting...");
+    m_debuggerContinue.wait(locker); // Wait for one-time breakpoint hit.
+    sendStopReply(locker);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Code is stopped and debugger replied");
+}
+
+bool ExecutionHandler::stepAtBreakpoint(Locker<Lock>& locker, DebugState* state)
+{
+    RELEASE_ASSERT(state->atBreakpoint());
+    auto& stopData = *state->stopData;
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Start with ", stopData);
+
+    uint8_t* currentPC = stopData.pc;
 
     auto setStepBreakpoint = [&](const uint8_t* nextPC) WTF_REQUIRES_LOCK(m_lock) {
-        VirtualAddress nextAddress = VirtualAddress(m_stopReason.address.value() + (nextPC - currentPC));
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step][SetOneTimeBreakpoint] current PC=", RawPointer(currentPC), "(", m_stopReason.address, "), next PC=", RawPointer(nextPC), "(", nextAddress, ")");
-        if (m_breakpointManager.findBreakpoint(nextAddress))
+        VirtualAddress nextAddress = VirtualAddress(stopData.address.value() + (nextPC - currentPC));
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step][SetOneTimeBreakpoint] current PC=", RawPointer(currentPC), "(", stopData.address, "), next PC=", RawPointer(nextPC), "(", nextAddress, ")");
+        if (m_breakpointManager->findBreakpoint(nextAddress))
             return;
-        m_breakpointManager.setBreakpoint(nextAddress, Breakpoint(const_cast<uint8_t*>(nextPC), Breakpoint::Type::Step));
+        m_breakpointManager->setBreakpoint(nextAddress, Breakpoint(const_cast<uint8_t*>(nextPC), Breakpoint::Type::Step));
     };
 
     auto setStepBreakpointAtCaller = [&]() WTF_REQUIRES_LOCK(m_lock) {
         uint8_t* returnPC = nullptr;
         VirtualAddress virtualReturnPC;
-        if (getWasmReturnPC(m_stopReason.callFrame, returnPC, virtualReturnPC))
-            m_breakpointManager.setBreakpoint(virtualReturnPC, Breakpoint(const_cast<uint8_t*>(returnPC), Breakpoint::Type::Step));
+        if (getWasmReturnPC(stopData.callFrame, returnPC, virtualReturnPC))
+            m_breakpointManager->setBreakpoint(virtualReturnPC, Breakpoint(const_cast<uint8_t*>(returnPC), Breakpoint::Type::Step));
     };
 
     auto setStepBreakpointsFromDebugInfo = [&]() WTF_REQUIRES_LOCK(m_lock) {
-        const auto& moduleInfo = m_stopReason.instance->moduleInformation();
-        auto functionIndex = m_stopReason.callee->functionIndex();
-        uint32_t offset = m_stopReason.address.offset();
+        const auto& moduleInfo = stopData.instance->moduleInformation();
+        auto functionIndex = stopData.callee->functionIndex();
+        uint32_t offset = stopData.address.offset();
         const auto* nextInstructions = moduleInfo.debugInfo->ensureFunctionDebugInfo(functionIndex).findNextInstructions(offset);
         RELEASE_ASSERT(nextInstructions, "Didn't find nextInstructions");
-        uint8_t* const basePC = m_stopReason.pc - offset;
+        uint8_t* const basePC = stopData.pc - offset;
         for (uint32_t nextOffset : *nextInstructions)
             setStepBreakpoint(basePC + nextOffset);
     };
 
-    switch (m_stopReason.originalBytecode) {
+    switch (stopData.originalBytecode) {
     case Nop:
     case Drop:
     case Select:
         setStepBreakpoint(currentPC + 1);
         break;
     case End:
-        if (currentPC != m_stopReason.callee->bytecodeEnd()) {
+        if (currentPC != stopData.callee->bytecodeEnd()) {
             setStepBreakpoint(currentPC + 1);
             break;
         }
@@ -265,11 +488,16 @@ void ExecutionHandler::step()
     case Return:
         setStepBreakpointAtCaller();
         break;
+    // Step-into event design: Set event flag and let runtime resolve callee/handler naturally to avoid
+    // duplicating complex resolution logic (call dispatch, exception unwinding). Runtime calls
+    // setStepIntoBreakpointForCall/Throw() with resolved target, minimizing changes to both debugger
+    // and runtime wasm code. However, the introduced two-phase protocol adds coordination complexity.
+    // FIXME: Resolve once in step(), cache for runtime reuse to eliminate two-phase protocol.
     case Throw:
     case Rethrow:
     case ThrowRef:
     case Delegate:
-        m_debugServer.vm()->setStepIntoWasmThrow();
+        state->setStepIntoThrow();
         break;
     case TailCall:
     case TailCallIndirect:
@@ -277,7 +505,7 @@ void ExecutionHandler::step()
         // The tail calls have two debugging behaviors:
         // 2. Step-into: If the callee is a Wasm call.
         // 1. Back to caller: If the callee is a non-Wasm call.
-        m_debugServer.vm()->setStepIntoWasmCall();
+        state->setStepIntoCall();
         setStepBreakpointAtCaller();
         break;
     case Call:
@@ -286,7 +514,7 @@ void ExecutionHandler::step()
         // The calls have two debugging behaviors:
         // 2. Step-into: If the callee is a Wasm call.
         // 1. Step-over: If the callee is a non-Wasm call.
-        m_debugServer.vm()->setStepIntoWasmCall();
+        state->setStepIntoCall();
         [[fallthrough]];
     default: {
         setStepBreakpointsFromDebugInfo();
@@ -294,13 +522,89 @@ void ExecutionHandler::step()
     }
     }
 
-    RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && m_mutatorState == MutatorState::Stopped);
-    m_mutatorContinue.notifyOne();
+    if (state->hasStepIntoEvent()) {
+        m_debuggerState = DebuggerState::StepRequested;
+        m_mutatorContinue.notifyOne(); // Notify to run and set breakpoints if possible.
+        m_debuggerContinue.wait(locker); // Wait for call/throw one-time breakpoint to be registered.
+    }
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Notified code to continue and waiting...");
-    m_debuggerState = DebuggerState::ContinueRequested;
-    m_debuggerContinue.wait(m_lock);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Confirmed that code is running...");
+    // If no one-time breakpoints registered, then resume all.
+    return !m_breakpointManager->hasOneTimeBreakpoints();
+}
+
+void ExecutionHandler::setStepIntoBreakpointForCall(VM& callerVM, CalleeBits boxedCallee, JSWebAssemblyInstance* calleeInstance)
+{
+    if (!callerVM.debugState()->takeStepIntoCall())
+        return;
+
+    [&]() {
+        Locker locker { m_lock };
+
+        RELEASE_ASSERT(Thread::currentSingleton().uid() == mutatorThreadId(*m_vm));
+        RELEASE_ASSERT(m_vm == &callerVM);
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Code][StepIntoEvent] Start for call");
+        RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
+
+        if (!calleeInstance)
+            return;
+        if (!boxedCallee.isNativeCallee())
+            return;
+        RefPtr wasmCallee = uncheckedDowncast<Wasm::Callee>(boxedCallee.asNativeCallee());
+        if (wasmCallee->compilationMode() != Wasm::CompilationMode::IPIntMode)
+            return;
+
+        // Set breakpoint at the callee's entry point.
+        // Use calleeInstance (not caller's instance) because:
+        // - Cross-instance calls: Callee may be in a different Wasm module instance
+        RELEASE_ASSERT(&calleeInstance->vm() == &callerVM);
+        setBreakpointAtEntry(calleeInstance, uncheckedDowncast<IPIntCallee>(wasmCallee.get()), Breakpoint::Type::Step);
+    }();
+
+    stopTheWorld(callerVM, StopTheWorldEvent::StepIntoSiteReached);
+}
+
+void ExecutionHandler::setStepIntoBreakpointForThrow(VM& throwVM)
+{
+    if (!throwVM.debugState()->takeStepIntoThrow())
+        return;
+
+    [&]() {
+        Locker locker { m_lock };
+
+        RELEASE_ASSERT(Thread::currentSingleton().uid() == mutatorThreadId(*m_vm));
+        RELEASE_ASSERT(m_vm == &throwVM);
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Code][StepIntoEvent] Start for throw");
+        RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
+
+        if (!throwVM.callFrameForCatch)
+            return;
+        if (!throwVM.callFrameForCatch->callee().isNativeCallee())
+            return;
+        RefPtr wasmCallee = uncheckedDowncast<Wasm::Callee>(throwVM.callFrameForCatch->callee().asNativeCallee());
+        if (wasmCallee->compilationMode() != Wasm::CompilationMode::IPIntMode)
+            return;
+
+        RefPtr catchCallee = uncheckedDowncast<IPIntCallee>(wasmCallee.get());
+        ASSERT(std::holds_alternative<uintptr_t>(throwVM.targetInterpreterPCForThrow));
+        uintptr_t handlerOffset = std::get<uintptr_t>(throwVM.targetInterpreterPCForThrow);
+        const uint8_t* handlerPC = catchCallee->bytecode() + handlerOffset;
+
+        if (*handlerPC == static_cast<uint8_t>(Wasm::OpType::TryTable) && throwVM.targetInterpreterMetadataPCForThrow) {
+            const uint8_t* metadataPtr = catchCallee->metadata() + throwVM.targetInterpreterMetadataPCForThrow;
+            metadataPtr += sizeof(IPInt::CatchMetadata);
+            const IPInt::BlockMetadata* blockMetadata = reinterpret_cast<const IPInt::BlockMetadata*>(metadataPtr);
+            handlerPC = handlerPC + blockMetadata->deltaPC;
+        }
+
+        // Set breakpoint at the exception handler.
+        // Use catchInstance (from callFrameForCatch, not thrower's instance) because:
+        // - Cross-instance throws: Exception may be caught in a different Wasm module instance
+        JSWebAssemblyInstance* catchInstance = throwVM.callFrameForCatch->wasmInstance();
+        RELEASE_ASSERT(&catchInstance->vm() == &throwVM);
+        setBreakpointAtPC(catchInstance, catchCallee->functionIndex(), Breakpoint::Type::Step, handlerPC);
+    }();
+
+    stopTheWorld(throwVM, StopTheWorldEvent::StepIntoSiteReached);
 }
 
 void ExecutionHandler::setBreakpointAtEntry(JSWebAssemblyInstance* instance, IPIntCallee* callee, Breakpoint::Type type)
@@ -312,9 +616,9 @@ void ExecutionHandler::setBreakpointAtPC(JSWebAssemblyInstance* instance, Functi
 {
     RELEASE_ASSERT(pc);
     VirtualAddress address = VirtualAddress::toVirtual(instance, functionIndex, pc);
-    if (m_breakpointManager.findBreakpoint(address))
+    if (m_breakpointManager->findBreakpoint(address))
         return;
-    m_breakpointManager.setBreakpoint(address, Breakpoint(const_cast<uint8_t*>(pc), type));
+    m_breakpointManager->setBreakpoint(address, Breakpoint(const_cast<uint8_t*>(pc), type));
 }
 
 void ExecutionHandler::setBreakpoint(StringView packet)
@@ -356,7 +660,7 @@ void ExecutionHandler::setBreakpoint(StringView packet)
         return;
     }
 
-    if (m_breakpointManager.findBreakpoint(address)) {
+    if (m_breakpointManager->findBreakpoint(address)) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] Breakpoint already exists at address: ", address);
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
@@ -369,7 +673,7 @@ void ExecutionHandler::setBreakpoint(StringView packet)
         return;
     }
 
-    m_breakpointManager.setBreakpoint(address, Breakpoint(pc, Breakpoint::Type::Regular));
+    m_breakpointManager->setBreakpoint(address, Breakpoint(pc, Breakpoint::Type::Regular));
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][SetBreakpoint] Successfully set breakpoint at ", address, " (physical: ", RawPointer(pc), ", original: 0x", hex(*pc, 2, Lowercase), ")");
     sendReplyOK();
 }
@@ -406,7 +710,7 @@ void ExecutionHandler::removeBreakpoint(StringView packet)
     }
 
     // Delegate to breakpoint manager
-    if (m_breakpointManager.removeBreakpoint(address)) {
+    if (m_breakpointManager->removeBreakpoint(address)) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Breakpoint removed successfully from ", address);
         sendReplyOK();
     } else {
@@ -417,35 +721,113 @@ void ExecutionHandler::removeBreakpoint(StringView packet)
 
 void ExecutionHandler::handleThreadStopInfo(StringView packet)
 {
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling qThreadStopInfo: ", packet);
+    // Format: qThreadStopInfo<thread-id-in-hex>
+    // Parse the thread ID
+    StringView threadIdStr = packet.substring(strlen("qThreadStopInfo"));
+    uint64_t requestedThreadId = parseHex(threadIdStr);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling qThreadStopInfo for thread: ", requestedThreadId);
+
     Locker locker { m_lock };
-    sendStopReply(locker);
+    sendStopReplyForThread(locker, requestedThreadId);
+}
+
+static uint64_t getStopPC(const DebugState& state)
+{
+    if (state.atBreakpoint() || state.atPrologue())
+        return state.stopData->address;
+    return VirtualAddress(VirtualAddress::INVALID_BASE).value();
+}
+
+static String getThreadName(const DebugState& state, uint64_t threadId)
+{
+    StringView stateName;
+    if (state.atBreakpoint())
+        stateName = "wasm-call"_s;
+    else if (state.atPrologue())
+        stateName = "wasm-prologue"_s;
+    else {
+        RELEASE_ASSERT(state.atSystemCall());
+        stateName = "system-call"_s;
+    }
+    return makeString(stateName, " tid:0x"_s, hex(threadId, Lowercase));
+}
+
+struct ThreadInfo {
+    uint64_t threadId;
+    uint64_t pc;
+    String name;
+    StringView stopReason;
+};
+
+static Vector<ThreadInfo> collectAllStoppedThreads()
+{
+    Vector<ThreadInfo> threads;
+    VMManager::forEachVM([&](VM& vm) {
+        auto* state = vm.debugState();
+        RELEASE_ASSERT(state->isStopped());
+        uint64_t threadId = ExecutionHandler::mutatorThreadId(vm);
+
+        StopData::Code code = state->atSystemCall() ? StopData::Code::Stop : state->stopData->code;
+        auto stopInfo = stopReasonCodeToInfo(code);
+        threads.append({ threadId, getStopPC(*state), getThreadName(*state, threadId), stopInfo.reasonSuffix });
+        return IterationStatus::Continue;
+    });
+    return threads;
 }
 
 void ExecutionHandler::sendStopReply(AbstractLocker& locker) WTF_REQUIRES_LOCK(m_lock)
 {
-    RELEASE_ASSERT(m_mutatorState == MutatorState::Stopped && m_stopReason.isValid());
-    uint64_t pc = m_stopReason.address;
+    sendStopReplyForThread(locker, mutatorThreadId(*m_vm));
+}
 
-    auto stopInfo = stopReasonCodeToInfo(m_stopReason.code);
-    String reasonString = stopInfo.reasonString;
-    StringView reasonSuffix = stopInfo.reasonSuffix;
-    String pcBytes = toNativeEndianHex(pc);
-    uint64_t mutatorThreadId = m_debugServer.mutatorThreadId();
+void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t requestedThreadId) WTF_REQUIRES_LOCK(m_lock)
+{
+    VM* targetVM = findVM(requestedThreadId);
+    DebugState* targetState = targetVM->debugState();
+    if (!targetVM || !targetState) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", requestedThreadId, " not found");
+        sendErrorReply(ProtocolError::InvalidAddress);
+        return;
+    }
 
-    String stopReplyStr = makeString(
-        reasonString,
-        "thread:"_s, hex(mutatorThreadId, Lowercase),
-        ";name:JSC-mutator;threads:"_s, hex(mutatorThreadId, Lowercase),
-        ";thread-pcs:"_s, hex(pc, 16, Lowercase),
-        ";00:"_s,
-        pcBytes,
-        ";reason:"_s,
-        reasonSuffix,
-        ";"_s);
+    RELEASE_ASSERT(targetState->isStopped());
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending stop reply: ", stopReplyStr);
-    sendReplyImpl(locker, stopReplyStr);
+    // Gather information for the requested thread
+    Vector<ThreadInfo> allThreads = collectAllStoppedThreads();
+
+    // FIXME: Use SIGSTOP for interrupts, breakpoint code for breakpoints. Passive thread handling will be done in a separate patch.
+    StopData::Code code = targetState->atBreakpoint() ? targetState->stopData->code : StopData::Code::Stop;
+    auto stopInfo = stopReasonCodeToInfo(code);
+
+    // Build packet with requested thread as the target
+    StringBuilder reply;
+    reply.append(stopInfo.reasonString);
+    reply.append("thread:"_s, hex(requestedThreadId, Lowercase), ';');
+    reply.append("name:"_s, getThreadName(*targetState, requestedThreadId), ';');
+
+    // All thread IDs
+    reply.append("threads:"_s);
+    for (size_t i = 0; i < allThreads.size(); ++i) {
+        if (i > 0)
+            reply.append(',');
+        reply.append(hex(allThreads[i].threadId, Lowercase));
+    }
+    reply.append(';');
+
+    // All thread PCs
+    reply.append("thread-pcs:"_s);
+    for (size_t i = 0; i < allThreads.size(); ++i) {
+        if (i > 0)
+            reply.append(',');
+        reply.append(hex(allThreads[i].pc, 16, Lowercase));
+    }
+    reply.append(';');
+
+    reply.append("00:"_s, toNativeEndianHex(getStopPC(*targetState)), ';');
+    reply.append("reason:"_s, stopInfo.reasonSuffix, ';');
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending stop reply: target thread="_s, hex(requestedThreadId), ", total threads="_s, allThreads.size(), ", packet="_s, reply.toString());
+    sendReplyImpl(locker, reply.toString());
 }
 
 void ExecutionHandler::sendReply(StringView reply)
@@ -489,22 +871,96 @@ void ExecutionHandler::reset()
     Locker locker { m_lock };
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling client disconnection in ExecutionHandler");
 
-    m_debuggerState = DebuggerState::Replied;
+    if (m_vm && targetState()->isStopped())
+        resumeImpl(locker);
 
-    if (m_mutatorState == MutatorState::Stopped) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Resuming stopped WebAssembly execution due to client disconnection");
-        m_mutatorState = MutatorState::Running;
-        m_stopReason.reset();
-        m_mutatorContinue.notifyAll();
-    }
+    m_breakpointManager->clearAllBreakpoints();
+    m_debuggerState = DebuggerState::Replied;
+    takeAwaitingResumeNotification();
+    m_vm = nullptr;
 }
 
 void ExecutionHandler::sendReplyOK() { m_debugServer.sendReplyOK(); }
 void ExecutionHandler::sendErrorReply(ProtocolError error) { m_debugServer.sendErrorReply(error); }
-ExecutionHandler::StopReason ExecutionHandler::stopReason() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+
+uint64_t ExecutionHandler::mutatorThreadId(const VM& vm)
 {
-    RELEASE_ASSERT(m_stopReason.isValid());
-    return m_stopReason;
+    auto ownerThread = vm.ownerThread();
+    RELEASE_ASSERT(ownerThread && *ownerThread);
+    return (*ownerThread)->uid();
+}
+
+DebugState* ExecutionHandler::targetState() const { return m_vm->debugState(); }
+
+DebugState* ExecutionHandler::targetStateSafe() const
+{
+    VM* vm = this->vm();
+    RELEASE_ASSERT(vm);
+    return vm->debugState();
+}
+
+bool ExecutionHandler::hasBreakpoints() const
+{
+    return m_breakpointManager && m_breakpointManager->hasBreakpoints();
+}
+
+String ExecutionHandler::callStackStringFor(uint64_t requestedThreadId)
+{
+    // Find the VM for the requested thread
+    VM* targetVM = vm();
+    if (mutatorThreadId(*targetVM) != requestedThreadId) {
+        targetVM = nullptr;
+        VMManager::forEachVM([&](VM& vm) {
+            auto ownerThread = vm.ownerThread();
+            if (ownerThread && *ownerThread && (*ownerThread)->uid() == requestedThreadId) {
+                targetVM = &vm;
+                return IterationStatus::Done;
+            }
+            return IterationStatus::Continue;
+        });
+    }
+
+    if (!targetVM) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: thread ", requestedThreadId, " not found");
+        return String();
+    }
+
+    auto* state = targetVM->debugState();
+    if (!state->isStopped()) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: thread ", requestedThreadId, " not stopped");
+        return String();
+    }
+
+    // For threads stopped at breakpoint with full call stack, walk the stack
+    if (state->atBreakpoint()) {
+        auto& stopData = *state->stopData;
+        RELEASE_ASSERT(stopData.callFrame);
+
+        Vector<VirtualAddress> frameAddresses;
+        frameAddresses.append(stopData.address);
+        CallFrame* currentFrame = stopData.callFrame;
+        uint8_t* returnPC = nullptr;
+        VirtualAddress virtualReturnPC;
+        unsigned frameIndex = 0;
+
+        // FIXME: Only supports consecutive wasm->wasm calls. Need to support interleaved wasm<->js calls.
+        while (getWasmReturnPC(currentFrame, returnPC, virtualReturnPC) && frameIndex < 100) {
+            frameAddresses.append(virtualReturnPC);
+            currentFrame = currentFrame->callerFrame();
+            frameIndex++;
+        }
+
+        StringBuilder result;
+        for (VirtualAddress address : frameAddresses)
+            result.append(toNativeEndianHex(address));
+
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: collected ", frameAddresses.size(), " frames");
+        return result.toString();
+    }
+
+    // For other stop states (prologue or system call), return just the current PC
+    uint64_t pc = getStopPC(*state);
+    return toNativeEndianHex(pc);
 }
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -27,7 +27,10 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "StopTheWorldCallback.h"
+#include "WasmDebugServer.h"
 #include "WasmDebugServerUtilities.h"
+#include "WasmModuleManager.h"
 #include "WasmVirtualAddress.h"
 
 #include <wtf/Condition.h>
@@ -39,8 +42,10 @@
 
 namespace JSC {
 
+class CalleeBits;
 class CallFrame;
 class JSWebAssemblyInstance;
+class VM;
 
 namespace IPInt {
 struct IPIntLocal;
@@ -49,151 +54,122 @@ struct IPIntStackEntry;
 
 namespace Wasm {
 
-class DebugServer;
 class IPIntCallee;
-class ModuleManager;
 class BreakpointManager;
 
 class ExecutionHandler {
     WTF_MAKE_TZONE_ALLOCATED(ExecutionHandler);
 
 public:
-    ExecutionHandler(DebugServer&, ModuleManager&, BreakpointManager&);
+    ExecutionHandler(DebugServer&, ModuleManager&);
 
-    bool stopCode(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* = nullptr, IPInt::IPIntStackEntry* = nullptr);
+    enum class ResumeMode : uint8_t {
+        One, // Resume only target VM
+        All, // Resume all VMs
+        Switch, // Switch to target VM
+    };
 
-    void resume();
-    void step();
-    void interrupt();
+    ResumeMode stopCode(Locker<Lock>&, StopTheWorldEvent) WTF_REQUIRES_LOCK(m_lock);
+    bool hitBreakpoint(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* = nullptr, IPInt::IPIntStackEntry* = nullptr);
+
+    JS_EXPORT_PRIVATE void resume();
+    JS_EXPORT_PRIVATE void step();
+    JS_EXPORT_PRIVATE void interrupt();
     void handleThreadStopInfo(StringView packet);
-    void reset();
+    String callStackStringFor(uint64_t threadId);
+    JS_EXPORT_PRIVATE void reset();
 
-    void setBreakpointAtEntry(JSWebAssemblyInstance*, IPIntCallee*, Breakpoint::Type);
+    JS_EXPORT_PRIVATE void setBreakpointAtEntry(JSWebAssemblyInstance*, IPIntCallee*, Breakpoint::Type);
     void setBreakpointAtPC(JSWebAssemblyInstance*, FunctionCodeIndex, Breakpoint::Type, const uint8_t* pc);
     void setBreakpoint(StringView packet);
     void removeBreakpoint(StringView packet);
+    JS_EXPORT_PRIVATE BreakpointManager* breakpointManager() { return m_breakpointManager.get(); };
 
-    struct StopReason {
-        // GDB Remote Protocol stop reason codes mapped to GDB Remote Protocol semantics
-        // Reference: https://sourceware.org/gdb/onlinedocs/gdb/Stop-Reply-Packets.html
-        enum class Code : uint8_t {
-            Unknown = 0,
-            Signal, // SIGINT - Interrupt signal (Ctrl+C) - reason:signal
-            Trace, // SIGTRAP - Single step/trace completion - reason:trace
-            Breakpoint // Custom - Breakpoint hit - reason:breakpoint (distinct from trace)
-        };
+    void setStepIntoBreakpointForCall(VM&, CalleeBits, JSWebAssemblyInstance*);
+    void setStepIntoBreakpointForThrow(VM&);
 
-        StopReason() = default;
-        StopReason(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
-            : address(address)
-            , originalBytecode(originalBytecode)
-            , pc(pc)
-            , mc(mc)
-            , locals(locals)
-            , stack(stack)
-            , callee(callee)
-            , instance(instance)
-            , callFrame(callFrame)
-        {
-            setCode(type);
-        }
+    bool hasBreakpoints() const;
 
-        bool isValid() const { return code != Code::Unknown; }
+    VM* vm() const
+    {
+        Locker locker { m_lock };
+        return m_vm;
+    }
 
-        void setCode(Breakpoint::Type type)
-        {
-            switch (type) {
-            case Breakpoint::Type::Interrupt:
-                code = Code::Signal;
-                break;
-            case Breakpoint::Type::Step:
-                code = Code::Trace;
-                break;
-            case Breakpoint::Type::Regular:
-                code = Code::Breakpoint;
-                break;
-            default:
-                break;
-            }
-        }
+    JS_EXPORT_PRIVATE static uint64_t mutatorThreadId(const VM&);
+    uint64_t debugServerThreadId() const
+    {
+        RELEASE_ASSERT(m_debugServerThreadId.has_value());
+        return *m_debugServerThreadId;
+    }
+    void setDebugServerThreadId(uint64_t threadId) { m_debugServerThreadId = threadId; }
 
-        void reset()
-        {
-            code = Code::Unknown;
-            address = VirtualAddress();
-            originalBytecode = 0;
-            pc = nullptr;
-            mc = nullptr;
-            locals = nullptr;
-            stack = nullptr;
-            callee = nullptr;
-            instance = nullptr;
-            callFrame = nullptr;
-        }
+    JS_EXPORT_PRIVATE DebugState* targetState() const WTF_REQUIRES_LOCK(m_lock);
+    JS_EXPORT_PRIVATE DebugState* targetStateSafe() const;
 
-        void dump(PrintStream& out) const
-        {
-            out.print("StopReason(Code:", code);
-            out.print(", address:", address);
-            out.print(", originalBytecode:", originalBytecode);
-            out.print(", pc:", RawPointer(pc));
-            out.print(", mc:", RawPointer(mc));
-            out.print(", locals:", RawPointer(locals));
-            out.print(", stack:", RawPointer(stack));
-            out.print(", callee:", RawPointer(callee.get()));
-            out.print(", instance:", RawPointer(instance));
-            out.print(", callFrame:", RawPointer(callFrame), ")");
-        }
+    JS_EXPORT_PRIVATE void switchTarget(uint64_t threadId);
 
-        Code code { Code::Unknown };
-        VirtualAddress address { VirtualAddress() };
-        uint8_t originalBytecode { 0 };
-        uint8_t* pc { nullptr };
-        uint8_t* mc { nullptr };
-        IPInt::IPIntLocal* locals { nullptr };
-        IPInt::IPIntStackEntry* stack { nullptr };
-        RefPtr<IPIntCallee> callee;
-        JSWebAssemblyInstance* instance { nullptr };
-        CallFrame* callFrame { nullptr };
-    };
-
-    StopReason stopReason() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
+    StopTheWorldStatus handleStopTheWorld(VM&, StopTheWorldEvent);
+    void handlePostResume();
+    bool takeAwaitingResumeNotification() WTF_REQUIRES_LOCK(m_lock) { return std::exchange(m_awaitingResumeNotification, false); }
 
 private:
     friend class DebugServer;
 
     enum class DebuggerState : uint8_t {
-        Replied, // Received LLDB message replied.
-        StopRequested, // Requested mutator to stop.
-        ContinueRequested, // Requested mutator to continue.
+        Replied, // Sent reply to LLDB, waiting for next command.
+        InterruptRequested, // Interrupt all mutators requested.
+        ContinueRequested, // Resume all mutators requested.
+        StepRequested, // Step target mutator requested.
+        SwitchRequested, // Switch to target mutator requested.
     };
 
-    enum class MutatorState : uint8_t {
-        Running,
-        Stopped,
-    };
+    void stopTheWorld(VM&, StopTheWorldEvent);
 
-    void stopImpl(StopReason&&);
+    ResumeMode stopImpl(Locker<Lock>&) WTF_REQUIRES_LOCK(m_lock);
+
+    void resumeImpl(Locker<Lock>&) WTF_REQUIRES_LOCK(m_lock);
+
+    bool stepAtBreakpoint(Locker<Lock>&, DebugState*) WTF_REQUIRES_LOCK(m_lock);
 
     void sendStopReply(AbstractLocker&);
+    void sendStopReplyForThread(AbstractLocker&, uint64_t threadId);
     void sendReplyOK();
     void sendReply(StringView reply);
     void sendReplyImpl(AbstractLocker&, StringView reply);
     void sendErrorReply(ProtocolError);
-    void handleClientDisconnectionLocked() WTF_REQUIRES_LOCK(m_lock);
+
+    void selectTargetVMIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(m_lock);
+    void markVMStates(VM* targetVM) WTF_REQUIRES_LOCK(m_lock);
+    void clearOtherVMStopData(VM* targetVM) WTF_REQUIRES_LOCK(m_lock);
+
+    bool requiresStopConfirmation() const WTF_REQUIRES_LOCK(m_lock)
+    {
+        switch (m_debuggerState) {
+        case DebuggerState::InterruptRequested:
+        case DebuggerState::StepRequested:
+        case DebuggerState::SwitchRequested:
+            return true;
+        default:
+            return false;
+        }
+    }
 
     DebugServer& m_debugServer;
     ModuleManager& m_moduleManager;
-    BreakpointManager& m_breakpointManager;
+    std::unique_ptr<BreakpointManager> m_breakpointManager;
 
-    Lock m_lock;
+    mutable Lock m_lock;
     Condition m_debuggerContinue;
     Condition m_mutatorContinue;
     DebuggerState m_debuggerState WTF_GUARDED_BY_LOCK(m_lock) { DebuggerState::Replied };
-    MutatorState m_mutatorState WTF_GUARDED_BY_LOCK(m_lock) { MutatorState::Running };
-
-    StopReason WTF_GUARDED_BY_LOCK(m_lock) m_stopReason;
+    bool m_awaitingResumeNotification WTF_GUARDED_BY_LOCK(m_lock) { false };
+    VM* m_vm WTF_GUARDED_BY_LOCK(m_lock) { nullptr }; // target mutator
+    std::optional<uint64_t> m_debugServerThreadId;
 };
+
+StopTheWorldStatus wasmDebuggerOnStopCallback(VM&, StopTheWorldEvent);
+void wasmDebuggerOnResumeCallback();
 
 } // namespace Wasm
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
@@ -31,6 +31,7 @@
 #include "WasmVirtualAddress.h"
 #include "WeakGCMap.h"
 #include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -50,31 +51,30 @@ class ModuleManager {
     WTF_MAKE_TZONE_ALLOCATED(ModuleManager);
 
 public:
-    JS_EXPORT_PRIVATE ModuleManager(VM&);
-    JS_EXPORT_PRIVATE ~ModuleManager();
+    ModuleManager() = default;
+    ~ModuleManager() = default;
 
     JS_EXPORT_PRIVATE uint32_t registerModule(Module&);
     JS_EXPORT_PRIVATE void unregisterModule(Module&);
     JS_EXPORT_PRIVATE Module* module(uint32_t moduleId) const;
 
     JS_EXPORT_PRIVATE uint32_t registerInstance(JSWebAssemblyInstance*);
+    JS_EXPORT_PRIVATE uint32_t unregisterInstance(JSWebAssemblyInstance*);
     JS_EXPORT_PRIVATE JSWebAssemblyInstance* jsInstance(uint32_t instanceId) const;
     JS_EXPORT_PRIVATE uint32_t nextInstanceId() const;
 
     JS_EXPORT_PRIVATE String generateLibrariesXML() const;
 
-    JS_EXPORT_PRIVATE String generateModuleName(VirtualAddress, const RefPtr<Module>&) const;
-
 private:
     using IdToModule = UncheckedKeyHashMap<uint32_t, Module*, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
-    using IdToInstance = WeakGCMap<uint32_t, JSWebAssemblyInstance, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    using IdToInstance = UncheckedKeyHashMap<uint32_t, JSWebAssemblyInstance*, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
-    // No locks needed: mutator thread is suspended during debug operations, preventing concurrent access
-    IdToModule m_moduleIdToModule;
-    IdToInstance m_instanceIdToInstance;
+    mutable Lock m_lock;
+    IdToModule m_moduleIdToModule WTF_GUARDED_BY_LOCK(m_lock);
+    IdToInstance m_instanceIdToInstance WTF_GUARDED_BY_LOCK(m_lock);
 
-    uint32_t m_nextModuleId { 0 };
-    uint32_t m_nextInstanceId { 0 };
+    uint32_t m_nextModuleId WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    uint32_t m_nextInstanceId WTF_GUARDED_BY_LOCK(m_lock) { 0 };
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -37,6 +37,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "Options.h"
 #include "StackVisitor.h"
 #include "VM.h"
+#include "VMManager.h"
 #include "WasmCallee.h"
 #include "WasmDebugServer.h"
 #include "WasmDebugServerUtilities.h"
@@ -209,17 +210,24 @@ bool QueryHandler::handleChunkedLibrariesResponse(size_t offset, size_t maxSize,
 
 String QueryHandler::buildWasmCallStackResponse()
 {
-    auto stopReason = m_debugServer.m_executionHandler->stopReason();
-    RELEASE_ASSERT(stopReason.isValid() && stopReason.callFrame);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: starting manual stack walk from CallFrame ", RawPointer(stopReason.callFrame));
+    auto* state = m_debugServer.execution().targetStateSafe();
+    if (!state->atBreakpoint()) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: not stopped at breakpoint, returning empty");
+        return String();
+    }
+
+    auto& stopData = *state->stopData;
+    RELEASE_ASSERT(stopData.callFrame);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: starting manual stack walk from CallFrame ", RawPointer(stopData.callFrame));
 
     Vector<VirtualAddress> frameAddresses;
-    frameAddresses.append(stopReason.address);
-    CallFrame* currentFrame = stopReason.callFrame;
+    frameAddresses.append(stopData.address);
+    CallFrame* currentFrame = stopData.callFrame;
     uint8_t* returnPC = nullptr;
     VirtualAddress virtualReturnPC;
     unsigned frameIndex = 0;
 
+    // FIXME: Only supports consecutive wasm->wasm calls. Need to support interleaved wasm<->js calls (skipping stubs, including JS frames).
     while (getWasmReturnPC(currentFrame, returnPC, virtualReturnPC) && frameIndex < 100) {
         frameAddresses.append(virtualReturnPC);
         currentFrame = currentFrame->callerFrame();
@@ -292,7 +300,7 @@ void QueryHandler::handleThreadStopInfo(StringView packet)
     // WebAssembly Context: Provide stop reason for WASM thread
     // Handled by execution handler for proper thread state management
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling qThreadStopInfo for frame variable support");
-    m_debugServer.m_executionHandler->handleThreadStopInfo(packet);
+    m_debugServer.execution().handleThreadStopInfo(packet);
 }
 
 void QueryHandler::handleLibrariesRead(StringView packet)
@@ -334,15 +342,17 @@ void QueryHandler::handleWasmCallStack(StringView packet)
     }
 
     StringView threadIdStr = strings[1];
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmCallStack thread ID: ", threadIdStr);
+    uint64_t requestedThreadId = parseHex(threadIdStr);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmCallStack thread ID: ", requestedThreadId);
 
-    uint64_t threadId = parseHex(threadIdStr);
-    uint64_t mutatorThreadId = m_debugServer.mutatorThreadId();
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Parsed qWasmCallStack thread ID: ", threadId, ", mutator ID: ", RawPointer((void*)mutatorThreadId));
-
-    RELEASE_ASSERT(threadId == mutatorThreadId);
-    String response = buildWasmCallStackResponse();
+    String response = m_debugServer.execution().callStackStringFor(requestedThreadId);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmCallStack response: ", response);
+
+    if (response.isEmpty()) {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+
     m_debugServer.sendReply(response);
 }
 
@@ -383,12 +393,18 @@ void QueryHandler::handleWasmLocal(StringView packet)
         return;
     }
 
-    auto stopReason = m_debugServer.m_executionHandler->stopReason();
-    auto functionIndex = stopReason.callee->functionIndex();
-    const auto& moduleInfo = stopReason.instance->module().moduleInformation();
+    auto* state = m_debugServer.execution().targetStateSafe();
+    if (!state->atBreakpoint()) {
+        m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
+        return;
+    }
+
+    auto& stopData = *state->stopData;
+    auto functionIndex = stopData.callee->functionIndex();
+    const auto& moduleInfo = stopData.instance->module().moduleInformation();
     const Vector<Type>& localTypes = moduleInfo.debugInfo->ensureFunctionDebugInfo(functionIndex).locals;
 
-    IPInt::IPIntLocal& local = stopReason.locals[localIndex];
+    IPInt::IPIntLocal& local = stopData.locals[localIndex];
     Type localType = localTypes[localIndex];
     logWasmLocalValue(localIndex, local, localType);
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
@@ -135,7 +135,7 @@ public:
 
     operator uint64_t() const { return m_value; }
 
-    void dump(PrintStream&) const;
+    JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 
 private:
     static uint64_t encode(Type type, uint32_t id, uint32_t offset)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -1,0 +1,509 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExecutionHandlerTest.h"
+
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
+
+#include "ExecutionHandlerTestSupport.h"
+#include "JSWebAssemblyInstance.h"
+#include "TestScripts.h"
+#include "VM.h"
+#include "VMManager.h"
+#include "WasmBreakpointManager.h"
+#include "WasmCalleeGroup.h"
+#include "WasmDebugServer.h"
+#include "WasmDebugServerUtilities.h"
+#include "WasmExecutionHandler.h"
+#include "WasmModule.h"
+#include "WasmModuleInformation.h"
+#include "WasmModuleManager.h"
+#include <wtf/MonotonicTime.h>
+#include <wtf/Seconds.h>
+#include <wtf/Threading.h>
+#include <wtf/Vector.h>
+
+namespace ExecutionHandlerTest {
+
+using ExecutionHandlerTestSupport::defaultTimeoutSeconds;
+using ExecutionHandlerTestSupport::setupTestEnvironment;
+using ExecutionHandlerTestSupport::verboseLogging;
+using ExecutionHandlerTestSupport::waitForCondition;
+using ExecutionHandlerTestSupport::workerThreadTask;
+using JSC::JSWebAssemblyInstance;
+using JSC::VM;
+using JSC::VMManager;
+using JSC::Wasm::Breakpoint;
+using JSC::Wasm::CalleeGroup;
+using JSC::Wasm::DebugServer;
+using JSC::Wasm::DebugState;
+using JSC::Wasm::ExecutionHandler;
+using JSC::Wasm::FunctionSpaceIndex;
+using JSC::Wasm::ModuleManager;
+using TestScripts::TestScript;
+
+// ========== Test runtime state ==========
+
+static constexpr unsigned RAPID_CYCLES_COUNT = 1000;
+static constexpr unsigned CONTEXT_SWITCH_MULTIPLIER = 1000;
+static constexpr unsigned BREAKPOINT_CONTINUE_CYCLES_COUNT = 1000;
+static constexpr unsigned SINGLE_STEPPING_CYCLES_COUNT = 1000;
+static constexpr ASCIILiteral WORKER_THREAD_NAME = "WasmStressTest"_s;
+
+static int failuresFound = 0;
+static DebugServer* debugServer = nullptr;
+static ExecutionHandler* executionHandler = nullptr;
+static const TestScript* currentScript = nullptr;
+bool doneTesting = false;
+
+#define VLOG(...) dataLogLnIf(verboseLogging, __VA_ARGS__)
+#define TEST_LOG(...) dataLogLn(__VA_ARGS__)
+
+#define CHECK(condition, ...) \
+    do { \
+        if (!(condition)) { \
+            dataLogLn("FAIL: ", #condition, ": ", __VA_ARGS__); \
+            dataLogLn("    @ " __FILE__, ":", __LINE__); \
+            CRASH(); \
+        } \
+    } while (false)
+
+static void waitForConditionAndCheck(const char* errorMessage, std::function<bool()> predicate)
+{
+    bool result = waitForCondition(predicate);
+    CHECK(result, errorMessage);
+}
+
+// ========== HELPER FUNCTIONS ==========
+
+static void interruptAndWaitForStop(const char* errorMessage)
+{
+    VLOG("Interrupting VMs...");
+    executionHandler->interrupt();
+    waitForConditionAndCheck(errorMessage, [&]() {
+        auto info = VMManager::info();
+        return info.worldMode == VMManager::Mode::Stopped && info.targetVM->debugState()->isStopped();
+    });
+}
+
+static unsigned setBreakpointsAtAllFunctionEntries(Breakpoint::Type type)
+{
+    VLOG("Setting breakpoints at all function entries...");
+    unsigned breakpointsSet = 0;
+
+    ModuleManager& moduleManager = debugServer->moduleManager();
+    uint32_t maxInstanceId = moduleManager.nextInstanceId();
+
+    for (uint32_t instanceId = 0; instanceId < maxInstanceId; ++instanceId) {
+        JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
+        if (!instance)
+            continue;
+
+        auto& module = instance->module();
+        auto& moduleInfo = module.moduleInformation();
+        uint32_t internalCount = moduleInfo.internalFunctionCount();
+
+        VLOG("  Instance ", instanceId, ": ", internalCount, " functions");
+
+        for (uint32_t funcIndex = 0; funcIndex < internalCount; ++funcIndex) {
+            FunctionSpaceIndex spaceIndex = moduleInfo.toSpaceIndex(JSC::Wasm::FunctionCodeIndex(funcIndex));
+            auto callee = instance->calleeGroup()->ipintCalleeFromFunctionIndexSpace(spaceIndex);
+            executionHandler->setBreakpointAtEntry(instance, callee.ptr(), type);
+            breakpointsSet++;
+        }
+    }
+
+    VLOG("Set ", breakpointsSet, " breakpoints total");
+    return breakpointsSet;
+}
+
+static void clearBreakpointsAndResume(const char* errorMessage)
+{
+    executionHandler->breakpointManager()->clearAllBreakpoints();
+    executionHandler->resume();
+    waitForConditionAndCheck(errorMessage, [&]() {
+        return VMManager::info().worldMode == VMManager::Mode::RunAll;
+    });
+}
+
+// ========== BASIC TESTS ==========
+
+static void testInterruptAndResume()
+{
+    TEST_LOG("\n=== Interrupt and Resume ===");
+
+    VLOG("Initial state: ", VMManager::info());
+
+    interruptAndWaitForStop("VMs did not stop after interrupt");
+
+    VLOG("After interrupt: ", VMManager::info());
+    CHECK(executionHandler->vm(), "Should have target VM");
+
+    VLOG("Calling resume()...");
+    executionHandler->resume();
+
+    waitForConditionAndCheck("VMs did not resume", [&]() {
+        return VMManager::info().worldMode == VMManager::Mode::RunAll;
+    });
+    VLOG("After resume: ", VMManager::info());
+
+    TEST_LOG(!failuresFound ? "PASS" : "FAIL");
+}
+
+static void testRapidInterruptResumeCycles()
+{
+    TEST_LOG("\n=== Rapid Interrupt/Resume Cycles ===");
+
+    int initialFailures = failuresFound;
+
+    for (unsigned i = 0; i < RAPID_CYCLES_COUNT; ++i) {
+        VLOG("Cycle ", i);
+
+        executionHandler->interrupt();
+        executionHandler->resume();
+    }
+
+    waitForConditionAndCheck("VMs did not resume after rapid cycles", [&]() {
+        return VMManager::info().worldMode == VMManager::Mode::RunAll;
+    });
+    auto info = VMManager::info();
+    CHECK(info.worldMode == VMManager::Mode::RunAll, "Should be running after cycles");
+
+    TEST_LOG(failuresFound == initialFailures ? "PASS" : "FAIL");
+}
+
+static void testVMContextSwitching()
+{
+    TEST_LOG("\n=== VM Context Switching ===");
+
+    int initialFailures = failuresFound;
+
+    interruptAndWaitForStop("VMs did not stop for context switching");
+
+    VM* firstTarget = executionHandler->vm();
+    CHECK(firstTarget, "Should have target VM");
+
+    Vector<VM*> allVMs;
+    VMManager::forEachVM([&](VM& vm) {
+        allVMs.append(&vm);
+        return IterationStatus::Continue;
+    });
+
+    VLOG("Found ", allVMs.size(), " VMs");
+
+    for (unsigned i = 0; i < allVMs.size() * CONTEXT_SWITCH_MULTIPLIER; ++i) {
+        VM* targetVM = allVMs[i % allVMs.size()];
+        uint64_t threadId = ExecutionHandler::mutatorThreadId(*targetVM);
+
+        VLOG("Switching to VM ", RawPointer(targetVM), " thread ", threadId);
+        executionHandler->switchTarget(threadId);
+
+        CHECK(executionHandler->vm() == targetVM, "Switch failed");
+    }
+
+    executionHandler->resume();
+
+    waitForConditionAndCheck("VMs did not resume after context switching", [&]() {
+        return VMManager::info().worldMode == VMManager::Mode::RunAll;
+    });
+
+    TEST_LOG(failuresFound == initialFailures ? "PASS" : "FAIL");
+}
+
+static void testBreakpointContinueCycles()
+{
+    TEST_LOG("\n=== Breakpoint Continue Cycles ===");
+
+    int initialFailures = failuresFound;
+
+    interruptAndWaitForStop("VMs did not stop for setting breakpoints");
+
+    unsigned breakpointsSet = setBreakpointsAtAllFunctionEntries(Breakpoint::Type::Regular);
+    CHECK(breakpointsSet >= currentScript->expectedFunctions, "Should have set at least ", currentScript->expectedFunctions, " breakpoints");
+
+    for (unsigned i = 0; i < BREAKPOINT_CONTINUE_CYCLES_COUNT; ++i) {
+        VLOG("Continue cycle ", i);
+
+        executionHandler->resume();
+
+        waitForConditionAndCheck("VMs did not stop at breakpoint in continue cycle", [&]() {
+            auto info = VMManager::info();
+            bool stopped = info.worldMode == VMManager::Mode::Stopped && info.targetVM->debugState()->isStopped();
+            return stopped;
+        });
+
+        DebugState* state = executionHandler->targetStateSafe();
+        CHECK(state->atBreakpoint(), "Should stop at a breakpoint");
+        VLOG("  Stopped at breakpoint in vm:", RawPointer(executionHandler->vm()));
+    }
+
+    clearBreakpointsAndResume("VMs did not resume after clearing breakpoints");
+
+    TEST_LOG(failuresFound == initialFailures ? "PASS" : "FAIL");
+}
+
+static void testBreakpointSingleStepping()
+{
+    TEST_LOG("\n=== Breakpoint Single Stepping ===");
+
+    int initialFailures = failuresFound;
+
+    // 1. Interrupt to stop all VMs
+    interruptAndWaitForStop("VMs did not stop for stepping test");
+
+    // 2. Set breakpoints at ALL function entries
+    unsigned breakpointsSet = setBreakpointsAtAllFunctionEntries(Breakpoint::Type::Regular);
+    CHECK(breakpointsSet >= currentScript->expectedFunctions, "Should have set at least ", currentScript->expectedFunctions, " breakpoints");
+
+    // 3. Continue - should hit a breakpoint immediately
+    VLOG("Continuing execution (expecting breakpoint hit)...");
+    executionHandler->resume();
+
+    waitForConditionAndCheck("Did not hit breakpoint after resume", [&]() {
+        auto info = VMManager::info();
+        if (info.worldMode != VMManager::Mode::Stopped || !info.targetVM->debugState()->isStopped())
+            return false;
+        DebugState* state = executionHandler->targetStateSafe();
+        return state && state->atBreakpoint();
+    });
+
+    DebugState* state = executionHandler->targetStateSafe();
+    CHECK(state->atBreakpoint(), "Should be at breakpoint");
+
+    // Record initial virtual address
+    CHECK(state->stopData, "Should have stopData");
+    JSC::Wasm::VirtualAddress currentAddress = state->stopData->address;
+    VLOG("Hit breakpoint ", currentAddress);
+
+    // 4. Single-step several times and verify we advance
+    for (unsigned step = 0; step < SINGLE_STEPPING_CYCLES_COUNT; ++step) {
+        VLOG("Step ", step + 1, "/", SINGLE_STEPPING_CYCLES_COUNT);
+
+        // Simulate lldb behavior:
+        // 1. If at Regular breakpoint: remove it, step, then re-insert it
+        // 2. If at one-time breakpoint: just step directly
+        Breakpoint* breakpoint = executionHandler->breakpointManager()->findBreakpoint(currentAddress);
+        Breakpoint breakpointCopy;
+
+        if (breakpoint) {
+            breakpointCopy = *breakpoint;
+            CHECK(breakpoint->type == Breakpoint::Type::Regular, "One-time breakpoints are cleared before stop. So, this must be a regular breakpoint");
+            executionHandler->breakpointManager()->removeBreakpoint(currentAddress);
+        }
+
+        executionHandler->step();
+
+        waitForConditionAndCheck("VMs did not stop at breakpoint in continue cycle", [&]() {
+            auto info = VMManager::info();
+            bool stopped = info.worldMode == VMManager::Mode::Stopped && info.targetVM->debugState()->isStopped();
+            return stopped;
+        });
+
+        if (breakpoint)
+            executionHandler->breakpointManager()->setBreakpoint(currentAddress, WTFMove(breakpointCopy));
+
+        state = executionHandler->targetStateSafe();
+        CHECK(state->atBreakpoint(), "Should be at breakpoint after step");
+
+        JSC::Wasm::VirtualAddress afterStepAddress = state->stopData->address;
+        VLOG("  After step: ", afterStepAddress);
+        CHECK(afterStepAddress != currentAddress, "Virtual address should advance after step");
+
+        currentAddress = afterStepAddress;
+    }
+
+    clearBreakpointsAndResume("VMs did not resume after stepping test");
+
+    TEST_LOG(failuresFound == initialFailures ? "PASS" : "FAIL");
+}
+
+// ========== TEST ORCHESTRATION HELPERS ==========
+
+// Waits for all VMs from previous test to be destroyed before starting next test.
+static void waitForVMCleanupFromPreviousTest()
+{
+    TEST_LOG("Waiting for VMs from previous test to be destroyed...");
+    bool vmsCleanedUp = waitForCondition([&]() {
+        return !VMManager::info().numberOfVMs;
+    });
+    if (!vmsCleanedUp) {
+        TEST_LOG("WARNING: VMs from previous test not cleaned up within timeout");
+        TEST_LOG("Current VM count: ", VMManager::info().numberOfVMs);
+    } else
+        TEST_LOG("All VMs cleaned up successfully");
+}
+
+// Creates worker thread, runs test script, and waits for expected VMs to start.
+// Returns true if VMs started successfully, false on timeout.
+static bool setupScriptAndWaitForVMs(const TestScript& script, unsigned initialVMCount, RefPtr<Thread>& outWorkerThread)
+{
+    TEST_LOG("\nStarting worker thread with ", script.name, "...");
+
+    outWorkerThread = Thread::create(WORKER_THREAD_NAME, [&script] {
+        workerThreadTask(script.scriptGenerator());
+    });
+
+    TEST_LOG("Waiting for ", script.expectedVMs, " NEW VMs to start (total expected: ", initialVMCount + script.expectedVMs, ")...");
+    bool vmsReady = waitForCondition([&]() {
+        auto info = VMManager::info();
+        unsigned currentCount = info.numberOfVMs;
+        VLOG("Current VM count: ", currentCount, ", target: ", initialVMCount + script.expectedVMs);
+        return currentCount >= initialVMCount + script.expectedVMs;
+    });
+
+    if (!vmsReady) {
+        TEST_LOG("FAIL: VMs did not start within timeout for ", script.name);
+        return false;
+    }
+
+    auto info = VMManager::info();
+    TEST_LOG("Multi-VM setup complete: ", info.numberOfVMs, " VMs running");
+    return true;
+}
+
+// Signals worker thread to exit, waits for completion, and resets ExecutionHandler state.
+static void cleanupAfterScript(const TestScript& script, RefPtr<Thread>& workerThread)
+{
+    TEST_LOG("\nCleaning up ", script.name, "...");
+
+    // Signal threads to exit their WASM loops
+    TEST_LOG("Signaling thread to exit...");
+    doneTesting = true;
+
+    // Wait for thread to exit cleanly
+    TEST_LOG("Waiting for thread to join...");
+    workerThread->waitForCompletion();
+
+    // Reset ExecutionHandler state for next test
+    executionHandler->reset();
+
+    // Reset flag for next test script
+    doneTesting = false;
+}
+
+// ========== MAIN TEST RUNNER ==========
+
+static int runTests()
+{
+    TEST_LOG("========================================");
+    TEST_LOG("WASM Debugger Stress Tests");
+    TEST_LOG("Testing ExecutionHandler with Real WASM");
+    TEST_LOG("========================================");
+
+    auto overallStartTime = MonotonicTime::now();
+    int totalFailures = 0;
+
+    // Get all registered test scripts
+    auto scripts = TestScripts::getTestScripts();
+
+    for (const auto& script : scripts) {
+        TEST_LOG("\n");
+        TEST_LOG("==========================================");
+        TEST_LOG("Running tests with script: ", script.name);
+        TEST_LOG(script.description);
+        TEST_LOG("==========================================");
+
+        waitForVMCleanupFromPreviousTest();
+
+        auto scriptStartTime = MonotonicTime::now();
+        failuresFound = 0; // Reset per-script failures
+        currentScript = &script;
+
+        // 1. SETUP with this script
+        setupTestEnvironment(debugServer, executionHandler);
+
+        // Track initial VM count (should be 0 after cleanup)
+        unsigned initialVMCount = VMManager::info().numberOfVMs;
+        TEST_LOG("Initial VM count: ", initialVMCount);
+
+        RefPtr<Thread> workerThread;
+        if (!setupScriptAndWaitForVMs(script, initialVMCount, workerThread)) {
+            totalFailures++;
+            continue; // Skip to next script
+        }
+
+        // 2. RUN ALL TESTS with this script
+        testInterruptAndResume();
+        testRapidInterruptResumeCycles();
+        testVMContextSwitching();
+        testBreakpointContinueCycles();
+        testBreakpointSingleStepping();
+
+        // 3. CLEANUP
+        cleanupAfterScript(script, workerThread);
+
+        auto scriptDuration = MonotonicTime::now() - scriptStartTime;
+
+        // Report per-script results
+        TEST_LOG("------------------------------------------");
+        TEST_LOG("Script ", script.name, ": ",
+            failuresFound ? "FAIL" : "PASS",
+            " (", failuresFound, " failures, ",
+            scriptDuration.millisecondsAs<long>(), " ms)");
+        TEST_LOG("------------------------------------------");
+
+        totalFailures += failuresFound;
+    }
+
+    auto overallDuration = MonotonicTime::now() - overallStartTime;
+
+    TEST_LOG("\n========================================");
+    TEST_LOG(totalFailures ? "FAIL" : "PASS", " - Overall Results");
+    TEST_LOG("Total Time: ", overallDuration.millisecondsAs<long>(), " ms");
+    TEST_LOG("Total Failures: ", totalFailures);
+    TEST_LOG("========================================");
+
+    return totalFailures > 0 ? 1 : 0;
+}
+
+#undef VLOG
+#undef TEST_LOG
+#undef CHECK
+
+} // namespace ExecutionHandlerTest
+
+int testExecutionHandler()
+{
+    return ExecutionHandlerTest::runTests();
+}
+
+#elif ENABLE(WEBASSEMBLY)
+
+int testExecutionHandler()
+{
+    dataLogLn("WASM Debugger Stress Tests SKIPPED (REMOTE_INSPECTOR not enabled)");
+    return 0;
+}
+
+#else
+
+int testExecutionHandler()
+{
+    dataLogLn("WASM Debugger Stress Tests SKIPPED (WEBASSEMBLY not enabled)");
+    return 0;
+}
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.h
@@ -27,51 +27,12 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "WasmDebugServerUtilities.h"
-#include "WasmVirtualAddress.h"
-#include <wtf/Forward.h>
-#include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
-#include <wtf/Lock.h>
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
+namespace ExecutionHandlerTest {
+extern bool doneTesting;
+}
 
-namespace JSC {
-
-class CallFrame;
-class JSWebAssemblyInstance;
-class JSWebAssemblyModule;
-
-namespace Wasm {
-
-class IPIntCallee;
-class ModuleManager;
-
-class BreakpointManager {
-    WTF_MAKE_TZONE_ALLOCATED(BreakpointManager);
-
-public:
-    JS_EXPORT_PRIVATE BreakpointManager() = default;
-    JS_EXPORT_PRIVATE ~BreakpointManager();
-
-    JS_EXPORT_PRIVATE bool hasBreakpoints();
-    JS_EXPORT_PRIVATE bool hasOneTimeBreakpoints();
-
-    JS_EXPORT_PRIVATE Breakpoint* findBreakpoint(VirtualAddress);
-    JS_EXPORT_PRIVATE void setBreakpoint(VirtualAddress, Breakpoint&&);
-    JS_EXPORT_PRIVATE bool removeBreakpoint(VirtualAddress);
-    JS_EXPORT_PRIVATE void clearAllOneTimeBreakpoints();
-    JS_EXPORT_PRIVATE void clearAllBreakpoints();
-
-private:
-    bool removeBreakpointImpl(VirtualAddress) WTF_REQUIRES_LOCK(m_lock);
-
-    mutable Lock m_lock;
-    UncheckedKeyHashMap<VirtualAddress, Breakpoint> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashSet<VirtualAddress> m_oneTimeBreakpoints WTF_GUARDED_BY_LOCK(m_lock);
-};
-
-} // namespace Wasm
-} // namespace JSC
+/* Returns the number of failures encountered. If all tests passed,
+   0 will be returned. */
+int testExecutionHandler();
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExecutionHandlerTestSupport.h"
+
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
+
+#include "Completion.h"
+#include "Exception.h"
+#include "ExecutionHandlerTest.h"
+#include "Identifier.h"
+#include "JSCJSValue.h"
+#include "JSCJSValueInlines.h"
+#include "JSFunction.h"
+#include "JSGlobalObject.h"
+#include "JSLock.h"
+#include "JSObject.h"
+#include "Options.h"
+#include "SourceCode.h"
+#include "SourceOrigin.h"
+#include "Structure.h"
+#include "StructureInlines.h"
+#include "TestScripts.h"
+#include "VM.h"
+#include "WasmDebugServer.h"
+#include "WasmExecutionHandler.h"
+#include <wtf/Condition.h>
+#include <wtf/DataLog.h>
+#include <wtf/Lock.h>
+#include <wtf/MainThread.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/NakedPtr.h>
+#include <wtf/SentinelLinkedList.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
+#include <wtf/URL.h>
+
+namespace ExecutionHandlerTestSupport {
+
+using JSC::Options;
+using JSC::VM;
+using JSC::Wasm::DebugServer;
+using JSC::Wasm::ExecutionHandler;
+
+std::atomic<unsigned> replyCount { 0 };
+
+// ========== Worker/Workers classes (duplicated from jsc.cpp) ==========
+// These are essential for proper VM tracking and $.agent.start() support
+
+class Worker;
+
+class Workers {
+    WTF_MAKE_TZONE_ALLOCATED(Workers);
+    WTF_MAKE_NONCOPYABLE(Workers);
+
+public:
+    Workers() = default;
+    ~Workers() = default;
+
+    static Workers& singleton()
+    {
+        static Workers* workers = new Workers();
+        return *workers;
+    }
+
+    Lock m_lock;
+    Condition m_condition;
+    SentinelLinkedList<Worker, BasicRawSentinelNode<Worker>> m_workers;
+};
+
+class Worker : public BasicRawSentinelNode<Worker> {
+public:
+    Worker(Workers& workers, bool isMain)
+        : m_workers(workers)
+        , m_isMain(isMain)
+    {
+        Locker locker { m_workers.m_lock };
+        m_workers.m_workers.append(this);
+
+        *currentWorker() = this;
+    }
+
+    ~Worker()
+    {
+        Locker locker { m_workers.m_lock };
+        RELEASE_ASSERT(isOnList());
+        remove();
+    }
+
+    bool isMain() const { return m_isMain; }
+
+    static Worker& current()
+    {
+        return **currentWorker();
+    }
+
+private:
+    static ThreadSpecific<Worker*>& currentWorker()
+    {
+        static ThreadSpecific<Worker*>* worker;
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [] {
+            worker = new ThreadSpecific<Worker*>();
+        });
+        return *worker;
+    }
+
+    Workers& m_workers;
+    const bool m_isMain;
+};
+
+// ========== GlobalObject with $.agent.start() support ==========
+
+class TestGlobalObject;
+static JSC_DECLARE_HOST_FUNCTION(functionDollarAgentStart);
+static JSC_DECLARE_HOST_FUNCTION(functionShouldExit);
+
+class TestGlobalObject final : public JSC::JSGlobalObject {
+public:
+    using Base = JSC::JSGlobalObject;
+
+    static TestGlobalObject* create(VM& vm, JSC::Structure* structure)
+    {
+        auto* object = new (NotNull, allocateCell<TestGlobalObject>(vm)) TestGlobalObject(vm, structure);
+        object->finishCreation(vm);
+        return object;
+    }
+
+    static JSC::Structure* createStructure(VM& vm, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, nullptr, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info());
+    }
+
+    DECLARE_INFO;
+
+private:
+    TestGlobalObject(VM& vm, JSC::Structure* structure)
+        : Base(vm, structure, nullptr)
+    {
+    }
+
+    void finishCreation(VM& vm)
+    {
+        Base::finishCreation(vm);
+        JSC::JSObject* dollar = JSC::JSFinalObject::create(vm, JSC::JSFinalObject::createStructure(vm, this, objectPrototype(), 0));
+        JSC::JSObject* agent = JSC::JSFinalObject::create(vm, JSC::JSFinalObject::createStructure(vm, this, objectPrototype(), 0));
+        JSC::Identifier startId = JSC::Identifier::fromString(vm, "start"_s);
+        agent->putDirect(vm, startId, JSC::JSFunction::create(vm, this, 1, "start"_s, functionDollarAgentStart, JSC::ImplementationVisibility::Public));
+        dollar->putDirect(vm, JSC::Identifier::fromString(vm, "agent"_s), agent);
+
+        // Add shouldExit() function to $
+        JSC::Identifier shouldExitId = JSC::Identifier::fromString(vm, "shouldExit"_s);
+        dollar->putDirect(vm, shouldExitId, JSC::JSFunction::create(vm, this, 0, "shouldExit"_s, functionShouldExit, JSC::ImplementationVisibility::Public));
+
+        putDirect(vm, JSC::Identifier::fromString(vm, "$"_s), dollar);
+    }
+};
+
+using namespace JSC;
+const JSC::ClassInfo TestGlobalObject::s_info = { "TestGlobalObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TestGlobalObject) };
+
+static constexpr ASCIILiteral RWI_REPLY_PREFIX = "[RWI] Reply: "_s;
+
+// Spawns a worker thread that creates its own VM and runs the provided script.
+// Follows jsc.cpp's Worker pattern for proper VM lifecycle management.
+JSC_DEFINE_HOST_FUNCTION(functionDollarAgentStart, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (callFrame->argumentCount() < 1)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+
+    JSC::JSValue scriptValue = callFrame->argument(0);
+    String script = scriptValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
+
+    Lock didStartLock;
+    Condition didStartCondition;
+    bool didStart = false;
+
+    Thread::create("JSC Agent"_s, [script = script.isolatedCopy(), &didStartLock, &didStartCondition, &didStart] {
+        Worker worker(Workers::singleton(), false);
+        VM& workerVM = VM::create(JSC::HeapType::Large).leakRef();
+
+        {
+            JSC::JSLockHolder locker(workerVM);
+            auto* workerGlobal = TestGlobalObject::create(workerVM, TestGlobalObject::createStructure(workerVM, JSC::jsNull()));
+
+            {
+                Locker locker { didStartLock };
+                didStart = true;
+                didStartCondition.notifyOne();
+            }
+
+            JSC::SourceOrigin origin(URL({ }, "agent-worker"_s));
+            JSC::SourceCode sourceCode = JSC::makeSource(script, origin, JSC::SourceTaintedOrigin::Untainted);
+
+            NakedPtr<JSC::Exception> exception;
+            JSC::evaluate(workerGlobal, sourceCode, JSC::JSValue(), exception);
+
+            if (exception)
+                dataLogLn("Worker exception: ", exception->value().toWTFString(workerGlobal));
+        }
+
+        {
+            JSC::JSLockHolder locker(workerVM);
+            workerVM.derefSuppressingSaferCPPChecking();
+        }
+    })->detach();
+
+    {
+        Locker locker { didStartLock };
+        while (!didStart)
+            didStartCondition.wait(didStartLock);
+    }
+
+    return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+// Returns true when tests are complete and WASM threads should exit their loops
+JSC_DEFINE_HOST_FUNCTION(functionShouldExit, (JSC::JSGlobalObject*, JSC::CallFrame*))
+{
+    return JSC::JSValue::encode(JSC::jsBoolean(ExecutionHandlerTest::doneTesting));
+}
+
+// ========== Helper functions ==========
+
+bool waitForCondition(std::function<bool()> predicate, Seconds timeout)
+{
+    auto deadline = MonotonicTime::now() + timeout;
+    while (!predicate()) {
+        if (MonotonicTime::now() >= deadline)
+            return false;
+    }
+    return true;
+}
+
+void setupTestEnvironment(DebugServer*& debugServer, ExecutionHandler*& executionHandler)
+{
+    WTF::initializeMainThread();
+    Options::setOptions("--enableWasmDebugger=true");
+
+    debugServer = &DebugServer::singleton();
+    bool started = debugServer->startRWI([](const String& packet) {
+        replyCount++;
+        dataLogLnIf(verboseLogging, RWI_REPLY_PREFIX, packet);
+        return true;
+    });
+
+    RELEASE_ASSERT(started, "Failed to start DebugServer in RWI mode");
+    RELEASE_ASSERT(debugServer->isConnected(), "DebugServer not connected");
+
+    executionHandler = &debugServer->execution();
+    executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());
+
+    dataLogLnIf(verboseLogging, "DebugServer setup complete in RWI mode");
+}
+
+void workerThreadTask(const String& script)
+{
+    dataLogLnIf(verboseLogging, "Worker thread starting");
+
+    Worker worker(Workers::singleton(), false);
+    VM& vm = VM::create(JSC::HeapType::Large).leakRef();
+
+    {
+        JSC::JSLockHolder locker(vm);
+        auto* globalObject = TestGlobalObject::create(vm, TestGlobalObject::createStructure(vm, JSC::jsNull()));
+
+        dataLogLnIf(verboseLogging, "Worker thread created VM ", RawPointer(&vm), " with TestGlobalObject");
+
+        NakedPtr<JSC::Exception> exception;
+        JSC::SourceOrigin origin(URL({ }, "worker"_s));
+        JSC::SourceCode sourceCode = JSC::makeSource(script, origin, JSC::SourceTaintedOrigin::Untainted);
+
+        JSC::evaluate(globalObject, sourceCode, JSC::JSValue(), exception);
+
+        if (exception)
+            dataLogLn("ERROR: Worker thread got exception: ", exception->value().toWTFString(globalObject));
+        else
+            dataLogLnIf(verboseLogging, "Worker thread script completed normally (shouldExit() returned true)");
+    }
+
+    {
+        JSC::JSLockHolder locker(vm);
+        vm.derefSuppressingSaferCPPChecking();
+    }
+
+    dataLogLnIf(verboseLogging, "Worker thread ending");
+}
+
+} // namespace ExecutionHandlerTestSupport
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExecutionHandlerTestSupport::Workers);
+
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -262,7 +262,7 @@ bool waitForCondition(std::function<bool()> predicate, Seconds timeout)
 void setupTestEnvironment(DebugServer*& debugServer, ExecutionHandler*& executionHandler)
 {
     WTF::initializeMainThread();
-    Options::setOptions("--enableWasmDebugger=true");
+    Options::setOptions("--enableWasmDebugger=true --verboseWasmDebugger=true");
 
     debugServer = &DebugServer::singleton();
     bool started = debugServer->startRWI([](const String& packet) {

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.h
@@ -25,53 +25,46 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
 
-#include "WasmDebugServerUtilities.h"
-#include "WasmVirtualAddress.h"
+#include <functional>
 #include <wtf/Forward.h>
-#include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
-#include <wtf/Lock.h>
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/Seconds.h>
 
 namespace JSC {
-
-class CallFrame;
-class JSWebAssemblyInstance;
-class JSWebAssemblyModule;
-
+class VM;
 namespace Wasm {
+class DebugServer;
+class ExecutionHandler;
+}
+}
 
-class IPIntCallee;
-class ModuleManager;
+namespace WTF {
+class Thread;
+}
 
-class BreakpointManager {
-    WTF_MAKE_TZONE_ALLOCATED(BreakpointManager);
+namespace TestScripts {
+struct TestScript;
+}
 
-public:
-    JS_EXPORT_PRIVATE BreakpointManager() = default;
-    JS_EXPORT_PRIVATE ~BreakpointManager();
+namespace ExecutionHandlerTestSupport {
 
-    JS_EXPORT_PRIVATE bool hasBreakpoints();
-    JS_EXPORT_PRIVATE bool hasOneTimeBreakpoints();
+using JSC::VM;
+using JSC::Wasm::DebugServer;
+using JSC::Wasm::ExecutionHandler;
+using TestScripts::TestScript;
 
-    JS_EXPORT_PRIVATE Breakpoint* findBreakpoint(VirtualAddress);
-    JS_EXPORT_PRIVATE void setBreakpoint(VirtualAddress, Breakpoint&&);
-    JS_EXPORT_PRIVATE bool removeBreakpoint(VirtualAddress);
-    JS_EXPORT_PRIVATE void clearAllOneTimeBreakpoints();
-    JS_EXPORT_PRIVATE void clearAllBreakpoints();
+constexpr bool verboseLogging = false;
+constexpr double defaultTimeoutSeconds = 5.0;
 
-private:
-    bool removeBreakpointImpl(VirtualAddress) WTF_REQUIRES_LOCK(m_lock);
+extern std::atomic<unsigned> replyCount;
 
-    mutable Lock m_lock;
-    UncheckedKeyHashMap<VirtualAddress, Breakpoint> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashSet<VirtualAddress> m_oneTimeBreakpoints WTF_GUARDED_BY_LOCK(m_lock);
-};
+bool waitForCondition(std::function<bool()> predicate, Seconds timeout = Seconds(defaultTimeoutSeconds));
+void setupTestEnvironment(DebugServer*&, ExecutionHandler*&);
+void workerThreadTask(const String&);
 
-} // namespace Wasm
-} // namespace JSC
+inline unsigned getReplyCount() { return replyCount.load(); }
 
-#endif // ENABLE(WEBASSEMBLY)
+} // namespace ExecutionHandlerTestSupport
+
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.h
@@ -54,7 +54,7 @@ using JSC::Wasm::DebugServer;
 using JSC::Wasm::ExecutionHandler;
 using TestScripts::TestScript;
 
-constexpr bool verboseLogging = false;
+constexpr bool verboseLogging = true;
 constexpr double defaultTimeoutSeconds = 5.0;
 
 extern std::atomic<unsigned> replyCount;

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestScripts.h"
+
+#include <mutex>
+#include <span>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestScripts {
+
+// WASM Module Structure:
+// - Magic + Version: 0x00-0x07
+// - Type section (0x08-0x0d): 1 function signature ([] -> [])
+// - Function section (0x0e-0x15): 5 functions (all use type 0)
+// - Export section (0x16-0x40): Exports "func1" through "func5"
+// - Code section (0x41-0x7a): Each function contains:
+//   * nop, i32.const N, drop, nop, i32.const M, drop, end
+//   (Note: All byte ranges are inclusive on both ends)
+static constexpr uint8_t wasmMultiFunctionModuleBytes[] = {
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [])
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 5 functions (all type 0)
+    0x03, 0x06, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+    // [0x16] Export section: export 5 functions
+    0x07, 0x29, 0x05,
+    // Export function 0 as "func1"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x31, 0x00, 0x00,
+    // Export function 1 as "func2"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x32, 0x00, 0x01,
+    // Export function 2 as "func3"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x33, 0x00, 0x02,
+    // Export function 3 as "func4"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x34, 0x00, 0x03,
+    // Export function 4 as "func5"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x35, 0x00, 0x04,
+
+    // [0x41] Code section
+    0x0a, // section id=10
+    0x38, // section size=56
+    0x05, // 5 functions
+
+    // Function 0: func1 (body size=10)
+    0x0a, // [0x44] body size
+    0x00, // [0x45] 0 local declarations
+    0x01, // [0x46] nop
+    0x41, 0x0a, // [0x47] i32.const 10
+    0x1a, // [0x49] drop
+    0x01, // [0x4a] nop
+    0x41, 0x14, // [0x4b] i32.const 20
+    0x1a, // [0x4d] drop
+    0x0b, // [0x4e] end
+
+    // Function 1: func2 (body size=10)
+    0x0a, // [0x4f] body size
+    0x00, // [0x50] 0 local declarations
+    0x01, // [0x51] nop
+    0x41, 0x1e, // [0x52] i32.const 30
+    0x1a, // [0x54] drop
+    0x01, // [0x55] nop
+    0x41, 0x28, // [0x56] i32.const 40
+    0x1a, // [0x58] drop
+    0x0b, // [0x59] end
+
+    // Function 2: func3 (body size=10)
+    0x0a, // [0x5a] body size
+    0x00, // [0x5b] 0 local declarations
+    0x01, // [0x5c] nop
+    0x41, 0x32, // [0x5d] i32.const 50
+    0x1a, // [0x5f] drop
+    0x01, // [0x60] nop
+    0x41, 0x3c, // [0x61] i32.const 60
+    0x1a, // [0x63] drop
+    0x0b, // [0x64] end
+
+    // Function 3: func4 (body size=10)
+    0x0a, // [0x65] body size
+    0x00, // [0x66] 0 local declarations
+    0x01, // [0x67] nop
+    0x41, 0x46, // [0x68] i32.const 70
+    0x1a, // [0x6a] drop
+    0x01, // [0x6b] nop
+    0x41, 0x50, // [0x6c] i32.const 80
+    0x1a, // [0x6e] drop
+    0x0b, // [0x6f] end
+
+    // Function 4: func5 (body size=10)
+    0x0a, // [0x70] body size
+    0x00, // [0x71] 0 local declarations
+    0x01, // [0x72] nop
+    0x41, 0x5a, // [0x73] i32.const 90
+    0x1a, // [0x75] drop
+    0x01, // [0x76] nop
+    0x41, 0x64, // [0x77] i32.const 100
+    0x1a, // [0x79] drop
+    0x0b // [0x7a] end
+};
+
+// Helper to convert bytes to JavaScript array string
+static String wasmBytesToJSArray(std::span<const uint8_t> bytes)
+{
+    StringBuilder result;
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        if (i > 0)
+            result.append(',');
+        result.append(String::number(bytes[i]));
+    }
+    return result.toString();
+}
+
+// Multi-VM test script: creates 5 VMs (main + 4 workers) all running WASM in infinite loops
+// Each VM runs a different function from the same module.
+String multiVMSameModuleDifferentFunction()
+{
+    static String* cachedScript = nullptr;
+    static std::once_flag once;
+
+    std::call_once(once, [] {
+        cachedScript = new String(makeString(R"script(
+            // WASM module with 5 different functions
+            const wasm = new Uint8Array([)script"_s,
+                wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+            R"script(]);
+
+            const module = new WebAssembly.Module(wasm);
+            const instance = new WebAssembly.Instance(module, { });
+
+            const NUM_WORKERS = 4;
+
+            // Worker script generator - each worker runs a different function in infinite loop
+            function workerScript(workerId, funcName) {
+                return `
+                    const wasm = new Uint8Array([)script"_s,
+                        wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+                        R"script(]);
+                    const module = new WebAssembly.Module(wasm);
+                    const instance = new WebAssembly.Instance(module, { });
+
+                    // Run specified function in loop until $.shouldExit() returns true
+                    while (!$.shouldExit())
+                        instance.exports.${funcName}();
+                `;
+            }
+
+            // Start worker threads via $.agent.start()
+            const functions = ['func2', 'func3', 'func4', 'func5'];
+            for (let i = 0; i < NUM_WORKERS; i++)
+                $.agent.start(workerScript(i + 1, functions[i]));
+
+            // Main thread also runs func1 in loop until $.shouldExit() returns true
+            while (!$.shouldExit())
+                instance.exports.func1();
+        )script"_s));
+    });
+
+    return *cachedScript;
+}
+
+// Multi-VM test script: creates 5 VMs (main + 4 workers) all running WASM in infinite loops
+// All VMs run the same function (func1) from the same module.
+String multiVMSameModuleSameFunction()
+{
+    static String* cachedScript = nullptr;
+    static std::once_flag once;
+
+    std::call_once(once, [] {
+        cachedScript = new String(makeString(R"script(
+            // WASM module with 5 functions, but all VMs will run func1
+            const wasm = new Uint8Array([)script"_s,
+                wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+            R"script(]);
+
+            const module = new WebAssembly.Module(wasm);
+            const instance = new WebAssembly.Instance(module, { });
+
+            const NUM_WORKERS = 4;
+
+            // Worker script generator - all workers run the same function in loop until $.shouldExit()
+            function workerScript(workerId) {
+                return `
+                    const wasm = new Uint8Array([)script"_s,
+                        wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+                        R"script(]);
+                    const module = new WebAssembly.Module(wasm);
+                    const instance = new WebAssembly.Instance(module, { });
+
+                    // All workers run func1 in loop until $.shouldExit() returns true
+                    while (!$.shouldExit())
+                        instance.exports.func1();
+                `;
+            }
+
+            // Start worker threads via $.agent.start()
+            for (let i = 0; i < NUM_WORKERS; i++)
+                $.agent.start(workerScript(i + 1));
+
+            // Main thread also runs func1 in loop until $.shouldExit() returns true
+            while (!$.shouldExit())
+                instance.exports.func1();
+        )script"_s));
+    });
+
+    return *cachedScript;
+}
+
+// ========== Test Script Registry ==========
+
+static const TestScript allScripts[] = {
+    {
+        .name = "MultiVMSameModuleDifferentFunction"_s,
+        .description = "5 VMs (1 main + 4 workers) running different WASM functions from same module"_s,
+        .scriptGenerator = multiVMSameModuleDifferentFunction,
+        .expectedVMs = 5,
+        .expectedFunctions = 5
+    },
+    {
+        .name = "MultiVMSameModuleSameFunction"_s,
+        .description = "5 VMs (1 main + 4 workers) all running same WASM function"_s,
+        .scriptGenerator = multiVMSameModuleSameFunction,
+        .expectedVMs = 5,
+        .expectedFunctions = 5
+    },
+};
+
+std::span<const TestScript> getTestScripts()
+{
+    return std::span(allScripts);
+}
+
+} // namespace TestScripts

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.h
@@ -27,51 +27,29 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "WasmDebugServerUtilities.h"
-#include "WasmVirtualAddress.h"
+#include <span>
 #include <wtf/Forward.h>
-#include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
-#include <wtf/Lock.h>
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/Seconds.h>
+#include <wtf/text/ASCIILiteral.h>
 
-namespace JSC {
+namespace TestScripts {
 
-class CallFrame;
-class JSWebAssemblyInstance;
-class JSWebAssemblyModule;
-
-namespace Wasm {
-
-class IPIntCallee;
-class ModuleManager;
-
-class BreakpointManager {
-    WTF_MAKE_TZONE_ALLOCATED(BreakpointManager);
-
-public:
-    JS_EXPORT_PRIVATE BreakpointManager() = default;
-    JS_EXPORT_PRIVATE ~BreakpointManager();
-
-    JS_EXPORT_PRIVATE bool hasBreakpoints();
-    JS_EXPORT_PRIVATE bool hasOneTimeBreakpoints();
-
-    JS_EXPORT_PRIVATE Breakpoint* findBreakpoint(VirtualAddress);
-    JS_EXPORT_PRIVATE void setBreakpoint(VirtualAddress, Breakpoint&&);
-    JS_EXPORT_PRIVATE bool removeBreakpoint(VirtualAddress);
-    JS_EXPORT_PRIVATE void clearAllOneTimeBreakpoints();
-    JS_EXPORT_PRIVATE void clearAllBreakpoints();
-
-private:
-    bool removeBreakpointImpl(VirtualAddress) WTF_REQUIRES_LOCK(m_lock);
-
-    mutable Lock m_lock;
-    UncheckedKeyHashMap<VirtualAddress, Breakpoint> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashSet<VirtualAddress> m_oneTimeBreakpoints WTF_GUARDED_BY_LOCK(m_lock);
+// Test script metadata
+struct TestScript {
+    ASCIILiteral name;
+    ASCIILiteral description;
+    String (*scriptGenerator)(); // Function pointer to generate script
+    unsigned expectedVMs;
+    unsigned expectedFunctions; // For breakpoint tests
 };
 
-} // namespace Wasm
-} // namespace JSC
+// Script generators
+String multiVMSameModuleDifferentFunction();
+String multiVMSameModuleSameFunction();
+
+// Get all registered test scripts
+std::span<const TestScript> getTestScripts();
+
+} // namespace TestScripts
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -181,6 +181,9 @@ JSWebAssemblyInstance::~JSWebAssemblyInstance()
         m_anchor->tearDown();
         m_anchor = nullptr;
     }
+
+    if (Options::enableWasmDebugger()) [[unlikely]]
+        Wasm::DebugServer::singleton().untrackInstance(this);
 }
 
 void JSWebAssemblyInstance::destroy(JSCell* cell)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -729,13 +729,11 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
 #if ENABLE(REMOTE_INSPECTOR) && ENABLE(WEBASSEMBLY)
     if (JSC::Options::enableWasmDebugger()) [[unlikely]] {
-        if (JSC::VM* vm = WebCore::commonVMOrNull()) {
-            bool success = JSC::Wasm::DebugServer::singleton().startRWI(vm, [](const String& response) {
-                return WebKit::WebProcess::singleton().send(Messages::WebProcessProxy::SendWasmDebuggerResponse(response), 0);
-            });
-            if (!success)
-                WEBPROCESS_RELEASE_LOG_ERROR(Inspector, "Failed to start WasmDebugServer in RWI mode");
-        }
+        bool success = JSC::Wasm::DebugServer::singleton().startRWI([](const String& response) {
+            return WebKit::WebProcess::singleton().send(Messages::WebProcessProxy::SendWasmDebuggerResponse(response), 0);
+        });
+        if (!success)
+            WEBPROCESS_RELEASE_LOG_ERROR(Inspector, "Failed to start WasmDebugServer in RWI mode");
     }
 #endif
 


### PR DESCRIPTION
#### 82d37a8bf9219a400174d359d00d1cc9a8ce16f9
<pre>
wip
</pre>
----------------------------------------------------------------------
#### b194ff3d8df521511608fa178981dd45292f3209
<pre>
[JSC][Wasm][Debugger] Implement multi-VM stop-the-world debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=302699">https://bugs.webkit.org/show_bug.cgi?id=302699</a>
<a href="https://rdar.apple.com/164945623">rdar://164945623</a>

Reviewed by NOBODY (OOPS!).

Implements comprehensive multi-VM stop-the-world Wasm debugger that stops ALL VMs
in the process when any VM hits a breakpoint or receives an interrupt.

Architecture:

* VMManager world modes coordinate multi-VM execution:
    - Running: Normal execution (all VMs running).
    - Stopped: All VMs paused at safe points for inspection.
    - RunOne: Single-step mode (target VM runs, others stopped).

* Two-phase callback system:
    - wasmDebuggerOnStop(): VMManager calls with ALL VMs stopped; returns resume mode.
    - wasmDebuggerOnResume(): VMManager calls after ALL VMs resume; releases barriers.

* Per-VM DebugState tracks execution state:
    - Running vs Stopped with stop reason (Prologue/Breakpoint/SystemCall).
    - StopData snapshot: PC, locals, stack, call frame for inspection.
    - Step-into event flags for cross-function stepping (call/throw).

* ExecutionHandler bridges LLDB commands to VM execution:
    - Detailed design in Debugger-Mutator-Protocol.md.
    - Two condition variables orchestrate debugger-mutator communication.
    - State machine (Replied/InterruptRequested/ContinueRequested/StepRequested/SwitchRequested).
    - Resume barrier prevents overlapping stop-the-world operations.
    - Target VM selection: prefers VM at prologue, falls back to triggering VM.

* Step-into design minimizes runtime changes:
    - step() sets event flag instead of resolving callee/handler immediately
    - Runtime resolves target naturally during execution (call dispatch, exception unwinding)
    - Callback sets breakpoint using resolved target, avoiding duplicate resolution logic
    - Reuses existing runtime mechanisms rather than duplicating complex resolution in debugger

Testing:

* Unit tests: ExecutionHandlerTest validates coordination logic.
* Integration tests: multi-vm test cases for same/different modules and functions.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82d37a8bf9219a400174d359d00d1cc9a8ce16f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131692 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83554 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/04dff4a1-8511-4ac4-9e91-00084180c76c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4738b679-854e-4b2f-b58a-9f08d01e5a5a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81451 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de3a10ec-839c-4107-8364-671103ef2c17) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2862 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82423 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123755 "Found unexpected failure with change (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141847 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130199 "Found unexpected failure with change (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109046 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109204 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2945 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57063 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3906 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32663 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163164 "Hash 82d37a8b for PR 54095 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3738 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67354 "Found 5 new failures in wasm/WasmInstanceAnchor.h, wasm/debugger/WasmDebugServerUtilities.h") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/163164 "Hash 82d37a8b for PR 54095 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3998 "Hash 82d37a8b for PR 54095 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3867 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->