### PR TITLE
[blocks-in-inline] Ignore blocks in line level pagination

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-block-adjust-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-block-adjust-expected.html
@@ -1,0 +1,10 @@
+<div style="columns:4; column-gap:0; column-fill:auto; width:100px; height:100px; orphans:1; widows:1; background:red;">
+  <span>
+    <div style="display:inline-block; vertical-align:top; width:100%; height:50px; background:green;"></div>
+    <div style="height:100px; background:green;">
+      <div style="height:150px;"></div>
+      <div style="height:200px; background:green;"></div>
+    </div>
+    <div style="display:inline-block; vertical-align:top; width:100%; height:50px; background:green;"></div>
+  </span>
+</div>

--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-block-adjust.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-block-adjust.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<div style="columns:4; column-gap:0; column-fill:auto; width:100px; height:100px; orphans:1; widows:1; background:red;">
+  <span>
+    <div style="display:inline-block; vertical-align:top; width:100%; height:50px; background:green;"></div>
+    <div style="height:100px; background:green;">
+      <div style="height:150px;"></div>
+      <div style="height:200px; background:green;"></div>
+    </div>
+    <div style="display:inline-block; vertical-align:top; width:100%; height:50px; background:green;"></div>
+  </span>
+</div>

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -58,6 +58,7 @@ public:
     bool isInlineBox() const;
     bool isRootInlineBox() const;
     bool isLineBreak() const;
+    bool isBlockLevelBox() const;
 
     FloatRect visualRect() const;
     FloatRect visualRectIgnoringBlockDirection() const;
@@ -235,6 +236,13 @@ inline bool Box::isLineBreak() const
 {
     return WTF::switchOn(m_pathVariant, [](auto& path) {
         return path.isLineBreak();
+    });
+}
+
+inline bool Box::isBlockLevelBox() const
+{
+    return WTF::switchOn(m_pathVariant, [](auto& path) {
+        return path.isBlockLevelBox();
     });
 }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
@@ -46,6 +46,7 @@ public:
     bool isText() const { return m_inlineBox->isInlineTextBox(); }
     bool isInlineBox() const { return m_inlineBox->isInlineFlowBox(); }
     bool isRootInlineBox() const { return m_inlineBox->isRootInlineBox(); }
+    bool isBlockLevelBox() const { return false; }
 
     FloatRect visualRectIgnoringBlockDirection() const { return m_inlineBox->frameRect(); }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
@@ -50,6 +50,8 @@ public:
     bool isText() const { return box().isTextOrSoftLineBreak(); }
     bool isInlineBox() const { return box().isInlineBox(); }
     bool isRootInlineBox() const { return box().isRootInlineBox(); }
+    // Blocks-in-inline.
+    bool isBlockLevelBox() const { return box().isBlockLevelBox(); }
 
     FloatRect visualRectIgnoringBlockDirection() const { return box().visualRectIgnoringBlockDirection(); }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3518,7 +3518,7 @@ RenderBox::LogicalExtentComputedValues RenderBox::computeLogicalHeight(LayoutUni
         auto visibleHeight = view().pageOrViewLogicalHeight();
         if (isDocumentElementRenderer())
             computedValues.m_extent = std::max(computedValues.m_extent, visibleHeight - margins);
-        else {
+        else if (parentBox()) {
             auto marginsBordersPadding = margins + parentBox()->marginBefore() + parentBox()->marginAfter() + parentBox()->borderAndPaddingLogicalHeight();
             computedValues.m_extent = std::max(computedValues.m_extent, visibleHeight - marginsBordersPadding);
         }


### PR DESCRIPTION
#### 8335d774e6098f8df97995710d3d14b5b5b5c342
<pre>
[blocks-in-inline] Ignore blocks in line level pagination
<a href="https://bugs.webkit.org/show_bug.cgi?id=302698">https://bugs.webkit.org/show_bug.cgi?id=302698</a>
<a href="https://rdar.apple.com/164946941">rdar://164946941</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-multicol-block-adjust.html
* LayoutTests/fast/inline/blocks-in-inline-multicol-block-adjust-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-multicol-block-adjust.html: Added.
* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
(WebCore::InlineIterator::Box::isBlockLevelBox const):

Add inline iterator accessor to see block level boxes.

* Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h:
(WebCore::InlineIterator::BoxLegacyPath::isBlockLevelBox const):
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h:
(WebCore::InlineIterator::BoxModernPath::isBlockLevelBox const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeLineAdjustmentForPagination):

Don&apos;t adjust lines that have block level content. Block layout code handles the adjustments.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeLogicalHeight const):

Drive-by crash fix.

Canonical link: <a href="https://commits.webkit.org/303183@main">https://commits.webkit.org/303183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/591263c188b11ca17ca37afd1ef95d33f9a3d4d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83384 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b23858d1-40d5-480e-99f7-cd52085df04f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3925 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3737 "Hash 591263c1 for PR 54096 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100440 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a8784881-3d78-4146-95b7-1d4323bba792) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81249 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d3e9998-dc5e-4d11-b1ae-f66daf744d56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2727 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82265 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141719 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3641 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36409 "Found 1 new test failure: fast/images/mac/play-all-pause-all-animations-context-menu-items.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108809 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3689 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/3737 "Hash 591263c1 for PR 54096 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2762 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56835 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3702 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32500 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3529 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3784 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->