### PR TITLE
REGRESSION(302787@main): [macOS Release wk2] fast/files/blob-stream-error.html is a flaky timeout

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2413,5 +2413,3 @@ webkit.org/b/302169 [ Debug ] css3/filters/backdrop/effect-hw.html [ ImageOnlyFa
 webkit.org/b/302172 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html [ ImageOnlyFailure ]
 
 webkit.org/b/302174 [ Tahoe Debug arm64 ] platform/mac/media/encrypted-media/fps-generateRequest.html [ Timeout ]
-
-webkit.org/b/302685 [ Release ] fast/files/blob-stream-error.html [ Pass Timeout ]

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -403,7 +403,11 @@ ExceptionOr<void> FetchBodyOwner::createReadableStream(JSC::JSGlobalObject& stat
             return readableStreamSource->pull(globalObject, controller);
         }, [readableStreamSource](auto& globalObject, auto& controller, auto&& value) {
             return readableStreamSource->cancel(globalObject, controller, WTFMove(value));
-        }, { }, 1, ReadableStream::StartSynchronously::Yes);
+        }, {
+            .highwaterMark = 1,
+            .startSynchronously = ReadableStream::StartSynchronously::Yes,
+            .isReachableFromOpaqueRootIfPulling = ReadableStream::IsReachableFromOpaqueRootIfPulling::Yes
+        });
 
         m_readableStreamSource = readableStreamSource.ptr();
         readableStreamSource->setByteController(*readableStream->controller());

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -95,6 +95,8 @@ public:
     ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBufferView&);
     ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBuffer&);
 
+    bool isPulling() const { return m_pulling; }
+
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
     JSValueInWrappedObject& underlyingSourceConcurrently() { return m_underlyingSource; }

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -74,6 +74,7 @@ public:
 
     void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, size_t, Ref<ReadableStreamReadIntoRequest>&&);
 
+    bool isReachableFromOpaqueRoots() const;
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
 private:

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
@@ -30,9 +30,9 @@ dictionary ReadableStreamBYOBReaderReadOptions {
 };
 
 [
+    CustomIsReachable,
     EnabledBySetting=ReadableByteStreamAPIEnabled,
     Exposed=*,
-    GenerateIsReachable,
     JSCustomMarkFunction,
 ] interface ReadableStreamBYOBReader {
     [CallWith=CurrentGlobalObject] constructor(ReadableStream stream);

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
@@ -72,6 +72,7 @@ public:
     void onClosedPromiseRejection(ClosedRejectionCallback&&);
     void onClosedPromiseResolution(Function<void()>&&);
 
+    bool isReachableFromOpaqueRoots() const;
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
 private:

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.idl
@@ -29,6 +29,7 @@
  */
 
 [
+    CustomIsReachable,
     Exposed=*,
     JSCustomMarkFunction,
     PrivateIdentifier,

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -270,8 +270,12 @@ ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& global
     };
 
     Vector<Ref<ReadableStream>> branches;
-    branches.append(ReadableStream::createReadableByteStream(globalObject, WTFMove(pull1Algorithm), WTFMove(cancel1Algorithm), &stream));
-    branches.append(ReadableStream::createReadableByteStream(globalObject, WTFMove(pull2Algorithm), WTFMove(cancel2Algorithm), &stream));
+    branches.append(ReadableStream::createReadableByteStream(globalObject, WTFMove(pull1Algorithm), WTFMove(cancel1Algorithm), {
+        .relatedStreamForGC = &stream
+    }));
+    branches.append(ReadableStream::createReadableByteStream(globalObject, WTFMove(pull2Algorithm), WTFMove(cancel2Algorithm), {
+        .relatedStreamForGC = &stream
+    }));
 
     state->setBranch1(branches[0]);
     state->setBranch2(branches[1]);


### PR DESCRIPTION
#### bbf1903f026b71822e0230b6a602c9a7a5c1db59
<pre>
REGRESSION(302787@main): [macOS Release wk2] fast/files/blob-stream-error.html is a flaky timeout
<a href="https://rdar.apple.com/164935746">rdar://164935746</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302685">https://bugs.webkit.org/show_bug.cgi?id=302685</a>

Reviewed by Chris Dumez.

When blob is loaded, the stream reader could be GCed.
This lead to read promises to never resolve.

To prevent this, we introduce a byte stream option to ReadableStream::createByteStream which marks the stream as reachable from opaque roots if pulling.
We do a refactoring to ReadableStream::createByteStream to pass a struct of options instead of individual parameters to improve code readability.

The ReadableStream reader (default or byob) implements a custom GC check by asking whether its ReadableStream is reachable from opaque roots.

We apply this strategy to Blob and FetchBodySource.
Covered by test no longer being flaky and existing stream tests.

We also align the blob stream source and fetch stream source by keeping the byte controller as a WeaKPtr instead of a RefPtr.
This model is better as it removes potential ref cycle (that was broken when blob loading finishes or fails previously).
The memory  model is now: ReadableStream reader -&gt; ReadableStream -&gt; ReadableStream controller and ReadableStream source.

Canonical link: <a href="https://commits.webkit.org/303180@main">https://commits.webkit.org/303180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/687ffaf491be9a29288b2fbd2010abe9acff2883

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139108 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c29374b4-3344-446a-ad89-86f521e2ee2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/48643183-942c-4da7-99a1-8fd182df19eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134545 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81273 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/497 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82299 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141753 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3675 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108836 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2780 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56874 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3736 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32516 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67147 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->