### PR TITLE
Stop using raw pointers in containers in RemoteResourceCacheProxy.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -636,7 +636,6 @@ platform/graphics/GraphicsLayer.h
 platform/graphics/ImageAdapter.cpp
 platform/graphics/ImageBackingStore.h
 platform/graphics/ImageBufferContextSwitcher.cpp
-platform/graphics/ImageFrame.h
 platform/graphics/ImageFrameWorkQueue.cpp
 platform/graphics/Path.cpp
 platform/graphics/TransparencyLayerContextSwitcher.cpp
@@ -652,7 +651,6 @@ platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/TileController.cpp
 platform/graphics/ca/TileCoverageMap.cpp
 platform/graphics/ca/TileGrid.cpp
-platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 [ iOS ] platform/graphics/cg/PDFDocumentImage.cpp

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -480,9 +480,9 @@ void BitmapImageSource::cacheNativeImageAtIndex(unsigned index, SubsamplingLevel
 
     auto& frame = m_frames[index];
     auto& source = frame.source(options.shouldDecodeToHDR());
-    source.nativeImage = WTFMove(nativeImage);
+    source.nativeImage = nativeImage.copyRef();
     source.decodingOptions = options;
-    source.headroom = source.nativeImage->headroom();
+    source.headroom = nativeImage->headroom();
 
     cacheMetadataAtIndex(index, subsamplingLevel, options);
     decodedSizeIncreased(frame.sizeInBytes());

--- a/Source/WebCore/platform/graphics/Gradient.cpp
+++ b/Source/WebCore/platform/graphics/Gradient.cpp
@@ -31,9 +31,12 @@
 #include <wtf/HashFunctions.h>
 #include <wtf/Hasher.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Gradient);
 
 Ref<Gradient> Gradient::create(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops, bool isTransient)
 {

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -33,6 +33,8 @@
 #include <WebCore/GradientColorStops.h>
 #include <WebCore/GraphicsTypes.h>
 #include <WebCore/RenderingResource.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
@@ -63,7 +65,9 @@ class FloatRect;
 class GraphicsContext;
 
 // Note: currently this class is not usable from multiple threads due to mutating interface.
-class Gradient final : public ThreadSafeRefCounted<Gradient> {
+class Gradient final : public ThreadSafeRefCounted<Gradient>, public CanMakeThreadSafeCheckedPtr<NativeImage> {
+    WTF_MAKE_TZONE_ALLOCATED(Gradient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Gradient);
 public:
     struct LinearData {
         FloatPoint point0;

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -112,13 +112,11 @@ private:
 
         void clear()
         {
-            if (!nativeImage)
-                return;
-
-            nativeImage->clearSubimages();
-            nativeImage = nullptr;
-            decodingOptions = DecodingOptions();
-            headroom = Headroom::None;
+            if (RefPtr image = std::exchange(nativeImage, nullptr)) {
+                image->clearSubimages();
+                decodingOptions = DecodingOptions();
+                headroom = Headroom::None;
+            }
         }
     };
 

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -31,6 +31,7 @@
 #include <WebCore/PlatformExportMacros.h>
 #include <WebCore/PlatformImage.h>
 #include <WebCore/RenderingResource.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
@@ -44,8 +45,9 @@ class IntSize;
 class NativeImageBackend;
 struct ImagePaintingOptions;
 
-class NativeImage : public ThreadSafeRefCounted<NativeImage> {
+class NativeImage : public ThreadSafeRefCounted<NativeImage>, public CanMakeThreadSafeCheckedPtr<NativeImage> {
     WTF_MAKE_TZONE_ALLOCATED(NativeImage);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NativeImage);
 public:
     static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&);
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
@@ -46,14 +46,15 @@ GraphicsLayerAsyncContentsDisplayDelegateCocoa::GraphicsLayerAsyncContentsDispla
 
 bool GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(ImageBuffer& image, bool opaque)
 {
-    m_image = ImageBuffer::sinkIntoNativeImage(image.clone());
-    if (!m_image)
+    RefPtr nativeImage = ImageBuffer::sinkIntoNativeImage(image.clone());
+    m_image = nativeImage;
+    if (!nativeImage)
         return false;
 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
 
-    [m_layer setContents:(__bridge id)m_image->platformImage().get()];
+    [m_layer setContents:(__bridge id)nativeImage->platformImage().get()];
     [m_layer setContentsOpaque:opaque];
 
     [CATransaction commit];
@@ -64,8 +65,8 @@ bool GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(ImageBuffer&
 void GraphicsLayerAsyncContentsDisplayDelegateCocoa::updateGraphicsLayerCA(GraphicsLayerCA& layer)
 {
     layer.setContentsToPlatformLayer(m_layer.get(), GraphicsLayer::ContentsLayerPurpose::Canvas);
-    if (m_image)
-        [m_layer setContents:(__bridge id)m_image->platformImage().get()];
+    if (RefPtr image = m_image)
+        [m_layer setContents:(__bridge id)image->platformImage().get()];
 }
 
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/DisplayListItems.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -41,9 +42,10 @@ namespace DisplayList {
 
 // Note: currently this class is not usable from multiple threads due to the underlying objects, such
 // Font instances, not being thread-safe.
-class DisplayList final : public ThreadSafeRefCounted<DisplayList> {
+class DisplayList final : public ThreadSafeRefCounted<DisplayList>, public CanMakeThreadSafeCheckedPtr<DisplayList> {
     WTF_MAKE_TZONE_ALLOCATED(DisplayList);
     WTF_MAKE_NONCOPYABLE(DisplayList);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DisplayList);
 public:
     static Ref<const DisplayList> create(Vector<Item>&& items)
     {

--- a/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
@@ -46,7 +46,7 @@ bool FEImageSoftwareApplier::apply(const Filter& filter, std::span<const Ref<Fil
     auto primitiveSubregion = result.primitiveSubregion();
     auto& context = resultImage->context();
 
-    if (auto nativeImage = sourceImage.nativeImageIfExists()) {
+    if (RefPtr nativeImage = sourceImage.nativeImageIfExists()) {
         auto imageRect = primitiveSubregion;
         auto srcRect = m_effect->sourceImageRect();
         m_effect->preserveAspectRatio().transformRect(imageRect, srcRect);

--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -119,7 +119,7 @@ RefPtr<const DisplayList::DisplayList> GlyphDisplayListCache::getDisplayList(con
 
     if (auto iterator = m_entries.find<GlyphDisplayListCacheKeyTranslator>(GlyphDisplayListCacheKey { textRun, font, context }); iterator != m_entries.end()) {
         Ref entry { iterator->get() };
-        auto* result = &entry->displayList();
+        RefPtr result = &entry->displayList();
         const_cast<LayoutRun&>(run).setIsInGlyphDisplayListCache();
         m_entriesForLayoutRun.add(&run, WTFMove(entry));
         return result;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h
@@ -37,6 +37,7 @@ class RemoteResourceCacheProxy;
 
 class RemoteNativeImageProxy final : public WebCore::NativeImage {
     WTF_MAKE_TZONE_ALLOCATED(RemoteNativeImageProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteNativeImageProxy);
 public:
     static Ref<RemoteNativeImageProxy> create(const WebCore::IntSize&, WebCore::PlatformColorSpace&&, bool hasAlpha, WeakRef<RemoteResourceCacheProxy>&&);
     ~RemoteNativeImageProxy() override;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -34,7 +34,7 @@
 #include <WebCore/Gradient.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/ShareableBitmap.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
@@ -103,10 +103,10 @@ private:
         RefPtr<WebCore::ShareableBitmap> bitmap; // Reused across GPUP crashes, held through the associated NativeImage lifetime.
         bool existsInRemote = true;
     };
-    HashMap<const WebCore::NativeImage*, NativeImageEntry> m_nativeImages;
-    HashMap<const WebCore::Gradient*, RemoteGradientIdentifier> m_gradients;
+    HashMap<CheckedPtr<const WebCore::NativeImage>, NativeImageEntry> m_nativeImages;
+    HashMap<CheckedPtr<const WebCore::Gradient>, RemoteGradientIdentifier> m_gradients;
     HashSet<WebCore::RenderingResourceIdentifier> m_filters;
-    HashMap<const WebCore::DisplayList::DisplayList*, RemoteDisplayListIdentifier> m_displayLists;
+    HashMap<CheckedPtr<const WebCore::DisplayList::DisplayList>, RemoteDisplayListIdentifier> m_displayLists;
     WeakPtrFactory<WebCore::RenderingResourceObserver> m_resourceObserverWeakFactory;
     WeakPtrFactory<WebCore::RenderingResourceObserver> m_nativeImageResourceObserverWeakFactory;
     WeakPtrFactory<RemoteResourceCacheProxy> m_remoteNativeImageProxyWeakFactory;


### PR DESCRIPTION
#### c6f528b1c6259e5a066c3a0123fb2b5835e46872
<pre>
Stop using raw pointers in containers in RemoteResourceCacheProxy.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302700">https://bugs.webkit.org/show_bug.cgi?id=302700</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::cacheNativeImageAtIndex):
* Source/WebCore/platform/graphics/Gradient.cpp:
* Source/WebCore/platform/graphics/Gradient.h:
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::Source::clear):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm:
(WebCore::GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer):
(WebCore::GraphicsLayerAsyncContentsDisplayDelegateCocoa::updateGraphicsLayerCA):
* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
* Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp:
(WebCore::FEImageSoftwareApplier::apply const):
* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCache::getDisplayList):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/303231@main">https://commits.webkit.org/303231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/603340a6906020e19f05863107bc7a47742b6346

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139222 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29978116-470a-4645-b91c-693edcefe31a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100689 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5f3147f-0eec-4721-bdb1-0f3b43691327) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134659 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81462 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab4149cc-34ef-4b1b-b0f9-bc7688ac0571) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82444 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141868 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3874 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109056 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109213 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27668 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2957 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57084 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32671 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3760 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67375 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->