### PR TITLE
[site-isolation] window.open should work with blob urls

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-blob-url-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/iframe-blob-url-expected.txt
@@ -1,0 +1,10 @@
+Tests opening a blob from a cross-site iframe
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Received event finish test
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/iframe-blob-url.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-blob-url.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+
+<script>
+description("Tests opening a blob from a cross-site iframe");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+addEventListener("message", (event) => {
+    if (event.data === "finish test" && window.testRunner)
+        testPassed("Received event " + event.data);
+        finishJSTest();
+});
+
+</script>
+<body>
+    <iframe src="http://127.0.0.1:8000/site-isolation/resources/window-open-blob-url.html"  width="600px" height="400px" frameborder=3></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/window-open-blob-url.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-open-blob-url.html
@@ -1,0 +1,14 @@
+<script>
+    const htmlContent = `
+        <!DOCTYPE html>
+        <html>
+        <h1>Blob URL Loaded</h1>
+        </html>
+        `;
+    
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    const blobUrl = URL.createObjectURL(blob);
+    const newWindow = window.open(blobUrl, '_blank', 'width=800,height=600,scrollbars=yes,resizable=yes');
+
+    window.parent.postMessage("finish test", "*");
+</script>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -81,7 +81,6 @@
 #include "MemoryCache.h"
 #include "MixedContentChecker.h"
 #include "NavigationNavigationType.h"
-#include "NavigationRequester.h"
 #include "NavigationScheduler.h"
 #include "NetworkLoadMetrics.h"
 #include "NetworkStorageSession.h"

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -46,6 +46,7 @@
 #include <WebCore/LinkIcon.h>
 #include <WebCore/NavigationAction.h>
 #include <WebCore/NavigationIdentifier.h>
+#include <WebCore/NavigationRequester.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceLoaderOptions.h>
@@ -544,6 +545,9 @@ public:
 
     WEBCORE_EXPORT void setNewResultingClientId(ScriptExecutionContextIdentifier);
 
+    std::optional<NavigationRequester> crossSiteRequester() const { return m_crossSiteRequester; }
+    void setCrossSiteRequester(NavigationRequester& crossSiteRequester) { m_crossSiteRequester = crossSiteRequester; }
+
 protected:
     WEBCORE_EXPORT DocumentLoader(ResourceRequest&&, SubstituteData&&);
 
@@ -771,6 +775,8 @@ private:
     PushAndNotificationsEnabledPolicy m_pushAndNotificationsEnabledPolicy { PushAndNotificationsEnabledPolicy::UseGlobalPolicy };
     InlineMediaPlaybackPolicy m_inlineMediaPlaybackPolicy { InlineMediaPlaybackPolicy::Default };
     WebpagePreferences m_preferences;
+    // The triggering action's requester should take precendence. This is used for site-isolation situations that require a cross-site requester.
+    std::optional<NavigationRequester> m_crossSiteRequester;
 
     Function<void(Document*)> m_whenDocumentIsCreatedCallback;
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -615,6 +615,12 @@ RefPtr<SearchPopupMenu> EmptyChromeClient::createSearchPopupMenu(PopupMenuClient
     return adoptRef(*new EmptySearchPopupMenu);
 }
 
+RefPtr<Page> EmptyChromeClient::createWindow(LocalFrame&, const String&, const WindowFeatures&, const NavigationAction&, const std::optional<Ref<Document>> requester)
+{
+    UNUSED_PARAM(requester);
+    return nullptr;
+}
+
 RefPtr<ColorChooser> EmptyChromeClient::createColorChooser(ColorChooserClient&, const Color&)
 {
     return nullptr;

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -74,7 +74,7 @@ class EmptyChromeClient : public ChromeClient {
     void focusedElementChanged(Element*, LocalFrame*, FocusOptions, BroadcastFocusedElement) final { }
     void focusedFrameChanged(Frame*) final { }
 
-    RefPtr<Page> createWindow(LocalFrame&, const String&, const WindowFeatures&, const NavigationAction&) final { return nullptr; }
+    RefPtr<Page> createWindow(LocalFrame&, const String&, const WindowFeatures&, const NavigationAction&, const std::optional<Ref<Document>> requester) final;
     void show() final { }
 
     bool canRunModal() const final { return false; }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1713,7 +1713,7 @@ SubstituteData FrameLoader::defaultSubstituteDataForURL(const URL& url)
     return SubstituteData(SharedBuffer::create(encodedSrcdoc.span()), URL(), WTFMove(response), iframeElement->srcdocSessionHistoryVisibility());
 }
 
-void FrameLoader::load(FrameLoadRequest&& request)
+void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationRequester> crossSiteRequester)
 {
     FRAMELOADER_RELEASE_LOG_FORWARDABLE(FRAMELOADER_LOAD_FRAMELOADREQUEST);
 
@@ -1751,6 +1751,9 @@ void FrameLoader::load(FrameLoadRequest&& request)
     loader->setIsContentRuleListRedirect(request.isContentRuleListRedirect());
     loader->setIsRequestFromClientOrUserInput(request.isRequestFromClientOrUserInput());
     loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
+    if (crossSiteRequester)
+        loader->setCrossSiteRequester(*crossSiteRequester);
+
     if (auto advancedPrivacyProtections = request.advancedPrivacyProtections())
         loader->setOriginatorAdvancedPrivacyProtections(*advancedPrivacyProtections);
     addSameSiteInfoToRequestIfNeeded(loader->request());
@@ -1920,7 +1923,7 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
     policyChecker().stopCheck();
     setPolicyDocumentLoader(loader);
     if (loader->triggeringAction().isEmpty()) {
-        NavigationAction action { frame->protectedDocument().releaseNonNull(), loader->request(), InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), policyChecker().loadType(), isFormSubmission };
+        NavigationAction action = loader->crossSiteRequester() ? NavigationAction { *loader->crossSiteRequester(), loader->request(), InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), policyChecker().loadType(), isFormSubmission } : NavigationAction { frame->protectedDocument().releaseNonNull(), loader->request(), InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), policyChecker().loadType(), isFormSubmission };
         action.setIsContentRuleListRedirect(loader->isContentRuleListRedirect());
         action.setNavigationAPIType(determineNavigationType(type, NavigationHistoryBehavior::Auto));
         loader->setTriggeringAction(WTFMove(action));
@@ -4869,7 +4872,7 @@ std::pair<RefPtr<Frame>, CreatedNewPage> createWindow(LocalFrame& openerFrame, F
     NavigationAction action { request, NavigationType::Other };
     action.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     action.setNewFrameOpenerPolicy(features.wantsNoOpener() ? NewFrameOpenerPolicy::Suppress : NewFrameOpenerPolicy::Allow);
-    RefPtr page = oldPage->chrome().createWindow(openerFrame, openedMainFrameName, features, action);
+    RefPtr page = oldPage->chrome().createWindow(openerFrame, openedMainFrameName, features, action, request.requester());
     if (!page)
         return { nullptr, CreatedNewPage::No };
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -36,6 +36,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/LoaderMalloc.h>
+#include <WebCore/NavigationRequester.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/ReferrerPolicy.h>
@@ -138,7 +139,7 @@ public:
     // FIXME: These are all functions which start loads. We have too many.
     WEBCORE_EXPORT void loadFrameRequest(FrameLoadRequest&&, Event*, RefPtr<FormState>&&, std::optional<PrivateClickMeasurement>&& = std::nullopt); // Called by submitForm, calls loadPostRequest and loadURL.
 
-    WEBCORE_EXPORT void load(FrameLoadRequest&&);
+    WEBCORE_EXPORT void load(FrameLoadRequest&&, const std::optional<NavigationRequester> crossSiteRequester = std::nullopt);
 
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
     WEBCORE_EXPORT void loadArchive(Ref<Archive>&&);

--- a/Source/WebCore/loader/NavigationAction.cpp
+++ b/Source/WebCore/loader/NavigationAction.cpp
@@ -72,6 +72,11 @@ static bool shouldTreatAsSameOriginNavigation(const Document& document, const UR
     return url.protocolIsAbout() || url.protocolIsData() || (url.protocolIsBlob() && document.protectedSecurityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton()));
 }
 
+static bool shouldTreatAsSameOriginNavigation(const NavigationRequester& requester, const URL& url)
+{
+    return url.protocolIsAbout() || url.protocolIsData() || (url.protocolIsBlob() && Ref { requester.securityOrigin }->canRequest(url, OriginAccessPatternsForWebProcess::singleton()));
+}
+
 static std::optional<NavigationAction::UIEventWithKeyStateData> keyStateDataForFirstEventWithKeyState(Event* event)
 {
     if (RefPtr uiEvent = findEventWithKeyState(event))
@@ -124,6 +129,21 @@ NavigationAction::NavigationAction(Document& requester, const ResourceRequest& o
     , m_type { navigationType(frameLoadType, isFormSubmission, !!event) }
     , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(requester, originalRequest.url()) }
 {
+    setDownloadAttribute(downloadAttribute);
+    setSourceElement(sourceElement);
+    setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
+    setInitiatedByMainFrame(initiatedByMainFrame);
+    setIsRequestFromClientOrUserInput(isRequestFromClientOrUserInput);
+}
+
+NavigationAction::NavigationAction(const NavigationRequester& requester, const ResourceRequest& originalRequest, InitiatedByMainFrame initiatedByMainFrame, bool isRequestFromClientOrUserInput, FrameLoadType frameLoadType, bool isFormSubmission, Event* event, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, const AtomString& downloadAttribute, Element* sourceElement)
+    : m_requester { requester }
+    , m_originalRequest { originalRequest }
+    , m_keyStateEventData { keyStateDataForFirstEventWithKeyState(event) }
+    , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
+    , m_type { navigationType(frameLoadType, isFormSubmission, !!event) }
+{
+    m_treatAsSameOriginNavigation = shouldTreatAsSameOriginNavigation(requester, originalRequest.url());
     setDownloadAttribute(downloadAttribute);
     setSourceElement(sourceElement);
     setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -60,7 +60,9 @@ class NavigationAction : public FrameLoadRequestBase {
 public:
     NavigationAction();
     WEBCORE_EXPORT NavigationAction(Document&, const ResourceRequest&, InitiatedByMainFrame, bool, NavigationType = NavigationType::Other, ShouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow, Event* = nullptr, const AtomString& downloadAttribute = nullAtom(), Element* sourceElement = nullptr);
+    WEBCORE_EXPORT NavigationAction(NavigationRequester&, const ResourceRequest&, InitiatedByMainFrame, bool, NavigationType = NavigationType::Other, ShouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow, Event* = nullptr, const AtomString& downloadAttribute = nullAtom(), Element* sourceElement = nullptr);
     NavigationAction(Document&, const ResourceRequest&, InitiatedByMainFrame, bool, FrameLoadType, bool isFormSubmission, Event* = nullptr, ShouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow, const AtomString& downloadAttribute = nullAtom(), Element* sourceElement = nullptr);
+    NavigationAction(const NavigationRequester&, const ResourceRequest&, InitiatedByMainFrame, bool, FrameLoadType, bool isFormSubmission, Event* = nullptr, ShouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow, const AtomString& downloadAttribute = nullAtom(), Element* sourceElement = nullptr);
     WEBCORE_EXPORT NavigationAction(FrameLoadRequest&, NavigationType = NavigationType::Other, Event* = nullptr);
 
     WEBCORE_EXPORT ~NavigationAction();

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class Document;
 
 struct NavigationRequester {
-    static NavigationRequester from(Document&);
+    WEBCORE_EXPORT static NavigationRequester from(Document&);
 
     URL url;
     Ref<SecurityOrigin> securityOrigin;

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -220,9 +220,9 @@ void Chrome::focusedFrameChanged(Frame* frame)
     m_client->focusedFrameChanged(frame);
 }
 
-RefPtr<Page> Chrome::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& features, const NavigationAction& action)
+RefPtr<Page> Chrome::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& features, const NavigationAction& action, std::optional<Ref<Document>> requester)
 {
-    RefPtr newPage = m_client->createWindow(frame, openedMainFrameName, features, action);
+    RefPtr newPage = m_client->createWindow(frame, openedMainFrameName, features, action, requester);
     if (!newPage)
         return nullptr;
 

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -23,6 +23,7 @@
 
 #include <WebCore/Cursor.h>
 #include <WebCore/DisabledAdaptations.h>
+#include <WebCore/Document.h>
 #include <WebCore/FocusDirection.h>
 #include <WebCore/HostWindow.h>
 #include <WebCore/ImageBufferFormat.h>
@@ -170,7 +171,7 @@ public:
     void focusedElementChanged(Element*, LocalFrame*, FocusOptions, BroadcastFocusedElement);
     void focusedFrameChanged(Frame*);
 
-    WEBCORE_EXPORT RefPtr<Page> createWindow(LocalFrame&, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&);
+    WEBCORE_EXPORT RefPtr<Page> createWindow(LocalFrame&, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&, const std::optional<Ref<Document>> requester = std::nullopt);
     WEBCORE_EXPORT void show();
 
     bool canRunModal() const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -241,7 +241,7 @@ public:
     // should not be shown to the user until the ChromeClient of the newly
     // created Page has its show method called.
     // The ChromeClient should not load the request.
-    virtual RefPtr<Page> createWindow(LocalFrame&, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&) = 0;
+    virtual RefPtr<Page> createWindow(LocalFrame&, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&, const std::optional<Ref<Document>> requester = std::nullopt) = 0;
     virtual void show() = 0;
 
     virtual bool canRunModal() const = 0;

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -34,6 +34,7 @@
 #include <WebCore/AdvancedPrivacyProtections.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/NavigationIdentifier.h>
+#include <WebCore/NavigationRequester.h>
 #include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PublicSuffixStore.h>
 #include <WebCore/ReferrerPolicy.h>
@@ -94,6 +95,7 @@ struct LoadParameters {
 
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion { 0 };
+    std::optional<WebCore::NavigationRequester> requester;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -61,4 +61,5 @@ enum class WebCore::LockBackForwardList : bool;
 
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion;
+    std::optional<WebCore::NavigationRequester> requester;
 };

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -34,6 +34,7 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/NavigationIdentifier.h>
+#include <WebCore/NavigationRequester.h>
 #include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/ReferrerPolicy.h>
@@ -68,8 +69,6 @@ struct NavigationActionData {
     bool isInitialFrameSrcLoad { false };
     bool isContentRuleListRedirect { false };
     String openedMainFrameName;
-    WebCore::SecurityOriginData requesterOrigin;
-    WebCore::SecurityOriginData requesterTopOrigin;
     std::optional<WebCore::BackForwardItemIdentifier> targetBackForwardItemIdentifier;
     std::optional<WebCore::BackForwardItemIdentifier> sourceBackForwardItemIdentifier;
     WebCore::LockHistory lockHistory { WebCore::LockHistory::No };
@@ -91,6 +90,7 @@ struct NavigationActionData {
     WebCore::ResourceRequest originalRequest;
     WebCore::ResourceRequest request;
     String invalidURLString;
+    std::optional<WebCore::NavigationRequester> requester;
 };
 
 }

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -41,8 +41,6 @@ struct WebKit::NavigationActionData {
     bool isInitialFrameSrcLoad;
     bool isContentRuleListRedirect;
     String openedMainFrameName;
-    WebCore::SecurityOriginData requesterOrigin;
-    WebCore::SecurityOriginData requesterTopOrigin;
     std::optional<WebCore::BackForwardItemIdentifier> targetBackForwardItemIdentifier;
     std::optional<WebCore::BackForwardItemIdentifier> sourceBackForwardItemIdentifier;
     WebCore::LockHistory lockHistory;
@@ -64,4 +62,5 @@ struct WebKit::NavigationActionData {
     WebCore::ResourceRequest originalRequest;
     [EncodeRequestBody] WebCore::ResourceRequest request;
     String invalidURLString;
+    std::optional<WebCore::NavigationRequester> requester;
 };

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -149,6 +149,13 @@ void Navigation::markRequestAsFromClientInput()
         m_lastNavigationAction->isRequestFromClientOrUserInput = true;
 }
 
+WebCore::SecurityOriginData Navigation::requesterOrigin() const
+{
+    if (m_lastNavigationAction && m_lastNavigationAction->requester)
+        return (*m_lastNavigationAction->requester).securityOrigin->data();
+    return WebCore::SecurityOriginData { };
+}
+
 void Navigation::setSafeBrowsingCheckOngoing(size_t index, bool ongoing)
 {
     if (ongoing)

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -141,7 +141,7 @@ public:
     bool hasOpenedFrames() const { return m_lastNavigationAction && m_lastNavigationAction->hasOpenedFrames; }
     bool openedByDOMWithOpener() const { return m_lastNavigationAction && m_lastNavigationAction->openedByDOMWithOpener; }
     bool isInitialFrameSrcLoad() const { return m_lastNavigationAction && m_lastNavigationAction->isInitialFrameSrcLoad; }
-    WebCore::SecurityOriginData requesterOrigin() const { return m_lastNavigationAction ? m_lastNavigationAction->requesterOrigin : WebCore::SecurityOriginData { }; }
+    WebCore::SecurityOriginData requesterOrigin() const;
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy() const { return m_lastNavigationAction ? m_lastNavigationAction->shouldOpenExternalURLsPolicy : WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow; }
 
     void setUserContentExtensionsEnabled(bool enabled) { m_userContentExtensionsEnabled = enabled; }

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -463,8 +463,9 @@ static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& actio
         weakPage->addConsoleMessage(*sourceFrameID, MessageSource::Network, MessageLevel::Error, makeString("Can't handle MarketplaceKit link "_s, url.string(), " due to error: "_s, error));
     };
 
-    if (!action->shouldOpenExternalSchemes() || !action->isProcessingUserGesture() || action->isRedirect() || action->data().requesterTopOrigin.isNull()) {
-        RELEASE_LOG_ERROR(Loading, "NavigationState: can't handle MarketplaceKit navigation with shouldOpenExternalSchemes: %d, isProcessingUserGesture: %d, isRedirect: %d, requesterTopOriginIsNull: %d", action->shouldOpenExternalSchemes(), action->isProcessingUserGesture(), action->isRedirect(), action->data().requesterTopOrigin.isNull());
+    auto requesterTopOrigin = action->data().requester ? std::optional { action->data().requester->topOrigin } : std::nullopt;
+    if (!action->shouldOpenExternalSchemes() || !action->isProcessingUserGesture() || action->isRedirect() || requesterTopOrigin) {
+        RELEASE_LOG_ERROR(Loading, "NavigationState: can't handle MarketplaceKit navigation with shouldOpenExternalSchemes: %d, isProcessingUserGesture: %d, isRedirect: %d, requesterTopOriginIsNull: %d", action->shouldOpenExternalSchemes(), action->isProcessingUserGesture(), action->isRedirect(), !!requesterTopOrigin);
 
         if (!action->isProcessingUserGesture())
             addConsoleError("must be activated via a user gesture"_s);
@@ -474,7 +475,7 @@ static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& actio
         return;
     }
 
-    RetainPtr requesterTopOriginURL = action->data().requesterTopOrigin.toURL().createNSURL();
+    RetainPtr requesterTopOriginURL = requesterTopOrigin ? requesterTopOrigin->get().toURL().createNSURL() : nullptr;
     RetainPtr url = action->request().url().createNSURL();
 
     if (!requesterTopOriginURL || !url) {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2189,6 +2189,8 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(url);
     loadParameters.requiredCookiesVersion = protectedWebsiteDataStore()->cookiesVersion();
     loadParameters.originatingFrame = navigation.lastNavigationAction() ? std::optional(navigation.lastNavigationAction()->originatingFrameInfoData) : std::nullopt;
+    if (navigation.lastNavigationAction())
+        loadParameters.requester = navigation.lastNavigationAction()->requester;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (protectedPreferences()->iFrameResourceMonitoringEnabled())
@@ -5171,6 +5173,9 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             loadParameters.ownerPermissionsPolicy = navigation->ownerPermissionsPolicy();
             loadParameters.isPerformingHTTPFallback = navigationAction->data().isPerformingHTTPFallback;
             loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());
+            if (navigation->lastNavigationAction())
+                loadParameters.requester = navigation->lastNavigationAction()->requester;
+
             processNavigatingTo->send(Messages::WebPage::LoadRequest(WTFMove(loadParameters)), webPageIDInProcess(processNavigatingTo));
         }
 
@@ -5442,6 +5447,8 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         loadParameters.ownerPermissionsPolicy = navigation.ownerPermissionsPolicy();
         loadParameters.isPerformingHTTPFallback = isPerformingHTTPFallback == IsPerformingHTTPFallback::Yes;
         loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());
+        if (navigation.lastNavigationAction())
+            loadParameters.requester = navigation.lastNavigationAction()->requester;
 
         if (navigation.isInitialFrameSrcLoad())
             frame.setIsPendingInitialHistoryItem(true);
@@ -9025,7 +9032,8 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
         if (privateClickMeasurement)
             newPage->internals().privateClickMeasurement = { { WTFMove(*privateClickMeasurement), { }, { } } };
 
-        if (navigationDataForNewProcess && !openedBlobURL) {
+        bool isBlobURLOpenedInSiteIsolation = openedBlobURL && protectedPreferences()->siteIsolationEnabled();
+        if (navigationDataForNewProcess && (isBlobURLOpenedInSiteIsolation || !openedBlobURL)) {
             bool isRequestFromClientOrUserInput = navigationDataForNewProcess->isRequestFromClientOrUserInput;
 
             reply(std::nullopt, std::nullopt);

--- a/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
@@ -83,8 +83,6 @@ void AutomationSessionClient::requestNewPageWithOptions(WebKit::WebAutomationSes
                 false, /* isInitialFrameSrcLoad */
                 false, /* isContentExtensionRedirect */
                 { }, /* openedMainFrameName */
-                { }, /* requesterOrigin */
-                { }, /* requesterTopOrigin */
                 std::nullopt, /* targetBackForwardItemIdentifier */
                 std::nullopt, /* sourceBackForwardItemIdentifier */
                 WebCore::LockHistory::No, /* lockHistory */
@@ -102,7 +100,8 @@ void AutomationSessionClient::requestNewPageWithOptions(WebKit::WebAutomationSes
                 std::nullopt, /* navigationID */
                 { }, /* originalRequest */
                 { }, /* request */
-                { } /* invalidURLString */
+                { }, /* invalidURLString */
+                std::nullopt, /* requester */
             };
 
             auto userInitiatedActivity = API::UserInitiatedAction::create();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -348,7 +348,7 @@ void WebChromeClient::focusedFrameChanged(Frame* frame)
     WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::FocusedFrameChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt), m_page->identifier());
 }
 
-RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction)
+RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction, const std::optional<Ref<WebCore::Document>> requester)
 {
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = frame.document())
@@ -387,8 +387,6 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         navigationAction.isInitialFrameSrcLoad(),
         navigationAction.isContentRuleListRedirect(),
         openedMainFrameName,
-        { }, /* requesterOrigin */
-        { }, /* requesterTopOrigin */
         std::nullopt, /* targetBackForwardItemIdentifier */
         std::nullopt, /* sourceBackForwardItemIdentifier */
         WebCore::LockHistory::No,
@@ -410,6 +408,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         originalRequest, /* originalRequest */
         originalRequest, /* request */
         originalRequest.url().isValid() ? String() : originalRequest.url().string(), /* invalidURLString */
+        requester ? NavigationRequester::from(requester.value().get()) : std::optional<NavigationRequester>(std::nullopt), /* requester */
     };
 
     auto sendResult = webProcess.protectedParentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page->identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -90,7 +90,7 @@ private:
     // Frame wants to create the new Page.  Also, the newly created window
     // should not be shown to the user until the ChromeClient of the newly
     // created Page has its show method called.
-    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&) final;
+    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&, const std::optional<Ref<WebCore::Document>> requester) final;
     void show() final;
     
     bool canRunModal() const final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -155,8 +155,6 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         navigationAction.isInitialFrameSrcLoad(),
         navigationAction.isContentRuleListRedirect(),
         { },
-        requester.securityOrigin->data(),
-        requester.topOrigin->data(),
         navigationAction.targetBackForwardItemIdentifier(),
         navigationAction.sourceBackForwardItemIdentifier(),
         navigationAction.lockHistory(),
@@ -178,6 +176,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         navigationAction.originalRequest(),
         request,
         request.url().isValid() ? String() : request.url().string(),
+        requester,
     };
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -500,8 +500,6 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         false, /* isInitialFrameSrcLoad */
         false, /* isContentRuleListRedirect */
         { }, /* openedMainFrameName */
-        { }, /* requesterOrigin */
-        { }, /* requesterTopOrigin */
         std::nullopt, /* targetBackForwardItemIdentifier */
         std::nullopt, /* sourceBackForwardItemIdentifier */
         WebCore::LockHistory::No,
@@ -523,6 +521,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         { }, /* originalRequest */
         { }, /* request */
         { }, /* invalidURLString */
+        std::nullopt, /* requester */
     };
 
     // Notify the UIProcess.
@@ -1009,8 +1008,6 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         navigationAction.isInitialFrameSrcLoad(),
         navigationAction.isContentRuleListRedirect(),
         { }, /* openedMainFrameName */
-        { }, /* requesterOrigin */
-        { }, /* requesterTopOrigin */
         std::nullopt, /* targetBackForwardItemIdentifier */
         std::nullopt, /* sourceBackForwardItemIdentifier */
         WebCore::LockHistory::No,
@@ -1032,6 +1029,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         { }, /* originalRequest */
         request,
         request.url().isValid() ? String() : request.url().string(), /* invalidURLString */
+        std::nullopt, /* requester */
     };
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForNewWindowAction(navigationActionData, frameName), [frame = m_frame, listenerID] (PolicyDecision&& policyDecision) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2200,7 +2200,7 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
 
     localFrame->loader().setHTTPFallbackInProgress(loadParameters.isPerformingHTTPFallback);
     localFrame->loader().setRequiredCookiesVersion(loadParameters.requiredCookiesVersion);
-    localFrame->loader().load(WTFMove(frameLoadRequest));
+    localFrame->loader().load(WTFMove(frameLoadRequest), loadParameters.requester);
 
     ASSERT(!m_pendingNavigationID);
     ASSERT(!m_internals->pendingWebsitePolicies);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -69,7 +69,7 @@ private:
     void focusedElementChanged(WebCore::Element*, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement) override;
     void focusedFrameChanged(WebCore::Frame*) final;
 
-    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&) final;
+    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&, const std::optional<Ref<WebCore::Document>> requester) final;
     void show() final;
 
     bool canRunModal() const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -260,7 +260,7 @@ void WebChromeClient::focusedFrameChanged(Frame*)
 {
 }
 
-RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& features, const NavigationAction&)
+RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& features, const NavigationAction&, const std::optional<Ref<Document>> requester)
 {
     id delegate = [m_webView UIDelegate];
     WebView *newWebView;


### PR DESCRIPTION
#### 9c5cc0cb17933f73560325390a0828f2279dddb8
<pre>
[site-isolation] window.open should work with blob urls
<a href="https://bugs.webkit.org/show_bug.cgi?id=302702">https://bugs.webkit.org/show_bug.cgi?id=302702</a>
<a href="https://rdar.apple.com/136853662">rdar://136853662</a>

Reviewed by NOBODY (OOPS!).

Initial draft

Test: http/tests/site-isolation/iframe-blob-url.html

* LayoutTests/http/tests/site-isolation/iframe-blob-url-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/iframe-blob-url.html: Added.
* LayoutTests/http/tests/site-isolation/resources/window-open-blob-url.html: Added.
* Source/WebCore/loader/DocumentLoader.cpp:
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::crossSiteRequester const):
(WebCore::DocumentLoader::setCrossSiteRequester):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyChromeClient::createWindow):
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::createWindow):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/NavigationAction.cpp:
(WebCore::shouldTreatAsSameOriginNavigation):
(WebCore::NavigationAction::NavigationAction):
* Source/WebCore/loader/NavigationAction.h:
* Source/WebCore/loader/NavigationRequester.h:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createWindow):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::requesterOrigin const):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::requesterOrigin const): Deleted.
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::interceptMarketplaceKitNavigation):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::createNewPage):
* Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp:
(WebKit::AutomationSessionClient::requestNewPageWithOptions):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c5cc0cb17933f73560325390a0828f2279dddb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131710 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4202 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139219 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83575 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eb015dd5-465c-45aa-9bac-1b3cee19dc1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133580 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4128 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100686 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/83575 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5629948e-e7a7-4dda-9f2e-97c72d3794a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134656 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/4128 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81458 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/89deabd5-e0c6-4c74-acd9-abba5e0caea3) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/4128 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/708 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82441 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/4128 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141865 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3871 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109050 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3952 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3422 "Found 2 new test failures: imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109207 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57081 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3924 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32670 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3756 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67372 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3885 "Hash 9c5cc0cb for PR 54135 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->