### PR TITLE
[blocks-in-inline] Allow column spanners

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-spanner-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-spanner-expected.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<div style="-webkit-columns:4; columns:4; orphans:1; widows:1; line-height:100px; background:blue;">
+<span>text
+<div style="column-span:all; background:yellow; ">spanner</div>
+</span>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-spanner.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-spanner.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<html>
+<body>
+<div style="-webkit-columns:4; columns:4; orphans:1; widows:1; line-height:100px; background:blue;">
+<span>text
+<div style="column-span:all; background:yellow; ">spanner</div>
+</span>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -91,17 +91,17 @@ static bool isValidColumnSpanner(const RenderMultiColumnFlow& fragmentedFlow, co
     if (descendantBox->isFloatingOrOutOfFlowPositioned())
         return false;
 
+    if (!descendantBox->isBlockLevelBox())
+        return false;
+
     if (descendantBox->style().columnSpan() != ColumnSpan::All)
         return false;
 
     if (descendantBox->isLegend())
         return false;
 
-    auto* parent = descendantBox->parent();
-    if (!is<RenderBlockFlow>(*parent) || parent->childrenInline()) {
-        // Needs to be block-level.
+    if (!is<RenderBlockFlow>(descendantBox->parent()) && !is<RenderInline>(descendantBox->parent()))
         return false;
-    }
 
     // We need to have the flow thread as the containing block. A spanner cannot break out of the flow thread.
     auto* enclosingFragmentedFlow = descendantBox->enclosingFragmentedFlow();
@@ -373,7 +373,7 @@ RenderObject* RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant(R
         // so that they live among the column sets. This simplifies the layout implementation, and
         // basically just relies on regular block layout done by the RenderBlockFlow that
         // establishes the multicol container.
-        RenderBlockFlow* container = downcast<RenderBlockFlow>(descendant.parent());
+        auto* container = descendant.parent();
         RenderMultiColumnSet* setToSplit = nullptr;
         if (nextRendererInFragmentedFlow) {
             setToSplit = findSetRendering(flow, descendant);


### PR DESCRIPTION
#### 0af56cb43e58ef015ec5826c0afd57315bc25f16
<pre>
[blocks-in-inline] Allow column spanners
<a href="https://bugs.webkit.org/show_bug.cgi?id=302704">https://bugs.webkit.org/show_bug.cgi?id=302704</a>
<a href="https://rdar.apple.com/164951804">rdar://164951804</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-multicol-spanner.html
* LayoutTests/fast/inline/blocks-in-inline-multicol-spanner-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-multicol-spanner.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::isValidColumnSpanner):

A block level box can be a valid spanner even if it has an inline parent.

(WebCore::RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant):

Canonical link: <a href="https://commits.webkit.org/303182@main">https://commits.webkit.org/303182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e9eb5f06f056cd2e292c13a8fc65135f7e44709

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131575 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3907 "Hash 1e9eb5f0 for PR 54103 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83363 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3936 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3747 "Hash 1e9eb5f0 for PR 54103 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100448 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb79c0cf-9391-4726-ada9-bf75c11a9b3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134521 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81257 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2736 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82275 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141729 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108819 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3699 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/3747 "Hash 1e9eb5f0 for PR 54103 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109062 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27638 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2768 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56847 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3712 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32502 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->