### PR TITLE
Add WTF::Ref::take

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -158,6 +158,12 @@ public:
         return result;
     }
 
+#ifdef __swift__
+    T* _Nonnull take() const SWIFT_RETURNS_RETAINED {
+        return &copyRef().leakRef();
+    }
+#endif
+
 private:
     friend Ref adoptRef<T>(T&);
     template<typename X, typename Y, typename Z> friend class Ref;


### PR DESCRIPTION
#### ebc36381eac4e6cf891c14d5495ee420fb9ca2dd
<pre>
Add WTF::Ref::take
<a href="https://bugs.webkit.org/show_bug.cgi?id=302705">https://bugs.webkit.org/show_bug.cgi?id=302705</a>
<a href="https://rdar.apple.com/164955075">rdar://164955075</a>

Reviewed by NOBODY (OOPS!).

This adds a method to convert from C++ Ref&lt;T&gt; to Swift T, for those C++ types
derived from WTF::RefCounted.

This method is currently called take(). Other options considered are:
* toSwift - ruled out because in WebKit it tends to imply a costly conversion
* unwrap - we considered symmetrical wrap/unwrap non-member functions,
  but that turns out to make code quite verbose and full of weirdly
  nested parentheses; Swift code has much less deeply nested parentheses
  with a member function like this.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebc36381eac4e6cf891c14d5495ee420fb9ca2dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3924 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42557 "Hash ebc36381 for PR 54104 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83381 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/963d39d8-bd90-4779-82c3-7898d00156c1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100466 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68047 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1b0d561-f0c1-43bf-be24-379c6b31be10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2830 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/42557 "Hash ebc36381 for PR 54104 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81275 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cf711fb9-b8e3-41e5-a686-5e5274a1890e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/492 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82292 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123617 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111367 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/42557 "Hash ebc36381 for PR 54104 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141746 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130046 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3668 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/42557 "Hash ebc36381 for PR 54104 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108839 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3716 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3254 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109081 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2777 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/42557 "Hash ebc36381 for PR 54104 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56867 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3729 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/42557 "Hash ebc36381 for PR 54104 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163063 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3556 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67140 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3811 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3659 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->