### PR TITLE
REGRESSION(303073@main): Twitch pages crash after exiting fullscreen on iPad

### DIFF
--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSTransition);
 
 Ref<CSSTransition> CSSTransition::create(const Styleable& owningElement, const AnimatableCSSProperty& property, MonotonicTime generationTime, const Style::Transition& backingStyleTransition, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
 {
-    auto result = adoptRef(*new CSSTransition(owningElement, property, generationTime, backingStyleTransition, oldStyle, newStyle, reversingAdjustedStartStyle, reversingShorteningFactor));
+    auto result = adoptRef(*new CSSTransition(owningElement, property, generationTime, backingStyleTransition, newStyle, reversingAdjustedStartStyle, reversingShorteningFactor));
     result->initialize(&oldStyle, newStyle, { nullptr });
     result->setTimingProperties(delay, duration);
 
@@ -48,12 +48,11 @@ Ref<CSSTransition> CSSTransition::create(const Styleable& owningElement, const A
     return result;
 }
 
-CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProperty& property, MonotonicTime generationTime, const Style::Transition& backingStyleTransition, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
+CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProperty& property, MonotonicTime generationTime, const Style::Transition& backingStyleTransition, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
     : StyleOriginatedAnimation(styleable)
     , m_property(property)
     , m_generationTime(generationTime)
     , m_targetStyle(RenderStyle::clonePtr(targetStyle))
-    , m_currentStyle(RenderStyle::clonePtr(oldStyle))
     , m_reversingAdjustedStartStyle(RenderStyle::clonePtr(reversingAdjustedStartStyle))
     , m_reversingShorteningFactor(reversingShorteningFactor)
     , m_backingStyleTransition(backingStyleTransition)
@@ -61,13 +60,6 @@ CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProp
 }
 
 CSSTransition::~CSSTransition() = default;
-
-OptionSet<AnimationImpact> CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, EndpointInclusiveActiveInterval endpointInclusiveActiveInterval)
-{
-    auto impact = StyleOriginatedAnimation::resolve(targetStyle, resolutionContext, endpointInclusiveActiveInterval);
-    m_currentStyle = RenderStyle::clonePtr(targetStyle);
-    return impact;
-}
 
 void CSSTransition::animationDidFinish()
 {

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -50,17 +50,15 @@ public:
     AnimatableCSSProperty property() const { return m_property; }
     MonotonicTime generationTime() const { return m_generationTime; }
     const RenderStyle& targetStyle() const { return *m_targetStyle; }
-    const RenderStyle& currentStyle() const { return *m_currentStyle; }
     const RenderStyle& reversingAdjustedStartStyle() const { return *m_reversingAdjustedStartStyle; }
     double reversingShorteningFactor() const { return m_reversingShorteningFactor; }
 
     const Style::Transition& backingStyleTransition() const { return m_backingStyleTransition; }
 
 private:
-    CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Style::Transition&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
+    CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Style::Transition&, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
     Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
-    OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }
 
@@ -70,7 +68,6 @@ private:
     AnimatableCSSProperty m_property;
     MonotonicTime m_generationTime;
     std::unique_ptr<RenderStyle> m_targetStyle;
-    std::unique_ptr<RenderStyle> m_currentStyle;
     std::unique_ptr<RenderStyle> m_reversingAdjustedStartStyle;
     double m_reversingShorteningFactor;
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -157,7 +157,7 @@ public:
     bool needsTick() const;
     virtual void tick();
     WEBCORE_EXPORT Seconds timeToNextTick() const;
-    virtual OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No);
+    OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No);
     void effectTargetDidChange(const std::optional<const Styleable>& previousTarget, const std::optional<const Styleable>& newTarget);
     void acceleratedStateDidChange();
     void willChangeRenderer();


### PR DESCRIPTION
#### 48e68eb17fb7ecf1b9d25c4101f06a200a185e08
<pre>
REGRESSION(303073@main): Twitch pages crash after exiting fullscreen on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=302713">https://bugs.webkit.org/show_bug.cgi?id=302713</a>
<a href="https://rdar.apple.com/164913157">rdar://164913157</a>

Reviewed by Antti Koivisto.

We made `KeyframeEffectStack::sortedEffects()` return a const reference in 303073@main whereas previously it would return a copy of
the list of sorted effects.

In the `updateCSSTransitionsForStyleableAndProperty()` function, called under `Style::TreeResolver::createAnimatedElementUpdate()`,
where we update transitions as part of an animation update, in order to determine the before-change style [0], we manually update
the underlying, non-animated style to the current state for animations that target the property in question. We use
`KeyframeEffectStack::sortedEffects()` to get the list of effects applied to the element we&apos;re processing, but we use a method,
`WebAnimation::resolve()`, to compute the animated styles that does more than just that, updating the finished state of the animation [1]
which may change whether the animation in question is considered relevant [2] and thus affect its membership in the effect list
we&apos;re iterating upon.

One way to address this would be to make a copy of the effect list, but we should be able to iterate through the effect list here
without it changing from under us. To that end, we now use `KeyframeEffect::apply()` instead of `WebAnimation::resolve()`. This change
alone addresses the reported issue.

However, this change yielded some test regressions in the WPT test `css/css-transitions/KeyframeEffect-setKeyframes.tentative.html`.
As it turns out, the current style of a transition was cached under an overridden implementation of `WebAnimation::resolve()` in the
`CSSTransition` class, and changing from calling `WebAnimation::resolve()` to `KeyframeEffect::apply()` meant that this style was no
longer current. It appears now that this approach was fragile, and also overkill since this transition current style is only ever used
in one of the branches of the CSS Transition update process and should be computed as requested. So on top of the change described above,
we now remove the CSS Transition current style caching, removing the `CSSTransition::m_currentStyle` member, in favor of computing it
directly as needed.

[0] <a href="https://drafts.csswg.org/css-transitions-1/#before-change-style">https://drafts.csswg.org/css-transitions-1/#before-change-style</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#updating-the-finished-state">https://drafts.csswg.org/web-animations-1/#updating-the-finished-state</a>
[2] <a href="https://drafts.csswg.org/web-animations-1/#relevant-animations-section">https://drafts.csswg.org/web-animations-1/#relevant-animations-section</a>

* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::create):
(WebCore::CSSTransition::CSSTransition):
(WebCore::CSSTransition::resolve): Deleted.
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::updateCSSTransitionsForStyleableAndProperty):

Canonical link: <a href="https://commits.webkit.org/303234@main">https://commits.webkit.org/303234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d385d9a56ecc990d7a272d6721fd27cb34ecde1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69ed98d6-c4e0-45ab-83c7-7da89be44775) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100661 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/77874342-cb94-482d-9135-2ed361e9d1b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81340 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f09e8c4d-e6be-40a6-bb39-a7f01d0a49db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2851 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/690 "Found 3 new API test failures: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82371 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141826 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109027 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109152 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2932 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57042 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3885 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32645 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3717 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3846 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->