### PR TITLE
REGRESSION (STP 232): comma-separated values for mask-size: auto gets unset

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-computed-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Property mask-size value '1px'
+PASS Property mask-size value '1px auto'
+PASS Property mask-size value '2% 3%'
+PASS Property mask-size value 'auto'
+PASS Property mask-size value 'auto auto'
+PASS Property mask-size value 'auto 4%'
+PASS Property mask-size value 'contain'
+PASS Property mask-size value 'cover'
+PASS Property mask-size value 'calc(10px + 0.5em) calc(10px - 0.5em)'
+PASS Property mask-size value 'calc(10px - 0.5em) calc(10px + 0.5em)'
+PASS Property mask-size value 'auto 1px, 2% 3%, contain'
+PASS Property mask-size value 'auto' multiple values
+PASS Property mask-size value 'auto, 100%' multiple values
+PASS Property mask-size value '100%' multiple values
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-computed.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: getComputedStyle().maskSize</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask-size">
+<meta name="assert" content="mask-size computed value is a list, each item a pair of sizes (one per axis) each represented as either a keyword or a computed length-percentage value.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("mask-size", "1px", "1px auto");
+test_computed_value("mask-size", "1px auto", "1px auto");
+test_computed_value("mask-size", "2% 3%");
+test_computed_value("mask-size", "auto");
+test_computed_value("mask-size", "auto auto", "auto");
+test_computed_value("mask-size", "auto 4%");
+test_computed_value("mask-size", "contain");
+test_computed_value("mask-size", "cover");
+test_computed_value("mask-size", "calc(10px + 0.5em) calc(10px - 0.5em)", "30px 0px");
+test_computed_value("mask-size", "calc(10px - 0.5em) calc(10px + 0.5em)", "0px 30px");
+test_computed_value("mask-size", "auto 1px, 2% 3%, contain", "auto 1px");
+
+document.getElementById("target").style['mask-image'] = "none, none";
+test_computed_value("mask-size", "auto", "auto, auto", "multiple values");
+test_computed_value("mask-size", "auto, 100%", "auto, 100% auto", "multiple values");
+test_computed_value("mask-size", "100%", "100% auto, 100% auto", "multiple values");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-invalid-expected.txt
@@ -1,0 +1,5 @@
+
+PASS e.style['mask-size'] = "-1px" should not set the property value
+PASS e.style['mask-size'] = "2% -3%" should not set the property value
+PASS e.style['mask-size'] = "1px 2px 3px" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing mask-size with invalid values</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask-size">
+<meta name="assert" content="mask-size supports only the grammar '<bg-size>#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("mask-size", "-1px");
+test_invalid_value("mask-size", "2% -3%");
+test_invalid_value("mask-size", "1px 2px 3px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-valid-expected.txt
@@ -1,0 +1,11 @@
+
+PASS e.style['mask-size'] = "1px" should set the property value
+PASS e.style['mask-size'] = "1px auto" should set the property value
+PASS e.style['mask-size'] = "2% 3%" should set the property value
+PASS e.style['mask-size'] = "auto" should set the property value
+PASS e.style['mask-size'] = "auto auto" should set the property value
+PASS e.style['mask-size'] = "auto 4%" should set the property value
+PASS e.style['mask-size'] = "contain" should set the property value
+PASS e.style['mask-size'] = "cover" should set the property value
+PASS e.style['mask-size'] = "auto 1px, 2% 3%, contain" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-valid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing mask-size with valid values</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask-size">
+<meta name="assert" content="mask-size supports the full grammar '<bg-size>#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("mask-size", "1px");
+test_valid_value("mask-size", "1px auto");
+test_valid_value("mask-size", "2% 3%");
+test_valid_value("mask-size", "auto");
+test_valid_value("mask-size", "auto auto", "auto");
+test_valid_value("mask-size", "auto 4%");
+test_valid_value("mask-size", "contain");
+test_valid_value("mask-size", "cover");
+test_valid_value("mask-size", "auto 1px, 2% 3%, contain");
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/values/backgrounds/StyleBackgroundSize.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleBackgroundSize.cpp
@@ -58,6 +58,8 @@ auto CSSValueConversion<BackgroundSize>::operator()(BuilderState& state, const C
 
     if (primitiveValue->isValueID()) {
         switch (primitiveValue->valueID()) {
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
         case CSSValueCover:
             return CSS::Keyword::Cover { };
         case CSSValueContain:


### PR DESCRIPTION
#### f27a04372bba0b7947d9eb7fc2ab8e5d04de60a8
<pre>
REGRESSION (STP 232): comma-separated values for mask-size: auto gets unset
<a href="https://bugs.webkit.org/show_bug.cgi?id=302533">https://bugs.webkit.org/show_bug.cgi?id=302533</a>
<a href="https://rdar.apple.com/164727930">rdar://164727930</a>

Reviewed by Tim Nguyen.

Fixes style building failure for `mask-size: auto`. The failure was due to
parsing code for `mask-size` using a single CSSPrimitiveValue as the specified
value representation for a single `auto` value, unlike `background-size`, which
always created a CSSValuePair with two identical CSSPrimitiveValues in that case,
coupled with the lack of handling as single CSSPrimitiveValue in the CSSValueConversion
code. The fix is simply to support a single CSSPrimitiveValue `auto` case.

There were also no parsing tests for `mask-size`, so the complete valid/invalid/computed
set was added.

Tests: imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-computed.html
       imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-invalid.html
       imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-valid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/mask-size-valid.html: Added.
* Source/WebCore/style/values/backgrounds/StyleBackgroundSize.cpp:
(WebCore::Style::CSSValueConversion&lt;BackgroundSize&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/303192@main">https://commits.webkit.org/303192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c600529f2aa5734d16d1ed69a5c4c672645b3e2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139133 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3797 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100489 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134570 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81297 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3700 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36454 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108863 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27642 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2806 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56910 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3761 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67172 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/3843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->