### PR TITLE
Add StreamBatched to ReleaseDisplayList IPC Message

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -32,7 +32,7 @@ messages -> RemoteRenderingBackend Stream {
     ReleaseImageBuffer(WebCore::RenderingResourceIdentifier identifier)
     CreateDisplayListRecorder(WebKit::RemoteDisplayListRecorderIdentifier identifier)
     SinkDisplayListRecorderIntoDisplayList(WebKit::RemoteDisplayListRecorderIdentifier identifier, WebKit::RemoteDisplayListIdentifier displayListIdentifier)
-    ReleaseDisplayList(WebKit::RemoteDisplayListIdentifier identifier)
+    ReleaseDisplayList(WebKit::RemoteDisplayListIdentifier identifier) StreamBatched
     GetImageBufferResourceLimitsForTesting() -> (struct WebCore::ImageBufferResourceLimits limits) Async
     DestroyGetPixelBufferSharedMemory()
     NativeImageBitmap(WebCore::RenderingResourceIdentifier identifier) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply


### PR DESCRIPTION
#### 46d43293638baf000be11d67dbef1f508df9f8f4
<pre>
Add StreamBatched to ReleaseDisplayList IPC Message
<a href="https://bugs.webkit.org/show_bug.cgi?id=302715">https://bugs.webkit.org/show_bug.cgi?id=302715</a>
<a href="https://rdar.apple.com/164971094">rdar://164971094</a>

Reviewed by Kimmo Kinnunen.

Add StreamBatched to ReleaseDisplayList IPC message.
This batches ReleaseDisplayList IPC messages, accumulating 100
messages on the WebContent process client side
before calling semaphore_signal_trap() to wake
the GPU process to delete a GlyphDisplayList cache
entry.
This is a performance optomization that reduces
the number semaphore signals. This is a
bottleneck seen in LayoutIntegration::InlineContent::~InlineContent()
which calls GlyphDisplayListCache::remove() frequently.

StreamBatched was previously used for ReleaseDecomposedGlyphs
(see <a href="https://commits.webkit.org/292098@main)">https://commits.webkit.org/292098@main)</a> but was
not added to the replacement ReleaseDisplayList message in
<a href="https://commits.webkit.org/299747@main.">https://commits.webkit.org/299747@main.</a> This restores
the batching optimization.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:

Canonical link: <a href="https://commits.webkit.org/303551@main">https://commits.webkit.org/303551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c31ac7e1701a4b395776156439c2ab4f082bf92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83648 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e22972b5-db6e-4b74-bded-fef7140794e2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100490 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68146 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f38e2a92-2433-4681-b354-4fc73a96d347) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81298 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/553a439f-44b3-467f-a2d4-d55668aed636) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82330 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111400 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141784 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3706 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27905 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2812 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56916 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3767 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32550 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->