### PR TITLE
[iOS] Viewport size does not update when `viewport-fit` value is changed

### DIFF
--- a/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change-expected.txt
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change-expected.txt
@@ -1,0 +1,18 @@
+Tests that changing the value of viewport-fit affects the size of the viewport.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial width, using viewport-fit: cover
+PASS document.body.clientWidth is 374
+
+Set safe area, but still using viewport-fit: cover
+PASS document.body.clientWidth is 374
+
+Change to viewport-fit: auto
+PASS document.body.clientWidth is 334
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+
+<html>
+<head>
+<meta name="viewport" content="initial-scale=1, width=device-width, viewport-fit=cover">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Tests that changing the value of viewport-fit affects the size of the viewport.");
+
+    debug("Initial width, using viewport-fit: cover");
+    shouldBe("document.body.clientWidth", "374");
+
+    debug("\nSet safe area, but still using viewport-fit: cover");
+    await UIHelper.setSafeAreaInsets(0, 20, 0, 20);
+    shouldBe("document.body.clientWidth", "374");
+
+    debug("\nChange to viewport-fit: auto");
+    let viewportMeta = document.querySelector('meta[name="viewport"]');
+    viewportMeta.setAttribute('content', 'initial-scale=1, width=device-width, viewport-fit=auto');
+
+    await UIHelper.ensurePresentationUpdate();
+
+    shouldBe("document.body.clientWidth", "334");
+
+    debug("");
+    finishJSTest();
+});
+
+</script>
+</head>
+
+<body>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -643,6 +643,20 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async setSafeAreaInsets(top, right, bottom, left)
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.setSafeAreaInsets(${top}, ${right}, ${bottom}, ${left});
+                uiController.doAfterNextVisibleContentRectAndStablePresentationUpdate(function() {
+                    uiController.uiScriptComplete();
+                });`, resolve);
+        });
+    }
+
     static async setInlinePrediction(text, startIndex = 0)
     {
         if (!this.isWebKit2())

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2542,6 +2542,11 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     _shouldUpdateNeedsTopScrollPocketDueToVisibleContentInset = YES;
 #endif
+
+#if !PLATFORM(WATCHOS)
+    if (!self._shouldDeferGeometryUpdates && !_overriddenLayoutParameters)
+        [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
+#endif
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -884,12 +884,16 @@ TEST(WKScrollViewTests, ContentInsetAdjustmentBehaviorChangeAfterViewportFitChan
     EXPECT_EQ([scrollView contentInsetAdjustmentBehavior], UIScrollViewContentInsetAdjustmentNever);
     EXPECT_EQ([scrollView adjustedContentInset], UIEdgeInsetsZero);
 
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.body.clientWidth"], "400");
+
     [webView loadSimulatedRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain2.com"]] responseHTMLString:@"<html><head><meta name='viewport' content='width=device-width, initial-scale=1'></head></html>"];
     [navigationDelegate waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];
 
     EXPECT_EQ([scrollView contentInsetAdjustmentBehavior], UIScrollViewContentInsetAdjustmentAlways);
     EXPECT_EQ([scrollView adjustedContentInset], insets);
+
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.body.clientWidth"], "280");
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 7928c62c0d1c69e1c9deafec127b236cc4663626
<pre>
[iOS] Viewport size does not update when `viewport-fit` value is changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=302696">https://bugs.webkit.org/show_bug.cgi?id=302696</a>
<a href="https://rdar.apple.com/164943708">rdar://164943708</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

When the `viewport-fit` value is changed, the adjusted content inset on the
`WKScrollView` is also changed. These insets should affect the viewport size.
However, there is currently no logic that ensures the view layout size is
updated following a change to the adjusted content inset. In the common case,
where safe areas are changed by the system, the size update is driven by
`-[WKWebView layoutSubviews]`, which triggers an update under
`-[WKWebView _frameOrBoundsMayHaveChanged]`. This does not account for
WebKit-driven changes.

Fix by dispatching a view layout size update whenever the adjusted content inset
is changed. This is a no-op if the size has not actually changed.

* LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change-expected.txt: Added.
* LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async setSafeAreaInsets):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewDidChangeAdjustedContentInset:]):

Exclude watchOS to align with existing safe area management logic.

* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, ContentInsetAdjustmentBehaviorChangeAfterViewportFitChange)):

Canonical link: <a href="https://commits.webkit.org/303251@main">https://commits.webkit.org/303251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/030b8c91efe2896373aa5372fe0d77486715a98a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83490 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/67a7d366-1d74-4f39-a249-b8d1ccb0ff5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100496 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68072 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6fc1f745-69db-466c-bebf-21fd967cad6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81304 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be5a3326-3508-4c24-b5d1-d6d370694628) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2830 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/533 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82333 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141787 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108869 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3757 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3289 "Found 1 new test failure: webgl/2.0.y/conformance/context/context-release-with-workers.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109113 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2811 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56919 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20493 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3770 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32549 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->