### PR TITLE
Introduce ThreadGroupSnapshot to encapsulate a list of threads that won't exit

### DIFF
--- a/Source/JavaScriptCore/heap/MachineStackMarker.cpp
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.cpp
@@ -152,7 +152,8 @@ bool MachineThreads::tryCopyOtherThreadStacks(const AbstractLocker& locker, void
     *size = 0;
 
     auto& currentThread = Thread::currentSingleton();
-    const ListHashSet<Ref<Thread>>& threads = m_threadGroup->threads(locker);
+    auto snapshot = m_threadGroup->snapshot(locker);
+    auto threads = snapshot.threads();
     BitVector isSuspended(threads.size());
 
     {
@@ -170,7 +171,7 @@ bool MachineThreads::tryCopyOtherThreadStacks(const AbstractLocker& locker, void
                         // These threads will be removed from the ThreadGroup. Thus, we do not do anything here except for reporting.
                         ASSERT(result.error() != KERN_SUCCESS);
                         WTFReportError(__FILE__, __LINE__, WTF_PRETTY_FUNCTION,
-                            "JavaScript garbage collection encountered an invalid thread (err 0x%x): Thread [%d/%d: %p].",
+                            "JavaScript garbage collection encountered an invalid thread (err 0x%x): Thread [%d/%lu: %p].",
                             result.error(), index, threads.size(), thread.ptr());
 #endif
                     }

--- a/Source/JavaScriptCore/heap/MachineStackMarker.h
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.h
@@ -52,7 +52,7 @@ public:
     bool addCurrentThread() { return m_threadGroup->addCurrentThread() == ThreadGroupAddResult::NewlyAdded; }
 
     WordLock& getLock() { return m_threadGroup->getLock(); }
-    const ListHashSet<Ref<Thread>>& threads(const AbstractLocker& locker) const { return m_threadGroup->threads(locker); }
+    ThreadGroupSnapshot snapshot(const AbstractLocker& locker) const { return m_threadGroup->snapshot(locker); }
 
 private:
     void gatherFromCurrentThread(ConservativeRoots&, JITStubRoutineSet&, CodeBlockSet&, CurrentThreadState&);

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -206,7 +206,8 @@ protected:
     bool isValidFramePointer(void* callFrame)
     {
         uint8_t* fpCast = std::bit_cast<uint8_t*>(callFrame);
-        for (auto& thread : m_vm.heap.machineThreads().threads(m_machineThreadsLocker)) {
+        auto snapshot = m_vm.heap.machineThreads().snapshot(m_machineThreadsLocker);
+        for (auto& thread : snapshot.threads()) {
             uint8_t* stackBase = static_cast<uint8_t*>(thread->stack().origin());
             uint8_t* stackLimit = static_cast<uint8_t*>(thread->stack().end());
             RELEASE_ASSERT(stackBase);

--- a/Source/JavaScriptCore/wasm/WasmMachineThreads.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMachineThreads.cpp
@@ -55,7 +55,8 @@ void resetInstructionCacheOnAllThreads()
 {
     Locker locker { wasmThreads().getLock() };
     ThreadSuspendLocker threadSuspendLocker;
-    for (auto& thread : wasmThreads().threads(locker)) {
+    auto snapshot = wasmThreads().snapshot(locker);
+    for (auto& thread : snapshot.threads()) {
         sendMessage(threadSuspendLocker, thread.get(), [] (const PlatformRegisters&) {
             // It's likely that the signal handler will already reset the instruction cache but we might as well be sure.
             WTF::crossModifyingCodeFence();

--- a/Source/WTF/wtf/ThreadGroup.h
+++ b/Source/WTF/wtf/ThreadGroup.h
@@ -34,6 +34,28 @@ namespace WTF {
 
 enum class ThreadGroupAddResult { NewlyAdded, AlreadyAdded, NotAdded };
 
+class ThreadGroupSnapshot {
+public:
+    WTF_MAKE_NONCOPYABLE(ThreadGroupSnapshot);
+    ThreadGroupSnapshot(Vector<Ref<Thread>>&& threads, Vector<Locker<WordLock>>&& threadLockers)
+        : m_threads(WTFMove(threads))
+        , m_threadLockers(WTFMove(threadLockers))
+    {
+    }
+
+    ThreadGroupSnapshot(ThreadGroupSnapshot&& other)
+        : m_threads(WTFMove(other.m_threads))
+        , m_threadLockers(WTFMove(other.m_threadLockers))
+    {
+    }
+
+    Vector<Ref<Thread>>& threads() LIFETIME_BOUND { return m_threads; }
+
+private:
+    Vector<Ref<Thread>> m_threads;
+    Vector<Locker<WordLock>> m_threadLockers;
+};
+
 class ThreadGroup final : public std::enable_shared_from_this<ThreadGroup> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ThreadGroup);
     WTF_MAKE_NONCOPYABLE(ThreadGroup);
@@ -49,7 +71,7 @@ public:
     WTF_EXPORT_PRIVATE ThreadGroupAddResult add(const AbstractLocker&, Thread&);
     WTF_EXPORT_PRIVATE ThreadGroupAddResult addCurrentThread();
 
-    const ListHashSet<Ref<Thread>>& threads(const AbstractLocker&) const { return m_threads; }
+    ThreadGroupSnapshot snapshot(const AbstractLocker&) const;
 
     WordLock& getLock() { return m_lock; }
 
@@ -72,3 +94,4 @@ private:
 
 using WTF::ThreadGroup;
 using WTF::ThreadGroupAddResult;
+using WTF::ThreadGroupSnapshot;

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -477,7 +477,8 @@ void activateSignalHandlersFor(Signal signal)
         activeExceptions |= toMachMask(signal);
         // activeExceptions should be a subset of addedExceptions.
         ASSERT(!(activeExceptions & ~handlers.addedExceptions));
-        for (auto& thread : activeThreads().threads(locker))
+        auto snapshot = activeThreads().snapshot(locker);
+        for (auto& thread : snapshot.threads())
             setExceptionPorts(locker, thread.get());
         return;
     }


### PR DESCRIPTION
#### 3881f3072ab01c25075d427b33de99f30945f2fc
<pre>
Introduce ThreadGroupSnapshot to encapsulate a list of threads that won&apos;t exit
<a href="https://bugs.webkit.org/show_bug.cgi?id=302722">https://bugs.webkit.org/show_bug.cgi?id=302722</a>
<a href="https://rdar.apple.com/164974979">rdar://164974979</a>

Reviewed by NOBODY (OOPS!).

This is motivated by the SaferCPP bot complaining about raw back-pointers from
Thread to ThreadGroup.

My goal is to eliminate those raw pointers, and also reduce overall complexity,
since this code has been subject to mysterious deadlocks in the past, and its
current state is the result of a speculative fix.

In theory, once we encapsulate a set of threads that won&apos;t exit, we don&apos;t need
an intricate handshake between Thread and ThreadGroup when it&apos;s time to exit.

In theory.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3881f3072ab01c25075d427b33de99f30945f2fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42603 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139146 "Hash 3881f307 for PR 54117 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83506 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c710743-4cfe-47d4-8e9b-d64fee56d35e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3810 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/139146 "Hash 3881f307 for PR 54117 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d581e131-7e9e-4e62-9903-da1ebb3e9d59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2943 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117823 "Found 2 new API test failures: TestWTF.WTF.ThreadGroupAddCurrentThread, TestWTF.WTF.ThreadGroupAdd (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/139146 "Hash 3881f307 for PR 54117 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9d7798d-98a9-404a-a1b6-9810f5d7cbaf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2831 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/660 "Failed to checkout and rebase branch from PR 54117") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82337 "Hash 3881f307 for PR 54117 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123662 "Found unexpected failure with change (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111404 "Found 2 new API test failures: TestWTF.WTF.ThreadGroupAddCurrentThread, TestWTF.WTF.ThreadGroupAdd (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35948 "Found 1 new test failure: workers/wasm-hashset-many-2.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141791 "Hash 3881f307 for PR 54117 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130091 "Found unexpected failure with change (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3713 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36464 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/141791 "Hash 3881f307 for PR 54117 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3761 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3292 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/141791 "Hash 3881f307 for PR 54117 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2814 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56923 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32552 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163109 "Hash 3881f307 for PR 54117 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67185 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/163109 "Hash 3881f307 for PR 54117 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->