### PR TITLE
[WebKit] [3f3912d74a915810] ASAN_TRAP | WebCore::RenderThemeMac::systemColor; WebCore::Style::toStyleColor; Style::CSSValueConversion::operator

### DIFF
--- a/LayoutTests/fast/css/cssom-border-image-width-crash-expected.txt
+++ b/LayoutTests/fast/css/cssom-border-image-width-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/cssom-border-image-width-crash.html
+++ b/LayoutTests/fast/css/cssom-border-image-width-crash.html
@@ -1,0 +1,11 @@
+<style>
+ div { border-image-width: auto; }
+</style>
+<script>
+window.testRunner?.dumpAsText();
+
+const div = document.createElement('div');
+document.documentElement.appendChild(div);
+div.attributeStyleMap.set('accent-color', div.computedStyleMap().get('border-image-width'));
+</script>
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/cssom-mask-border-width-crash-expected.txt
+++ b/LayoutTests/fast/css/cssom-mask-border-width-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/cssom-mask-border-width-crash.html
+++ b/LayoutTests/fast/css/cssom-mask-border-width-crash.html
@@ -1,0 +1,8 @@
+<script>
+window.testRunner?.dumpAsText();
+
+const n2 = document.createElement('div');
+document.documentElement.appendChild(n2);
+n2.attributeStyleMap.set('accent-color', document.documentElement.computedStyleMap().get('mask-border-width'));
+</script>
+This test passes if it doesn't crash.

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -378,7 +378,12 @@ auto CSSValueConversion<Color>::operator()(BuilderState& builderState, const CSS
 
     if (RefPtr color = dynamicDowncast<CSSColorValue>(value))
         return toStyle(color->color(), builderState, forVisitedLink);
-    return toStyle(CSS::Color { CSS::KeywordColor { value.valueID() } }, builderState, forVisitedLink);
+
+    if (CSS::isColorKeyword(value.valueID()))
+        return toStyle(CSS::Color { CSS::KeywordColor { value.valueID() } }, builderState, forVisitedLink);
+
+    builderState.setCurrentPropertyInvalidAtComputedValueTime();
+    return Color { WebCore::Color { } };
 }
 
 auto CSSValueConversion<Color>::operator()(BuilderState& builderState, const CSSValue& value) -> Color


### PR DESCRIPTION
#### cd9a578ec975fec293f54e7cd35d41ea925e3e61
<pre>
[WebKit] [3f3912d74a915810] ASAN_TRAP | WebCore::RenderThemeMac::systemColor; WebCore::Style::toStyleColor; Style::CSSValueConversion::operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=298299">https://bugs.webkit.org/show_bug.cgi?id=298299</a>
<a href="https://rdar.apple.com/159650421">rdar://159650421</a>

Reviewed by Tim Nguyen.

Add missing check for valid color keywords when building Style::Colors.

Tests: fast/css/cssom-border-image-width-crash.html
       fast/css/cssom-mask-border-width-crash.html

* LayoutTests/fast/css/cssom-border-image-width-crash-expected.txt: Added.
* LayoutTests/fast/css/cssom-border-image-width-crash.html: Added.
* LayoutTests/fast/css/cssom-mask-border-width-crash-expected.txt: Added.
* LayoutTests/fast/css/cssom-mask-border-width-crash.html: Added.
* Source/WebCore/style/values/color/StyleColor.cpp:

Canonical link: <a href="https://commits.webkit.org/303207@main">https://commits.webkit.org/303207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47b1ccaffe8895db06a5b0699707516f0f16b322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83495 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8ef0aef-0220-43db-a563-28f814259654) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b6fc8014-c105-4308-8a28-fb9ada05adeb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134584 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117826 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81305 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/764f3e5b-1929-4be1-baf6-8096fde8424a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/534 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141792 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108871 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3762 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3291 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109115 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2815 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114154 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56924 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3775 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32553 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3602 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3944 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->