### PR TITLE
AX: Move live region announcements into webkit behind feature flag

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt
@@ -1,0 +1,16 @@
+This test verifies that live region notifications are properly formatted on iOS devices.
+
+Announcement received, notification: AXAnnouncementRequested, attributed string: Price: $10{
+    UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityLow;
+    UIAccessibilitySpeechAttributeIsLiveRegion = 1;
+}
+Announcement received, notification: AXAnnouncementRequested, attributed string: Count: 5{
+    UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityDefault;
+    UIAccessibilitySpeechAttributeIsLiveRegion = 1;
+}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Price: $10
+Count: 5

--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types.html
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="polite-region" aria-live="polite" aria-atomic="true">
+    Price: $0
+</div>
+
+<div id="assertive-region" aria-live="assertive" aria-atomic="true">
+    Count: 0
+</div>
+
+<script>
+var output = "This test verifies that live region notifications are properly formatted on iOS devices.\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Announcement received, notification: ${notification}, attributed string: ${userInfo["AXAnnouncementRequested"]}\n`;
+        notificationCount++;
+
+        if (notificationCount == 1)
+            document.getElementById('assertive-region').textContent = "Count: 5";
+        else if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    document.getElementById('polite-region').textContent = "Price: $10";
+ 
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-alert-added-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-alert-added-expected.txt
@@ -1,0 +1,12 @@
+This tests alerts that are added to the page dynamically are announced.
+
+Received announcement request:
+AnnouncementKey: This is an alert!!
+AXPriorityKey: 90
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is an alert!!

--- a/LayoutTests/accessibility/mac/live-regions/live-region-alert-added.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-alert-added.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body id="body">
+
+<script>
+var output = "This tests alerts that are added to the page dynamically are announced.\n\n";
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+
+        notificationCount++; 
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    // Add a live region, since this is an alert it should make an announcement.
+    const newRegion = document.createElement("div");
+    newRegion.setAttribute("role", "alert");
+    newRegion.setAttribute("id", "region");
+    newRegion.textContent = "This is an alert!!";
+    document.getElementById("body").appendChild(newRegion);
+ 
+    setTimeout(async function() {        
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load-expected.txt
@@ -1,0 +1,13 @@
+This tests that when an alert (implicit live region) is initialized, it is announced.
+
+Received announcement request:
+AnnouncementKey: Important announcement
+AXPriorityKey: 90
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Unimportant announcement
+Important announcement

--- a/LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<!-- This live region shouldn't make any announcement when AX is first initialized -->
+<div id="regular-region" aria-live="polite">Unimportant announcement</div>
+
+<div id="alert-region" role="alert">Important announcement</div>
+
+<script>
+var output = "This tests that when an alert (implicit live region) is initialized, it is announced.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("regular-region");
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added-expected.txt
@@ -1,0 +1,12 @@
+This tests live regions that are added to the page dynamically behave correctly.
+
+Received announcement request:
+AnnouncementKey: Alert! Region changed
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Alert! Region changed

--- a/LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body id="body">
+
+<script>
+var output = "This tests live regions that are added to the page dynamically behave correctly.\n\n";    
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+
+        notificationCount++; 
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    // Add a live region, this shouldn't make any announcement.
+    const newRegion = document.createElement("div");
+    newRegion.setAttribute("aria-live", "polite");
+    newRegion.setAttribute("id", "region");
+    newRegion.textContent = "Alerts will appear here.";
+    document.getElementById("body").appendChild(newRegion);
+ 
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.accessibleElementById("region") != null);
+        
+        // Now that the live region has been added to the page, any changes should be announced.
+        newRegion.textContent = "Alert! Region changed";
+        
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-hidden-content-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-hidden-content-expected.txt
@@ -1,0 +1,15 @@
+This tests that changes to aria-hidden regions don't result in live region changes.
+
+Received announcement request:
+AnnouncementKey: More exposed content.
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Important Title
+
+Extremely unimportant, hidden content.
+More exposed content.

--- a/LayoutTests/accessibility/mac/live-regions/live-region-hidden-content.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-hidden-content.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div aria-live="polite" id="region">
+    <h1>Important Title</h1>
+    <div id="hidden-content" aria-hidden="true">
+        Unimportant, hidden content.
+    </div>
+</div>
+
+<script>
+var output = "This tests that changes to aria-hidden regions don't result in live region changes.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("team-list");
+
+    // Modifying the aria-hidden content shouldn't result in an announcement notification.
+    document.getElementById("hidden-content").textContent = "Extremely unimportant, hidden content.";
+ 
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.accessibleElementById("region") != null);
+        // We should speak a remove notification for this item because of aria-relevant="removals".
+        const newContent = document.createElement("p");
+        newContent.textContent = "More exposed content.";
+        document.getElementById("region").appendChild(newContent);
+    
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
@@ -1,0 +1,15 @@
+This tests that the notifications for aria-relevant=removals are correct.
+
+Received announcement request:
+AnnouncementKey: removed Mariners
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Giants
+Cubs
+Orioles
+Tigers

--- a/LayoutTests/accessibility/mac/live-regions/live-region-removals.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-removals.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+<meta charset="utf-8" />
+</head>
+<body>
+
+<ul id="team-list" aria-live="polite" aria-relevant="removals" style="list-style-type: none;">
+    <li>Giants</li>
+    <li>Cubs</li>
+    <li>Orioles</li>
+    <li>Tigers</li>
+</ul>
+
+<script>
+var output = "This tests that the notifications for aria-relevant=removals are correct.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+        
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("team-list");
+
+    // Adding an element shouldn't speak anything when aria-relevant="removals" is set.
+    const newTeam = document.createElement("li");
+    newTeam.textContent = "Mariners";
+    document.getElementById("team-list").appendChild(newTeam);
+ 
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.accessibleElementById("team-list") != null);
+        // We should speak a remove notification for this item because of aria-relevant="removals".
+        document.getElementById("team-list").lastElementChild.remove();
+    
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-types-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-types-expected.txt
@@ -1,0 +1,18 @@
+This tests that the notifications for aria-live=polite and aria-live=assertive are properly formatted.
+
+Received announcement request:
+AnnouncementKey: Price: $10
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+Received announcement request:
+AnnouncementKey: Count: 5
+AXPriorityKey: 90
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Price: $10
+Count: 5

--- a/LayoutTests/accessibility/mac/live-regions/live-region-types.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-types.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="polite-region" aria-live="polite" aria-atomic="true">
+    Price: $0
+</div>
+
+<div id="assertive-region" aria-live="assertive" aria-atomic="true">
+    Count: 0
+</div>
+
+<script>
+var output = "This tests that the notifications for aria-live=polite and aria-live=assertive are properly formatted.\n\n";    
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+
+        notificationCount++;  
+    }
+	
+    if (notificationCount == 1)
+        document.getElementById('assertive-region').textContent = "Count: 5";
+    else if (notificationCount == 2)
+        testFinished = true;
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    document.getElementById('polite-region').textContent = "Price: $10";
+ 
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt
@@ -1,0 +1,26 @@
+This tests that an atomic region within a live region is announced together when changed.
+
+Received announcement request:
+AnnouncementKey: 1. California
+1. Cupertino
+2. San Francisco
+3. Los Angeles
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+Received announcement request:
+AnnouncementKey: 4. Washington
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+California
+Cupertino
+San Francisco
+Los Angeles
+Hawaii
+Illinois
+Washington

--- a/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<ol id="state-list" aria-live="polite">
+    <li aria-atomic="true">California
+        <ol id="city-list">
+            <li>Cupertino</li>
+            <li>San Francisco</li>
+        </ol>
+    </li>
+    <li>Hawaii</li>
+    <li>Illinois</li>
+</ol>
+
+<script>
+var output = "This tests that an atomic region within a live region is announced together when changed.\n\n";    
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+
+        notificationCount++;
+        
+        if (notificationCount == 1) {
+            // This live region change should only speak this addition, since it is not in an aria-atomic="true" region.
+            const newState = document.createElement("li");
+            newState.textContent = "Washington";
+            document.getElementById("state-list").appendChild(newState);
+        } else if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("city-list");
+
+    const newCity = document.createElement("li");
+    newCity.textContent = "Los Angeles";
+
+    // The entire city-list should be spoken when this is added, since it is in an aria-atomic region.
+    document.getElementById("city-list").appendChild(newCity);
+ 
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -452,3 +452,12 @@ function formatAriaNotifyUserInfo(userInfo) {
     result += `AXAnnouncementLanguageKey: ${userInfo["AXAnnouncementLanguageKey"]}\n\n`
     return result;
 }
+
+function formatAnnouncementUserInfo(userInfo) {
+    var result = "";
+    result += `AnnouncementKey: ${userInfo["AXAnnouncementKey"]}\n`;
+    result += `AXPriorityKey: ${userInfo["AXPriorityKey"]}\n`;
+    result += `AXAnnouncementIsLiveRegionKey: ${userInfo["AXAnnouncementIsLiveRegionKey"]}\n`;
+    return result;
+}
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4223,6 +4223,19 @@ IsAccessibilityIsolatedTreeEnabled:
     WebCore:
       default: false
 
+IsAriaLiveRegionManagementEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "ARIA Live Regions in WebKit"
+  humanReadableDescription: "Turn on ARIA live-region management within WebKit"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: The 'Is' prefix is inconsistent with most other preferences and should be removed.
 IsFirstPartyWebsiteDataRemovalDisabled:
   type: bool

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -587,6 +587,7 @@ accessibility/AXAttributeCacheScope.cpp
 accessibility/AXComputedObjectAttributeCache.cpp
 accessibility/AXCoreObject.cpp
 accessibility/AXGeometryManager.cpp
+accessibility/AXLiveRegionManager.cpp
 accessibility/AXLocalFrame.cpp
 accessibility/AXLogger.cpp
 accessibility/AXLoggerBase.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -258,6 +258,7 @@ enum class AccessibilityOrientation : uint8_t {
 
 enum class DidTimeout : bool { No, Yes };
 enum class IncludeListMarkerText : bool { No, Yes };
+enum class IncludeImageAltText : bool { No, Yes };
 enum class TrimWhitespace : bool { No, Yes };
 
 struct TextUnderElementMode {

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXLiveRegionManager.h"
+
+#include "AXNotifications.h"
+#include "AXObjectCache.h"
+#include "AccessibilityObject.h"
+#include "LocalizedStrings.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AXLiveRegionManager);
+
+AXLiveRegionManager::AXLiveRegionManager(AXObjectCache& cache)
+    : m_cache(cache)
+{
+}
+
+static UNUSED_FUNCTION String debugDescriptionForSnapshot(LiveRegionSnapshot snapshot)
+{
+    StringBuilder result;
+    result.append("SNAPSHOT:\n"_s);
+    result.append("\tStatus: "_s);
+
+    switch (snapshot.liveRegionStatus) {
+    case LiveRegionStatus::Off:
+        result.append("Off"_s);
+        break;
+    case LiveRegionStatus::Polite:
+        result.append("Polite"_s);
+        break;
+    case LiveRegionStatus::Assertive:
+        result.append("Assertive"_s);
+        break;
+    }
+    result.append('\n');
+
+    result.append("\tRelevant: "_s);
+    if (snapshot.liveRegionRelevant.isEmpty())
+        result.append("(default: additions text)"_s);
+    else {
+        bool isFirst = true;
+        if (snapshot.liveRegionRelevant.contains(LiveRegionRelevant::Additions)) {
+            result.append("additions"_s);
+            isFirst = false;
+        }
+        if (snapshot.liveRegionRelevant.contains(LiveRegionRelevant::Removals)) {
+            if (!isFirst)
+                result.append(' ');
+            result.append("removals"_s);
+            isFirst = false;
+        }
+        if (snapshot.liveRegionRelevant.contains(LiveRegionRelevant::Text)) {
+            if (!isFirst)
+                result.append(' ');
+            result.append("text"_s);
+            isFirst = false;
+        }
+        if (snapshot.liveRegionRelevant.contains(LiveRegionRelevant::All)) {
+            if (!isFirst)
+                result.append(' ');
+            result.append("all"_s);
+        }
+    }
+    result.append('\n');
+
+    result.append("\tObjects: "_s);
+    result.append(snapshot.objects.size());
+    result.append('\n');
+
+    for (size_t i = 0; i < snapshot.objects.size(); ++i) {
+        const auto& object = snapshot.objects[i];
+        result.append("\t\t["_s);
+        result.append(i);
+        result.append("] AXID="_s);
+        result.append(object.objectID.loggingString());
+        result.append(" text=\""_s);
+        result.append(object.text);
+        result.append("\"\n"_s);
+    }
+
+    return result.toString();
+}
+
+void AXLiveRegionManager::registerLiveRegion(AccessibilityObject& object, bool speakIfNecessary)
+{
+    m_liveRegions.set(object.objectID(), buildLiveRegionSnapshot(object));
+    // Alerts should speak when added to the page (or initialized for the first time), unlike all other live regions.
+    bool isAlertOrAlertDialog = speakIfNecessary && (object.role() == AccessibilityRole::ApplicationAlert || object.role() == AccessibilityRole::ApplicationAlertDialog);
+    if (isAlertOrAlertDialog)
+        handleLiveRegionChange(object, AnnouncementContents::All);
+}
+
+static LiveRegionStatus stringToLiveRegionStatus(const String& string)
+{
+    String lowercaseString = string.convertToASCIILowercase();
+    if (lowercaseString == "assertive")
+        return LiveRegionStatus::Assertive;
+    if (lowercaseString == "polite")
+        return LiveRegionStatus::Polite;
+
+    return LiveRegionStatus::Off;
+}
+
+static OptionSet<LiveRegionRelevant> stringToLiveRegionRelevant(const String& string)
+{
+    Vector<String> strings = string.convertToASCIILowercase().split(" "_s);
+    OptionSet<LiveRegionRelevant> result;
+    for (const auto& attribute : strings) {
+        if (attribute == "additions")
+            result.add(LiveRegionRelevant::Additions);
+        else if (attribute == "all")
+            result.add(LiveRegionRelevant::All);
+        else if (attribute == "removals")
+            result.add(LiveRegionRelevant::Removals);
+        else if (attribute == "text")
+            result.add(LiveRegionRelevant::Text);
+    }
+    return result;
+}
+
+void AXLiveRegionManager::handleLiveRegionChange(AccessibilityObject& object, AnnouncementContents contents)
+{
+    // If this is a new live region, don't speak it upon registering.
+    auto iterator = m_liveRegions.find(object.objectID());
+    if (iterator == m_liveRegions.end()) {
+        registerLiveRegion(object);
+        return;
+    }
+
+    LiveRegionSnapshot oldSnapshot = contents == AnnouncementContents::All ? LiveRegionSnapshot { } : iterator->value;
+    LiveRegionSnapshot newSnapshot = buildLiveRegionSnapshot(object);
+
+    iterator->value = newSnapshot;
+
+    postAnnouncementForChange(object, oldSnapshot, newSnapshot);
+}
+
+LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObject& object) const
+{
+    LiveRegionSnapshot snapshot;
+    snapshot.liveRegionStatus = stringToLiveRegionStatus(object.liveRegionStatus());
+    snapshot.liveRegionRelevant = stringToLiveRegionRelevant(object.liveRegionRelevant());
+
+    std::function<void(AccessibilityObject&)> buildObjectList = [this, &buildObjectList, &snapshot] (AccessibilityObject& object) {
+        // Treat atomic objects as one object, so when they change the entire subtree is announced.
+        if (object.liveRegionAtomic()) {
+            snapshot.objects.append({ object.objectID(), textForObject(object) });
+            return;
+        }
+
+        if (shouldIncludeInSnapshot(object))
+            snapshot.objects.append({ object.objectID(), textForObject(object) });
+
+        for (auto& child : object.unignoredChildren())
+            buildObjectList(downcast<AccessibilityObject>(child.get()));
+    };
+
+    buildObjectList(object);
+
+    return snapshot;
+}
+
+bool AXLiveRegionManager::shouldIncludeInSnapshot(AccessibilityObject& object) const
+{
+    if (object.isStaticText())
+        return true;
+
+    // If an object has unignored children, there isn't a need to include it in the snapshot since the children will return YES.
+    if (object.firstUnignoredChild())
+        return false;
+
+    // For leaf objects, include if they have a value (e.g., form controls).
+    if (!object.stringValue().isEmpty())
+        return true;
+
+#if PLATFORM(COCOA)
+    // For leaf objects, include if they have accessible description text (e.g., images with alt text).
+    if (!object.descriptionAttributeValue().isEmpty())
+        return true;
+#endif
+
+    return false;
+}
+
+String AXLiveRegionManager::textForObject(AccessibilityObject& object) const
+{
+    return object.textMarkerRange().toString(IncludeListMarkerText::Yes, IncludeImageAltText::Yes);
+}
+
+AXLiveRegionManager::LiveRegionDiff AXLiveRegionManager::computeChanges(const Vector<LiveRegionObject>& oldObjects, const Vector<LiveRegionObject>& newObjects) const
+{
+    // Here we compare the old and new live region to compute:
+    // - Additions: New objects
+    // - Deletions: Objects that were removed from the region
+    // - Changes: Text content/values that changed between the same object.
+
+    LiveRegionDiff diff;
+
+    // Build a map of old objects for lookup. As we match them with new objects, we'll remove them.
+    // Whatever remains unmatched at the end represents removals.
+    HashMap<AXID, String> unmatchedOldObjects;
+    unmatchedOldObjects.reserveInitialCapacity(oldObjects.size());
+
+    for (auto& object : oldObjects)
+        unmatchedOldObjects.set(object.objectID, object.text);
+
+    for (auto& newObject : newObjects) {
+        auto iterator = unmatchedOldObjects.find(newObject.objectID);
+        if (iterator == unmatchedOldObjects.end())
+            diff.added.append(newObject);
+        else {
+            if (iterator->value != newObject.text)
+                diff.changed.append(newObject);
+            unmatchedOldObjects.remove(iterator);
+        }
+    }
+
+    // Anything left in unmatchedOldObjects is a removal.
+    for (auto& entry : unmatchedOldObjects)
+        diff.removed.append({ entry.key, entry.value });
+
+    return diff;
+}
+
+static const size_t maximumAnnouncementLength = 2500;
+
+String AXLiveRegionManager::computeAnnouncement(const LiveRegionSnapshot& newSnapshot, const LiveRegionDiff& diff) const
+{
+    bool hasAll = newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::All);
+    bool hasAdditions = hasAll || newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::Additions);
+    bool hasRemovals = hasAll || newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::Removals);
+    bool hasText = hasAll || newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::Text);
+
+    Vector<String> strings;
+
+    bool reachedCharacterLimit = false;
+    size_t characterCount = 0;
+
+    if (hasAdditions && !diff.added.isEmpty()) {
+        for (auto& object : diff.added) {
+            if (!object.text.isEmpty()) {
+                strings.append(object.text);
+                characterCount += object.text.length();
+            }
+
+            if (characterCount > maximumAnnouncementLength) {
+                reachedCharacterLimit = true;
+                break;
+            }
+        }
+    }
+
+    if (!reachedCharacterLimit && hasRemovals && !diff.removed.isEmpty()) {
+        StringBuilder removalString;
+        removalString.append(AXRemovedText());
+        for (auto& object : diff.removed) {
+            if (!object.text.isEmpty()) {
+                removalString.append(' ');
+                removalString.append(object.text);
+                characterCount += object.text.length() + 1; // Add an extra character for the space above.
+            }
+
+            if (characterCount > maximumAnnouncementLength) {
+                reachedCharacterLimit = true;
+                break;
+            }
+        }
+        strings.append(removalString.toString());
+    }
+
+    if (!reachedCharacterLimit && hasText && !diff.changed.isEmpty()) {
+        for (auto& object : diff.changed) {
+            if (!object.text.isEmpty()) {
+                strings.append(object.text);
+                characterCount += object.text.length();
+            }
+
+            if (characterCount > maximumAnnouncementLength) {
+                reachedCharacterLimit = true;
+                break;
+            }
+        }
+    }
+
+    return makeStringByJoining(strings, " "_s);
+}
+
+void AXLiveRegionManager::postAnnouncementForChange(AccessibilityObject& object, const LiveRegionSnapshot& oldSnapshot, const LiveRegionSnapshot& newSnapshot)
+{
+    auto diff = computeChanges(oldSnapshot.objects, newSnapshot.objects);
+    if (diff.added.isEmpty() && diff.removed.isEmpty() && diff.changed.isEmpty())
+        return;
+
+    String announcementText = computeAnnouncement(newSnapshot, diff);
+    if (announcementText.isEmpty())
+        return;
+
+    if (CheckedPtr cache = m_cache)
+        cache->postLiveRegionNotification(object, newSnapshot.liveRegionStatus, announcementText);
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/accessibility/AXLiveRegionManager.h
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AXCoreObject.h"
+#include <wtf/HashMap.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class AccessibilityObject;
+class AXObjectCache;
+enum class LiveRegionStatus : uint8_t;
+
+enum class LiveRegionRelevant : uint8_t {
+    Additions = 1 << 0,
+    Removals  = 1 << 1,
+    Text      = 1 << 2,
+    All       = 1 << 3
+};
+
+struct LiveRegionObject {
+    AXID objectID;
+    String text;
+};
+
+struct LiveRegionSnapshot {
+    Vector<LiveRegionObject> objects;
+    LiveRegionStatus liveRegionStatus { LiveRegionStatus::Off };
+    OptionSet<LiveRegionRelevant> liveRegionRelevant { { LiveRegionRelevant::Additions, LiveRegionRelevant::Text } };
+};
+
+enum class AnnouncementContents : bool { All, Changes };
+
+class AXLiveRegionManager {
+    WTF_MAKE_NONCOPYABLE(AXLiveRegionManager);
+    WTF_MAKE_TZONE_ALLOCATED(AXLiveRegionManager);
+public:
+    explicit AXLiveRegionManager(AXObjectCache&);
+    ~AXLiveRegionManager() = default;
+
+    void registerLiveRegion(AccessibilityObject&, bool = false);
+    void unregisterLiveRegion(AXID axID) { m_liveRegions.remove(axID); }
+
+    void handleLiveRegionChange(AccessibilityObject&, AnnouncementContents = AnnouncementContents::Changes);
+private:
+    struct LiveRegionDiff {
+        Vector<LiveRegionObject> added;
+        Vector<LiveRegionObject> removed;
+        Vector<LiveRegionObject> changed;
+    };
+
+    LiveRegionSnapshot buildLiveRegionSnapshot(AccessibilityObject&) const;
+    bool shouldIncludeInSnapshot(AccessibilityObject&) const;
+    String textForObject(AccessibilityObject&) const;
+    void postAnnouncementForChange(AccessibilityObject&, const LiveRegionSnapshot&, const LiveRegionSnapshot&);
+    LiveRegionDiff computeChanges(const Vector<LiveRegionObject>&, const Vector<LiveRegionObject>&) const;
+    String computeAnnouncement(const LiveRegionSnapshot&, const LiveRegionDiff&) const;
+
+    CheckedRef<AXObjectCache> m_cache;
+    HashMap<AXID, LiveRegionSnapshot> m_liveRegions;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -417,7 +417,7 @@ public:
     bool isCollapsed() const { return m_start.isEqual(m_end); }
     bool isConfinedTo(std::optional<AXID>) const;
     bool isConfined() const;
-    String toString(IncludeListMarkerText = IncludeListMarkerText::Yes) const;
+    String toString(IncludeListMarkerText = IncludeListMarkerText::Yes, IncludeImageAltText = IncludeImageAltText::No) const;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     // Returns the bounds (frame) of the text in this range relative to the viewport.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -112,6 +112,8 @@ public:
     FontOrientation fontOrientation() const final { return propertyValue<FontOrientation>(AXProperty::FontOrientation); }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
+    String description() const final { return stringAttributeValue(AXProperty::Description); }
+
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     bool isIgnored() const final { return boolAttributeValue(AXProperty::IsIgnored); }
 #else
@@ -556,7 +558,6 @@ private:
     String textContentPrefixFromListMarker() const final;
     String webAreaTitle() const final { return stringAttributeValue(AXProperty::WebAreaTitle); }
     String titleAttribute() const final { return stringAttributeValue(AXProperty::TitleAttribute); }
-    String description() const final { return stringAttributeValue(AXProperty::Description); }
 
     std::optional<String> textContent() const final;
 

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -504,3 +504,5 @@
 
 // User info key to specify an announcment's language.
 #define NSAccessibilityAnnouncementLanguageKey @"AXAnnouncementLanguageKey"
+
+#define NSAccessibilityAnnouncementIsLiveRegionKey @"AXAnnouncementIsLiveRegionKey"

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -2068,6 +2068,9 @@
 /* accessibility label for time remaining display */
 "remaining time" = "remaining time";
 
+/* prefix for announcing removed content in ARIA live regions */
+"removed" = "removed";
+
 /* Action from safe browsing warning */
 "report an error" = "report an error";
 

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -127,6 +127,7 @@ class EmptyChromeClient : public ChromeClient {
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const final { };
     void relayAriaNotifyNotification(AriaNotifyData&&) const final { };
+    void relayLiveRegionNotification(LiveRegionAnnouncementData&&) const final { };
 #endif
 
     void didFinishLoadingImageForElement(HTMLImageElement&) final { }

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -153,6 +153,11 @@ void Chrome::relayAriaNotifyNotification(AriaNotifyData&& notificationData) cons
 {
     return m_client->relayAriaNotifyNotification(WTFMove(notificationData));
 }
+
+void Chrome::relayLiveRegionNotification(LiveRegionAnnouncementData&& notificationData) const
+{
+    return m_client->relayLiveRegionNotification(WTFMove(notificationData));
+}
 #endif
 
 PlatformPageClient Chrome::platformPageClient() const

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -88,6 +88,7 @@ struct AriaNotifyData;
 struct ContactInfo;
 struct ContactsRequestData;
 struct FocusOptions;
+struct LiveRegionAnnouncementData;
 struct ShareDataWithParsedURL;
 struct ViewportArguments;
 struct WindowFeatures;
@@ -125,6 +126,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const override;
     void relayAriaNotifyNotification(AriaNotifyData&&) const;
+    void relayLiveRegionNotification(LiveRegionAnnouncementData&&) const;
 #endif
     void setCursor(const Cursor&) override;
     void setCursorHiddenUntilMouseMoves(bool) override;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -163,6 +163,7 @@ struct DataDetectorElementInfo;
 struct DateTimeChooserParameters;
 struct FocusOptions;
 struct GraphicsDeviceAdapter;
+struct LiveRegionAnnouncementData;
 struct MockWebAuthenticationConfiguration;
 struct ResolvedCaptionDisplaySettingsOptions;
 struct ShareDataWithParsedURL;
@@ -289,6 +290,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     virtual void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const = 0;
     virtual void relayAriaNotifyNotification(AriaNotifyData&&) const = 0;
+    virtual void relayLiveRegionNotification(LiveRegionAnnouncementData&&) const = 0;
 #endif
 
     virtual void mainFrameDidChange() { };

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -713,7 +713,12 @@ String AXAttachmentRoleText()
 {
     return WEB_UI_STRING("attachment", "accessibility role description for an attachment element");
 }
-    
+
+String AXRemovedText()
+{
+    return WEB_UI_STRING("removed", "prefix for announcing removed content in live regions");
+}
+
 String AXSearchFieldCancelButtonText()
 {
     return WEB_UI_STRING("cancel", "accessibility description for a search field cancel button");

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -231,6 +231,7 @@ namespace WebCore {
     String AXOutputText();
     String AXSearchFieldCancelButtonText();
     String AXAttachmentRoleText();
+    String AXRemovedText();
     String AXDetailsText();
     String AXSummaryText();
     String AXFeedText();

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1022,6 +1022,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WallTime': ['<wtf/WallTime.h>'],
         'WebCore::AXDebugInfo': ['<WebCore/AXObjectCache.h>'],
         'WebCore::AriaNotifyData': ['<WebCore/AXObjectCache.h>'],
+        'WebCore::LiveRegionAnnouncementData': ['<WebCore/AXObjectCache.h>'],
         'WebCore::AlternativeTextType': ['<WebCore/AlternativeTextClient.h>'],
         'WebCore::ApplyTrackingPrevention': ['<WebCore/NetworkStorageSession.h>'],
         'WebCore::AttachmentAssociatedElementType': ['<WebCore/AttachmentAssociatedElement.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8964,6 +8964,13 @@ header: <WebCore/AXObjectCache.h>
 };
 
 header: <WebCore/AXObjectCache.h>
+[CustomHeader] enum class WebCore::LiveRegionStatus : uint8_t {
+    Off,
+    Polite,
+    Assertive
+};
+
+header: <WebCore/AXObjectCache.h>
 [CustomHeader] struct WebCore::AXDebugInfo {
     bool isAccessibilityEnabled;
     bool isAccessibilityThreadInitialized;
@@ -8979,6 +8986,12 @@ header: <WebCore/AXObjectCache.h>
     WebCore::NotifyPriority priority;
     WebCore::InterruptBehavior interrupt;
     String language;
+};
+
+header: <WebCore/AXObjectCache.h>
+[CustomHeader] struct WebCore::LiveRegionAnnouncementData {
+    String message;
+    WebCore::LiveRegionStatus status;
 };
 
 header: <WebCore/ScriptTrackingPrivacyCategory.h>

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -138,6 +138,7 @@ struct DataDetectorElementInfo;
 struct DictionaryPopupInfo;
 struct ElementContext;
 struct FixedContainerEdges;
+struct LiveRegionAnnouncementData;
 struct ResolvedCaptionDisplaySettingsOptions;
 struct TextIndicatorData;
 struct ShareDataWithParsedURL;
@@ -417,6 +418,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     virtual void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) = 0;
     virtual void relayAriaNotifyNotification(const WebCore::AriaNotifyData&) = 0;
+    virtual void relayLiveRegionNotification(const WebCore::LiveRegionAnnouncementData&) = 0;
 #endif
 #if PLATFORM(MAC)
     virtual WebCore::IntRect rootViewToWindow(const WebCore::IntRect&) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -284,6 +284,7 @@ struct ImageBufferParameters;
 struct InspectorOverlayHighlight;
 struct LinkIcon;
 struct LinkDecorationFilteringData;
+struct LiveRegionAnnouncementData;
 struct MarkupExclusionRule;
 struct MediaControlsContextMenuItem;
 struct MediaDeviceHashSalts;
@@ -2999,6 +3000,7 @@ private:
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, std::span<const uint8_t>);
     void relayAriaNotifyNotification(WebCore::AriaNotifyData&&);
+    void relayLiveRegionNotification(WebCore::LiveRegionAnnouncementData&&);
 #endif
     void runBeforeUnloadConfirmPanel(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, String&& message, CompletionHandler<void(bool)>&&);
     void pageDidScroll(const WebCore::IntPoint&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -56,6 +56,7 @@ messages -> WebPageProxy {
 #if PLATFORM(IOS_FAMILY)
     RelayAccessibilityNotification(String notificationName, std::span<const uint8_t> notificationData)
     RelayAriaNotifyNotification(struct WebCore::AriaNotifyData notificationData)
+    RelayLiveRegionNotification(struct WebCore::LiveRegionAnnouncementData notificationData)
 #endif
     EnableAccessibilityForAllProcesses()
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -134,6 +134,7 @@ private:
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) override;
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) override;
     void relayAriaNotifyNotification(const WebCore::AriaNotifyData&) override;
+    void relayLiveRegionNotification(const WebCore::LiveRegionAnnouncementData&) override;
     void doneWithKeyEvent(const NativeWebKeyboardEvent&, bool wasEventHandled) override;
 #if ENABLE(TOUCH_EVENTS)
     void doneWithTouchEvent(const WebTouchEvent&, bool wasEventHandled) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -540,6 +540,28 @@ void PageClientImpl::relayAriaNotifyNotification(const WebCore::AriaNotifyData& 
     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, attributedString.get());
 }
 
+
+static NSString * const UIAccessibilityPriorityLow = @"UIAccessibilityPriorityLow";
+static NSString * const UIAccessibilityPriorityDefault = @"UIAccessibilityPriorityDefault";
+static NSString * const UIAccessibilitySpeechAttributeAnnouncementPriority = @"UIAccessibilitySpeechAttributeAnnouncementPriority";
+static NSString * const UIAccessibilitySpeechAttributeIsLiveRegion = @"UIAccessibilitySpeechAttributeIsLiveRegion";
+
+void PageClientImpl::relayLiveRegionNotification(const WebCore::LiveRegionAnnouncementData& notificationData)
+{
+    RetainPtr message = notificationData.message.createNSString();
+
+    // Assertive = UIAccessibilityPriorityDefault, Polite = UIAccessibilityPriorityLow
+    RetainPtr priority = (notificationData.status == WebCore::LiveRegionStatus::Assertive) ? UIAccessibilityPriorityDefault : UIAccessibilityPriorityLow;
+
+    RetainPtr attributes = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:
+        priority.get(), UIAccessibilitySpeechAttributeAnnouncementPriority, @(YES), UIAccessibilitySpeechAttributeIsLiveRegion,
+        nil]);
+
+    RetainPtr attributedString = adoptNS([[NSAttributedString alloc] initWithString:message.get() attributes:attributes.get()]);
+
+    UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, attributedString.get());
+}
+
 IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
 {
     CGRect rootViewRect = rect;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -797,6 +797,12 @@ void WebPageProxy::relayAriaNotifyNotification(WebCore::AriaNotifyData&& notific
         pageClient->relayAriaNotifyNotification(notificationData);
 }
 
+void WebPageProxy::relayLiveRegionNotification(WebCore::LiveRegionAnnouncementData&& notificationData)
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->relayLiveRegionNotification(notificationData);
+}
+
 void WebPageProxy::assistiveTechnologyMakeFirstResponder()
 {
     if (RefPtr pageClient = this->pageClient())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -66,6 +66,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const final;
     void relayAriaNotifyNotification(WebCore::AriaNotifyData&&) const final;
+    void relayLiveRegionNotification(WebCore::LiveRegionAnnouncementData&&) const final;
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
@@ -207,6 +207,12 @@ void WebChromeClient::relayAriaNotifyNotification(WebCore::AriaNotifyData&& noti
         page->relayAriaNotifyNotification(WTFMove(notificationData));
 }
 
+void WebChromeClient::relayLiveRegionNotification(WebCore::LiveRegionAnnouncementData&& notificationData) const
+{
+    if (RefPtr page = m_page.get())
+        page->relayLiveRegionNotification(WTFMove(notificationData));
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -308,6 +308,7 @@ class HandleUserInputEventResult;
 #endif
 struct InteractionRegion;
 struct KeypressCommand;
+struct LiveRegionAnnouncementData;
 struct MarkupExclusionRule;
 struct MediaDeviceHashSalts;
 struct MediaPlayerClientIdentifierType;
@@ -992,6 +993,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&);
     void relayAriaNotifyNotification(WebCore::AriaNotifyData&&);
+    void relayLiveRegionNotification(WebCore::LiveRegionAnnouncementData&&);
 #endif
 
     RefPtr<WebImage> scaledSnapshotWithOptions(const WebCore::IntRect&, double additionalScaleFactor, SnapshotOptions);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -308,6 +308,11 @@ void WebPage::relayAriaNotifyNotification(WebCore::AriaNotifyData&& notification
     send(Messages::WebPageProxy::RelayAriaNotifyNotification(WTFMove(notificationData)));
 }
 
+void WebPage::relayLiveRegionNotification(WebCore::LiveRegionAnnouncementData&& notificationData)
+{
+    send(Messages::WebPageProxy::RelayLiveRegionNotification(WTFMove(notificationData)));
+}
+
 static void computeEditableRootHasContentAndPlainText(const VisibleSelection& selection, EditorState::PostLayoutData& data)
 {
     data.hasContent = false;

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
@@ -106,6 +106,7 @@ private:
     RefPtr<WebCore::SearchPopupMenu> createSearchPopupMenu(WebCore::PopupMenuClient&) const final;
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const final { }
     void relayAriaNotifyNotification(WebCore::AriaNotifyData&&) const final { }
+    void relayLiveRegionNotification(WebCore::LiveRegionAnnouncementData&&) const final { }
     void webAppOrientationsUpdated() final;
     void focusedElementChanged(WebCore::Element*, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement) final;
     void showPlaybackTargetPicker(bool hasVideo, WebCore::RouteSharingPolicy, const String&) final;


### PR DESCRIPTION
#### c148f97f417f7724d88b029ab049b06c27468dd7
<pre>
AX: Move live region announcements into webkit behind feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=302716">https://bugs.webkit.org/show_bug.cgi?id=302716</a>
<a href="https://rdar.apple.com/164972478">rdar://164972478</a>

Reviewed by Tyler Wilcock.

This patch consists of the initial implementation of bringing live region announcements into
WebKit (guarded behind a runtime flag). In doing so, we can streamline how live regions
function across different ATs.

There are a few pieces to this patch:
- AXLiveRegionManager: this encapsulates the logic to compute announcements, changes, and
keep track of live regions. Each AXObjectCache has one AXLiveRegionManager, which is also
an indicator that the feature flag is enabled. Live regions are stored in the manager as
an array of &quot;snapshots&quot;, which are used to calculate changes when a live region changes.
- AXObjectCache changes: This is where we initialize the manager, and route node additions/
removals so that they are registered properly by the manager. The cache is also responsible
for posting the announcement notifications, using information computed by the manager.
- IPC (relayLiveRegionNotification): On iOS, we need to post notifications from the UI
process, rather than the web content process. These new IPC messages forward the information
needed to build an announcement notification in the UI process.

When this runtime flag is enabled, AXLiveRegionChanged and AXLiveRegionCreated notifications
will no longer be sent.

Several new tests are added to verify this initial behavior.

Tests: accessibility/ios-simulator/live-regions/live-region-types.html
       accessibility/mac/live-regions/live-region-alert-added.html
       accessibility/mac/live-regions/live-region-alert-on-initial-load.html
       accessibility/mac/live-regions/live-region-dynamically-added.html
       accessibility/mac/live-regions/live-region-hidden-content.html
       accessibility/mac/live-regions/live-region-removals.html
       accessibility/mac/live-regions/live-region-types.html
       accessibility/mac/live-regions/live-region-with-atomic.html

* LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/live-regions/live-region-types.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-alert-added-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-alert-added.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-hidden-content-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-hidden-content.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-removals.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-types-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-types.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-with-atomic.html: Added.
* LayoutTests/resources/accessibility-helper.js:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp: Added.
(WebCore::AXLiveRegionManager::AXLiveRegionManager):
(WebCore::debugDescriptionForSnapshot):
(WebCore::AXLiveRegionManager::registerLiveRegion):
(WebCore::stringToLiveRegionStatus):
(WebCore::stringToLiveRegionRelevant):
(WebCore::AXLiveRegionManager::handleLiveRegionChange):
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
(WebCore::AXLiveRegionManager::shouldIncludeInSnapshot const):
(WebCore::AXLiveRegionManager::textForObject const):
(WebCore::AXLiveRegionManager::computeChanges const):
(WebCore::AXLiveRegionManager::computeAnnouncement const):
(WebCore::AXLiveRegionManager::postAnnouncementForChange):
* Source/WebCore/accessibility/AXLiveRegionManager.h: Added.
(WebCore::AXLiveRegionManager::unregisterLiveRegion):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::handleLiveRegionCreated):
(WebCore::AXObjectCache::initializeLiveRegionManager):
(WebCore::AXObjectCache::postLiveRegionNotification):
(WebCore::AXObjectCache::postLiveRegionChangeNotification):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::postPlatformARIANotifyNotification):
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):
(WebCore::AXObjectCache::deferSortForNewLiveRegion):
(WebCore::AXObjectCache::sortedLiveRegions):
(WebCore::AXObjectCache::initializeSortedIDLists):
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::relayLiveRegionNotification const):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::AXRemovedText):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::relayLiveRegionNotification):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::relayLiveRegionNotification):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm:
(WebKit::WebChromeClient::relayLiveRegionNotification const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::relayAriaNotifyNotification):
(WebKit::WebPage::relayLiveRegionNotification):
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h:

Canonical link: <a href="https://commits.webkit.org/303361@main">https://commits.webkit.org/303361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65835b1dcff695135fb1456e9a570b0b608dcce9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84001 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1c1e68c-e2b7-4238-8a20-2556086ddb10) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100972 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01087531-0529-4b89-b9b0-b836634cb993) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c36cc779-f445-4b36-9f53-1ccf2297f812) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/131437 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82822 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124151 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142249 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130595 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109344 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109518 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3228 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57494 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4304 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32977 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163562 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67750 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42511 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4395 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4263 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->