### PR TITLE
Web Inspector: Layers tab should show a visual representation of the layer

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/LayerTree.json
+++ b/Source/JavaScriptCore/inspector/protocol/LayerTree.json
@@ -108,6 +108,16 @@
             "returns": [
                 { "name": "compositingReasons", "$ref": "CompositingReasons", "description": "An object containing the reasons why the layer was composited as properties." }
             ]
+        },
+        {
+            "name": "requestContent",
+            "description": "Captures a snapshot of the layer's rendered content as a PNG data URL.",
+            "parameters": [
+                { "name": "layerId", "$ref": "LayerId", "description": "The id of the layer to snapshot." }
+            ],
+            "returns": [
+                { "name": "content", "type": "string", "description": "Base64-encoded PNG data URL of the layer's rendered content." }
+            ]
         }
     ],
     "events": [

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
@@ -61,6 +61,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> disable();
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::LayerTree::Layer>>> layersForNode(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::LayerTree::CompositingReasons>> reasonsForCompositingLayer(const Inspector::Protocol::LayerTree::LayerId&);
+    Inspector::CommandResult<String> requestContent(const Inspector::Protocol::LayerTree::LayerId&);
 
     // InspectorInstrumentation
     void layerTreeDidChange();

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -996,6 +996,7 @@ localizedStrings["Latency"] = "Latency";
 localizedStrings["Layer Count: %d"] = "Layer Count: %d";
 localizedStrings["Layer Info"] = "Layer Info";
 localizedStrings["Layers"] = "Layers";
+localizedStrings["Layers:"] = "Layers:";
 /* Name of Layers Tab */
 localizedStrings["Layers Tab Name"] = "Layers";
 localizedStrings["Layout & Rendering"] = "Layout & Rendering";
@@ -1597,6 +1598,7 @@ localizedStrings["Show hidden tabs\u2026"] = "Show hidden tabs\u2026";
 localizedStrings["Show independent Styles sidebar @ Settings Elements Pane"] = "Show independent Styles sidebar";
 localizedStrings["Show jump to effective property button"] = "Show jump to effective property button";
 localizedStrings["Show jump to variable declaration button"] = "Show jump to variable declaration button";
+localizedStrings["Show layer contents"] = "Show layer contents";
 /* Settings tab checkbox label for whether the details sidebars (on the right in LTR locales) are at the bottom */
 localizedStrings["Show on bottom when narrow @ Settings General Pane"] = "Show on bottom when narrow";
 localizedStrings["Show page rulers and node border lines"] = "Show page rulers and node border lines";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -246,6 +246,7 @@ WI.settings = {
     experimentalLimitSourceCodeHighlighting: new WI.Setting("engineering-limit-source-code-highlighting", false),
     experimentalUseFuzzyMatchingForCSSCodeCompletion: new WI.Setting("experimental-use-fuzzy-matching-for-css-code-completion", true),
     experimentalUseStrictCheckForGlobMatching: new WI.Setting("experimental-use-strict-check-for-glob-matching", false),
+    experimentalLayers3DShowLayerContents: new WI.Setting("experimental-layers-3d-show-layer-contents", true),
 
     // Protocol
     protocolLogAsText: new WI.Setting("protocol-log-as-text", false),

--- a/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
@@ -197,6 +197,21 @@ WI.LayerTreeManager = class LayerTreeManager extends WI.Object
         });
     }
 
+    snapshotForLayer(layer, callback)
+    {
+        console.assert(this.supported);
+
+        let target = WI.assumingMainTarget();
+        target.LayerTreeAgent.requestContent(layer.layerId, function(error, content) {
+            if (error) {
+                WI.reportInternalError(error);
+                callback(null);
+                return;
+            }
+            callback(content);
+        });
+    }
+
     // LayerTreeObserver
 
     layerTreeDidChange()

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -426,6 +426,13 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
             experimentalSettingsView.addSeparator();
         }
 
+        if (InspectorBackend.hasCommand("LayerTree.requestContent")) {
+            let layersGroup = experimentalSettingsView.addGroup(WI.UIString("Layers:"));
+            layersGroup.addSetting(WI.settings.experimentalLayers3DShowLayerContents, WI.UIString("Show layer contents"));
+
+            experimentalSettingsView.addSeparator();
+        }
+
         let hasNetworkEmulatedCondition = InspectorBackend.hasCommand("Network.setEmulatedConditions");
         if (hasNetworkEmulatedCondition) {
             let networkGroup = experimentalSettingsView.addGroup(WI.UIString("Network:"));
@@ -473,6 +480,9 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
             listenForChange(WI.settings.experimentalEnableStylesJumpToVariableDeclaration);
             listenForChange(WI.settings.experimentalCSSSortPropertyNameAutocompletionByUsage);
         }
+
+        if (InspectorBackend.hasCommand("LayerTree.requestContent"))
+            listenForChange(WI.settings.experimentalLayers3DShowLayerContents);
 
         if (hasNetworkEmulatedCondition)
             listenForChange(WI.settings.experimentalEnableNetworkEmulatedCondition);


### PR DESCRIPTION
#### 79db54bf56d12e55ab0e60eb1e7db6827a9d0f58
<pre>
Web Inspector: Layers tab should show a visual representation of the layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=302723">https://bugs.webkit.org/show_bug.cgi?id=302723</a>
<a href="https://rdar.apple.com/problem/164977594">rdar://problem/164977594</a>

Reviewed by Devin Rousso.

Implemented layer snapshot rendering to display actual composited content in the 3D Layers view.
Added LayerTree.snapshotForLayer protocol command that uses
GraphicsLayer::paintGraphicsLayerContents to capture rendered output as PNG data URLs. The
frontend loads these snapshots as Three.js textures and maps them onto layer meshes with proper
UV coordinates, replacing the previous solid-color placeholder rectangles. This approach provides
direct visualization of what each compositing layer actually renders, making it easier to debug
compositing issues and understand layer content at a glance.

* Source/JavaScriptCore/inspector/protocol/LayerTree.json:
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::requestContent):
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js:
(WI.LayerTreeManager.prototype.snapshotForLayer):
* Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js:
(WI.Layers3DContentView):
(WI.Layers3DContentView.prototype.get navigationItems):
(WI.Layers3DContentView.prototype.attached):
(WI.Layers3DContentView.prototype.detached):
(WI.Layers3DContentView.prototype._updateLayers):
(WI.Layers3DContentView.prototype._createLayerGroup):
(WI.Layers3DContentView.prototype._populateLayerGroup):
(WI.Layers3DContentView.prototype._loadLayerTexture):
(WI.Layers3DContentView.prototype._createLayerMesh):
(WI.Layers3DContentView.prototype._handleLayerContentsSettingChanged):
(WI.Layers3DContentView.prototype._handleRefreshLayersButtonClicked):
(WI.Layers3DContentView.prototype._refreshAllLayers):
(WI.Layers3DContentView.prototype._zInterval):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createExperimentalSettingsView):

Canonical link: <a href="https://commits.webkit.org/304758@main">https://commits.webkit.org/304758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd797ddbf0d497561b9708822974651cb4a466de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/715737b5-0b47-4422-b091-4aad48f4654e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102171 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69539 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e414bc92-ebeb-4d2e-a826-2f990643ddc5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82967 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e42ca88d-a9ef-44f8-9bcf-5a2d4703d33f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4539 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2151 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/498 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125629 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143761 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132066 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5729 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110546 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110723 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28068 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4395 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115989 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59478 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21037 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5781 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34304 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69239 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43124 "Found 327 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Regex/captures.js.default, ChakraCore.yaml/ChakraCore/test/Regex/regex1.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/NoBacktrackingChomp.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/acid.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/assertion.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/captures.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/class-case.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/es5SpecExamples.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/fastRegexCaptures.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/match_global.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5872 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5736 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->