### PR TITLE
[Site Isolation] Update Document::initSecurityContext

### DIFF
--- a/LayoutTests/http/tests/security/iframe-open-about-blank-expected.txt
+++ b/LayoutTests/http/tests/security/iframe-open-about-blank-expected.txt
@@ -1,0 +1,3 @@
+ALERT: should be empty:
+ALERT: should also be empty:
+

--- a/LayoutTests/http/tests/security/iframe-open-about-blank.html
+++ b/LayoutTests/http/tests/security/iframe-open-about-blank.html
@@ -1,0 +1,9 @@
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText()
+    }
+
+    document.cookie = 'key1=value1';
+</script>
+<iframe src="http://localhost:8000/security/resources/open-about-blank.html"></iframe>

--- a/LayoutTests/http/tests/security/resources/open-about-blank.html
+++ b/LayoutTests/http/tests/security/resources/open-about-blank.html
@@ -1,0 +1,9 @@
+<script>
+    alert('should be empty:' + document.cookie);
+    document.cookie = 'key2=value2';
+    let w = window.open('about:blank');
+    alert('should also be empty:' + w.document.cookie);
+    if (window.testRunner) {
+        testRunner.notifyDone()
+    }
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8496,11 +8496,8 @@ void Document::initSecurityContext()
     // If we do not obtain a meaningful origin from the URL, then we try to
     // find one via the frame hierarchy.
     RefPtr parentFrame = m_frame->tree().parent();
-    RefPtr openerFrame = dynamicDowncast<LocalFrame>(m_frame->opener());
-
-    RefPtr ownerFrame = dynamicDowncast<LocalFrame>(parentFrame.get());
-    if (!ownerFrame)
-        ownerFrame = openerFrame;
+    RefPtr openerFrame = m_frame->opener();
+    RefPtr ownerFrame = parentFrame ? parentFrame : openerFrame;
 
     if (!ownerFrame) {
         didFailToInitializeSecurityOrigin();
@@ -8508,61 +8505,87 @@ void Document::initSecurityContext()
     }
 
     CheckedPtr contentSecurityPolicy = this->contentSecurityPolicy();
-    contentSecurityPolicy->copyStateFrom(protect(ownerFrame->document())->checkedContentSecurityPolicy().get());
-    contentSecurityPolicy->updateSourceSelf(protect(ownerFrame->document()->securityOrigin()));
-
-    setCrossOriginEmbedderPolicy(ownerFrame->document()->crossOriginEmbedderPolicy());
+    if (auto ownerSecurityPolicy = ownerFrame->frameDocumentSecurityPolicy()) {
+        contentSecurityPolicy->inheritHeadersFrom(ownerSecurityPolicy->contentSecurityPolicyResponseHeaders);
+        contentSecurityPolicy->setReferrer(ownerSecurityPolicy->cspReferrer);
+        contentSecurityPolicy->setHttpStatusCode(ownerSecurityPolicy->cspHttpStatusCode);
+        if (RefPtr ownerSecurityOrigin = ownerFrame->frameDocumentSecurityOrigin())
+            contentSecurityPolicy->updateSourceSelf(*ownerSecurityOrigin);
+        setCrossOriginEmbedderPolicy(ownerSecurityPolicy->crossOriginEmbedderPolicy);
+    }
 
     // https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context (Step 12)
     // If creator is non-null and creator's origin is same origin with creator's relevant settings object's top-level origin, then set coop
     // to creator's browsing context's top-level browsing context's active document's cross-origin opener policy.
-    if (m_frame->isMainFrame() && openerFrame && openerFrame->document() && openerFrame->document()->isSameOriginAsTopDocument())
-        setCrossOriginOpenerPolicy(openerFrame->document()->crossOriginOpenerPolicy());
+    if (m_frame->isMainFrame() && openerFrame) {
+        if (auto openerSecurityPolicy = openerFrame->frameDocumentSecurityPolicy()) {
+            if (openerSecurityPolicy->isSameOriginAsTopDocument)
+                setCrossOriginOpenerPolicy(openerSecurityPolicy->crossOriginOpenerPolicy);
+        }
+    }
 
     // Per <http://www.w3.org/TR/upgrade-insecure-requests/>, new browsing contexts must inherit from an
     // ongoing set of upgraded requests. When opening a new browsing context, we need to capture its
     // existing upgrade request. Nested browsing contexts are handled during DocumentWriter::begin.
-    if (RefPtr openerDocument = openerFrame ? openerFrame->document() : nullptr)
-        contentSecurityPolicy->inheritInsecureNavigationRequestsToUpgradeFromOpener(*openerDocument->checkedContentSecurityPolicy());
+    if (openerFrame) {
+        if (auto openerSecurityPolicy = openerFrame->frameDocumentSecurityPolicy())
+            contentSecurityPolicy->setInsecureNavigationRequestsToUpgrade(HashSet { openerSecurityPolicy->insecureNavigationRequestsToUpgrade });
+    }
 
     if (isSandboxed(SandboxFlag::Origin)) {
         // If we're supposed to inherit our security origin from our owner,
         // but we're also sandboxed, the only thing we inherit is the ability
         // to load local resources. This lets about:blank iframes in file://
         // URL documents load images and other resources from the file system.
-        if (ownerFrame->document()->securityOrigin().canLoadLocalResources())
-            securityOrigin().grantLoadLocalResources();
+        if (RefPtr ownerSecurityOrigin = ownerFrame->frameDocumentSecurityOrigin()) {
+            if (ownerSecurityOrigin->canLoadLocalResources())
+                securityOrigin().grantLoadLocalResources();
+        }
         return;
     }
 
-    setCookieURL(ownerFrame->document()->cookieURL());
+    if (auto ownerSecurityPolicy = ownerFrame->frameDocumentSecurityPolicy()) {
+        if (!ownerSecurityPolicy->cookieURL.isNull())
+            setCookieURL(ownerSecurityPolicy->cookieURL);
+    }
+
     // We alias the SecurityOrigins to match Firefox, see Bug 15313
     // https://bugs.webkit.org/show_bug.cgi?id=15313
-    setSecurityOriginPolicy(ownerFrame->document()->securityOriginPolicy());
+    if (RefPtr ownerSecurityOrigin = ownerFrame->frameDocumentSecurityOrigin())
+        setSecurityOriginPolicy(SecurityOriginPolicy::create(Ref { *ownerSecurityOrigin }));
 }
 
 void Document::initContentSecurityPolicy()
 {
     if (!m_frame)
         return;
-    RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
-    if (parentFrame)
-        checkedContentSecurityPolicy()->copyUpgradeInsecureRequestStateFrom(*protect(parentFrame->document())->checkedContentSecurityPolicy());
+
+    RefPtr parentFrame = m_frame->tree().parent();
+    if (parentFrame) {
+        if (auto parentSecurityPolicy = parentFrame->frameDocumentSecurityPolicy()) {
+            checkedContentSecurityPolicy()->setUpgradeInsecureRequests(parentSecurityPolicy->upgradeInsecureRequests);
+            checkedContentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(HashSet { parentSecurityPolicy->insecureNavigationRequestsToUpgrade });
+        }
+    }
 
     // FIXME: Remove this special plugin document logic. We are stricter than the CSP 3 spec. with regards to plugins: we prefer to
     // inherit the full policy unless the plugin document is opened in a new window. The CSP 3 spec. implies that only plugin documents
     // delivered with a local scheme (e.g. blob, file, data) should inherit a policy.
     if (!isPluginDocument())
         return;
-    RefPtr openerFrame = dynamicDowncast<LocalFrame>(m_frame->opener());
-    bool shouldInhert = parentFrame || (openerFrame && protect(openerFrame->document()->securityOrigin())->isSameOriginDomain(securityOrigin()));
-    if (!shouldInhert)
+
+    RefPtr openerFrame = m_frame->opener();
+    RefPtr<LocalFrame> localParentFrame = dynamicDowncast<LocalFrame>(parentFrame.get());
+    RefPtr<LocalFrame> localOpenerFrame = dynamicDowncast<LocalFrame>(openerFrame.get());
+    bool shouldInherit = localParentFrame || (localOpenerFrame && protect(localOpenerFrame->document()->securityOrigin())->isSameOriginDomain(securityOrigin()));
+    if (!shouldInherit)
         return;
+
     setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { m_url }, *this));
-    if (openerFrame)
-        checkedContentSecurityPolicy()->createPolicyForPluginDocumentFrom(*protect(openerFrame->document())->checkedContentSecurityPolicy());
-    else
-        checkedContentSecurityPolicy()->copyStateFrom(protect(parentFrame->document())->checkedContentSecurityPolicy().get());
+    if (localOpenerFrame)
+        checkedContentSecurityPolicy()->createPolicyForPluginDocumentFrom(*protect(localOpenerFrame->document())->checkedContentSecurityPolicy());
+    else if (localParentFrame)
+        checkedContentSecurityPolicy()->copyStateFrom(protect(localParentFrame->document())->checkedContentSecurityPolicy().get());
 }
 
 void Document::inheritPolicyContainerFrom(const PolicyContainer& policyContainer)

--- a/Source/WebCore/dom/DocumentSecurityPolicy.h
+++ b/Source/WebCore/dom/DocumentSecurityPolicy.h
@@ -25,14 +25,26 @@
 
 #pragma once
 
+#include <WebCore/ContentSecurityPolicyResponseHeaders.h>
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
+#include <WebCore/SecurityOriginData.h>
+#include <wtf/HashSet.h>
+#include <wtf/URL.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 struct DocumentSecurityPolicy {
     CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     CrossOriginOpenerPolicy crossOriginOpenerPolicy;
+    ContentSecurityPolicyResponseHeaders contentSecurityPolicyResponseHeaders;
+    HashSet<SecurityOriginData> insecureNavigationRequestsToUpgrade;
+    URL cookieURL;
+    String cspReferrer;
+    int cspHttpStatusCode { 0 };
+    bool isSameOriginAsTopDocument { false };
+    bool upgradeInsecureRequests { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1685,7 +1685,30 @@ std::optional<DocumentSecurityPolicy> LocalFrame::frameDocumentSecurityPolicy() 
     if (!document)
         return std::nullopt;
 
-    return DocumentSecurityPolicy { document->crossOriginEmbedderPolicy(), document->crossOriginOpenerPolicy() };
+    ContentSecurityPolicyResponseHeaders cspHeaders;
+    HashSet<SecurityOriginData> insecureNavRequests;
+    String cspReferrer;
+    int cspHttpStatusCode = 0;
+    bool upgradeInsecureRequests = false;
+    if (CheckedPtr csp = document->contentSecurityPolicy()) {
+        cspHeaders = csp->responseHeaders();
+        insecureNavRequests = csp->insecureNavigationRequestsToUpgrade();
+        cspReferrer = csp->referrer();
+        cspHttpStatusCode = csp->httpStatusCode();
+        upgradeInsecureRequests = csp->upgradeInsecureRequests();
+    }
+
+    return DocumentSecurityPolicy {
+        document->crossOriginEmbedderPolicy(),
+        document->crossOriginOpenerPolicy(),
+        WTF::move(cspHeaders),
+        WTF::move(insecureNavRequests),
+        document->cookieURL(),
+        WTF::move(cspReferrer),
+        cspHttpStatusCode,
+        document->isSameOriginAsTopDocument(),
+        upgradeInsecureRequests
+    };
 }
 
 Ref<FrameInspectorController> LocalFrame::protectedInspectorController() const

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -222,6 +222,7 @@ public:
     WEBCORE_EXPORT void upgradeInsecureRequestIfNeeded(URL&, InsecureRequestType, AlwaysUpgradeRequest = AlwaysUpgradeRequest::No) const;
 
     HashSet<SecurityOriginData> takeNavigationRequestsToUpgrade();
+    const HashSet<SecurityOriginData>& insecureNavigationRequestsToUpgrade() const { return m_insecureNavigationRequestsToUpgrade; }
     void inheritInsecureNavigationRequestsToUpgradeFromOpener(const ContentSecurityPolicy&);
     void setInsecureNavigationRequestsToUpgrade(HashSet<SecurityOriginData>&&);
 
@@ -231,6 +232,11 @@ public:
     void setDocumentURL(URL& documentURL) { m_documentURL = documentURL; }
 
     SandboxFlags sandboxFlags() const { return m_sandboxFlags; }
+
+    const String& referrer() const { return m_referrer; }
+    void setReferrer(const String& referrer) { m_referrer = referrer; }
+    int httpStatusCode() const { return m_httpStatusCode; }
+    void setHttpStatusCode(int httpStatusCode) { m_httpStatusCode = httpStatusCode; }
 
     bool isHeaderDelivered() const { return m_isHeaderDelivered; }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9148,6 +9148,13 @@ enum class WebCore::ShouldGoToHistoryItem : uint8_t {
 struct WebCore::DocumentSecurityPolicy {
     WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     WebCore::CrossOriginOpenerPolicy crossOriginOpenerPolicy;
+    WebCore::ContentSecurityPolicyResponseHeaders contentSecurityPolicyResponseHeaders;
+    HashSet<WebCore::SecurityOriginData> insecureNavigationRequestsToUpgrade;
+    URL cookieURL;
+    String cspReferrer;
+    int cspHttpStatusCode;
+    bool isSameOriginAsTopDocument;
+    bool upgradeInsecureRequests;
 };
 
 header: <WebCore/ProcessSwapDisposition.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1789,6 +1789,12 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     m_mainFrame = WebFrameProxy::create(*this, browsingContextGroup->ensureProcessForSite(effectiveSite, site, process, preferences), generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, WebFrameProxy::protectedWebFrame(m_openerFrameIdentifier).get(), IsMainFrame::Yes);
     if (preferences->siteIsolationEnabled())
         browsingContextGroup->addPage(*this);
+
+    // Register the cookie domain for this new page. For about:blank pages opened via window.open,
+    // effectiveSite contains the opener's origin which is the correct domain for cookie access.
+    if (!effectiveSite.domain().isEmpty())
+        protect(protect(websiteDataStore())->networkProcess())->addAllowedFirstPartyForCookies(m_mainFrame->process(), effectiveSite.domain(), LoadedWebArchive::No, [] { });
+
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protect(drawingArea()), m_mainFrame->frameID(), std::nullopt)), 0);
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)


### PR DESCRIPTION
#### 62e6d3041ba98f49b914ac48b4e580a9be635d4c
<pre>
[Site Isolation] Update Document::initSecurityContext
<a href="https://rdar.apple.com/141188809">rdar://141188809</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284343">https://bugs.webkit.org/show_bug.cgi?id=284343</a>

Reviewed by NOBODY (OOPS!).

WIP

* LayoutTests/http/tests/security/iframe-open-about-blank-expected.txt: Added.
* LayoutTests/http/tests/security/iframe-open-about-blank.html: Added.
* LayoutTests/http/tests/security/resources/open-about-blank.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::initSecurityContext):
(WebCore::Document::initContentSecurityPolicy):
* Source/WebCore/dom/DocumentSecurityPolicy.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::frameDocumentSecurityPolicy const):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62e6d3041ba98f49b914ac48b4e580a9be635d4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95743 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16685b20-6467-48a9-a0de-2863fd323bd6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109632 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79099 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ca0379d-4a5e-4db2-a011-7a798d6e388a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90541 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1271a988-cfa1-440a-aa7a-afbff1911fe3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9288 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1221 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153536 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117654 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117990 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14011 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124863 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70340 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14691 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3819 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14428 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78393 "Found 2 new failures in UIProcess/WebPageProxy.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->