### PR TITLE
[AutoFill Debugging] Add an interaction type to scroll by a given distance

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
@@ -6,6 +6,10 @@ PASS selectMenuItemError is ""
 PASS select.value is "Three"
 PASS selectTextError is ""
 PASS getSelection().toString() is "Subject"
+PASS scrollChildContainerError is ""
+PASS childScroller.scrollTop is 100
+PASS scrollPageError is ""
+PASS document.scrollingElement.scrollTop is 100
 PASS invalidActionError is "Failed to resolve nodeIdentifier 4294967293"
 PASS successfullyParsed is true
 
@@ -16,3 +20,6 @@ Subject
 Hello world.
 
 1
+
+Foo bar
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true AsyncOverflowScrollingEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -6,6 +6,18 @@
 <head>
     <script src="../../resources/js-test.js"></script>
     <script src="../../resources/ui-helper.js"></script>
+    <style>
+        .tall {
+            height: 4000px;
+        }
+
+        .scroller {
+            overflow: scroll;
+            width: 200px;
+            height: 200px;
+            border: 1px solid tomato;
+        }
+    </style>
 </head>
 <body>
     <button id="test-button" aria-label="Click Me">Test</button>
@@ -20,6 +32,10 @@
         <p>Hello world.</p>
     </div>
     <h1 class="click-count">0</h1>
+    <div class="scroller" aria-label="Child scroller">
+        <div class="tall">Foo bar</div>
+    </div>
+    <div class="tall"></div>
     <script>
     jsTestIsAsync = true;
 
@@ -27,6 +43,7 @@
         textField = document.querySelector("input");
         select = document.querySelector("select");
         clickCount = document.querySelector(".click-count");
+        childScroller = document.querySelector(".scroller");
         document.getElementById("test-button").addEventListener("click", () => {
             clickCount.textContent = parseInt(clickCount.textContent) + 1;
         });
@@ -60,6 +77,21 @@
             text: "Subject"
         });
 
+        scrollChildContainerError = await UIHelper.performTextExtractionInteraction("scrollby", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Child scroller"),
+            scrollDelta: {
+                x: 0,
+                y: 100
+            }
+        });
+
+        scrollPageError = await UIHelper.performTextExtractionInteraction("scrollby", {
+            scrollDelta: {
+                x: 0,
+                y: 100
+            }
+        });
+
         invalidActionError = await UIHelper.performTextExtractionInteraction("click", {
             nodeIdentifier: "4294967293",
         });
@@ -72,6 +104,10 @@
         shouldBeEqualToString("select.value", "Three");
         shouldBeEqualToString("selectTextError", "");
         shouldBeEqualToString("getSelection().toString()", "Subject");
+        shouldBeEqualToString("scrollChildContainerError", "");
+        shouldBe("childScroller.scrollTop", "100");
+        shouldBeEqualToString("scrollPageError", "");
+        shouldBe("document.scrollingElement.scrollTop", "100");
         shouldBeEqualToString("invalidActionError", "Failed to resolve nodeIdentifier 4294967293");
 
         finishJSTest();

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -410,6 +410,8 @@ public:
     WEBCORE_EXPORT void updateMouseEventTargetAfterLayoutIfNeeded();
     WEBCORE_EXPORT void scheduleMouseEventTargetUpdateAfterLayout();
 
+    ScrollableArea* enclosingScrollableArea(Node*) const;
+
 private:
 #if ENABLE(DRAG_SUPPORT)
     static DragState& dragState();
@@ -480,7 +482,6 @@ private:
     enum class FireMouseOverOut : bool { No, Yes };
     void updateMouseEventTargetNode(const AtomString& eventType, Node*, const PlatformMouseEvent&, FireMouseOverOut);
 
-    ScrollableArea* enclosingScrollableArea(Node*) const;
     void notifyScrollableAreasOfMouseEvents(const AtomString& eventType, Element* lastElementUnderMouse, Element* elementUnderMouse);
 
     MouseEventWithHitTestResults prepareMouseEvent(const HitTestRequest&, const PlatformMouseEvent&);

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -43,6 +43,7 @@ enum class Action : uint8_t {
     TextInput,
     KeyPress,
     HighlightText,
+    ScrollBy,
 };
 
 struct Interaction {
@@ -50,6 +51,7 @@ struct Interaction {
     String text;
     std::optional<FloatPoint> locationInRootView;
     std::optional<NodeIdentifier> nodeIdentifier;
+    FloatSize scrollDelta;
     bool replaceAll { false };
     bool scrollToVisible { false };
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6714,7 +6714,8 @@ header: <WebCore/TextExtractionTypes.h>
     SelectMenuItem,
     TextInput,
     KeyPress,
-    HighlightText
+    HighlightText,
+    ScrollBy
 };
 
 header: <WebCore/TextExtractionTypes.h>
@@ -6730,6 +6731,7 @@ header: <WebCore/TextExtractionTypes.h>
     String text;
     std::optional<WebCore::FloatPoint> locationInRootView;
     std::optional<WebCore::NodeIdentifier> nodeIdentifier;
+    WebCore::FloatSize scrollDelta;
     bool replaceAll;
     bool scrollToVisible;
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6759,6 +6759,8 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
             return WebCore::TextExtraction::Action::KeyPress;
         case _WKTextExtractionActionHighlightText:
             return WebCore::TextExtraction::Action::HighlightText;
+        case _WKTextExtractionActionScrollBy:
+            return WebCore::TextExtraction::Action::ScrollBy;
         default:
             ASSERT_NOT_REACHED();
             return WebCore::TextExtraction::Action::Click;
@@ -6776,6 +6778,7 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
     interaction.text = wkInteraction.text;
     interaction.replaceAll = wkInteraction.replaceAll;
     interaction.scrollToVisible = wkInteraction.scrollToVisible;
+    interaction.scrollDelta = WebCore::FloatSize { wkInteraction.scrollDelta };
     return interaction;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -137,6 +137,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
     _WKTextExtractionActionTextInput,
     _WKTextExtractionActionKeyPress,
     _WKTextExtractionActionHighlightText,
+    _WKTextExtractionActionScrollBy
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
@@ -154,6 +155,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @property (nonatomic, copy, nullable) NSString *text;
 @property (nonatomic) BOOL replaceAll;
 @property (nonatomic) BOOL scrollToVisible;
+@property (nonatomic) CGSize scrollDelta;
 
 // Must be within the visible bounds of the web view.
 @property (nonatomic) CGPoint location;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -164,6 +164,7 @@
 @synthesize location = _location;
 @synthesize hasSetLocation = _hasSetLocation;
 @synthesize scrollToVisible = _scrollToVisible;
+@synthesize scrollDelta = _scrollDelta;
 
 - (instancetype)initWithAction:(_WKTextExtractionAction)action
 {

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -58,8 +58,8 @@ dictionary TextExtractionTestOptions {
 dictionary TextExtractionInteractionOptions {
     DOMString nodeIdentifier;
     DOMString text;
-    double x = -1;
-    double y = -1;
+    object location;
+    object scrollDelta;
     boolean replaceAll = false;
     boolean scrollToVisible = false;
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -76,6 +76,7 @@ struct TextExtractionInteractionOptions {
     JSRetainPtr<JSStringRef> nodeIdentifier;
     JSRetainPtr<JSStringRef> text;
     std::optional<std::pair<double, double>> location;
+    std::optional<std::pair<double, double>> scrollDelta;
     bool replaceAll { false };
     bool scrollToVisible { false };
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -103,6 +103,14 @@ TextExtractionInteractionOptions* toTextExtractionInteractionOptions(JSContextRe
     options.replaceAll = booleanProperty(context, (JSObjectRef)argument, "replaceAll");
     options.scrollToVisible = booleanProperty(context, (JSObjectRef)argument, "scrollToVisible");
 
+    if (auto deltaObject = objectProperty(context, (JSObjectRef)argument, "scrollDelta")) {
+        options.scrollDelta = {
+            numericProperty(context, deltaObject, "x"),
+            numericProperty(context, deltaObject, "y")
+        };
+    } else
+        options.scrollDelta = std::nullopt;
+
     if (auto locationObject = objectProperty(context, (JSObjectRef)argument, "location")) {
         options.location = {
             numericProperty(context, locationObject, "x"),

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -419,6 +419,8 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         action = _WKTextExtractionActionKeyPress;
     if (equalLettersIgnoringASCIICase(actionName, "highlighttext"))
         action = _WKTextExtractionActionHighlightText;
+    if (equalLettersIgnoringASCIICase(actionName, "scrollby"))
+        action = _WKTextExtractionActionScrollBy;
 
     if (!action) {
         ASSERT_NOT_REACHED();
@@ -440,6 +442,9 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         auto [x, y] = *location;
         [interaction setLocation:CGPointMake(x, y)];
     }
+
+    if (auto scrollDelta = options->scrollDelta)
+        [interaction setScrollDelta:std::apply(CGSizeMake, *scrollDelta)];
 
     [webView() _performInteraction:interaction.get() completionHandler:^(_WKTextExtractionInteractionResult *result) {
         if (!m_context)


### PR DESCRIPTION
#### 78f799e6ecc67e9bc5a6dc35028edca1653a7c4f
<pre>
[AutoFill Debugging] Add an interaction type to scroll by a given distance
<a href="https://bugs.webkit.org/show_bug.cgi?id=302728">https://bugs.webkit.org/show_bug.cgi?id=302728</a>
<a href="https://rdar.apple.com/164990607">rdar://164990607</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Add support for a new interaction type, `_WKTextExtractionActionScrollBy`. This interaction takes:

-   A scrolling offset delta, in the form of a new property on `_WKTextExtractionInteraction` (this
    must be non-zero)

-   A node identifier representing a subscrollable container (or a node underneath a subscrollable
    container); if unspecified, this scrolls the page.

* LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:

Augment this existing test to cover the change.

* Source/WebCore/page/EventHandler.h:

Move this helper into the public section, so that we can call it below.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::scrollBy):
(WebCore::TextExtraction::handleInteraction):
(WebCore::TextExtraction::interactionDescription):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _convertToWebCoreInteraction:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionInteractionOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::performTextExtractionInteraction):

Canonical link: <a href="https://commits.webkit.org/303235@main">https://commits.webkit.org/303235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ede421c8fafb2f2bd96a9d956bb900b40bcace1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83564 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7734710f-85e4-446a-a062-fee4bfccfb4e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100676 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/24478308-967c-4247-9569-4910b047c98f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81446 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5d3b18a-7f0e-4586-bb0e-66df71ee3f94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2864 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/702 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82431 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141855 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3861 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2953 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57071 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3914 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32665 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3875 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->