### PR TITLE
[WebGPU] Clean up MTLSamplerState cache logic

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1231,7 +1231,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     return BindGroup::createInvalid(*this);
                 }
 
-                id<MTLSamplerState> sampler = apiSampler->samplerState();
+                id<MTLSamplerState> sampler = apiSampler->tryCacheSamplerState();
                 if (stage != ShaderStage::Undefined) {
                     argumentIndices[stage].remove(index);
                     [argumentEncoder[stage] setSamplerState:sampler atIndex:index];
@@ -1466,11 +1466,11 @@ bool BindGroup::rebindSamplersIfNeeded() const
     for (auto& [samplerRefPtr, shaderStageArray] : m_samplers) {
         auto sampler = samplerRefPtr;
         ASSERT(sampler);
-        if (!sampler || sampler->cachedSampler())
+        if (!sampler || sampler->cachedSamplerState())
             continue;
 
         WTFLogAlways("Rebinding of samplers required, if this occurs frequently the application is using too many unique samplers");
-        id<MTLSamplerState> samplerState = sampler->samplerState();
+        id<MTLSamplerState> samplerState = sampler->tryCacheSamplerState();
         if (!samplerState)
             return false;
         if (shaderStageArray[ShaderStage::Vertex].has_value() && setArgumentBuffer(m_bindGroupLayout->vertexArgumentEncoder(), vertexArgumentBuffer()))

--- a/Source/WebGPU/WebGPU/Sampler.h
+++ b/Source/WebGPU/WebGPU/Sampler.h
@@ -69,8 +69,8 @@ public:
 
     bool isValid() const;
 
-    id<MTLSamplerState> cachedSampler() const;
-    id<MTLSamplerState> samplerState() const;
+    id<MTLSamplerState> cachedSamplerState() const { return m_cachedSamplerState; }
+    id<MTLSamplerState> tryCacheSamplerState() const;
     const WGPUSamplerDescriptor& descriptor() const { return m_descriptor; }
     bool isComparison() const { return descriptor().compare != WGPUCompareFunction_Undefined; }
     bool isFiltering() const { return descriptor().minFilter == WGPUFilterMode_Linear || descriptor().magFilter == WGPUFilterMode_Linear || descriptor().mipmapFilter == WGPUMipmapFilterMode_Linear; }
@@ -85,18 +85,6 @@ private:
     WGPUSamplerDescriptor m_descriptor { };
 
     const Ref<Device> m_device;
-    // static is intentional here as the limit is per process
-    static Lock samplerStateLock;
-    using CachedSamplerStateContainer = HashMap<GenericHashKey<UniqueSamplerIdentifier>, WeakObjCPtr<id<MTLSamplerState>>>;
-    struct SamplerStateWithReferences {
-        RetainPtr<id<MTLSamplerState>> samplerState;
-        HashSet<uintptr_t> apiSamplerList;
-    };
-    using RetainedSamplerStateContainer = HashMap<GenericHashKey<UniqueSamplerIdentifier>, SamplerStateWithReferences>;
-    using CachedKeyContainer = ListHashSet<GenericHashKey<UniqueSamplerIdentifier>>;
-    static std::unique_ptr<CachedSamplerStateContainer> cachedSamplerStates WTF_GUARDED_BY_LOCK(samplerStateLock);
-    static std::unique_ptr<RetainedSamplerStateContainer> retainedSamplerStates WTF_GUARDED_BY_LOCK(samplerStateLock);
-    static std::unique_ptr<CachedKeyContainer> lastAccessedKeys;
 
     mutable __weak id<MTLSamplerState> m_cachedSamplerState { nil };
 };


### PR DESCRIPTION
#### 66035f0df72081e8a186bbcfe25042046f586069
<pre>
[WebGPU] Clean up MTLSamplerState cache logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=302729">https://bugs.webkit.org/show_bug.cgi?id=302729</a>
<a href="https://rdar.apple.com/164991782">rdar://164991782</a>

Reviewed by Mike Wyrzykowski.

This patch does two things:

1. Remove the reinterpret_cast&lt;uintptr_t&gt; I just added for SaferCPP. Pointer =&gt;
integer cast is technically memory-safe so long as you don&apos;t cast back. But it&apos;s
still sketchy. This patch replaces explicit pointer tracking with a use count.

2. Fix the cache eviction logic regression in 294328@main. I realized that the
reinterpret_cast logic was a no-op, so I considered just removing it, but Mike
and I discovered that the no-op was a regression. So let&apos;s fix it instead.

In extreme cases, we want to evict live entries from the cache and regenerate
them on demand. For example, if a program is churning Sampler allocations, and
GC is not keeping up -- similar to a problem we sometimes have with &lt;canvas&gt; --
we want to reclaim live MTLSamplers instead of just failing. We model this using
a strong + weak reference in the cache. We use our weak reference to detect
whether reclamation succeeds when we clear our strong reference.

Canonical link: <a href="https://commits.webkit.org/303218@main">https://commits.webkit.org/303218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ea4ddcb1de872bde6da7f2126888dd106c2e4ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139217 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/597a45cb-eedb-4788-bcef-a5c67eaa4136) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3962 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5314d07a-e830-4d60-aa55-8e44f45ab2ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81452 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/03bd1a18-b522-4fb8-b675-7e068f81ac7a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82439 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111593 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141863 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3869 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109048 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109205 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2950 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57079 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3922 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32669 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67370 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->