### PR TITLE
[GTK][WPE] Centralize Skia GL context initialization with automatic CPU fallback

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -113,8 +113,9 @@ public:
 #endif
 
 #if USE(SKIA)
-    GLContext* skiaGLContext();
-    GrDirectContext* skiaGrContext();
+    bool tryEnsureSkiaGLContext();
+    GLContext* skiaGLContext() const;
+    GrDirectContext* skiaGrContext() const;
     unsigned msaaSampleCount() const;
 #endif
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -84,6 +84,9 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
     if (parameters.purpose != RenderingPurpose::Canvas && !ProcessCapabilities::canUseAcceleratedBuffers())
         return nullptr;
 
+    if (!PlatformDisplay::sharedDisplay().tryEnsureSkiaGLContext())
+        return nullptr;
+
     auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
     if (!glContext || !glContext->makeContextCurrent())
         return nullptr;

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -278,22 +278,27 @@ private:
 };
 #endif
 
-GLContext* PlatformDisplay::skiaGLContext()
+bool PlatformDisplay::tryEnsureSkiaGLContext()
 {
 #if PLATFORM(GTK) || PLATFORM(WPE) || (PLATFORM(PLAYSTATION) && !USE(COORDINATED_GRAPHICS))
     if (!s_skiaGLContext) {
         s_skiaGLContext = SkiaGLContext::create(*this);
         m_skiaGLContexts.add(*s_skiaGLContext);
     }
-    return s_skiaGLContext->skiaGLContext();
+    return !!s_skiaGLContext->skiaGLContext();
 #else
     // The PlayStation OpenGL implementation does not dispatch to the context bound to
     // the current thread so Skia cannot use OpenGL with coordinated graphics.
-    return nullptr;
+    return false;
 #endif
 }
 
-GrDirectContext* PlatformDisplay::skiaGrContext()
+GLContext* PlatformDisplay::skiaGLContext() const
+{
+    return s_skiaGLContext ? s_skiaGLContext->skiaGLContext() : nullptr;
+}
+
+GrDirectContext* PlatformDisplay::skiaGrContext() const
 {
     RELEASE_ASSERT(s_skiaGLContext);
     return s_skiaGLContext->skiaGrContext();

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -51,10 +51,10 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaPaintingEngine);
 
 // Note:
-// If WEBKIT_SKIA_ENABLE_CPU_RENDERING is unset, we will allocate a GPU-only worker pool with WEBKIT_SKIA_GPU_PAINTING_THREADS threads (default: 1).
+// If WEBKIT_SKIA_ENABLE_CPU_RENDERING is unset, we will allocate a GPU-only worker pool with WEBKIT_SKIA_GPU_PAINTING_THREADS threads.
 // If WEBKIT_SKIA_ENABLE_CPU_RENDERING is unset, and WEBKIT_SKIA_GPU_PAINTING_THREADS is set to 0, we will use GPU rendering on main thread.
 //
-// If WEBKIT_SKIA_ENABLE_CPU_RENDERING=1 is set, we will allocate a CPU-only worker pool with WEBKIT_SKIA_CPU_PAINTING_THREADS threads (default: nCores/2).
+// If WEBKIT_SKIA_ENABLE_CPU_RENDERING=1 is set, we will allocate a CPU-only worker pool with WEBKIT_SKIA_CPU_PAINTING_THREADS threads.
 // if WEBKIT_SKIA_ENABLE_CPU_RENDERING=1 is set, and WEBKIT_SKIA_CPU_PAINTING_THREADS is set to 0, we will use CPU rendering on main thread.
 
 SkiaPaintingEngine::SkiaPaintingEngine()
@@ -77,11 +77,6 @@ SkiaPaintingEngine::~SkiaPaintingEngine() = default;
 std::unique_ptr<SkiaPaintingEngine> SkiaPaintingEngine::create()
 {
     return makeUnique<SkiaPaintingEngine>();
-}
-
-static bool canPerformAcceleratedRendering()
-{
-    return ProcessCapabilities::canUseAcceleratedBuffers() && PlatformDisplay::sharedDisplay().skiaGLContext();
 }
 
 void SkiaPaintingEngine::paintIntoGraphicsContext(const GraphicsLayer& layer, GraphicsContext& context, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const
@@ -123,8 +118,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::paint(const GraphicsLayer& layer,
 {
     // ### Synchronous rendering on main thread ###
     ASSERT(!useThreadedRendering());
-
-    auto renderingMode = canPerformAcceleratedRendering() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
+    auto renderingMode = ProcessCapabilities::canUseAcceleratedBuffers() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
 
     auto buffer = createBuffer(renderingMode, dirtyRect.size(), contentsOpaque);
     buffer->beginPainting();
@@ -149,9 +143,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayer& layer, 
 {
     // ### Asynchronous rendering on worker threads ###
     ASSERT(useThreadedRendering());
-    ASSERT(m_workerPool);
-
-    auto renderingMode = canPerformAcceleratedRendering() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
+    auto renderingMode = ProcessCapabilities::canUseAcceleratedBuffers() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
 
     WTFBeginSignpost(this, RecordTile);
     SkPictureRecorder pictureRecorder;
@@ -171,11 +163,16 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const RefPtr<SkiaRecording
     // ### Asynchronous rendering on worker threads ###
     ASSERT(useThreadedRendering());
 
-    auto renderingMode = recording->renderingMode();
-    auto buffer = createBuffer(renderingMode, dirtyRect.size(), recording->contentsOpaque());
+    auto buffer = createBuffer(recording->renderingMode(), dirtyRect.size(), recording->contentsOpaque());
     buffer->beginPainting();
 
     m_workerPool->postTask([buffer = Ref { buffer }, dirtyRect, recording = RefPtr { recording }]() mutable {
+        // Ensure the worker thread has a valid Skia GL context
+        if (recording->renderingMode() == RenderingMode::Accelerated) {
+            bool hasValidSkiaGLContext = PlatformDisplay::sharedDisplay().tryEnsureSkiaGLContext();
+            ASSERT_UNUSED(hasValidSkiaGLContext, hasValidSkiaGLContext);
+        }
+
         auto* canvas = buffer->canvas();
         if (!canvas) {
             buffer->completePainting();
@@ -233,10 +230,6 @@ unsigned SkiaPaintingEngine::numberOfGPUPaintingThreads()
     static unsigned numberOfThreads = 0;
 
     std::call_once(onceFlag, [] {
-        // If WEBKIT_SKIA_ENABLE_CPU_RENDERING=1 is set in the environment, no GPU painting is used.
-        if (!ProcessCapabilities::canUseAcceleratedBuffers())
-            return;
-
         // By default, use 2 GPU worker threads if there are four or more CPU cores, otherwise use 1 thread only.
         numberOfThreads = WTF::numberOfProcessorCores() >= 4 ? 2 : 1;
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -141,6 +141,20 @@ void WebProcess::platformInitializeProcess(const AuxiliaryProcessInitializationP
     addSupplementWithoutRefCountedCheck<SystemSettingsManager>();
 }
 
+static inline void initializeSharedDisplay(std::unique_ptr<PlatformDisplay>&& display)
+{
+    PlatformDisplay::setSharedDisplay(WTFMove(display));
+
+#if USE(SKIA)
+    if (ProcessCapabilities::canUseAcceleratedBuffers()) {
+        if (!PlatformDisplay::sharedDisplay().tryEnsureSkiaGLContext()) {
+            WTFLogAlways("Could not create Skia GL context: falling back to CPU rendering...");
+            ProcessCapabilities::setCanUseAcceleratedBuffers(false);
+        }
+    }
+#endif
+}
+
 void WebProcess::initializePlatformDisplayIfNeeded() const
 {
     if (PlatformDisplay::sharedDisplayIfExists())
@@ -157,7 +171,7 @@ void WebProcess::initializePlatformDisplayIfNeeded() const
 #endif
         if (!disabled) {
             if (auto device = DRMDeviceManager::singleton().mainGBMDevice(DRMDeviceManager::NodeType::Render)) {
-                PlatformDisplay::setSharedDisplay(PlatformDisplayGBM::create(device->device()));
+                initializeSharedDisplay(PlatformDisplayGBM::create(device->device()));
                 return;
             }
         }
@@ -166,19 +180,19 @@ void WebProcess::initializePlatformDisplayIfNeeded() const
 
 #if OS(ANDROID)
     if (auto display = PlatformDisplayAndroid::create()) {
-        PlatformDisplay::setSharedDisplay(WTFMove(display));
+        initializeSharedDisplay(WTFMove(display));
         return;
     }
 #endif
 
     if (auto display = PlatformDisplaySurfaceless::create()) {
-        PlatformDisplay::setSharedDisplay(WTFMove(display));
+        initializeSharedDisplay(WTFMove(display));
         return;
     }
 
 #if PLATFORM(GTK) || OS(ANDROID)
     if (auto display = PlatformDisplayDefault::create()) {
-        PlatformDisplay::setSharedDisplay(WTFMove(display));
+        initializeSharedDisplay(WTFMove(display));
         return;
     }
 #endif
@@ -212,7 +226,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
             auto& implementationLibraryName = parameters.implementationLibraryName;
             if (!implementationLibraryName.isNull() && implementationLibraryName.data()[0] != '\0')
                 wpe_loader_init(parameters.implementationLibraryName.data());
-            PlatformDisplay::setSharedDisplay(PlatformDisplayLibWPE::create(parameters.hostClientFileDescriptor.release()));
+            initializeSharedDisplay(PlatformDisplayLibWPE::create(parameters.hostClientFileDescriptor.release()));
         } else
             initializePlatformDisplayIfNeeded();
     }


### PR DESCRIPTION
#### a669cbc3b05e91a0be669a07f95659298a0caed6
<pre>
[GTK][WPE] Centralize Skia GL context initialization with automatic CPU fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=302734">https://bugs.webkit.org/show_bug.cgi?id=302734</a>

Reviewed by NOBODY (OOPS!).

Refactor Skia GL context management by splitting context initialization from
access. Introduce PlatformDisplay::tryEnsureSkiaGLContext() for safe GL context
initialization, and convert skiaGLContext()/skiaGrContext() to const accessors.

Centralize GL context initialization in WebProcessGLib.cpp through a new
initializeSharedDisplay() helper that attempts to create the GL context and
automatically falls back to CPU rendering if initialization fails, logging
a warning when this occurs.

Explicitely ensure a Skia GL context exists in worker threads in SkiaPaintingEngine
to ensure accelerated rendering works correctly in background threads.

Remove the redundant canPerformAcceleratedRendering() static helper, replacing
its usage with direct ProcessCapabilities::canUseAcceleratedBuffers()
checks, which is now the primary source of truth.

Covered by existing tests.

* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::PlatformDisplay::tryEnsureSkiaGLContext):
(WebCore::PlatformDisplay::skiaGLContext const):
(WebCore::PlatformDisplay::skiaGrContext const):
(WebCore::PlatformDisplay::skiaGLContext): Deleted.
(WebCore::PlatformDisplay::skiaGrContext): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::paint):
(WebCore::SkiaPaintingEngine::record):
(WebCore::SkiaPaintingEngine::replay):
(WebCore::SkiaPaintingEngine::numberOfGPUPaintingThreads):
(WebCore::canPerformAcceleratedRendering): Deleted.
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::initializeSharedDisplay):
(WebKit::WebProcess::initializePlatformDisplayIfNeeded const):
(WebKit::WebProcess::platformInitializeWebProcess):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a669cbc3b05e91a0be669a07f95659298a0caed6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132022 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139536 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4276 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100922 "Found 6 new test failures: fast/canvas/canvas-bg.html fast/images/large-image-webkit-canvas.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-webgl.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation.html imported/w3c/web-platform-tests/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134968 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81712 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/940 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142183 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4184 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36944 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109291 "Found 3 new test failures: imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation.html imported/w3c/web-platform-tests/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109463 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3168 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57405 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4238 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67684 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->