### PR TITLE
WIP; experiment with managing shared WebInjectedScriptManager

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -28,11 +28,9 @@ heap/HeapSnapshotBuilder.h
 heap/MarkedBlock.h
 heap/SlotVisitor.h
 heap/WeakSet.h
-inspector/InspectorAgentBase.h
 inspector/InspectorBackendDispatchers.h
 inspector/JSGlobalObjectConsoleClient.h
 inspector/JSGlobalObjectInspectorController.h
-inspector/agents/InspectorDebuggerAgent.h
 interpreter/StackVisitor.h
 jit/JIT.h
 jit/JITCode.h

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -53,7 +53,9 @@ InjectedScriptManager::InjectedScriptManager(InspectorEnvironment& environment, 
 {
 }
 
-InjectedScriptManager::~InjectedScriptManager() = default;
+InjectedScriptManager::~InjectedScriptManager()
+{
+}
 
 void InjectedScriptManager::connect()
 {

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -47,9 +48,10 @@ namespace Inspector {
 
 class InjectedScriptHost;
 
-class InjectedScriptManager {
+class InjectedScriptManager : public CanMakeCheckedPtr<InjectedScriptManager> {
     WTF_MAKE_NONCOPYABLE(InjectedScriptManager);
     WTF_MAKE_TZONE_ALLOCATED(InjectedScriptManager);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InjectedScriptManager);
 public:
     JS_EXPORT_PRIVATE InjectedScriptManager(InspectorEnvironment&, Ref<InjectedScriptHost>&&);
     JS_EXPORT_PRIVATE virtual ~InjectedScriptManager();

--- a/Source/JavaScriptCore/inspector/InspectorAgentBase.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentBase.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <wtf/CheckedRef.h>
@@ -39,11 +40,10 @@ class JSGlobalObject;
 namespace Inspector {
 
 class BackendDispatcher;
-class InjectedScriptManager;
 
 struct AgentContext {
     CheckedRef<InspectorEnvironment> environment;
-    InjectedScriptManager& injectedScriptManager;
+    CheckedRef<InjectedScriptManager> injectedScriptManager;
     CheckedRef<FrontendRouter> frontendRouter;
     BackendDispatcher& backendDispatcher;
 };

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -301,7 +301,7 @@ JSAgentContext JSGlobalObjectInspectorController::jsAgentContext()
 {
     AgentContext baseContext = {
         *this,
-        m_injectedScriptManager,
+        m_injectedScriptManager.get(),
         m_frontendRouter.get(),
         m_backendDispatcher
     };

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -72,7 +73,7 @@ protected:
 
 private:
     const Ref<AuditBackendDispatcher> m_backendDispatcher;
-    InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<InjectedScriptManager> m_injectedScriptManager;
     JSC::Debugger& m_debugger;
 
     JSC::Strong<JSC::JSObject> m_injectedWebInspectorAuditValue;

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -76,11 +76,11 @@ Protocol::ErrorStringOr<void> InspectorConsoleAgent::enable()
 
     if (m_expiredConsoleMessageCount) {
         ConsoleMessage expiredMessage(MessageSource::Other, MessageType::Log, MessageLevel::Warning, makeString(m_expiredConsoleMessageCount, " console messages are not shown."_s));
-        expiredMessage.addToFrontend(m_frontendDispatcher, m_injectedScriptManager, false);
+        expiredMessage.addToFrontend(m_frontendDispatcher, checkedInjectedScriptManager().get(), false);
     }
 
     for (auto& message : m_consoleMessages)
-        message->addToFrontend(m_frontendDispatcher, m_injectedScriptManager, false);
+        message->addToFrontend(m_frontendDispatcher, checkedInjectedScriptManager().get(), false);
 
     return { };
 }
@@ -109,7 +109,7 @@ Protocol::ErrorStringOr<void> InspectorConsoleAgent::setConsoleClearAPIEnabled(b
 
 bool InspectorConsoleAgent::developerExtrasEnabled() const
 {
-    return m_injectedScriptManager.inspectorEnvironment().developerExtrasEnabled();
+    return m_injectedScriptManager->inspectorEnvironment().developerExtrasEnabled();
 }
 
 void InspectorConsoleAgent::mainFrameNavigated()
@@ -128,7 +128,7 @@ void InspectorConsoleAgent::clearMessages(Inspector::Protocol::Console::ClearRea
     m_consoleMessages.clear();
     m_expiredConsoleMessageCount = 0;
 
-    m_injectedScriptManager.releaseObjectGroup("console"_s);
+    m_injectedScriptManager->releaseObjectGroup("console"_s);
 
     if (m_enabled)
         m_frontendDispatcher->messagesCleared(reason);
@@ -258,7 +258,7 @@ void InspectorConsoleAgent::addConsoleMessage(std::unique_ptr<ConsoleMessage> co
             auto generatePreview = !m_isAddingMessageToFrontend;
             SetForScope isAddingMessageToFrontend(m_isAddingMessageToFrontend, true);
 
-            consoleMessage->addToFrontend(m_frontendDispatcher, m_injectedScriptManager, generatePreview);
+            consoleMessage->addToFrontend(m_frontendDispatcher, checkedInjectedScriptManager().get(), generatePreview);
         }
 
         m_consoleMessages.append(WTFMove(consoleMessage));

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/MonotonicTime.h>
@@ -86,10 +87,12 @@ public:
     void countReset(JSC::JSGlobalObject*, const String& label);
 
 protected:
+    CheckedRef<InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
+
     void addConsoleMessage(std::unique_ptr<ConsoleMessage>);
     void clearMessages(Protocol::Console::ClearReason);
 
-    InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<InjectedScriptManager> m_injectedScriptManager;
     const UniqueRef<ConsoleFrontendDispatcher> m_frontendDispatcher;
     const Ref<ConsoleBackendDispatcher> m_backendDispatcher;
     InspectorHeapAgent* m_heapAgent { nullptr };

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -649,7 +649,7 @@ Protocol::ErrorStringOr<void> InspectorDebuggerAgent::removeBreakpoint(const Pro
 
     for (auto& debuggerBreakpoint : m_debuggerBreakpointsForProtocolBreakpointID.take(protocolBreakpointID)) {
         for (const auto& action : debuggerBreakpoint->actions())
-            m_injectedScriptManager.releaseObjectGroup(objectGroupForBreakpointAction(action.id));
+            checkedInjectedScriptManager()->releaseObjectGroup(objectGroupForBreakpointAction(action.id));
 
         JSC::JSLockHolder locker(m_debugger.vm());
         m_debugger.removeBreakpoint(debuggerBreakpoint);
@@ -972,7 +972,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Debugger::FunctionDetails>> InspectorDebug
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(functionId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(functionId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given functionId"_s);
 
@@ -1257,7 +1257,7 @@ Protocol::ErrorStringOr<void> InspectorDebuggerAgent::setPauseOnMicrotasks(bool 
 
 Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> InspectorDebuggerAgent::evaluateOnCallFrame(const Protocol::Debugger::CallFrameId& callFrameId, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(callFrameId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(callFrameId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given callFrameId"_s);
 
@@ -1586,7 +1586,7 @@ bool InspectorDebuggerAgent::isInspectorDebuggerAgent() const
 
 JSC::JSObject* InspectorDebuggerAgent::debuggerScopeExtensionObject(JSC::Debugger& debugger, JSC::JSGlobalObject* globalObject, JSC::DebuggerCallFrame& debuggerCallFrame)
 {
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(globalObject);
     ASSERT(!injectedScript.hasNoValue());
     if (injectedScript.hasNoValue())
         return JSC::Debugger::Client::debuggerScopeExtensionObject(debugger, globalObject, debuggerCallFrame);
@@ -1694,7 +1694,7 @@ void InspectorDebuggerAgent::didPause(JSC::JSGlobalObject* globalObject, JSC::De
     auto* debuggerGlobalObject = debuggerCallFrame.scope(globalObject->vm())->globalObject();
     m_currentCallStack = { m_pausedGlobalObject->vm(), toJS(debuggerGlobalObject, debuggerGlobalObject, JavaScriptCallFrame::create(debuggerCallFrame).ptr()) };
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(m_pausedGlobalObject);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptFor(m_pausedGlobalObject);
 
     // If a high level pause pause reason is not already set, try to infer a reason from the debugger.
     if (m_pauseReason == DebuggerFrontendDispatcher::Reason::Other) {
@@ -1780,7 +1780,7 @@ void InspectorDebuggerAgent::didPause(JSC::JSGlobalObject* globalObject, JSC::De
         m_continueToLocationDebuggerBreakpoint = nullptr;
     }
 
-    auto& stopwatch = m_injectedScriptManager.checkedInspectorEnvironment()->executionStopwatch();
+    auto& stopwatch = checkedInjectedScriptManager()->checkedInspectorEnvironment()->executionStopwatch();
     if (stopwatch.isActive()) {
         stopwatch.stop();
         m_didPauseStopwatch = true;
@@ -1809,7 +1809,7 @@ void InspectorDebuggerAgent::breakpointActionSound(JSC::BreakpointActionID id)
 
 void InspectorDebuggerAgent::breakpointActionProbe(JSC::JSGlobalObject* globalObject, JSC::BreakpointActionID actionID, unsigned batchId, unsigned sampleId, JSC::JSValue sample)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptFor(globalObject);
     auto payload = injectedScript.wrapObject(sample, objectGroupForBreakpointAction(actionID), true);
     if (!payload)
         return;
@@ -1818,7 +1818,7 @@ void InspectorDebuggerAgent::breakpointActionProbe(JSC::JSGlobalObject* globalOb
         .setProbeId(actionID)
         .setBatchId(batchId)
         .setSampleId(sampleId)
-        .setTimestamp(m_injectedScriptManager.checkedInspectorEnvironment()->executionStopwatch().elapsedTime().seconds())
+        .setTimestamp(checkedInjectedScriptManager()->checkedInspectorEnvironment()->executionStopwatch().elapsedTime().seconds())
         .setPayload(payload.releaseNonNull())
         .release();
     m_frontendDispatcher->didSampleProbe(WTFMove(result));
@@ -1828,12 +1828,12 @@ void InspectorDebuggerAgent::didContinue()
 {
     if (m_didPauseStopwatch) {
         m_didPauseStopwatch = false;
-        m_injectedScriptManager.checkedInspectorEnvironment()->executionStopwatch().start();
+        checkedInjectedScriptManager()->checkedInspectorEnvironment()->executionStopwatch().start();
     }
 
     m_pausedGlobalObject = nullptr;
     m_currentCallStack = { };
-    m_injectedScriptManager.releaseObjectGroup(InspectorDebuggerAgent::backtraceObjectGroup);
+    checkedInjectedScriptManager()->releaseObjectGroup(InspectorDebuggerAgent::backtraceObjectGroup);
     clearPauseDetails();
     clearExceptionValue();
 
@@ -1954,7 +1954,7 @@ void InspectorDebuggerAgent::clearPauseDetails()
 void InspectorDebuggerAgent::clearExceptionValue()
 {
     if (m_hasExceptionValue) {
-        m_injectedScriptManager.clearExceptionValue();
+        checkedInjectedScriptManager()->clearExceptionValue();
         m_hasExceptionValue = false;
     }
 }

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/Microtask.h>
 #include <JavaScriptCore/RegularExpression.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -170,6 +171,7 @@ protected:
     Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> evaluateOnCallFrame(InjectedScript&, const Protocol::Debugger::CallFrameId&, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture);
 
     InjectedScriptManager& injectedScriptManager() const { return m_injectedScriptManager; }
+    CheckedRef<InjectedScriptManager> checkedInjectedScriptManager() const { return injectedScriptManager(); }
     virtual InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
 
     JSC::Debugger& debugger() { return m_debugger; }
@@ -250,7 +252,7 @@ private:
     const Ref<DebuggerBackendDispatcher> m_backendDispatcher;
 
     JSC::Debugger& m_debugger;
-    InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<InjectedScriptManager> m_injectedScriptManager;
     UncheckedKeyHashMap<JSC::SourceID, JSC::Debugger::Script> m_scripts;
 
     struct BlackboxedScript {

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -204,7 +204,7 @@ Protocol::ErrorStringOr<std::tuple<String, RefPtr<Protocol::Debugger::FunctionDe
     if (!globalObject)
         return makeUnexpected("Unable to get object details - GlobalObject"_s);
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptFor(globalObject);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Unable to get object details - InjectedScript"_s);
 
@@ -244,7 +244,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorHeapAgent
     if (!globalObject)
         return makeUnexpected("Unable to get object details - GlobalObject"_s);
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptFor(globalObject);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Unable to get object details - InjectedScript"_s);
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
@@ -78,11 +79,12 @@ protected:
     virtual void dispatchGarbageCollectedEvent(Protocol::Heap::GarbageCollection::Type, Seconds startTime, Seconds endTime);
 
     CheckedRef<InspectorEnvironment> checkedEnvironment() { return m_environment.get(); }
+    CheckedRef<InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
 
 private:
     std::optional<JSC::HeapSnapshotNode> nodeForHeapObjectIdentifier(Protocol::ErrorString&, unsigned heapObjectIdentifier);
 
-    InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<InjectedScriptManager> m_injectedScriptManager;
     const UniqueRef<HeapFrontendDispatcher> m_frontendDispatcher;
     const Ref<HeapBackendDispatcher> m_backendDispatcher;
     WeakRef<InspectorEnvironment> m_environment;

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -166,7 +166,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::op
 
 void InspectorRuntimeAgent::awaitPromise(const Protocol::Runtime::RemoteObjectId& promiseObjectId, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, Ref<AwaitPromiseCallback>&& callback)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(promiseObjectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(promiseObjectId);
     if (injectedScript.hasNoValue()) {
         callback->sendFailure("Missing injected script for given promiseObjectId"_s);
         return;
@@ -182,7 +182,7 @@ void InspectorRuntimeAgent::awaitPromise(const Protocol::Runtime::RemoteObjectId
 
 void InspectorRuntimeAgent::callFunctionOn(const Protocol::Runtime::RemoteObjectId& objectId, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture, std::optional<bool>&& awaitPromise, Ref<CallFunctionOnCallback>&& callback)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue()) {
         callback->sendFailure("Missing injected script for given objectId"_s);
         return;
@@ -219,7 +219,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> InspectorRuntimeA
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -244,7 +244,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Protocol::Runtime::Property
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -282,7 +282,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Protocol::Runtime::Property
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -320,7 +320,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Runtime::CollectionEntry>>> 
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -354,7 +354,7 @@ Protocol::ErrorStringOr<std::optional<int> /* saveResultIndex */> InspectorRunti
         if (injectedScript.hasNoValue())
             return makeUnexpected(errorString);
     } else {
-        injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+        injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
         if (injectedScript.hasNoValue())
             return makeUnexpected("Missing injected script for given objectId"_s);
     }
@@ -371,14 +371,14 @@ Protocol::ErrorStringOr<std::optional<int> /* saveResultIndex */> InspectorRunti
 
 Protocol::ErrorStringOr<void> InspectorRuntimeAgent::setSavedResultAlias(const String& savedResultAlias)
 {
-    m_injectedScriptManager.injectedScriptHost().setSavedResultAlias(savedResultAlias);
+    checkedInjectedScriptManager()->injectedScriptHost().setSavedResultAlias(savedResultAlias);
 
     return { };
 }
 
 Protocol::ErrorStringOr<void> InspectorRuntimeAgent::releaseObject(const Protocol::Runtime::RemoteObjectId& objectId)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
     if (!injectedScript.hasNoValue())
         injectedScript.releaseObject(objectId);
 
@@ -387,7 +387,7 @@ Protocol::ErrorStringOr<void> InspectorRuntimeAgent::releaseObject(const Protoco
 
 Protocol::ErrorStringOr<void> InspectorRuntimeAgent::releaseObjectGroup(const String& objectGroup)
 {
-    m_injectedScriptManager.releaseObjectGroup(objectGroup);
+    checkedInjectedScriptManager()->releaseObjectGroup(objectGroup);
 
     return { };
 }

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
@@ -33,6 +33,7 @@
 
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -85,7 +86,8 @@ protected:
     Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> evaluate(InjectedScript&, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture);
     void callFunctionOn(InjectedScript&, const Protocol::Runtime::RemoteObjectId&, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture, std::optional<bool>&& awaitPromise, Ref<CallFunctionOnCallback>&&);
 
-    InjectedScriptManager& injectedScriptManager() { return m_injectedScriptManager; }
+    InjectedScriptManager& injectedScriptManager() const { return m_injectedScriptManager; }
+    CheckedRef<InjectedScriptManager> checkedInjectedScriptManager() const { return injectedScriptManager(); }
 
     virtual InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
 
@@ -96,7 +98,7 @@ private:
     void setTypeProfilerEnabledState(bool);
     void setControlFlowProfilerEnabledState(bool);
 
-    InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<InjectedScriptManager> m_injectedScriptManager;
     JSC::Debugger& m_debugger;
     JSC::VM& m_vm;
     bool m_enabled {false};

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -49,7 +49,6 @@ inspector/InspectorStyleSheet.h
 inspector/InstrumentingAgents.h
 inspector/PageInspectorController.h
 inspector/UserGestureEmulationScope.h
-inspector/agents/InspectorNetworkAgent.h
 inspector/agents/InspectorPageAgent.h
 layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineItemsBuilder.cpp

--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -34,6 +34,7 @@
 #include "Database.h"
 #include "Document.h"
 #include "EventTarget.h"
+#include "FrameInspectorController.h"
 #include "InspectorDOMStorageAgent.h"
 #include "JSCommandLineAPIHost.h"
 #include "JSDOMGlobalObject.h"
@@ -42,9 +43,12 @@
 #include "Pasteboard.h"
 #include "Storage.h"
 #include "WebConsoleAgent.h"
+#include "WorkerGlobalScope.h"
+#include "WorkerInspectorController.h"
 #include <JavaScriptCore/InjectedScriptBase.h>
 #include <JavaScriptCore/InspectorAgent.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <wtf/JSONValues.h>
@@ -74,20 +78,28 @@ CommandLineAPIHost::CommandLineAPIHost()
 {
 }
 
-CommandLineAPIHost::~CommandLineAPIHost()
+static InstrumentingAgents* instrumentingAgentsForGlobalObject(JSC::JSGlobalObject& globalObject)
 {
-    RELEASE_ASSERT(!m_instrumentingAgents);
-}
+    auto* domGlobalObject = jsDynamicCast<JSDOMGlobalObject*>(&globalObject);
+    if (!domGlobalObject)
+        return nullptr;
 
-void CommandLineAPIHost::disconnect()
-{
+    RefPtr executionContext = domGlobalObject->scriptExecutionContext();
+    if (!executionContext)
+        return nullptr;
 
-    m_instrumentingAgents = nullptr;
+    if (executionContext->isDocument()) {
+        if (RefPtr frame = downcast<Document>(executionContext)->frame())
+            return &frame->protectedInspectorController()->instrumentingAgents();
+    } else if (executionContext->isWorkerGlobalScope())
+        return &downcast<WorkerGlobalScope>(executionContext)->inspectorController().instrumentingAgents();
+
+    return nullptr;
 }
 
 void CommandLineAPIHost::inspect(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue object, JSC::JSValue hints)
 {
-    RefPtr agents = m_instrumentingAgents.get();
+    RefPtr agents = instrumentingAgentsForGlobalObject(lexicalGlobalObject);
     if (!agents)
         return;
 

--- a/Source/WebCore/inspector/CommandLineAPIHost.h
+++ b/Source/WebCore/inspector/CommandLineAPIHost.h
@@ -37,6 +37,7 @@
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
+class JSGlobalObject;
 class JSValue;
 }
 
@@ -56,14 +57,7 @@ struct EventListenerInfo;
 class CommandLineAPIHost : public RefCounted<CommandLineAPIHost> {
 public:
     static Ref<CommandLineAPIHost> create();
-    ~CommandLineAPIHost();
-
-    void init(InstrumentingAgents& instrumentingAgents)
-    {
-        m_instrumentingAgents = &instrumentingAgents;
-    }
-
-    void disconnect();
+    ~CommandLineAPIHost() = default;
 
     void copyText(const String& text);
 
@@ -99,7 +93,6 @@ public:
 private:
     CommandLineAPIHost();
 
-    WeakPtr<InstrumentingAgents> m_instrumentingAgents;
     std::unique_ptr<InspectableObject> m_inspectedObject; // $0
     Inspector::PerGlobalObjectWrapperWorld m_wrappers;
 };

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -49,6 +49,7 @@
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/Strong.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Stopwatch.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -88,11 +89,16 @@ void FrameInspectorController::deref() const
     m_frame->deref();
 }
 
+CheckedRef<WebInjectedScriptManager> FrameInspectorController::checkedInjectedScriptManager() const
+{
+    return m_injectedScriptManager.get();
+}
+
 FrameAgentContext FrameInspectorController::frameAgentContext()
 {
     AgentContext baseContext = {
         *this,
-        m_injectedScriptManager,
+        checkedInjectedScriptManager().get(),
         m_frontendRouter.get(),
         m_backendDispatcher
     };
@@ -130,6 +136,7 @@ void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& front
 
     if (connectedFirstFrontend) {
         m_agents.didCreateFrontendAndBackend();
+        checkedInjectedScriptManager()->addClient();
         InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents.get());
     }
 }
@@ -142,11 +149,12 @@ void FrameInspectorController::disconnectFrontend(Inspector::FrontendChannel& fr
     bool disconnectedLastFrontend = !m_frontendRouter->hasFrontends();
     if (disconnectedLastFrontend) {
         InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+        checkedInjectedScriptManager()->removeClient();
         m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectorDestroyed);
     }
 }
 
-void FrameInspectorController::inspectedFrameDestroyed()
+void FrameInspectorController::disconnectAllFrontends()
 {
     if (!m_frontendRouter->hasFrontends())
         return;
@@ -157,9 +165,20 @@ void FrameInspectorController::inspectedFrameDestroyed()
     InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
     m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectedTargetDestroyed);
 
+    checkedInjectedScriptManager()->removeClient();
     m_frontendRouter->disconnectAllFrontends();
 
     m_agents.discardValues();
+}
+
+void FrameInspectorController::inspectedFrameWillDestroy()
+{
+    disconnectAllFrontends();
+}
+
+void FrameInspectorController::inspectedFrameWillDetachPage()
+{
+    disconnectAllFrontends();
 }
 
 void FrameInspectorController::dispatchMessageFromFrontend(const String& message)

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -81,6 +81,8 @@ public:
 
     void inspectedFrameDestroyed();
 
+    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
+
     // InspectorEnvironment
     bool developerExtrasEnabled() const override;
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override;

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -49,6 +49,7 @@ class FrontendRouter;
 namespace WebCore {
 
 class InspectorBackendClient;
+class InspectorController;
 class InspectorFrontendClient;
 class InspectorInstrumentation;
 class InstrumentingAgents;
@@ -77,9 +78,11 @@ public:
 
     WEBCORE_EXPORT void connectFrontend(Inspector::FrontendChannel&, bool isAutomaticInspection = false, bool immediatelyPause = false);
     WEBCORE_EXPORT void disconnectFrontend(Inspector::FrontendChannel&);
+    void disconnectAllFrontends();
     WEBCORE_EXPORT void dispatchMessageFromFrontend(const String& message);
 
-    void inspectedFrameDestroyed();
+    void inspectedFrameWillDetachPage();
+    void inspectedFrameWillDestroy();
 
     InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
 
@@ -96,12 +99,14 @@ public:
 private:
     friend class InspectorInstrumentation;
 
+    CheckedRef<WebInjectedScriptManager> checkedInjectedScriptManager() const;
+
     FrameAgentContext frameAgentContext();
     void createLazyAgents();
 
     WeakRef<LocalFrame> m_frame;
     const Ref<InstrumentingAgents> m_instrumentingAgents;
-    const Ref<WebInjectedScriptManager> m_injectedScriptManager;
+    const CheckedRef<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
     const Ref<WTF::Stopwatch> m_executionStopwatch;

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -96,7 +96,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PageInspectorController);
 PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<InspectorBackendClient>&& inspectorBackendClient)
     : m_page(page)
     , m_instrumentingAgents(InstrumentingAgents::create(*this))
-    , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
+    , m_injectedScriptManager(makeUniqueRef<WebInjectedScriptManager>(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this, inspectorBackendClient.get()))
@@ -126,7 +126,7 @@ PageAgentContext PageInspectorController::pageAgentContext()
 {
     AgentContext baseContext = {
         *this,
-        m_injectedScriptManager,
+        m_injectedScriptManager.get(),
         m_frontendRouter.get(),
         m_backendDispatcher
     };
@@ -152,8 +152,6 @@ void PageInspectorController::createLazyAgents()
     m_didCreateLazyAgents = true;
 
     m_debugger = makeUnique<PageDebugger>(m_page);
-
-    m_injectedScriptManager->connect();
 
     auto pageContext = pageAgentContext();
 
@@ -188,9 +186,6 @@ void PageInspectorController::createLazyAgents()
     m_agents.append(makeUniqueRef<PageCanvasAgent>(pageContext));
     m_agents.append(makeUniqueRef<PageTimelineAgent>(pageContext));
     m_agents.append(makeUniqueRef<InspectorAnimationAgent>(pageContext));
-
-    if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.get());
 }
 
 void PageInspectorController::inspectedPageDestroyed()
@@ -260,6 +255,7 @@ void PageInspectorController::connectFrontend(Inspector::FrontendChannel& fronte
 
     if (connectedFirstFrontend) {
         InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents.get());
+        m_injectedScriptManager->addClient();
         m_agents.didCreateFrontendAndBackend();
     }
 
@@ -286,7 +282,7 @@ void PageInspectorController::disconnectFrontend(FrontendChannel& frontendChanne
         m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectorDestroyed);
 
         // Clean up inspector resources.
-        m_injectedScriptManager->discardInjectedScripts();
+        m_injectedScriptManager->removeClient();
 
         // Unplug all instrumentations since they aren't needed now.
         InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
@@ -322,7 +318,7 @@ void PageInspectorController::disconnectAllFrontends()
     m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectedTargetDestroyed);
 
     // Clean up inspector resources.
-    m_injectedScriptManager->disconnect();
+    m_injectedScriptManager->removeClient();
 
     // Disconnect any remaining remote frontends.
     m_frontendRouter->disconnectAllFrontends();

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -153,7 +153,7 @@ private:
 
     WeakRef<Page> m_page;
     const Ref<InstrumentingAgents> m_instrumentingAgents;
-    const Ref<WebInjectedScriptManager> m_injectedScriptManager;
+    const UniqueRef<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
     const UniqueRef<InspectorOverlay> m_overlay;

--- a/Source/WebCore/inspector/WebInjectedScriptManager.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.cpp
@@ -30,6 +30,8 @@
 #include "Document.h"
 #include "JSExecState.h"
 #include "LocalDOMWindow.h"
+#include <JavaScriptCore/InjectedScriptManager.h>
+#include <wtf/Assertions.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -38,11 +40,6 @@ using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInjectedScriptManager);
 
-Ref<WebInjectedScriptManager> WebInjectedScriptManager::create(Inspector::InspectorEnvironment& environment, Ref<Inspector::InjectedScriptHost>&& host)
-{
-    return adoptRef(*new WebInjectedScriptManager(environment, WTFMove(host)));
-}
-
 WebInjectedScriptManager::WebInjectedScriptManager(InspectorEnvironment& environment, Ref<InjectedScriptHost>&& host)
     : InjectedScriptManager(environment, WTFMove(host))
 {
@@ -50,7 +47,25 @@ WebInjectedScriptManager::WebInjectedScriptManager(InspectorEnvironment& environ
 
 WebInjectedScriptManager::~WebInjectedScriptManager()
 {
-    if (isConnected())
+    ASSERT(!m_clientCount);
+    if (m_clientCount > 0) {
+        m_clientCount = 0;
+        disconnect();
+    }
+}
+
+void WebInjectedScriptManager::addClient()
+{
+    ++m_clientCount;
+    if (m_clientCount == 1)
+        connect();
+}
+
+void WebInjectedScriptManager::removeClient()
+{
+    ASSERT(m_clientCount > 0);
+    --m_clientCount;
+    if (!m_clientCount)
         disconnect();
 }
 
@@ -65,10 +80,7 @@ void WebInjectedScriptManager::disconnect()
 {
     InjectedScriptManager::disconnect();
 
-    if (m_commandLineAPIHost) {
-        m_commandLineAPIHost->disconnect();
-        m_commandLineAPIHost = nullptr;
-    }
+    m_commandLineAPIHost = nullptr;
 }
 
 void WebInjectedScriptManager::discardInjectedScripts()

--- a/Source/WebCore/inspector/WebInjectedScriptManager.h
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.h
@@ -27,6 +27,7 @@
 
 #include "CommandLineAPIHost.h"
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -34,16 +35,19 @@ namespace WebCore {
 
 class LocalDOMWindow;
 
-// FIXME <https://webkit.org/b/302124>: Make the base class InjectedScriptManager ref-counted instead.
-class WebInjectedScriptManager final : public Inspector::InjectedScriptManager, public RefCounted<WebInjectedScriptManager> {
+class WebInjectedScriptManager final : public Inspector::InjectedScriptManager {
     WTF_MAKE_NONCOPYABLE(WebInjectedScriptManager);
     WTF_MAKE_TZONE_ALLOCATED(WebInjectedScriptManager);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebInjectedScriptManager);
 public:
-    static Ref<WebInjectedScriptManager> create(Inspector::InspectorEnvironment&, Ref<Inspector::InjectedScriptHost>&&);
+    WebInjectedScriptManager(Inspector::InspectorEnvironment&, Ref<Inspector::InjectedScriptHost>&&);
 
     ~WebInjectedScriptManager() override;
 
     const RefPtr<CommandLineAPIHost>& commandLineAPIHost() const { return m_commandLineAPIHost; }
+
+    void addClient();
+    void removeClient();
 
     void connect() override;
     void disconnect() override;
@@ -52,12 +56,10 @@ public:
     void discardInjectedScriptsFor(LocalDOMWindow&);
 
 private:
-    WebInjectedScriptManager(Inspector::InspectorEnvironment&, Ref<Inspector::InjectedScriptHost>&&);
-
-    bool isConnected() const { return m_commandLineAPIHost; }
     void didCreateInjectedScript(const Inspector::InjectedScript&) override;
 
     RefPtr<CommandLineAPIHost> m_commandLineAPIHost;
+    int m_clientCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -69,7 +69,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerInspectorController);
 
 WorkerInspectorController::WorkerInspectorController(WorkerOrWorkletGlobalScope& globalScope)
     : m_instrumentingAgents(InstrumentingAgents::create(*this))
-    , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
+    , m_injectedScriptManager(makeUniqueRef<WebInjectedScriptManager>(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_executionStopwatch(Stopwatch::create())
@@ -94,8 +94,6 @@ WorkerInspectorController::~WorkerInspectorController()
 
 void WorkerInspectorController::workerTerminating()
 {
-    m_injectedScriptManager->disconnect();
-
     disconnectFrontend(Inspector::DisconnectReason::InspectedTargetDestroyed);
 
     m_agents.discardValues();
@@ -139,6 +137,7 @@ void WorkerInspectorController::connectFrontend(bool isAutomaticInspection, bool
 
     m_forwardingChannel = makeUnique<WorkerToPageFrontendChannel>(m_globalScope);
     m_frontendRouter->connectFrontend(*m_forwardingChannel.get());
+    m_injectedScriptManager->addClient();
     m_agents.didCreateFrontendAndBackend();
 
     updateServiceWorkerPageFrontendCount();
@@ -159,6 +158,7 @@ void WorkerInspectorController::disconnectFrontend(Inspector::DisconnectReason r
     });
 
     m_agents.willDestroyFrontendAndBackend(reason);
+    m_injectedScriptManager->removeClient();
     m_frontendRouter->disconnectFrontend(*m_forwardingChannel.get());
     m_forwardingChannel = nullptr;
 
@@ -195,7 +195,7 @@ WorkerAgentContext WorkerInspectorController::workerAgentContext()
 {
     AgentContext baseContext = {
         *this,
-        m_injectedScriptManager,
+        m_injectedScriptManager.get(),
         m_frontendRouter.get(),
         m_backendDispatcher,
     };
@@ -222,8 +222,6 @@ void WorkerInspectorController::createLazyAgents()
 
     m_debugger = makeUnique<WorkerDebugger>(m_globalScope);
 
-    m_injectedScriptManager->connect();
-
     auto workerContext = workerAgentContext();
 
     m_agents.append(makeUniqueRef<WorkerRuntimeAgent>(workerContext));
@@ -247,9 +245,6 @@ void WorkerInspectorController::createLazyAgents()
     auto scriptProfilerAgent = makeUniqueRef<InspectorScriptProfilerAgent>(workerContext);
     m_instrumentingAgents->setPersistentScriptProfilerAgent(scriptProfilerAgent.ptr());
     m_agents.append(WTFMove(scriptProfilerAgent));
-
-    if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.get());
 }
 
 WorkerDebuggerAgent& WorkerInspectorController::ensureDebuggerAgent()

--- a/Source/WebCore/inspector/WorkerInspectorController.h
+++ b/Source/WebCore/inspector/WorkerInspectorController.h
@@ -69,6 +69,8 @@ public:
 
     void dispatchMessageFromFrontend(const String&);
 
+    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
+
     // InspectorEnvironment
     bool developerExtrasEnabled() const override { return true; }
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override { return true; }
@@ -89,7 +91,7 @@ private:
     void updateServiceWorkerPageFrontendCount();
 
     const Ref<InstrumentingAgents> m_instrumentingAgents;
-    const Ref<WebInjectedScriptManager> m_injectedScriptManager;
+    const UniqueRef<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
     const Ref<WTF::Stopwatch> m_executionStopwatch;

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -367,7 +367,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObjec
         return makeUnexpected("Animation is detached from context"_s);
 
     auto* state = scriptExecutionContext->globalObject();
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(state);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(state);
     ASSERT(!injectedScript.hasNoValue());
 
     JSC::JSValue value;

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -91,12 +91,14 @@ private:
     void animationDestroyedTimerFired();
     void reset();
 
+    CheckedRef<Inspector::InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
+
     void stopTrackingStyleOriginatedAnimation(StyleOriginatedAnimation&);
 
     const UniqueRef<Inspector::AnimationFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::AnimationBackendDispatcher> m_backendDispatcher;
 
-    Inspector::InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
     WeakRef<Page> m_inspectedPage;
 
     // FIXME <https://webkit.org/b/303593>: Animation should not be destroyed before notifying this agent to unbind it.

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -205,7 +205,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObjec
         return makeUnexpected(errorString);
 
     auto* state = inspectorCanvas->scriptExecutionContext()->globalObject();
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(state);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(state);
     ASSERT(!injectedScript.hasNoValue());
 
     JSC::JSValue value = inspectorCanvas->resolveContext(state);

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <initializer_list>
 #include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RobinHoodHashSet.h>
@@ -121,6 +122,8 @@ protected:
 
     virtual bool matchesCurrentContext(ScriptExecutionContext*) const = 0;
 
+    CheckedRef<Inspector::InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
+
     const UniqueRef<Inspector::CanvasFrontendDispatcher> m_frontendDispatcher;
 
     MemoryCompactRobinHoodHashMap<String, RefPtr<InspectorCanvas>> m_identifierToInspectorCanvas;
@@ -148,7 +151,7 @@ private:
 
     const Ref<Inspector::CanvasBackendDispatcher> m_backendDispatcher;
 
-    Inspector::InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
 
     Vector<String> m_removedCanvasIdentifiers;
     Timer m_canvasDestroyedTimer;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1312,7 +1312,7 @@ void InspectorDOMAgent::focusNode()
         return;
 
     auto& globalObject = mainWorldGlobalObject(*frame);
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&globalObject);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(&globalObject);
     if (injectedScript.hasNoValue())
         return;
 
@@ -1860,7 +1860,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Ins
 
     m_inspectedNode = node;
 
-    if (auto& commandLineAPIHost = static_cast<WebInjectedScriptManager&>(m_injectedScriptManager).commandLineAPIHost())
+    CheckedRef manager = m_injectedScriptManager;
+    if (auto& commandLineAPIHost = static_cast<WebInjectedScriptManager&>(manager.get()).commandLineAPIHost())
         commandLineAPIHost->addInspectedObject(makeUnique<InspectableNode>(node));
 
     m_suppressEventListenerChangedEvent = false;
@@ -3124,7 +3125,7 @@ Node* InspectorDOMAgent::nodeForPath(const String& path)
 
 Node* InspectorDOMAgent::nodeForObjectId(const Inspector::Protocol::Runtime::RemoteObjectId& objectId)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InjectedScript injectedScript = checkedInjectedScriptManager()->injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return nullptr;
 
@@ -3154,7 +3155,7 @@ RefPtr<Inspector::Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNod
         return nullptr;
 
     auto& globalObject = mainWorldGlobalObject(*frame);
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&globalObject);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(&globalObject);
     if (injectedScript.hasNoValue())
         return nullptr;
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/JSONValues.h>
@@ -278,8 +279,9 @@ private:
     void relayoutDocument();
 
     Ref<InspectorOverlay> protectedOverlay() const;
+    CheckedRef<Inspector::InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
 
-    Inspector::InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
     const UniqueRef<Inspector::DOMFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     WeakRef<Page> m_inspectedPage;

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -274,7 +274,7 @@ void InspectorDOMDebuggerAgent::willHandleEvent(ScriptExecutionContext& scriptEx
     // `scriptExecutionContext` parameter will always match in companion calls to `willHandleEvent` and
     // `didHandleEvent`, and will not be null.
     auto state = globalObjectFor(scriptExecutionContext, registeredEventListener.callback());
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(state);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(state);
     if (injectedScript.hasNoValue())
         return;
 
@@ -323,7 +323,7 @@ void InspectorDOMDebuggerAgent::didHandleEvent(ScriptExecutionContext& scriptExe
     // could also be nullptr. The passed `scriptExecutionContext` parameter here will always match in companion calls to
     // `willHandleEvent` and `didHandleEvent`, and will not be null.
     auto state = globalObjectFor(scriptExecutionContext, registeredEventListener.callback());
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(state);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(state);
     if (injectedScript.hasNoValue())
         return;
 

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/Breakpoint.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorDebuggerAgent.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/JSONValues.h>
@@ -94,13 +95,15 @@ protected:
     virtual void enable();
     virtual void disable();
 
+    CheckedRef<Inspector::InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
+
     Inspector::InspectorDebuggerAgent* m_debuggerAgent { nullptr };
 
 private:
     void breakOnURLIfNeeded(const String&);
 
     const Ref<Inspector::DOMDebuggerBackendDispatcher> m_backendDispatcher;
-    Inspector::InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
 
     struct EventBreakpoint {
         String eventName;

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -634,7 +634,7 @@ void InspectorIndexedDBAgent::requestData(const String& securityOrigin, const St
         }
     }
 
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&mainWorldGlobalObject(*frame));
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(&mainWorldGlobalObject(*frame));
     auto dataLoader = DataLoader::create(document, WTFMove(callback), injectedScript, objectStoreName, indexName, WTFMove(idbKeyRange), skipCount, pageSize);
     dataLoader->start(idbFactory, document->protectedSecurityOrigin().ptr(), databaseName);
 }

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
@@ -33,6 +33,7 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
@@ -65,8 +66,9 @@ public:
 
 private:
     Ref<Page> protectedInspectedPage() const;
+    CheckedRef<Inspector::InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
 
-    Inspector::InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::IndexedDBBackendDispatcher> m_backendDispatcher;
 
     WeakRef<Page> m_inspectedPage;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1030,7 +1030,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObjec
         return makeUnexpected("Missing frame of web socket for given requestId"_s);
 
     auto& globalObject = mainWorldGlobalObject(*frame);
-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&globalObject);
+    auto injectedScript = checkedInjectedScriptManager()->injectedScriptFor(&globalObject);
     ASSERT(!injectedScript.hasNoValue());
 
     auto object = injectedScript.wrapObject(webSocketAsScriptValue(globalObject, *webSocket), objectGroup);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/RegularExpression.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/JSONValues.h>
 #include <wtf/RobinHoodHashMap.h>
@@ -141,6 +142,8 @@ public:
 protected:
     InspectorNetworkAgent(WebAgentContext&, const NetworkResourcesData::Settings&);
 
+    CheckedRef<Inspector::InjectedScriptManager> checkedInjectedScriptManager() const { return m_injectedScriptManager.get(); }
+
     virtual Inspector::Protocol::Network::LoaderId loaderIdentifier(DocumentLoader*) = 0;
     virtual Inspector::Protocol::Network::FrameId frameIdentifier(DocumentLoader*) = 0;
     virtual Vector<Ref<WebSocket>> activeWebSockets() WTF_REQUIRES_LOCK(WebSocket::allActiveWebSocketsLock()) = 0;
@@ -171,7 +174,7 @@ private:
 
     const UniqueRef<Inspector::NetworkFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::NetworkBackendDispatcher> m_backendDispatcher;
-    Inspector::InjectedScriptManager& m_injectedScriptManager;
+    CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
 
     const UniqueRef<NetworkResourcesData> m_resourcesData;
 

--- a/Source/WebCore/inspector/agents/WebConsoleAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebConsoleAgent.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptArguments.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -70,7 +71,8 @@ void WebConsoleAgent::frameWindowDiscarded(LocalDOMWindow& window)
                 message->clear();
         }
     }
-    Ref { static_cast<WebInjectedScriptManager&>(m_injectedScriptManager) }->discardInjectedScriptsFor(window);
+    CheckedRef manager = m_injectedScriptManager;
+    static_cast<WebInjectedScriptManager&>(manager.get()).discardInjectedScriptsFor(window);
 }
 
 void WebConsoleAgent::didReceiveResponse(ResourceLoaderIdentifier requestIdentifier, const ResourceResponse& response)

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -242,7 +242,7 @@ LocalFrame::~LocalFrame()
 {
     setView(nullptr);
 
-    m_inspectorController->inspectedFrameDestroyed();
+    m_inspectorController->inspectedFrameWillDestroy();
 
     Ref loader = this->loader();
     if (!loader->isComplete())
@@ -891,6 +891,8 @@ CheckedRef<const ScriptController> LocalFrame::checkedScript() const
 
 void LocalFrame::willDetachPage()
 {
+    m_inspectorController->inspectedFrameWillDetachPage();
+
     if (RefPtr parent = dynamicDowncast<LocalFrame>(tree().parent()))
         parent->loader().checkLoadComplete();
 


### PR DESCRIPTION
#### aa86f6a0672fefc1a3849dad5c162fe7877af33d
<pre>
WIP; experiment with managing shared WebInjectedScriptManager
</pre>
----------------------------------------------------------------------
#### c30257985eb5346e5a12494abe5fd47e8ea9d13f
<pre>
[Site Isolation] Web Inspector: Remote iframe still can&apos;t console log with frame target console support
<a href="https://rdar.apple.com/166892920">rdar://166892920</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304511">https://bugs.webkit.org/show_bug.cgi?id=304511</a>

Reviewed by NOBODY (OOPS!).

Summary: Introduce client-counting to WebInjectedScriptManager to auto
set up for remote frame targets without a parent page target.

With our recent site isolation work in [1] to move the Console agent
into frame target, we intend to let frame targets use its parent page&apos;s
WebInjectedScriptManager, maintaining the &quot;one InjectedScriptManager per
page&quot; pattern. However, a remote web process doesn&apos;t surface a page
target to the frontend that would set up the manager upon connection.
As a result, any remote frame target will try to use an unprepared
InjectedScriptManager and its CommandLineAPIHost when adding a
console message.

[1] Related landed work:
   - Shared InjectedScriptManager: <a href="https://github.com/WebKit/WebKit/pull/53561">https://github.com/WebKit/WebKit/pull/53561</a>
   - Move Console agent to frame target: <a href="https://github.com/WebKit/WebKit/pull/51217">https://github.com/WebKit/WebKit/pull/51217</a>

This patch makes WebInjectedScriptManager set up or torn down
automatically by introducing a client-counting strategy, to ensure the
manager is ready independently as long as there&apos;s any client connection
(page, frame, worker). Further, while not necessarily attached to one
target, the internal CommandLineAPIHost must now work with more than
one potential targets and sets of InstrumentingAgents. We address that
by making the host access the right agents according to the
JSGlobalObject, so that it can adapt to any execution context
(document, worker) without requiring explicit initialization.

The reason we kept one manager per page was that other domains that also
work with InjectedScriptManager (like Debugger and Runtime) still live
in page target. We are avoiding agents having out-of-sync states due to
being moved into frame as we go through this site isolation transition.
However, it should be worth revisiting whether objects like
InjectedScriptManager should either still be frame-isolated even in the
same process or become per-VM instead (filed follow-up <a href="https://bugs.webkit.org/b/??????).">https://bugs.webkit.org/b/??????).</a>

No new tests. The existing inspector test message-from-iframe should now
progress with --site-isolation turned on (Timeout -&gt; Pass).

* Source/WebCore/inspector/CommandLineAPIHost.cpp:
(WebCore::instrumentingAgentsForGlobalObject):
(WebCore::CommandLineAPIHost::inspect):
(WebCore::CommandLineAPIHost::~CommandLineAPIHost): Deleted.
(WebCore::CommandLineAPIHost::disconnect): Deleted.
   Adapt to being used by more than one inspector targets and figure out
   the right InstrumentingAgents to use automatically.

   Remove init and disconnect which are no longer useful due to this
   autonomy.

* Source/WebCore/inspector/CommandLineAPIHost.h:
(WebCore::CommandLineAPIHost::init): Deleted.
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::connectFrontend):
(WebCore::FrameInspectorController::disconnectFrontend):
(WebCore::FrameInspectorController::inspectedFrameDestroyed):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::createLazyAgents):
(WebCore::PageInspectorController::connectFrontend):
(WebCore::PageInspectorController::disconnectFrontend):
(WebCore::PageInspectorController::disconnectAllFrontends):
* Source/WebCore/inspector/WebInjectedScriptManager.cpp:
(WebCore::WebInjectedScriptManager::~WebInjectedScriptManager):
(WebCore::WebInjectedScriptManager::addClient):
(WebCore::WebInjectedScriptManager::removeClient):
(WebCore::WebInjectedScriptManager::disconnect):
* Source/WebCore/inspector/WebInjectedScriptManager.h:
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::workerTerminating):
(WebCore::WorkerInspectorController::connectFrontend):
(WebCore::WorkerInspectorController::disconnectFrontend):
(WebCore::WorkerInspectorController::createLazyAgents):
* Source/WebCore/inspector/WorkerInspectorController.h:
   Make WebInjectedScriptManager client-counted. Before and after using
   the manager, update the client count rather than explicitly
   connecting or disconnecting the manager.

   In page and worker, move the client count updating work to be in sync
   with connecting and disconnecting the frontend rather than the
   agents&apos; lifetime. This creates consistency with the frame target, as
   no client should dictate WebInjectedScriptManager&apos;s connection
   anymore.

   Expose m_instrumentingAgents in frame and worker for
   CommandLineAPIHost to access.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa86f6a0672fefc1a3849dad5c162fe7877af33d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144206 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89464 "Failed to checkout and rebase branch from PR 54133") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8694 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104375 "Found 2 new test failures: fast/animation/request-animation-frame-during-modal.html http/tests/cookies/document-cookie-after-showModalDialog.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/89464 "Failed to checkout and rebase branch from PR 54133") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139438 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6961 "Found 4 new test failures: fast/harness/show-modal-dialog.html http/tests/cookies/document-cookie-after-showModalDialog.html http/tests/security/navigate-when-restoring-cached-page.html http/tests/security/showModalDialog-sync-cross-origin-page-load2.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122300 "Found 5 new API test failures: TestWebKitAPI.WebKit.CreateIconDataFromImageDataSVGWithSubresource, TestWebKitAPI.WebKitLegacy.WebViewCloseInsideDidFinishLoadForFrame, TestWebKitAPI.WebKitLegacy.CloseNewWindowInNavigationPolicyDelegate, TestWebKitAPI.WebKitLegacy.CloseWhileCommittingLoad, TestWebKitAPI.WebKitLegacy.ClosingWebViewThenSendingItAKeyDownEvent (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85210 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6605 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4266 "Found 5 new API test failures: TestWebKitAPI.WebKit.CreateIconDataFromImageDataSVGWithSubresource, TestWebKitAPI.WebKitLegacy.WebViewCloseInsideDidFinishLoadForFrame, TestWebKitAPI.WebKitLegacy.CloseNewWindowInNavigationPolicyDelegate, TestWebKitAPI.WebKitLegacy.CloseWhileCommittingLoad, TestWebKitAPI.WebKitLegacy.ClosingWebViewThenSendingItAKeyDownEvent (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4799 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128450 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115908 "Found 1 new API test failure: TestWebKitAPI.WebKit.CreateIconDataFromImageDataSVGWithSubresource (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40504 "Found 1 new test failure: inspector/dom/setOuterHTML-no-document-element.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146955 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134977 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8532 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41073 "Found 3 new test failures: http/tests/cookies/document-cookie-after-showModalDialog.html http/tests/security/navigate-when-restoring-cached-page.html http/tests/security/showModalDialog-sync-cross-origin-page-load2.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112715 "Found 1 new test failure: http/tests/cookies/document-cookie-after-showModalDialog.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8549 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7170 "Found 2 new test failures: http/tests/cookies/document-cookie-after-showModalDialog.html http/tests/security/navigate-when-restoring-cached-page.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113059 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6540 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118608 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62524 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8580 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36660 "Found 3 new test failures: http/tests/cookies/document-cookie-after-showModalDialog.html http/tests/security/navigate-when-restoring-cached-page.html http/tests/security/showModalDialog-sync-cross-origin-page-load2.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8299 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72139 "Found 10 new failures in inspector/agents/page/PageDebuggerAgent.cpp, inspector/agents/JSGlobalObjectDebuggerAgent.cpp, inspector/agents/JSGlobalObjectAuditAgent.cpp, inspector/agents/WebConsoleAgent.cpp, inspector/agents/page/PageAuditAgent.cpp, inspector/agents/InspectorDOMAgent.cpp, inspector/agents/JSGlobalObjectRuntimeAgent.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43754 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->