### PR TITLE
[GTK][WPE] Always use BGRA8 pixel format for unaccelerated tile buffers

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -56,8 +56,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 #endif
 
-#include "PixelFormat.h"
-
 namespace WebCore {
 
 Lock CoordinatedTileBuffer::s_layersMemoryUsageLock;
@@ -135,17 +133,6 @@ CoordinatedUnacceleratedTileBuffer::CoordinatedUnacceleratedTileBuffer(const Int
     }
 }
 
-PixelFormat CoordinatedUnacceleratedTileBuffer::pixelFormat() const
-{
-#if USE(SKIA)
-    // For GPU/hybrid rendering, prefer RGBA, otherwise use BGRA.
-    if (ProcessCapabilities::canUseAcceleratedBuffers())
-        return PixelFormat::RGBA8;
-#endif
-
-    return PixelFormat::BGRA8;
-}
-
 CoordinatedUnacceleratedTileBuffer::~CoordinatedUnacceleratedTileBuffer()
 {
     const auto checkedArea = m_size.area().value() * 4;
@@ -161,8 +148,7 @@ bool CoordinatedUnacceleratedTileBuffer::tryEnsureSurface()
     if (m_surface)
         return true;
 
-    auto colorType = pixelFormat() == PixelFormat::BGRA8 ? kBGRA_8888_SkColorType : kRGBA_8888_SkColorType;
-    auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), colorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     // FIXME: ref buffer and unref on release proc?
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -31,6 +31,7 @@
 #if USE(COORDINATED_GRAPHICS)
 
 #include "IntSize.h"
+#include "PixelFormat.h"
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
 #include <wtf/MallocSpan.h>
@@ -47,7 +48,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 namespace WebCore {
 class BitmapTexture;
 class GLFence;
-enum class PixelFormat : uint8_t;
 
 class CoordinatedTileBuffer : public ThreadSafeRefCounted<CoordinatedTileBuffer> {
 public:
@@ -112,7 +112,7 @@ public:
     const unsigned char* data() const { return m_data.span().data(); }
     unsigned char* data() { return m_data.mutableSpan().data(); }
 
-    PixelFormat pixelFormat() const;
+    PixelFormat pixelFormat() const { return PixelFormat::BGRA8; }
 
 private:
     CoordinatedUnacceleratedTileBuffer(const IntSize&, Flags);


### PR DESCRIPTION
#### 049f84c04b72220eb8a4f91e58a860ced13c3ac8
<pre>
[GTK][WPE] Always use BGRA8 pixel format for unaccelerated tile buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=302740">https://bugs.webkit.org/show_bug.cgi?id=302740</a>

Reviewed by Carlos Garcia Campos.

After the removal of hybrid mode in 303171@main, we can simplify
CoordinatedUnacceleratedTileBuffer::pixelFormat() to always
return BGRA8, removing conditional logic that selected RGBA8 for
GPU/hybrid rendering.

Covered by existing tests.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedUnacceleratedTileBuffer::tryEnsureSurface):
(WebCore::CoordinatedUnacceleratedTileBuffer::pixelFormat const): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h:

Canonical link: <a href="https://commits.webkit.org/303244@main">https://commits.webkit.org/303244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fa82f723a8abe1315eca1afb5d9c51b3a0d622e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134651 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117972 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81454 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/705 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82436 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3866 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109201 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27679 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2952 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114252 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57076 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3919 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32668 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67367 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3880 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->