### PR TITLE
[GTK][WPE] Add OpenGL ES 3.x support with fallback to 2.0

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -73,8 +73,15 @@ const char* GLContext::lastErrorString()
 }
 
 IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
-bool GLContext::getEGLConfig(EGLDisplay display, EGLConfig* config, int surfaceType)
+bool GLContext::getEGLConfig(EGLDisplay display, EGLConfig* config, int surfaceType, OpenGLESMode mode)
 {
+    auto [forcedMajor, forcedMinor] = GLContext::forcedEGLVersion();
+    UNUSED_PARAM(forcedMinor);
+    if (forcedMajor == 3 && mode != OpenGLESMode::Version3)
+        return false;
+    if (forcedMajor == 2 && mode != OpenGLESMode::Version2)
+        return false;
+
     std::array<EGLint, 4> rgbaSize = { 8, 8, 8, 8 };
     if (const char* environmentVariable = getenv("WEBKIT_EGL_PIXEL_LAYOUT")) {
         if (!strcmp(environmentVariable, "RGB565"))
@@ -85,7 +92,7 @@ bool GLContext::getEGLConfig(EGLDisplay display, EGLConfig* config, int surfaceT
 
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib / Windows ports.
     EGLint attributeList[] = {
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_RENDERABLE_TYPE, mode == OpenGLESMode::Version3 ? EGL_OPENGL_ES3_BIT : EGL_OPENGL_ES2_BIT,
         EGL_RED_SIZE, rgbaSize[0],
         EGL_GREEN_SIZE, rgbaSize[1],
         EGL_BLUE_SIZE, rgbaSize[2],
@@ -134,9 +141,11 @@ std::unique_ptr<GLContext> GLContext::createWindowContext(GLDisplay& display, Ta
 {
     EGLDisplay eglDisplay = display.eglDisplay();
     EGLConfig config;
-    if (!getEGLConfig(eglDisplay, &config, EGL_WINDOW_BIT)) {
-        RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL window context configuration: %s\n", lastErrorString());
-        return nullptr;
+    if (!getEGLConfig(eglDisplay, &config, EGL_WINDOW_BIT, OpenGLESMode::Version3)) {
+        if (!getEGLConfig(eglDisplay, &config, EGL_WINDOW_BIT, OpenGLESMode::Version2)) {
+            RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL window context configuration: %s\n", lastErrorString());
+            return nullptr;
+        }
     }
 
     EGLContext context = createContextForEGLVersion(eglDisplay, config, sharingContext);
@@ -189,9 +198,12 @@ std::unique_ptr<GLContext> GLContext::createSurfacelessContext(GLDisplay& displa
     }
 
     EGLConfig config;
-    if (!getEGLConfig(eglDisplay, &config, target == Target::Surfaceless ? EGL_PBUFFER_BIT : EGL_WINDOW_BIT)) {
-        RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL surfaceless configuration: %s\n", lastErrorString());
-        return nullptr;
+    int surfaceType = target == Target::Surfaceless ? EGL_PBUFFER_BIT : EGL_WINDOW_BIT;
+    if (!getEGLConfig(eglDisplay, &config, surfaceType, OpenGLESMode::Version3)) {
+        if (!getEGLConfig(eglDisplay, &config, surfaceType, OpenGLESMode::Version2)) {
+            RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL surfaceless configuration: %s\n", lastErrorString());
+            return nullptr;
+        }
     }
 
     EGLContext context = createContextForEGLVersion(eglDisplay, config, sharingContext);
@@ -207,9 +219,11 @@ std::unique_ptr<GLContext> GLContext::createPbufferContext(GLDisplay& display, E
 {
     EGLDisplay eglDisplay = display.eglDisplay();
     EGLConfig config;
-    if (!getEGLConfig(eglDisplay, &config, EGL_PBUFFER_BIT)) {
-        RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL Pbuffer configuration: %s\n", lastErrorString());
-        return nullptr;
+    if (!getEGLConfig(eglDisplay, &config, EGL_PBUFFER_BIT, OpenGLESMode::Version3)) {
+        if (!getEGLConfig(eglDisplay, &config, EGL_PBUFFER_BIT, OpenGLESMode::Version2)) {
+            RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL Pbuffer configuration: %s\n", lastErrorString());
+            return nullptr;
+        }
     }
 
     EGLContext context = createContextForEGLVersion(eglDisplay, config, sharingContext);
@@ -356,21 +370,88 @@ RefPtr<GLDisplay> GLContext::display() const
     return m_display.get();
 }
 
+std::pair<unsigned, unsigned> GLContext::forcedEGLVersion()
+{
+    static std::once_flag onceFlag;
+    static unsigned majorVersion = 0;
+    static unsigned minorVersion = 0;
+
+    std::call_once(onceFlag, [] {
+        if (const char* envString = getenv("WEBKIT_FORCE_EGL_VERSION")) {
+            auto version = parseInteger<unsigned>(StringView::fromLatin1(envString)).value_or(0);
+            if (version >= 200 && version <= 320) {
+                majorVersion = version / 100;
+                minorVersion = (version % 100) / 10;
+                WTFLogAlways("WEBKIT_FORCE_EGL_VERSION=%d: Forcing OpenGL ES %d.%d", version, majorVersion, minorVersion);
+            } else
+                WTFLogAlways("WEBKIT_FORCE_EGL_VERSION=%d: Invalid version string, must be >= 200 <= 320", version);
+        }
+    });
+
+    return std::make_pair(majorVersion, minorVersion);
+}
+
 EGLContext GLContext::createContextForEGLVersion(EGLDisplay eglDisplay, EGLConfig config, EGLContext sharingContext)
 {
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib / Windows ports.
-    static EGLint contextAttributes[3];
+    static EGLint contextAttributes[7];
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     static bool contextAttributesInitialized = false;
 
     if (!contextAttributesInitialized) {
         contextAttributesInitialized = true;
 
-        contextAttributes[0] = EGL_CONTEXT_CLIENT_VERSION;
-        contextAttributes[1] = 2;
-        contextAttributes[2] = EGL_NONE;
+        struct VersionAttempt {
+            unsigned major { 0 };
+            unsigned minor { 0 };
+        };
+
+        // Try versions in descending order: 3.2 -> 3.1 -> 3.0 -> 2.0.
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib / Windows ports.
+        static const VersionAttempt versions[] = {
+            { 3, 2 },
+            { 3, 1 },
+            { 3, 0 },
+            { 2, 0 }
+        };
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+        // Check for forced version via environment variable
+        auto [forcedMajor, forcedMinor] = GLContext::forcedEGLVersion();
+
+        bool versionFound = false;
+        for (const auto& version : versions) {
+            // If version is forced, skip versions that don't match
+            if (forcedMajor && (version.major != forcedMajor || version.minor != forcedMinor))
+                continue;
+
+            // Success! Cache these attributes for future use
+            contextAttributes[0] = EGL_CONTEXT_MAJOR_VERSION;
+            contextAttributes[1] = version.major;
+            contextAttributes[2] = EGL_CONTEXT_MINOR_VERSION;
+            contextAttributes[3] = version.minor;
+            contextAttributes[4] = EGL_CONTEXT_CLIENT_VERSION;
+            contextAttributes[5] = version.major;
+            contextAttributes[6] = EGL_NONE;
+
+            auto context = eglCreateContext(eglDisplay, config, sharingContext, contextAttributes);
+            if (context != EGL_NO_CONTEXT) {
+                RELEASE_LOG_INFO(Compositing, "WebKit will use OpenGL ES %d.%d for accelerated content", version.major, version.minor);
+
+                versionFound = true;
+                return context;
+            }
+
+            RELEASE_LOG_INFO(Compositing, "Failed to create OpenGL ES %d.%d context: %s. Trying lower version...", version.major, version.minor, lastErrorString());
+        }
+
+        if (!versionFound) {
+            RELEASE_LOG_INFO(Compositing, "Failed to create any OpenGL ES context");
+            return EGL_NO_CONTEXT;
+        }
     }
 
+    // Create context using cached attributes
     return eglCreateContext(eglDisplay, config, sharingContext, contextAttributes);
 }
 
@@ -587,12 +668,14 @@ EGLConfig GLContext::eglConfig() const
     if (!display)
         return nullptr;
 
-    if (!getEGLConfig(display->eglDisplay(), &config, WindowSurface)) {
-        WTFLogAlways("Cannot obtain EGL window context configuration: %s\n", lastErrorString());
-        config = nullptr;
-        ASSERT_NOT_REACHED();
+    auto eglDisplay = display->eglDisplay();
+    if (!getEGLConfig(eglDisplay, &config, WindowSurface, OpenGLESMode::Version3)) {
+        if (!getEGLConfig(eglDisplay, &config, WindowSurface, OpenGLESMode::Version2)) {
+            WTFLogAlways("Cannot obtain EGL window context configuration: %s\n", lastErrorString());
+            config = nullptr;
+            ASSERT_NOT_REACHED();
+        }
     }
-
     return config;
 }
 

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -137,6 +137,7 @@ public:
     };
 
 private:
+    static std::pair<unsigned, unsigned> forcedEGLVersion();
     static EGLContext createContextForEGLVersion(EGLDisplay, EGLConfig, EGLContext);
 
     static std::unique_ptr<GLContext> createWindowContext(GLDisplay&, Target, GLNativeWindowType, EGLContext sharingContext);
@@ -150,7 +151,12 @@ private:
     void destroyWPETarget();
 #endif
 
-    static bool getEGLConfig(EGLDisplay, EGLConfig*, int);
+    enum class OpenGLESMode : uint8_t {
+        Version2,
+        Version3
+    };
+
+    static bool getEGLConfig(EGLDisplay, EGLConfig*, int, OpenGLESMode);
 
     // GLContextWrapper
     GLContextWrapper::Type type() const override { return GLContextWrapper::Type::Native; }

--- a/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<GLContext> GLContext::createWPEContext(GLDisplay& display, EGLCo
 {
     EGLDisplay eglDisplay = display.eglDisplay();
     EGLConfig config;
-    if (!getEGLConfig(eglDisplay, &config, EGL_WINDOW_BIT)) {
+    if (!getEGLConfig(eglDisplay, &config, EGL_WINDOW_BIT, OpenGLESMode::Version2)) {
         RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL WPE context configuration: %s\n", lastErrorString());
         return nullptr;
     }

--- a/Source/WebKit/glib/environment-variables.md.in
+++ b/Source/WebKit/glib/environment-variables.md.in
@@ -39,6 +39,17 @@ Example: `AR24:0:scanout`
 
 #endif
 
+- `WEBKIT_EGL_PIXEL_LAYOUT`:
+Specifies the pixel format for EGL rendering contexts. By default, WebKit uses an 8-8-8-8 RGBA format.
+Supported values:
+    - `RGB565` - Use 16-bit RGB565 format (5 bits red, 6 bits green, 5 bits blue)
+Example: `RGB565`
+
+- `WEBKIT_FORCE_EGL_VERSION`:
+Forces WebKit to use a specific OpenGL ES version for testing purposes. The value should be specified as a three-digit number in the format `MNN`, where `M` is the major version and `NN` is the minor version multiplied by 10. By default, WebKit attempts to create contexts in descending order: ES 3.2, 3.1, 3.0, then falls back to ES 2.0.
+Valid range: 200-320 (ES 2.0 through ES 3.2)
+Example: `310` (forces OpenGL ES 3.1)
+
 - `WEBKIT_SKIA_CPU_PAINTING_THREADS`:
 Specifies the amount of CPU worker threads to use for multi-threaded tile rendering using Skia.
 By default we use as much CPU worker threads as the amount of CPU cores in the system divided by two, capped at eight.


### PR DESCRIPTION
#### 66eafba52e73f412676fde24adb90fb1c1447bb0
<pre>
[GTK][WPE] Add OpenGL ES 3.x support with fallback to 2.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=302742">https://bugs.webkit.org/show_bug.cgi?id=302742</a>

Reviewed by NOBODY (OOPS!).

This patch adds support for OpenGL ES 3.x contexts in EGL, with automatic
fallback to OpenGL ES 2.0 if 3.x is not available. The implementation tries
versions in descending order (3.2 -&gt; 3.1 -&gt; 3.0 -&gt; 2.0) and caches the first
successful version.

Adds WEBKIT_FORCE_EGL_VERSION environment variable to force a specific
OpenGL ES version for testing purposes.

Covered by existing tests.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::getEGLConfig):
(WebCore::GLContext::createWindowContext):
(WebCore::GLContext::createSurfacelessContext):
(WebCore::GLContext::createPbufferContext):
(WebCore::GLContext::forcedEGLVersion):
(WebCore::GLContext::createContextForEGLVersion):
(WebCore::GLContext::eglConfig const):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp:
(WebCore::GLContext::createWPEContext):
* Source/WebKit/glib/environment-variables.md.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66eafba52e73f412676fde24adb90fb1c1447bb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131719 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139228 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100688 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2872 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/714 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3880 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109054 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109211 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2958 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57090 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32673 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67381 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->