### PR TITLE
Use ThreadSafeWeakHashSet for Thread

### DIFF
--- a/Source/JavaScriptCore/heap/MachineStackMarker.h
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.h
@@ -49,7 +49,7 @@ public:
     void gatherConservativeRoots(ConservativeRoots&, JITStubRoutineSet&, CodeBlockSet&, CurrentThreadState*, Thread*);
 
     // Only needs to be called by clients that can use the same heap from multiple threads.
-    bool addCurrentThread() { return m_threadGroup->addCurrentThread() == ThreadGroupAddResult::NewlyAdded; }
+    bool addCurrentThread() { return Ref { m_threadGroup }->addCurrentThread() == ThreadGroupAddResult::NewlyAdded; }
 
     WordLock& getLock() { return m_threadGroup->getLock(); }
     const ListHashSet<Ref<Thread>>& threads(const AbstractLocker& locker) const { return m_threadGroup->threads(locker); }
@@ -60,7 +60,7 @@ private:
     void tryCopyOtherThreadStack(const ThreadSuspendLocker&, Thread&, void*, size_t capacity, size_t*);
     bool tryCopyOtherThreadStacks(const AbstractLocker&, void*, size_t capacity, size_t*, Thread&);
 
-    std::shared_ptr<ThreadGroup> m_threadGroup;
+    Ref<ThreadGroup> m_threadGroup;
 };
 
 #define DECLARE_AND_COMPUTE_CURRENT_THREAD_STATE(stateName) \

--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -43,6 +43,8 @@ struct LockInspector;
 
 namespace WTF {
 
+class WTF_CAPABILITY_LOCK WordLock;
+
 typedef LockAlgorithm<uint8_t, 1, 2> DefaultLockAlgorithm;
 
 // This is a fully adaptive mutex that only requires 1 byte of storage. It has fast paths that are
@@ -189,14 +191,14 @@ private:
 inline void assertIsHeld(const UnfairLock& lock) WTF_ASSERTS_ACQUIRED_LOCK(lock) { lock.assertIsOwner(); }
 #endif // ENABLE(UNFAIR_LOCK)
 
-// Locker specialization to use with Lock and UnfairLock that integrates with thread safety analysis.
+// Locker specialization to use with Lock, WordLock, and UnfairLock that integrates with thread safety analysis.
 // Non-movable simple scoped lock holder.
 // Example: Locker locker { m_lock };
 template<typename T>
 #if ENABLE(UNFAIR_LOCK)
-    requires (std::same_as<T, Lock> || std::same_as<T, UnfairLock>)
+    requires (std::same_as<T, Lock> || std::same_as<T, WordLock> || std::same_as<T, UnfairLock>)
 #else
-    requires (std::same_as<T, Lock>)
+    requires (std::same_as<T, Lock> || std::same_as<T, WordLock>)
 #endif
 class WTF_CAPABILITY_SCOPED_LOCK Locker<T> : public AbstractLocker {
 public:
@@ -264,6 +266,9 @@ private:
 
 Locker(Lock&) -> Locker<Lock>;
 Locker(AdoptLockTag, Lock&) -> Locker<Lock>;
+
+Locker(WordLock&) -> Locker<WordLock>;
+Locker(AdoptLockTag, WordLock&) -> Locker<WordLock>;
 
 #if ENABLE(UNFAIR_LOCK)
 Locker(UnfairLock&) -> Locker<UnfairLock>;

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -312,26 +312,32 @@ Vector<Bucket*> lockHashtable()
             }
         }
 
+IGNORE_CLANG_WARNINGS_BEGIN("thread-safety")
         // Now lock the buckets in the right order.
         std::ranges::sort(buckets);
         for (Bucket* bucket : buckets)
             bucket->lock.lock();
+IGNORE_CLANG_WARNINGS_END
 
         // If the hashtable didn't change (wasn't rehashed) while we were locking it, then we own it
         // now.
         if (hashtable.load() == currentHashtable)
             return buckets;
 
+IGNORE_CLANG_WARNINGS_BEGIN("thread-safety")
         // The hashtable rehashed. Unlock everything and try again.
         for (Bucket* bucket : buckets)
             bucket->lock.unlock();
+IGNORE_CLANG_WARNINGS_END
     }
 }
 
 void unlockHashtable(const Vector<Bucket*>& buckets)
 {
+IGNORE_CLANG_WARNINGS_BEGIN("thread-safety")
     for (Bucket* bucket : buckets)
         bucket->lock.unlock();
+IGNORE_CLANG_WARNINGS_END
 }
 
 // Rehash the hashtable to handle numThreads threads.

--- a/Source/WTF/wtf/ThreadGroup.cpp
+++ b/Source/WTF/wtf/ThreadGroup.cpp
@@ -28,12 +28,7 @@
 
 namespace WTF {
 
-ThreadGroup::~ThreadGroup()
-{
-    Locker locker { m_lock };
-    for (auto& thread : m_threads)
-        thread->removeFromThreadGroup(locker, *this);
-}
+ThreadGroup::~ThreadGroup() = default;
 
 ThreadGroupAddResult ThreadGroup::add(const AbstractLocker& locker, Thread& thread)
 {

--- a/Source/WTF/wtf/ThreadGroup.h
+++ b/Source/WTF/wtf/ThreadGroup.h
@@ -34,15 +34,15 @@ namespace WTF {
 
 enum class ThreadGroupAddResult { NewlyAdded, AlreadyAdded, NotAdded };
 
-class ThreadGroup final : public std::enable_shared_from_this<ThreadGroup> {
+class ThreadGroup final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ThreadGroup> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ThreadGroup);
     WTF_MAKE_NONCOPYABLE(ThreadGroup);
 public:
     friend class Thread;
 
-    static std::shared_ptr<ThreadGroup> create()
+    static Ref<ThreadGroup> create()
     {
-        return std::allocate_shared<ThreadGroup>(FastAllocator<ThreadGroup>());
+        return adoptRef(*new ThreadGroup());
     }
 
     WTF_EXPORT_PRIVATE ThreadGroupAddResult add(Thread&);
@@ -58,11 +58,6 @@ public:
     ThreadGroup() = default;
 
 private:
-    std::weak_ptr<ThreadGroup> weakFromThis()
-    {
-        return shared_from_this();
-    }
-
     // We use WordLock since it can be used when deallocating TLS.
     WordLock m_lock;
     ListHashSet<Ref<Thread>> m_threads;

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include <wtf/HashSet.h>
+#include <wtf/Lock.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WordLock.h>
 
 namespace WTF {
 
@@ -236,7 +238,7 @@ private:
     mutable HashSet<std::pair<ControlBlockRefPtr, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
     mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable unsigned m_maxOperationCountWithoutCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
-    mutable Lock m_lock;
+    mutable WordLock m_lock;
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -31,6 +31,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/SwiftBridging.h>
 #include <wtf/TaggedPtr.h>
+#include <wtf/WordLock.h>
 
 namespace WTF {
 
@@ -178,7 +179,7 @@ private:
 
     void setStrongReferenceCountDuringInitialization(size_t count) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { m_strongReferenceCount = count; }
 
-    mutable Lock m_lock;
+    mutable WordLock m_lock;
     mutable size_t m_strongReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 1 };
     mutable size_t m_weakReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable void* m_object WTF_GUARDED_BY_LOCK(m_lock) { nullptr };

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -320,15 +320,10 @@ void Thread::didExit()
 
     if (shouldRemoveThreadFromThreadGroup()) {
         {
-            Vector<std::shared_ptr<ThreadGroup>> threadGroups;
+            Vector<Ref<ThreadGroup>> threadGroups;
             {
                 Locker locker { m_mutex };
-                for (auto& threadGroupPointerPair : m_threadGroupMap) {
-                    // If ThreadGroup is just being destroyed,
-                    // we do not need to perform unregistering.
-                    if (auto retained = threadGroupPointerPair.value.lock())
-                        threadGroups.append(WTFMove(retained));
-                }
+                threadGroups = m_threadGroups.values();
                 m_isShuttingDown = true;
             }
             for (auto& threadGroup : threadGroups) {
@@ -352,25 +347,16 @@ ThreadGroupAddResult Thread::addToThreadGroup(const AbstractLocker& threadGroupL
     if (m_isShuttingDown)
         return ThreadGroupAddResult::NotAdded;
     if (threadGroup.m_threads.add(*this).isNewEntry) {
-        m_threadGroupMap.add(&threadGroup, threadGroup.weakFromThis());
+        m_threadGroups.add(threadGroup);
         return ThreadGroupAddResult::NewlyAdded;
     }
     return ThreadGroupAddResult::AlreadyAdded;
 }
 
-void Thread::removeFromThreadGroup(const AbstractLocker& threadGroupLocker, ThreadGroup& threadGroup)
-{
-    UNUSED_PARAM(threadGroupLocker);
-    Locker locker { m_mutex };
-    if (m_isShuttingDown)
-        return;
-    m_threadGroupMap.remove(&threadGroup);
-}
-
 unsigned Thread::numberOfThreadGroups()
 {
     Locker locker { m_mutex };
-    return m_threadGroupMap.size();
+    return m_threadGroups.values().size();
 }
 
 bool Thread::exchangeIsCompilationThread(bool newValue)

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -361,7 +361,6 @@ protected:
 
     // These functions are only called from ThreadGroup.
     ThreadGroupAddResult addToThreadGroup(const AbstractLocker& threadGroupLocker, ThreadGroup&);
-    void removeFromThreadGroup(const AbstractLocker& threadGroupLocker, ThreadGroup&);
 
     // For pthread, the Thread instance is ref'ed and held in thread-specific storage. It will be deref'ed by destructTLS at thread destruction time.
     // It employs pthreads-specific 2-pass destruction to reliably remove Thread.
@@ -397,7 +396,7 @@ protected:
     // Use WordLock since WordLock does not depend on ThreadSpecific and this "Thread".
     WordLock m_mutex;
     StackBounds m_stack { StackBounds::emptyBounds() };
-    HashMap<ThreadGroup*, std::weak_ptr<ThreadGroup>> m_threadGroupMap;
+    ThreadSafeWeakHashSet<ThreadGroup> m_threadGroups;
     PlatformThreadHandle m_handle;
     uint32_t m_uid { ++s_uid };
 #if OS(WINDOWS)

--- a/Source/WTF/wtf/linux/RealTimeThreads.h
+++ b/Source/WTF/wtf/linux/RealTimeThreads.h
@@ -60,7 +60,7 @@ private:
     void discardRealTimeKitProxyTimerFired();
 #endif
 
-    std::shared_ptr<ThreadGroup> m_threadGroup;
+    Ref<ThreadGroup> m_threadGroup;
     bool m_enabled { true };
 #if USE(GLIB)
     std::optional<GRefPtr<GDBusProxy>> m_realTimeKitProxy;

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -400,7 +400,7 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
 
 static ThreadGroup& activeThreads()
 {
-    static LazyNeverDestroyed<std::shared_ptr<ThreadGroup>> activeThreads;
+    static LazyNeverDestroyed<RefPtr<ThreadGroup>> activeThreads;
     static std::once_flag initializeKey;
     std::call_once(initializeKey, [&] {
         activeThreads.construct(ThreadGroup::create());
@@ -416,7 +416,7 @@ void registerThreadForMachExceptionHandling(Thread& thread)
         return;
 
     Locker locker { activeThreads().getLock() };
-    if (activeThreads().add(locker, thread) == ThreadGroupAddResult::NewlyAdded)
+    if (Ref { activeThreads() }->add(locker, thread) == ThreadGroupAddResult::NewlyAdded)
         setExceptionPorts(locker, thread);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/ThreadGroup.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ThreadGroup.cpp
@@ -163,7 +163,7 @@ TEST(WTF, ThreadGroupRemove)
 
     Vector<Ref<Thread>> threads;
 
-    auto threadGroup = ThreadGroup::create();
+    RefPtr threadGroup = ThreadGroup::create().ptr();
     for (unsigned i = 0; i < NumberOfThreads; i++) {
         auto thread = Thread::create("ThreadGroupWorker"_s, [&]() {
             Locker locker { lock };


### PR DESCRIPTION
#### 0f137772c935fe6f8d188ab40bceefe731c719e2
<pre>
Use ThreadSafeWeakHashSet for Thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=302743">https://bugs.webkit.org/show_bug.cgi?id=302743</a>
<a href="https://rdar.apple.com/165000250">rdar://165000250</a>

Reviewed by Marcus Plutowski.

Because SaferCPP objects to HashMap&lt;Thread*, ...&gt;.

Re-landed 258267@main now that 287313@main has fixed the bugs that originally
blocked the conversion to ThreadSafeWeakHashSet.

Updated clients to use Ref/RefPtr instead of std::shared_ptr.

Also changed ThreadSafeWeakHashSet and ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr
to use WordLock instead of Lock. Thread and ThreadGroup require a lock that can
be used without access to TLS.

Also adopted WTF_CAPABILITY_LOCK annotations for WordLock, so that we don&apos;t
regress thread-safety analysis coverage by switching to WordLock. This required
suppressing some existing inconsistencies (which are fine, just not verifiable).

Canonical link: <a href="https://commits.webkit.org/303280@main">https://commits.webkit.org/303280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a36370c3e40e8d3d4efa95d01723728bb97d8696

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139375 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/08b970c8-6f36-426b-8ad1-c383bdd7c577) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100793 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e55312c0-9453-46fc-bead-6c019bc53526) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134809 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81583 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/402eefa9-b064-4e16-831e-d9a4105726bb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82595 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123926 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142018 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130370 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4024 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109168 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109334 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3063 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57241 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20507 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4078 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32812 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67525 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42466 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4038 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->