### PR TITLE
[JSC][Wasm][Debugger] Implement multi-VM stop-the-world debugging

### DIFF
--- a/JSTests/wasm/debugger/lib/core/base.py
+++ b/JSTests/wasm/debugger/lib/core/base.py
@@ -254,6 +254,9 @@ class BaseTestCase:
 
         cmd = [jsc_path, f"--wasm-debugger={self.current_port}"]
 
+        if self._verbose_wasm_debugger:
+            cmd.append("--verboseWasmDebugger=1")
+
         cmd.append(test_file)
 
         self.logger.verbose(f"Starting debugger on port {self.current_port}")
@@ -272,6 +275,9 @@ class BaseTestCase:
                 # Update the command to use just the filename
                 test_filename = os.path.basename(test_file)
                 cmd = [jsc_path, f"--wasm-debugger={self.current_port}"]
+
+                if self._verbose_wasm_debugger:
+                    cmd.append("--verboseWasmDebugger=1")
 
                 cmd.append(test_filename)
             else:
@@ -430,7 +436,7 @@ class BaseTestCase:
         if not self.start_debugger(test_file):
             return False
 
-        if not self.start_lldb(connection_timeout=20.0):
+        if not self.start_lldb(connection_timeout=60.0):
             return False
 
         self.logger.success(f"Debugging session ready for {self.name}")
@@ -488,7 +494,7 @@ class BaseTestCase:
             return result
 
     def send_lldb_command_or_raise(
-        self, command: str, patterns=None, mode=PatternMatchMode.ALL, timeout=5.0
+        self, command: str, patterns=None, mode=PatternMatchMode.ALL, timeout=30.0
     ):
         """Send LLDB command with patterns and raise exception on failure"""
         result = self.send_lldb_command_with_patterns(command, patterns, mode, timeout)
@@ -650,7 +656,7 @@ class BaseTestCase:
 
                     if UtilsLogger._verbose:
                         print(
-                            f"{Colors.DIM}🔍 [{process_name}][{stream_name.upper()}] {line}{Colors.RESET}"
+                            f"{Colors.DIM}🔍 [{self.name}][{process_name}][{stream_name.upper()}] {line}{Colors.RESET}"
                         )
 
             except Exception as e:

--- a/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-different-funcs.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-different-funcs.js
@@ -1,0 +1,111 @@
+// Multi-VM WebAssembly Debugger Test - Different Functions
+// This test creates multiple VMs running different functions from the SAME WebAssembly module
+// to verify that the debugger properly handles different VMs executing different functions
+
+// WASM module with 3 different functions
+// Compiled from multi-funcs.wat using wat2wasm
+const wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [])
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 3 functions (all type 0)
+    0x03, 0x04, 0x03, 0x00, 0x00, 0x00,
+
+    // [0x14] Export section: export 3 functions
+    0x07, 0x19, 0x03,
+    // Export function 0 as "func1"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x31, 0x00, 0x00,
+    // Export function 1 as "func2"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x32, 0x00, 0x01,
+    // Export function 2 as "func3"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x33, 0x00, 0x02,
+
+    // [0x30] Code section
+    0x0a,                   // section id=10
+    0x22,                   // section size=34
+    0x03,                   // 3 functions
+
+    // Function 0: func1 (body size=10)
+    0x0a,                   // body size
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x35] nop
+    0x41, 0x0a,             // [0x36] i32.const 10
+    0x1a,                   // [0x38] drop
+    0x01,                   // [0x39] nop
+    0x41, 0x14,             // [0x3a] i32.const 20
+    0x1a,                   // [0x3c] drop
+    0x0b,                   // [0x3d] end
+
+    // Function 1: func2 (body size=10)
+    0x0a,                   // body size
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x40] nop
+    0x41, 0x1e,             // [0x41] i32.const 30
+    0x1a,                   // [0x43] drop
+    0x01,                   // [0x44] nop
+    0x41, 0x28,             // [0x45] i32.const 40
+    0x1a,                   // [0x47] drop
+    0x0b,                   // [0x48] end
+
+    // Function 2: func3 (body size=10)
+    0x0a,                   // body size
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x4b] nop
+    0x41, 0x32,             // [0x4c] i32.const 50
+    0x1a,                   // [0x4e] drop
+    0x01,                   // [0x4f] nop
+    0x41, 0x3c,             // [0x50] i32.const 60
+    0x1a,                   // [0x52] drop
+    0x0b                    // [0x53] end
+]);
+
+const NUM_WORKERS = 2;
+const PRINT_INTERVAL = 1e7;
+
+print("=== Multi-VM Different Functions Test ===");
+print(`Creating ${NUM_WORKERS} workers + main thread (${NUM_WORKERS + 1} VMs total)`);
+print("Each VM runs a DIFFERENT function from the same WASM module");
+print("");
+
+// Worker script: each worker runs a specific function
+const workerScript = (workerId, funcName) => `
+    const wasmBytes = new Uint8Array([${Array.from(wasm).join(',')}]);
+    const wasmModule = new WebAssembly.Module(wasmBytes);
+    const wasmInstance = new WebAssembly.Instance(wasmModule, {});
+
+    // Run a specific wasm function in an infinite loop
+    const func = wasmInstance.exports.${funcName};
+    let iteration = 0;
+    for (; ;) {
+        func();
+        iteration += 1;
+        if (iteration % ${PRINT_INTERVAL} == 0)
+            print("Worker ${workerId} (${funcName}) iteration=", iteration);
+    }
+`;
+
+// Start workers, each running a different function
+const functions = ['func2', 'func3'];
+for (let i = 0; i < NUM_WORKERS; i++) {
+    $.agent.start(workerScript(i + 1, functions[i]));
+    print(`Started worker ${i + 1}/${NUM_WORKERS} running ${functions[i]}`);
+}
+
+// Main thread runs func1
+print("Main thread starting func1 execution...");
+print("");
+const mainModule = new WebAssembly.Module(wasm);
+const mainInstance = new WebAssembly.Instance(mainModule, {});
+const func1 = mainInstance.exports.func1;
+
+let iteration = 0;
+for (; ;) {
+    func1();
+    iteration += 1;
+    if (iteration % PRINT_INTERVAL == 0)
+        print("Main (func1) iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-same-func.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-same-func.js
@@ -1,0 +1,77 @@
+// Multi-VM WebAssembly Debugger Test
+// This test creates multiple VMs (main thread + 2 workers) running WebAssembly code concurrently
+// to verify that the debugger properly handles cross-VM/instance scenarios
+
+// Simple WASM module: (func [] -> [])
+const wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [])
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x12] Export section: export function 0 as "compute"
+    0x07, 0x0b, 0x01, 0x07, 0x63, 0x6f, 0x6d, 0x70, 0x75, 0x74, 0x65, 0x00, 0x00,
+
+    // [0x1f] Code section
+    0x0a,                   // section id=10
+    0x09,                   // section size=9
+    0x01,                   // 1 function
+    0x07,                   // function body size=7
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x24] nop
+    0x41, 0x2a,             // [0x25] i32.const 42
+    0x1a,                   // [0x27] drop
+    0x01,                   // [0x28] nop
+    0x0b                    // [0x29] end function
+]);
+
+const NUM_WORKERS = 2;
+const PRINT_INTERVAL = 1e7;
+
+print("=== Multi-VM WebAssembly Debugger Test ===");
+print(`Creating ${NUM_WORKERS} workers + main thread (${NUM_WORKERS + 1} VMs total)`);
+print("Each VM will run in an infinite loop - attach debugger to test");
+print("");
+
+// Worker script: each worker instantiates the wasm module and calls it in an infinite loop
+const workerScript = (workerId) => `
+    const wasmBytes = new Uint8Array([${Array.from(wasm).join(',')}]);
+    const wasmModule = new WebAssembly.Module(wasmBytes);
+    const wasmInstance = new WebAssembly.Instance(wasmModule, {});
+
+    // Run the wasm function in an infinite loop
+    const compute = wasmInstance.exports.compute;
+    let iteration = 0;
+    for (; ;) {
+        compute();
+        iteration += 1;
+        if (iteration % ${PRINT_INTERVAL} == 0)
+            print("Worker ${workerId} iteration=", iteration);
+    }
+`;
+
+// Start workers
+for (let i = 0; i < NUM_WORKERS; i++) {
+    $.agent.start(workerScript(i + 1));
+    print(`Started worker ${i + 1}/${NUM_WORKERS}`);
+}
+
+// Main thread also runs WebAssembly in an infinite loop
+print("Main thread starting WebAssembly execution...");
+print("");
+const mainModule = new WebAssembly.Module(wasm);
+const mainInstance = new WebAssembly.Instance(mainModule, {});
+const mainCompute = mainInstance.exports.compute;
+
+let iteration = 0;
+for (; ;) {
+    mainCompute();
+    iteration += 1;
+    if (iteration % PRINT_INTERVAL == 0)
+        print("Main iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/system-call.js
+++ b/JSTests/wasm/debugger/resources/wasm/system-call.js
@@ -1,0 +1,6 @@
+let iteration = 0;
+for (; ;) {
+    iteration += 1;
+    if (iteration % 1e8 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/test-wasm-debugger.py
+++ b/JSTests/wasm/debugger/test-wasm-debugger.py
@@ -48,13 +48,13 @@ def calculate_smart_workers(test_count, requested_workers=None):
 
 
 def create_test_runner(
-    verbose=False, build_config=None, parallel=False, workers=None, test_names=None
+    verbose=False, build_config=None, parallel=False, workers=None, test_names=None, verbose_wasm_debugger=False
 ):
     """Create test runner with auto-discovered test cases and smart worker calculation"""
     if parallel:
         # First create a temporary runner to get test count
         temp_runner = create_auto_registered_runner(
-            build_config=build_config, verbose_wasm_debugger=False
+            build_config=build_config, verbose_wasm_debugger=verbose_wasm_debugger
         )
 
         # Calculate test count
@@ -79,7 +79,7 @@ def create_test_runner(
 
         runner = ParallelWebAssemblyDebuggerTestRunner(
             build_config=build_config,
-            verbose_wasm_debugger=False,
+            verbose_wasm_debugger=verbose_wasm_debugger,
             max_workers=smart_workers,
             verbose_parallel=verbose,
         )
@@ -87,7 +87,7 @@ def create_test_runner(
         discovery.auto_register_tests(runner.registry)
     else:
         runner = create_auto_registered_runner(
-            build_config=build_config, verbose_wasm_debugger=False
+            build_config=build_config, verbose_wasm_debugger=verbose_wasm_debugger
         )
     return runner
 
@@ -97,6 +97,9 @@ def main():
     parser = argparse.ArgumentParser(description="WebAssembly Debugger Test Framework")
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose logging"
+    )
+    parser.add_argument(
+        "--verbose-wasm-debugger", action="store_true", help="Enable verbose WebAssembly debugger logging (--verboseWasmDebugger=1)"
     )
     parser.add_argument(
         "--pid-tid", action="store_true", help="Enable PID/TID prefixes"
@@ -128,6 +131,9 @@ def main():
     # Use -1 as sentinel for auto-detect, otherwise use specified value
     workers = None if args.parallel == -1 else args.parallel
 
+    if args.verbose_wasm_debugger:
+        args.verbose = True
+
     if args.verbose:
         Logger.set_verbose(True)
 
@@ -135,7 +141,7 @@ def main():
         Logger.set_pid_tid_logging(True)
 
     runner = create_test_runner(
-        args.verbose, build_config, parallel, workers, args.test
+        args.verbose, build_config, parallel, workers, args.test, args.verbose_wasm_debugger
     )
 
     if args.list:

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -357,7 +357,7 @@ class SwiftWasmTestCase(BaseTestCase):
     def stepTest(self):
         self.send_lldb_command_or_raise("b processNumber")
 
-        # TODO: Step over - Current Swift LLDB is problematic with step over
+        # FIXME: Step over - Current Swift LLDB is problematic with step over
 
         # Step Into
         self.send_lldb_command_or_raise(
@@ -1427,3 +1427,75 @@ class TryTableTestCase(BaseTestCase):
         self.send_lldb_command_or_raise(
             "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
         )
+
+
+class SystemCallTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/system-call.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Try table test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("si", patterns=[])
+        self.send_lldb_command_or_raise("process interrupt")
+
+        self.send_lldb_command_or_raise("s", patterns=[])
+        self.send_lldb_command_or_raise("process interrupt")
+
+        self.send_lldb_command_or_raise("n", patterns=[])
+        self.send_lldb_command_or_raise("process interrupt")
+
+        # FIXME: `dis` hangs LLDB when stop in the system call.
+
+
+class MultiVMSameModuleSameFunctionTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise(
+            "resources/wasm/multi-vm-same-module-same-func.js"
+        )
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Try table test failed: {e}")
+
+    def stepTest(self):
+        # FIXME: Add tests when thread select is full supported
+        return
+
+
+class MultiVMSameModuleDifferentFunctionsTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise(
+            "resources/wasm/multi-vm-same-module-different-funcs.js"
+        )
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Try table test failed: {e}")
+
+    def stepTest(self):
+        # FIXME: Add tests when thread select is full supported
+        return

--- a/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
+++ b/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
@@ -800,9 +800,9 @@ static int test()
     dataLogLn("");
     dataLogLn("Starting VMManager StopTheWorld Test");
 
-    auto* originalWasmDebugger = g_jscConfig.wasmDebuggerStopTheWorld;
+    auto* originalWasmDebugger = g_jscConfig.wasmDebuggerOnStop;
     auto* originalMemoryDebugger = g_jscConfig.memoryDebuggerStopTheWorld;
-    VMManager::setWasmDebuggerCallback(wasmDebuggerTestCallback);
+    VMManager::setWasmDebuggerOnStop(wasmDebuggerTestCallback);
     VMManager::setMemoryDebuggerCallback(memoryDebuggerTestCallback);
 
     // FIXME: for now, VMTraps doesn't completely work on JIT runs yet. Once we fix that, we'll need
@@ -813,7 +813,7 @@ static int test()
 
     auto resetSettings = makeScopeExit([&] {
         Options::setOptions(savedOptionsBuilder.toString().ascii().data());
-        VMManager::setWasmDebuggerCallback(originalWasmDebugger);
+        VMManager::setWasmDebuggerOnStop(originalWasmDebugger);
         VMManager::setMemoryDebuggerCallback(originalMemoryDebugger);
     });
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2285,8 +2285,11 @@
 		FFD49E742E276CA10083E383 /* WasmMemoryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5E2E276CA10083E383 /* WasmMemoryHandler.h */; };
 		FFE21FE52CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */; };
 		FFE31BDB2E6212CD006FE0B7 /* WasmVirtualAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = FFE31BDA2E6212CD006FE0B7 /* WasmVirtualAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */; };
 		FFF3373F2BCDF1240070D04B /* JSCBytecodeCacheVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFF4D5A32CE304CD006EA634 /* DeferredWorkTimerInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFFAF8CB2EC97B2B00042238 /* TestScripts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */; };
+		FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -6354,9 +6357,15 @@
 		FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGLoopUnrollingPhase.h; path = dfg/DFGLoopUnrollingPhase.h; sourceTree = "<group>"; };
 		FFE21FE42CC1BE1800DEC268 /* DFGLoopUnrollingPhase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGLoopUnrollingPhase.cpp; path = dfg/DFGLoopUnrollingPhase.cpp; sourceTree = "<group>"; };
 		FFE31BDA2E6212CD006FE0B7 /* WasmVirtualAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmVirtualAddress.h; sourceTree = "<group>"; };
+		FFE88B9C2EC96CA700C9F5E2 /* ExecutionHandlerTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerTest.h; sourceTree = "<group>"; };
+		FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionHandlerTest.cpp; sourceTree = "<group>"; };
 		FFF3373D2BCDF1240070D04B /* JSCBytecodeCacheVersion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSCBytecodeCacheVersion.cpp; sourceTree = "<group>"; };
 		FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSCBytecodeCacheVersion.h; sourceTree = "<group>"; };
 		FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeferredWorkTimerInlines.h; sourceTree = "<group>"; };
+		FFFAF8C92EC97B2B00042238 /* TestScripts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestScripts.h; sourceTree = "<group>"; };
+		FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestScripts.cpp; sourceTree = "<group>"; };
+		FFFAF8CC2EC9A7C000042238 /* ExecutionHandlerTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerTestSupport.h; sourceTree = "<group>"; };
+		FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionHandlerTestSupport.cpp; sourceTree = "<group>"; };
 		FFFAFBE02E6ABDCB006BFA2E /* WasmVirtualAddress.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmVirtualAddress.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -10544,9 +10553,15 @@
 			children = (
 				FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */,
 				FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */,
+				FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */,
+				FFE88B9C2EC96CA700C9F5E2 /* ExecutionHandlerTest.h */,
+				FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */,
+				FFFAF8CC2EC9A7C000042238 /* ExecutionHandlerTestSupport.h */,
 				FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */,
 				FFA2E0232EA16F37006661A3 /* MemoryTests.cpp */,
 				FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */,
+				FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */,
+				FFFAF8C92EC97B2B00042238 /* TestScripts.h */,
 				FF18EBC42EA5C73E00185CFA /* TestUtilities.cpp */,
 				FFA2E0252EA16F37006661A3 /* TestUtilities.h */,
 				FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */,
@@ -13796,9 +13811,12 @@
 			files = (
 				FFA2E02D2EA16F37006661A3 /* BinaryTests.cpp in Sources */,
 				FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */,
+				FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */,
+				FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */,
 				FF1344662EB3F2A600940C00 /* ExtGCTests.cpp in Sources */,
 				FFA2E02E2EA16F37006661A3 /* MemoryTests.cpp in Sources */,
 				FFA2E02C2EA16F37006661A3 /* SpecialTests.cpp in Sources */,
+				FFFAF8CB2EC97B2B00042238 /* TestScripts.cpp in Sources */,
 				FF18EBC52EA5C73E00185CFA /* TestUtilities.cpp in Sources */,
 				FF0F569A2E3348CA002A232A /* testwasmdebugger.cpp in Sources */,
 				FFA2E02F2EA16F37006661A3 /* UnaryTests.cpp in Sources */,

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4312,6 +4312,9 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
         constexpr auto wasmDebugOption = "--wasm-debugger"_s;
         bool isBareOption = argView.length() == wasmDebugOption.length();
         if (argView.startsWith(wasmDebugOption) && (isBareOption || argView[wasmDebugOption.length()] == '=')) {
+#if !CPU(ARM64)
+            dataLogLn("ERROR: --wasm-debugger only supported on ARM64");
+#else
             JSC::Options::enableWasmDebugger() = true;
             JSC::Options::useBBQJIT() = false;
             JSC::Options::useOMGJIT() = false;
@@ -4322,6 +4325,7 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
                 else
                     dataLogLn("ERROR: invalid port number for --wasm-debugger=", suffix);
             }
+#endif
             continue;
         }
 #endif
@@ -4403,7 +4407,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
 
 #if ENABLE(WEBASSEMBLY)
             if (Options::enableWasmDebugger()) [[unlikely]]
-                Wasm::DebugServer::singleton().start(&vm);
+                Wasm::DebugServer::singleton().start();
 #endif
 
             func(vm, globalObject, success);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -269,7 +269,12 @@ end
 .checkStack:
     operationCallMayThrowPreservingVolatileRegisters(macro()
         move scratch, a1
+if X86_64
+        # On x86_64, callee parameter (ws0) gets clobbered by saveCallSiteIndex(). Reload from stack.
+        loadp UnboxedWasmCalleeStackSlot[cfr], a2
+else
         move callee, a2
+end
         cCall3(_ipint_extern_check_stack_and_vm_traps)
     end)
 

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -40,8 +40,10 @@
 #include "Options.h"
 #include "StructureAlignedMemoryAllocator.h"
 #include "SuperSampler.h"
+#include "VMManager.h"
 #include "VMTraps.h"
 #include "WasmCapabilities.h"
+#include "WasmExecutionHandler.h"
 #include "WasmFaultSignalHandler.h"
 #include "WasmThunks.h"
 #include <mutex>
@@ -142,8 +144,13 @@ void initializeWithOptionsCustomization(const ScopedLambda<void()>& optionsCusto
         if (Wasm::isSupported() || !Options::usePollingTraps()) {
             if (!Options::usePollingTraps())
                 VMTraps::initializeSignals();
-            if (Wasm::isSupported())
+            if (Wasm::isSupported()) {
                 Wasm::prepareSignalingMemory();
+#if ENABLE(WEBASSEMBLY)
+                VMManager::setWasmDebuggerOnStop(Wasm::wasmDebuggerOnStopCallback);
+                VMManager::setWasmDebuggerOnResume(Wasm::wasmDebuggerOnResumeCallback);
+#endif
+            }
         }
 
         assertInvariants();

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -107,7 +107,9 @@ struct Config {
     using ShellTimeoutCheckCallback = void (*)(VM&);
     ShellTimeoutCheckCallback JSC_CONFIG_METHOD(shellTimeoutCheckCallback);
 
-    StopTheWorldCallback JSC_CONFIG_METHOD(wasmDebuggerStopTheWorld);
+    StopTheWorldCallback JSC_CONFIG_METHOD(wasmDebuggerOnStop);
+    using PostResumeCallback = void (*)();
+    PostResumeCallback JSC_CONFIG_METHOD(wasmDebuggerOnResume);
     StopTheWorldCallback JSC_CONFIG_METHOD(memoryDebuggerStopTheWorld);
 
     struct {

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -827,10 +827,14 @@ void Options::notifyOptionsChanged()
 #endif
 
 #if ENABLE(WEBASSEMBLY)
+#if CPU(ARM64)
     if (Options::enableWasmDebugger()) [[unlikely]] {
         Options::useBBQJIT() = false;
         Options::useOMGJIT() = false;
     }
+#else
+    Options::enableWasmDebugger() = false;
+#endif
 #endif
 
     // At initialization time, we may decide that useJIT should be false for any

--- a/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
+++ b/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
@@ -48,6 +48,8 @@ enum class StopTheWorldEvent : uint8_t {
     VMCreated,
     VMActivated,
     VMStopped,
+    BreakpointHit,
+    StepIntoSiteReached,
 };
 
 // The VMManager Stop the World (STW) mechanism will call handlers of this shape once the world
@@ -74,5 +76,6 @@ enum class StopTheWorldEvent : uint8_t {
 // RunAll or RunOne mode).
 
 using StopTheWorldCallback = StopTheWorldStatus (*)(VM&, StopTheWorldEvent);
+using PostResumeCallback = void (*)();
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -63,7 +63,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/ThunkGenerator.h>
 #include <JavaScriptCore/VMThreadContext.h>
 #include <JavaScriptCore/WasmContext.h>
-#include <JavaScriptCore/WasmDebugServerUtilities.h>
 #include <JavaScriptCore/WeakGCMap.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <wtf/BumpPointerAllocator.h>
@@ -177,6 +176,14 @@ class Database;
 namespace DOMJIT {
 class Signature;
 }
+
+#if ENABLE(WEBASSEMBLY)
+class JSWebAssemblyInstance;
+namespace Wasm {
+class IPIntCallee;
+struct DebugState;
+}
+#endif
 
 struct EntryFrame;
 
@@ -1164,14 +1171,8 @@ public:
     void notifyDebuggerHookInjected() { m_isDebuggerHookInjected = true; }
     bool isDebuggerHookInjected() const { return m_isDebuggerHookInjected; }
 
-    bool isWasmStopWorldActive() { return m_isWasmStopWorldActive; }
-    void setIsWasmStopWorldActive(bool isWasmStopWorldActive) { m_isWasmStopWorldActive = isWasmStopWorldActive; }
-
 #if ENABLE(WEBASSEMBLY)
-    bool takeStepIntoWasmCall() { return m_stepIntoEvent.take(Wasm::StepIntoEvent::StepIntoCall); }
-    void setStepIntoWasmCall() { m_stepIntoEvent.set(Wasm::StepIntoEvent::StepIntoCall); }
-    bool takeStepIntoWasmThrow() { return m_stepIntoEvent.take(Wasm::StepIntoEvent::StepIntoThrow); }
-    void setStepIntoWasmThrow() { m_stepIntoEvent.set(Wasm::StepIntoEvent::StepIntoThrow); }
+    JS_EXPORT_PRIVATE Wasm::DebugState* debugState();
 #endif
 
 private:
@@ -1304,10 +1305,9 @@ private:
     bool m_executionForbidden { false };
     bool m_executionForbiddenOnTermination { false };
     bool m_isDebuggerHookInjected { false };
-    bool m_isWasmStopWorldActive { false };
 
 #if ENABLE(WEBASSEMBLY)
-    Wasm::StepIntoEvent m_stepIntoEvent;
+    std::unique_ptr<Wasm::DebugState> m_debugState;
 #endif
 
     Lock m_loopHintExecutionCountLock;

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -88,9 +88,12 @@ if (DEVELOPER_MODE)
 
         ../wasm/debugger/tests/BinaryTests.cpp
         ../wasm/debugger/tests/ControlFlowTests.cpp
+        ../wasm/debugger/tests/ExecutionHandlerTest.cpp
+        ../wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
         ../wasm/debugger/tests/ExtGCTests.cpp
         ../wasm/debugger/tests/MemoryTests.cpp
         ../wasm/debugger/tests/SpecialTests.cpp
+        ../wasm/debugger/tests/TestScripts.cpp
         ../wasm/debugger/tests/TestUtilities.cpp
         ../wasm/debugger/tests/UnaryTests.cpp
     )

--- a/Source/JavaScriptCore/wasm/WasmInstanceAnchor.h
+++ b/Source/JavaScriptCore/wasm/WasmInstanceAnchor.h
@@ -33,6 +33,10 @@
 #include <wtf/Expected.h>
 #include <wtf/text/WTFString.h>
 
+namespace JSC {
+class JSWebAssemblyInstance;
+}
+
 namespace JSC::Wasm {
 
 class Module;

--- a/Source/JavaScriptCore/wasm/debugger/Debugger-Mutator-Protocol.md
+++ b/Source/JavaScriptCore/wasm/debugger/Debugger-Mutator-Protocol.md
@@ -1,0 +1,239 @@
+# Debugger-Mutator Communication Protocol
+
+**ExecutionHandler Thread Synchronization in WebAssembly Debugging**
+
+This document describes the thread communication protocol used in `WasmExecutionHandler.cpp` to coordinate between the debugger thread (LLDB commands) and mutator threads (WebAssembly execution), along with VMManager coordination for stop-the-world operations.
+
+---
+
+## Thread Actors
+
+### 1. **Debugger Thread**
+
+- Runs on the debug server's WorkQueue thread
+- Processes LLDB commands: continue, step, interrupt, thread selection
+- Initiates debugging operations
+- Thread ID: `m_debugServerThreadId`
+
+### 2. **Mutator Thread(s)**
+
+- Runs WebAssembly bytecode execution
+- One per VM (main thread + worker threads)
+- Responds to debugging commands
+- Thread ID: `VM::ownerThread()->uid()`
+
+### 3. **VMManager** (Coordinator)
+
+- Singleton managing all VMs in the process
+- Implements stop-the-world coordination
+- Calls `wasmDebuggerOnStop()` and `wasmDebuggerOnResume()` callbacks
+- Ensures all VMs stopped before debugger accesses state
+
+---
+
+## Synchronization Primitives
+
+### Key State Variables
+
+```cpp
+m_debuggeeContinue            // Debugger signals debuggee to continue
+m_debuggerContinue            // Debuggee signals debugger to continue
+
+m_debuggerState               // Current debugger operation state
+m_debuggee                    // VM being debugged
+m_awaitingResumeNotification  // Resume barrier flag
+```
+
+### Debugger States
+
+```cpp
+enum class DebuggerState {
+    Replied,              // Idle, ready for next command
+    InterruptRequested,   // Async interrupt in progress
+    ContinueRequested,    // Resume all VMs
+    StepRequested,        // Single-step with breakpoints
+    SwitchRequested       // VM context switch
+};
+```
+
+---
+
+## Protocol Flow Diagrams
+
+### 1. **Continue Operation** (Resume All VMs)
+
+```
+Debugger Thread                             Debuggee Thread                                           Other Thread(s)
+==================       ==========================================================================================================================
+                                      ExecutionHandler::stopCode()                            VMManager::notifyVMStop()
+                                   ┌──>├─ wait(debuggeeCV)                           ┌────────>├─ wait(worldCV)
+resumeImpl()                       │   │                                             │         └─ Other VMs exiting notifyVMStop()
+  ├─ Set state = ContinueRequested │   │                                             │
+  ├─ notifyOne(debuggeeCV) ────────┘   │                                             │
+  ├─ wait(debuggerCV) <──┐             │                                             │
+  │                      │             │                                             │
+  │                      │             ├─ Check state -> ContinueRequested           │
+  │                      │             ├─ Set m_awaitingResumeNotification = true    │
+  │                      │             └─ Return ResumeMode::All                     │
+  │                      │                └─ VMManager::resumeAll() ─────────────────┘
+  │                      │                    └─ Debuggee VM exiting notifyVMStop()
+  │                      │                                                                Some VMs May exit notifyVMStop() early and hit breakpoints
+  │                      │                                                                 ├─ stopTheWorld()
+  │                      │                                                            ┌───>├─ wait(debuggeeCV) on m_awaitingResumeNotification
+  │                      │ Last VM exiting notifyVMStop() ─> wasmDebuggerOnResume()   │    │
+  │                      │                                   ├─ handlePostResume()    │    │  
+  │                      │                                   ├─ Set m_awaitingResumeNotification = false
+  │                      └───────────────────────────────────├─ notifyOne(debuggerCV) │    │  
+  │                                                          └─ notifyAll(debuggeeCV) ┘    │ 
+  └─ Debugger resumes                                                                      └─ notifyVMStop() and send stop reply to debugger
+```
+
+**Key Points:**
+
+- Debugger waits for **post-resume** confirmation to prevent interrupt() race
+- `m_awaitingResumeNotification` acts as resume barrier
+- VMManager ensures all VMs actually resumed before callback
+
+---
+
+### 2. **Interrupt Operation** (Async Stop Request)
+
+```
+Debugger Thread                                               All Thread(s)
+==================         ===========================================================================================
+                                                            [Running Wasm]
+interrupt()
+  ├─ Set state = InterruptRequested
+  ├─ VMManager::requestStopAll() ──────────────────-----───> VMTraps fire
+  ├─ wait(debuggerCV) <──┐              notifyVMStop()                    notifyVMStop()
+  │                      │               ├─ One VM picked as debuggee      └─ Other VMs wait(worldCV)
+  │                      │               ├─ On stop callback
+  │                      │               ├─ stopCode()
+  │                      │               ├─ setStopped()
+  │                      │               ├─ Check state -> InterruptRequested
+  │                      └───────────────┼─ notifyOne(debuggerCV)
+  │                                      └─ wait(debuggeeCV)
+  │
+  └─ sendStopReply()
+```
+
+**Key Points:**
+
+- **Asynchronous**: Debugger initiates trap via VMManager
+- All VMs stopped via trap mechanism (no direct wait/notify initially)
+- Once debuggee VM stops, it notifies debugger
+- Multiple VMs coordinate through VMManager stop-the-world
+
+---
+
+### 3. **Single Step Operation**
+
+```
+Debugger Thread                         Mutator Thread (Debuggee)                                  Other Thread(s)
+==================       ==========================================================================================================================
+                                      ExecutionHandler::stopCode()                            VMManager::notifyVMStop()
+                                   ┌──>├─ wait(debuggeeCV)                                      └─ wait(worldCV)
+step()                             │   │
+  ├─ stepAtBreakpoint()            │   │
+  │   └─ Set one-time breakpoints  │   │
+  ├─ Set state = StepRequested     │   │
+  ├─ notifyOne(debuggeeCV) ────────┘   │
+  ├─ wait(debuggerCV) <──┐             │
+  │                      │             ├─ Check state -> StepRequested
+  │                      │             └─ Return ResumeMode::One
+  │                      │                └─ VMManager::resumeOne(debuggee)
+  │                      │                    └─ Debuggee VM exiting notifyVMStop() (others stay stopped)
+  │                      │                        ├─ Debuggee VM executes
+  │                      │                        ├─ Hits one-time breakpoint
+  │                      │                        └─ stopTheWorld()
+  │                      │                            └─ notifyVMStop()
+  │                      │                                └─ stopCode()
+  │                      │                                    ├─ setStopped()
+  │                      │                                    ├─ Check state -> StepRequested
+  │                      └────────────────────────────────────┼─ notifyOne(debuggerCV)
+  │                                                           └─ wait(debuggeeCV)
+  └─ sendStopReply()
+```
+
+**Key Points:**
+
+- One-time breakpoints set before resume
+- Only debuggee VM runs (RunOne mode)
+- All other VMs remain stopped
+- Breakpoint hit triggers another stop-the-world
+
+---
+
+### 4. **Step-Into (Call/Throw)** - Two-Phase Protocol
+
+```
+Debugger Thread                         Mutator Thread (Debuggee)                                  Other Thread(s)
+==================       ==========================================================================================================================
+                                      ExecutionHandler::stopCode()                            VMManager::notifyVMStop()
+                                   ┌──>├─ wait(debuggeeCV)                                      └─ wait(worldCV)
+step()                             │   │
+  └─ stepAtBreakpoint()            │   │
+      ├─ Detect call/throw         │   │
+      ├─ Set hasStepIntoEvent flag │   │
+      ├─ notifyOne(debuggeeCV) ────┘   │
+      ├─ wait(debuggerCV) <──┐         │                                 
+      │                      │         ├─ Wakes up, executes call/throw  
+      │                      │         └─ setStepIntoBreakpointForCall/Throw()             
+      │                      │             ├─ Set breakpoint at callee or exception handler   
+      │                      │             └─ stopTheWorld()           
+      │                      │                 └─ notifyVMStop()
+      │                      │                     ├─ stopCode(StepIntoSiteReached)
+      │                      │                     ├─ Check state -> StepRequested                 
+      │                      └─────────────────────┼─ notifyOne(debuggerCV)
+      │                           ┌──────────────> ├─ wait(debuggeeCV)
+      │                           │                │
+      │                           │                │
+      ├─ notifyOne(debuggeeCV) ───┘                │
+      ├─ wait(debuggerCV) <┐                       │
+      │                    │                       ├─ Wakes up, runs to step-into breakpoint
+      │                    │                       ├─ Breakpoint hit -> stopCode()
+      │                    │                       ├─ setStopped()
+      │                    │                       ├─ Check state -> StepRequested
+      │                    └───────────────────────┼─ notifyOne(debuggerCV)
+      │                                            └─ wait(debuggeeCV)
+      └─ sendStopReply()
+```
+
+**Key Points:**
+
+- **Two-phase handshake**:
+  1. Execute call/throw and register breakpoint
+  2. Resume and hit step-into breakpoint
+- Breakpoint set dynamically at call/throw site
+
+---
+
+### 5. **VM Context Switch**
+
+```
+Debugger Thread                    Old Mutator Thread (Old Debuggee)       New Mutator Thread (New Debuggee)            Other Thread(s)
+==================           ========================================    ==================================        ========================
+                               ExecutionHandler::stopCode()               VMManager::notifyVMStop()                 VMManager::notifyVMStop()
+                          ┌─────>├─ wait(debuggeeCV)                    ┌──>├─ wait(worldCV)                         └─ wait(worldCV)
+switchTarget(threadId)    │      │                                      │   │
+  ├─ m_debuggee = newDebuggee    │                                      │   │
+  ├─ Set state = SwitchRequested │                                      │   │
+  ├─ notifyOne(debuggeeCV)┘      │                                      │   │
+  ├─ wait(debuggerCV) <────┐     │                                      │   │
+  │                        │     ├─ Check state -> SwitchRequested      │   │
+  │                        │     └─ Return ResumeMode::Switch           │   │
+  │                        │         └─ VMManager switch context ───────┘   │
+  │                        │             └─ wait(worldCV)                   │
+  │                        │                                                └─ wasmDebuggerOnStop()
+  │                        │                                                    └─ handleStopTheWorld() -> stopCode()
+  │                        │                                                        ├─ setStopped()
+  │                        │                                                        ├─ Check state -> SwitchRequested
+  │                        └────────────────────────────────────────────────────────┼─ notifyOne(debuggerCV)
+  │                                                                                 └─ wait(debuggeeCV)
+  └── sendStopReply()
+```
+
+**Key Points:**
+
+- Switch debuggee between VMs
+- VMManager coordinates transition

--- a/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
+++ b/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
@@ -213,12 +213,8 @@ Unlike Web Inspector which initializes/tears down controllers per page, WebAssem
 
 ### Stop-the-World Design
 
-WebAssembly debugging is designed with a **stop-the-world** pause model:
-- When LLDB hits a Wasm breakpoint, the VM that hit the breakpoint pauses execution
-- **Design Intent**: Stop ALL VMs in the process (main thread + all worker threads) for comprehensive debugging
-- **Current Implementation**: Only stops the single VM that hit the breakpoint (multi-VM support not yet implemented)
-- This matches standard native debugging behavior (LLDB/GDB debugging C++ code)
-- Provides consistent state inspection guarantees during pause
+WebAssembly debugging uses a **stop-the-world** pause model:
+- When LLDB requests an interrupt or hits a breakpoint, ALL VMs in the process stop execution (main thread + all worker threads)
 
 ### Asymmetric Interaction with JavaScript Debugger
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
@@ -138,7 +138,7 @@ public:
 
     operator uint64_t() const { return m_value; }
 
-    void dump(PrintStream&) const;
+    JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 
 private:
     static uint64_t encode(Type type, uint32_t id, uint32_t offset)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -1,0 +1,451 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExecutionHandlerTest.h"
+
+#include <wtf/DataLog.h>
+
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
+
+#include "ExecutionHandlerTestSupport.h"
+#include "JSWebAssemblyInstance.h"
+#include "TestScripts.h"
+#include "VM.h"
+#include "VMManager.h"
+#include "WasmBreakpointManager.h"
+#include "WasmCalleeGroup.h"
+#include "WasmDebugServer.h"
+#include "WasmDebugServerUtilities.h"
+#include "WasmExecutionHandler.h"
+#include "WasmModule.h"
+#include "WasmModuleInformation.h"
+#include "WasmModuleManager.h"
+#include <wtf/MonotonicTime.h>
+#include <wtf/Seconds.h>
+#include <wtf/Threading.h>
+#include <wtf/Vector.h>
+
+namespace ExecutionHandlerTest {
+
+using ExecutionHandlerTestSupport::defaultTimeoutSeconds;
+using ExecutionHandlerTestSupport::setupTestEnvironment;
+using ExecutionHandlerTestSupport::verboseLogging;
+using ExecutionHandlerTestSupport::waitForCondition;
+using ExecutionHandlerTestSupport::workerThreadTask;
+using JSC::JSWebAssemblyInstance;
+using JSC::VM;
+using JSC::VMManager;
+using JSC::Wasm::Breakpoint;
+using JSC::Wasm::CalleeGroup;
+using JSC::Wasm::DebugServer;
+using JSC::Wasm::DebugState;
+using JSC::Wasm::ExecutionHandler;
+using JSC::Wasm::FunctionSpaceIndex;
+using JSC::Wasm::ModuleManager;
+using TestScripts::TestScript;
+
+// ========== Test runtime state ==========
+
+static constexpr unsigned RAPID_CYCLES_COUNT = 1000;
+static constexpr unsigned CONTEXT_SWITCH_MULTIPLIER = 1000;
+static constexpr unsigned BREAKPOINT_CONTINUE_CYCLES_COUNT = 1000;
+static constexpr unsigned SINGLE_STEPPING_CYCLES_COUNT = 1000;
+static constexpr ASCIILiteral WORKER_THREAD_NAME = "WasmStressTest"_s;
+
+static int failuresFound = 0;
+static DebugServer* debugServer = nullptr;
+static ExecutionHandler* executionHandler = nullptr;
+static const TestScript* currentScript = nullptr;
+UNUSED_FUNCTION bool doneTesting = false;
+
+#define VLOG(...) dataLogLnIf(verboseLogging, __VA_ARGS__)
+#define TEST_LOG(...) dataLogLn(__VA_ARGS__)
+
+#define CHECK(condition, ...)                                   \
+    do {                                                        \
+        if (!(condition)) {                                     \
+            dataLogLn("FAIL: ", #condition, ": ", __VA_ARGS__); \
+            dataLogLn("    @ " __FILE__, ":", __LINE__);        \
+            CRASH();                                            \
+        }                                                       \
+    } while (false)
+
+static void waitForConditionAndCheck(const char* errorMessage, std::function<bool()> predicate)
+{
+    bool result = waitForCondition(predicate);
+    CHECK(result, errorMessage);
+}
+
+// ========== HELPER FUNCTIONS ==========
+
+static void validateStop()
+{
+    auto info = VMManager::info();
+    CHECK(info.worldMode == VMManager::Mode::Stopped, "All VMs should be stopped");
+    auto* state = executionHandler->debuggeeStateSafe();
+    CHECK(state->isStopped(), "Debuggee VM should be stopped");
+    CHECK(info.targetVM == executionHandler->debuggeeVM(), "VMManager's targetVM should match ExecutionHandler's debuggee VM");
+}
+
+static void interrupt()
+{
+    executionHandler->interrupt();
+    validateStop();
+}
+
+static void resume()
+{
+    executionHandler->resume();
+
+    auto info = VMManager::info();
+    CHECK(info.worldMode == VMManager::Mode::RunAll, "All VMs should be running");
+    auto* state = executionHandler->debuggeeStateSafe();
+    CHECK(state->isRunning(), "Debuggee VM should be running");
+}
+
+static void switchTarget(VM* newDebuggee)
+{
+    uint64_t threadId = ExecutionHandler::threadId(*newDebuggee);
+    executionHandler->switchTarget(threadId);
+    validateStop();
+    CHECK(executionHandler->debuggeeVM() == newDebuggee, "Switch to new debuggee failed");
+}
+
+static void setBreakpointsAtAllFunctionEntries(Breakpoint::Type type)
+{
+    VLOG("Setting breakpoints at all function entries...");
+    unsigned count = 0;
+
+    ModuleManager& moduleManager = debugServer->moduleManager();
+    uint32_t maxInstanceId = moduleManager.nextInstanceId();
+
+    for (uint32_t instanceId = 0; instanceId < maxInstanceId; ++instanceId) {
+        JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
+        if (!instance)
+            continue;
+
+        auto& module = instance->module();
+        auto& moduleInfo = module.moduleInformation();
+        uint32_t internalCount = moduleInfo.internalFunctionCount();
+
+        VLOG("  Instance ", instanceId, ": ", internalCount, " functions");
+
+        for (uint32_t funcIndex = 0; funcIndex < internalCount; ++funcIndex) {
+            FunctionSpaceIndex spaceIndex = moduleInfo.toSpaceIndex(JSC::Wasm::FunctionCodeIndex(funcIndex));
+            auto callee = instance->calleeGroup()->ipintCalleeFromFunctionIndexSpace(spaceIndex);
+            executionHandler->setBreakpointAtEntry(instance, callee.ptr(), type);
+            count++;
+        }
+    }
+
+    VLOG("Set ", count, " breakpoints total");
+}
+
+static void clearBreakpointsAndResume(const char* errorMessage)
+{
+    executionHandler->breakpointManager()->clearAllBreakpoints();
+    executionHandler->resume();
+    waitForConditionAndCheck(errorMessage, [&]() {
+        return VMManager::info().worldMode == VMManager::Mode::RunAll;
+    });
+}
+
+// ========== BASIC TESTS ==========
+
+static void testRapidInterruptResumeCycles()
+{
+    TEST_LOG("\n=== Rapid Interrupt/Resume Cycles ===");
+    for (unsigned i = 0; i < RAPID_CYCLES_COUNT; ++i) {
+        VLOG("Cycle ", i);
+        interrupt();
+        resume();
+    }
+
+    TEST_LOG("PASS");
+}
+
+static void testVMContextSwitching()
+{
+    TEST_LOG("\n=== VM Context Switching ===");
+
+    interrupt();
+
+    Vector<VM*> allVMs;
+    VMManager::forEachVM([&](VM& vm) {
+        allVMs.append(&vm);
+        return IterationStatus::Continue;
+    });
+    VLOG("Found ", allVMs.size(), " VMs");
+
+    for (unsigned i = 0; i < allVMs.size() * CONTEXT_SWITCH_MULTIPLIER; ++i) {
+        VM* nextDebuggee = allVMs[i % allVMs.size()];
+        switchTarget(nextDebuggee);
+    }
+
+    resume();
+
+    TEST_LOG("PASS");
+}
+
+static void testBreakpointContinueCycles()
+{
+    TEST_LOG("\n=== Breakpoint Continue Cycles ===");
+
+    interrupt();
+
+    setBreakpointsAtAllFunctionEntries(Breakpoint::Type::Regular);
+    for (unsigned i = 0; i < BREAKPOINT_CONTINUE_CYCLES_COUNT; ++i) {
+        VLOG("Continue cycle ", i);
+
+        executionHandler->resume();
+
+        waitForConditionAndCheck("VMs did not stop at breakpoint in continue cycle", [&]() {
+            auto info = VMManager::info();
+            bool stopped = info.worldMode == VMManager::Mode::Stopped && info.targetVM->debugState()->isStopped();
+            return stopped;
+        });
+
+        DebugState* state = executionHandler->debuggeeStateSafe();
+        CHECK(state->atBreakpoint(), "Should stop at a breakpoint");
+        VLOG("  Stopped at breakpoint in vm:", RawPointer(executionHandler->debuggeeVM()));
+    }
+
+    clearBreakpointsAndResume("VMs did not resume after clearing breakpoints");
+
+    TEST_LOG("PASS");
+}
+
+static void testBreakpointSingleStepping()
+{
+    TEST_LOG("\n=== Breakpoint Single Stepping ===");
+
+    int initialFailures = failuresFound;
+
+    // 1. Interrupt to stop all VMs
+    interrupt();
+
+    // 2. Set breakpoints at ALL function entries
+    setBreakpointsAtAllFunctionEntries(Breakpoint::Type::Regular);
+
+    // 3. Continue - should hit a breakpoint immediately
+    VLOG("Continuing execution (expecting breakpoint hit)...");
+    executionHandler->resume();
+
+    waitForConditionAndCheck("Did not hit breakpoint after resume", [&]() {
+        auto info = VMManager::info();
+        if (info.worldMode != VMManager::Mode::Stopped || !info.targetVM->debugState()->isStopped())
+            return false;
+        DebugState* state = executionHandler->debuggeeStateSafe();
+        return state && state->atBreakpoint();
+    });
+
+    DebugState* state = executionHandler->debuggeeStateSafe();
+    CHECK(state->atBreakpoint(), "Should be at breakpoint");
+
+    // Record initial virtual address
+    CHECK(state->stopData, "Should have stopData");
+    JSC::Wasm::VirtualAddress currentAddress = state->stopData->address;
+    VLOG("Hit breakpoint ", currentAddress);
+
+    // 4. Single-step several times and verify we advance
+    for (unsigned step = 0; step < SINGLE_STEPPING_CYCLES_COUNT; ++step) {
+        VLOG("Step ", step + 1, "/", SINGLE_STEPPING_CYCLES_COUNT);
+
+        // Simulate lldb behavior:
+        // 1. If at Regular breakpoint: remove it, step, then re-insert it
+        // 2. If at one-time breakpoint: just step directly
+        Breakpoint* breakpoint = executionHandler->breakpointManager()->findBreakpoint(currentAddress);
+        Breakpoint breakpointCopy;
+
+        if (breakpoint) {
+            breakpointCopy = *breakpoint;
+            CHECK(breakpoint->type == Breakpoint::Type::Regular, "One-time breakpoints are cleared before stop. So, this must be a regular breakpoint");
+            executionHandler->breakpointManager()->removeBreakpoint(currentAddress);
+        }
+
+        executionHandler->step();
+
+        waitForConditionAndCheck("VMs did not stop after step", [&]() {
+            auto info = VMManager::info();
+            bool stopped = info.worldMode == VMManager::Mode::Stopped && info.targetVM->debugState()->isStopped();
+            return stopped;
+        });
+
+        if (breakpoint)
+            executionHandler->breakpointManager()->setBreakpoint(currentAddress, WTF::move(breakpointCopy));
+
+        state = executionHandler->debuggeeStateSafe();
+        CHECK(state->atBreakpoint(), "Should be at breakpoint after step");
+
+        JSC::Wasm::VirtualAddress afterStepAddress = state->stopData->address;
+        VLOG("  After step: ", afterStepAddress);
+        CHECK(afterStepAddress != currentAddress, "Virtual address should advance after step");
+
+        currentAddress = afterStepAddress;
+    }
+
+    clearBreakpointsAndResume("VMs did not resume after stepping test");
+
+    TEST_LOG(failuresFound == initialFailures ? "PASS" : "FAIL");
+}
+
+// ========== TEST ORCHESTRATION HELPERS ==========
+
+static void waitForVMCleanupFromPreviousTest()
+{
+    TEST_LOG("Waiting for VMs from previous test to be destroyed...");
+    bool cleanedUp = waitForCondition([]() {
+        return !VMManager::info().numberOfVMs;
+    });
+
+    if (!cleanedUp)
+        TEST_LOG("WARNING: VMs not cleaned up within timeout (count: ", VMManager::info().numberOfVMs, ")");
+    else
+        TEST_LOG("All VMs cleaned up successfully");
+}
+
+// FIXME: Add tests for VM lifecycle edge cases (construction, initialization, instance registration) and
+// interrupt() race conditions. Currently we only wait for VM construction and instance registration, which
+// doesn't guarantee VMs are actively running code that checks traps.
+static bool setupScriptAndWaitForVMs(const TestScript& script, unsigned initialVMCount, RefPtr<Thread>& outWorkerThread)
+{
+    CHECK(!initialVMCount, "Expected initial VM count to be 0, got ", initialVMCount);
+
+    ModuleManager& moduleManager = debugServer->moduleManager();
+    unsigned initialInstanceId = moduleManager.nextInstanceId();
+
+    TEST_LOG("\nStarting worker thread with ", script.name, "...");
+    outWorkerThread = Thread::create(WORKER_THREAD_NAME, [&script] {
+        workerThreadTask(script.scriptGenerator());
+    });
+
+    TEST_LOG("Waiting for ", script.expectedVMs, " VMs to start...");
+    if (!waitForCondition([&]() { return VMManager::info().numberOfVMs >= script.expectedVMs; })) {
+        TEST_LOG("FAIL: VMs did not start within timeout");
+        return false;
+    }
+
+    unsigned expectedInstanceId = initialInstanceId + script.expectedVMs;
+    TEST_LOG("Waiting for ", script.expectedVMs, " instances (ID: ", initialInstanceId, " -> ", expectedInstanceId, ")...");
+    if (!waitForCondition([&]() { return moduleManager.nextInstanceId() >= expectedInstanceId; })) {
+        TEST_LOG("FAIL: Instances timeout (expected: ", expectedInstanceId, ", got: ", moduleManager.nextInstanceId(), ")");
+        return false;
+    }
+
+    unsigned finalInstanceId = moduleManager.nextInstanceId();
+    unsigned instanceIncrement = finalInstanceId - initialInstanceId;
+    CHECK(instanceIncrement == script.expectedVMs, "Expected ", script.expectedVMs, " new instances, got ", instanceIncrement);
+
+    TEST_LOG("Setup complete: ", VMManager::info().numberOfVMs, " VMs, ", instanceIncrement, " instances (ID: ", initialInstanceId, " -> ", finalInstanceId, ")");
+    return true;
+}
+
+static void cleanupAfterScript(const TestScript& script, RefPtr<Thread>& workerThread)
+{
+    TEST_LOG("\nCleaning up ", script.name, "...");
+    doneTesting = true;
+    workerThread->waitForCompletion();
+    executionHandler->reset();
+    doneTesting = false;
+}
+
+// ========== MAIN TEST RUNNER ==========
+
+UNUSED_FUNCTION static int runTests()
+{
+    TEST_LOG("========================================");
+    TEST_LOG("WASM Debugger Stress Tests");
+    TEST_LOG("Testing ExecutionHandler with Real WASM");
+    TEST_LOG("========================================");
+
+    auto overallStartTime = MonotonicTime::now();
+    int totalFailures = 0;
+
+    setupTestEnvironment(debugServer, executionHandler);
+    auto scripts = TestScripts::getTestScripts();
+
+    for (const auto& script : scripts) {
+        TEST_LOG("\n==========================================");
+        TEST_LOG("Running tests with script: ", script.name);
+        TEST_LOG(script.description);
+        TEST_LOG("==========================================");
+
+        auto scriptStartTime = MonotonicTime::now();
+        failuresFound = 0;
+        currentScript = &script;
+
+        waitForVMCleanupFromPreviousTest();
+
+        RefPtr<Thread> workerThread;
+        if (!setupScriptAndWaitForVMs(script, VMManager::info().numberOfVMs, workerThread)) {
+            totalFailures++;
+            continue;
+        }
+
+        testRapidInterruptResumeCycles();
+        testVMContextSwitching();
+        testBreakpointContinueCycles();
+        testBreakpointSingleStepping();
+
+        cleanupAfterScript(script, workerThread);
+
+        auto scriptDuration = MonotonicTime::now() - scriptStartTime;
+        TEST_LOG("------------------------------------------");
+        TEST_LOG("Script ", script.name, ": ", failuresFound ? "FAIL" : "PASS",
+            " (", failuresFound, " failures, ", scriptDuration.millisecondsAs<long>(), " ms)");
+        TEST_LOG("------------------------------------------");
+
+        totalFailures += failuresFound;
+    }
+
+    auto overallDuration = MonotonicTime::now() - overallStartTime;
+
+    TEST_LOG("\n========================================");
+    TEST_LOG(totalFailures ? "FAIL" : "PASS", " - Overall Results");
+    TEST_LOG("Total Time: ", overallDuration.millisecondsAs<long>(), " ms");
+    TEST_LOG("Total Failures: ", totalFailures);
+    TEST_LOG("========================================");
+
+    return totalFailures;
+}
+
+#undef VLOG
+#undef TEST_LOG
+#undef CHECK
+
+} // namespace ExecutionHandlerTest
+
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
+
+int testExecutionHandler()
+{
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR) && CPU(ARM64)
+    return ExecutionHandlerTest::runTests();
+#else
+    dataLogLn("WASM Debugger Stress Tests SKIPPED (only supported on ARM64)");
+    return 0;
+#endif
+}

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.h
@@ -27,43 +27,12 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "WasmDebugServerUtilities.h"
-#include "WasmVirtualAddress.h"
-#include <wtf/Forward.h>
-#include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
-#include <wtf/Lock.h>
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
-
-namespace JSC {
-namespace Wasm {
-
-class JS_EXPORT_PRIVATE BreakpointManager {
-    WTF_MAKE_TZONE_ALLOCATED(BreakpointManager);
-
-public:
-    BreakpointManager() = default;
-    ~BreakpointManager();
-
-    bool hasBreakpoints();
-    bool hasOneTimeBreakpoints();
-
-    Breakpoint* findBreakpoint(VirtualAddress);
-    void setBreakpoint(VirtualAddress, Breakpoint&&);
-    bool removeBreakpoint(VirtualAddress);
-    void clearAllOneTimeBreakpoints();
-    void clearAllBreakpoints();
-
-private:
-    bool removeBreakpointImpl(VirtualAddress) WTF_REQUIRES_LOCK(m_lock);
-
-    mutable Lock m_lock;
-    UncheckedKeyHashMap<VirtualAddress, Breakpoint> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashSet<VirtualAddress> m_oneTimeBreakpoints WTF_GUARDED_BY_LOCK(m_lock);
-};
-
-} // namespace Wasm
-} // namespace JSC
+namespace ExecutionHandlerTest {
+extern bool doneTesting;
+}
 
 #endif // ENABLE(WEBASSEMBLY)
+
+/* Returns the number of failures encountered. If all tests passed,
+   0 will be returned. */
+int testExecutionHandler();

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExecutionHandlerTestSupport.h"
+
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
+
+#include "Completion.h"
+#include "Exception.h"
+#include "ExecutionHandlerTest.h"
+#include "Identifier.h"
+#include "JSCJSValue.h"
+#include "JSCJSValueInlines.h"
+#include "JSFunction.h"
+#include "JSGlobalObject.h"
+#include "JSLock.h"
+#include "JSObject.h"
+#include "Options.h"
+#include "SourceCode.h"
+#include "SourceOrigin.h"
+#include "Structure.h"
+#include "StructureInlines.h"
+#include "TestScripts.h"
+#include "VM.h"
+#include "WasmDebugServer.h"
+#include "WasmExecutionHandler.h"
+#include <wtf/Condition.h>
+#include <wtf/DataLog.h>
+#include <wtf/Lock.h>
+#include <wtf/MainThread.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/NakedPtr.h>
+#include <wtf/SentinelLinkedList.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
+#include <wtf/URL.h>
+
+namespace ExecutionHandlerTestSupport {
+
+using JSC::Options;
+using JSC::VM;
+using JSC::Wasm::DebugServer;
+using JSC::Wasm::ExecutionHandler;
+
+std::atomic<unsigned> replyCount { 0 };
+
+// ========== Worker/Workers classes (duplicated from jsc.cpp) ==========
+// These are essential for proper VM tracking and $.agent.start() support
+
+class Worker;
+
+class Workers {
+    WTF_MAKE_TZONE_ALLOCATED(Workers);
+    WTF_MAKE_NONCOPYABLE(Workers);
+
+public:
+    Workers() = default;
+    ~Workers() = default;
+
+    static Workers& singleton()
+    {
+        static Workers* workers = new Workers();
+        return *workers;
+    }
+
+    Lock m_lock;
+    Condition m_condition;
+    SentinelLinkedList<Worker, BasicRawSentinelNode<Worker>> m_workers;
+};
+
+class Worker : public BasicRawSentinelNode<Worker> {
+public:
+    Worker(Workers& workers, bool isMain)
+        : m_workers(workers)
+        , m_isMain(isMain)
+    {
+        Locker locker { m_workers.m_lock };
+        m_workers.m_workers.append(this);
+
+        *currentWorker() = this;
+    }
+
+    ~Worker()
+    {
+        Locker locker { m_workers.m_lock };
+        RELEASE_ASSERT(isOnList());
+        remove();
+    }
+
+    bool isMain() const { return m_isMain; }
+
+    static Worker& current()
+    {
+        return **currentWorker();
+    }
+
+private:
+    static ThreadSpecific<Worker*>& currentWorker()
+    {
+        static ThreadSpecific<Worker*>* worker;
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [] {
+            worker = new ThreadSpecific<Worker*>();
+        });
+        return *worker;
+    }
+
+    Workers& m_workers;
+    const bool m_isMain;
+};
+
+// ========== GlobalObject with $.agent.start() support ==========
+
+class TestGlobalObject;
+static JSC_DECLARE_HOST_FUNCTION(functionDollarAgentStart);
+static JSC_DECLARE_HOST_FUNCTION(functionShouldExit);
+
+class TestGlobalObject final : public JSC::JSGlobalObject {
+public:
+    using Base = JSC::JSGlobalObject;
+
+    static TestGlobalObject* create(VM& vm, JSC::Structure* structure)
+    {
+        auto* object = new (NotNull, allocateCell<TestGlobalObject>(vm)) TestGlobalObject(vm, structure);
+        object->finishCreation(vm);
+        return object;
+    }
+
+    static JSC::Structure* createStructure(VM& vm, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, nullptr, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info());
+    }
+
+    DECLARE_INFO;
+
+private:
+    TestGlobalObject(VM& vm, JSC::Structure* structure)
+        : Base(vm, structure, nullptr)
+    {
+    }
+
+    void finishCreation(VM& vm)
+    {
+        Base::finishCreation(vm);
+        JSC::JSObject* dollar = JSC::JSFinalObject::create(vm, JSC::JSFinalObject::createStructure(vm, this, objectPrototype(), 0));
+        JSC::JSObject* agent = JSC::JSFinalObject::create(vm, JSC::JSFinalObject::createStructure(vm, this, objectPrototype(), 0));
+        JSC::Identifier startId = JSC::Identifier::fromString(vm, "start"_s);
+        agent->putDirect(vm, startId, JSC::JSFunction::create(vm, this, 1, "start"_s, functionDollarAgentStart, JSC::ImplementationVisibility::Public));
+        dollar->putDirect(vm, JSC::Identifier::fromString(vm, "agent"_s), agent);
+
+        // Add shouldExit() function to $
+        JSC::Identifier shouldExitId = JSC::Identifier::fromString(vm, "shouldExit"_s);
+        dollar->putDirect(vm, shouldExitId, JSC::JSFunction::create(vm, this, 0, "shouldExit"_s, functionShouldExit, JSC::ImplementationVisibility::Public));
+
+        putDirect(vm, JSC::Identifier::fromString(vm, "$"_s), dollar);
+    }
+};
+
+using namespace JSC;
+const JSC::ClassInfo TestGlobalObject::s_info = { "TestGlobalObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TestGlobalObject) };
+
+static constexpr ASCIILiteral RWI_REPLY_PREFIX = "[RWI] Reply: "_s;
+
+// Spawns a worker thread that creates its own VM and runs the provided script.
+// Follows jsc.cpp's Worker pattern for proper VM lifecycle management.
+JSC_DEFINE_HOST_FUNCTION(functionDollarAgentStart, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (callFrame->argumentCount() < 1)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+
+    JSC::JSValue scriptValue = callFrame->argument(0);
+    String script = scriptValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
+
+    Lock didStartLock;
+    Condition didStartCondition;
+    bool didStart = false;
+
+    Thread::create("JSC Agent"_s, [script = script.isolatedCopy(), &didStartLock, &didStartCondition, &didStart] {
+        Worker worker(Workers::singleton(), false);
+        VM& workerVM = VM::create(JSC::HeapType::Large).leakRef();
+
+        {
+            JSC::JSLockHolder locker(workerVM);
+            auto* workerGlobal = TestGlobalObject::create(workerVM, TestGlobalObject::createStructure(workerVM, JSC::jsNull()));
+
+            {
+                Locker locker { didStartLock };
+                didStart = true;
+                didStartCondition.notifyOne();
+            }
+
+            JSC::SourceOrigin origin(URL({ }, "agent-worker"_s));
+            JSC::SourceCode sourceCode = JSC::makeSource(script, origin, JSC::SourceTaintedOrigin::Untainted);
+
+            NakedPtr<JSC::Exception> exception;
+            JSC::evaluate(workerGlobal, sourceCode, JSC::JSValue(), exception);
+
+            if (exception)
+                dataLogLn("Worker exception: ", exception->value().toWTFString(workerGlobal));
+        }
+
+        {
+            JSC::JSLockHolder locker(workerVM);
+            workerVM.derefSuppressingSaferCPPChecking();
+        }
+    })->detach();
+
+    {
+        Locker locker { didStartLock };
+        while (!didStart)
+            didStartCondition.wait(didStartLock);
+    }
+
+    return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+// Returns true when tests are complete and WASM threads should exit their loops
+JSC_DEFINE_HOST_FUNCTION(functionShouldExit, (JSC::JSGlobalObject*, JSC::CallFrame*))
+{
+    return JSC::JSValue::encode(JSC::jsBoolean(ExecutionHandlerTest::doneTesting));
+}
+
+// ========== Helper functions ==========
+
+bool waitForCondition(std::function<bool()> predicate, Seconds timeout)
+{
+    auto deadline = MonotonicTime::now() + timeout;
+    while (!predicate()) {
+        if (MonotonicTime::now() >= deadline)
+            return false;
+    }
+    return true;
+}
+
+void setupTestEnvironment(DebugServer*& debugServer, ExecutionHandler*& executionHandler)
+{
+    WTF::initializeMainThread();
+    Options::setOptions("--enableWasmDebugger=true");
+
+    debugServer = &DebugServer::singleton();
+    bool started = debugServer->startRWI([](const String& packet) {
+        replyCount++;
+        dataLogLnIf(verboseLogging, RWI_REPLY_PREFIX, packet);
+        return true;
+    });
+
+    RELEASE_ASSERT(started, "Failed to start DebugServer in RWI mode");
+    RELEASE_ASSERT(debugServer->isConnected(), "DebugServer not connected");
+
+    executionHandler = &debugServer->execution();
+    executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());
+
+    dataLogLnIf(verboseLogging, "DebugServer setup complete in RWI mode");
+}
+
+void workerThreadTask(const String& script)
+{
+    dataLogLnIf(verboseLogging, "Worker thread starting");
+
+    Worker worker(Workers::singleton(), false);
+    VM& vm = VM::create(JSC::HeapType::Large).leakRef();
+
+    {
+        JSC::JSLockHolder locker(vm);
+        auto* globalObject = TestGlobalObject::create(vm, TestGlobalObject::createStructure(vm, JSC::jsNull()));
+
+        dataLogLnIf(verboseLogging, "Worker thread created VM ", RawPointer(&vm), " with TestGlobalObject");
+
+        NakedPtr<JSC::Exception> exception;
+        JSC::SourceOrigin origin(URL({ }, "worker"_s));
+        JSC::SourceCode sourceCode = JSC::makeSource(script, origin, JSC::SourceTaintedOrigin::Untainted);
+
+        JSC::evaluate(globalObject, sourceCode, JSC::JSValue(), exception);
+
+        if (exception)
+            dataLogLn("ERROR: Worker thread got exception: ", exception->value().toWTFString(globalObject));
+        else
+            dataLogLnIf(verboseLogging, "Worker thread script completed normally (shouldExit() returned true)");
+    }
+
+    {
+        JSC::JSLockHolder locker(vm);
+        vm.derefSuppressingSaferCPPChecking();
+    }
+
+    dataLogLnIf(verboseLogging, "Worker thread ending");
+}
+
+} // namespace ExecutionHandlerTestSupport
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExecutionHandlerTestSupport::Workers);
+
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestScripts.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <mutex>
+#include <span>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestScripts {
+
+// WASM Module Structure:
+// - Magic + Version: 0x00-0x07
+// - Type section (0x08-0x0d): 1 function signature ([] -> [])
+// - Function section (0x0e-0x15): 5 functions (all use type 0)
+// - Export section (0x16-0x40): Exports "func1" through "func5"
+// - Code section (0x41-0x7a): Each function contains:
+//   * nop, i32.const N, drop, nop, i32.const M, drop, end
+//   (Note: All byte ranges are inclusive on both ends)
+static constexpr uint8_t wasmMultiFunctionModuleBytes[] = {
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [])
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 5 functions (all type 0)
+    0x03, 0x06, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+    // [0x16] Export section: export 5 functions
+    0x07, 0x29, 0x05,
+    // Export function 0 as "func1"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x31, 0x00, 0x00,
+    // Export function 1 as "func2"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x32, 0x00, 0x01,
+    // Export function 2 as "func3"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x33, 0x00, 0x02,
+    // Export function 3 as "func4"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x34, 0x00, 0x03,
+    // Export function 4 as "func5"
+    0x05, 0x66, 0x75, 0x6e, 0x63, 0x35, 0x00, 0x04,
+
+    // [0x41] Code section
+    0x0a, // section id=10
+    0x38, // section size=56
+    0x05, // 5 functions
+
+    // Function 0: func1 (body size=10)
+    0x0a, // [0x44] body size
+    0x00, // [0x45] 0 local declarations
+    0x01, // [0x46] nop
+    0x41, 0x0a, // [0x47] i32.const 10
+    0x1a, // [0x49] drop
+    0x01, // [0x4a] nop
+    0x41, 0x14, // [0x4b] i32.const 20
+    0x1a, // [0x4d] drop
+    0x0b, // [0x4e] end
+
+    // Function 1: func2 (body size=10)
+    0x0a, // [0x4f] body size
+    0x00, // [0x50] 0 local declarations
+    0x01, // [0x51] nop
+    0x41, 0x1e, // [0x52] i32.const 30
+    0x1a, // [0x54] drop
+    0x01, // [0x55] nop
+    0x41, 0x28, // [0x56] i32.const 40
+    0x1a, // [0x58] drop
+    0x0b, // [0x59] end
+
+    // Function 2: func3 (body size=10)
+    0x0a, // [0x5a] body size
+    0x00, // [0x5b] 0 local declarations
+    0x01, // [0x5c] nop
+    0x41, 0x32, // [0x5d] i32.const 50
+    0x1a, // [0x5f] drop
+    0x01, // [0x60] nop
+    0x41, 0x3c, // [0x61] i32.const 60
+    0x1a, // [0x63] drop
+    0x0b, // [0x64] end
+
+    // Function 3: func4 (body size=10)
+    0x0a, // [0x65] body size
+    0x00, // [0x66] 0 local declarations
+    0x01, // [0x67] nop
+    0x41, 0x46, // [0x68] i32.const 70
+    0x1a, // [0x6a] drop
+    0x01, // [0x6b] nop
+    0x41, 0x50, // [0x6c] i32.const 80
+    0x1a, // [0x6e] drop
+    0x0b, // [0x6f] end
+
+    // Function 4: func5 (body size=10)
+    0x0a, // [0x70] body size
+    0x00, // [0x71] 0 local declarations
+    0x01, // [0x72] nop
+    0x41, 0x5a, // [0x73] i32.const 90
+    0x1a, // [0x75] drop
+    0x01, // [0x76] nop
+    0x41, 0x64, // [0x77] i32.const 100
+    0x1a, // [0x79] drop
+    0x0b // [0x7a] end
+};
+
+// Helper to convert bytes to JavaScript array string
+static String wasmBytesToJSArray(std::span<const uint8_t> bytes)
+{
+    StringBuilder result;
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        if (i > 0)
+            result.append(',');
+        result.append(String::number(bytes[i]));
+    }
+    return result.toString();
+}
+
+// Multi-VM test script: creates 5 VMs (main + 4 workers) all running WASM in infinite loops
+// Each VM runs a different function from the same module.
+String multiVMSameModuleDifferentFunction()
+{
+    static String* cachedScript = nullptr;
+    static std::once_flag once;
+
+    std::call_once(once, [] {
+        cachedScript = new String(makeString(R"script(
+            // WASM module with 5 different functions
+            const wasm = new Uint8Array([)script"_s,
+                wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+            R"script(]);
+
+            const module = new WebAssembly.Module(wasm);
+            const instance = new WebAssembly.Instance(module, { });
+
+            const NUM_WORKERS = 4;
+
+            // Worker script generator - each worker runs a different function in infinite loop
+            function workerScript(workerId, funcName) {
+                return `
+                    const wasm = new Uint8Array([)script"_s,
+                        wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+                        R"script(]);
+                    const module = new WebAssembly.Module(wasm);
+                    const instance = new WebAssembly.Instance(module, { });
+
+                    // Run specified function in loop until $.shouldExit() returns true
+                    while (!$.shouldExit())
+                        instance.exports.${funcName}();
+                `;
+            }
+
+            // Start worker threads via $.agent.start()
+            const functions = ['func2', 'func3', 'func4', 'func5'];
+            for (let i = 0; i < NUM_WORKERS; i++)
+                $.agent.start(workerScript(i + 1, functions[i]));
+
+            // Main thread also runs func1 in loop until $.shouldExit() returns true
+            while (!$.shouldExit())
+                instance.exports.func1();
+        )script"_s));
+    });
+
+    return *cachedScript;
+}
+
+// Multi-VM test script: creates 5 VMs (main + 4 workers) all running WASM in infinite loops
+// All VMs run the same function (func1) from the same module.
+String multiVMSameModuleSameFunction()
+{
+    static String* cachedScript = nullptr;
+    static std::once_flag once;
+
+    std::call_once(once, [] {
+        cachedScript = new String(makeString(R"script(
+            // WASM module with 5 functions, but all VMs will run func1
+            const wasm = new Uint8Array([)script"_s,
+                wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+            R"script(]);
+
+            const module = new WebAssembly.Module(wasm);
+            const instance = new WebAssembly.Instance(module, { });
+
+            const NUM_WORKERS = 4;
+
+            // Worker script generator - all workers run the same function in loop until $.shouldExit()
+            function workerScript(workerId) {
+                return `
+                    const wasm = new Uint8Array([)script"_s,
+                        wasmBytesToJSArray(wasmMultiFunctionModuleBytes),
+                        R"script(]);
+                    const module = new WebAssembly.Module(wasm);
+                    const instance = new WebAssembly.Instance(module, { });
+
+                    // All workers run func1 in loop until $.shouldExit() returns true
+                    while (!$.shouldExit())
+                        instance.exports.func1();
+                `;
+            }
+
+            // Start worker threads via $.agent.start()
+            for (let i = 0; i < NUM_WORKERS; i++)
+                $.agent.start(workerScript(i + 1));
+
+            // Main thread also runs func1 in loop until $.shouldExit() returns true
+            while (!$.shouldExit())
+                instance.exports.func1();
+        )script"_s));
+    });
+
+    return *cachedScript;
+}
+
+// ========== Test Script Registry ==========
+
+static const TestScript allScripts[] = {
+    {
+        .name = "MultiVMSameModuleDifferentFunction"_s,
+        .description = "5 VMs (1 main + 4 workers) running different WASM functions from same module"_s,
+        .scriptGenerator = multiVMSameModuleDifferentFunction,
+        .expectedVMs = 5,
+        .expectedFunctions = 5
+    },
+    {
+        .name = "MultiVMSameModuleSameFunction"_s,
+        .description = "5 VMs (1 main + 4 workers) all running same WASM function"_s,
+        .scriptGenerator = multiVMSameModuleSameFunction,
+        .expectedVMs = 5,
+        .expectedFunctions = 5
+    },
+};
+
+std::span<const TestScript> getTestScripts()
+{
+    return std::span(allScripts);
+}
+
+} // namespace TestScripts
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestScripts.h
@@ -27,43 +27,29 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "WasmDebugServerUtilities.h"
-#include "WasmVirtualAddress.h"
+#include <span>
 #include <wtf/Forward.h>
-#include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
-#include <wtf/Lock.h>
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/Seconds.h>
+#include <wtf/text/ASCIILiteral.h>
 
-namespace JSC {
-namespace Wasm {
+namespace TestScripts {
 
-class JS_EXPORT_PRIVATE BreakpointManager {
-    WTF_MAKE_TZONE_ALLOCATED(BreakpointManager);
-
-public:
-    BreakpointManager() = default;
-    ~BreakpointManager();
-
-    bool hasBreakpoints();
-    bool hasOneTimeBreakpoints();
-
-    Breakpoint* findBreakpoint(VirtualAddress);
-    void setBreakpoint(VirtualAddress, Breakpoint&&);
-    bool removeBreakpoint(VirtualAddress);
-    void clearAllOneTimeBreakpoints();
-    void clearAllBreakpoints();
-
-private:
-    bool removeBreakpointImpl(VirtualAddress) WTF_REQUIRES_LOCK(m_lock);
-
-    mutable Lock m_lock;
-    UncheckedKeyHashMap<VirtualAddress, Breakpoint> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashSet<VirtualAddress> m_oneTimeBreakpoints WTF_GUARDED_BY_LOCK(m_lock);
+// Test script metadata
+struct TestScript {
+    ASCIILiteral name;
+    ASCIILiteral description;
+    String (*scriptGenerator)(); // Function pointer to generate script
+    unsigned expectedVMs;
+    unsigned expectedFunctions; // For breakpoint tests
 };
 
-} // namespace Wasm
-} // namespace JSC
+// Script generators
+String multiVMSameModuleDifferentFunction();
+String multiVMSameModuleSameFunction();
+
+// Get all registered test scripts
+std::span<const TestScript> getTestScripts();
+
+} // namespace TestScripts
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.cpp
@@ -459,7 +459,7 @@ bool SourceModule::parseAndVerifyDebugInfo(OpcodeType expectedOpcode, std::initi
 template bool SourceModule::parseAndVerifyDebugInfo(JSC::Wasm::OpType, std::initializer_list<std::pair<uint32_t, std::initializer_list<uint32_t>>>) const;
 template bool SourceModule::parseAndVerifyDebugInfo(JSC::Wasm::ExtGCOpType, std::initializer_list<std::pair<uint32_t, std::initializer_list<uint32_t>>>) const;
 
-static int test()
+UNUSED_FUNCTION static int test()
 {
     dataLogLn("Starting WASM Debug Info Test Suite");
     dataLogLn("===============================================");
@@ -506,7 +506,12 @@ static int test()
 
 int testWasmDebugInfo()
 {
+#if !CPU(ARM64)
+    dataLogLn("WASM Debug Info Tests SKIPPED (only supported on ARM64)");
+    return 0;
+#else
     return WasmDebugInfoTest::test();
+#endif
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -181,6 +181,9 @@ JSWebAssemblyInstance::~JSWebAssemblyInstance()
         m_anchor->tearDown();
         m_anchor = nullptr;
     }
+
+    if (Options::enableWasmDebugger()) [[unlikely]]
+        Wasm::DebugServer::singleton().untrackInstance(this);
 }
 
 void JSWebAssemblyInstance::destroy(JSCell* cell)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -734,13 +734,11 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
 #if ENABLE(REMOTE_INSPECTOR) && ENABLE(WEBASSEMBLY)
     if (JSC::Options::enableWasmDebugger()) [[unlikely]] {
-        if (JSC::VM* vm = WebCore::commonVMOrNull()) {
-            bool success = JSC::Wasm::DebugServer::singleton().startRWI(vm, [](const String& response) {
-                return WebKit::WebProcess::singleton().send(Messages::WebProcessProxy::SendWasmDebuggerResponse(response), 0);
-            });
-            if (!success)
-                WEBPROCESS_RELEASE_LOG_ERROR(Inspector, "Failed to start WasmDebugServer in RWI mode");
-        }
+        bool success = JSC::Wasm::DebugServer::singleton().startRWI([](const String& response) {
+            return WebKit::WebProcess::singleton().send(Messages::WebProcessProxy::SendWasmDebuggerResponse(response), 0);
+        });
+        if (!success)
+            WEBPROCESS_RELEASE_LOG_ERROR(Inspector, "Failed to start WasmDebugServer in RWI mode");
     }
 #endif
 


### PR DESCRIPTION
#### e51159c6bbedb25e0e9eeb217917dce4eb7bf327
<pre>
[JSC][Wasm][Debugger] Implement multi-VM stop-the-world debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=302699">https://bugs.webkit.org/show_bug.cgi?id=302699</a>
<a href="https://rdar.apple.com/164945623">rdar://164945623</a>

Reviewed by Keith Miller.

Implements comprehensive multi-VM stop-the-world Wasm debugger that stops ALL VMs
in the process when any VM hits a breakpoint or receives an interrupt.

Architecture:

* VMManager world modes coordinate multi-VM execution:
    - Running: Normal execution (all VMs running).
    - Stopped: All VMs paused at safe points for inspection.
    - RunOne: Single-step mode (target VM runs, others stopped).

* Two-phase callback system:
    - wasmDebuggerOnStop(): VMManager calls with ALL VMs stopped; returns resume mode.
    - wasmDebuggerOnResume(): VMManager calls after ALL VMs resume; releases barriers.

* Per-VM DebugState tracks execution state:
    - Running vs Stopped with stop reason (Prologue/Breakpoint/SystemCall).
    - StopData snapshot: PC, locals, stack, call frame for inspection.
    - Step-into event flags for cross-function stepping (call/throw).

* ExecutionHandler bridges LLDB commands to VM execution:
    - Detailed design in Debugger-Mutator-Protocol.md.
    - Two condition variables orchestrate debugger-mutator communication.
    - State machine (Replied/InterruptRequested/ContinueRequested/StepRequested/SwitchRequested).
    - Resume barrier prevents overlapping stop-the-world operations.
    - Target VM selection: prefers VM at prologue, falls back to triggering VM.

* Step-into design minimizes runtime changes:
    - step() sets event flag instead of resolving callee/handler immediately
    - Runtime resolves target naturally during execution (call dispatch, exception unwinding)
    - Callback sets breakpoint using resolved target, avoiding duplicate resolution logic
    - Reuses existing runtime mechanisms rather than duplicating complex resolution in debugger

Testing:

* Unit tests: ExecutionHandlerTest validates coordination logic.
* Integration tests: multi-vm test cases for same/different modules and functions.

Note that the WebAssembly debugger currently supports ARM64 platforms only.

Canonical link: <a href="https://commits.webkit.org/305160@main">https://commits.webkit.org/305160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/442f46edfb04c7829905391b93c2a5a2ce3f4bee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137622 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90595 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0cbb05b4-618d-4dcc-a747-378a438118ef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105259 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86113 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1f5b781d-04e6-44b9-a6be-c016a778d281) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7568 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5291 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5963 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129583 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148147 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136143 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113641 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113984 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7497 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64329 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9714 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37626 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168892 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73279 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44060 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9654 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->