### PR TITLE
Propagate user gesture scope through promise microtasks for fetch #54143

### DIFF
--- a/LayoutTests/fast/events/popup-forwarded-gesture-fetch-expected.txt
+++ b/LayoutTests/fast/events/popup-forwarded-gesture-fetch-expected.txt
@@ -1,0 +1,4 @@
+Test that a user gesture is forwarded through fetch() promise chains, allowing popups to open when the async operation completes.
+
+Click Here
+PASSED: popup allowed

--- a/LayoutTests/fast/events/popup-forwarded-gesture-fetch.html
+++ b/LayoutTests/fast/events/popup-forwarded-gesture-fetch.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+        <script src="../../imported/w3c/web-platform-tests/resources/testdriver-actions.js"></script>
+        <script src="../../resources/testdriver-vendor.js"></script>
+    </head>
+    <body>
+        <p>
+            Test that a user gesture is forwarded through fetch() promise chains,
+            allowing popups to open when the async operation completes.
+        </p>
+        <button id="button" onclick="fetchAndPopup()">Click Here</button>
+        <div id="console"></div>
+        <script>
+            function fetchAndPopup() {
+                fetch('data:text/plain,test')
+                    .then(() => {
+                        let win = window.open("about:blank", "window");
+                        if (!win)
+                            document.getElementById("console").innerText = "FAILED: popup blocked";
+                        else {
+                            document.getElementById("console").innerText = "PASSED: popup allowed";
+                            win.close();
+                        }
+                        if (window.testRunner)
+                            testRunner.notifyDone();
+                    });
+            }
+
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                testRunner.waitUntilDone();
+            }
+
+            const button = document.getElementById("button");
+            test_driver.click(button);
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -66,7 +66,7 @@ static void doFetch(ScriptExecutionContext& scope, FetchRequest::Info&& input, F
                 promise.settle(WTFMove(result));
                 return;
             }
-            UserGestureIndicator gestureIndicator(userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::ShouldPropagateToMicroTask::Yes);
+            UserGestureIndicator gestureIndicator(userGestureToken, userGestureToken->scope(), UserGestureToken::ShouldPropagateToMicroTask::Yes);
             promise.settle(WTFMove(result));
         });
     }, cachedResourceRequestInitiatorTypes().fetch);

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -264,7 +264,7 @@ public:
     {
         auto runnability = currentRunnability();
         if (runnability == JSC::QueuedTask::Result::Executed) {
-            UserGestureIndicator gestureIndicator(m_userGestureToken.ptr(), UserGestureToken::GestureScope::MediaOnly, UserGestureToken::ShouldPropagateToMicroTask::Yes);
+            UserGestureIndicator gestureIndicator(m_userGestureToken.ptr(), m_userGestureToken->scope(), UserGestureToken::ShouldPropagateToMicroTask::Yes);
             JSExecState::runTaskWithDebugger(task.globalObject(), task);
         }
         return runnability;

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -88,6 +88,7 @@ public:
     enum class GestureScope { All, MediaOnly };
     void setScope(GestureScope scope) { m_scope = scope; }
     void resetScope() { m_scope = GestureScope::All; }
+    GestureScope scope() const { return m_scope; }
 
     // Expand the following methods if more propagation sources are added later.
     enum class ShouldPropagateToMicroTask : bool { No, Yes };


### PR DESCRIPTION
#### a65fcfd58f654367419cbde0de9901fd940c7bce
<pre>
Propagate user gesture scope through promise microtasks for fetch #54143
<a href="https://bugs.webkit.org/show_bug.cgi?id=302803">https://bugs.webkit.org/show_bug.cgi?id=302803</a>
<a href="https://rdar.apple.com/157791649">rdar://157791649</a>

Reviewed by Brent Fulgham.

We already forward user gestures but we hardcode its scope to GestureScope::MediaOnly.
LocalDOMWindow::allowPopUp depends on UserGestureIndicator::processingUserGesture(),
which returns false if the user gesture scope is not GestureScope::All.

Instead of hardcoding the gesture&apos;s scope to ::MediaOnly when forwarding, we can
pass whatever its original scope is.

Test: fast/events/popup-forwarded-gesture-fetch.html

* LayoutTests/fast/events/popup-forwarded-gesture-fetch-expected.txt: Added.
* LayoutTests/fast/events/popup-forwarded-gesture-fetch.html: Added.
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
(WebCore::doFetch):
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
* Source/WebCore/dom/UserGestureIndicator.h:
(WebCore::UserGestureToken::scope const):

Canonical link: <a href="https://commits.webkit.org/303733@main">https://commits.webkit.org/303733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4343110cb6f661d38b8efab24d5b33232e1045e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141001 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cfd0563c-ebbc-4105-b687-2fa899e98816) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102081 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ca47a6c5-0e6e-4a37-adfb-53f80e3da651) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82877 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c3ebdcc0-c75d-4df3-9eb1-82c3c5a35fa7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2051 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143647 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5616 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110456 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110639 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28044 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4318 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59366 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5671 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34199 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5517 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->