### PR TITLE
Swift version check is incorrect

### DIFF
--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -202,10 +202,16 @@ static bool swiftCompilerSupportsWebGPU()
         return false;
 
     auto clangVersion = *maybeClangVersion;
-    if (clangVersion[0] == 1700 && clangVersion[1] >= 6 && clangVersion[2] >= 1 && clangVersion[3] >= 1)
+    if (clangVersion[0] == 1700
+        && clangVersion[1] >= 6
+        && (clangVersion[1] > 6 || clangVersion[2] >= 1)
+        && (clangVersion[1] > 6 || clangVersion[2] > 1 || clangVersion[3] >= 1))
         return true;
 
-    if (clangVersion[0] == 2100 && clangVersion[1] >= 0 && clangVersion[2] >= 101 && clangVersion[3] >= 15)
+    if (clangVersion[0] == 2100
+        && clangVersion[1] >= 0
+        && (clangVersion[1] > 0 || clangVersion[2] >= 101)
+        && (clangVersion[1] > 0 || clangVersion[2] > 101 || clangVersion[3] >= 15))
         return true;
 
     if (clangVersion[0] > 2100)


### PR DESCRIPTION
#### 75019e71b331a1de6d6af9da5e99233bc35c1ea1
<pre>
Swift version check is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=302748">https://bugs.webkit.org/show_bug.cgi?id=302748</a>
<a href="https://rdar.apple.com/165008184">rdar://165008184</a>

Reviewed by Geoffrey Garen.

We can not simply say:

  A == B &amp;&amp; C &gt;= D &amp;&amp; E &gt;= F...

counter-example:
  C=100, D=99, E=0, and F=1

fails but we expected it to pass

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::swiftCompilerSupportsWebGPU):

Canonical link: <a href="https://commits.webkit.org/303227@main">https://commits.webkit.org/303227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0315e20984300c7e5ad3fe69628e48c5ef9423ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139261 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100705 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134698 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/2997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81486 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82483 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111616 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141907 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3913 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109075 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3994 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109236 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2978 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57123 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3967 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32693 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3799 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67414 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->