### PR TITLE
Use C++20 std::ranges::sort in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -3869,9 +3869,7 @@ public:
 
     Vector<LinkRecord, 0, UnsafeVectorOverflow>& jumpsToLink()
     {
-        std::sort(m_jumpsToLink.begin(), m_jumpsToLink.end(), [](auto& a, auto& b) {
-            return a.from() < b.from();
-        });
+        std::ranges::sort(m_jumpsToLink, { }, &LinkRecord::from);
         return m_jumpsToLink;
     }
 

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -2638,9 +2638,7 @@ public:
     
     Vector<LinkRecord, 0, UnsafeVectorOverflow>& jumpsToLink()
     {
-        std::sort(m_jumpsToLink.begin(), m_jumpsToLink.end(), [](auto& a, auto& b) {
-            return a.from() < b.from();
-        });
+        std::ranges::sort(m_jumpsToLink, { }, &LinkRecord::from);
         return m_jumpsToLink;
     }
 

--- a/Source/JavaScriptCore/b3/B3InferSwitches.cpp
+++ b/Source/JavaScriptCore/b3/B3InferSwitches.cpp
@@ -215,7 +215,7 @@ private:
             switchValue->appendCase(switchCase);
             predecessorCases.append(switchCase.caseValue());
         }
-        std::sort(predecessorCases.begin(), predecessorCases.end());
+        std::ranges::sort(predecessorCases);
         auto isPredecessorCase = [&] (int64_t value) -> bool {
             return !!tryBinarySearch<int64_t>(
                 predecessorCases, predecessorCases.size(), value,

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -287,11 +287,9 @@ private:
                 Vector<SwitchCase> cases;
                 for (SwitchCase switchCase : switchValue->cases(m_block))
                     cases.append(switchCase);
-                std::sort(
-                    cases.begin(), cases.end(),
-                    [] (const SwitchCase& left, const SwitchCase& right) {
-                        return left.caseValue() < right.caseValue();
-                    });
+                std::ranges::sort(cases, [](const auto& left, const auto& right) {
+                    return left.caseValue() < right.caseValue();
+                });
                 FrequentedBlock fallThrough = m_block->fallThrough();
                 m_block->values().removeLast();
                 recursivelyBuildSwitch(cases, fallThrough, 0, false, cases.size(), m_block);

--- a/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
+++ b/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
@@ -191,7 +191,7 @@ bool OptimizeAssociativeExpressionTrees::optimizeRootedTree(Value* root, Inserti
         return false;
     }
 
-    std::sort(leaves.begin(), leaves.end(), [](Value* x, Value* y) {
+    std::ranges::sort(leaves, [](auto* x, auto* y) {
         return x->index() < y->index();
     });
     Vector<Value*, 4> optLeaves;

--- a/Source/JavaScriptCore/b3/B3UseCounts.cpp
+++ b/Source/JavaScriptCore/b3/B3UseCounts.cpp
@@ -43,7 +43,7 @@ UseCounts::UseCounts(Procedure& procedure)
             m_counts[child].numUses++;
             children.append(child);
         }
-        std::sort(children.begin(), children.end());
+        std::ranges::sort(children);
         Value* last = nullptr;
         for (Value* child : children) {
             if (child == last)

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -881,7 +881,7 @@ public:
                 
                 // Check that there are no duplicate cases.
                 Vector<int64_t> caseValues = value->as<SwitchValue>()->caseValues();
-                std::sort(caseValues.begin(), caseValues.end());
+                std::ranges::sort(caseValues);
                 for (unsigned i = 1; i < caseValues.size(); ++i)
                     VALIDATE(caseValues[i - 1] != caseValues[i], ("At ", *value, ", caseValue = ", caseValues[i]));
                 break;

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
@@ -300,11 +300,9 @@ private:
             }
         }
 
-        std::sort(
-            m_clobbers.begin(), m_clobbers.end(),
-            [] (Clobber& a, Clobber& b) -> bool {
-                return a.index < b.index;
-            });
+        std::ranges::sort(m_clobbers, [](auto& a, auto& b) {
+            return a.index < b.index;
+        });
 
         if (verbose()) {
             dataLog("Intervals:\n");
@@ -369,11 +367,9 @@ private:
                 m_tmps.append(tmp);
             });
 
-        std::sort(
-            m_tmps.begin(), m_tmps.end(),
-            [&] (Tmp& a, Tmp& b) {
-                return m_map[a].interval.begin() < m_map[b].interval.begin();
-            });
+        std::ranges::sort(m_tmps, [&](auto& a, auto& b) {
+            return m_map[a].interval.begin() < m_map[b].interval.begin();
+        });
 
         if (verbose())
             dataLog("Tmps: ", listDump(m_tmps), "\n");

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1164,8 +1164,7 @@ private:
         m_code.forEachTmp<bank>([&](Tmp tmp) {
             ASSERT(!tmp.isReg());
             TmpData& data = m_map[tmp];
-            std::sort(data.coalescables.begin(), data.coalescables.end(),
-                [this] (const auto& a, const auto& b) -> bool {
+            std::ranges::sort(data.coalescables, [this](const auto& a, const auto& b) {
                     if (a.moveCost != b.moveCost)
                         return a.moveCost > b.moveCost;
                     // Favor coalescing shorter live ranges.
@@ -1181,15 +1180,14 @@ private:
             }
         });
 
-        std::sort(moves.begin(), moves.end(),
-            [](Move& a, Move& b) -> bool {
+        std::ranges::sort(moves, [](auto& a, auto& b) {
                 if (a.cost != b.cost)
                     return a.cost > b.cost;
                 if (a.tmp0.tmpIndex(bank) != b.tmp1.tmpIndex(bank))
                     return a.tmp0.tmpIndex(bank) < a.tmp0.tmpIndex(bank);
                 ASSERT(a.tmp1.tmpIndex(bank) != b.tmp1.tmpIndex(bank));
                 return a.tmp1.tmpIndex(bank) < b.tmp1.tmpIndex(bank);
-            });
+        });
 
         auto hasConflict = [this, &worklist0, &worklist1](Tmp group0, Tmp group1) {
             bool conflicts = false;

--- a/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
@@ -246,11 +246,9 @@ public:
         }
 
         // Now try to coalesce some moves.
-        std::sort(
-            m_coalescableMoves.begin(), m_coalescableMoves.end(),
-            [&] (CoalescableMove& a, CoalescableMove& b) -> bool {
-                return a.frequency > b.frequency;
-            });
+        std::ranges::sort(m_coalescableMoves, [&](auto& a, auto& b) {
+            return a.frequency > b.frequency;
+        });
 
         for (const CoalescableMove& move : m_coalescableMoves) {
             IndexType slotToKill = remap(move.src);

--- a/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
+++ b/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
@@ -577,13 +577,13 @@ private:
 
         void sort()
         {
-            std::sort(regConst.begin(), regConst.end(), [] (const RegConst& a, const RegConst& b) {
+            std::ranges::sort(regConst, [](const auto& a, const auto& b) {
                 return a < b;
             });
-            std::sort(slotConst.begin(), slotConst.end(), [] (const SlotConst& a, const SlotConst& b) {
+            std::ranges::sort(slotConst, [](const auto& a, const auto& b) {
                 return a < b;
             });
-            std::sort(regSlot.begin(), regSlot.end(), [] (const RegSlot& a, const RegSlot& b) {
+            std::ranges::sort(regSlot, [](const auto& a, const auto& b) {
                 return a < b;
             });
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -182,11 +182,9 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
         
         RELEASE_ASSERT(edges.size());
         
-        std::sort(
-            edges.begin(), edges.end(),
-            [] (CallEdge a, CallEdge b) {
-                return a.count() > b.count();
-            });
+        std::ranges::sort(edges, [](auto a, auto b) {
+            return a.count() > b.count();
+        });
         RELEASE_ASSERT(edges.first().count() >= edges.last().count());
         
         double totalCallsToKnown = 0;

--- a/Source/JavaScriptCore/bytecode/PreciseJumpTargets.cpp
+++ b/Source/JavaScriptCore/bytecode/PreciseJumpTargets.cpp
@@ -67,7 +67,7 @@ void computePreciseJumpTargetsInternal(Block* codeBlock, const JSInstructionStre
         getJumpTargetsForInstruction(codeBlock, instruction, out);
     }
     
-    std::sort(out.begin(), out.end());
+    std::ranges::sort(out);
     
     // We will have duplicates, and we must remove them.
     unsigned toIndex = 0;

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
@@ -83,7 +83,7 @@ void MetadataStatistics::reportMetadataStatistics()
         opcodeIds[i] = i;
         memoryUsagePerOpcode[i] = perOpcodeCount[i] * metadataSize(static_cast<OpcodeID>(i));
     }
-    std::sort(opcodeIds.begin(), opcodeIds.end(), [&](auto a, auto b) {
+    std::ranges::sort(opcodeIds, [&](auto a, auto b) {
         return memoryUsagePerOpcode[a] > memoryUsagePerOpcode[b];
     });
     for (unsigned i = 0; i < NUMBER_OF_BYTECODE_WITH_METADATA; ++i) {

--- a/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
@@ -51,7 +51,7 @@ void DebuggerPausePositions::forEachBreakpointLocation(int startLine, int startC
                 uniquePositions.appendIfNotContains(*resolvedPosition);
         }
     }
-    std::sort(uniquePositions.begin(), uniquePositions.end(), [] (const auto& a, const auto& b) {
+    std::ranges::sort(uniquePositions, [](const auto& a, const auto& b) {
         if (a.line == b.line)
             return a.column() < b.column();
         return a.line < b.line;
@@ -145,7 +145,7 @@ std::optional<JSTextPosition> DebuggerPausePositions::breakpointLocationForLineC
 
 void DebuggerPausePositions::sort()
 {
-    std::sort(m_positions.begin(), m_positions.end(), [] (const DebuggerPausePosition& a, const DebuggerPausePosition& b) {
+    std::ranges::sort(m_positions, [](const auto& a, const auto& b) {
         if (a.position.offset == b.position.offset)
             return a.type < b.type;
         return a.position.offset < b.position.offset;

--- a/Source/JavaScriptCore/dfg/DFGCommonData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.cpp
@@ -152,8 +152,9 @@ void CommonData::validateReferences(const TrackedReferences& trackedReferences)
 
 void CommonData::finalizeCatchEntrypoints(Vector<CatchEntrypointData>&& catchEntrypoints)
 {
-    std::sort(catchEntrypoints.begin(), catchEntrypoints.end(),
-        [] (const CatchEntrypointData& a, const CatchEntrypointData& b) { return a.bytecodeIndex < b.bytecodeIndex; });
+    std::ranges::sort(catchEntrypoints, [](const auto& a, const auto& b) {
+        return a.bytecodeIndex < b.bytecodeIndex;
+    });
     ASSERT(m_catchEntrypoints.isEmpty());
     m_catchEntrypoints = WTFMove(catchEntrypoints);
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -517,7 +517,7 @@ void Graph::dumpBlockHeader(PrintStream& out, const char* prefixStr, BasicBlock*
             Vector<BlockIndex> sortedBlockList;
             for (unsigned i = 0; i < loop->size(); ++i)
                 sortedBlockList.append(unboxLoopNode(loop->at(i))->index);
-            std::sort(sortedBlockList.begin(), sortedBlockList.end());
+            std::ranges::sort(sortedBlockList);
             for (unsigned i = 0; i < sortedBlockList.size(); ++i)
                 out.print(" #", sortedBlockList[i]);
             out.print("\n");

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -426,7 +426,7 @@ void JITCode::finalizeOSREntrypoints(Vector<OSREntryData>&& osrEntry)
     auto comparator = [] (const auto& a, const auto& b) {
         return a.m_bytecodeIndex < b.m_bytecodeIndex;
     };
-    std::sort(osrEntry.begin(), osrEntry.end(), comparator);
+    std::ranges::sort(osrEntry, comparator);
 
 #if ASSERT_ENABLED
     auto verifyIsSorted = [&] (auto& osrVector) {

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -192,7 +192,7 @@ public:
             }
             loops[loopIndex] = std::tuple { &loop, depth };
         }
-        std::sort(loops.begin(), loops.end(), [&](const auto& lhs, const auto& rhs) {
+        std::ranges::sort(loops, [&](const auto& lhs, const auto& rhs) {
             return std::get<1>(lhs) > std::get<1>(rhs);
         });
         return loops;

--- a/Source/JavaScriptCore/dfg/DFGMinifiedGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMinifiedGraph.cpp
@@ -35,7 +35,7 @@ namespace JSC { namespace DFG {
 
 void MinifiedGraph::prepareAndShrink()
 {
-    std::sort(m_list.begin(), m_list.end(), MinifiedNode::compareByNodeIndex);
+    std::ranges::sort(m_list, MinifiedNode::compareByNodeIndex);
     m_list.shrinkToFit();
 }
 

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -4015,7 +4015,7 @@ CString nodeMapDump(const T& nodeMap, DumpContext* context = nullptr)
         typename T::const_iterator iter = nodeMap.begin();
         iter != nodeMap.end(); ++iter)
         keys.append(iter->key);
-    std::sort(keys.begin(), keys.end(), NodeComparator());
+    std::ranges::sort(keys, NodeComparator());
     StringPrintStream out;
     CommaPrinter comma;
     for(unsigned i = 0; i < keys.size(); ++i)
@@ -4026,9 +4026,8 @@ CString nodeMapDump(const T& nodeMap, DumpContext* context = nullptr)
 template<typename T>
 CString nodeValuePairListDump(const T& nodeValuePairList, DumpContext* context = nullptr)
 {
-    using V = typename T::ValueType;
     T sortedList = nodeValuePairList;
-    std::sort(sortedList.begin(), sortedList.end(), [](const V& a, const V& b) {
+    std::ranges::sort(sortedList, [](const auto& a, const auto& b) {
         return NodeComparator()(a.node, b.node);
     });
 

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -2804,12 +2804,9 @@ escapeChildren:
             if (structures.isEmpty())
                 return m_graph.addNode(ForceOSRExit, origin.takeValidExit(canExit));
 
-            std::sort(
-                structures.begin(),
-                structures.end(),
-                [uid] (RegisteredStructure a, RegisteredStructure b) -> bool {
-                    return a->getConcurrently(uid) < b->getConcurrently(uid);
-                });
+            std::ranges::sort(structures, [uid](auto a, auto b) {
+                return a->getConcurrently(uid) < b->getConcurrently(uid);
+            });
 
             RELEASE_ASSERT(structures.size());
             PropertyOffset firstOffset = structures[0]->getConcurrently(uid);

--- a/Source/JavaScriptCore/dfg/DFGScoreBoard.h
+++ b/Source/JavaScriptCore/dfg/DFGScoreBoard.h
@@ -55,7 +55,7 @@ public:
     
     void sortFree()
     {
-        std::sort(m_free.begin(), m_free.end());
+        std::ranges::sort(m_free);
     }
     
     void assertClear()

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierClusteringPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierClusteringPhase.cpp
@@ -133,11 +133,9 @@ private:
             if (!m_barrierPoints[nodeIndex])
                 continue;
             
-            std::sort(
-                m_neededBarriers.begin(), m_neededBarriers.end(),
-                [&] (const ChildAndOrigin& a, const ChildAndOrigin& b) -> bool {
-                    return a.child < b.child;
-                });
+            std::ranges::sort(m_neededBarriers, [&](const auto& a, const auto& b) {
+                return a.child < b.child;
+            });
             removeRepeatedElements(
                 m_neededBarriers, 
                 [&] (const ChildAndOrigin& a, const ChildAndOrigin& b) -> bool{

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -17744,7 +17744,7 @@ IGNORE_CLANG_WARNINGS_END
                 }
 
                 if (!indices.isEmpty()) {
-                    std::sort(indices.begin(), indices.end());
+                    std::ranges::sort(indices);
 
                     Vector<LBasicBlock> blocksWithStores(indices.size());
                     Vector<LBasicBlock> blocksWithChecks(indices.size());
@@ -20373,11 +20373,9 @@ IGNORE_CLANG_WARNINGS_END
         }
 
         if (structuresChecked) {
-            std::sort(
-                cases.begin(), cases.end(),
-                [&] (const SwitchCase& a, const SwitchCase& b) -> bool {
-                    return a.value()->asInt() < b.value()->asInt();
-                });
+            std::ranges::sort(cases, [&](const auto& a, const auto& b) {
+                return a.value()->asInt() < b.value()->asInt();
+            });
             SwitchCase last = cases.takeLast();
             m_out.switchInstruction(
                 m_out.load32(base, m_heaps.JSCell_structureID), cases, last.target(), Weight(0));

--- a/Source/JavaScriptCore/heap/HeapSnapshot.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.cpp
@@ -113,7 +113,7 @@ void HeapSnapshot::finalize()
         m_lastObjectIdentifier = m_nodes.last().identifier;
     }
 
-    std::sort(m_nodes.begin(), m_nodes.end(), [] (const HeapSnapshotNode& a, const HeapSnapshotNode& b) {
+    std::ranges::sort(m_nodes, [](const auto& a, const auto& b) {
         return a.cell < b.cell;
     });
 

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -559,7 +559,7 @@ void HeapSnapshotBuilder::dumpToStream(PrintStream& out)
     m_edges.shrinkToFit();
 
     // Sort edges based on from identifier.
-    std::sort(m_edges.begin(), m_edges.end(), [&] (const HeapSnapshotEdge& a, const HeapSnapshotEdge& b) {
+    std::ranges::sort(m_edges, [&](const auto& a, const auto& b) {
         return a.from.identifier < b.from.identifier;
     });
 

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
@@ -85,11 +85,9 @@ void JITStubRoutineSet::prepareForConservativeScan()
         m_range = Range<uintptr_t> { 0, 0 };
         return;
     }
-    std::sort(
-        m_routines.begin(), m_routines.end(),
-        [&] (const Routine& a, const Routine& b) {
-            return a.startAddress < b.startAddress;
-        });
+    std::ranges::sort(m_routines, [&](const auto& a, const auto& b) {
+        return a.startAddress < b.startAddress;
+    });
     m_range = Range<uintptr_t> {
         m_routines.first().startAddress,
         m_routines.last().routine->endAddress()

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -127,7 +127,7 @@ static Vector<size_t> sizeClasses()
 
     {
         // Sort and deduplicate.
-        std::sort(result.begin(), result.end());
+        std::ranges::sort(result);
         auto it = std::unique(result.begin(), result.end());
         result.shrinkCapacity(it - result.begin());
     }

--- a/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
@@ -132,9 +132,7 @@ bool MarkingConstraintSet::executeConvergenceImpl(SlotVisitor& visitor)
     // constraints before returning.
     bool isWavefrontAdvancing = this->isWavefrontAdvancing(visitor);
     
-    std::sort(
-        m_ordered.begin(), m_ordered.end(),
-        [&] (MarkingConstraint* a, MarkingConstraint* b) -> bool {
+    std::ranges::sort(m_ordered, [&](auto* a, auto* b) {
             // Remember: return true if a should come before b.
             
             auto volatilityScore = [] (MarkingConstraint* constraint) -> unsigned {

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -1010,7 +1010,7 @@ JSValue JSInjectedScriptHost::queryHolders(JSGlobalObject* globalObject, CallFra
         HeapHolderFinder holderFinder(vm.ensureHeapProfiler(), target.asCell());
 
         auto holders = copyToVector(holderFinder.holders());
-        std::sort(holders.begin(), holders.end());
+        std::ranges::sort(holders);
         for (auto* holder : holders)
             result->putDirectIndex(globalObject, result->length(), holder);
     }

--- a/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
+++ b/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
@@ -67,7 +67,7 @@ void JITSizeStatistics::dump(PrintStream& out) const
     for (auto pair : m_data)
         entries.append(std::make_pair(pair.key, pair.value));
 
-    std::sort(entries.begin(), entries.end(), [] (const auto& lhs, const auto& rhs) {
+    std::ranges::sort(entries, [](const auto& lhs, const auto& rhs) {
         return lhs.second.totalBytes > rhs.second.totalBytes;
     });
 

--- a/Source/JavaScriptCore/parser/VariableEnvironment.cpp
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.cpp
@@ -216,7 +216,7 @@ void VariableEnvironment::dump(PrintStream& out) const
 
 void CompactTDZEnvironment::sortCompact(Compact& compact)
 {
-    std::sort(compact.begin(), compact.end(), [] (auto& a, auto& b) {
+    std::ranges::sort(compact, [](auto& a, auto& b) {
         return a.get() < b.get();
     });
 }

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -872,10 +872,9 @@ static ALWAYS_INLINE std::tuple<uint64_t, IndexingType, std::span<EncodedJSValue
 static unsigned sortBucketSort(std::span<EncodedJSValue> sorted, unsigned dst, SortEntryVector& bucket, unsigned depth)
 {
     if (bucket.size() < 32 || depth > 32) {
-        std::sort(bucket.begin(), bucket.end(),
-            [](const auto& lhs, const auto& rhs) {
-                return codePointCompareLessThan(std::get<1>(lhs), std::get<1>(rhs));
-            });
+        std::ranges::sort(bucket, WTF::codePointCompareLessThan, [](const auto& element) {
+            return std::get<1>(element);
+        });
         for (auto& entry : bucket)
             sorted[dst++] = JSValue::encode(std::get<0>(entry));
         return dst;

--- a/Source/JavaScriptCore/runtime/ImportMap.cpp
+++ b/Source/JavaScriptCore/runtime/ImportMap.cpp
@@ -65,10 +65,9 @@ ImportMap::ImportMap(SpecifierMap&& imports, ScopesMap&& scopesMap, IntegrityMap
     // is code unit less than a’s key.</spec>
     ASSERT(m_scopesVector.isEmpty());
     m_scopesVector = copyToVector(m_scopesMap.keys());
-    std::sort(m_scopesVector.begin(), m_scopesVector.end(),
-        [](const URL& a, const URL& b) {
-            return codePointCompareLessThan(b.string(), a.string());
-        });
+    std::ranges::sort(m_scopesVector, [](const auto& a, const auto& b) {
+        return codePointCompareLessThan(b.string(), a.string());
+    });
 }
 
 Expected<URL, String> ImportMap::resolveImportMatch(const AtomString& normalizedSpecifier, const URL& asURL, const SpecifierMap& specifierMap)

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -692,7 +692,7 @@ static Vector<IntlNumberFormatField> flattenFields(Vector<IntlNumberFormatField>
     //     H:    (14, 15) endRange   group ","
     //     I:    (15, 18) endRange   integer
 
-    std::sort(fields.begin(), fields.end(), [](auto& lhs, auto& rhs) {
+    std::ranges::sort(fields, [](auto& lhs, auto& rhs) {
         if (lhs.m_range.begin() < rhs.m_range.begin())
             return true;
         if (lhs.m_range.begin() > rhs.m_range.begin())

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1717,10 +1717,7 @@ static JSArray* availableCollations(JSGlobalObject* globalObject)
 
     // The AvailableCollations abstract operation returns a List, ordered as if an Array of the same
     // values had been sorted using %Array.prototype.sort% using undefined as comparator
-    std::sort(elements.begin(), elements.end(),
-        [](const String& a, const String& b) {
-            return WTF::codePointCompare(a, b) < 0;
-        });
+    std::ranges::sort(elements, WTF::codePointCompareLessThan);
     auto end = std::unique(elements.begin(), elements.end());
     elements.shrink(elements.size() - (elements.end() - end));
 
@@ -1773,10 +1770,7 @@ static JSArray* availableCurrencies(JSGlobalObject* globalObject)
 
     // The AvailableCurrencies abstract operation returns a List, ordered as if an Array of the same
     // values had been sorted using %Array.prototype.sort% using undefined as comparator
-    std::sort(elements.begin(), elements.end(),
-        [](const String& a, const String& b) {
-            return WTF::codePointCompare(a, b) < 0;
-        });
+    std::ranges::sort(elements, WTF::codePointCompareLessThan);
     auto end = std::unique(elements.begin(), elements.end());
     elements.shrink(elements.size() - (elements.end() - end));
 
@@ -1823,10 +1817,7 @@ static JSArray* availableNumberingSystems(JSGlobalObject* globalObject)
 
     // The AvailableNumberingSystems abstract operation returns a List, ordered as if an Array of the same
     // values had been sorted using %Array.prototype.sort% using undefined as comprator
-    std::sort(elements.begin(), elements.end(),
-        [](const String& a, const String& b) {
-            return WTF::codePointCompare(a, b) < 0;
-        });
+    std::ranges::sort(elements, WTF::codePointCompareLessThan);
 
     RELEASE_AND_RETURN(scope, createArrayFromStringVector(globalObject, WTFMove(elements)));
 }
@@ -1881,10 +1872,7 @@ const Vector<String>& intlAvailableTimeZones()
 
         // The AvailableTimeZones abstract operation returns a List, ordered as if an Array of the same
         // values had been sorted using %Array.prototype.sort% using undefined as comparator
-        std::sort(temporary.begin(), temporary.end(),
-            [](const String& a, const String& b) {
-                return WTF::codePointCompare(a, b) < 0;
-            });
+        std::ranges::sort(temporary, WTF::codePointCompareLessThan);
         auto end = std::unique(temporary.begin(), temporary.end());
         availableTimeZones.construct();
 

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -53,8 +53,8 @@ void JSModuleNamespaceObject::finishCreation(JSGlobalObject* globalObject, Abstr
     //     The list is ordered as if an Array of those String values had been sorted using Array.prototype.sort using SortCompare as comparator.
     //
     // Sort the exported names by the code point order.
-    std::sort(resolutions.begin(), resolutions.end(), [](const auto& lhs, const auto& rhs) {
-        return codePointCompare(lhs.first.impl(), rhs.first.impl()) < 0;
+    std::ranges::sort(resolutions, WTF::codePointCompareLessThan, [](const auto& resolution) {
+        return resolution.first.impl();
     });
 
     m_moduleRecord.set(vm, this, moduleRecord);

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -770,7 +770,7 @@ static void logOutcomeImpl(String&& outcome)
         Vector<KeyValuePair<String, unsigned>> vector;
         for (auto& pair : set.get())
             vector.append(pair);
-        std::sort(vector.begin(), vector.end(), [](auto& a, auto &b) {
+        std::ranges::sort(vector, [](auto& a, auto &b) {
             return a.value != b.value ? a.value > b.value : codePointCompareLessThan(a.key, b.key);
         });
         dataLogLn("fastStringify outcomes");

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2775,7 +2775,7 @@ void JSObject::getOwnIndexedPropertyNames(JSGlobalObject*, PropertyNameArrayBuil
                     return std::nullopt;
                 });
                 
-                std::sort(keys.begin(), keys.end());
+                std::ranges::sort(keys);
                 for (unsigned i = 0; i < keys.size(); ++i)
                     propertyNames.add(keys[i]);
             }

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -1032,7 +1032,7 @@ void JSObject::forEachOwnIndexedProperty(JSGlobalObject* globalObject, const Fun
                     }
                 }
 
-                std::sort(propertyAndValueIndexTuples.begin(), propertyAndValueIndexTuples.end(), [](auto a, auto b) {
+                std::ranges::sort(propertyAndValueIndexTuples, [](auto a, auto b) {
                     return std::get<0>(a) < std::get<0>(b);
                 });
                 for (size_t i = 0; i < propertyAndValueIndexTuples.size(); ++i) {

--- a/Source/JavaScriptCore/wasm/WasmMergedProfile.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMergedProfile.cpp
@@ -119,10 +119,9 @@ auto MergedProfile::Candidates::finalize() const -> Candidates
     Candidates result(*this);
     unsigned totalCount = 0;
     auto mutableSpan = std::span { result.m_callees }.first(result.m_size);
-    std::sort(mutableSpan.begin(), mutableSpan.end(),
-        [&](const auto& lhs, const auto& rhs) {
-            return std::get<1>(lhs) > std::get<1>(rhs);
-        });
+    std::ranges::sort(mutableSpan, [&](const auto& lhs, const auto& rhs) {
+        return std::get<1>(lhs) > std::get<1>(rhs);
+    });
     for (auto& [callee, count] : mutableSpan)
         totalCount += count;
     result.m_totalCount = totalCount;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -5793,11 +5793,9 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     });
     JIT_COMMENT(jit, "ReturnPC has srcOffset ", fpOffsetToSPOffset(CallFrame::returnPCOffset()), " dstOffset ", newReturnPCOffset);
 
-    std::sort(
-        argsToMove.begin(), argsToMove.end(),
-        [] (const auto& left, const auto& right) {
-            return std::get<0>(left) > std::get<0>(right);
-        });
+    std::ranges::sort(argsToMove, [](const auto& left, const auto& right) {
+        return std::get<0>(left) > std::get<0>(right);
+    });
 
     for (unsigned i = 0; i < argsToMove.size(); ++i) {
         auto [srcOffset, dstOffset, width] = argsToMove[i];

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -6007,11 +6007,9 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
             argsToMove.append({ stackPatchArgSpill[i], fpOffsetToSPOffset(tailCallPatchpointScratchOffsets[i] + newFPOffsetFromFP), WidthPtr });
     }
 
-    std::sort(
-        argsToMove.begin(), argsToMove.end(),
-        [] (const auto& left, const auto& right) {
-            return std::get<0>(left) > std::get<0>(right);
-        });
+    std::ranges::sort(argsToMove, [](const auto& left, const auto& right) {
+        return std::get<0>(left) > std::get<0>(right);
+    });
 
     for (unsigned i = 0; i < argsToMove.size(); ++i) {
         auto [srcOffset, dstOffset, width] = argsToMove[i];

--- a/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
@@ -74,7 +74,7 @@ void WasmOpcodeCounter::dump(Atomic<uint64_t>* counter, NumberOfRegisteredOpcode
         vector.append({ (OpcodeType)i, count });
     }
 
-    std::sort(vector.begin(), vector.end(), [](Pair& a, Pair& b) {
+    std::ranges::sort(vector, [](auto& a, auto& b) {
         return b.count < a.count;
     });
 

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.cpp
@@ -377,7 +377,7 @@ static bool parseAndVerifyDebugInfoImpl(JSC::VM* vm, const SourceModule& sourceM
         Vector<uint32_t> relative;
         for (uint32_t abs : absSet)
             relative.append(abs - sourceModule.bytecodeStart);
-        std::sort(relative.begin(), relative.end());
+        std::ranges::sort(relative);
         return relative;
     };
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1002,10 +1002,10 @@ class YarrGenerator final : public YarrJITInfo {
             return lhs.begin < rhs.begin;
         }));
 
-        std::sort(unifiedMatches.begin(), unifiedMatches.end(), [](auto& lhs, auto& rhs) {
+        std::ranges::sort(unifiedMatches, [](auto& lhs, auto& rhs) {
             return lhs < rhs;
         });
-        std::sort(unifiedRanges.begin(), unifiedRanges.end(), [](auto& lhs, auto& rhs) {
+        std::ranges::sort(unifiedRanges, [](auto& lhs, auto& rhs) {
             return lhs.begin < rhs.begin;
         });
 
@@ -4555,7 +4555,7 @@ class YarrGenerator final : public YarrJITInfo {
                     PatternDisjunction* nestedDisjunction = term->parentheses.disjunction;
                     nestedDisjunction->m_alternatives.last()->m_isLastAlternative = false;
 
-                    std::sort(nestedDisjunction->m_alternatives.begin(), nestedDisjunction->m_alternatives.end(), [](auto& l, auto& r) -> bool {
+                    std::ranges::sort(nestedDisjunction->m_alternatives, [](auto& l, auto& r) {
                         return l->m_terms.size() > r->m_terms.size();
                     });
                     nestedDisjunction->m_alternatives.last()->m_isLastAlternative = true;

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -419,7 +419,7 @@ public:
         // Sort the incoming Unicode matches, since Unicode case folding canonicalization may cause
         // characters to be added to rhsMatches out of code point order.
         Vector<char32_t> rhsSortedMatchesUnicode(rhsMatchesUnicode);
-        std::sort(rhsSortedMatchesUnicode.begin(), rhsSortedMatchesUnicode.end());
+        std::ranges::sort(rhsSortedMatchesUnicode);
 
         unicodeOpSorted(rhsSortedMatchesUnicode, rhsRangesUnicode);
     }
@@ -449,10 +449,9 @@ public:
 
     static void sort(Vector<Vector<char32_t>>& utf32Strings)
     {
-        std::sort(utf32Strings.begin(), utf32Strings.end(), [](const Vector<char32_t>& a, const Vector<char32_t>& b)
-            {
-                return compareUTF32Strings(a, b) < 0;
-            });
+        std::ranges::sort(utf32Strings, [](const auto& a, const auto& b) {
+            return compareUTF32Strings(a, b) < 0;
+        });
     }
 
     std::unique_ptr<CharacterClass> charClass()


### PR DESCRIPTION
#### 38a918f22e55503276704745b0cc0b1278d96b42
<pre>
Use C++20 std::ranges::sort in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=302761">https://bugs.webkit.org/show_bug.cgi?id=302761</a>
<a href="https://rdar.apple.com/165017405">rdar://165017405</a>

Reviewed by Sam Weinig.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::jumpsToLink):
* Source/JavaScriptCore/b3/B3InferSwitches.cpp:
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp:
(JSC::B3::OptimizeAssociativeExpressionTrees::optimizeRootedTree):
* Source/JavaScriptCore/b3/B3UseCounts.cpp:
(JSC::B3::UseCounts::UseCounts):
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::finalizeGroups):
* Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp:
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::computeFromCallLinkInfo):
* Source/JavaScriptCore/bytecode/PreciseJumpTargets.cpp:
(JSC::computePreciseJumpTargetsInternal):
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp:
(JSC::MetadataStatistics::reportMetadataStatistics):
* Source/JavaScriptCore/debugger/DebuggerParseData.cpp:
(JSC::DebuggerPausePositions::forEachBreakpointLocation):
(JSC::DebuggerPausePositions::sort):
* Source/JavaScriptCore/dfg/DFGCommonData.cpp:
(JSC::DFG::CommonData::finalizeCatchEntrypoints):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dumpBlockHeader):
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITCode::finalizeOSREntrypoints):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::populateCandidateLoops):
* Source/JavaScriptCore/dfg/DFGMinifiedGraph.cpp:
(JSC::DFG::MinifiedGraph::prepareAndShrink):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::nodeMapDump):
(JSC::DFG::nodeValuePairListDump):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGScoreBoard.h:
(JSC::DFG::ScoreBoard::sortFree):
* Source/JavaScriptCore/dfg/DFGStoreBarrierClusteringPhase.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/HeapSnapshot.cpp:
(JSC::HeapSnapshot::finalize):
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::HeapSnapshotBuilder::dumpToStream):
* Source/JavaScriptCore/heap/JITStubRoutineSet.cpp:
(JSC::JITStubRoutineSet::prepareForConservativeScan):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
* Source/JavaScriptCore/heap/MarkingConstraintSet.cpp:
(JSC::MarkingConstraintSet::executeConvergenceImpl):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::queryHolders):
* Source/JavaScriptCore/jit/JITSizeStatistics.cpp:
(JSC::JITSizeStatistics::dump const):
* Source/JavaScriptCore/parser/VariableEnvironment.cpp:
(JSC::CompactTDZEnvironment::sortCompact):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::sortBucketSort):
* Source/JavaScriptCore/runtime/ImportMap.cpp:
(JSC::ImportMap::ImportMap):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::flattenFields):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::availableCollations):
(JSC::availableCurrencies):
(JSC::availableNumberingSystems):
(JSC::intlAvailableTimeZones):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp:
(JSC::JSModuleNamespaceObject::finishCreation):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::logOutcomeImpl):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::getOwnIndexedPropertyNames):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::forEachOwnIndexedProperty):
* Source/JavaScriptCore/wasm/WasmMergedProfile.cpp:
(JSC::Wasm::MergedProfile::Candidates::finalize const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::prepareForTailCallImpl):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::prepareForTailCallImpl):
* Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp:
(JSC::Wasm::WasmOpcodeCounter::dump):
* Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.cpp:
(WasmDebugInfoTest::parseAndVerifyDebugInfoImpl):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::performSetOpWithMatches):
(JSC::Yarr::CharacterClassConstructor::sort):

Canonical link: <a href="https://commits.webkit.org/303399@main">https://commits.webkit.org/303399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4c32d9ab165f4cbdedfd71e6dfcabfc58730842

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84146 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101063 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3187 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82954 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124282 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142381 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130726 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109441 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27787 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3318 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4435 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33082 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163693 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67881 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42535 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->