### PR TITLE
[JSC] A bit more optimizations for `n % power-of-two` in FTL

### DIFF
--- a/JSTests/stress/arith-modulo-power-of-two-int32.js
+++ b/JSTests/stress/arith-modulo-power-of-two-int32.js
@@ -1,0 +1,343 @@
+function testMod2(n) {
+    n |= 0; // Ensure int32
+    return n % 2;
+}
+noInline(testMod2);
+
+function testMod4(n) {
+    n |= 0;
+    return n % 4;
+}
+noInline(testMod4);
+
+function testMod8(n) {
+    n |= 0;
+    return n % 8;
+}
+noInline(testMod8);
+
+function testMod16(n) {
+    n |= 0;
+    return n % 16;
+}
+noInline(testMod16);
+
+function testMod32(n) {
+    n |= 0;
+    return n % 32;
+}
+noInline(testMod32);
+
+function testMod64(n) {
+    n |= 0;
+    return n % 64;
+}
+noInline(testMod64);
+
+function testMod128(n) {
+    n |= 0;
+    return n % 128;
+}
+noInline(testMod128);
+
+function testMod256(n) {
+    n |= 0;
+    return n % 256;
+}
+noInline(testMod256);
+
+function testMod512(n) {
+    n |= 0;
+    return n % 512;
+}
+noInline(testMod512);
+
+function testMod1024(n) {
+    n |= 0;
+    return n % 1024;
+}
+noInline(testMod1024);
+
+function testMod2048(n) {
+    n |= 0;
+    return n % 2048;
+}
+noInline(testMod2048);
+
+function testMod4096(n) {
+    n |= 0;
+    return n % 4096;
+}
+noInline(testMod4096);
+
+function testMod65536(n) {
+    n |= 0;
+    return n % 65536;
+}
+noInline(testMod65536);
+
+function testMod1048576(n) {
+    n |= 0;
+    return n % 1048576;
+}
+noInline(testMod1048576);
+
+// Test values covering important edge cases
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
+const testValues = [
+    // Edge cases
+    INT32_MIN,
+    INT32_MIN + 1,
+    INT32_MIN + 255,
+    INT32_MIN + 256,
+    INT32_MAX,
+    INT32_MAX - 1,
+    INT32_MAX - 255,
+    INT32_MAX - 256,
+
+    // Zero and near zero
+    0,
+    -1,
+    1,
+
+    // Small negative numbers
+    -2, -3, -4, -5, -7, -8, -15, -16, -17, -31, -32, -33,
+    -63, -64, -65, -127, -128, -129, -255, -256, -257,
+    -511, -512, -513, -1023, -1024, -1025,
+
+    // Small positive numbers
+    2, 3, 4, 5, 7, 8, 15, 16, 17, 31, 32, 33,
+    63, 64, 65, 127, 128, 129, 255, 256, 257,
+    511, 512, 513, 1023, 1024, 1025,
+
+    // Medium numbers
+    -1000, -10000, -100000, -1000000,
+    1000, 10000, 100000, 1000000,
+
+    // Large numbers (close to boundaries)
+    -1073741824, // -2^30
+    1073741824,  // 2^30
+    -536870912,  // -2^29
+    536870912,   // 2^29
+];
+
+// Expected results for mod 256 (manual verification)
+const expectedMod256 = {
+    [INT32_MIN]: 0,
+    [INT32_MIN + 1]: -255,
+    [INT32_MIN + 255]: -1,
+    [INT32_MIN + 256]: 0,
+    [INT32_MAX]: 255,
+    [INT32_MAX - 1]: 254,
+    [INT32_MAX - 255]: 0,
+    [INT32_MAX - 256]: 255,
+    0: 0,
+    [-1]: -1,
+    1: 1,
+    [-5]: -5,
+    5: 5,
+    [-128]: -128,
+    128: 128,
+    [-255]: -255,
+    255: 255,
+    [-256]: 0,
+    256: 0,
+    [-257]: -1,
+    257: 1,
+};
+
+// Warm up functions to trigger JIT compilation
+for (let i = 0; i < testLoopCount; ++i) {
+    testMod2(i);
+    testMod4(i);
+    testMod8(i);
+    testMod16(i);
+    testMod32(i);
+    testMod64(i);
+    testMod128(i);
+    testMod256(i);
+    testMod512(i);
+    testMod1024(i);
+    testMod2048(i);
+    testMod4096(i);
+    testMod65536(i);
+    testMod1048576(i);
+}
+
+// Test with edge case values
+for (let value of testValues) {
+    let result;
+
+    // Test mod 2
+    result = testMod2(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod2(${value}) returned non-number or NaN: ${result}`);
+    let expected2 = value % 2;
+    if (result !== expected2)
+        throw new Error(`testMod2(${value}) returned ${result}, expected ${expected2}`);
+
+    // Test mod 4
+    result = testMod4(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod4(${value}) returned non-number or NaN: ${result}`);
+    let expected4 = value % 4;
+    if (result !== expected4)
+        throw new Error(`testMod4(${value}) returned ${result}, expected ${expected4}`);
+
+    // Test mod 8
+    result = testMod8(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod8(${value}) returned non-number or NaN: ${result}`);
+    let expected8 = value % 8;
+    if (result !== expected8)
+        throw new Error(`testMod8(${value}) returned ${result}, expected ${expected8}`);
+
+    // Test mod 16
+    result = testMod16(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod16(${value}) returned non-number or NaN: ${result}`);
+    let expected16 = value % 16;
+    if (result !== expected16)
+        throw new Error(`testMod16(${value}) returned ${result}, expected ${expected16}`);
+
+    // Test mod 32
+    result = testMod32(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod32(${value}) returned non-number or NaN: ${result}`);
+    let expected32 = value % 32;
+    if (result !== expected32)
+        throw new Error(`testMod32(${value}) returned ${result}, expected ${expected32}`);
+
+    // Test mod 64
+    result = testMod64(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod64(${value}) returned non-number or NaN: ${result}`);
+    let expected64 = value % 64;
+    if (result !== expected64)
+        throw new Error(`testMod64(${value}) returned ${result}, expected ${expected64}`);
+
+    // Test mod 128
+    result = testMod128(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod128(${value}) returned non-number or NaN: ${result}`);
+    let expected128 = value % 128;
+    if (result !== expected128)
+        throw new Error(`testMod128(${value}) returned ${result}, expected ${expected128}`);
+
+    // Test mod 256 (most important case)
+    result = testMod256(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod256(${value}) returned non-number or NaN: ${result}`);
+    let expected256 = value % 256;
+    if (result !== expected256)
+        throw new Error(`testMod256(${value}) returned ${result}, expected ${expected256}`);
+
+    // Verify against manual expected values if available
+    if (value in expectedMod256) {
+        if (result !== expectedMod256[value])
+            throw new Error(`testMod256(${value}) returned ${result}, manually expected ${expectedMod256[value]}`);
+    }
+
+    // Test mod 512
+    result = testMod512(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod512(${value}) returned non-number or NaN: ${result}`);
+    let expected512 = value % 512;
+    if (result !== expected512)
+        throw new Error(`testMod512(${value}) returned ${result}, expected ${expected512}`);
+
+    // Test mod 1024
+    result = testMod1024(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod1024(${value}) returned non-number or NaN: ${result}`);
+    let expected1024 = value % 1024;
+    if (result !== expected1024)
+        throw new Error(`testMod1024(${value}) returned ${result}, expected ${expected1024}`);
+
+    // Test mod 2048
+    result = testMod2048(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod2048(${value}) returned non-number or NaN: ${result}`);
+    let expected2048 = value % 2048;
+    if (result !== expected2048)
+        throw new Error(`testMod2048(${value}) returned ${result}, expected ${expected2048}`);
+
+    // Test mod 4096
+    result = testMod4096(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod4096(${value}) returned non-number or NaN: ${result}`);
+    let expected4096 = value % 4096;
+    if (result !== expected4096)
+        throw new Error(`testMod4096(${value}) returned ${result}, expected ${expected4096}`);
+
+    // Test mod 65536
+    result = testMod65536(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod65536(${value}) returned non-number or NaN: ${result}`);
+    let expected65536 = value % 65536;
+    if (result !== expected65536)
+        throw new Error(`testMod65536(${value}) returned ${result}, expected ${expected65536}`);
+
+    // Test mod 1048576
+    result = testMod1048576(value);
+    if (typeof result !== 'number' || isNaN(result))
+        throw new Error(`testMod1048576(${value}) returned non-number or NaN: ${result}`);
+    let expected1048576 = value % 1048576;
+    if (result !== expected1048576)
+        throw new Error(`testMod1048576(${value}) returned ${result}, expected ${expected1048576}`);
+}
+
+// Additional test: Verify results stay in expected range
+for (let i = -10000; i < 10000; i++) {
+    let result = testMod256(i);
+
+    // Result must be in range [-255, 255]
+    if (result < -255 || result > 255)
+        throw new Error(`testMod256(${i}) returned ${result} which is outside valid range [-255, 255]`);
+
+    // Result must have same sign as dividend (or be zero)
+    if (i > 0 && result < 0)
+        throw new Error(`testMod256(${i}) returned negative ${result} for positive input`);
+    if (i < 0 && result > 0)
+        throw new Error(`testMod256(${i}) returned positive ${result} for negative input`);
+
+    // Verify the result is an int32 (not a double)
+    if ((result | 0) !== result)
+        throw new Error(`testMod256(${i}) returned ${result} which is not an int32`);
+}
+
+// Test that INT32_MIN % power-of-two doesn't cause issues
+let intMinMod2 = testMod2(INT32_MIN);
+if (intMinMod2 !== 0)
+    throw new Error(`INT32_MIN % 2 should be 0, got ${intMinMod2}`);
+
+let intMinMod256 = testMod256(INT32_MIN);
+if (intMinMod256 !== 0)
+    throw new Error(`INT32_MIN % 256 should be 0, got ${intMinMod256}`);
+
+let intMinMod1024 = testMod1024(INT32_MIN);
+if (intMinMod1024 !== 0)
+    throw new Error(`INT32_MIN % 1024 should be 0, got ${intMinMod1024}`);
+
+// Test chained modulo operations (strength reduction should handle this)
+function chainedMod(n) {
+    n |= 0;
+    let a = n % 256;
+    let b = a % 16;
+    let c = b % 4;
+    return c;
+}
+noInline(chainedMod);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    chainedMod(i);
+}
+
+for (let value of testValues) {
+    let result = chainedMod(value);
+    let expected = ((value % 256) % 16) % 4;
+    if (result !== expected)
+        throw new Error(`chainedMod(${value}) returned ${result}, expected ${expected}`);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -6120,7 +6120,7 @@ void SpeculativeJIT::compileArithMod(Node* node)
         if (node->child2()->isInt32Constant()) {
             int32_t divisor = node->child2()->asInt32();
             if (divisor > 1 && hasOneBitSet(divisor)) {
-                unsigned logarithm = WTF::fastLog2(static_cast<uint32_t>(divisor));
+                unsigned logarithm = WTF::ctz(static_cast<uint32_t>(divisor));
                 GPRReg dividendGPR = op1.gpr();
                 GPRTemporary result(this);
                 GPRReg resultGPR = result.gpr();
@@ -6163,9 +6163,8 @@ void SpeculativeJIT::compileArithMod(Node* node)
                 // Subtract resultGPR from dividendGPR, which yields the remainder:
                 //
                 // resultGPR = dividendGPR - resultGPR
-                neg32(resultGPR);
-                add32(dividendGPR, resultGPR);
-                
+                sub32(dividendGPR, resultGPR, resultGPR);
+
                 if (shouldCheckNegativeZero(node->arithMode())) {
                     // Check that we're not about to create negative zero.
                     Jump numeratorPositive = branch32(GreaterThanOrEqual, dividendGPR, TrustedImm32(0));


### PR DESCRIPTION
#### 3ec66a7fd7e54ddc27c98b3c51995f5ec9a8749a
<pre>
[JSC] A bit more optimizations for `n % power-of-two` in FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=302763">https://bugs.webkit.org/show_bug.cgi?id=302763</a>
<a href="https://rdar.apple.com/165021624">rdar://165021624</a>

Reviewed by Keith Miller.

We should do a bit more optimizations for `n % power-of-two`.

1. Int32 / Int32-power-of-two (larger than 1) never generates
   non-Int32 value except for negative 0 `-1 % 1`
2. Use DFG&apos;s ArithMod optimization to FTL.

Test: JSTests/stress/arith-modulo-power-of-two-int32.js

* JSTests/stress/arith-modulo-power-of-two-int32.js: Added.
(testMod2):
(testMod4):
(testMod8):
(testMod16):
(testMod32):
(testMod64):
(testMod128):
(testMod256):
(testMod512):
(testMod1024):
(testMod2048):
(testMod4096):
(testMod65536):
(testMod1048576):
(chainedMod):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithMod):

Canonical link: <a href="https://commits.webkit.org/303241@main">https://commits.webkit.org/303241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a66b312936e8f204c370d7c803ed8bd2ccdaa704

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131801 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139312 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b69f51a8-546b-495f-8633-7d5f0ef0e448) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134747 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81527 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/37885545-0061-4e71-94d1-c86475c5beea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82532 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123864 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141956 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130308 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3962 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109112 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4043 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109276 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3010 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57172 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20490 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4016 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163274 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67463 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->