### PR TITLE
Stop using raw pointers in containers in ScriptExecutionContext.h

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -91,15 +91,17 @@ class XRBinding;
 class GPUDevice : public RefCounted<GPUDevice>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GPUDevice);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<GPUDevice> create(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing, String&& queueLabel, GPUAdapterInfo& info)
     {
         return adoptRef(*new GPUDevice(scriptExecutionContext, WTFMove(backing), WTFMove(queueLabel), info));
     }
 
     virtual ~GPUDevice();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     String label() const;
     void setLabel(String&&);

--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h
@@ -61,6 +61,10 @@ public:
 
     void finishSession(std::optional<bool>&&);
 
+    // ContextDestructionObserver.
+    void ref() const final { PaymentHandler::ref(); }
+    void deref() const final { PaymentHandler::deref(); }
+
 private:
     friend class PaymentHandler;
     explicit ApplePayAMSUIPaymentHandler(Document&, const PaymentRequest::MethodIdentifier&, PaymentRequest&);

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -62,11 +62,13 @@ template<typename> class ExceptionOr;
 class ApplePaySession final : public PaymentSession, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ApplePaySession);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static ExceptionOr<Ref<ApplePaySession>> create(Document&, unsigned version, ApplePayPaymentRequest&&);
     virtual ~ApplePaySession();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     static constexpr auto STATUS_SUCCESS = ApplePayPaymentAuthorizationResult::Success;
     static constexpr auto STATUS_FAILURE = ApplePayPaymentAuthorizationResult::Failure;

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
@@ -50,6 +50,10 @@ public:
     static bool handlesIdentifier(const PaymentRequest::MethodIdentifier&);
     static bool hasActiveSession(Document&);
 
+    // ContextDestructionObserver.
+    void ref() const final { PaymentHandler::ref(); }
+    void deref() const final { PaymentHandler::deref(); }
+
 private:
     friend class PaymentHandler;
     explicit ApplePayPaymentHandler(Document&, const PaymentRequest::MethodIdentifier&, PaymentRequest&);

--- a/Source/WebCore/Modules/encryptedmedia/CDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.h
@@ -54,13 +54,17 @@ class Document;
 class ScriptExecutionContext;
 class SharedBuffer;
 
-class CDM : public RefCountedAndCanMakeWeakPtr<CDM>, public CDMPrivateClient, private ContextDestructionObserver {
+class CDM : public RefCounted<CDM>, public CDMPrivateClient, private ContextDestructionObserver {
 public:
     static bool supportsKeySystem(const String&);
     static bool isPersistentType(MediaKeySessionType);
 
     static Ref<CDM> create(Document&, const String& keySystem, const String& mediaKeysHashSalt);
     ~CDM();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     using SupportedConfigurationCallback = Function<void(std::optional<MediaKeySystemConfiguration>)>;
     void getSupportedConfiguration(MediaKeySystemConfiguration&& candidateConfiguration, SupportedConfigurationCallback&&);

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
@@ -43,7 +43,7 @@ class DeferredPromise;
 class Document;
 class MediaKeys;
 
-class MediaKeySystemAccess : public RefCountedAndCanMakeWeakPtr<MediaKeySystemAccess>, public ActiveDOMObject {
+class MediaKeySystemAccess : public RefCounted<MediaKeySystemAccess>, public ActiveDOMObject {
 public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }

--- a/Source/WebCore/Modules/entriesapi/ErrorCallback.h
+++ b/Source/WebCore/Modules/entriesapi/ErrorCallback.h
@@ -38,6 +38,10 @@ class ErrorCallback : public RefCounted<ErrorCallback>, public ActiveDOMCallback
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(DOMException&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(DOMException&) = 0;
 

--- a/Source/WebCore/Modules/entriesapi/FileCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileCallback.h
@@ -38,6 +38,10 @@ class FileCallback : public RefCounted<FileCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(File&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(File&) = 0;
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
@@ -38,6 +38,10 @@ class FileSystemEntriesCallback : public RefCounted<FileSystemEntriesCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(const Vector<Ref<FileSystemEntry>>&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const Vector<Ref<FileSystemEntry>>&) = 0;
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
@@ -38,6 +38,10 @@ class FileSystemEntryCallback : public RefCounted<FileSystemEntryCallback>, publ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(FileSystemEntry&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(FileSystemEntry&) = 0;
 

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -46,7 +46,7 @@ template<typename> class ExceptionOr;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchBodyOwner);
 
-class FetchBodyOwner : public RefCountedAndCanMakeWeakPtr<FetchBodyOwner>, public ActiveDOMObject {
+class FetchBodyOwner : public RefCounted<FetchBodyOwner>, public ActiveDOMObject {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FetchBodyOwner, FetchBodyOwner);
 public:
     void ref() const final { RefCounted::ref(); }

--- a/Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.h
@@ -41,7 +41,7 @@ class FileSystemFileHandle;
 template<typename> class DOMPromiseDeferred;
 template<typename> class ExceptionOr;
 
-class FileSystemSyncAccessHandle : public RefCountedAndCanMakeWeakPtr<FileSystemSyncAccessHandle>, public ActiveDOMObject {
+class FileSystemSyncAccessHandle : public RefCounted<FileSystemSyncAccessHandle>, public ActiveDOMObject {
 public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -54,7 +54,7 @@ class ScriptExecutionContext;
 class SecurityOrigin;
 struct PositionOptions;
 
-class Geolocation final : public RefCountedAndCanMakeWeakPtr<Geolocation>, public ScriptWrappable, public ActiveDOMObject {
+class Geolocation final : public RefCounted<Geolocation>, public ScriptWrappable, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(Geolocation, WEBCORE_EXPORT);
     friend class GeoNotifier;
 public:

--- a/Source/WebCore/Modules/geolocation/PositionCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionCallback.h
@@ -37,6 +37,10 @@ class PositionCallback : public RefCounted<PositionCallback>, public ActiveDOMCa
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(GeolocationPosition*) = 0;
     virtual CallbackResult<void> invokeRethrowingException(GeolocationPosition*) = 0;
 

--- a/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
@@ -37,6 +37,10 @@ class PositionErrorCallback : public RefCounted<PositionErrorCallback>, public A
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(GeolocationPositionError&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(GeolocationPositionError&) = 0;
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -50,7 +50,7 @@ struct ExceptionData;
 
 using CredentialPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<BasicCredential>>>;
 
-class CredentialRequestCoordinator final : public RefCounted<CredentialRequestCoordinator>, public CanMakeWeakPtr<CredentialRequestCoordinator>, public ActiveDOMObject {
+class CredentialRequestCoordinator final : public RefCounted<CredentialRequestCoordinator>, public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CredentialRequestCoordinator, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(CredentialRequestCoordinator);
 

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -79,6 +79,8 @@ public:
     static Ref<IDBRequest> createObjectStoreGet(ScriptExecutionContext&, IDBObjectStore&, IndexedDB::ObjectStoreRecordType, IDBTransaction&);
     static Ref<IDBRequest> createIndexGet(ScriptExecutionContext&, IDBIndex&, IndexedDB::IndexRecordType, IDBTransaction&);
 
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     const IDBResourceIdentifier& resourceIdentifier() const { return m_resourceIdentifier; }
 
     virtual ~IDBRequest();

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -73,6 +73,8 @@ public:
     static Ref<IDBTransaction> create(IDBDatabase&, const IDBTransactionInfo&);
     static Ref<IDBTransaction> create(IDBDatabase&, const IDBTransactionInfo&, IDBOpenDBRequest&);
 
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     static uint64_t generateOperationID();
 
     WEBCORE_EXPORT ~IDBTransaction() final;

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.h
@@ -41,6 +41,10 @@ class MediaControlsUtils
 public:
     static Ref<MediaControlsUtils> create(Document& document) { return adoptRef(*new MediaControlsUtils(document)); }
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     String formattedStringForDuration(double);
     RefPtr<HTMLImageElement> createImageForIconNameAndType(const String& iconName, const String& iconType);
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -69,7 +69,7 @@ public:
 #endif
 };
 
-class MediaSession : public RefCountedAndCanMakeWeakPtr<MediaSession>, public ActiveDOMObject {
+class MediaSession : public RefCounted<MediaSession>, public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(MediaSession);
 public:
     void ref() const final { RefCounted::ref(); }
@@ -205,8 +205,10 @@ void MediaSession::visitActionHandlers(Visitor& visitor) const
 {
     Locker lock { m_actionHandlersLock };
     for (auto& actionHandler : m_actionHandlers) {
-        if (actionHandler.value)
-            actionHandler.value->visitJSFunction(visitor);
+        if (actionHandler.value) {
+            // We are not ref'ing here as this function may get called from the GC thread.
+            SUPPRESS_UNCOUNTED_ARG actionHandler.value->visitJSFunction(visitor);
+        }
     }
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
@@ -39,6 +39,10 @@ class MediaSessionActionHandler : public RefCounted<MediaSessionActionHandler>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(const MediaSessionActionDetails&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const MediaSessionActionDetails&) = 0;
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -67,7 +67,7 @@ template<typename> class ExceptionOr;
 enum class MediaSourceReadyState { Closed, Open, Ended };
 
 class MediaSource
-    : public RefCountedAndCanMakeWeakPtr<MediaSource>
+    : public RefCounted<MediaSource>
     , public ActiveDOMObject
     , public EventTarget
     , public URLRegistrable
@@ -78,16 +78,16 @@ class MediaSource
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaSource);
 public:
-    void ref() const final { RefCountedAndCanMakeWeakPtr::ref(); }
-    void deref() const final { RefCountedAndCanMakeWeakPtr::deref(); }
-
-    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<MediaSource>);
-
     static void setRegistry(URLRegistry*);
     static MediaSource* lookup(const String& url) { return s_registry ? downcast<MediaSource>(s_registry->lookup(url)) : nullptr; }
 
     static Ref<MediaSource> create(ScriptExecutionContext&, MediaSourceInit&&);
     virtual ~MediaSource();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(ActiveDOMObject);
 
     static bool enabledForContext(ScriptExecutionContext&);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -62,7 +62,6 @@ template<typename> class ExceptionOr;
 
 class SourceBuffer
     : public RefCounted<SourceBuffer>
-    , public CanMakeWeakPtr<SourceBuffer>
     , public ActiveDOMObject
     , public EventTarget
     , private AudioTrackClient
@@ -80,7 +79,7 @@ public:
     static Ref<SourceBuffer> create(Ref<SourceBufferPrivate>&&, MediaSource&);
     virtual ~SourceBuffer();
 
-    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<SourceBuffer>);
+    USING_CAN_MAKE_WEAKPTR(ActiveDOMObject);
 
     static bool enabledForContext(ScriptExecutionContext&);
 

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -46,11 +46,13 @@ class WebCoreOpaqueRoot;
 class SourceBufferList final : public RefCounted<SourceBufferList>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SourceBufferList);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<SourceBufferList> create(ScriptExecutionContext*);
     virtual ~SourceBufferList();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const { return m_list.size(); }

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -60,12 +60,14 @@ template<typename IDLType> class DOMPromiseDeferred;
 class MediaDevices final : public RefCounted<MediaDevices>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaDevices);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<MediaDevices> create(Document&);
 
     ~MediaDevices();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     Document* document() const;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -65,9 +65,6 @@ class MediaStreamTrack
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaStreamTrack);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     class Observer {
     public:
         virtual ~Observer() = default;
@@ -78,6 +75,11 @@ public:
     static Ref<MediaStreamTrack> create(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&, RegisterCaptureTrackToOwner = RegisterCaptureTrackToOwner::Yes);
     static Ref<MediaStreamTrack> create(ScriptExecutionContext&, UniqueRef<MediaStreamTrackDataHolder>&&);
     virtual ~MediaStreamTrack();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     static MediaProducerMediaStateFlags captureState(const RealtimeMediaSource&);
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -45,8 +45,7 @@ template<typename> class ExceptionOr;
 
 class MediaStreamTrackProcessor
     : public RefCounted<MediaStreamTrackProcessor>
-    , public CanMakeWeakPtr<MediaStreamTrackProcessor>
-    , private ContextDestructionObserver {
+    , public ContextDestructionObserver {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaStreamTrackProcessor);
 public:
     struct Init {
@@ -56,6 +55,10 @@ public:
 
     static ExceptionOr<Ref<MediaStreamTrackProcessor>> create(ScriptExecutionContext&, Init&&);
     ~MediaStreamTrackProcessor();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); };
+    void deref() const final { RefCounted::deref(); };
 
     ExceptionOr<Ref<ReadableStream>> readable(JSC::JSGlobalObject&);
 

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -43,11 +43,13 @@ template<typename> class ExceptionOr;
 class RTCDTMFSender final : public RefCounted<RTCDTMFSender>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCDTMFSender);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<RTCDTMFSender> create(ScriptExecutionContext&, RTCRtpSender&, std::unique_ptr<RTCDTMFSenderBackend>&&);
     virtual ~RTCDTMFSender();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     bool canInsertDTMF() const;
     String toneBuffer() const;

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -54,12 +54,14 @@ template<typename> class ExceptionOr;
 class RTCDataChannel final : public RefCounted<RTCDataChannel>, public ActiveDOMObject, public RTCDataChannelHandlerClient, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCDataChannel);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<RTCDataChannel> create(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&, RTCDataChannelState);
     static Ref<RTCDataChannel> create(ScriptExecutionContext&, RTCDataChannelIdentifier, String&&, RTCDataChannelInit&&, RTCDataChannelState);
     WEBCORE_EXPORT virtual ~RTCDataChannel();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     bool ordered() const { return *m_options.ordered; }
     std::optional<unsigned short> maxPacketLifeTime() const { return m_options.maxPacketLifeTime; }
@@ -97,7 +99,7 @@ public:
 private:
     RTCDataChannel(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&, RTCDataChannelState);
 
-    static NetworkSendQueue createMessageQueue(ScriptExecutionContext&, RTCDataChannel&);
+    static Ref<NetworkSendQueue> createMessageQueue(ScriptExecutionContext&, RTCDataChannel&);
 
     void scheduleDispatchEvent(Ref<Event>&&);
     void removeFromDataChannelLocalMapIfNeeded();
@@ -135,7 +137,7 @@ private:
     size_t m_bufferedAmountLowThreshold { 0 };
     bool m_isDetachable { true };
     bool m_isDetached { false };
-    NetworkSendQueue m_messageQueue;
+    const Ref<NetworkSendQueue> m_messageQueue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -43,11 +43,13 @@ class ScriptExecutionContext;
 class RTCDtlsTransport final : public RefCounted<RTCDtlsTransport>, public ActiveDOMObject, public EventTarget, public RTCDtlsTransportBackendClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCDtlsTransport);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<RTCDtlsTransport> create(ScriptExecutionContext&, UniqueRef<RTCDtlsTransportBackend>&&, Ref<RTCIceTransport>&&);
     ~RTCDtlsTransport();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     RTCIceTransport& iceTransport() { return m_iceTransport.get(); }
     RTCDtlsTransportState state() { return m_state; }

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -51,11 +51,13 @@ class RTCPeerConnection;
 class RTCIceTransport : public RefCounted<RTCIceTransport>, public ActiveDOMObject, public EventTarget, public RTCIceTransportBackendClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCIceTransport);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<RTCIceTransport> create(ScriptExecutionContext&, UniqueRef<RTCIceTransportBackend>&&, RTCPeerConnection&);
     ~RTCIceTransport();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     RTCIceTransportState state() const { return m_transportState; }
     RTCIceGatheringState gatheringState() const { return m_gatheringState; }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -92,11 +92,13 @@ class RTCPeerConnection final
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(RTCPeerConnection, WEBCORE_EXPORT);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static ExceptionOr<Ref<RTCPeerConnection>> create(Document&, RTCConfiguration&&);
     WEBCORE_EXPORT virtual ~RTCPeerConnection();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     using DataChannelInit = RTCDataChannelInit;
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -79,6 +79,7 @@ public:
     // ActiveDOMObject.
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
 private:
     RTCRtpSFrameTransform(ScriptExecutionContext&, Options);

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -53,8 +53,7 @@ template<typename> class ExceptionOr;
 
 class RTCRtpScriptTransformer
     : public RefCounted<RTCRtpScriptTransformer>
-    , public ActiveDOMObject
-    , public CanMakeWeakPtr<RTCRtpScriptTransformer> {
+    , public ActiveDOMObject {
 public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -39,11 +39,13 @@ class RTCDtlsTransport;
 class RTCSctpTransport final : public RefCounted<RTCSctpTransport>, public ActiveDOMObject, public EventTarget, public RTCSctpTransportBackendClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCSctpTransport);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<RTCSctpTransport> create(ScriptExecutionContext&, UniqueRef<RTCSctpTransportBackend>&&, Ref<RTCDtlsTransport>&&);
     ~RTCSctpTransport();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     RTCDtlsTransport& transport() { return m_transport.get(); }
     RTCSctpTransportState state() const { return m_state; }

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -60,9 +60,6 @@ struct NotificationData;
 class Notification final : public RefCounted<Notification>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(Notification, WEBCORE_EXPORT);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     using Permission = NotificationPermission;
     using Direction = NotificationDirection;
 
@@ -88,6 +85,11 @@ public:
     static Ref<Notification> create(ScriptExecutionContext&, const URL& registrationURL, const NotificationPayload&);
 
     WEBCORE_EXPORT virtual ~Notification();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     void show(CompletionHandler<void()>&& = [] { });
     void close();

--- a/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
+++ b/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
@@ -39,6 +39,10 @@ class NotificationPermissionCallback : public RefCounted<NotificationPermissionC
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(Notification::Permission) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Notification::Permission) = 0;
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -55,15 +55,17 @@ template<typename> class ExceptionOr;
 class PaymentRequest final : public ActiveDOMObject, public EventTarget, public RefCounted<PaymentRequest> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PaymentRequest);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     using AbortPromise = DOMPromiseDeferred<void>;
     using CanMakePaymentPromise = DOMPromiseDeferred<IDLBoolean>;
     using ShowPromise = DOMPromiseDeferred<IDLInterface<PaymentResponse>>;
 
     static ExceptionOr<Ref<PaymentRequest>> create(Document&, Vector<PaymentMethodData>&&, PaymentDetailsInit&&, PaymentOptions&&);
     ~PaymentRequest();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     void show(Document&, RefPtr<DOMPromise>&& detailsPromise, ShowPromise&&);
     void abort(AbortPromise&&);

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -51,9 +51,6 @@ template<typename IDLType> class DOMPromiseDeferred;
 class PaymentResponse final : public ActiveDOMObject, public EventTarget, public RefCounted<PaymentResponse> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PaymentResponse);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     using DetailsFunction = Function<JSC::Strong<JSC::JSObject>(JSC::JSGlobalObject&)>;
 
     static Ref<PaymentResponse> create(ScriptExecutionContext* context, PaymentRequest& request)
@@ -64,6 +61,11 @@ public:
     }
 
     ~PaymentResponse();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     const String& requestId() const { return m_requestId; }
     void setRequestId(const String& requestId) { m_requestId = requestId; }

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -42,11 +42,13 @@ class PictureInPictureWindow final
     , public RefCounted<PictureInPictureWindow> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PictureInPictureWindow);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<PictureInPictureWindow> create(Document&);
     virtual ~PictureInPictureWindow();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     int width() const { return m_size.width(); }
     int height() const { return m_size.height(); }

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -51,11 +51,13 @@ class RemotePlayback final
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemotePlayback);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<RemotePlayback> create(HTMLMediaElement&);
     ~RemotePlayback();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     void watchAvailability(Ref<RemotePlaybackAvailabilityCallback>&&, Ref<DeferredPromise>&&);
     void cancelWatchAvailability(std::optional<int32_t> id, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
@@ -38,6 +38,10 @@ class RemotePlaybackAvailabilityCallback : public RefCounted<RemotePlaybackAvail
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<bool> invoke(bool) = 0;
     virtual CallbackResult<bool> invokeRethrowingException(bool) = 0;
 

--- a/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
@@ -39,6 +39,10 @@ class ReportingObserverCallback : public RefCounted<ReportingObserverCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
 

--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -44,11 +44,15 @@ class Report;
 class ReportingObserver;
 class ScriptExecutionContext;
 
-class ReportingScope final : public RefCountedAndCanMakeWeakPtr<ReportingScope>, public ContextDestructionObserver {
+class ReportingScope final : public RefCounted<ReportingScope>, public ContextDestructionObserver {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ReportingScope, WEBCORE_EXPORT);
 public:
     static Ref<ReportingScope> create(ScriptExecutionContext&);
     WEBCORE_EXPORT virtual ~ReportingScope();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void removeAllObservers();
     void clearReports();

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
@@ -43,6 +43,10 @@ public:
         return adoptRef(*new WakeLock(document));
     }
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void request(WakeLockType, Ref<DeferredPromise>&&);
 
 private:

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -39,15 +39,17 @@ class WakeLockManager;
 class WakeLockSentinel final : public RefCounted<WakeLockSentinel>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WakeLockSentinel);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<WakeLockSentinel> create(Document& document, WakeLockType type)
     {
         auto sentinel = adoptRef(*new WakeLockSentinel(document, type));
         sentinel->suspendIfNeeded();
         return sentinel;
     }
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     bool released() const { return m_wasReleased; }
     WakeLockType type() const { return m_type; }

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -49,8 +49,10 @@ public:
     static Ref<SpeechSynthesis> create(ScriptExecutionContext&);
     virtual ~SpeechSynthesis();
 
+    // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     bool pending() const;
     bool speaking() const;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -41,9 +41,6 @@ namespace WebCore {
 class WEBCORE_EXPORT SpeechSynthesisUtterance final : public PlatformSpeechSynthesisUtteranceClient, public RefCounted<SpeechSynthesisUtterance>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(SpeechSynthesisUtterance, WEBCORE_EXPORT);
 public:
-    void ref() const final;
-    void deref() const final;
-
     using UtteranceCompletionHandler = Function<void(const SpeechSynthesisUtterance&)>;
     static Ref<SpeechSynthesisUtterance> create(ScriptExecutionContext&, const String&, UtteranceCompletionHandler&&);
     static Ref<SpeechSynthesisUtterance> create(ScriptExecutionContext&, const String&);
@@ -52,6 +49,11 @@ public:
     SpeechSynthesisUtterance();
 
     virtual ~SpeechSynthesisUtterance();
+
+    // ContextDestructionObserver.
+    void ref() const final;
+    void deref() const final;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     const String& text() const { return m_platformUtterance->text(); }
     void setText(const String& text) { m_platformUtterance->setText(text); }

--- a/Source/WebCore/Modules/streams/QueuingStrategySize.h
+++ b/Source/WebCore/Modules/streams/QueuingStrategySize.h
@@ -40,6 +40,10 @@ class QueuingStrategySize : public RefCounted<QueuingStrategySize>, public Activ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<double> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<double> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -54,7 +54,7 @@ struct UnderlyingSource;
 
 using ReadableStreamReader = Variant<RefPtr<ReadableStreamDefaultReader>, RefPtr<ReadableStreamBYOBReader>>;
 
-class ReadableStream : public RefCountedAndCanMakeWeakPtr<ReadableStream>, public ContextDestructionObserver {
+class ReadableStream : public RefCounted<ReadableStream>, public ContextDestructionObserver {
 public:
     enum class ReaderMode { Byob };
     struct GetReaderOptions {
@@ -71,6 +71,10 @@ public:
     static Ref<ReadableStream> create(Ref<InternalReadableStream>&&);
 
     virtual ~ReadableStream();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     Ref<DOMPromise> cancelForBindings(JSDOMGlobalObject&, JSC::JSValue);
     ExceptionOr<ReadableStreamReader> getReader(JSDOMGlobalObject&, const GetReaderOptions&);

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -42,7 +42,7 @@
 namespace WebCore {
 
 class PipeToDefaultReadRequest;
-class StreamPipeToState : public RefCountedAndCanMakeWeakPtr<StreamPipeToState>, public ContextDestructionObserver {
+class StreamPipeToState : public RefCounted<StreamPipeToState>, public ContextDestructionObserver {
 public:
     static Ref<StreamPipeToState> create(JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& source, Ref<WritableStream>&& destination, Ref<ReadableStreamDefaultReader>&& reader, Ref<InternalWritableStreamWriter>&& writer, StreamPipeOptions&& options, RefPtr<DeferredPromise>&& promise)
     {
@@ -59,6 +59,10 @@ public:
         return state;
     }
     ~StreamPipeToState();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void doWrite(JSC::JSValue);
     JSDOMGlobalObject* globalObject();

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-class StreamTeeState : public RefCountedAndCanMakeWeakPtr<StreamTeeState>, public ContextDestructionObserver {
+class StreamTeeState : public RefCounted<StreamTeeState>, public ContextDestructionObserver {
 public:
     template<typename Reader>
     static Ref<StreamTeeState> create(JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& stream, Ref<Reader>&& reader)
@@ -51,6 +51,10 @@ public:
     }
 
     ~StreamTeeState();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool isReader(const ReadableStreamDefaultReader* thisReader) const { return m_defaultReader && m_defaultReader.get() == thisReader; }
     bool isReader(const ReadableStreamBYOBReader* thisReader) const { return m_byobReader && m_byobReader.get() == thisReader; }

--- a/Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h
@@ -40,6 +40,10 @@ class UnderlyingSourceCancelCallback : public RefCounted<UnderlyingSourceCancelC
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<RefPtr<DOMPromise>> invoke(JSC::JSValue thisValue, JSC::JSValue reason) = 0;
 
 private:

--- a/Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h
@@ -42,6 +42,10 @@ class UnderlyingSourcePullCallback : public RefCounted<UnderlyingSourcePullCallb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<RefPtr<DOMPromise>> invoke(JSC::JSValue, ReadableByteStreamController&) = 0;
 
 private:

--- a/Source/WebCore/Modules/streams/UnderlyingSourceStartCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourceStartCallback.h
@@ -42,6 +42,10 @@ class UnderlyingSourceStartCallback : public RefCounted<UnderlyingSourceStartCal
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, ReadableByteStreamController&) = 0;
     virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, ReadableByteStreamController&) = 0;
 

--- a/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
+++ b/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
@@ -39,6 +39,10 @@ class WebLockGrantedCallback : public RefCounted<WebLockGrantedCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<RefPtr<DOMPromise>> invoke(WebLock*) = 0;
 
 private:

--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -42,7 +42,7 @@ class WebLockRegistry;
 struct ClientOrigin;
 struct WebLockManagerSnapshot;
 
-class WebLockManager : public RefCountedAndCanMakeWeakPtr<WebLockManager>, public ActiveDOMObject {
+class WebLockManager : public RefCounted<WebLockManager>, public ActiveDOMObject {
 public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }

--- a/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
@@ -38,6 +38,10 @@ class AudioBufferCallback : public RefCounted<AudioBufferCallback>, public Activ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(AudioBuffer*) = 0;
     virtual CallbackResult<void> invokeRethrowingException(AudioBuffer*) = 0;
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
@@ -43,6 +43,10 @@ class AudioWorkletProcessorConstructor : public RefCounted<AudioWorkletProcessor
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<RefPtr<AudioWorkletProcessor>> invoke(JSC::Strong<JSC::JSObject> options) = 0;
     virtual CallbackResult<RefPtr<AudioWorkletProcessor>> invokeRethrowingException(JSC::Strong<JSC::JSObject> options) = 0;
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -97,6 +97,8 @@ class BaseAudioContext
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(BaseAudioContext);
 public:
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     virtual ~BaseAudioContext();
 
     // This is used for lifetime testing.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
@@ -57,6 +57,10 @@ public:
     static Ref<WebCodecsAudioData> create(ScriptExecutionContext&, Ref<PlatformRawAudioData>&&);
     static Ref<WebCodecsAudioData> create(ScriptExecutionContext& context, WebCodecsAudioInternalData&& data) { return adoptRef(*new WebCodecsAudioData(context, WTFMove(data))); }
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<AudioSampleFormat> format() const;
     float sampleRate() const;
     size_t numberOfFrames() const;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
@@ -41,6 +41,10 @@ class WebCodecsAudioDataOutputCallback : public RefCounted<WebCodecsAudioDataOut
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(WebCodecsAudioData&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsAudioData&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
@@ -56,6 +56,7 @@ public:
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
     bool virtualHasPendingActivity() const final;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
 protected:
     WebCodecsBase(ScriptExecutionContext&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
@@ -42,6 +42,10 @@ class WebCodecsEncodedAudioChunkOutputCallback : public RefCounted<WebCodecsEnco
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
@@ -41,6 +41,10 @@ class WebCodecsEncodedVideoChunkOutputCallback : public RefCounted<WebCodecsEnco
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
@@ -40,6 +40,10 @@ class WebCodecsErrorCallback : public RefCounted<WebCodecsErrorCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(DOMException&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(DOMException&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -56,6 +56,10 @@ class WebCodecsVideoFrame : public RefCounted<WebCodecsVideoFrame>, public Conte
 public:
     ~WebCodecsVideoFrame();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     using CanvasImageSource = Variant<RefPtr<HTMLImageElement>
         , RefPtr<SVGImageElement>
         , RefPtr<HTMLCanvasElement>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
@@ -40,6 +40,10 @@ class WebCodecsVideoFrameOutputCallback : public RefCounted<WebCodecsVideoFrameO
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(WebCodecsVideoFrame&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsVideoFrame&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
@@ -42,6 +42,10 @@ class DatabaseCallback : public ThreadSafeRefCounted<DatabaseCallback>, public A
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(Database&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Database&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
@@ -41,6 +41,10 @@ class SQLStatementCallback : public ThreadSafeRefCounted<SQLStatementCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(SQLTransaction&, SQLResultSet&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(SQLTransaction&, SQLResultSet&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
@@ -41,6 +41,10 @@ class SQLStatementErrorCallback : public ThreadSafeRefCounted<SQLStatementErrorC
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual CallbackResult<bool> invoke(SQLTransaction&, SQLError&) = 0;
     virtual CallbackResult<bool> invokeRethrowingException(SQLTransaction&, SQLError&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
@@ -40,6 +40,10 @@ class SQLTransactionCallback : public ThreadSafeRefCounted<SQLTransactionCallbac
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(SQLTransaction&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(SQLTransaction&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
@@ -40,6 +40,10 @@ class SQLTransactionErrorCallback : public ThreadSafeRefCounted<SQLTransactionEr
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(SQLError&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(SQLError&) = 0;
 

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -53,15 +53,17 @@ class WebSocket final : public RefCounted<WebSocket>, public EventTarget, public
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebSocket);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSocket);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static ASCIILiteral subprotocolSeparator();
 
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url);
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const String& protocol);
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols);
     virtual ~WebSocket();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     static HashSet<CheckedPtr<WebSocket>>& allActiveWebSockets() WTF_REQUIRES_LOCK(s_allActiveWebSocketsLock);
     static Lock& allActiveWebSocketsLock() WTF_RETURNS_LOCK(s_allActiveWebSocketsLock);

--- a/Source/WebCore/Modules/webxr/WebXRInputSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSpace.h
@@ -41,8 +41,9 @@ public:
     static Ref<WebXRInputSpace> create(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&);
     virtual ~WebXRInputSpace();
 
-    using RefCounted<WebXRInputSpace>::ref;
-    using RefCounted<WebXRInputSpace>::deref;
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     std::optional<bool> isPositionEmulated() const final { return m_pose.isPositionEmulated; }
     void setPose(const PlatformXR::FrameData::InputSourcePose& pose) { m_pose = pose; }

--- a/Source/WebCore/Modules/webxr/WebXRJointSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRJointSpace.h
@@ -48,8 +48,9 @@ public:
     static Ref<WebXRJointSpace> create(Document&, WebXRHand&, XRHandJoint, std::optional<PlatformXR::FrameData::InputSourceHandJoint>&& = std::nullopt);
     virtual ~WebXRJointSpace();
 
-    using RefCounted<WebXRJointSpace>::ref;
-    using RefCounted<WebXRJointSpace>::deref;
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     XRHandJoint jointName() const { return m_jointName; }
 

--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -43,8 +43,9 @@ class WebXRLayer : public RefCounted<WebXRLayer>, public EventTarget, public Con
 public:
     virtual ~WebXRLayer();
 
-    using RefCounted<WebXRLayer>::ref;
-    using RefCounted<WebXRLayer>::deref;
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     virtual void startFrame(PlatformXR::FrameData&) = 0;
     virtual PlatformXR::Device::Layer endFrame() = 0;

--- a/Source/WebCore/Modules/webxr/WebXRReferenceSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRReferenceSpace.h
@@ -46,8 +46,9 @@ public:
 
     virtual ~WebXRReferenceSpace();
 
-    using RefCounted<WebXRReferenceSpace>::ref;
-    using RefCounted<WebXRReferenceSpace>::deref;
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     WebXRSession* session() const final { return m_session.get(); }
     std::optional<TransformationMatrix> nativeOrigin() const override;

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -45,6 +45,10 @@ class WebXRSpace : public EventTarget, public ContextDestructionObserver {
 public:
     virtual ~WebXRSpace();
 
+    using ContextDestructionObserver::ref;
+    using ContextDestructionObserver::deref;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     virtual WebXRSession* session() const = 0;
     virtual std::optional<TransformationMatrix> nativeOrigin() const = 0;
     std::optional<TransformationMatrix> effectiveOrigin() const;
@@ -83,8 +87,9 @@ public:
     }
     virtual ~WebXRViewerSpace();
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     WebXRViewerSpace(Document&, WebXRSession&);

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -60,14 +60,16 @@ struct XRSessionInit;
 class WebXRSystem final : public RefCounted<WebXRSystem>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRSystem);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     using IsSessionSupportedPromise = DOMPromiseDeferred<IDLBoolean>;
     using RequestSessionPromise = DOMPromiseDeferred<IDLInterface<WebXRSession>>;
 
     static Ref<WebXRSystem> create(Navigator&);
     ~WebXRSystem();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     void isSessionSupported(XRSessionMode, IsSessionSupportedPromise&&);
     void requestSession(Document&, XRSessionMode, const XRSessionInit&, RequestSessionPromise&&);
@@ -116,6 +118,10 @@ private:
     public:
         static Ref<DummyInlineDevice> create(ScriptExecutionContext&);
         virtual ~DummyInlineDevice() = default;
+
+        // ContextDestructionObserver.
+        void ref() const final { PlatformXR::Device::ref(); }
+        void deref() const final { PlatformXR::Device::deref(); }
 
     private:
         DummyInlineDevice(ScriptExecutionContext&);

--- a/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
+++ b/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
@@ -39,6 +39,10 @@ class XRFrameRequestCallback : public RefCounted<XRFrameRequestCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(double highResTimeMs, WebXRFrame&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double highResTimeMs, WebXRFrame&) = 0;
 

--- a/Source/WebCore/animation/CustomEffectCallback.h
+++ b/Source/WebCore/animation/CustomEffectCallback.h
@@ -36,6 +36,10 @@ class CustomEffectCallback : public RefCounted<CustomEffectCallback>, public Act
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(double progress) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double progress) = 0;
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -63,12 +63,14 @@ struct ResolutionContext;
 class WebAnimation : public RefCounted<WebAnimation>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebAnimation);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<WebAnimation> create(Document&, AnimationEffect*);
     static Ref<WebAnimation> create(Document&, AnimationEffect*, AnimationTimeline*);
     ~WebAnimation();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     WEBCORE_EXPORT static HashSet<WebAnimation*>& instances();
 

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -61,6 +61,10 @@ public:
         return adoptRef(*new JSCustomElementInterface(name, callback, globalObject));
     }
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     Ref<Element> constructElementWithFallback(Document&, CustomElementRegistry&, const AtomString&, ParserConstructElementWithEmptyStack = ParserConstructElementWithEmptyStack::No);
     Ref<Element> constructElementWithFallback(Document&, CustomElementRegistry&, const QualifiedName&);
     Ref<HTMLElement> createElement(Document&);

--- a/Source/WebCore/bindings/js/JSDOMGuardedObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGuardedObject.h
@@ -38,6 +38,10 @@ class WEBCORE_EXPORT DOMGuardedObject : public RefCounted<DOMGuardedObject>, pub
 public:
     ~DOMGuardedObject();
 
+    // ActiveDOMCallback.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     bool isSuspended() const { return !m_guarded || !canInvokeCallback(); } // The wrapper world has gone away or active DOM objects have been suspended.
 
     template<typename Visitor> void visitAggregate(Visitor& visitor) { visitor.append(m_guarded); }

--- a/Source/WebCore/crypto/SubtleCrypto.h
+++ b/Source/WebCore/crypto/SubtleCrypto.h
@@ -50,10 +50,14 @@ class DeferredPromise;
 enum class CryptoAlgorithmIdentifier : uint8_t;
 enum class CryptoKeyUsage : uint8_t;
 
-class SubtleCrypto : public RefCountedAndCanMakeWeakPtr<SubtleCrypto>, public ContextDestructionObserver {
+class SubtleCrypto : public RefCounted<SubtleCrypto>, public ContextDestructionObserver {
 public:
     static Ref<SubtleCrypto> create(ScriptExecutionContext* context) { return adoptRef(*new SubtleCrypto(context)); }
     ~SubtleCrypto();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     using KeyFormat = CryptoKeyFormat;
 

--- a/Source/WebCore/css/CSSPaintCallback.h
+++ b/Source/WebCore/css/CSSPaintCallback.h
@@ -39,9 +39,13 @@ class JSValue;
 namespace WebCore {
 class PaintRenderingContext2D;
 
-class CSSPaintCallback : public RefCountedAndCanMakeWeakPtr<CSSPaintCallback>, public ActiveDOMCallback {
+class CSSPaintCallback : public RefCounted<CSSPaintCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     virtual CallbackResult<void> invoke(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -44,9 +44,6 @@ template<typename> class ExceptionOr;
 
 class FontFace final : public RefCounted<FontFace>, public ActiveDOMObject, public CSSFontFaceClient {
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     struct Descriptors {
         String style;
         String weight;
@@ -64,6 +61,11 @@ public:
     static Ref<FontFace> create(ScriptExecutionContext&, const String& family, Source&&, const Descriptors&);
     static Ref<FontFace> create(ScriptExecutionContext*, CSSFontFace&);
     virtual ~FontFace();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(CSSFontFaceClient);
 
     ExceptionOr<void> setFamily(const String&);
     ExceptionOr<void> setStyle(ScriptExecutionContext&, const String&);

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -42,12 +42,14 @@ class DOMException;
 class FontFaceSet final : public RefCounted<FontFaceSet>, private FontEventClient, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(FontFaceSet);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<FontFaceSet> create(ScriptExecutionContext&, const Vector<Ref<FontFace>>& initialFaces);
     static Ref<FontFaceSet> create(ScriptExecutionContext&, CSSFontFaceSet& backing);
     virtual ~FontFaceSet();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     bool has(FontFace&) const;
     size_t size();

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -39,11 +39,13 @@ class MediaQueryEvaluator;
 class MediaQueryList final : public RefCounted<MediaQueryList>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaQueryList);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<MediaQueryList> create(Document&, MediaQueryMatcher&, MQ::MediaQueryList&&, bool matches);
     ~MediaQueryList();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     String media() const;
     bool matches();

--- a/Source/WebCore/dom/AbortAlgorithm.h
+++ b/Source/WebCore/dom/AbortAlgorithm.h
@@ -39,6 +39,10 @@ class AbortAlgorithm : public ThreadSafeRefCounted<AbortAlgorithm>, public Activ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -47,6 +47,11 @@ public:
     static Ref<AbortSignal> create(ScriptExecutionContext*);
     WEBCORE_EXPORT ~AbortSignal();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     static Ref<AbortSignal> abort(JSDOMGlobalObject&, ScriptExecutionContext&, JSC::JSValue reason);
     static Ref<AbortSignal> timeout(ScriptExecutionContext&, uint64_t milliseconds);
     static Ref<AbortSignal> any(ScriptExecutionContext&, const Vector<Ref<AbortSignal>>&);

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -50,7 +50,7 @@ enum class ReasonForSuspension : uint8_t {
     PageWillBeSuspended,
 };
 
-class WEBCORE_EXPORT ActiveDOMObject : public AbstractRefCounted, public ContextDestructionObserver {
+class WEBCORE_EXPORT ActiveDOMObject : public ContextDestructionObserver {
 public:
     // The suspendIfNeeded must be called exactly once after object construction to update
     // the suspended state to match that of the ScriptExecutionContext.

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -57,6 +57,7 @@ public:
     // ActiveDOMObject.
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     BroadcastChannelIdentifier identifier() const;
     String name() const;

--- a/Source/WebCore/dom/ContextDestructionObserver.h
+++ b/Source/WebCore/dom/ContextDestructionObserver.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 
@@ -33,7 +34,7 @@ namespace WebCore {
 
 class ScriptExecutionContext;
 
-class ContextDestructionObserver {
+class ContextDestructionObserver : public AbstractRefCountedAndCanMakeWeakPtr<ContextDestructionObserver> {
 public:
     WEBCORE_EXPORT virtual void contextDestroyed();
 

--- a/Source/WebCore/dom/CreateHTMLCallback.h
+++ b/Source/WebCore/dom/CreateHTMLCallback.h
@@ -36,6 +36,10 @@ class CreateHTMLCallback : public ThreadSafeRefCounted<CreateHTMLCallback>, publ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual bool hasCallback() const = 0;
 
     virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;

--- a/Source/WebCore/dom/CreateScriptCallback.h
+++ b/Source/WebCore/dom/CreateScriptCallback.h
@@ -36,6 +36,10 @@ class CreateScriptCallback : public ThreadSafeRefCounted<CreateScriptCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual bool hasCallback() const = 0;
 
     virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;

--- a/Source/WebCore/dom/CreateScriptURLCallback.h
+++ b/Source/WebCore/dom/CreateScriptURLCallback.h
@@ -36,6 +36,10 @@ class CreateScriptURLCallback : public ThreadSafeRefCounted<CreateScriptURLCallb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual bool hasCallback() const = 0;
 
     virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -64,6 +64,10 @@ public:
     static Ref<CustomElementRegistry> create(ScriptExecutionContext&);
     ~CustomElementRegistry();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     bool isScoped() const { return !m_window; }
     Document* document() const;
 

--- a/Source/WebCore/dom/DataTransferItemList.h
+++ b/Source/WebCore/dom/DataTransferItemList.h
@@ -47,7 +47,7 @@ class Document;
 class File;
 template<typename> class ExceptionOr;
 
-class DataTransferItemList final : public ScriptWrappable, public ContextDestructionObserver, public CanMakeWeakPtr<DataTransferItemList> {
+class DataTransferItemList final : public ScriptWrappable, public ContextDestructionObserver {
     WTF_MAKE_NONCOPYABLE(DataTransferItemList);
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DataTransferItemList);
 public:
@@ -55,8 +55,8 @@ public:
     ~DataTransferItemList();
 
     // DataTransfer owns DataTransferItemList, and DataTransfer is kept alive as long as DataTransferItemList is alive.
-    void ref() { m_dataTransfer->ref(); }
-    void deref() { m_dataTransfer->deref(); }
+    void ref() const final { m_dataTransfer->ref(); }
+    void deref() const final { m_dataTransfer->deref(); }
     DataTransfer& dataTransfer() { return m_dataTransfer.get(); }
 
     // DOM API

--- a/Source/WebCore/dom/EventTargetConcrete.h
+++ b/Source/WebCore/dom/EventTargetConcrete.h
@@ -39,8 +39,10 @@ class EventTargetConcrete final : public RefCounted<EventTargetConcrete>, public
 public:
     static Ref<EventTargetConcrete> create(ScriptExecutionContext&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
 private:
     explicit EventTargetConcrete(ScriptExecutionContext&);

--- a/Source/WebCore/dom/IdleRequestCallback.h
+++ b/Source/WebCore/dom/IdleRequestCallback.h
@@ -37,6 +37,10 @@ class IdleRequestCallback : public RefCounted<IdleRequestCallback>, public Activ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(IdleDeadline&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(IdleDeadline&) = 0;
 

--- a/Source/WebCore/dom/MapperCallback.h
+++ b/Source/WebCore/dom/MapperCallback.h
@@ -35,6 +35,10 @@ class MapperCallback : public RefCounted<MapperCallback>, public ActiveDOMCallba
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -107,7 +107,7 @@ MessagePort::MessagePort(ScriptExecutionContext& scriptExecutionContext, const M
     portToContextIdentifier().set(m_identifier, scriptExecutionContext.identifier());
 
     // Make sure the WeakPtrFactory gets initialized eagerly on the thread the MessagePort gets constructed on for thread-safety reasons.
-    initializeWeakPtrFactory();
+    EventTarget::initializeWeakPtrFactory();
 
     scriptExecutionContext.createdMessagePort(*this);
 

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -59,6 +59,7 @@ public:
     // ActiveDOMObject.
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
 

--- a/Source/WebCore/dom/MutationCallback.h
+++ b/Source/WebCore/dom/MutationCallback.h
@@ -45,6 +45,10 @@ class MutationCallback : public RefCounted<MutationCallback>, public ActiveDOMCa
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual bool hasCallback() const = 0;
 
     virtual CallbackResult<void> invoke(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;

--- a/Source/WebCore/dom/NodeFilter.h
+++ b/Source/WebCore/dom/NodeFilter.h
@@ -37,6 +37,10 @@ class NodeFilter : public RefCounted<NodeFilter>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<unsigned short> acceptNode(Node&) = 0;
     virtual CallbackResult<unsigned short> acceptNodeRethrowingException(Node&) = 0;
 

--- a/Source/WebCore/dom/ObservableInspectorAbortCallback.h
+++ b/Source/WebCore/dom/ObservableInspectorAbortCallback.h
@@ -35,6 +35,10 @@ class ObservableInspectorAbortCallback : public RefCounted<ObservableInspectorAb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/dom/PredicateCallback.h
+++ b/Source/WebCore/dom/PredicateCallback.h
@@ -35,6 +35,10 @@ class PredicateCallback : public RefCounted<PredicateCallback>, public ActiveDOM
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<bool> invoke(JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<bool> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/dom/ReducerCallback.h
+++ b/Source/WebCore/dom/ReducerCallback.h
@@ -35,6 +35,10 @@ class ReducerCallback : public RefCounted<ReducerCallback>, public ActiveDOMCall
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/dom/RequestAnimationFrameCallback.h
+++ b/Source/WebCore/dom/RequestAnimationFrameCallback.h
@@ -42,6 +42,10 @@ class RequestAnimationFrameCallback : public RefCounted<RequestAnimationFrameCal
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(double highResTimeMs) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double highResTimeMs) = 0;
 

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -426,8 +426,8 @@ private:
     WEBCORE_EXPORT GuaranteedSerialFunctionDispatcher& nativePromiseDispatcher();
 
     WeakHashSet<MessagePort, WeakPtrImplWithEventTargetData> m_messagePorts;
-    HashSet<ContextDestructionObserver*> m_destructionObservers;
-    HashSet<ActiveDOMObject*> m_activeDOMObjects;
+    WeakHashSet<ContextDestructionObserver> m_destructionObservers;
+    WeakHashSet<ActiveDOMObject> m_activeDOMObjects;
 
     HashMap<int, RefPtr<DOMTimer>> m_timeouts;
 

--- a/Source/WebCore/dom/StringCallback.h
+++ b/Source/WebCore/dom/StringCallback.h
@@ -43,6 +43,10 @@ class StringCallback : public RefCounted<StringCallback>, public ActiveDOMCallba
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(const String& data) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const String& data) = 0;
 

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -37,12 +37,12 @@ namespace WebCore {
 
 class ScriptExecutionContext;
 
-class Subscriber final : public ActiveDOMObject, public ScriptWrappable, public RefCountedAndCanMakeWeakPtr<Subscriber> {
+class Subscriber final : public ActiveDOMObject, public ScriptWrappable, public RefCounted<Subscriber> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Subscriber);
 
 public:
-    void ref() const final { RefCountedAndCanMakeWeakPtr::ref(); }
-    void deref() const final { RefCountedAndCanMakeWeakPtr::deref(); }
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void next(JSC::JSValue);
     void complete();

--- a/Source/WebCore/dom/SubscriberCallback.h
+++ b/Source/WebCore/dom/SubscriberCallback.h
@@ -37,6 +37,10 @@ class SubscriberCallback : public RefCounted<SubscriberCallback>, public ActiveD
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(Subscriber&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Subscriber&) = 0;
 

--- a/Source/WebCore/dom/SubscriptionObserverCallback.h
+++ b/Source/WebCore/dom/SubscriptionObserverCallback.h
@@ -35,6 +35,10 @@ class SubscriptionObserverCallback : public RefCounted<SubscriptionObserverCallb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.h
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.h
@@ -46,6 +46,10 @@ public:
     static Ref<TrustedTypePolicyFactory> create(ScriptExecutionContext&);
     ~TrustedTypePolicyFactory();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     ExceptionOr<Ref<TrustedTypePolicy>> createPolicy(ScriptExecutionContext&, const String& policyName, const TrustedTypePolicyOptions&);
     bool isHTML(JSC::JSValue) const;
     bool isScript(JSC::JSValue) const;

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -173,13 +173,15 @@ public:
 class ViewTransition : public RefCounted<ViewTransition>, public VisibilityChangeClient, public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(ViewTransition);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<ViewTransition> createSamePage(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     static RefPtr<ViewTransition> resolveInboundCrossDocumentViewTransition(Document&, std::unique_ptr<ViewTransitionParams>);
     static Ref<ViewTransition> setupCrossDocumentViewTransition(Document&);
     ~ViewTransition();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(VisibilityChangeClient);
 
     void skipTransition();
     void skipViewTransition(ExceptionOr<JSC::JSValue>&&);

--- a/Source/WebCore/dom/ViewTransitionUpdateCallback.h
+++ b/Source/WebCore/dom/ViewTransitionUpdateCallback.h
@@ -38,6 +38,10 @@ class ViewTransitionUpdateCallback : public RefCounted<ViewTransitionUpdateCallb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<RefPtr<DOMPromise>> invoke() = 0;
 
 private:

--- a/Source/WebCore/dom/VisitorCallback.h
+++ b/Source/WebCore/dom/VisitorCallback.h
@@ -35,6 +35,10 @@ class VisitorCallback : public RefCounted<VisitorCallback>, public ActiveDOMCall
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/fileapi/BlobCallback.h
+++ b/Source/WebCore/fileapi/BlobCallback.h
@@ -39,6 +39,10 @@ class BlobCallback : public RefCounted<BlobCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(Blob*) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Blob*) = 0;
 

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -53,12 +53,14 @@ template<typename> class ExceptionOr;
 class FileReader final : public RefCounted<FileReader>, public ActiveDOMObject, public EventTarget, private FileReaderLoaderClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(FileReader);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<FileReader> create(ScriptExecutionContext&);
 
     virtual ~FileReader();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     enum ReadyState {
         EMPTY = 0,

--- a/Source/WebCore/html/DOMFormData.h
+++ b/Source/WebCore/html/DOMFormData.h
@@ -53,6 +53,10 @@ public:
     static ExceptionOr<Ref<DOMFormData>> create(ScriptExecutionContext&, HTMLFormElement*, HTMLElement*);
     static Ref<DOMFormData> create(ScriptExecutionContext*, const PAL::TextEncoding&);
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     const Vector<Item>& items() const { return m_items; }
     const PAL::TextEncoding& encoding() const { return m_encoding; }
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -69,6 +69,7 @@ public:
     // ActiveDOMObject.
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
+    USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
     void formOwnerRemovedFromTree(const Node& formRoot);
 

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -48,6 +48,7 @@ public:
     // ActiveDOMObject.
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
+    USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
     void scheduleErrorEvent();
     void cancelPendingErrorEvent();

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -775,6 +775,7 @@ class PendingImageBitmap final : public RefCounted<PendingImageBitmap>, public A
 public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(FileReaderLoaderClient);
 
     static void fetch(ScriptExecutionContext& scriptExecutionContext, RefPtr<Blob>&& blob, ImageBitmapOptions&& options, std::optional<IntRect> rect, ImageBitmap::ImageBitmapCompletionHandler&& completionHandler)
     {

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -53,6 +53,11 @@ public:
     static Ref<MediaController> create(ScriptExecutionContext&);
     virtual ~MediaController();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     Ref<TimeRanges> buffered() const final;
     Ref<TimeRanges> seekable() const final;
     Ref<TimeRanges> played() final;

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -100,9 +100,6 @@ private:
 class OffscreenCanvas final : public ActiveDOMObject, public CanvasBase, public RefCounted<OffscreenCanvas>, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(OffscreenCanvas, WEBCORE_EXPORT);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     struct ImageEncodeOptions {
         String type = "image/png"_s;
         double quality = 1.0;
@@ -122,6 +119,11 @@ public:
     static Ref<OffscreenCanvas> create(ScriptExecutionContext&, std::unique_ptr<DetachedOffscreenCanvas>&&);
     static Ref<OffscreenCanvas> create(ScriptExecutionContext&, PlaceholderRenderingContext&);
     WEBCORE_EXPORT virtual ~OffscreenCanvas();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     void setWidth(unsigned);
     void setHeight(unsigned);

--- a/Source/WebCore/html/VideoFrameRequestCallback.h
+++ b/Source/WebCore/html/VideoFrameRequestCallback.h
@@ -40,6 +40,10 @@ class VideoFrameRequestCallback : public RefCounted<VideoFrameRequestCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(double, const VideoFrameMetadata&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double, const VideoFrameMetadata&) = 0;
 

--- a/Source/WebCore/html/VoidCallback.h
+++ b/Source/WebCore/html/VoidCallback.h
@@ -35,6 +35,10 @@ class VoidCallback : public RefCounted<VoidCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke() = 0;
     virtual CallbackResult<void> invokeRethrowingException() = 0;
 

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -36,9 +36,10 @@ class HTMLCanvasElement;
 class GPUBasedCanvasRenderingContext : public CanvasRenderingContext, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_NON_HEAP_ALLOCATABLE(GPUBasedCanvasRenderingContext);
 public:
-    // ActiveDOMObject.
+    // ContextDestructionObserver.
     void ref() const final { CanvasRenderingContext::ref(); }
     void deref() const final { CanvasRenderingContext::deref(); }
+    USING_CAN_MAKE_WEAKPTR(CanvasRenderingContext);
 
     virtual void reshape() = 0;
 protected:

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -55,6 +55,10 @@ public:
     static RefPtr<WebGLProgram> create(WebGLRenderingContextBase&);
     virtual ~WebGLProgram();
 
+    // ContextDestructionObserver.
+    void ref() const final { WebGLObject::ref(); }
+    void deref() const final { WebGLObject::deref(); }
+
     static HashMap<WebGLProgram*, WebGLRenderingContextBase*>& instances() WTF_REQUIRES_LOCK(instancesLock());
     static Lock& instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
 

--- a/Source/WebCore/html/closewatcher/CloseWatcher.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.h
@@ -57,8 +57,11 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 
+    // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
 private:
     static Ref<CloseWatcher> establish(Document&);
 

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -46,12 +46,14 @@ class VTTRegionList;
 class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TextTrack);
 public:
-    void ref() const override { TrackBase::ref(); }
-    void deref() const override { TrackBase::deref(); }
-
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language);
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);
     virtual ~TextTrack();
+
+    // ContextDestructionObserver.
+    void ref() const override { TrackBase::ref(); }
+    void deref() const override { TrackBase::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     void didMoveToNewDocument(Document& newDocument) final;
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -69,10 +69,12 @@ private:
 class TextTrackCue : public RefCounted<TextTrackCue>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TextTrackCue);
 public:
+    static ExceptionOr<Ref<TextTrackCue>> create(Document&, double start, double end, DocumentFragment&);
+
+    // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
-
-    static ExceptionOr<Ref<TextTrackCue>> create(Document&, double start, double end, DocumentFragment&);
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     void didMoveToNewDocument(Document&);
 

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -53,6 +53,10 @@ class TrackBase
 public:
     virtual ~TrackBase();
 
+    // ContextDestructionObserver.
+    void ref() const override { RefCounted::ref(); }
+    void deref() const override { RefCounted::deref(); }
+
     virtual void didMoveToNewDocument(Document&);
 
     enum Type { BaseTrack, TextTrack, AudioTrack, VideoTrack };

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -43,10 +43,12 @@ using TrackID = uint64_t;
 class TrackListBase : public RefCounted<TrackListBase>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TrackListBase);
 public:
+    virtual ~TrackListBase();
+
+    // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
-
-    virtual ~TrackListBase();
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     enum Type { BaseTrackList, TextTrackList, AudioTrackList, VideoTrackList };
     Type type() const { return m_type; }

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -45,7 +45,7 @@ class HTMLDivElement;
 class VTTCueBox;
 class VTTScanner;
 
-class WEBCORE_EXPORT VTTRegion final : public RefCountedAndCanMakeWeakPtr<VTTRegion>, public ContextDestructionObserver {
+class WEBCORE_EXPORT VTTRegion final : public RefCounted<VTTRegion>, public ContextDestructionObserver {
 public:
     static Ref<VTTRegion> create(ScriptExecutionContext& context)
     {
@@ -53,6 +53,10 @@ public:
     }
 
     virtual ~VTTRegion();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     const String& id() const { return m_id; }
     void setId(const String&);

--- a/Source/WebCore/inspector/RTCLogsCallback.h
+++ b/Source/WebCore/inspector/RTCLogsCallback.h
@@ -35,6 +35,10 @@ class RTCLogsCallback : public RefCounted<RTCLogsCallback>, public ActiveDOMCall
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     struct Logs {
         String type;
         String message;

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -49,11 +49,15 @@ class Element;
 class MediaResource;
 class WeakPtrImplWithEventTargetData;
 
-class MediaResourceLoader final : public PlatformMediaResourceLoader, public CanMakeWeakPtr<MediaResourceLoader>, public ContextDestructionObserver {
+class MediaResourceLoader final : public PlatformMediaResourceLoader, public ContextDestructionObserver {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(MediaResourceLoader, WEBCORE_EXPORT);
 public:
     static Ref<MediaResourceLoader> create(Document& document, Element& element, const String& crossOriginMode, FetchOptions::Destination destination) { return adoptRef(*new MediaResourceLoader(document, element, crossOriginMode, destination)); }
     WEBCORE_EXPORT virtual ~MediaResourceLoader();
+
+    // ContextDestructionObserver.
+    void ref() const final { PlatformMediaResourceLoader::ref(); }
+    void deref() const final { PlatformMediaResourceLoader::deref(); }
 
     RefPtr<PlatformMediaResource> requestResource(ResourceRequest&&, LoadOptions) final;
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&&) final;

--- a/Source/WebCore/page/Crypto.h
+++ b/Source/WebCore/page/Crypto.h
@@ -45,6 +45,10 @@ public:
     static Ref<Crypto> create(ScriptExecutionContext* context) { return adoptRef(*new Crypto(context)); }
     virtual ~Crypto();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     ExceptionOr<void> getRandomValues(JSC::ArrayBufferView&);
     String randomUUID() const;
 

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -43,7 +43,7 @@ class Document;
 class ImminentlyScheduledWorkScope;
 class ScheduledAction;
 
-class DOMTimer final : public RefCountedAndCanMakeWeakPtr<DOMTimer>, public ActiveDOMObject {
+class DOMTimer final : public RefCounted<DOMTimer>, public ActiveDOMObject {
     WTF_MAKE_NONCOPYABLE(DOMTimer);
     WTF_MAKE_TZONE_ALLOCATED(DOMTimer);
 public:

--- a/Source/WebCore/page/IntersectionObserverCallback.h
+++ b/Source/WebCore/page/IntersectionObserverCallback.h
@@ -39,6 +39,10 @@ class IntersectionObserverCallback : public RefCounted<IntersectionObserverCallb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual bool hasCallback() const = 0;
 
     virtual CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>&, IntersectionObserver&) = 0;

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -89,6 +89,11 @@ public:
     static Ref<LocalDOMWindow> create(Document& document) { return adoptRef(*new LocalDOMWindow(document)); }
     WEBCORE_EXPORT virtual ~LocalDOMWindow();
 
+    // ContextDestructionObserver.
+    void ref() const final { DOMWindow::ref(); }
+    void deref() const final { DOMWindow::deref(); }
+    USING_CAN_MAKE_WEAKPTR(DOMWindow);
+
     // In some rare cases, we'll reuse a LocalDOMWindow for a new Document. For example,
     // when a script calls window.open("..."), the browser gives JavaScript a window
     // synchronously but kicks off the load in the window asynchronously. Web sites
@@ -378,9 +383,6 @@ public:
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     PushManager& pushManager();
-
-    void ref() const final { DOMWindow::ref(); }
-    void deref() const final { DOMWindow::deref(); }
 #endif
 
 private:

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -51,8 +51,10 @@ public:
 
     ~NavigationHistoryEntry();
 
+    // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     const String& url() const;
     String key() const;

--- a/Source/WebCore/page/NavigationInterceptHandler.h
+++ b/Source/WebCore/page/NavigationInterceptHandler.h
@@ -35,6 +35,10 @@ class NavigationInterceptHandler : public ThreadSafeRefCounted<NavigationInterce
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual CallbackResult<WTF::RefPtr<DOMPromise>> invoke() = 0;
 
 private:

--- a/Source/WebCore/page/NavigatorBase.h
+++ b/Source/WebCore/page/NavigatorBase.h
@@ -44,11 +44,15 @@ class WebCoreOpaqueRoot;
 class WebLockManager;
 template<typename> class ExceptionOr;
 
-class NavigatorBase : public RefCountedAndCanMakeWeakPtr<NavigatorBase>, public ContextDestructionObserver, public CanMakeCheckedPtr<NavigatorBase> {
+class NavigatorBase : public RefCounted<NavigatorBase>, public ContextDestructionObserver, public CanMakeCheckedPtr<NavigatorBase> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NavigatorBase);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NavigatorBase);
 public:
     virtual ~NavigatorBase();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     static String appName();
     String appVersion() const;

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -81,6 +81,11 @@ public:
     static Ref<Performance> create(ScriptExecutionContext* context, MonotonicTime timeOrigin) { return adoptRef(*new Performance(context, timeOrigin)); }
     ~Performance();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     DOMHighResTimeStamp now() const;
     DOMHighResTimeStamp timeOrigin() const;
     ReducedResolutionSeconds nowInReducedResolutionSeconds() const;

--- a/Source/WebCore/page/PerformanceObserverCallback.h
+++ b/Source/WebCore/page/PerformanceObserverCallback.h
@@ -38,6 +38,10 @@ class PerformanceObserverCallback : public RefCounted<PerformanceObserverCallbac
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual bool hasCallback() const = 0;
 
     virtual CallbackResult<void> invoke(PerformanceObserver&, PerformanceObserverEntryList&, PerformanceObserver&) = 0;

--- a/Source/WebCore/page/ResizeObserverCallback.h
+++ b/Source/WebCore/page/ResizeObserverCallback.h
@@ -38,6 +38,10 @@ class ResizeObserverCallback : public RefCounted<ResizeObserverCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual bool hasCallback() const = 0;
 
     virtual CallbackResult<void> invoke(ResizeObserver&, const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&) = 0;

--- a/Source/WebCore/testing/EventTargetForTesting.h
+++ b/Source/WebCore/testing/EventTargetForTesting.h
@@ -48,6 +48,7 @@ public:
     // MessageClientForTesting, ActiveDOMObject
     void ref() const final { return RefCounted::ref(); }
     void deref() const final { return RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
 private:
     EventTargetForTesting(ScriptExecutionContext&, MessageTargetForTesting&);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -195,7 +195,7 @@ struct MockWebAuthenticationConfiguration;
 
 class Internals final
     : public RefCounted<Internals>
-    , private ContextDestructionObserver
+    , public ContextDestructionObserver
 #if ENABLE(MEDIA_STREAM)
     , public CanMakeCheckedPtr<Internals>
     , public RealtimeMediaSourceObserver
@@ -210,6 +210,11 @@ class Internals final
 public:
     static Ref<Internals> create(Document&);
     virtual ~Internals();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(ContextDestructionObserver);
 
     static void resetToConsistentState(Page&);
 

--- a/Source/WebCore/testing/XRSimulateUserActivationFunction.h
+++ b/Source/WebCore/testing/XRSimulateUserActivationFunction.h
@@ -39,6 +39,10 @@ class XRSimulateUserActivationFunction : public RefCounted<XRSimulateUserActivat
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual CallbackResult<void> invoke(void) = 0;
     virtual CallbackResult<void> invokeRethrowingException(void) = 0;
 

--- a/Source/WebCore/workers/WorkerEventLoop.h
+++ b/Source/WebCore/workers/WorkerEventLoop.h
@@ -42,6 +42,10 @@ public:
     // FIXME: This should be removed once MicrotaskQueue is integrated with EventLoopTaskGroup.
     void clearMicrotaskQueue();
 
+    // ContextDestructionObserver.
+    void ref() const final { EventLoop::ref(); }
+    void deref() const final { EventLoop::deref(); }
+
 private:
     explicit WorkerEventLoop(WorkerOrWorkletGlobalScope&);
 

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -49,13 +49,15 @@ struct StructuredSerializeOptions;
 class ServiceWorker final : public RefCounted<ServiceWorker>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ServiceWorker, WEBCORE_EXPORT);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     using State = ServiceWorkerState;
     static Ref<ServiceWorker> getOrCreate(ScriptExecutionContext&, ServiceWorkerData&&);
 
     WEBCORE_EXPORT virtual ~ServiceWorker();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     const URL& scriptURL() const { return m_data.scriptURL; }
 

--- a/Source/WebCore/workers/service/ServiceWorkerClient.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.h
@@ -55,6 +55,10 @@ public:
 
     ~ServiceWorkerClient();
 
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     const URL& url() const;
     FrameType frameType() const;
     Type type() const;

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -62,9 +62,10 @@ public:
 
     ~ServiceWorkerContainer();
 
-    // ActiveDOMObject.
+    // ContextDestructionObserver.
     void ref() const final;
     void deref() const final;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     ServiceWorker* controller() const;
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -57,12 +57,14 @@ struct CookieStoreGetOptions;
 class ServiceWorkerRegistration final : public RefCounted<ServiceWorkerRegistration>, public Supplementable<ServiceWorkerRegistration>, public EventTarget, public ActiveDOMObject, public PushSubscriptionOwner {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ServiceWorkerRegistration, WEBCORE_EXPORT);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     static Ref<ServiceWorkerRegistration> getOrCreate(ScriptExecutionContext&, Ref<ServiceWorkerContainer>&&, ServiceWorkerRegistrationData&&);
 
     WEBCORE_EXPORT ~ServiceWorkerRegistration();
+
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     ServiceWorkerRegistrationIdentifier identifier() const { return m_registrationData.identifier; }
 

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -48,8 +48,10 @@ public:
     static ExceptionOr<Ref<SharedWorker>> create(Document&, Variant<RefPtr<TrustedScriptURL>, String>&&, std::optional<Variant<String, WorkerOptions>>&&);
     ~SharedWorker();
 
+    // ContextDestructionObserver.
     void ref() const final { AbstractWorker::ref(); }
     void deref() const final { AbstractWorker::deref(); }
+    USING_CAN_MAKE_WEAKPTR(AbstractWorker);
 
     static SharedWorker* fromIdentifier(SharedWorkerObjectIdentifier);
     MessagePort& port() const { return m_port.get(); }

--- a/Source/WebCore/worklets/Worklet.h
+++ b/Source/WebCore/worklets/Worklet.h
@@ -40,13 +40,14 @@ class Document;
 class WorkletGlobalScopeProxy;
 class WorkletPendingTasks;
 
-class Worklet : public RefCountedAndCanMakeWeakPtr<Worklet>, public ScriptWrappable, public ActiveDOMObject {
+class Worklet : public RefCounted<Worklet>, public ScriptWrappable, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Worklet);
 public:
+    virtual ~Worklet();
+
+    // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
-
-    virtual ~Worklet();
 
     virtual void addModule(const String& moduleURL, WorkletOptions&&, DOMPromiseDeferred<void>&&);
 

--- a/Source/WebCore/xml/CustomXPathNSResolver.h
+++ b/Source/WebCore/xml/CustomXPathNSResolver.h
@@ -36,6 +36,10 @@ class CustomXPathNSResolver : public XPathNSResolver, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    // ContextDestructionObserver.
+    void ref() const final { XPathNSResolver::ref(); }
+    void deref() const final { XPathNSResolver::deref(); }
+
     virtual CallbackResult<String> lookupNamespaceURIForBindings(const AtomString& prefix) = 0;
     virtual CallbackResult<String> lookupNamespaceURIForBindingsRethrowingException(const AtomString& prefix) = 0;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -46,7 +46,7 @@ class InjectedBundleScriptWorld;
 class WebFrame;
 class WebImage;
 
-class InjectedBundleNodeHandle : public API::ObjectImpl<API::Object::Type::BundleNodeHandle>, public WebCore::ActiveDOMObject, public CanMakeWeakPtr<InjectedBundleNodeHandle> {
+class InjectedBundleNodeHandle : public API::ObjectImpl<API::Object::Type::BundleNodeHandle>, public WebCore::ActiveDOMObject {
 public:
     static RefPtr<InjectedBundleNodeHandle> getOrCreate(JSContextRef, JSObjectRef);
     static RefPtr<InjectedBundleNodeHandle> getOrCreate(WebCore::Node*);

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -65,7 +65,7 @@ public:
 private:
     WebSocketChannel(WebPageProxyIdentifier, WebCore::Document&, WebCore::WebSocketChannelClient&);
 
-    static WebCore::NetworkSendQueue createMessageQueue(WebCore::Document&, WebSocketChannel&);
+    static Ref<WebCore::NetworkSendQueue> createMessageQueue(WebCore::Document&, WebSocketChannel&);
 
     // ThreadableWebSocketChannel
     ConnectStatus connect(const URL&, const String& protocol) final;
@@ -116,7 +116,7 @@ private:
     String m_extensions;
     size_t m_bufferedAmount { 0 };
     bool m_isClosing { false };
-    WebCore::NetworkSendQueue m_messageQueue;
+    const Ref<WebCore::NetworkSendQueue> m_messageQueue;
     WebCore::WebSocketChannelInspector m_inspector;
     WebCore::ResourceRequest m_handshakeRequest;
     WebCore::ResourceResponse m_handshakeResponse;


### PR DESCRIPTION
#### ca9a027f94b8e3e679bed8206ffc15e752464a53
<pre>
Stop using raw pointers in containers in ScriptExecutionContext.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302764">https://bugs.webkit.org/show_bug.cgi?id=302764</a>

Reviewed by Darin Adler.

To make it happens, I had to make ContextDestructionObserver subclass
CanMakeWeakPtr. Both ActiveDOMObject and ContextDestructionObserver were
used as raw pointers but the good news is that ActiveDOMObject subclasses
ContextDestructionObserver and is thus now CanMakeWeakPtr as well.

Use WeakHashSet in ScriptExecutionContext instead of HashSet of raw pointers,
which is a lot safer.

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h:
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h:
* Source/WebCore/Modules/encryptedmedia/CDM.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h:
* Source/WebCore/Modules/entriesapi/ErrorCallback.h:
* Source/WebCore/Modules/entriesapi/FileCallback.h:
* Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h:
* Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h:
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
* Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.h:
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/geolocation/PositionCallback.h:
* Source/WebCore/Modules/geolocation/PositionErrorCallback.h:
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsUtils.h:
* Source/WebCore/Modules/mediasession/MediaSession.h:
(WebCore::MediaSession::visitActionHandlers const):
* Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h:
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::createMessageQueue):
(WebCore::RTCDataChannel::send):
(WebCore::RTCDataChannel::close):
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/NotificationPermissionCallback.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h:
* Source/WebCore/Modules/reporting/ReportingObserverCallback.h:
* Source/WebCore/Modules/reporting/ReportingScope.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLock.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/streams/QueuingStrategySize.h:
* Source/WebCore/Modules/streams/ReadableStream.h:
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
* Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h:
* Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h:
* Source/WebCore/Modules/streams/UnderlyingSourceStartCallback.h:
* Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h:
* Source/WebCore/Modules/web-locks/WebLockManager.h:
* Source/WebCore/Modules/webaudio/AudioBufferCallback.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsBase.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h:
* Source/WebCore/Modules/webdatabase/DatabaseCallback.h:
* Source/WebCore/Modules/webdatabase/SQLStatementCallback.h:
* Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h:
* Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h:
* Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h:
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/webxr/WebXRInputSpace.h:
* Source/WebCore/Modules/webxr/WebXRJointSpace.h:
* Source/WebCore/Modules/webxr/WebXRLayer.h:
* Source/WebCore/Modules/webxr/WebXRReferenceSpace.h:
* Source/WebCore/Modules/webxr/WebXRSpace.h:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/Modules/webxr/XRFrameRequestCallback.h:
* Source/WebCore/animation/CustomEffectCallback.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
* Source/WebCore/bindings/js/JSDOMGuardedObject.h:
* Source/WebCore/crypto/SubtleCrypto.h:
* Source/WebCore/css/CSSPaintCallback.h:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/dom/AbortAlgorithm.h:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/ContextDestructionObserver.h:
* Source/WebCore/dom/CreateHTMLCallback.h:
* Source/WebCore/dom/CreateScriptCallback.h:
* Source/WebCore/dom/CreateScriptURLCallback.h:
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/DataTransferItemList.h:
* Source/WebCore/dom/EventTargetConcrete.h:
* Source/WebCore/dom/IdleRequestCallback.h:
* Source/WebCore/dom/MapperCallback.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::MessagePort):
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/MutationCallback.h:
* Source/WebCore/dom/NodeFilter.h:
* Source/WebCore/dom/ObservableInspectorAbortCallback.h:
* Source/WebCore/dom/PredicateCallback.h:
* Source/WebCore/dom/ReducerCallback.h:
* Source/WebCore/dom/RequestAnimationFrameCallback.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::checkConsistency const):
(WebCore::ScriptExecutionContext::~ScriptExecutionContext):
(WebCore::ScriptExecutionContext::forEachActiveDOMObject const):
(WebCore::ScriptExecutionContext::suspendActiveDOMObjectIfNeeded):
(WebCore::ScriptExecutionContext::didCreateActiveDOMObject):
(WebCore::ScriptExecutionContext::willDestroyActiveDOMObject):
(WebCore::ScriptExecutionContext::didCreateDestructionObserver):
(WebCore::ScriptExecutionContext::willDestroyDestructionObserver):
(WebCore::ScriptExecutionContext::hasPendingActivity const):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/StringCallback.h:
* Source/WebCore/dom/Subscriber.h:
* Source/WebCore/dom/SubscriberCallback.h:
* Source/WebCore/dom/SubscriptionObserverCallback.h:
* Source/WebCore/dom/TrustedTypePolicyFactory.h:
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/dom/ViewTransitionUpdateCallback.h:
* Source/WebCore/dom/VisitorCallback.h:
* Source/WebCore/fileapi/BlobCallback.h:
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/fileapi/NetworkSendQueue.cpp:
(WebCore::NetworkSendQueue::create):
(WebCore::NetworkSendQueue::enqueue):
* Source/WebCore/fileapi/NetworkSendQueue.h:
* Source/WebCore/html/DOMFormData.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/MediaController.h:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/VideoFrameRequestCallback.h:
* Source/WebCore/html/VoidCallback.h:
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/WebGLProgram.h:
* Source/WebCore/html/closewatcher/CloseWatcher.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/inspector/RTCLogsCallback.h:
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/page/Crypto.h:
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/IntersectionObserverCallback.h:
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/NavigationInterceptHandler.h:
* Source/WebCore/page/NavigatorBase.h:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceObserverCallback.h:
* Source/WebCore/page/ResizeObserverCallback.h:
* Source/WebCore/testing/EventTargetForTesting.h:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/XRSimulateUserActivationFunction.h:
* Source/WebCore/workers/WorkerEventLoop.h:
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerClient.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/worklets/Worklet.h:
* Source/WebCore/xml/CustomXPathNSResolver.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::createMessageQueue):
(WebKit::WebSocketChannel::send):
(WebKit::WebSocketChannel::disconnect):
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/303309@main">https://commits.webkit.org/303309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7467b33297faa1aeeb1ba618211bbe75e9eb65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131987 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139501 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1bd5ab0d-1163-449b-a349-294b6c699ef9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/56103313-0f4d-42b9-95d8-7b556c576b9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134933 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81681 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d1e6089b-793b-444c-b1ec-b8ea440b9a05) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82719 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142146 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36909 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109262 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4230 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3141 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114485 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4202 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32881 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67649 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->