### PR TITLE
[Logging] Report whether video and audio tracks are protected in logging and in Web Inspector

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -223,7 +223,8 @@
                 { "name": "codec", "type": "string", "description": "The codec string of the primary audio track. (E.g., \"hvc1.1.6.L123.B0\")" },
                 { "name": "humanReadableCodecString", "type": "string", "description": "A human readable version of the `codec` parameter."},
                 { "name": "numberOfChannels", "type": "integer", "description": "The number of audio channels in the primary audio track." },
-                { "name": "sampleRate", "type": "number", "description": "The sample rate of the primary audio track in hertz." }
+                { "name": "sampleRate", "type": "number", "description": "The sample rate of the primary audio track in hertz." },
+                { "name": "isProtected", "type": "boolean", "optional": true, "description": "Whether the track contains protected contents" }
             ]
         },
         {
@@ -239,7 +240,8 @@
                 { "name": "height", "type": "integer", "description": "The native height of the video track in CSS pixels" },
                 { "name": "width", "type": "integer", "description": "The native width of the video track in CSS pixels" },
                 { "name": "spatialVideoMetadata", "$ref": "SpatialVideoMetadata", "optional": true },
-                { "name": "videoProjectionMetadata", "$ref": "VideoProjectionMetadata", "optional": true }
+                { "name": "videoProjectionMetadata", "$ref": "VideoProjectionMetadata", "optional": true },
+                { "name": "isProtected", "type": "boolean", "optional": true, "description": "Whether the track contains protected contents" }
             ]
         },
         {

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1671,6 +1671,8 @@ void MediaElementSession::clientCharacteristicsChanged(bool positionChanged)
 #if !RELEASE_LOG_DISABLED
 String MediaElementSession::descriptionForTrack(const AudioTrack& track)
 {
+    if (track.configuration().isProtected())
+        return makeString(track.configuration().codec(), " protected"_s);
     return track.configuration().codec();
 }
 
@@ -1681,6 +1683,8 @@ String MediaElementSession::descriptionForTrack(const VideoTrack& track)
     builder.append(track.configuration().width(), 'x', track.configuration().height());
     if (!track.configuration().codec().isEmpty())
         builder.append(' ', track.configuration().codec());
+    if (track.configuration().isProtected())
+        builder.append(" protected"_s);
     if (track.configuration().spatialVideoMetadata())
         builder.append(" spatial"_s);
     if (auto metadata = track.configuration().videoProjectionMetadata())

--- a/Source/WebCore/html/track/AudioTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.cpp
@@ -42,6 +42,7 @@ Ref<JSON::Object> AudioTrackConfiguration::toJSON() const
     json->setInteger("sampleRate"_s, sampleRate());
     json->setInteger("numberOfChannels"_s, numberOfChannels());
     json->setInteger("bitrate"_s, bitrate());
+    json->setBoolean("isProtected"_s, isProtected());
     return json;
 }
 

--- a/Source/WebCore/html/track/AudioTrackConfiguration.h
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.h
@@ -55,6 +55,9 @@ public:
     uint64_t bitrate() const { return m_state.bitrate; }
     void setBitrate(uint64_t bitrate) { m_state.bitrate = bitrate; }
 
+    bool isProtected() const { return m_state.isProtected; }
+    void setProtected(bool isProtected) { m_state.isProtected = isProtected; }
+
     Ref<JSON::Object> toJSON() const;
 
 private:

--- a/Source/WebCore/html/track/VideoTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.cpp
@@ -117,6 +117,15 @@ void VideoTrackConfiguration::setVideoProjectionMetadata(std::optional<VideoProj
     notifyObservers();
 }
 
+void VideoTrackConfiguration::setProtected(bool isProtected)
+{
+    if (m_state.isProtected == isProtected)
+        return;
+
+    m_state.isProtected = isProtected;
+    notifyObservers();
+}
+
 void VideoTrackConfiguration::notifyObservers()
 {
     m_observers.forEach([] (auto& observer) {
@@ -135,6 +144,7 @@ Ref<JSON::Object> VideoTrackConfiguration::toJSON() const
     json->setInteger("bitrate"_s, bitrate());
     json->setBoolean("isSpatial"_s, !!spatialVideoMetadata());
     json->setBoolean("isImmersive"_s, !!videoProjectionMetadata());
+    json->setBoolean("isProtected"_s, isProtected());
     return json;
 }
 

--- a/Source/WebCore/html/track/VideoTrackConfiguration.h
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.h
@@ -71,6 +71,9 @@ public:
     std::optional<VideoProjectionMetadata> videoProjectionMetadata() const { return m_state.videoProjectionMetadata; }
     void setVideoProjectionMetadata(std::optional<VideoProjectionMetadata>);
 
+    bool isProtected() const { return m_state.isProtected; }
+    void setProtected(bool);
+
     using ChangedStateObserver = Observer<void()>;
     void addStateObserver(ChangedStateObserver&);
     void removeStateObserver(const ChangedStateObserver&);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3284,6 +3284,8 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> In
                 .release();
             videoJSON->setVideoProjectionMetadata(WTFMove(metadataJSON));
         }
+        if (configuration.isProtected())
+            videoJSON->setIsProtected(true);
         stats->setVideo(WTFMove(videoJSON));
     }
 
@@ -3296,6 +3298,8 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> In
             .setNumberOfChannels(configuration.numberOfChannels())
             .setSampleRate(configuration.sampleRate())
             .release();
+        if (configuration.isProtected())
+            audioJSON->setIsProtected(true);
         stats->setAudio(WTFMove(audioJSON));
     }
 

--- a/Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h
@@ -35,6 +35,7 @@ struct PlatformAudioTrackConfiguration : PlatformTrackConfiguration {
     uint32_t sampleRate { 0 };
     uint32_t numberOfChannels { 0 };
     uint64_t bitrate { 0 };
+    bool isProtected { false };
 
     friend bool operator==(const PlatformAudioTrackConfiguration&, const PlatformAudioTrackConfiguration&) = default;
 };

--- a/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
@@ -43,6 +43,7 @@ struct PlatformVideoTrackConfiguration : PlatformTrackConfiguration {
     uint64_t bitrate { 0 };
     std::optional<SpatialVideoMetadata> spatialVideoMetadata;
     std::optional<VideoProjectionMetadata> videoProjectionMetadata;
+    bool isProtected { false };
 
     friend bool operator==(const PlatformVideoTrackConfiguration&, const PlatformVideoTrackConfiguration&) = default;
 };

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
@@ -111,6 +111,7 @@ private:
     std::optional<VideoProjectionMetadata> videoProjectionMetadata() const;
     uint32_t sampleRate() const;
     uint32_t numberOfChannels() const;
+    bool isProtected() const;
 
     const RetainPtr<AVPlayerItemTrack> m_playerItemTrack;
     const RefPtr<MediaSelectionOptionAVFObjC> m_mediaSelectionOption;

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -364,6 +364,7 @@ PlatformVideoTrackConfiguration AVTrackPrivateAVFObjCImpl::videoTrackConfigurati
         bitrate(),
         spatialVideoMetadata(),
         videoProjectionMetadata(),
+        isProtected(),
     };
 }
 
@@ -374,6 +375,7 @@ PlatformAudioTrackConfiguration AVTrackPrivateAVFObjCImpl::audioTrackConfigurati
         sampleRate(),
         numberOfChannels(),
         bitrate(),
+        isProtected(),
     };
 }
 
@@ -474,6 +476,11 @@ uint64_t AVTrackPrivateAVFObjCImpl::bitrate() const
     if (!std::isfinite(assetTrack.estimatedDataRate))
         return 0;
     return assetTrack.estimatedDataRate;
+}
+
+bool AVTrackPrivateAVFObjCImpl::isProtected() const
+{
+    return formatDescriptionIsProtected(formatDescriptionFor(*this).get());
 }
 
 std::optional<SpatialVideoMetadata> AVTrackPrivateAVFObjCImpl::spatialVideoMetadata() const

--- a/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
@@ -130,6 +130,10 @@ String codecFromFormatDescription(CMFormatDescriptionRef formatDescription)
         return emptyString();
 
     auto subType = PAL::softLink_CoreMedia_CMFormatDescriptionGetMediaSubType(formatDescription);
+    CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::kCMFormatDescriptionExtension_ProtectedContentOriginalFormat : CFSTR("CommonEncryptionOriginalFormat");
+    if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, originalFormatKey)))
+        CFNumberGetValue(originalFormat, kCFNumberSInt32Type, &subType);
+
     switch (subType) {
     case kCMVideoCodecType_H264:
     case 'cavc':
@@ -223,6 +227,22 @@ String codecFromFormatDescription(CMFormatDescriptionRef formatDescription)
     }
 
     return emptyString();
+}
+
+bool formatDescriptionIsProtected(CMFormatDescriptionRef formatDescription)
+{
+    if (!formatDescription)
+        return false;
+
+    CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::kCMFormatDescriptionExtension_ProtectedContentOriginalFormat : CFSTR("CommonEncryptionOriginalFormat");
+
+    // Note: this assumes only-and-all content which is protected will have the ProtectedContentOriginalFormat key.
+    if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, originalFormatKey))) {
+        UNUSED_PARAM(originalFormat);
+        return true;
+    }
+
+    return false;
 }
 
 std::optional<SpatialVideoMetadata> spatialVideoMetadataFromFormatDescription(CMFormatDescriptionRef formatDescription)

--- a/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.h
+++ b/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.h
@@ -42,6 +42,7 @@ TrackInfoTrackType typeFromFormatDescription(CMFormatDescriptionRef);
 FloatSize presentationSizeFromFormatDescription(CMFormatDescriptionRef);
 std::optional<PlatformVideoColorSpace> colorSpaceFromFormatDescription(CMFormatDescriptionRef);
 String codecFromFormatDescription(CMFormatDescriptionRef);
+bool formatDescriptionIsProtected(CMFormatDescriptionRef);
 std::optional<SpatialVideoMetadata> spatialVideoMetadataFromFormatDescription(CMFormatDescriptionRef);
 std::optional<VideoProjectionMetadata> videoProjectionMetadataFromFormatDescription(CMFormatDescriptionRef);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
@@ -49,6 +49,7 @@ void AudioTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
     setId(m_impl->id());
     setLabel(m_impl->label());
     setLanguage(m_impl->language());
+    setConfiguration(m_impl->audioTrackConfiguration());
 }
 
 AVAssetTrack* AudioTrackPrivateMediaSourceAVFObjC::assetTrack()

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1338,6 +1338,8 @@ localizedStrings["Property"] = "Property";
 localizedStrings["Proportional Numerals @ Font Details Sidebar Property Value"] = "Proportional Numerals";
 /* Property value for `font-variant-alternates: proportional-width`. */
 localizedStrings["Proportional-Width Variants @ Font Details Sidebar Property Value"] = "Proportional-Width Variants";
+/* Title for Protected row in Media Sidebar */
+localizedStrings["Protected @ Media Sidebar"] = "Protected";
 localizedStrings["Protocol"] = "Protocol";
 /* Label for button that shows controls for toggling CSS pseudo-classes on the selected element. */
 localizedStrings["Pseudo @ Styles details sidebar panel"] = "Pseudo";

--- a/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
@@ -46,19 +46,21 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.#ui.generalSection = new WI.DetailsSection("media-details-general", WI.UIString("General", "General @ Media Sidebar", "Title for General Section in Media Sidebar"), [generalGroup]);
 
         this.#ui.videoCodecRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Video Codec", "Video Codec @ Media Sidebar", "Title for Video Codec row in Media Sidebar"));
+        this.#ui.videoProtectedRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Protected", "Protected @ Media Sidebar", "Title for Protected row in Media Sidebar"));
         this.#ui.transferRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Transfer Function", "Transfer Function @ Media Sidebar", "Title for Transfer Function row in Media Sidebar"));
         this.#ui.primariesRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Color Primaries", "Color Primaries @ Media Sidebar", "Title for Color Primaries row in Media Sidebar"));
         this.#ui.matrixRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Matrix Coefficients", "Matrix Coefficients @ Media Sidebar", "Title for Matrix Coefficients row in Media Sidebar"));
         this.#ui.fullRangeRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Color Range", "Color Range @ Media Sidebar", "Title for Color Range row in Media Sidebar"));
         this.#ui.projectionRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Projection", "Projections @ Media Sidebar", "Title for Projection row in Media Sidebar"));
 
-        let videoGroup = new WI.DetailsSectionGroup([this.#ui.videoCodecRow, this.#ui.primariesRow, this.#ui.transferRow, this.#ui.matrixRow, this.#ui.fullRangeRow, this.#ui.projectionRow]);
+        let videoGroup = new WI.DetailsSectionGroup([this.#ui.videoCodecRow, this.#ui.videoProtectedRow, this.#ui.primariesRow, this.#ui.transferRow, this.#ui.matrixRow, this.#ui.fullRangeRow, this.#ui.projectionRow]);
         this.#ui.videoSection = new WI.DetailsSection("media-video-details", WI.UIString("Video Details", "Video Details @ Media Sidebar", "Title for Video Details section in Media Sidebar"), [videoGroup]);
         this.#ui.audioCodecRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Audio Codec", "Audio Codec @ Media Sidebar", "Title for Audio Codec row in Media Sidebar"));
+        this.#ui.audioProtectedRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Protected", "Protected @ Media Sidebar", "Title for Protected row in Media Sidebar"));
         this.#ui.sampleRateRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Sample Rate", "Sample Rate @ Media Sidebar", "Title for Sample Rate row in Media Sidebar"));
         this.#ui.channelsRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Channels", "Channels @ Media Sidebar", "Title for Channels row in Media Sidebar"));
 
-        let audioGroup = new WI.DetailsSectionGroup([this.#ui.audioCodecRow, this.#ui.sampleRateRow, this.#ui.channelsRow]);
+        let audioGroup = new WI.DetailsSectionGroup([this.#ui.audioCodecRow, this.#ui.audioProtectedRow, this.#ui.sampleRateRow, this.#ui.channelsRow]);
         this.#ui.audioSection = new WI.DetailsSection("media-audio-details", WI.UIString("Audio Details", "Audio Details @ Media Sidebar", "Title for Audio Details section in Media Sidebar"), [audioGroup]);
 
         this.#ui.spatialSizeRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Size", "Size @ Spatial Section @ Media Sidebar", "Titel for Size row in Spatial Section of Media Sidebar"));
@@ -79,12 +81,14 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.#ui.videoFormatRow.updateValue();
         this.#ui.audioFormatRow.updateValue();
         this.#ui.videoCodecRow.updateValue();
+        this.#ui.videoProtectedRow.updateValue();
         this.#ui.transferRow.updateValue();
         this.#ui.primariesRow.updateValue();
         this.#ui.matrixRow.updateValue();
         this.#ui.fullRangeRow.updateValue();
         this.#ui.projectionRow.updateValue();
         this.#ui.audioCodecRow.updateValue();
+        this.#ui.audioProtectedRow.updateValue();
         this.#ui.sampleRateRow.updateValue();
         this.#ui.channelsRow.updateValue();
         this.#ui.spatialSizeRow.updateValue();
@@ -307,6 +311,8 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
 
     #setVideo(video)
     {
+        const checkmark = "\u2713";
+
         if (this.#values.video === video)
             return;
 
@@ -317,7 +323,8 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
             && Object.shallowEqual(this.#values.video?.colorSpace, video?.colorSpace)
             && this.#values.video?.colorSpace?.primaries === video?.colorSpace?.primaries
             && this.#values.video?.colorSpace?.matrix === video?.colorSpace?.matrix
-            && this.#values.video?.fullRange === video?.fullRange)
+            && this.#values.video?.fullRange === video?.fullRange
+            && this.#values.video?.isProtected === video?.isProtected)
             return;
 
         this.#values.video = video;
@@ -325,6 +332,7 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.#ui.resolutionRow.pendingValue = WI.UIString("%dx%d (%dfps)").format(video?.width ?? 0, video?.height ?? 0, video?.framerate ?? 0);
         this.#ui.resolutionRow.element.classList.toggle("hidden", !video);
         this.#ui.videoCodecRow.pendingValue = video?.codec;
+        this.#ui.videoProtectedRow.pendingValue = video?.isProtected ? checkmark : null;
         this.#ui.transferRow.pendingValue = video?.colorSpace?.transfer;
         this.#ui.primariesRow.pendingValue = video?.colorSpace?.primaries;
         this.#ui.matrixRow.pendingValue = video?.colorSpace?.matrix;
@@ -350,6 +358,7 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.#values.audio = audio;
         this.#ui.audioSection.element.classList.toggle("hidden", !audio);
         this.#ui.audioCodecRow.pendingValue = audio?.codec;
+        this.#ui.audioProtectedRow.pendingValue = audio?.isProtected ? WI.UIString("True") : null;
         this.#ui.sampleRateRow.pendingValue = WI.UIString("%d Hz").format(audio?.sampleRate);
         switch (audio?.numberOfChannels) {
         case 1:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5733,6 +5733,7 @@ struct WebCore::PlatformVideoTrackConfiguration : WebCore::PlatformTrackConfigur
     uint64_t bitrate;
     std::optional<WebCore::SpatialVideoMetadata> spatialVideoMetadata;
     std::optional<WebCore::VideoProjectionMetadata> videoProjectionMetadata;
+    bool isProtected;
 };
 
 #endif


### PR DESCRIPTION
#### 3ff93e0dd934c5319ed32743636e5320e674993f
<pre>
[Logging] Report whether video and audio tracks are protected in logging and in Web Inspector
<a href="https://rdar.apple.com/165026619">rdar://165026619</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302768">https://bugs.webkit.org/show_bug.cgi?id=302768</a>

Reviewed by Devin Rousso.

Use the CMFormatDescription ProtectedContentOriginalFormat extention to determine whether
the given track has protected contents, and report that data in logging, including via
Web Inspector.

Drive-by fix: Audio tracks were not having their configuration updated by AVTrackPrivateAVFObjCImpl.

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::descriptionForTrack):
* Source/WebCore/html/track/AudioTrackConfiguration.cpp:
(WebCore::AudioTrackConfiguration::toJSON const):
* Source/WebCore/html/track/AudioTrackConfiguration.h:
(WebCore::AudioTrackConfiguration::isProtected const):
(WebCore::AudioTrackConfiguration::setProtected):
* Source/WebCore/html/track/VideoTrackConfiguration.cpp:
(WebCore::VideoTrackConfiguration::setProtected):
(WebCore::VideoTrackConfiguration::toJSON const):
* Source/WebCore/html/track/VideoTrackConfiguration.h:
(WebCore::VideoTrackConfiguration::isProtected const):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::getMediaStats):
* Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h:
* Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::videoTrackConfiguration const):
(WebCore::AVTrackPrivateAVFObjCImpl::audioTrackConfiguration const):
(WebCore::AVTrackPrivateAVFObjCImpl::isProtected const):
* Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp:
(WebCore::codecFromFormatDescription):
(WebCore::formatDescriptionIsProtected):
* Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp:
(WebCore::AudioTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js:
(WI.MediaDetailsSidebarPanel):
(WI.MediaDetailsSidebarPanel.prototype.layout):
(WI.MediaDetailsSidebarPanel.prototype.setVideo):
(WI.MediaDetailsSidebarPanel.prototype.setAudio):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303255@main">https://commits.webkit.org/303255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b72052e9f42458599aabb442166be2112c45a74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139324 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100748 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81536 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2929 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82544 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123876 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141968 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130320 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109123 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4055 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3481 "Found 2 new test failures: http/tests/webgpu/webgpu/api/operation/sampling/filter_mode.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27686 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3018 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57184 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4028 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32738 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163286 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3860 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67475 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3988 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->