### PR TITLE
[WebAuthn] Support large blob storage extension over CTAP

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -24,4 +24,5 @@ PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitatin
 PASS PublicKeyCredential's [[create]] with excludeCredentials - verify preflighted credentials not sent in main request.
 PASS PublicKeyCredential's [[create]] with PIN Protocol 2 support in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with PIN Protocol 1 fallback in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with largeBlob extension support=preferred in a mock hid authenticator.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -683,4 +683,42 @@
         });
     }, "PublicKeyCredential's [[create]] with PIN Protocol 1 fallback in a mock hid authenticator.");
 
+    promise_test(t => {
+        // Test largeBlob extension with support=preferred
+        // Mock response includes unsignedExtensionOutputs (key 0x06) with largeBlob.supported=true
+        let config = {
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                payloadBase64: [testLargeBlobMakeCredentialMessageBase64]
+            }
+        };
+
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                extensions: { largeBlob: { support: "preferred" } },
+                timeout: 1000
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+            assert_true(credential.getClientExtensionResults().largeBlob !== undefined, "largeBlob extension output should be present");
+            assert_true(credential.getClientExtensionResults().largeBlob.supported === true, "largeBlob.supported should be true");
+        });
+    }, "PublicKeyCredential's [[create]] with largeBlob extension support=preferred in a mock hid authenticator.");
+
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
@@ -14,4 +14,6 @@ PASS PublicKeyCredential's [[get]] uses maxCredentialCountInList for batching wi
 PASS PublicKeyCredential's [[get]] with CTAP2â†’U2F downgrade skips wasteful CTAP2 tap (multi-credential).
 PASS PublicKeyCredential's [[get]] with CTAP2â†’U2F downgrade skips wasteful CTAP2 tap (single credential).
 PASS PublicKeyCredential's [[get]] with empty allowCredentials does NOT skip CTAP2 (resident key safety).
+PASS PublicKeyCredential's [[get]] with largeBlob extension read=true in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with largeBlob extension write in a mock hid authenticator.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -350,4 +350,63 @@
             return checkCtapGetAssertionResult(credential);
         });
     }, "PublicKeyCredential's [[get]] with empty allowCredentials does NOT skip CTAP2 (resident key safety).");
+
+    promise_test(t => {
+        // Test largeBlob extension with read=true
+        // Mock response includes unsignedExtensionOutputs (key 0x08) with largeBlob.blob
+        let config = {
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                payloadBase64: [testLargeBlobGetAssertionReadMessageBase64]
+            }
+        };
+
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                extensions: { largeBlob: { read: true } },
+                timeout: 100
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            checkCtapGetAssertionResult(credential);
+            assert_true(credential.getClientExtensionResults().largeBlob !== undefined, "largeBlob extension output should be present");
+            assert_true(credential.getClientExtensionResults().largeBlob.blob !== undefined, "largeBlob.blob should be present");
+        });
+    }, "PublicKeyCredential's [[get]] with largeBlob extension read=true in a mock hid authenticator.");
+
+    promise_test(t => {
+        // Test largeBlob extension with write
+        // Mock response includes unsignedExtensionOutputs (key 0x08) with largeBlob.written=true
+        let config = {
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                payloadBase64: [testLargeBlobGetAssertionWriteMessageBase64]
+            }
+        };
+
+        const testData = new Uint8Array([1, 2, 3, 4]);
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                extensions: { largeBlob: { write: testData } },
+                timeout: 100
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            checkCtapGetAssertionResult(credential);
+            assert_true(credential.getClientExtensionResults().largeBlob !== undefined, "largeBlob extension output should be present");
+            assert_true(credential.getClientExtensionResults().largeBlob.written === true, "largeBlob.written should be true");
+        });
+    }, "PublicKeyCredential's [[get]] with largeBlob extension write in a mock hid authenticator.");
 </script>

--- a/LayoutTests/http/wpt/webauthn/resources/util.js
+++ b/LayoutTests/http/wpt/webauthn/resources/util.js
@@ -146,6 +146,25 @@ const testAssertionMessageApduBase64 =
 const testCcidNoUidBase64 = "aIE=";
 const testCcidValidUidBase64 = "CH+d1ZAA";
 const testCreateMessageFullKeyStoreBase64 = "KA==";
+const testLargeBlobMakeCredentialMessageBase64 =
+    "AKQBZnBhY2tlZAJYxEbMf7lnnVWy25CS4cjZ5eHQK3WA8LSBLHcJYuHkj1rYQQAA" +
+    "AE74oBHzjApNFYAGFxEfntx9AEAoCK3O6P5OyXN6V/f+9nAga0NA2Cgp4V3mgSJ5" +
+    "jOHLMDrmxp/S0rbD+aihru1C0aAN3BkiM6GNy5nSlDVqOgTgpQECAyYgASFYIEFb" +
+    "he3RkNud6sgyraBGjlh1pzTlCZehQlL/b18HZ6WGIlggJgfUd/en9p5AIqMQbUni" +
+    "nEeXdFLkvW0/zV5BpEjjNxADoAahaWxhcmdlQmxvYqFpc3VwcG9ydGVk9Q==";
+const testLargeBlobGetAssertionReadMessageBase64 =
+    "AKQBomJpZFhAKAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2" +
+    "w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4GR0eXBlanB1YmxpYy1rZXkCWCVGzH+5" +
+    "Z51VstuQkuHI2eXh0Ct1gPC0gSx3CWLh5I9a2AEAAABQA1hIMEUCIQCSRRe64FaA" +
+    "Hj8XRUHuw5VFVNPSBz5sXtTMx1MEaAkWWwgCIBii/r2gYcdjBP6v+ijbPDrrc4T9" +
+    "gkKCdS+xXuuBvbgXCKFpbGFyZ2VCbG9ioWRibG9iRGRhdGE=";
+const testLargeBlobGetAssertionWriteMessageBase64 =
+    "AKQBomJpZFhAKAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2" +
+    "w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4GR0eXBlanB1YmxpYy1rZXkCWCVGzH+5" +
+    "Z51VstuQkuHI2eXh0Ct1gPC0gSx3CWLh5I9a2AEAAABQA1hIMEUCIQCSRRe64FaA" +
+    "Hj8XRUHuw5VFVNPSBz5sXtTMx1MEaAkWWwgCIBii/r2gYcdjBP6v+ijbPDrrc4T9" +
+    "gkKCdS+xXuuBvbgXCKFpbGFyZ2VCbG9ioWd3cml0dGVu9Q==";
+
 
 const RESOURCES_DIR = "/WebKit/webauthn/resources/";
 

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -103,12 +103,12 @@ RefPtr<AuthenticatorAttestationResponse> readCTAPMakeCredentialResponse(const Ve
         return nullptr;
     const auto& responseMap = decodedMap->getMap();
 
-    auto it = responseMap.find(CBOR(1));
+    auto it = responseMap.find(CBOR(kCtapMakeCredentialResponseFormatKey));
     if (it == responseMap.end() || !it->second.isString())
         return nullptr;
     auto format = it->second.clone();
 
-    it = responseMap.find(CBOR(2));
+    it = responseMap.find(CBOR(kCtapMakeCredentialResponseAuthDataKey));
     if (it == responseMap.end() || !it->second.isByteString())
         return nullptr;
     auto authenticatorData = it->second.clone();
@@ -117,10 +117,20 @@ RefPtr<AuthenticatorAttestationResponse> readCTAPMakeCredentialResponse(const Ve
     if (credentialId.isEmpty())
         return nullptr;
 
-    it = responseMap.find(CBOR(3));
+    it = responseMap.find(CBOR(kCtapMakeCredentialResponseAttStmtKey));
     if (it == responseMap.end() || !it->second.isMap())
         return nullptr;
     auto attStmt = it->second.clone();
+
+    // Check for unsigned extension outputs (key 0x06)
+    std::optional<AuthenticationExtensionsClientOutputs> extensions;
+    it = responseMap.find(CBOR(kCtapMakeCredentialResponseUnsignedExtensionOutputsKey));
+    if (it != responseMap.end() && it->second.isMap()) {
+        // Convert the CBOR map to bytes and parse it
+        auto extensionsCBOR = cbor::CBORWriter::write(it->second);
+        if (extensionsCBOR)
+            extensions = AuthenticationExtensionsClientOutputs::fromCBOR(*extensionsCBOR);
+    }
 
     std::optional<Vector<uint8_t>> attestationObject;
     if (attestation == AttestationConveyancePreference::None) {
@@ -136,7 +146,10 @@ RefPtr<AuthenticatorAttestationResponse> readCTAPMakeCredentialResponse(const Ve
         attestationObject = cbor::CBORWriter::write(CBOR(WTFMove(attestationObjectMap)));
     }
 
-    return AuthenticatorAttestationResponse::create(credentialId, *attestationObject, attachment, WTFMove(transports));
+    auto response = AuthenticatorAttestationResponse::create(credentialId, *attestationObject, attachment, WTFMove(transports));
+    if (extensions)
+        response->setExtensions(WTFMove(*extensions));
+    return response;
 }
 
 RefPtr<AuthenticatorAssertionResponse> readCTAPGetAssertionResponse(const Vector<uint8_t>& inBuffer, WebCore::AuthenticatorAttachment attachment)
@@ -146,7 +159,7 @@ RefPtr<AuthenticatorAssertionResponse> readCTAPGetAssertionResponse(const Vector
         return nullptr;
     const auto& responseMap = decodedMap->getMap();
 
-    auto it = responseMap.find(CBOR(1));
+    auto it = responseMap.find(CBOR(kCtapGetAssertionResponseCredentialKey));
     if (it == responseMap.end() || !it->second.isMap())
         return nullptr;
     auto& credential = it->second.getMap();
@@ -155,18 +168,18 @@ RefPtr<AuthenticatorAssertionResponse> readCTAPGetAssertionResponse(const Vector
         return nullptr;
     auto& credentialId = itr->second.getByteString();
 
-    it = responseMap.find(CBOR(2));
+    it = responseMap.find(CBOR(kCtapGetAssertionResponseAuthDataKey));
     if (it == responseMap.end() || !it->second.isByteString())
         return nullptr;
     auto& authData = it->second.getByteString();
 
-    it = responseMap.find(CBOR(3));
+    it = responseMap.find(CBOR(kCtapGetAssertionResponseSignatureKey));
     if (it == responseMap.end() || !it->second.isByteString())
         return nullptr;
     auto& signature = it->second.getByteString();
 
     RefPtr<AuthenticatorAssertionResponse> response;
-    it = responseMap.find(CBOR(4));
+    it = responseMap.find(CBOR(kCtapGetAssertionResponseUserKey));
     if (it != responseMap.end() && it->second.isMap()) {
         auto& user = it->second.getMap();
         auto itr = user.find(CBOR(kEntityIdMapKey));
@@ -192,9 +205,20 @@ RefPtr<AuthenticatorAssertionResponse> readCTAPGetAssertionResponse(const Vector
         response = AuthenticatorAssertionResponse::create(credentialId, authData, signature, { }, attachment);
     }
 
-    it = responseMap.find(CBOR(5));
+    it = responseMap.find(CBOR(kCtapGetAssertionResponseNumberOfCredentialsKey));
     if (it != responseMap.end() && it->second.isUnsigned())
         response->setNumberOfCredentials(it->second.getUnsigned());
+
+    // Check for unsigned extension outputs (key 0x08)
+    it = responseMap.find(CBOR(kCtapGetAssertionResponseUnsignedExtensionOutputsKey));
+    if (it != responseMap.end() && it->second.isMap()) {
+        // Convert the CBOR map to bytes and parse it
+        auto extensionsCBOR = cbor::CBORWriter::write(it->second);
+        if (extensionsCBOR) {
+            if (auto extensions = AuthenticationExtensionsClientOutputs::fromCBOR(*extensionsCBOR))
+                response->setExtensions(WTFMove(*extensions));
+        }
+    }
 
     return response;
 }

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
@@ -297,6 +297,20 @@ constexpr int64_t kCtapGetAssertionRequestOptionsKey = 5;
 constexpr int64_t kCtapGetAssertionPinUvAuthParamKey = 6;
 constexpr int64_t kCtapGetAssertionPinUvAuthProtocolKey = 7;
 
+// CTAP2 authenticatorMakeCredential response keys
+constexpr int64_t kCtapMakeCredentialResponseFormatKey = 1;
+constexpr int64_t kCtapMakeCredentialResponseAuthDataKey = 2;
+constexpr int64_t kCtapMakeCredentialResponseAttStmtKey = 3;
+constexpr int64_t kCtapMakeCredentialResponseUnsignedExtensionOutputsKey = 6;
+
+// CTAP2 authenticatorGetAssertion response keys
+constexpr int64_t kCtapGetAssertionResponseCredentialKey = 1;
+constexpr int64_t kCtapGetAssertionResponseAuthDataKey = 2;
+constexpr int64_t kCtapGetAssertionResponseSignatureKey = 3;
+constexpr int64_t kCtapGetAssertionResponseUserKey = 4;
+constexpr int64_t kCtapGetAssertionResponseNumberOfCredentialsKey = 5;
+constexpr int64_t kCtapGetAssertionResponseUnsignedExtensionOutputsKey = 8;
+
 constexpr int64_t kCtapAuthenticatorGetInfoVersionsKey = 0x01;
 constexpr int64_t kCtapAuthenticatorGetInfoExtensionsKey = 0x02;
 constexpr int64_t kCtapAuthenticatorGetInfoAAGUIDKey = 0x03;

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.cpp
@@ -66,6 +66,16 @@ RefPtr<Data> WebAuthenticationAssertionResponse::credentialID() const
     return data;
 }
 
+RefPtr<Data> WebAuthenticationAssertionResponse::largeBlob() const
+{
+    RefPtr<API::Data> data;
+    if (RefPtr blob = m_response->largeBlob()) {
+        auto blobSpan = blob->span();
+        data = API::Data::createWithoutCopying(blobSpan, [blob = WTFMove(blob)] { });
+    }
+    return data;
+}
+
 } // namespace API
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
@@ -46,6 +46,7 @@ public:
     const WTF::String& group() const { return m_response->group(); }
     RefPtr<Data> credentialID() const;
     const WTF::String& accessGroup() const { return m_response->accessGroup(); }
+    RefPtr<Data> largeBlob() const;
 
     void setLAContext(LAContext *context) { m_response->setLAContext(context); }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
@@ -31,10 +31,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKAuthenticationExtensionsLargeBlobInputs : NSObject
+@property (nullable, nonatomic, copy) NSString *support;
+@property (nonatomic) BOOL read;
+@property (nullable, nonatomic, copy) NSData *write;
+@end
+
 WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @interface _WKAuthenticationExtensionsClientInputs : NSObject
 
 @property (nullable, nonatomic, copy) NSString *appid;
+@property (nullable, nonatomic, strong) _WKAuthenticationExtensionsLargeBlobInputs *largeBlob WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm
@@ -26,11 +26,23 @@
 #import "config.h"
 #import "_WKAuthenticationExtensionsClientInputs.h"
 
+@implementation _WKAuthenticationExtensionsLargeBlobInputs
+
+- (void)dealloc
+{
+    SUPPRESS_UNRETAINED_ARG [_support release];
+    SUPPRESS_UNRETAINED_ARG [_write release];
+    [super dealloc];
+}
+
+@end
+
 @implementation _WKAuthenticationExtensionsClientInputs
 
 - (void)dealloc
 {
     SUPPRESS_UNRETAINED_ARG [_appid release];
+    SUPPRESS_UNRETAINED_ARG [_largeBlob release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h
@@ -31,10 +31,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKAuthenticationExtensionsLargeBlobOutputs : NSObject
+@property (nonatomic, readonly) BOOL supported;
+@property (nullable, nonatomic, readonly, copy) NSData *blob;
+@property (nonatomic, readonly) BOOL written;
+@end
+
 WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @interface _WKAuthenticationExtensionsClientOutputs : NSObject
 
 @property (nonatomic, readonly) BOOL appid;
+@property (nullable, nonatomic, readonly, strong) _WKAuthenticationExtensionsLargeBlobOutputs *largeBlob WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
@@ -26,6 +26,27 @@
 #import "config.h"
 #import "_WKAuthenticationExtensionsClientOutputs.h"
 
+@implementation _WKAuthenticationExtensionsLargeBlobOutputs
+
+- (instancetype)initWithSupported:(BOOL)supported blob:(NSData *)blob written:(BOOL)written
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _supported = supported;
+    _blob = [blob copy];
+    _written = written;
+    return self;
+}
+
+- (void)dealloc
+{
+    SUPPRESS_UNRETAINED_ARG [_blob release];
+    [super dealloc];
+}
+
+@end
+
 @implementation _WKAuthenticationExtensionsClientOutputs
 
 - (instancetype)initWithAppid:(BOOL)appid
@@ -35,6 +56,22 @@
 
     _appid = appid;
     return self;
+}
+
+- (instancetype)initWithAppid:(BOOL)appid largeBlob:(_WKAuthenticationExtensionsLargeBlobOutputs *)largeBlob
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _appid = appid;
+    _largeBlob = [largeBlob retain];
+    return self;
+}
+
+- (void)dealloc
+{
+    SUPPRESS_UNRETAINED_ARG [_largeBlob release];
+    [super dealloc];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h
@@ -29,9 +29,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface _WKAuthenticationExtensionsLargeBlobOutputs ()
+- (instancetype)initWithSupported:(BOOL)supported blob:(NSData * _Nullable)blob written:(BOOL)written;
+@end
+
 @interface _WKAuthenticationExtensionsClientOutputs ()
 
 - (instancetype)initWithAppid:(BOOL)appid;
+- (instancetype)initWithAppid:(BOOL)appid largeBlob:(_WKAuthenticationExtensionsLargeBlobOutputs * _Nullable)largeBlob WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
@@ -27,7 +27,10 @@
 #import "_WKAuthenticatorResponseInternal.h"
 
 #import "_WKAuthenticationExtensionsClientOutputs.h"
+#import "_WKAuthenticationExtensionsClientOutputsInternal.h"
+#import <WebCore/AuthenticationExtensionsClientOutputs.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 @implementation _WKAuthenticatorResponse {
     RetainPtr<_WKAuthenticationExtensionsClientOutputs> _extensions;
@@ -69,6 +72,30 @@
 
 - (_WKAuthenticationExtensionsClientOutputs *)extensions
 {
+    if (!_extensions && _extensionOutputsCBOR) {
+        // Parse CBOR to create extensions object
+        auto extensionOutputs = WebCore::AuthenticationExtensionsClientOutputs::fromCBOR(makeVector(_extensionOutputsCBOR));
+        if (extensionOutputs) {
+            // Only create the Cocoa extensions object if there are actual extension values
+            bool hasExtensions = extensionOutputs->appid.has_value() || extensionOutputs->largeBlob.has_value();
+            if (!hasExtensions)
+                return nil;
+
+            RetainPtr<_WKAuthenticationExtensionsLargeBlobOutputs> largeBlobOutputs;
+
+            if (extensionOutputs->largeBlob) {
+                BOOL supported = extensionOutputs->largeBlob->supported.value_or(false);
+                RetainPtr<NSData> blob;
+                if (extensionOutputs->largeBlob->blob)
+                    blob = adoptNS([[NSData alloc] initWithBytes:extensionOutputs->largeBlob->blob->data() length:extensionOutputs->largeBlob->blob->byteLength()]);
+                BOOL written = extensionOutputs->largeBlob->written.value_or(false);
+
+                largeBlobOutputs = adoptNS([[_WKAuthenticationExtensionsLargeBlobOutputs alloc] initWithSupported:supported blob:blob.get() written:written]);
+            }
+
+            _extensions = adoptNS([[_WKAuthenticationExtensionsClientOutputs alloc] initWithAppid:extensionOutputs->appid.value_or(false) largeBlob:largeBlobOutputs.get()]);
+        }
+    }
     return _extensions.get();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h
@@ -40,6 +40,7 @@ WK_CLASS_AVAILABLE(macos(11.0), ios(14.0))
 @property (nonatomic, readonly, copy) NSString *group;
 @property (nonatomic, readonly, copy) NSData *credentialID;
 @property (nonatomic, readonly, copy) NSString *accessGroup;
+@property (nonatomic, readonly, nullable, copy) NSData *largeBlob WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 - (void)setLAContext:(LAContext *)context WK_API_AVAILABLE(macos(12.0), ios(15.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
@@ -87,6 +87,11 @@ static Ref<API::WebAuthenticationAssertionResponse> protectedResponse(_WKWebAuth
     return _response->accessGroup().createNSString().autorelease();
 }
 
+- (NSData *)largeBlob
+{
+    return wrapper(protectedResponse(self)->largeBlob()).autorelease();
+}
+
 #endif // ENABLE(WEB_AUTHN)
 
 - (void)setLAContext:(LAContext *)context

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -973,6 +973,18 @@ static WebCore::AuthenticationExtensionsClientInputs authenticationExtensionsCli
     WebCore::AuthenticationExtensionsClientInputs result;
     result.appid = extensions.appid;
 
+    if (extensions.largeBlob) {
+        WebCore::AuthenticationExtensionsClientInputs::LargeBlobInputs largeBlob;
+        largeBlob.support = extensions.largeBlob.support;
+        if (extensions.largeBlob.read)
+            largeBlob.read = extensions.largeBlob.read;
+        if (extensions.largeBlob.write) {
+            RefPtr<ArrayBuffer> buffer = ArrayBuffer::create(span(extensions.largeBlob.write));
+            largeBlob.write = WebCore::BufferSource(WTFMove(buffer));
+        }
+        result.largeBlob = largeBlob;
+    }
+
     return result;
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -204,6 +204,8 @@ void CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials(bool
         return;
     }
     Vector<String> authenticatorSupportedExtensions;
+    if (m_info.extensions())
+        authenticatorSupportedExtensions = *m_info.extensions();
     if (m_isKeyStoreFull || (m_info.remainingDiscoverableCredentials() && !m_info.remainingDiscoverableCredentials())) {
         if (options.authenticatorSelection && (options.authenticatorSelection->requireResidentKey || options.authenticatorSelection->residentKey() == ResidentKeyRequirement::Required)) {
             protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::KeyStoreFull);
@@ -338,6 +340,8 @@ void CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials()
 
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     Vector<String> authenticatorSupportedExtensions;
+    if (m_info.extensions())
+        authenticatorSupportedExtensions = *m_info.extensions();
     std::optional<Vector<PublicKeyCredentialDescriptor>> overrideAllowCredentials;
     if (options.allowCredentials.size() > 1 && m_currentBatch < m_batches.size())
         overrideAllowCredentials = m_batches[m_currentBatch];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -2641,6 +2641,237 @@ TEST(WebAuthenticationPanel, DeleteOneCredential)
     EXPECT_NOT_NULL(credentials);
     EXPECT_EQ([credentials count], 0lu);
 }
+
+TEST(WebAuthenticationPanel, EncodeCTAPCreationWithLargeBlobSupport)
+{
+    uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
+    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
+    auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+
+    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
+
+    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+
+    // Set up largeBlob extension with support="preferred"
+    auto largeBlobInputs = adoptNS([[_WKAuthenticationExtensionsLargeBlobInputs alloc] init]);
+    [largeBlobInputs setSupport:@"preferred"];
+
+    auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
+    [extensions setLargeBlob:largeBlobInputs.get()];
+    [options setExtensions:extensions.get()];
+
+    NSArray<NSString *> *authenticatorSupportedExtensions = @[ @"largeBlob" ];
+    auto *command = [_WKWebAuthenticationPanel encodeMakeCredentialCommandWithClientDataHash:nsHash.get() options:options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported authenticatorSupportedExtensions:authenticatorSupportedExtensions];
+
+    // Verify the command includes largeBlob extension (key 6 with {"largeBlob": {"support": "preferred"}})
+    EXPECT_NOT_NULL(command);
+    EXPECT_GT([command length], 0u);
+}
+
+TEST(WebAuthenticationPanel, EncodeCTAPAssertionWithLargeBlobRead)
+{
+    uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
+    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+
+    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+
+    // Set up largeBlob extension with read=true
+    auto largeBlobInputs = adoptNS([[_WKAuthenticationExtensionsLargeBlobInputs alloc] init]);
+    [largeBlobInputs setRead:YES];
+
+    auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
+    [extensions setLargeBlob:largeBlobInputs.get()];
+    [options setExtensions:extensions.get()];
+
+    NSArray<NSString *> *authenticatorSupportedExtensions = @[ @"largeBlob" ];
+    auto *command = [_WKWebAuthenticationPanel encodeGetAssertionCommandWithClientDataHash:nsHash.get() options:options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported authenticatorSupportedExtensions:authenticatorSupportedExtensions];
+
+    // Verify the command includes largeBlob extension (key 4 with {"largeBlob": {"read": true}})
+    EXPECT_NOT_NULL(command);
+    EXPECT_GT([command length], 0u);
+}
+
+TEST(WebAuthenticationPanel, EncodeCTAPAssertionWithLargeBlobWrite)
+{
+    uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
+    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+
+    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+
+    // Set up largeBlob extension with write data
+    auto largeBlobInputs = adoptNS([[_WKAuthenticationExtensionsLargeBlobInputs alloc] init]);
+    uint8_t testData[] = { 0x01, 0x02, 0x03, 0x04 };
+    auto nsTestData = adoptNS([[NSData alloc] initWithBytes:testData length:sizeof(testData)]);
+    [largeBlobInputs setWrite:nsTestData.get()];
+
+    auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
+    [extensions setLargeBlob:largeBlobInputs.get()];
+    [options setExtensions:extensions.get()];
+
+    NSArray<NSString *> *authenticatorSupportedExtensions = @[ @"largeBlob" ];
+    auto *command = [_WKWebAuthenticationPanel encodeGetAssertionCommandWithClientDataHash:nsHash.get() options:options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported authenticatorSupportedExtensions:authenticatorSupportedExtensions];
+
+    // Verify the command includes largeBlob extension (key 4 with {"largeBlob": {"write": <data>}})
+    EXPECT_NOT_NULL(command);
+    EXPECT_GT([command length], 0u);
+}
+
+TEST(WebAuthenticationPanel, MakeCredentialLargeBlobSupport)
+{
+    reset();
+
+    NSString *html = @"<input type='text' id='input'>"
+    "<script>"
+    "const testLargeBlobMakeCredentialMessageBase64 ="
+    "    'AKQBZnBhY2tlZAJYxEbMf7lnnVWy25CS4cjZ5eHQK3WA8LSBLHcJYuHkj1rYQQAA' +"
+    "    'AE74oBHzjApNFYAGFxEfntx9AEAoCK3O6P5OyXN6V/f+9nAga0NA2Cgp4V3mgSJ5' +"
+    "    'jOHLMDrmxp/S0rbD+aihru1C0aAN3BkiM6GNy5nSlDVqOgTgpQECAyYgASFYIEFb' +"
+    "    'he3RkNud6sgyraBGjlh1pzTlCZehQlL/b18HZ6WGIlggJgfUd/en9p5AIqMQbUni' +"
+    "    'nEeXdFLkvW0/zV5BpEjjNxADoAahaWxhcmdlQmxvYqFpc3VwcG9ydGVk9Q==';"
+    "if (window.internals) {"
+    "    internals.setMockWebAuthenticationConfiguration({"
+    "        hid: {"
+    "            payloadBase64: [testLargeBlobMakeCredentialMessageBase64]"
+    "        }"
+    "    });"
+    "    internals.withUserGesture(() => { input.focus(); });"
+    "}"
+    "const options = {"
+    "    publicKey: {"
+    "        rp: { name: 'localhost' },"
+    "        user: {"
+    "            name: 'John Appleseed',"
+    "            id: new Uint8Array(16),"
+    "            displayName: 'Appleseed'"
+    "        },"
+    "        challenge: new Uint8Array(16),"
+    "        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],"
+    "        extensions: { largeBlob: { support: 'preferred' } },"
+    "        timeout: 100"
+    "    }"
+    "};"
+    "navigator.credentials.create(options).then(credential => {"
+    "    const result = credential.getClientExtensionResults();"
+    "    if (result.largeBlob && result.largeBlob.supported === true) {"
+    "        window.webkit.messageHandlers.testHandler.postMessage('Succeeded!');"
+    "    } else {"
+    "        window.webkit.messageHandlers.testHandler.postMessage('No largeBlob extension output');"
+    "    }"
+    "}, error => {"
+    "    window.webkit.messageHandlers.testHandler.postMessage(error.message);"
+    "});"
+    "</script>";
+
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
+    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+    [webView focus];
+
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://localhost:443"]];
+    [webView waitForMessage:@"Succeeded!"];
+}
+
+TEST(WebAuthenticationPanel, GetAssertionLargeBlobRead)
+{
+    reset();
+
+    NSString *html = @"<input type='text' id='input'>"
+    "<script>"
+    "const testLargeBlobGetAssertionReadMessageBase64 ="
+    "    'AKQBomJpZFhAKAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2' +"
+    "    'w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4GR0eXBlanB1YmxpYy1rZXkCWCVGzH+5' +"
+    "    'Z51VstuQkuHI2eXh0Ct1gPC0gSx3CWLh5I9a2AEAAABQA1hIMEUCIQCSRRe64FaA' +"
+    "    'Hj8XRUHuw5VFVNPSBz5sXtTMx1MEaAkWWwgCIBii/r2gYcdjBP6v+ijbPDrrc4T9' +"
+    "    'gkKCdS+xXuuBvbgXCKFpbGFyZ2VCbG9ioWRibG9iRGRhdGE=';"
+    "if (window.internals) {"
+    "    internals.setMockWebAuthenticationConfiguration({"
+    "        hid: {"
+    "            payloadBase64: [testLargeBlobGetAssertionReadMessageBase64]"
+    "        }"
+    "    });"
+    "    internals.withUserGesture(() => { input.focus(); });"
+    "}"
+    "const options = {"
+    "    publicKey: {"
+    "        challenge: new Uint8Array(16),"
+    "        extensions: { largeBlob: { read: true } },"
+    "        timeout: 100"
+    "    }"
+    "};"
+    "navigator.credentials.get(options).then(credential => {"
+    "    const result = credential.getClientExtensionResults();"
+    "    if (result.largeBlob && result.largeBlob.blob) {"
+    "        window.webkit.messageHandlers.testHandler.postMessage('Succeeded!');"
+    "    } else {"
+    "        window.webkit.messageHandlers.testHandler.postMessage('No largeBlob blob data');"
+    "    }"
+    "}, error => {"
+    "    window.webkit.messageHandlers.testHandler.postMessage(error.message);"
+    "});"
+    "</script>";
+
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
+    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+    [webView focus];
+
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://localhost:443"]];
+    [webView waitForMessage:@"Succeeded!"];
+}
+
+TEST(WebAuthenticationPanel, GetAssertionLargeBlobWrite)
+{
+    reset();
+
+    NSString *html = @"<input type='text' id='input'>"
+    "<script>"
+    "const testLargeBlobGetAssertionWriteMessageBase64 ="
+    "    'AKQBomJpZFhAKAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2' +"
+    "    'w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4GR0eXBlanB1YmxpYy1rZXkCWCVGzH+5' +"
+    "    'Z51VstuQkuHI2eXh0Ct1gPC0gSx3CWLh5I9a2AEAAABQA1hIMEUCIQCSRRe64FaA' +"
+    "    'Hj8XRUHuw5VFVNPSBz5sXtTMx1MEaAkWWwgCIBii/r2gYcdjBP6v+ijbPDrrc4T9' +"
+    "    'gkKCdS+xXuuBvbgXCKFpbGFyZ2VCbG9ioWd3cml0dGVu9Q==';"
+    "if (window.internals) {"
+    "    internals.setMockWebAuthenticationConfiguration({"
+    "        hid: {"
+    "            payloadBase64: [testLargeBlobGetAssertionWriteMessageBase64]"
+    "        }"
+    "    });"
+    "    internals.withUserGesture(() => { input.focus(); });"
+    "}"
+    "const testData = new Uint8Array([1, 2, 3, 4]);"
+    "const options = {"
+    "    publicKey: {"
+    "        challenge: new Uint8Array(16),"
+    "        extensions: { largeBlob: { write: testData } },"
+    "        timeout: 100"
+    "    }"
+    "};"
+    "navigator.credentials.get(options).then(credential => {"
+    "    const result = credential.getClientExtensionResults();"
+    "    if (result.largeBlob && result.largeBlob.written === true) {"
+    "        window.webkit.messageHandlers.testHandler.postMessage('Succeeded!');"
+    "    } else {"
+    "        window.webkit.messageHandlers.testHandler.postMessage('largeBlob not written');"
+    "    }"
+    "}, error => {"
+    "    window.webkit.messageHandlers.testHandler.postMessage(error.message);"
+    "});"
+    "</script>";
+
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
+    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+    [webView focus];
+
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://localhost:443"]];
+    [webView waitForMessage:@"Succeeded!"];
+}
+
 #endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 70db4b098e99a754d2c62094f1759bf5c4389360
<pre>
[WebAuthn] Support large blob storage extension over CTAP
<a href="https://rdar.apple.com/96255388">rdar://96255388</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=242204">https://bugs.webkit.org/show_bug.cgi?id=242204</a>

Reviewed by NOBODY (OOPS!).

This patch does the WebKit plumbing for the largeBlob CTAP extension and adds tests for it.
More work will be required to hook this up in WebAuthenticatorCoordinatorProxy when/if API
is available.

Added API and layout tests.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/resources/util.js:
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::readCTAPMakeCredentialResponse):
(fido::readCTAPGetAssertionResponse):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.cpp:
(API::WebAuthenticationAssertionResponse::largeBlob const):
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm:
(-[_WKAuthenticationExtensionsLargeBlobInputs dealloc]):
(-[_WKAuthenticationExtensionsClientInputs dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm:
(-[_WKAuthenticationExtensionsLargeBlobOutputs initWithSupported:blob:written:]):
(-[_WKAuthenticationExtensionsLargeBlobOutputs dealloc]):
(-[_WKAuthenticationExtensionsClientOutputs initWithAppid:largeBlob:]):
(-[_WKAuthenticationExtensionsClientOutputs dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm:
(-[_WKAuthenticatorResponse extensions]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm:
(-[_WKWebAuthenticationAssertionResponse largeBlob]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(authenticationExtensionsClientInputs):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):
(WebKit::CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, EncodeCTAPCreationWithLargeBlobSupport)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, EncodeCTAPAssertionWithLargeBlobRead)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, EncodeCTAPAssertionWithLargeBlobWrite)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialLargeBlobSupport)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionLargeBlobRead)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionLargeBlobWrite)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70db4b098e99a754d2c62094f1759bf5c4389360

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83676 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100737 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68155 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/808476db-4ba3-420c-a465-1b4fc923f681) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81525 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82531 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111652 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141955 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109111 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4042 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3472 "Found 2 new test failures: http/tests/webgpu/webgpu/api/operation/labels.html http/tests/webgpu/webgpu/api/validation/encoding/encoder_open_state.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109275 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3009 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114324 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57171 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4015 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32726 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3847 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67462 "Found 2 new failures in UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4107 "Hash 70db4b09 for PR 54164 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3975 "Hash 70db4b09 for PR 54164 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->