### PR TITLE
Pipe datagram properties to the network process

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
@@ -39,6 +39,7 @@ class DOMPromise;
 class ReadableStream;
 class ScriptExecutionContext;
 class WebTransport;
+class WebTransportSession;
 class WritableStream;
 struct WebTransportSendOptions;
 template<typename> class ExceptionOr;
@@ -50,13 +51,13 @@ public:
 
     ReadableStream& readable() { return m_readable; }
     ExceptionOr<Ref<WritableStream>> createWritable(ScriptExecutionContext&, WebTransportSendOptions&&);
-    unsigned maxDatagramSize() { return m_outgoingMaxDatagramSize; }
-    double incomingMaxAge() { return m_incomingDatagramsExpirationDuration; }
-    double outgoingMaxAge() { return m_outgoingDatagramsExpirationDuration; }
-    double incomingHighWaterMark() { return m_incomingDatagramsHighWaterMark; }
-    double outgoingHighWaterMark() { return m_outgoingDatagramsHighWaterMark; }
-    ExceptionOr<void> setIncomingMaxAge(double);
-    ExceptionOr<void> setOutgoingMaxAge(double);
+    unsigned maxDatagramSize() const { return std::numeric_limits<uint16_t>::max(); }
+    std::optional<double> incomingMaxAge() const { return m_incomingMaxAge; }
+    std::optional<double> outgoingMaxAge() const { return m_outgoingMaxAge; }
+    double incomingHighWaterMark() const { return m_incomingHighWaterMark; }
+    double outgoingHighWaterMark() const { return m_outgoingHighWaterMark; }
+    ExceptionOr<void> setIncomingMaxAge(std::optional<double>);
+    ExceptionOr<void> setOutgoingMaxAge(std::optional<double>);
     ExceptionOr<void> setIncomingHighWaterMark(double);
     ExceptionOr<void> setOutgoingHighWaterMark(double);
 
@@ -65,15 +66,13 @@ public:
 private:
     WebTransportDatagramDuplexStream(Ref<ReadableStream>&&);
 
+    RefPtr<WebTransportSession> session();
+
     const Ref<ReadableStream> m_readable;
-    Deque<std::pair<Vector<uint8_t>, MonotonicTime>> m_incomingDatagramsQueue;
-    RefPtr<DOMPromise> m_incomingDatagramsPullPromise;
-    double m_incomingDatagramsHighWaterMark { 1 };
-    double m_incomingDatagramsExpirationDuration { std::numeric_limits<double>::infinity() };
-    Deque<std::tuple<Vector<uint8_t>, MonotonicTime, Ref<DOMPromise>>> m_outgoingDatagramsQueue;
-    double m_outgoingDatagramsHighWaterMark { 1 };
-    double m_outgoingDatagramsExpirationDuration { std::numeric_limits<double>::infinity() };
-    size_t m_outgoingMaxDatagramSize { 1024 };
+    double m_incomingHighWaterMark { 1 };
+    double m_outgoingHighWaterMark { 1 };
+    std::optional<double> m_incomingMaxAge;
+    std::optional<double> m_outgoingMaxAge;
     ThreadSafeWeakPtr<WebTransport> m_transport;
 };
 

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.idl
@@ -32,8 +32,8 @@
     readonly attribute ReadableStream readable;
 
     readonly attribute unsigned long maxDatagramSize;
-    attribute unrestricted double incomingMaxAge;
-    attribute unrestricted double outgoingMaxAge;
+    attribute unrestricted double? incomingMaxAge;
+    attribute unrestricted double? outgoingMaxAge;
     attribute unrestricted double incomingHighWaterMark;
     attribute unrestricted double outgoingHighWaterMark;
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -75,6 +75,10 @@ public:
     virtual void cancelSendStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) = 0;
     virtual void destroyStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) = 0;
     virtual void terminate(WebTransportSessionErrorCode, CString&&) = 0;
+    virtual void datagramIncomingMaxAgeUpdated(std::optional<double>) = 0;
+    virtual void datagramOutgoingMaxAgeUpdated(std::optional<double>) = 0;
+    virtual void datagramIncomingHighWaterMarkUpdated(double) = 0;
+    virtual void datagramOutgoingHighWaterMarkUpdated(double) = 0;
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -219,4 +219,40 @@ void WorkerWebTransportSession::destroyStream(WebTransportStreamIdentifier ident
         ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
 }
 
+void WorkerWebTransportSession::datagramIncomingMaxAgeUpdated(std::optional<double> maxAge)
+{
+    ASSERT(!RunLoop::isMain());
+    if (RefPtr session = m_session)
+        session->datagramIncomingMaxAgeUpdated(maxAge);
+    else
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
+}
+
+void WorkerWebTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double> maxAge)
+{
+    ASSERT(!RunLoop::isMain());
+    if (RefPtr session = m_session)
+        session->datagramOutgoingMaxAgeUpdated(maxAge);
+    else
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
+}
+
+void WorkerWebTransportSession::datagramIncomingHighWaterMarkUpdated(double watermark)
+{
+    ASSERT(!RunLoop::isMain());
+    if (RefPtr session = m_session)
+        session->datagramIncomingHighWaterMarkUpdated(watermark);
+    else
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
+}
+
+void WorkerWebTransportSession::datagramOutgoingHighWaterMarkUpdated(double watermark)
+{
+    ASSERT(!RunLoop::isMain());
+    if (RefPtr session = m_session)
+        session->datagramOutgoingHighWaterMarkUpdated(watermark);
+    else
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
+}
+
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -65,6 +65,10 @@ private:
     void cancelSendStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) final;
     void destroyStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) final;
     void terminate(WebTransportSessionErrorCode, CString&&) final;
+    void datagramIncomingMaxAgeUpdated(std::optional<double>) final;
+    void datagramOutgoingMaxAgeUpdated(std::optional<double>) final;
+    void datagramIncomingHighWaterMarkUpdated(double) final;
+    void datagramOutgoingHighWaterMarkUpdated(double) final;
 
     const ScriptExecutionContextIdentifier m_contextID;
     ThreadSafeWeakPtr<WebTransportSessionClient> m_client;

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -134,6 +134,26 @@ void NetworkTransportSession::getSendGroupStats(WebCore::WebTransportSendGroupId
     });
 }
 
+void NetworkTransportSession::datagramIncomingMaxAgeUpdated(std::optional<double>)
+{
+    // FIXME: Use this value.
+}
+
+void NetworkTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double>)
+{
+    // FIXME: Use this value.
+}
+
+void NetworkTransportSession::datagramIncomingHighWaterMarkUpdated(double)
+{
+    // FIXME: Use this value.
+}
+
+void NetworkTransportSession::datagramOutgoingHighWaterMarkUpdated(double)
+{
+    // FIXME: Use this value.
+}
+
 #if !PLATFORM(COCOA)
 RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, URL&&, WebCore::WebTransportOptions&&, WebKit::WebPageProxyIdentifier&&, WebCore::ClientOrigin&&)
 {

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -87,6 +87,10 @@ public:
     void destroyBidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void streamSendBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool withFin, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
     void terminate(WebCore::WebTransportSessionErrorCode, CString&&);
+    void datagramIncomingMaxAgeUpdated(std::optional<double>);
+    void datagramOutgoingMaxAgeUpdated(std::optional<double>);
+    void datagramIncomingHighWaterMarkUpdated(double);
+    void datagramOutgoingHighWaterMarkUpdated(double);
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
@@ -38,4 +38,8 @@ messages -> NetworkTransportSession {
     CancelSendStream(WebCore::WebTransportStreamIdentifier identifier, std::optional<uint64_t> errorCode)
     DestroyStream(WebCore::WebTransportStreamIdentifier identifier, std::optional<uint64_t> errorCode)
     Terminate(uint32_t code, CString reason)
+    DatagramIncomingMaxAgeUpdated(std::optional<double> maxAge)
+    DatagramOutgoingMaxAgeUpdated(std::optional<double> maxAge)
+    DatagramIncomingHighWaterMarkUpdated(double watermark)
+    DatagramOutgoingHighWaterMarkUpdated(double watermark)
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -227,4 +227,24 @@ void WebTransportSession::destroyStream(WebCore::WebTransportStreamIdentifier id
     send(Messages::NetworkTransportSession::DestroyStream(identifier, errorCode));
 }
 
+void WebTransportSession::datagramIncomingMaxAgeUpdated(std::optional<double> maxAge)
+{
+    send(Messages::NetworkTransportSession::DatagramIncomingMaxAgeUpdated(maxAge));
+}
+
+void WebTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double> maxAge)
+{
+    send(Messages::NetworkTransportSession::DatagramOutgoingMaxAgeUpdated(maxAge));
+}
+
+void WebTransportSession::datagramIncomingHighWaterMarkUpdated(double watermark)
+{
+    send(Messages::NetworkTransportSession::DatagramIncomingHighWaterMarkUpdated(watermark));
+}
+
+void WebTransportSession::datagramOutgoingHighWaterMarkUpdated(double watermark)
+{
+    send(Messages::NetworkTransportSession::DatagramOutgoingHighWaterMarkUpdated(watermark));
+}
+
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -95,6 +95,10 @@ private:
     void cancelSendStream(WebCore::WebTransportStreamIdentifier, std::optional<WebCore::WebTransportStreamErrorCode>);
     void destroyStream(WebCore::WebTransportStreamIdentifier, std::optional<WebCore::WebTransportStreamErrorCode>);
     void terminate(WebCore::WebTransportSessionErrorCode, CString&&) final;
+    void datagramIncomingMaxAgeUpdated(std::optional<double>) final;
+    void datagramOutgoingMaxAgeUpdated(std::optional<double>) final;
+    void datagramIncomingHighWaterMarkUpdated(double) final;
+    void datagramOutgoingHighWaterMarkUpdated(double) final;
 
     // MessageSender
     IPC::Connection* messageSenderConnection() const final;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -181,13 +181,13 @@ TEST(WebTransport, Datagram)
         "    const groupStats = await g.getStats();"
         "    t.close();"
         "    await w.closed;"
-        "    alert('successfully read ' + new TextDecoder().decode(value) + ', group sent ' + groupStats.bytesWritten + ' bytes');"
+        "    alert('successfully read ' + new TextDecoder().decode(value) + ', group sent ' + groupStats.bytesWritten + ' bytes, maxDatagramSize ' + t.datagrams.maxDatagramSize);"
         "  } catch (e) { alert('caught ' + e); }"
         "}; test();"
         "</script>",
         port];
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc, group sent 3 bytes");
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc, group sent 3 bytes, maxDatagramSize 65535");
     EXPECT_TRUE(challenged);
 }
 


### PR DESCRIPTION
#### 7d08e130dc4395638075edb553966d2b4a6659b9
<pre>
Pipe datagram properties to the network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=302769">https://bugs.webkit.org/show_bug.cgi?id=302769</a>
<a href="https://rdar.apple.com/165028265">rdar://165028265</a>

Reviewed by Matthew Finkel.

JavaScript can specify 4 values to control the timing and buffering of datagrams.
These values need to get to the network process to be hooked up to interfaces that
don&apos;t exist yet.  I thought about using one IPC message for updating a property
with WebKit&apos;s first use of std::in_place_index_t, but that didn&apos;t read as well
as 4 different IPC messages for the 4 different values.

While I was touching WebTransportDatagramDuplexStream, I did make one observable
change to make maxDatagramSize 65535 as advised by Ankshit instead of the random
value I blindly chose several years ago.  I added a test for this.

* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp:
(WebCore::WebTransportDatagramDuplexStream::session):
(WebCore::WebTransportDatagramDuplexStream::setIncomingMaxAge):
(WebCore::WebTransportDatagramDuplexStream::setOutgoingMaxAge):
(WebCore::WebTransportDatagramDuplexStream::setIncomingHighWaterMark):
(WebCore::WebTransportDatagramDuplexStream::setOutgoingHighWaterMark):
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h:
(WebCore::WebTransportDatagramDuplexStream::maxDatagramSize const):
(WebCore::WebTransportDatagramDuplexStream::incomingMaxAge const):
(WebCore::WebTransportDatagramDuplexStream::outgoingMaxAge const):
(WebCore::WebTransportDatagramDuplexStream::incomingHighWaterMark const):
(WebCore::WebTransportDatagramDuplexStream::outgoingHighWaterMark const):
(WebCore::WebTransportDatagramDuplexStream::maxDatagramSize): Deleted.
(WebCore::WebTransportDatagramDuplexStream::incomingMaxAge): Deleted.
(WebCore::WebTransportDatagramDuplexStream::outgoingMaxAge): Deleted.
(WebCore::WebTransportDatagramDuplexStream::incomingHighWaterMark): Deleted.
(WebCore::WebTransportDatagramDuplexStream::outgoingHighWaterMark): Deleted.
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.idl:
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::datagramIncomingMaxAgeUpdated):
(WebCore::WorkerWebTransportSession::datagramOutgoingMaxAgeUpdated):
(WebCore::WorkerWebTransportSession::datagramIncomingHighWaterMarkUpdated):
(WebCore::WorkerWebTransportSession::datagramOutgoingHighWaterMarkUpdated):
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::datagramIncomingMaxAgeUpdated):
(WebKit::NetworkTransportSession::datagramOutgoingMaxAgeUpdated):
(WebKit::NetworkTransportSession::datagramIncomingHighWaterMarkUpdated):
(WebKit::NetworkTransportSession::datagramOutgoingHighWaterMarkUpdated):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in:
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::datagramIncomingMaxAgeUpdated):
(WebKit::WebTransportSession::datagramOutgoingMaxAgeUpdated):
(WebKit::WebTransportSession::datagramIncomingHighWaterMarkUpdated):
(WebKit::WebTransportSession::datagramOutgoingHighWaterMarkUpdated):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, Datagram)):

Canonical link: <a href="https://commits.webkit.org/303291@main">https://commits.webkit.org/303291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78019665f47afa9ecf353a44dd5b83d8cb20cb94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83682 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/88c228a0-4b1e-40a8-b790-97dc481dde6a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100742 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/732c436f-b274-4c8e-9c14-3f0b698eb222) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81530 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82536 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141960 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109116 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4047 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3475 "Found 1 new test failure: http/tests/webgpu/webgpu/api/operation/sampling/anisotropy.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109280 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3012 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114330 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57176 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20512 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4020 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32732 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3980 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->