### PR TITLE
Add WebAVPlayerLayer caption preview API mocking for AVKit coordination

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -95,6 +95,11 @@ public:
     virtual void setRequiresTextTrackRepresentation(bool) { }
     virtual void setTextTrackRepresentationBounds(const IntRect&) { }
 
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    virtual void requestShowCaptionDisplaySettingsPreview() { }
+    virtual void requestHideCaptionDisplaySettingsPreview() { }
+#endif
+
     virtual void requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&& completionHandler) { completionHandler(RouteSharingPolicy::Default, emptyString()); }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
@@ -50,7 +50,11 @@ WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 @property (nonatomic, copy, nullable) NSDictionary *pixelBufferAttributes;
 @property CGSize videoDimensions;
 @property (nonatomic) NSEdgeInsets legibleContentInsets;
+@property (nonatomic, readonly) BOOL showingCaptionPreview;
 - (WebCore::FloatRect)calculateTargetVideoFrame;
+
+- (void)setCaptionPreviewProfileID:(NSString * _Nonnull)profileID position:(CGPoint)position text:(nullable NSString *)text;
+- (void)stopShowingCaptionPreview;
 @end
 
 #endif // HAVE(AVKIT)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
+#include "FrameInfoData.h"
 #include "LayerHostingContext.h"
 #include "MessageReceiver.h"
 #include "PlaybackSessionContextIdentifier.h"
@@ -123,6 +124,11 @@ private:
 #endif
     void setRequiresTextTrackRepresentation(bool) final;
     void setTextTrackRepresentationBounds(const WebCore::IntRect&) final;
+
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    void requestShowCaptionDisplaySettingsPreview() final;
+    void requestHideCaptionDisplaySettingsPreview() final;
+#endif
 
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const final;
@@ -255,6 +261,12 @@ private:
     void textTrackRepresentationSetHidden(PlaybackSessionContextIdentifier, bool hidden);
     void setRequiresTextTrackRepresentation(PlaybackSessionContextIdentifier, bool);
     void setTextTrackRepresentationBounds(PlaybackSessionContextIdentifier, const WebCore::IntRect&);
+
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    void requestShowCaptionDisplaySettingsPreview(PlaybackSessionContextIdentifier);
+    void requestHideCaptionDisplaySettingsPreview(PlaybackSessionContextIdentifier);
+    void performCaptionDisplaySettingsAction(PlaybackSessionContextIdentifier, Function<void(WebPageProxy&, const FrameInfoData&, WebCore::HTMLMediaElementIdentifier)>&& action);
+#endif
 
     // Messages to VideoPresentationManager
     void requestFullscreenMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false);


### PR DESCRIPTION
#### 12fa34cb62cfab5e9933be77ac4a3a0f984606c8
<pre>
Add WebAVPlayerLayer caption preview API mocking for AVKit coordination
<a href="https://bugs.webkit.org/show_bug.cgi?id=302774">https://bugs.webkit.org/show_bug.cgi?id=302774</a>
<a href="https://rdar.apple.com/164426429">rdar://164426429</a>

Reviewed by Jer Noble.

WebKit needs to mock new AVPlayerLayer APIs to support FCC subtitles caption preview functionality.
AVKit calls these APIs during caption preview, and WebKit must coordinate by hiding/showing its own
caption layer appropriately.

Establish clean architecture where caption preview requests flow through
VideoPresentationManagerProxy → WebPageProxy → IPC → MediaControlsHost, ensuring proper process
separation and following WebKit&apos;s established cross-process communication patterns.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/VideoPresentationMode.mm

* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModel::requestShowCaptionDisplaySettingsPreview):
(WebCore::VideoPresentationModel::requestHideCaptionDisplaySettingsPreview):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer init]):
(-[WebAVPlayerLayer showingCaptionPreview]):
(-[WebAVPlayerLayer setCaptionPreviewProfileID:position:text:]):
(-[WebAVPlayerLayer stopShowingCaptionPreview]):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::requestShowCaptionDisplaySettingsPreview):
(WebKit::VideoPresentationModelContext::requestHideCaptionDisplaySettingsPreview):
(WebKit::VideoPresentationManagerProxy::performCaptionDisplaySettingsAction):
(WebKit::VideoPresentationManagerProxy::requestShowCaptionDisplaySettingsPreview):
(WebKit::VideoPresentationManagerProxy::requestHideCaptionDisplaySettingsPreview):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/VideoPresentationMode.mm:
(TEST(VideoPresentationMode, CaptionPreview)):

Canonical link: <a href="https://commits.webkit.org/303684@main">https://commits.webkit.org/303684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/977d21cebd0d06e083f188fd77fe2c9d9a3596c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83935 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68296 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81716 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d531706-e344-4af1-bbcf-8b71dd444a55) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3074 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/972 "Found 1 new API test failure: TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEventsInReadOnlyField (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82761 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142188 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4189 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109295 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28009 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3177 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114526 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57410 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4243 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32921 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4202 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->