### PR TITLE
FetchRequest constructor should create a body proxy when reusing the body of a FetchRequest

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any-expected.txt
@@ -4,7 +4,7 @@ PASS Request without body cannot be disturbed
 PASS Check cloning a disturbed request
 PASS Check creating a new request from a disturbed request
 PASS Check creating a new request with a new body from a disturbed request
-FAIL Input request used for creating new request became disturbed assert_equals: body should not change expected object "[object ReadableStream]" but got object "[object ReadableStream]"
+PASS Input request used for creating new request became disturbed
 FAIL Input request used for creating new request became disturbed even if body is not used assert_true: bodyUsed is true when request is disturbed expected true got false
 PASS Check consuming a disturbed request
 PASS Request construction failure should not set "bodyUsed"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any.serviceworker-expected.txt
@@ -4,7 +4,7 @@ PASS Request without body cannot be disturbed
 PASS Check cloning a disturbed request
 PASS Check creating a new request from a disturbed request
 PASS Check creating a new request with a new body from a disturbed request
-FAIL Input request used for creating new request became disturbed assert_equals: body should not change expected object "[object ReadableStream]" but got object "[object ReadableStream]"
+PASS Input request used for creating new request became disturbed
 FAIL Input request used for creating new request became disturbed even if body is not used assert_true: bodyUsed is true when request is disturbed expected true got false
 PASS Check consuming a disturbed request
 PASS Request construction failure should not set "bodyUsed"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any.sharedworker-expected.txt
@@ -4,7 +4,7 @@ PASS Request without body cannot be disturbed
 PASS Check cloning a disturbed request
 PASS Check creating a new request from a disturbed request
 PASS Check creating a new request with a new body from a disturbed request
-FAIL Input request used for creating new request became disturbed assert_equals: body should not change expected object "[object ReadableStream]" but got object "[object ReadableStream]"
+PASS Input request used for creating new request became disturbed
 FAIL Input request used for creating new request became disturbed even if body is not used assert_true: bodyUsed is true when request is disturbed expected true got false
 PASS Check consuming a disturbed request
 PASS Request construction failure should not set "bodyUsed"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-disturbed.any.worker-expected.txt
@@ -4,7 +4,7 @@ PASS Request without body cannot be disturbed
 PASS Check cloning a disturbed request
 PASS Check creating a new request from a disturbed request
 PASS Check creating a new request with a new body from a disturbed request
-FAIL Input request used for creating new request became disturbed assert_equals: body should not change expected object "[object ReadableStream]" but got object "[object ReadableStream]"
+PASS Input request used for creating new request became disturbed
 FAIL Input request used for creating new request became disturbed even if body is not used assert_true: bodyUsed is true when request is disturbed expected true got false
 PASS Check consuming a disturbed request
 PASS Request construction failure should not set "bodyUsed"

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -93,6 +93,7 @@ public:
     bool hasConsumerPendingActivity() const { SUPPRESS_UNCHECKED_ARG return m_consumer && m_consumer->hasPendingActivity(); }
 
     FetchBody clone(JSDOMGlobalObject&);
+    FetchBody createProxy(JSDOMGlobalObject&);
 
     bool hasReadableStream() const { return !!m_readableStream; }
     const ReadableStream* readableStream() const { return m_readableStream.get(); }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -437,6 +437,11 @@ RefPtr<JSC::ArrayBuffer> FetchBodyConsumer::takeAsArrayBuffer()
     return m_buffer.takeAsArrayBuffer();
 }
 
+RefPtr<JSC::ArrayBuffer> FetchBodyConsumer::asArrayBuffer()
+{
+    return m_buffer.tryCreateArrayBuffer();
+}
+
 Ref<Blob> FetchBodyConsumer::takeAsBlob(ScriptExecutionContext* context, const String& contentType)
 {
     String normalizedContentType = Blob::normalizedContentType(extractMIMETypeFromMediaType(contentType));

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -62,6 +62,7 @@ public:
 
     bool hasData() const { return !!m_buffer; }
     const FragmentedSharedBuffer* data() const LIFETIME_BOUND { return m_buffer.get().unsafeGet(); }
+    RefPtr<JSC::ArrayBuffer> asArrayBuffer();
     void setData(Ref<FragmentedSharedBuffer>&&);
 
     RefPtr<FragmentedSharedBuffer> takeData();

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -318,8 +318,10 @@ ExceptionOr<void> FetchRequest::setBody(FetchRequest& request)
     if (!request.isBodyNull()) {
         if (!methodCanHaveBody(m_request))
             return Exception { ExceptionCode::TypeError, makeString("Request has method '"_s, m_request.httpMethod(), "' and cannot have a body"_s) };
-        // FIXME: If body has a readable stream, we should pipe it to this new body stream.
-        m_body = WTFMove(*request.m_body);
+
+        RefPtr context = scriptExecutionContext();
+        auto* globalObject = context ? JSC::jsCast<JSDOMGlobalObject*>(context->globalObject()) : nullptr;
+        m_body = request.m_body->createProxy(*globalObject);
         request.setDisturbed();
     }
 


### PR DESCRIPTION
#### b5ac557f7d0455da7ebe774cd786c07c103240a8
<pre>
FetchRequest constructor should create a body proxy when reusing the body of a FetchRequest
<a href="https://rdar.apple.com/165033754">rdar://165033754</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302775">https://bugs.webkit.org/show_bug.cgi?id=302775</a>

Reviewed by Chris Dumez.

We align with the spec when using a Request body as the body in a newly constructed Request.
This means that we create a new ReadableStream instead of directly reusing the ReadableStream.

Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/303487@main">https://commits.webkit.org/303487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b5c4faf15dcc3934def64d7f33f7afe269ef16f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140123 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/37b4ee16-0bbb-40da-b1d0-4b168426fa79) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101370 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d2a696c-4844-4c01-83fd-93384ab4370f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135548 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82168 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83358 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4767 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109747 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4849 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4117 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109927 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3631 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58207 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4821 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33406 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4912 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->