### PR TITLE
Delay showing modal alerts until Safe Browsing response

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2423,6 +2423,22 @@ DefaultTextEncodingName:
     WebCore:
       default: '{ }'
 
+DelayModalsUntilSafeBrowsingResultEnabled:
+  type: bool
+  status: embedder
+  humanReadableName: "Delay Modals Until Safe Browsing Result"
+  humanReadableDescription: "Delay showing modal alerts until Safe Browsing response"
+  webcoreBinding: none
+  condition: HAVE(SAFE_BROWSING)
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DeprecationReportingEnabled:
   type: bool
   status: testable

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1404,6 +1404,18 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     protectedPreferences(self)->setSafeBrowsingEnabled(enabled);
 }
 
+#if HAVE(SAFE_BROWSING)
+- (BOOL)_isDelayModalsUntilSafeBrowsingResultEnabled
+{
+    return protectedPreferences(self)->delayModalsUntilSafeBrowsingResultEnabled();
+}
+
+- (void)_setDelayModalsUntilSafeBrowsingResultEnabled:(BOOL)enabled
+{
+    protectedPreferences(self)->setDelayModalsUntilSafeBrowsingResultEnabled(enabled);
+}
+#endif
+
 - (void)_setVideoQualityIncludesDisplayCompositingEnabled:(BOOL)videoQualityIncludesDisplayCompositingEnabled
 {
     protectedPreferences(self)->setVideoQualityIncludesDisplayCompositingEnabled(videoQualityIncludesDisplayCompositingEnabled);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -155,6 +155,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setShouldEnableTextAutosizingBoost:) BOOL _shouldEnableTextAutosizingBoost WK_API_AVAILABLE(macos(10.14), ios(12.0));
 
 @property (nonatomic, getter=_isSafeBrowsingEnabled, setter=_setSafeBrowsingEnabled:) BOOL _safeBrowsingEnabled WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
+@property (nonatomic, getter=_isDelayModalsUntilSafeBrowsingResultEnabled, setter=_setDelayModalsUntilSafeBrowsingResultEnabled:) BOOL _delayModalsUntilSafeBrowsingResultEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @property (nonatomic, setter=_setColorFilterEnabled:) BOOL _colorFilterEnabled WK_API_AVAILABLE(macos(10.14), ios(12.0));
 @property (nonatomic, setter=_setPunchOutWhiteBackgroundsInDarkMode:) BOOL _punchOutWhiteBackgroundsInDarkMode WK_API_AVAILABLE(macos(10.14), ios(12.0));

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -275,6 +275,7 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
     size_t redirectChainIndex = navigation.redirectChainIndex(url);
 
     navigation.setSafeBrowsingCheckOngoing(redirectChainIndex, true);
+    m_isSafeBrowsingCheckInProgress = true;
 
     auto performLookup = [weakThis = WeakPtr { *this }, navigation = Ref { navigation }, forMainFrameNavigation, url = url.isolatedCopy(), redirectChainIndex](RetainPtr<SSBLookupResult> cachedResult) mutable {
         RefPtr protectedThis = weakThis.get();
@@ -324,6 +325,38 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
     [historyDelegate _webView:webView.get() cachedSafeBrowsingResultForURL:url.createNSURL().get() completionHandler:cacheCompletionHandler.get()];
 #endif
 }
+
+#if HAVE(SAFE_BROWSING)
+void WebPageProxy::deferModalUntilSafeBrowsingCompletes(CompletionHandler<void(bool)>&& handler)
+{
+    ASSERT(isMainRunLoop());
+    ASSERT(handler);
+
+    if (!protectedPreferences()->delayModalsUntilSafeBrowsingResultEnabled() || !m_isSafeBrowsingCheckInProgress) {
+        handler(true);
+        return;
+    }
+
+    // Queue the handler to be called when Safe Browsing completes
+    m_deferredModalHandlers.append(WTFMove(handler));
+}
+
+void WebPageProxy::completeSafeBrowsingCheckForModals(bool userProceeded)
+{
+    ASSERT(isMainRunLoop());
+
+    auto& handlers = m_deferredModalHandlers;
+    if (handlers.isEmpty())
+        return;
+
+    // Call all queued handlers with the result
+    // Sequential execution maintains ordering
+    for (auto& handler : std::exchange(handlers, { }))
+        handler(userProceeded);
+
+    m_isSafeBrowsingCheckInProgress = false;
+}
+#endif
 
 #if ENABLE(CONTENT_FILTERING)
 void WebPageProxy::contentFilterDidBlockLoadForFrame(const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7108,6 +7108,13 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
         m_pageLoadTiming = nullptr;
         m_pageLoadTimingPendingCommit = makeUnique<WebPageLoadTiming>(timestamp);
         m_generatePageLoadTimingTimer.stop();
+
+#if HAVE(SAFE_BROWSING)
+        // Clear any deferred modals when starting a new main frame navigation
+        for (auto& handler : std::exchange(m_deferredModalHandlers, { }))
+            handler(false);
+        m_isSafeBrowsingCheckInProgress = false;
+#endif
     }
 
     // If a provisional load has since been started in another process, ignore this message.
@@ -8408,9 +8415,14 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         navigationAction,
         message = WTFMove(message),
         frameInfo,
-        protectedPageClient = RefPtr { pageClient() }
+        protectedPageClient = RefPtr { pageClient() },
+        shouldExpectSafeBrowsingResult
     ] (PolicyAction policyAction, API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain> isAppBoundDomain, WasNavigationIntercepted wasNavigationIntercepted) mutable {
         WEBPAGEPROXY_RELEASE_LOG(Loading, "decidePolicyForNavigationAction: listener called: frameID=%" PRIu64 ", isMainFrame=%d, navigationID=%" PRIu64  ", policyAction=%" PUBLIC_LOG_STRING ", isAppBoundDomain=%d, wasNavigationIntercepted=%d", frame->frameID().toUInt64(), frame->isMainFrame(), navigation ? navigation->navigationID().toUInt64() : 0, toString(policyAction).characters(), !!isAppBoundDomain, wasNavigationIntercepted == WasNavigationIntercepted::Yes);
+
+#if !HAVE(SAFE_BROWSING)
+        UNUSED_VARIABLE(shouldExpectSafeBrowsingResult);
+#endif
 
         if (policies && !policies->alternateRequest().isNull())
             navigation->setCurrentRequest(ResourceRequest(policies->alternateRequest()), std::nullopt);
@@ -8489,16 +8501,25 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
                 protectedPageLoadState->setTitleFromBrowsingWarning(transaction, { });
 
                 switchOn(result, [&] (const URL& url) {
+#if HAVE(SAFE_BROWSING)
+                    protectedThis->completeSafeBrowsingCheckForModals(false);
+#endif
                     completionHandler(PolicyAction::Ignore);
                     protectedThis->loadRequest({ URL { url } });
                 }, [&protectedThis, &completionHandler, policyAction] (ContinueUnsafeLoad continueUnsafeLoad) {
                     switch (continueUnsafeLoad) {
                     case ContinueUnsafeLoad::No:
+#if HAVE(SAFE_BROWSING)
+                        protectedThis->completeSafeBrowsingCheckForModals(false);
+#endif
                         if (!protectedThis->hasCommittedAnyProvisionalLoads())
                             protectedThis->m_uiClient->close(protectedThis.ptr());
                         completionHandler(PolicyAction::Ignore);
                         break;
                     case ContinueUnsafeLoad::Yes:
+#if HAVE(SAFE_BROWSING)
+                        protectedThis->completeSafeBrowsingCheckForModals(true);
+#endif
                         completionHandler(policyAction);
                         break;
                     }
@@ -8507,6 +8528,11 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
             m_uiClient->didShowSafeBrowsingWarning();
             return;
         }
+#if HAVE(SAFE_BROWSING)
+        // Safe Browsing check completed with no warning (clean result)
+        if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
+            protectedThis->completeSafeBrowsingCheckForModals(true);
+#endif
         completionHandlerWrapper(policyAction);
 
     }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData);
@@ -8786,16 +8812,25 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
                 protectedPageLoadState->setTitleFromBrowsingWarning(transaction, { });
 
                 switchOn(result, [&] (const URL& url) {
+#if HAVE(SAFE_BROWSING)
+                    protectedThis->completeSafeBrowsingCheckForModals(false);
+#endif
                     completionHandler(PolicyAction::Ignore);
                     protectedThis->loadRequest(URL { url });
                 }, [&protectedThis, &completionHandler, policyAction] (ContinueUnsafeLoad continueUnsafeLoad) {
                     switch (continueUnsafeLoad) {
                     case ContinueUnsafeLoad::No:
+#if HAVE(SAFE_BROWSING)
+                        protectedThis->completeSafeBrowsingCheckForModals(false);
+#endif
                         if (!protectedThis->hasCommittedAnyProvisionalLoads())
                             protectedThis->m_uiClient->close(protectedThis.ptr());
                         completionHandler(PolicyAction::Ignore);
                         break;
                     case ContinueUnsafeLoad::Yes:
+#if HAVE(SAFE_BROWSING)
+                        protectedThis->completeSafeBrowsingCheckForModals(true);
+#endif
                         completionHandler(policyAction);
                         break;
                     }
@@ -8839,12 +8874,22 @@ void WebPageProxy::showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&& safeBro
         protectedPageLoadState->setTitleFromBrowsingWarning(transaction, { });
 
         switchOn(result, [protectedThis] (const URL& url) {
+#if HAVE(SAFE_BROWSING)
+            protectedThis->completeSafeBrowsingCheckForModals(false);
+#endif
             protectedThis->loadRequest(URL { url });
         }, [protectedThis] (ContinueUnsafeLoad continueUnsafeLoad) {
-            if (continueUnsafeLoad == ContinueUnsafeLoad::No)
+            if (continueUnsafeLoad == ContinueUnsafeLoad::No) {
+#if HAVE(SAFE_BROWSING)
+                protectedThis->completeSafeBrowsingCheckForModals(false);
+#endif
                 protectedThis->goBack();
-            else
+            } else {
+#if HAVE(SAFE_BROWSING)
+                protectedThis->completeSafeBrowsingCheckForModals(true);
+#endif
                 protectedThis->protectedPageClient()->clearBrowsingWarning();
+            }
         });
     });
     m_uiClient->didShowSafeBrowsingWarning();
@@ -9349,12 +9394,26 @@ void WebPageProxy::runJavaScriptAlert(IPC::Connection& connection, FrameIdentifi
             automationSession->willShowJavaScriptDialog(*this, message, std::nullopt);
     }
 
-    runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
-        page.m_uiClient->runJavaScriptAlert(page, WTFMove(message), frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
-            reply();
-            completion();
+    auto showModal = [protectedThis = Ref { *this }](RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& reply) mutable {
+        protectedThis->runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
+            page.m_uiClient->runJavaScriptAlert(page, WTFMove(message), frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
+                reply();
+                completion();
+            });
         });
+    };
+
+#if HAVE(SAFE_BROWSING)
+    deferModalUntilSafeBrowsingCompletes([protectedThis = Ref { *this }, frame = WTFMove(frame), frameInfo = WTFMove(frameInfo), message = WTFMove(message), reply = WTFMove(reply), showModal = WTFMove(showModal)](bool shouldShow) mutable {
+        if (!shouldShow) {
+            reply();
+            return;
+        }
+        showModal(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), WTFMove(reply));
     });
+#else
+    showModal(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), WTFMove(reply));
+#endif
 }
 
 void WebPageProxy::runJavaScriptConfirm(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(bool)>&& reply)
@@ -9373,12 +9432,26 @@ void WebPageProxy::runJavaScriptConfirm(IPC::Connection& connection, FrameIdenti
             automationSession->willShowJavaScriptDialog(*this, message, std::nullopt);
     }
 
-    runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
-        page.m_uiClient->runJavaScriptConfirm(page, WTFMove(message), frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-            reply(result);
-            completion();
+    auto showModal = [protectedThis = Ref { *this }](RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(bool)>&& reply) mutable {
+        protectedThis->runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
+            page.m_uiClient->runJavaScriptConfirm(page, WTFMove(message), frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
+                reply(result);
+                completion();
+            });
         });
+    };
+
+#if HAVE(SAFE_BROWSING)
+    deferModalUntilSafeBrowsingCompletes([protectedThis = Ref { *this }, frame = WTFMove(frame), frameInfo = WTFMove(frameInfo), message = WTFMove(message), reply = WTFMove(reply), showModal = WTFMove(showModal)](bool shouldShow) mutable {
+        if (!shouldShow) {
+            reply(false);
+            return;
+        }
+        showModal(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), WTFMove(reply));
     });
+#else
+    showModal(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), WTFMove(reply));
+#endif
 }
 
 void WebPageProxy::runJavaScriptPrompt(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, String&& defaultValue, CompletionHandler<void(const String&)>&& reply)
@@ -9397,12 +9470,26 @@ void WebPageProxy::runJavaScriptPrompt(IPC::Connection& connection, FrameIdentif
             automationSession->willShowJavaScriptDialog(*this, message, defaultValue);
     }
 
-    runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), [reply = WTFMove(reply), defaultValue= WTFMove(defaultValue)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
-        page.m_uiClient->runJavaScriptPrompt(page, WTFMove(message), WTFMove(defaultValue), frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-            reply(result);
-            completion();
+    auto showModal = [protectedThis = Ref { *this }](RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, String&& defaultValue, CompletionHandler<void(const String&)>&& reply) mutable {
+        protectedThis->runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), [reply = WTFMove(reply), defaultValue = WTFMove(defaultValue)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
+            page.m_uiClient->runJavaScriptPrompt(page, WTFMove(message), WTFMove(defaultValue), frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
+                reply(result);
+                completion();
+            });
         });
+    };
+
+#if HAVE(SAFE_BROWSING)
+    deferModalUntilSafeBrowsingCompletes([protectedThis = Ref { *this }, frame = WTFMove(frame), frameInfo = WTFMove(frameInfo), message = WTFMove(message), defaultValue = WTFMove(defaultValue), reply = WTFMove(reply), showModal = WTFMove(showModal)](bool shouldShow) mutable {
+        if (!shouldShow) {
+            reply({ });
+            return;
+        }
+        showModal(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), WTFMove(defaultValue), WTFMove(reply));
     });
+#else
+    showModal(WTFMove(frame), WTFMove(frameInfo), WTFMove(message), WTFMove(defaultValue), WTFMove(reply));
+#endif
 }
 
 void WebPageProxy::setStatusText(const String& text)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2970,6 +2970,10 @@ private:
     void decidePolicyForResponse(IPC::Connection&, FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
     void beginSafeBrowsingCheck(const URL&, API::Navigation&, bool forMainFrameNavigation);
     void showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&&);
+#if HAVE(SAFE_BROWSING)
+    void deferModalUntilSafeBrowsingCompletes(CompletionHandler<void(bool shouldShow)>&&);
+    void completeSafeBrowsingCheckForModals(bool userProceeded);
+#endif
 
     WebContentMode effectiveContentModeAfterAdjustingPolicies(API::WebsitePolicies&, const WebCore::ResourceRequest&);
 
@@ -4002,6 +4006,11 @@ private:
     bool m_lastNavigationWasAppInitiated { true };
     bool m_isRunningModalJavaScriptDialog { false };
     bool m_isSuspended { false };
+
+#if HAVE(SAFE_BROWSING)
+    Vector<CompletionHandler<void(bool)>> m_deferredModalHandlers;
+    bool m_isSafeBrowsingCheckInProgress { false };
+#endif
     bool m_isLockdownModeExplicitlySet { false };
 
     bool m_needsScrollGeometryUpdates { false };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
@@ -58,6 +58,10 @@ SOFT_LINK_CLASS(SafariSafeBrowsing, SSBServiceLookupResult);
 static bool committedNavigation;
 static bool warningShown;
 static bool didCloseCalled;
+static bool alertShown;
+static bool confirmShown;
+static bool promptShown;
+static size_t modalCount;
 
 @interface SafeBrowsingNavigationDelegate : NSObject <WKNavigationDelegate, WKUIDelegatePrivate>
 @end
@@ -77,6 +81,55 @@ static bool didCloseCalled;
 - (void)webViewDidClose:(WKWebView *)webView
 {
     didCloseCalled = true;
+}
+
+@end
+
+@interface ModalDeferralDelegate : NSObject <WKNavigationDelegate, WKUIDelegate, WKUIDelegatePrivate>
+@property (nonatomic, copy) void (^onAlert)(NSString *);
+@property (nonatomic, copy) void (^onConfirm)(NSString *, void (^)(BOOL));
+@property (nonatomic, copy) void (^onPrompt)(NSString *, NSString *, void (^)(NSString *));
+@end
+
+@implementation ModalDeferralDelegate
+
+- (void)webView:(WKWebView *)webView didCommitNavigation:(WKNavigation *)navigation
+{
+    committedNavigation = true;
+}
+
+- (void)_webViewDidShowSafeBrowsingWarning:(WKWebView *)webView
+{
+    warningShown = true;
+}
+
+- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
+{
+    alertShown = true;
+    modalCount++;
+    if (_onAlert)
+        _onAlert(message);
+    completionHandler();
+}
+
+- (void)webView:(WKWebView *)webView runJavaScriptConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL))completionHandler
+{
+    confirmShown = true;
+    modalCount++;
+    if (_onConfirm)
+        _onConfirm(message, completionHandler);
+    else
+        completionHandler(YES);
+}
+
+- (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString *))completionHandler
+{
+    promptShown = true;
+    modalCount++;
+    if (_onPrompt)
+        _onPrompt(prompt, defaultText, completionHandler);
+    else
+        completionHandler(@"test");
 }
 
 @end
@@ -867,6 +920,386 @@ TEST(SafeBrowsing, PhishingInFrame)
     TestWebKitAPI::Util::run(&navigationFailed);
     EXPECT_TRUE(navigationFailed);
     EXPECT_TRUE(navigationFinished);
+}
+
+// TEST 1: Modal shown immediately when no Safe Browsing check is in progress
+TEST(SafeBrowsing, ModalShownImmediatelyWhenNoCheck)
+{
+    // Use SimpleLookupContext configured to return clean result
+    phishingResourceName = @"phishing"; // Different from what we'll load
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto delegate = adoptNS([ModalDeferralDelegate new]);
+    auto webView = adoptNS([WKWebView new]);
+    [webView configuration].preferences._safeBrowsingEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+    [webView setNavigationDelegate:delegate.get()];
+    [webView setUIDelegate:delegate.get()];
+
+    // Load a clean page
+    [webView loadRequest:[NSURLRequest requestWithURL:resourceURL(@"simple2")]];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Modal should show immediately (not deferred)
+    alertShown = false;
+    [webView evaluateJavaScript:@"alert('test')" completionHandler:nil];
+    TestWebKitAPI::Util::run(&alertShown);
+
+    EXPECT_TRUE(alertShown);
+    EXPECT_FALSE([webView _safeBrowsingWarning]);
+}
+
+// TEST 2: Modal deferred when Safe Browsing check is in progress
+TEST(SafeBrowsing, ModalDeferredDuringCheck)
+{
+    delayDuration = 50_ms;
+    TestWebKitAPI::HTTPServer server({
+        { "/malicious"_s, { "<html><body><script>alert('deferred')</script><h1>Test</h1></body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+    auto configuration = server.httpsProxyConfiguration();
+
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:delegate.get()];
+
+    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    [webView setUIDelegate:modalDelegate.get()];
+
+    committedNavigation = false;
+    alertShown = false;
+
+    // Navigate to malicious URL
+    [webView evaluateJavaScript:@"window.location = 'https://example2.com/malicious'" completionHandler:nil];
+
+    // Wait for Safe Browsing warning to appear
+    while (![webView _safeBrowsingWarning])
+        TestWebKitAPI::Util::spinRunLoop();
+
+#if !PLATFORM(MAC)
+    [[webView _safeBrowsingWarning] didMoveToWindow];
+#endif
+
+    // Alert should not be shown yet (deferred)
+    EXPECT_FALSE(alertShown);
+
+    // Click through warning
+    visitUnsafeSite([webView _safeBrowsingWarning]);
+
+    // Now the deferred alert should be shown
+    TestWebKitAPI::Util::run(&alertShown);
+    EXPECT_TRUE(alertShown);
+}
+
+// TEST 3: Deferred modal shown when user proceeds through warning
+TEST(SafeBrowsing, DeferredModalShownWhenProceedingThroughWarning)
+{
+    delayDuration = 50_ms;
+    TestWebKitAPI::HTTPServer server({
+        { "/malicious"_s, { "<html><body onload='alert(\"proceed test\")'><h1>Test</h1></body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+    auto configuration = server.httpsProxyConfiguration();
+
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+
+    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    __block bool alertCalled = false;
+    __block RetainPtr<NSString> alertMessage;
+    modalDelegate.get().onAlert = ^(NSString *message) {
+        alertCalled = true;
+        alertMessage = message;
+    };
+    [webView setUIDelegate:modalDelegate.get()];
+
+    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    [navDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navDelegate.get()];
+
+    // Navigate to malicious page
+    [webView evaluateJavaScript:@"window.location = 'https://example2.com/malicious'" completionHandler:nil];
+
+    // Wait for warning
+    while (![webView _safeBrowsingWarning])
+        TestWebKitAPI::Util::spinRunLoop();
+
+#if !PLATFORM(MAC)
+    [[webView _safeBrowsingWarning] didMoveToWindow];
+#endif
+
+    // Alert should be deferred
+    EXPECT_FALSE(alertCalled);
+
+    // Proceed through warning
+    visitUnsafeSite([webView _safeBrowsingWarning]);
+
+    // Now alert should be shown
+    TestWebKitAPI::Util::run(&alertCalled);
+    EXPECT_TRUE(alertCalled);
+    EXPECT_WK_STREQ(alertMessage.get(), "proceed test");
+}
+
+// TEST 4: Deferred modal suppressed when user goes back from warning
+TEST(SafeBrowsing, DeferredModalSuppressedWhenGoingBack)
+{
+    delayDuration = 50_ms;
+    TestWebKitAPI::HTTPServer server({
+        { "/malicious"_s, { "<html><body onload='alert(\"should not show\")'><h1>Phishing</h1></body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+    auto configuration = server.httpsProxyConfiguration();
+
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+
+    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    __block bool alertCalled = false;
+    modalDelegate.get().onAlert = ^(NSString *message) {
+        alertCalled = true;
+    };
+    [webView setUIDelegate:modalDelegate.get()];
+
+    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    [navDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navDelegate.get()];
+
+    // First load a safe page
+    [webView loadRequest:[NSURLRequest requestWithURL:resourceURL(@"simple2")]];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Now navigate to malicious page with alert
+    [webView evaluateJavaScript:@"window.location = 'https://example2.com/malicious'" completionHandler:nil];
+
+    // Wait for warning
+    while (![webView _safeBrowsingWarning])
+        TestWebKitAPI::Util::spinRunLoop();
+
+#if !PLATFORM(MAC)
+    [[webView _safeBrowsingWarning] didMoveToWindow];
+#endif
+
+    // Alert should be deferred
+    EXPECT_FALSE(alertCalled);
+
+    // Go back from warning
+    goBack([webView _safeBrowsingWarning]);
+
+    // Give time for any potential alert to appear (it shouldn't)
+    TestWebKitAPI::Util::spinRunLoop(10);
+
+    // Alert should NOT be shown (suppressed)
+    EXPECT_FALSE(alertCalled);
+}
+
+// TEST 5: Multiple modals deferred and shown in order
+TEST(SafeBrowsing, MultipleDeferredModalsShownInOrder)
+{
+    delayDuration = 50_ms;
+    TestWebKitAPI::HTTPServer server({
+        { "/malicious"_s, { "<html><body onload='test()'><script>function test() { alert('first'); alert('second'); alert('third'); }</script></body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+    auto configuration = server.httpsProxyConfiguration();
+
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+
+    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    __block Vector<String> modalMessages;
+    modalDelegate.get().onAlert = ^(NSString *message) {
+        modalMessages.append(String(message));
+    };
+    [webView setUIDelegate:modalDelegate.get()];
+
+    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    [navDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navDelegate.get()];
+
+    // Navigate to malicious page with multiple alerts
+    [webView evaluateJavaScript:@"window.location = 'https://example2.com/malicious'" completionHandler:nil];
+
+    // Wait for warning
+    while (![webView _safeBrowsingWarning])
+        TestWebKitAPI::Util::spinRunLoop();
+
+#if !PLATFORM(MAC)
+    [[webView _safeBrowsingWarning] didMoveToWindow];
+#endif
+
+    // No alerts should be shown yet
+    EXPECT_EQ(modalMessages.size(), 0u);
+
+    // Proceed through warning
+    modalCount = 0;
+    visitUnsafeSite([webView _safeBrowsingWarning]);
+
+    // Wait for all three alerts
+    while (modalCount < 3)
+        TestWebKitAPI::Util::spinRunLoop();
+
+    // Verify order
+    EXPECT_EQ(modalMessages.size(), 3u);
+    EXPECT_STREQ(modalMessages[0].utf8().data(), "first");
+    EXPECT_STREQ(modalMessages[1].utf8().data(), "second");
+    EXPECT_STREQ(modalMessages[2].utf8().data(), "third");
+}
+
+// TEST 6: Deferred modals cleared on navigation
+TEST(SafeBrowsing, DeferredModalsClearedOnNavigation)
+{
+    delayDuration = 50_ms;
+    TestWebKitAPI::HTTPServer server({
+        { "/malicious"_s, { "<html><body onload='alert(\"deferred\")'><h1>Test</h1></body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+    auto configuration = server.httpsProxyConfiguration();
+
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+
+    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    __block bool alertCalled = false;
+    modalDelegate.get().onAlert = ^(NSString *message) {
+        alertCalled = true;
+    };
+    [webView setUIDelegate:modalDelegate.get()];
+
+    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    [navDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navDelegate.get()];
+
+    // Navigate to malicious page with alert
+    [webView evaluateJavaScript:@"window.location = 'https://example2.com/malicious'" completionHandler:nil];
+
+    // Wait for warning
+    while (![webView _safeBrowsingWarning])
+        TestWebKitAPI::Util::spinRunLoop();
+
+#if !PLATFORM(MAC)
+    [[webView _safeBrowsingWarning] didMoveToWindow];
+#endif
+
+    EXPECT_FALSE(alertCalled);
+
+    // Navigate to different page (should clear deferred modals)
+    [webView loadRequest:[NSURLRequest requestWithURL:resourceURL(@"simple2")]];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Give time for any potential alert
+    TestWebKitAPI::Util::spinRunLoop(10);
+
+    // Alert should NOT appear (was cleared)
+    EXPECT_FALSE(alertCalled);
+    EXPECT_FALSE([webView _safeBrowsingWarning]);
+}
+
+// TEST 7: Modal shown when Safe Browsing check completes with clean result
+TEST(SafeBrowsing, ModalShownWhenCheckCompletesClean)
+{
+    // Configure to return clean result
+    phishingResourceName = @"different-url";
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto delegate = adoptNS([ModalDeferralDelegate new]);
+    __block bool alertCalled = false;
+    delegate.get().onAlert = ^(NSString *message) {
+        alertCalled = true;
+    };
+
+    auto webView = adoptNS([WKWebView new]);
+    [webView configuration].preferences._safeBrowsingEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+    [webView setNavigationDelegate:delegate.get()];
+    [webView setUIDelegate:delegate.get()];
+
+    // Load page with alert (clean result from Safe Browsing)
+    committedNavigation = false;
+    [webView loadHTMLString:@"<html><body onload='alert(\"clean\")'><h1>Test</h1></body></html>" baseURL:[NSURL URLWithString:@"https://clean.example.com"]];
+
+    // Wait for navigation to complete (no warning should appear)
+    TestWebKitAPI::Util::run(&committedNavigation);
+
+    // Alert should be shown (Safe Browsing returned clean, so modal was deferred then released)
+    TestWebKitAPI::Util::run(&alertCalled);
+    EXPECT_TRUE(alertCalled);
+    EXPECT_FALSE([webView _safeBrowsingWarning]);
+}
+
+// TEST 8: All three modal types (alert, confirm, prompt) are properly deferred
+TEST(SafeBrowsing, AllModalTypesProperlyDeferred)
+{
+    delayDuration = 50_ms;
+    TestWebKitAPI::HTTPServer server({
+        { "/malicious"_s, { "<html><body onload='test()'><script>function test() { alert('test alert'); confirm('test confirm'); prompt('test prompt', 'default'); }</script></body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+    auto configuration = server.httpsProxyConfiguration();
+
+    ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
+    [webView configuration].preferences._delayModalsUntilSafeBrowsingResultEnabled = YES;
+
+    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    __block Vector<String> modalTypes;
+    modalDelegate.get().onAlert = ^(NSString *message) {
+        modalTypes.append("alert"_s);
+    };
+    modalDelegate.get().onConfirm = ^(NSString *message, void (^completionHandler)(BOOL)) {
+        modalTypes.append("confirm"_s);
+        completionHandler(YES);
+    };
+    modalDelegate.get().onPrompt = ^(NSString *message, NSString *defaultText, void (^completionHandler)(NSString *)) {
+        modalTypes.append("prompt"_s);
+        completionHandler(@"test");
+    };
+    [webView setUIDelegate:modalDelegate.get()];
+
+    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    [navDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navDelegate.get()];
+
+    // Navigate to malicious page with all modal types
+    [webView evaluateJavaScript:@"window.location = 'https://example2.com/malicious'" completionHandler:nil];
+
+    // Wait for warning
+    while (![webView _safeBrowsingWarning])
+        TestWebKitAPI::Util::spinRunLoop();
+
+#if !PLATFORM(MAC)
+    [[webView _safeBrowsingWarning] didMoveToWindow];
+#endif
+
+    // No modals should be shown yet
+    EXPECT_EQ(modalTypes.size(), 0u);
+
+    // Proceed through warning
+    modalCount = 0;
+    visitUnsafeSite([webView _safeBrowsingWarning]);
+
+    // Wait for all three modals
+    while (modalCount < 3)
+        TestWebKitAPI::Util::spinRunLoop();
+
+    // Verify all types were deferred and shown
+    EXPECT_EQ(modalTypes.size(), 3u);
+    EXPECT_STREQ(modalTypes[0].utf8().data(), "alert");
+    EXPECT_STREQ(modalTypes[1].utf8().data(), "confirm");
+    EXPECT_STREQ(modalTypes[2].utf8().data(), "prompt");
 }
 
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1386,6 +1386,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         WKPreferencesSetMinimumFontSize(preferences, 0);
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
+        WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("WebGPUEnabled").get());
 
         for (const auto& [key, value] : options.boolWebPreferenceFeatures())
             WKPreferencesSetBoolValueForKeyForTesting(preferences, value, toWK(key).get());


### PR DESCRIPTION
#### 1e3708b1d46e9053917471115012990599a32665
<pre>
Delay showing modal alerts until Safe Browsing response
<a href="https://rdar.apple.com/163939987">rdar://163939987</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302772">https://bugs.webkit.org/show_bug.cgi?id=302772</a>

Reviewed by NOBODY (OOPS!).

In the case where a Safe Browsing check takes long enough that we load
the page, we should delay showing modal dialogs until we get a response
back. This patch does it for alerts, but it can be expanded.

The absolute max time this could take is 5 seconds.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::beginSafeBrowsingCheck):
(WebKit::WebPageProxy::deferModalUntilSafeBrowsingCompletes):
(WebKit::WebPageProxy::completeSafeBrowsingCheckForModals):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::showBrowsingWarning):
(WebKit::WebPageProxy::runJavaScriptAlert):
(WebKit::WebPageProxy::runJavaScriptConfirm):
(WebKit::WebPageProxy::runJavaScriptPrompt):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm:
(-[ModalDeferralDelegate webView:didCommitNavigation:]):
(-[ModalDeferralDelegate _webViewDidShowSafeBrowsingWarning:]):
(-[ModalDeferralDelegate webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:]):
(-[ModalDeferralDelegate webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:]):
(-[ModalDeferralDelegate webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:]):
(TEST(SafeBrowsing, ModalShownImmediatelyWhenNoCheck)):
(TEST(SafeBrowsing, ModalDeferredDuringCheck)):
(TEST(SafeBrowsing, DeferredModalShownWhenProceedingThroughWarning)):
(TEST(SafeBrowsing, DeferredModalSuppressedWhenGoingBack)):
(TEST(SafeBrowsing, MultipleDeferredModalsShownInOrder)):
(TEST(SafeBrowsing, DeferredModalsClearedOnNavigation)):
(TEST(SafeBrowsing, ModalShownWhenCheckCompletesClean)):
(TEST(SafeBrowsing, AllModalTypesProperlyDeferred)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e3708b1d46e9053917471115012990599a32665

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166544 "Failed to checkout and rebase branch from PR 54171") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/40034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33615 "Failed to checkout and rebase branch from PR 54171") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168410 "Failed to checkout and rebase branch from PR 54171") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40042 "Failed to checkout and rebase branch from PR 54171") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/175592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169503 "Failed to checkout and rebase branch from PR 54171") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/40466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/33615 "Failed to checkout and rebase branch from PR 54171") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/40466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/40042 "Failed to checkout and rebase branch from PR 54171") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/158701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/40466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/33615 "Failed to checkout and rebase branch from PR 54171") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/178126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/27438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/33615 "Failed to checkout and rebase branch from PR 54171") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/178126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/40104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/40042 "Failed to checkout and rebase branch from PR 54171") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/178126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/33615 "Failed to checkout and rebase branch from PR 54171") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/33615 "Failed to checkout and rebase branch from PR 54171") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/199223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/39302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/199223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/33615 "Failed to checkout and rebase branch from PR 54171") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->