### PR TITLE
[intersection-observer] scroll-margin should not be applied to scrollers in cross-origin frames

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-1.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<script src="/common/get-host-info.sub.js"></script>
+
+<p>Iframe 1</p>
+
+<div style="width: 300px; height: 300px; overflow-y: scroll; outline: 1px red solid" id="scroller">
+  <!-- Spacer to trigger scrolling -->
+  <div style="height: 400px"></div>
+
+  <iframe id="iframe" width=250 height=300></iframe>
+</div>
+
+<script>
+  iframe.src = get_host_info().ORIGIN + "/intersection-observer/resources/scroll-margin-propagation-iframe-2.html";
+
+  window.addEventListener("message", event => {
+    const data = event.data;
+
+    if (data.msgName === "setScrollTop") {
+      if (data.target === "iframe1") {
+        scroller.scrollTop = data.scrollTop;
+        window.top.postMessage({ msgName: "scrollEnd", source: "iframe1" }, "*");
+      } else
+        iframe.contentWindow.postMessage(data, "*");
+    }
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-2.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+<script src="/common/get-host-info.sub.js"></script>
+
+<p>Iframe 2</p>
+
+<div style="width: 200px; height: 200px; overflow-y: scroll; outline: 1px solid purple" id="scroller">
+  <!-- Spacer to trigger scrolling -->
+  <div style="height: 300px"></div>
+
+  <iframe id="iframe" width=150 height=200></iframe>
+</div>
+
+<script>
+  iframe.src = get_host_info().ORIGIN + "/intersection-observer/resources/scroll-margin-propagation-iframe-3.html";
+
+  window.addEventListener("message", event => {
+    const data = event.data;
+
+    if (data.msgName === "setScrollTop" && data.target === "iframe2") {
+        scroller.scrollTop = data.scrollTop;
+        window.top.postMessage({ msgName: "scrollEnd", source: "iframe2" }, "*");
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-3.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<p>Iframe 3</p>
+<div style="width: 100px; height: 100px; background: green" id="target">Target</div>
+
+<script>
+const options = {
+  root: null,
+  scrollMargin: "50px"
+};
+
+const observer = new IntersectionObserver(records => {
+  window.top.postMessage({ msgName: "isIntersectingChanged", value: records[0].isIntersecting }, "*");
+}, options);
+
+observer.observe(target);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation-expected.txt
@@ -1,0 +1,8 @@
+Top page
+
+
+
+PASS Scroll margin is applied to iframe 2, because it's same-origin-domain with iframe 3
+PASS Scroll margin is not applied to iframe 1, because it's cross-origin-domain with iframe 3
+PASS Scroll margin is not applied to top page, because scroll margin doesn't propagate past cross-origin-domain iframe 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<title>Scroll margin propagation from descendant frame to top page</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<meta name="timeout" content="long">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+
+<!--
+  This tests that when
+  (1) an implicit root intersection observer includes a scroll margin
+  (2) the observer target is in a frame descendant of the top page
+
+  Then the scroll margin is applied up to, and excluding, the first cross-origin-domain
+  frame in the chain from the target to the top page. Then, subsequent frames won't
+  have scroll margin applied, even if any of subsequent frames are same-origin-domain.
+
+  This follows the discussion at [1] that says:
+  > Implementation notes:
+  > * [...]
+  > * Should stop margins at a cross-origin iframe boundary for security
+
+  [1]: https://github.com/w3c/IntersectionObserver/issues/431#issuecomment-1542502858
+
+  The setup:
+    * 3-level iframe nesting: top page -> iframe 1 -> iframe 2 -> iframe 3
+    * Iframe 1 is cross-origin-domain with top page, iframe 2/3 are same-origin-domain
+    * Top page and iframe 1/2 have a scroller, which consists of a spacer to trigger
+      scrolling, and an iframe to the next level.
+    * Iframe 3 has an implicit root intersection observer and the target.
+    * The observer specifies a scroll margin, which should be applied to iframe 2,
+      and not to iframe 1 and top page.
+
+  Communication between frames:
+    * Iframe 3 sends a "isIntersectingChanged" to the top page when the target's
+      isIntersecting changed.
+    * Iframe 1, 2 accepts a "setScrollTop" message to set the scrollTop of its scroller.
+      The message contains a destination, if the destination matches, it sets the scrollTop,
+      otherwise it passes the message down the chain. After setting scrollTop, the iframe emits
+      a "scrollEnd" message to the top frame.
+-->
+
+<p>Top page</p>
+<div style="width: 400px; height: 400px; outline: 1px solid blue; overflow-y: scroll" id="scroller">
+  <!-- Spacer to trigger scrolling -->
+  <div style="height: 500px"></div>
+
+  <iframe width=350 height=400 id="iframe"></iframe>
+</div>
+
+<script>
+iframe.src =
+  get_host_info().HTTP_NOTSAMESITE_ORIGIN + "/intersection-observer/resources/scroll-margin-propagation-iframe-1.html";
+const iframeWindow = iframe.contentWindow;
+
+// Set the scrollTop of the scroller in the frame specified by `target`:
+// "this" - top frame, "iframe1" - iframe 1, "iframe2" - iframe2
+// When setting scrollTop of remote frames, remote frame will send a "scrollEnd"
+// message to indicate the scroll has been set. Wait for this message before returning.
+async function setScrollTop(target, scrollTop) {
+  if (target === "this") {
+    scroller.scrollTop = scrollTop;
+  } else {
+    iframeWindow.postMessage({
+      msgName: "setScrollTop",
+      target: target,
+      scrollTop: scrollTop
+    }, "*");
+
+    await new Promise(resolve => {
+      window.addEventListener("message", event => {
+        if (event.data.msgName === "scrollEnd" && event.data.source === target)
+          resolve();
+
+      }, { once: true })
+    })
+  }
+
+  // Wait for IntersectionObserver notifications to be generated.
+  await new Promise(resolve => waitForNotification(null, resolve));
+  await new Promise(resolve => waitForNotification(null, resolve));
+}
+
+var grandchildFrameIsIntersecting = null;
+
+promise_setup(() => {
+  // Wait for the initial IntersectionObserver notification.
+  // This indicates iframe 3 is fully ready for test.
+  return new Promise(resolve => {
+    window.addEventListener("message", event => {
+      if (event.data.msgName === "isIntersectingChanged") {
+        grandchildFrameIsIntersecting = event.data.value;
+
+        // Install a long-lasting event listener, since this listerner is one-shot
+        window.addEventListener("message", event => {
+          if (event.data.msgName === "isIntersectingChanged")
+            grandchildFrameIsIntersecting = event.data.value;
+        });
+
+        resolve();
+      }
+    }, { once: true });
+  });
+});
+
+promise_test(async t => {
+  // Scroll everything to bottom, so target is fully visible
+  await setScrollTop("this", 99999);
+  await setScrollTop("iframe1", 99999);
+  await setScrollTop("iframe2", 99999);
+  assert_true(grandchildFrameIsIntersecting, "Target is fully visible and intersecting");
+
+  // Scroll iframe 2 up a bit so that target is not visible, but still intersecting
+  // because of scroll margin.
+  await setScrollTop("iframe2", 130);
+  assert_true(grandchildFrameIsIntersecting, "Target is not visible, but in the scroll margin zone, so still intersects");
+
+  await setScrollTop("iframe2", 85);
+  assert_false(grandchildFrameIsIntersecting, "Target is fully outside the visible and scroll margin zone");
+}, "Scroll margin is applied to iframe 2, because it's same-origin-domain with iframe 3");
+
+promise_test(async t => {
+  // Scroll everything to bottom, so target is fully visible
+  await setScrollTop("this", 99999);
+  await setScrollTop("iframe1", 99999);
+  await setScrollTop("iframe2", 99999);
+  assert_true(grandchildFrameIsIntersecting, "Target is fully visible");
+
+  await setScrollTop("iframe1", 180);
+  assert_false(grandchildFrameIsIntersecting, "Target is not visible, in the scroll margin zone, but not intersecting because scroll margin doesn't apply to cross-origin-domain frames");
+}, "Scroll margin is not applied to iframe 1, because it's cross-origin-domain with iframe 3");
+
+promise_test(async t => {
+  // Scroll everything to bottom, so target is fully visible
+  await setScrollTop("this", 99999);
+  await setScrollTop("iframe1", 99999);
+  await setScrollTop("iframe2", 99999);
+  assert_true(grandchildFrameIsIntersecting, "Target is fully visible");
+
+  await setScrollTop("this", 235);
+  assert_false(grandchildFrameIsIntersecting, "Target is not visible, in the scroll margin zone, but not intersecting because scroll margin doesn't apply to frames beyond cross-origin-domain frames");
+
+}, "Scroll margin is not applied to top page, because scroll margin doesn't propagate past cross-origin-domain iframe 1");
+</script>


### PR DESCRIPTION
#### 9d1b2ba86390b4d32457a0ff0089da31cec31e68
<pre>
[intersection-observer] scroll-margin should not be applied to scrollers in cross-origin frames
<a href="https://rdar.apple.com/164994009">rdar://164994009</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302732">https://bugs.webkit.org/show_bug.cgi?id=302732</a>

Reviewed by Simon Fraser.

Currently, WebKit applies scroll margin to every frame in the chain from the target&apos;s
frame to the main frame. This includes cross-origin-domain frames, which might leak
information about the frame. In the discussion about adding scroll margin [1], there&apos;s
an implementation notes about not propagating scroll margin past the first cross-origin
frame:

&gt; Implementation notes:
&gt; * [...]
&gt; * Should stop margins at a cross-origin iframe boundary for security

Fix WebKit&apos;s implementation to follow this implementation note. Included is a test case
that fully passes in Firefox Nightly 147.0a1 (2025-11-19) (aarch64). Chrome seems to
have an issue wrt. intersection observers not firing in deeply nested iframes.

[1]: <a href="https://github.com/w3c/IntersectionObserver/issues/431#issuecomment-1542502858">https://github.com/w3c/IntersectionObserver/issues/431#issuecomment-1542502858</a>

Test: imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-1.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/scroll-margin-propagation-iframe-3.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html: Added.
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::computeClippedRectInRootContentsSpace):
    - When traversing up the frame chain, stop applying and propagating
      scroll margin if we visit a cross-origin-domain frame.
(WebCore::IntersectionObserver::computeIntersectionState const):

Canonical link: <a href="https://commits.webkit.org/303367@main">https://commits.webkit.org/303367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf69bfea13b0999cc11f81a803fb208e594de3b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139685 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3227e88-ea86-46ec-b732-5d7c49e77ee7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135116 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81821 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d97a32a-0dac-4608-a8e3-3f0aa3e8e44c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82905 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142332 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37073 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4413 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109581 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27758 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114649 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4386 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4218 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->