### PR TITLE
[blocks-in-inline] Fix local previous/nextLinePosition to adjust for local offset

### DIFF
--- a/LayoutTests/editing/deleting/pruning-after-merge-3-expected.html
+++ b/LayoutTests/editing/deleting/pruning-after-merge-3-expected.html
@@ -1,0 +1,10 @@
+<p>You should see:<br>b<b>arbaz</b></p>
+<div id="b" contenteditable="true">boo<b><br><div style="display:inline-block"><div id=e>bar</div><div>baz</div></div></b></div>
+
+<script>
+var s = window.getSelection();
+
+s.setBaseAndExtent(b.firstChild, 1, e.firstChild, 1);
+
+document.execCommand("Delete");
+</script>

--- a/LayoutTests/editing/deleting/pruning-after-merge-3.html
+++ b/LayoutTests/editing/deleting/pruning-after-merge-3.html
@@ -1,0 +1,12 @@
+<p>You should see:<br>b<b>arbaz</b></p>
+<div id="b" contenteditable="true">boo<b><br><div style="display:inline-block"><div>bar</div><div>baz</div></div></b></div>
+
+<script>
+var s = window.getSelection();
+
+s.setPosition(b, 0);
+s.modify("move", "forward", "character");
+s.modify("extend", "forward", "line");
+
+document.execCommand("Delete");
+</script>

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -1005,7 +1005,9 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
             return positionInParentBeforeNode(node.get());
         // FIXME: The HitTestSource state should be propagated down from calls into JavaScript bindings.
         // For the time being, just err on the side of passing in `Bindings`.
-        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine, HitTestSource::Script);
+        auto* renderBox = dynamicDowncast<RenderBox>(renderer.get());
+        auto localOffset = renderBox ? renderBox->locationOffset() : LayoutSize { };
+        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine - localOffset, HitTestSource::Script);
     }
     
     // Could not find a previous line. This means we must already be on the first line.
@@ -1065,7 +1067,9 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
             return positionInParentBeforeNode(node.get());
         // FIXME: The HitTestSource state should be propagated down from calls into JavaScript bindings.
         // For the time being, just err on the side of passing in `Bindings`.
-        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine, HitTestSource::Script);
+        auto* renderBox = dynamicDowncast<RenderBox>(renderer.get());
+        auto localOffset = renderBox ? renderBox->locationOffset() : LayoutSize { };
+        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine - localOffset, HitTestSource::Script);
     }
 
     // Could not find a next line. This means we must already be on the last line.


### PR DESCRIPTION
#### 66fe01ec84acda612d27f76459c2ea9d5f191b97
<pre>
[blocks-in-inline] Fix local previous/nextLinePosition to adjust for local offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=302777">https://bugs.webkit.org/show_bug.cgi?id=302777</a>
<a href="https://rdar.apple.com/165041221">rdar://165041221</a>

Reviewed by Alan Baradlay.

Blocks-in-inline revealed an existing bug in these functions.
If the selection was extended to an inline block we would select wrong line inside it because
bad coordinates. This becomes more important with blocks-in-inline.

Test: editing/deleting/pruning-after-merge-3.html
* LayoutTests/editing/deleting/pruning-after-merge-3-expected.html: Added.
* LayoutTests/editing/deleting/pruning-after-merge-3.html: Added.

Add a test where we extend selection to an inline-block.
The tested behavior matches Chrome.

* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::previousLinePosition):
(WebCore::nextLinePosition):

visiblePositionForPoint() expects point in the local coordinates of the renderer.

Canonical link: <a href="https://commits.webkit.org/303253@main">https://commits.webkit.org/303253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ef99043b9b259974ab9cf29c8fa520d60a0e03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139357 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/052b6051-a16a-4e12-9f07-76bef75651fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0cdc5cc-878a-43c3-9e48-f086ee176e6f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134791 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81566 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c0c9077-c85a-4beb-b76c-c5461886c046) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82576 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142000 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4006 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109151 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4087 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109317 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27683 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3045 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114367 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57216 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4060 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32768 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67507 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->