### PR TITLE
[JSC] Support select in BBQ's fused branch compare

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4870,7 +4870,7 @@ ALWAYS_INLINE void BBQJIT::willParseOpcode()
 
 #if ASSERT_ENABLED
     if (shouldFuseBranchCompare && isCompareOpType(m_prevOpcode)
-        && (m_parser->currentOpcode() == OpType::BrIf || m_parser->currentOpcode() == OpType::If)) {
+        && (m_parser->currentOpcode() == OpType::BrIf || m_parser->currentOpcode() == OpType::If || m_parser->currentOpcode() == OpType::Select)) {
         m_prevOpcode = m_parser->currentOpcode();
         return;
     }
@@ -5121,74 +5121,80 @@ static MacroAssembler::Jump emitBranchF64(CCallHelpers& jit, MacroAssembler::Dou
     return jit.branchDouble(condition, leftLocation.asFPR(), rightLocation.asFPR());
 }
 
-BBQJIT::Jump BBQJIT::emitFusedBranchCompareBranch(OpType opType, ExpressionType left, Location leftLocation, ExpressionType right, Location rightLocation)
+BBQJIT::Jump BBQJIT::emitFusedBranchCompareBranch(OpType opType, ExpressionType left, Location leftLocation, ExpressionType right, Location rightLocation, bool branchIfTrue)
 {
-    // Emit a branch with the inverse of the comparison. We're generating the "branch-if-false" case.
+    // When branchIfTrue=false (default), emit branch-if-false (inverse of comparison).
+    // When branchIfTrue=true, emit branch-if-true (comparison as-is).
+
+    auto conditionForBranch = [&](auto cond) ALWAYS_INLINE_LAMBDA {
+        return branchIfTrue ? cond : MacroAssembler::invert(cond);
+    };
+
     switch (opType) {
     case OpType::I32LtS:
-        return emitBranchI32(m_jit, RelationalCondition::GreaterThanOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::LessThan), left, leftLocation, right, rightLocation);
     case OpType::I32LtU:
-        return emitBranchI32(m_jit, RelationalCondition::AboveOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::Below), left, leftLocation, right, rightLocation);
     case OpType::I32GtS:
-        return emitBranchI32(m_jit, RelationalCondition::LessThanOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::GreaterThan), left, leftLocation, right, rightLocation);
     case OpType::I32GtU:
-        return emitBranchI32(m_jit, RelationalCondition::BelowOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::Above), left, leftLocation, right, rightLocation);
     case OpType::I32LeS:
-        return emitBranchI32(m_jit, RelationalCondition::GreaterThan, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::LessThanOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I32LeU:
-        return emitBranchI32(m_jit, RelationalCondition::Above, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::BelowOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I32GeS:
-        return emitBranchI32(m_jit, RelationalCondition::LessThan, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::GreaterThanOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I32GeU:
-        return emitBranchI32(m_jit, RelationalCondition::Below, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::AboveOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I32Eq:
-        return emitBranchI32(m_jit, RelationalCondition::NotEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::Equal), left, leftLocation, right, rightLocation);
     case OpType::I32Ne:
-        return emitBranchI32(m_jit, RelationalCondition::Equal, left, leftLocation, right, rightLocation);
+        return emitBranchI32(m_jit, conditionForBranch(RelationalCondition::NotEqual), left, leftLocation, right, rightLocation);
     case OpType::I64LtS:
-        return emitBranchI64(m_jit, RelationalCondition::GreaterThanOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::LessThan), left, leftLocation, right, rightLocation);
     case OpType::I64LtU:
-        return emitBranchI64(m_jit, RelationalCondition::AboveOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::Below), left, leftLocation, right, rightLocation);
     case OpType::I64GtS:
-        return emitBranchI64(m_jit, RelationalCondition::LessThanOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::GreaterThan), left, leftLocation, right, rightLocation);
     case OpType::I64GtU:
-        return emitBranchI64(m_jit, RelationalCondition::BelowOrEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::Above), left, leftLocation, right, rightLocation);
     case OpType::I64LeS:
-        return emitBranchI64(m_jit, RelationalCondition::GreaterThan, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::LessThanOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I64LeU:
-        return emitBranchI64(m_jit, RelationalCondition::Above, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::BelowOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I64GeS:
-        return emitBranchI64(m_jit, RelationalCondition::LessThan, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::GreaterThanOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I64GeU:
-        return emitBranchI64(m_jit, RelationalCondition::Below, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::AboveOrEqual), left, leftLocation, right, rightLocation);
     case OpType::I64Eq:
-        return emitBranchI64(m_jit, RelationalCondition::NotEqual, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::Equal), left, leftLocation, right, rightLocation);
     case OpType::I64Ne:
-        return emitBranchI64(m_jit, RelationalCondition::Equal, left, leftLocation, right, rightLocation);
+        return emitBranchI64(m_jit, conditionForBranch(RelationalCondition::NotEqual), left, leftLocation, right, rightLocation);
     case OpType::F32Lt:
-        return emitBranchF32(m_jit, MacroAssembler::invert(DoubleCondition::DoubleLessThanAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF32(m_jit, conditionForBranch(DoubleCondition::DoubleLessThanAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F32Gt:
-        return emitBranchF32(m_jit, MacroAssembler::invert(DoubleCondition::DoubleGreaterThanAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF32(m_jit, conditionForBranch(DoubleCondition::DoubleGreaterThanAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F32Le:
-        return emitBranchF32(m_jit, MacroAssembler::invert(DoubleCondition::DoubleLessThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF32(m_jit, conditionForBranch(DoubleCondition::DoubleLessThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F32Ge:
-        return emitBranchF32(m_jit, MacroAssembler::invert(DoubleCondition::DoubleGreaterThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF32(m_jit, conditionForBranch(DoubleCondition::DoubleGreaterThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F32Eq:
-        return emitBranchF32(m_jit, MacroAssembler::invert(DoubleCondition::DoubleEqualAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF32(m_jit, conditionForBranch(DoubleCondition::DoubleEqualAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F32Ne:
-        return emitBranchF32(m_jit, MacroAssembler::invert(DoubleCondition::DoubleNotEqualOrUnordered), left, leftLocation, right, rightLocation);
+        return emitBranchF32(m_jit, conditionForBranch(DoubleCondition::DoubleNotEqualOrUnordered), left, leftLocation, right, rightLocation);
     case OpType::F64Lt:
-        return emitBranchF64(m_jit, MacroAssembler::invert(DoubleCondition::DoubleLessThanAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF64(m_jit, conditionForBranch(DoubleCondition::DoubleLessThanAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F64Gt:
-        return emitBranchF64(m_jit, MacroAssembler::invert(DoubleCondition::DoubleGreaterThanAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF64(m_jit, conditionForBranch(DoubleCondition::DoubleGreaterThanAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F64Le:
-        return emitBranchF64(m_jit, MacroAssembler::invert(DoubleCondition::DoubleLessThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF64(m_jit, conditionForBranch(DoubleCondition::DoubleLessThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F64Ge:
-        return emitBranchF64(m_jit, MacroAssembler::invert(DoubleCondition::DoubleGreaterThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF64(m_jit, conditionForBranch(DoubleCondition::DoubleGreaterThanOrEqualAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F64Eq:
-        return emitBranchF64(m_jit, MacroAssembler::invert(DoubleCondition::DoubleEqualAndOrdered), left, leftLocation, right, rightLocation);
+        return emitBranchF64(m_jit, conditionForBranch(DoubleCondition::DoubleEqualAndOrdered), left, leftLocation, right, rightLocation);
     case OpType::F64Ne:
-        return emitBranchF64(m_jit, MacroAssembler::invert(DoubleCondition::DoubleNotEqualOrUnordered), left, leftLocation, right, rightLocation);
+        return emitBranchF64(m_jit, conditionForBranch(DoubleCondition::DoubleNotEqualOrUnordered), left, leftLocation, right, rightLocation);
     default:
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Op type '%s' is not a binary comparison and should not have been fused.\n", makeString(opType).characters());
     }
@@ -5286,6 +5292,182 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addFusedIfCompare(OpType op, Expression
         result.setIfBranch(m_jit.jump()); // Emit direct branch if we know the condition is false.
     else if (foldResult == BranchNotFolded) // Otherwise, we only emit a branch at all if we don't know the condition statically.
         result.setIfBranch(emitFusedBranchCompareBranch(op, left, leftLocation, right, rightLocation));
+    return { };
+}
+
+PartialResult BBQJIT::addFusedSelectCompare(OpType opType, ExpressionType condition, ExpressionType val1, ExpressionType val2, ExpressionType& result)
+{
+    Location conditionLocation = loadIfNecessary(condition);
+    Location val1Location = Location::none(), val2Location = Location::none();
+
+    if (!val1.isConst())
+        val1Location = loadIfNecessary(val1);
+    if (!val2.isConst())
+        val2Location = loadIfNecessary(val2);
+
+    ASSERT(val1.isConst() || val1Location.isRegister());
+    ASSERT(val2.isConst() || val2Location.isRegister());
+
+    consume(condition);
+    consume(val1);
+    consume(val2);
+
+    result = topValue(val1.type());
+    Location resultLocation = allocate(result);
+
+    LOG_INSTRUCTION("SelectCompare", makeString(opType).characters(), condition, conditionLocation, val1, val1Location, val2, val2Location, RESULT(result));
+    LOG_INDENT();
+
+    if (val2.isConst())
+        emitMoveConst(val2, resultLocation);
+    else
+        emitMove(val2.type(), val2Location, resultLocation);
+
+    Jump skipVal1;
+    switch (opType) {
+    case OpType::I32Eqz:
+        skipVal1 = m_jit.branchTest32(ResultCondition::NonZero, conditionLocation.asGPR());
+        break;
+    case OpType::I64Eqz:
+#if USE(JSVALUE64)
+        skipVal1 = m_jit.branchTest64(ResultCondition::NonZero, conditionLocation.asGPR());
+#else
+        skipVal1 = m_jit.branchTest64(ResultCondition::NonZero, conditionLocation.asGPRhi(), conditionLocation.asGPRlo());
+#endif
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Op type '%s' is not a unary comparison.\n", makeString(opType).characters());
+    }
+
+    if (val1.isConst())
+        emitMoveConst(val1, resultLocation);
+    else
+        emitMove(val1.type(), val1Location, resultLocation);
+
+    skipVal1.link(&m_jit);
+
+    LOG_DEDENT();
+    return { };
+}
+
+PartialResult BBQJIT::addFusedSelectCompare(OpType opType, ExpressionType left, ExpressionType right, ExpressionType val1, ExpressionType val2, ExpressionType& result)
+{
+    if (left.isConst() && right.isConst()) {
+        BranchFoldResult foldResult = tryFoldFusedBranchCompare(opType, left, right);
+        Value src = (foldResult == BranchAlwaysTaken) ? val1 : val2;
+        Location srcLocation;
+        if (src.isConst())
+            result = src;
+        else {
+            result = topValue(val1.type());
+            srcLocation = loadIfNecessary(src);
+        }
+
+        LOG_INSTRUCTION("SelectCompare", makeString(opType).characters(), left, right, val1, val2, RESULT(result));
+        consume(left);
+        consume(right);
+        consume(val1);
+        consume(val2);
+        if (!result.isConst()) {
+            Location resultLocation = allocate(result);
+            emitMove(val1.type(), srcLocation, resultLocation);
+        }
+        return { };
+    }
+
+    Location leftLocation, rightLocation;
+    Location val1Location = Location::none(), val2Location = Location::none();
+
+    if (!left.isConst())
+        leftLocation = loadIfNecessary(left);
+    else if (left.isFloat()) {
+        leftLocation = Location::fromFPR(wasmScratchFPR);
+        emitMove(left, leftLocation);
+    }
+
+    if (!right.isConst())
+        rightLocation = loadIfNecessary(right);
+    else if (right.isFloat()) {
+        if (!leftLocation.isFPR() || leftLocation.asFPR() != wasmScratchFPR) {
+            rightLocation = Location::fromFPR(wasmScratchFPR);
+            emitMove(right, rightLocation);
+        }
+    }
+
+    if (!val1.isConst())
+        val1Location = loadIfNecessary(val1);
+    if (!val2.isConst())
+        val2Location = loadIfNecessary(val2);
+
+    ASSERT(val1.isConst() || val1Location.isRegister());
+    ASSERT(val2.isConst() || val2Location.isRegister());
+
+    consume(val1);
+    consume(val2);
+
+    result = topValue(val1.type());
+    Location resultLocation = allocate(result);
+
+    LOG_INSTRUCTION("SelectCompare", makeString(opType).characters(), left, leftLocation, right, rightLocation, val1, val1Location, val2, val2Location, RESULT(result));
+    LOG_INDENT();
+
+    bool inverted = false;
+    if (val2Location == resultLocation) {
+        std::swap(val1, val2);
+        std::swap(val1Location, val2Location);
+        inverted = true;
+    }
+
+    // If the comparison operands alias with the result, we need to preserve them
+    // since we'll overwrite the result with val1 before doing the comparison
+    if (leftLocation == resultLocation && !left.isConst()) {
+        if (left.isFloat()) {
+            m_jit.moveDouble(leftLocation.asFPR(), wasmScratchFPR);
+            leftLocation = Location::fromFPR(wasmScratchFPR);
+#if USE(JSVALUE32_64)
+        } else if (leftLocation.isGPR2()) {
+            m_jit.move(leftLocation.asGPRlo(), wasmScratchGPR);
+            m_jit.move(leftLocation.asGPRhi(), wasmScratchGPR2);
+            leftLocation = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+#endif
+        } else {
+            m_jit.move(leftLocation.asGPR(), wasmScratchGPR);
+            leftLocation = Location::fromGPR(wasmScratchGPR);
+        }
+    } else if (rightLocation == resultLocation && !right.isConst()) {
+        if (right.isFloat()) {
+            m_jit.moveDouble(rightLocation.asFPR(), wasmScratchFPR);
+            rightLocation = Location::fromFPR(wasmScratchFPR);
+#if USE(JSVALUE32_64)
+        } else if (rightLocation.isGPR2()) {
+            m_jit.move(rightLocation.asGPRlo(), wasmScratchGPR);
+            m_jit.move(rightLocation.asGPRhi(), wasmScratchGPR2);
+            rightLocation = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+#endif
+        } else {
+            m_jit.move(rightLocation.asGPR(), wasmScratchGPR);
+            rightLocation = Location::fromGPR(wasmScratchGPR);
+        }
+    }
+
+    if (val1.isConst())
+        emitMoveConst(val1, resultLocation);
+    else
+        emitMove(val1.type(), val1Location, resultLocation);
+
+    Jump skipVal2 = emitFusedBranchCompareBranch(opType, left, leftLocation, right, rightLocation, /* branchIfTrue = */ !inverted);
+
+    consume(left);
+    consume(right);
+
+    if (val2.isConst())
+        emitMoveConst(val2, resultLocation);
+    else
+        emitMove(val2.type(), val2Location, resultLocation);
+
+    skipVal2.link(&m_jit);
+
+    LOG_DEDENT();
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2007,12 +2007,14 @@ public:
     BranchFoldResult WARN_UNUSED_RETURN tryFoldFusedBranchCompare(OpType, ExpressionType);
     Jump WARN_UNUSED_RETURN emitFusedBranchCompareBranch(OpType, ExpressionType, Location);
     BranchFoldResult WARN_UNUSED_RETURN tryFoldFusedBranchCompare(OpType, ExpressionType, ExpressionType);
-    Jump WARN_UNUSED_RETURN emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location);
+    Jump WARN_UNUSED_RETURN emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location, bool branchIfTrue = false);
 
     PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType& target, ExpressionType, Stack&);
     PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType& target, ExpressionType, ExpressionType, Stack&);
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 
     // Flush a value to its canonical slot.
     void flushValue(Value value);

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -659,6 +659,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) CONST_EXPR_STUB
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
     PartialResult WARN_UNUSED_RETURN endBlock(ControlEntry& entry, Stack& expressionStack)
     {

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -631,6 +631,26 @@ auto FunctionParser<Context>::binaryCompareCase(OpType op, BinaryOperationHandle
             m_context.didParseOpcode();
             return { };
         }
+        if (nextOpcode == OpType::Select) {
+            m_currentOpcodeStartingOffset = m_offset;
+            m_currentOpcode = static_cast<OpType>(nextOpcode);
+            bool didParseNextOpcode = parseUInt8(nextOpcode); // We're going to fuse this compare to the select, so we consume the opcode.
+            ASSERT_UNUSED(didParseNextOpcode, didParseNextOpcode);
+            m_context.willParseOpcode();
+
+            TypedExpression val2;
+            TypedExpression val1;
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(val2, "select val2"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(val1, "select val1"_s);
+
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(val2.type(), val1.type()) && !isSubtype(val1.type(), val2.type()), "select val1 and val2 must have compatible types"_s);
+
+            ExpressionType result;
+            WASM_TRY_ADD_TO_CONTEXT(addFusedSelectCompare(op, left, right, val1, val2, result));
+            m_expressionStack.constructAndAppend(val1.type(), result);
+            m_context.didParseOpcode();
+            return { };
+        }
     }
 
     ExpressionType result;
@@ -696,6 +716,22 @@ auto FunctionParser<Context>::unaryCompareCase(OpType op, UnaryOperationHandler 
 
             m_controlStack.append({ WTFMove(m_expressionStack), newStack, getLocalInitStackHeight(), WTFMove(control) });
             m_expressionStack = WTFMove(newStack);
+            return { };
+        }
+        if (nextOpcode == OpType::Select) {
+            bool didParseNextOpcode = parseUInt8(nextOpcode); // We're going to fuse this compare to the select, so we consume the opcode.
+            ASSERT_UNUSED(didParseNextOpcode, didParseNextOpcode);
+
+            TypedExpression val2;
+            TypedExpression val1;
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(val2, "select val2"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(val1, "select val1"_s);
+
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(val2.type(), val1.type()) && !isSubtype(val1.type(), val2.type()), "select val1 and val2 must have compatible types"_s);
+
+            ExpressionType result;
+            WASM_TRY_ADD_TO_CONTEXT(addFusedSelectCompare(op, value, val1, val2, result));
+            m_expressionStack.constructAndAppend(val1.type(), result);
             return { };
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -518,6 +518,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) { RELEASE_ASSERT_NOT_REACHED(); }
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -763,6 +763,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) { RELEASE_ASSERT_NOT_REACHED(); }
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
     PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -764,6 +764,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
     PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) { RELEASE_ASSERT_NOT_REACHED(); }
+    PartialResult WARN_UNUSED_RETURN addFusedSelectCompare(OpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
     PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);


### PR DESCRIPTION
#### b69deef8a5e983b6baa2dba6453e6ceadc0ab323
<pre>
[JSC] Support select in BBQ&apos;s fused branch compare
<a href="https://bugs.webkit.org/show_bug.cgi?id=302788">https://bugs.webkit.org/show_bug.cgi?id=302788</a>

Reviewed by NOBODY (OOPS!).

This PR adds support for optimizing select op in fused branch compare for all
platforms.

For example, in ARMv7 it results in changes from:

    [    0x25] I32LeU
              0xf14237ca: cmp r1, r2
              0xf14237cc: ite ls
              0xf14237ce: movls r1, #1
              0xf14237d0: movhi r1, #0
    [    0x26] Select
              0xf14237d2: tst r1, r1
              0xf14237d4: bne.w #0xf14237da

to

    [    0x25] I32LeU
    [    0x26] Select
              0xf15241ea: cmp r1, r2
              0xf15241ec: bls.w #0xf15241f2
              0xf15241f0: movs r0, #0

This patch saves -2,2KiB in code size of JetStream3&apos;s tfjs-wasm.js, a -0.52%
improvement on ARMv7:

Base total code size: 423708 bytes (414KiB)
New total code size: 421516 bytes (412KiB)

Difference (new - base): -2192 bytes (-2,2KiB)
Percentage change: -0.52%

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseOpcode):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitFusedBranchCompareBranch):
(JSC::Wasm::BBQJITImpl::BBQJIT::addFusedSelectCompare):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::binaryCompareCase):
(JSC::Wasm::FunctionParser&lt;Context&gt;::unaryCompareCase):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addFusedSelectCompare):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addFusedSelectCompare):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addFusedSelectCompare):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/146e2f17c6f9991f51a2f83e9f96bc4cdde4726e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85030 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101705 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69023 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4074 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1665 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83769 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125069 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143188 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131507 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5169 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110263 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3966 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58740 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5223 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33784 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164488 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68675 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42821 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->