### PR TITLE
[AutoFill Debugging] Refactor debug text extraction to return an extraction result object

### DIFF
--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -84,6 +84,11 @@ struct TextExtractionOptions {
     TextExtractionOptionFlags flags;
 };
 
-void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(String&&)>&&);
+struct TextExtractionResult {
+    String textContent;
+    bool filteredOutAnyText { false };
+};
+
+void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(TextExtractionResult&&)>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -661,6 +661,8 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
 #endif // !__has_feature(modules)
 #endif // __cplusplus
 
+@class WKTextExtractionItem;
+
 @interface WKWebView (NonCpp)
 
 #if PLATFORM(MAC)
@@ -680,7 +682,7 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
 
 - (void)_scrollToEdge:(_WKRectEdge)edge animated:(BOOL)animated;
 
-- (void)_requestTextExtraction:(_WKTextExtractionConfiguration *)configuration completionHandler:(void (^)(WKTextExtractionResult *))completionHandler;
+- (void)_requestTextExtraction:(_WKTextExtractionConfiguration *)configuration completionHandler:(void (^)(WKTextExtractionItem *))completionHandler;
 - (void)_describeInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(void (^)(NSString *, NSError *))completionHandler;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @class _WKTextExtractionConfiguration;
 @class _WKTextExtractionInteraction;
 @class _WKTextExtractionInteractionResult;
-@class WKTextExtractionResult;
+@class _WKTextExtractionResult;
 @class _WKTextManipulationConfiguration;
 @class _WKTextManipulationItem;
 @class _WKTextRun;
@@ -653,6 +653,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 #endif
 
 - (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
+- (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_extractDebugText(with:completionHandler:));
 - (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -130,6 +130,19 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 
 @end
 
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+@interface _WKTextExtractionResult : NSObject
+
+@property (nonatomic, readonly) NSString *textContent;
+
+/*!
+ Set to `YES` if and only if any output text was filtered out as a result
+ of `_WKTextExtractionFilterOptions` or the maximum paragraph word limit.
+ */
+@property (nonatomic, readonly) BOOL filteredOutAnyText;
+
+@end
+
 typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
     _WKTextExtractionActionClick,
     _WKTextExtractionActionSelectText,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -154,6 +154,26 @@
 
 @end
 
+@implementation _WKTextExtractionResult {
+    RetainPtr<NSString> _textContent;
+}
+
+- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText
+{
+    if (self = [super init]) {
+        _textContent = textContent;
+        _filteredOutAnyText = filteredOutAnyText;
+    }
+    return self;
+}
+
+- (NSString *)textContent
+{
+    return _textContent.get();
+}
+
+@end
+
 @implementation _WKTextExtractionInteraction {
     RetainPtr<NSString> _nodeIdentifier;
     RetainPtr<NSString> _text;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
@@ -459,18 +459,4 @@ extension WKTextExtractionImageItem {
     #endif
 }
 
-@_objcImplementation
-extension WKTextExtractionResult {
-    let rootItem: WKTextExtractionItem
-
-    init(rootItem: WKTextExtractionItem) {
-        self.rootItem = rootItem
-    }
-
-    #if compiler(<6.0)
-    @objc
-    deinit {}
-    #endif
-}
-
 #endif // USE_APPLE_INTERNAL_SDK || (!os(tvOS) && !os(watchOS))

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -60,6 +60,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface _WKTextExtractionResult ()
+
+- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText;
+
+@end
+
 @interface _WKTextExtractionInteraction ()
 
 @property (nonatomic, readonly) BOOL hasSetLocation;
@@ -178,11 +184,6 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 - (instancetype)initWithName:(NSString *)name altText:(NSString *)altText rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *altText;
-@end
-
-@interface WKTextExtractionResult : NSObject
-- (instancetype)initWithRootItem:(WKTextExtractionItem *)rootItem;
-@property (nonatomic, readonly) WKTextExtractionItem *rootItem;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -115,8 +115,8 @@ extension WKWebView {
             configuration.includeEventListeners = false
             configuration.includeAccessibilityAttributes = false
             configuration.filterOptions = []
-            if let result = await _requestTextExtraction(configuration) {
-                collector.collect(createIntelligenceElement(item: result.rootItem))
+            if let rootItem = await _requestTextExtraction(configuration) {
+                collector.collect(createIntelligenceElement(item: rootItem))
             }
 
             coordinator.finishCollection(collector)

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -374,11 +374,11 @@ void UIScriptControllerCocoa::requestTextExtraction(JSValueRef callback, TextExt
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
     RetainPtr configuration = createTextExtractionConfiguration(webView(), options);
     auto includeRects = [configuration includeRects] ? IncludeRects::Yes : IncludeRects::No;
-    [webView() _requestTextExtraction:configuration.get() completionHandler:^(WKTextExtractionResult *result) {
+    [webView() _requestTextExtraction:configuration.get() completionHandler:^(WKTextExtractionItem *rootItem) {
         if (!m_context)
             return;
 
-        auto description = adopt(JSStringCreateWithCFString((__bridge CFStringRef)recursiveDescription([result rootItem], includeRects)));
+        auto description = adopt(JSStringCreateWithCFString((__bridge CFStringRef)recursiveDescription(rootItem, includeRects)));
         m_context->asyncTaskComplete(callbackID, { JSValueMakeString(m_context->jsContext(), description.get()) });
     }];
 }

--- a/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.h
+++ b/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.h
@@ -29,10 +29,9 @@
 #import <WebKit/_WKTextExtraction.h>
 
 @class WKTextExtractionItem;
-@class WKTextExtractionResult;
 
 @interface WKWebView (TextExtractionTesting)
-- (void)_requestTextExtraction:(_WKTextExtractionConfiguration *)configuration completionHandler:(void(^)(WKTextExtractionResult *))completionHandler;
+- (void)_requestTextExtraction:(_WKTextExtractionConfiguration *)configuration completionHandler:(void(^)(WKTextExtractionItem *))completionHandler;
 @end
 
 namespace WTR {


### PR DESCRIPTION
#### d497a4e16f25635feecb5b07e9cfa6e8bc4c07b7
<pre>
[AutoFill Debugging] Refactor debug text extraction to return an extraction result object
<a href="https://bugs.webkit.org/show_bug.cgi?id=302791">https://bugs.webkit.org/show_bug.cgi?id=302791</a>
<a href="https://rdar.apple.com/165019791">rdar://165019791</a>

Reviewed by Abrar Rahman Protyasha.

Currently, `-_debugTextWithConfiguration:completionHandler:` passes a string back to the completion
handler, representing rendered DOM content. For clients that need additional metadata, we introduce
a new version of this method that passes a `_WKTextExtractionResult` object back to the client which
contains additional data alongside text output.

For now, the only metadata we include is a flag indicating whether or not any text was filtered out.

Test: TextExtractionTests.FilterOptions

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::TextExtractionAggregator):
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::create):
(WebKit::TextExtractionAggregator::filter):
(WebKit::TextExtractionAggregator::filterRecursive):
(WebKit::convertToText):
(WebKit::TextExtractionAggregator::filter const): Deleted.
(WebKit::TextExtractionAggregator::filterRecursive const): Deleted.
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _debugTextWithConfiguration:completionHandler:]):

Reimplement this in terms of `-_extractDebugTextWithConfiguration:completionHandler:`.

(-[WKWebView _extractDebugTextWithConfiguration:completionHandler:]):
(-[WKWebView _requestTextExtraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionResult initWithTextContent:filteredOutAnyText:]):
(-[_WKTextExtractionResult textContent]):

Add an object representing extraction results.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:

Repurpose `WKTextExtractionResult` (currently, an internal Swift object) to be a privately-exposed
object representing debug text extraction output; refactor anything that previously used
`WKTextExtractionResult` to instead just take a `WKTextExtractionItem` representing the root item.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(-[WKWebView synchronouslyGetDebugText:]):
(-[WKWebView synchronouslyExtractDebugTextResult:]):
(TestWebKitAPI::TEST(TextExtractionTests, FilterOptions)):

Augment this test to also check `filteredOutAnyText`.

* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::requestTextExtraction):
* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.h:

Canonical link: <a href="https://commits.webkit.org/303273@main">https://commits.webkit.org/303273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59cd8f6b165fbe961b3b69d2d468261a85d0ae5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139390 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4b2f81a1-8ad2-4ba2-b9e9-49ae5348301e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100805 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8da28a45-17eb-4194-9698-44d8f1303506) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134824 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81594 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6877d0ca-6f3d-42b9-a778-aeffaeb85c6e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82610 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142034 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109179 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4120 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3072 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114395 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57261 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4093 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32795 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67540 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->