### PR TITLE
[GFC] Remove requirement for GFC to be inside a BFC.

### DIFF
--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -45,46 +45,46 @@ enum class ReasonCollectionMode : bool {
 };
 
 enum class GridAvoidanceReason : uint64_t {
-    GridHasNonFixedWidth = 1LLU << 0,
-    GridHasNonFixedHeight = 1LLU << 1,
-    GridHasVerticalWritingMode = 1LLU << 2,
-    GridHasMarginTrim = 1LLU << 3,
-    GridIsNotInBFC = 1LLU << 4,
-    GridNeedsBaseline = 1LLU << 5,
-    GridHasOutOfFlowChild = 1LLU << 6,
-    GridHasNonVisibleOverflow = 1LLU << 7,
-    GridHasUnsupportedRenderer = 1LLU << 8,
-    GridIsEmpty = 1LLU << 9,
-    GridHasNonInitialMinWidth = 1LLU << 10,
-    GridHasNonInitialMaxWidth = 1LLU << 11,
-    GridHasNonInitialMinHeight = 1LLU << 12,
-    GridHasNonInitialMaxHeight = 1LLU << 13,
-    GridHasNonZeroMinWidth = 1LLU << 14,
-    GridHasGridTemplateAreas = 1LLU << 15,
-    GridHasNonInitialGridAutoFlow = 1LLU << 16,
-    GridHasNonFixedGaps = 1LLU << 17,
-    GridIsOutOfFlow = 1LLU << 18,
-    GridHasContainsSize = 1LLU << 19,
-    GridHasUnsupportedGridTemplateColumns = 1LLU << 20,
-    GridHasUnsupportedGridTemplateRows = 1LLU << 21,
-    GridItemHasNonFixedWidth = 1LLU << 22,
-    GridItemHasNonFixedHeight = 1LLU << 23,
-    GridItemHasNonInitialMaxWidth = 1LLU << 24,
-    GridItemHasNonZeroMinHeight = 1LLU << 25,
-    GridItemHasNonInitialMaxHeight = 1LLU << 26,
-    GridItemHasBorder = 1LLU << 27,
-    GridItemHasPadding = 1LLU << 28,
-    GridItemHasMargin = 1LLU << 29,
-    GridItemHasVerticalWritingMode = 1LLU << 30,
-    GridItemHasAspectRatio = 1LLU << 31,
-    GridItemHasUnsupportedInlineAxisAlignment = 1LLU << 32,
-    GridItemHasUnsupportedBlockAxisAlignment = 1LLU << 33,
-    GridItemHasNonVisibleOverflow = 1LLU << 34,
-    GridItemHasContainsSize = 1LLU << 35,
-    GridItemHasUnsupportedColumnPlacement = 1LLU << 36,
-    GridItemHasUnsupportedRowPlacement = 1LLU << 37,
-    NotAGrid = 1LLU << 38,
-    GridFormattingContextIntegrationDisabled = 1LLU << 39,
+    GridHasNonFixedWidth                        = 1LLU << 0,
+    GridHasNonFixedHeight                       = 1LLU << 1,
+    GridHasVerticalWritingMode                  = 1LLU << 2,
+    GridHasMarginTrim                           = 1LLU << 3,
+    // Unused                                   = 1LLU << 4,
+    GridNeedsBaseline                           = 1LLU << 5,
+    GridHasOutOfFlowChild                       = 1LLU << 6,
+    GridHasNonVisibleOverflow                   = 1LLU << 7,
+    GridHasUnsupportedRenderer                  = 1LLU << 8,
+    GridIsEmpty                                 = 1LLU << 9,
+    GridHasNonInitialMinWidth                   = 1LLU << 10,
+    GridHasNonInitialMaxWidth                   = 1LLU << 11,
+    GridHasNonInitialMinHeight                  = 1LLU << 12,
+    GridHasNonInitialMaxHeight                  = 1LLU << 13,
+    GridHasNonZeroMinWidth                      = 1LLU << 14,
+    GridHasGridTemplateAreas                    = 1LLU << 15,
+    GridHasNonInitialGridAutoFlow               = 1LLU << 16,
+    GridHasNonFixedGaps                         = 1LLU << 17,
+    GridIsOutOfFlow                             = 1LLU << 18,
+    GridHasContainsSize                         = 1LLU << 19,
+    GridHasUnsupportedGridTemplateColumns       = 1LLU << 20,
+    GridHasUnsupportedGridTemplateRows          = 1LLU << 21,
+    GridItemHasNonFixedWidth                    = 1LLU << 22,
+    GridItemHasNonFixedHeight                   = 1LLU << 23,
+    GridItemHasNonInitialMaxWidth               = 1LLU << 24,
+    GridItemHasNonZeroMinHeight                 = 1LLU << 25,
+    GridItemHasNonInitialMaxHeight              = 1LLU << 26,
+    GridItemHasBorder                           = 1LLU << 27,
+    GridItemHasPadding                          = 1LLU << 28,
+    GridItemHasMargin                           = 1LLU << 29,
+    GridItemHasVerticalWritingMode              = 1LLU << 30,
+    GridItemHasAspectRatio                      = 1LLU << 31,
+    GridItemHasUnsupportedInlineAxisAlignment   = 1LLU << 32,
+    GridItemHasUnsupportedBlockAxisAlignment    = 1LLU << 33,
+    GridItemHasNonVisibleOverflow               = 1LLU << 34,
+    GridItemHasContainsSize                     = 1LLU << 35,
+    GridItemHasUnsupportedColumnPlacement       = 1LLU << 36,
+    GridItemHasUnsupportedRowPlacement          = 1LLU << 37,
+    NotAGrid                                    = 1LLU << 38,
+    GridFormattingContextIntegrationDisabled    = 1LLU << 39,
 };
 
 #ifndef NDEBUG
@@ -153,19 +153,6 @@ static OptionSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid
 
     if (!renderGridStyle->gridTemplateAreas().isNone())
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasGridTemplateAreas, reasons, reasonCollectionMode);
-
-    auto isInBFC = [&] {
-        for (CheckedPtr containingBlock = renderGrid.containingBlock(); containingBlock && !is<RenderView>(*containingBlock); containingBlock = containingBlock->containingBlock()) {
-            if (containingBlock->style().display() != DisplayType::Block)
-                return false;
-            if (containingBlock->createsNewFormattingContext())
-                return true;
-        }
-        return true;
-    };
-
-    if (!isInBFC())
-        ADD_REASON_AND_RETURN_IF_NEEDED(GridIsNotInBFC, reasons, reasonCollectionMode);
 
     auto& gridTemplateColumns = renderGridStyle->gridTemplateColumns();
     auto& gridTemplateColumnsTrackList = gridTemplateColumns.list;
@@ -393,9 +380,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
         break;
     case GridAvoidanceReason::GridHasMarginTrim:
         stream << "grid has margin-trim";
-        break;
-    case GridAvoidanceReason::GridIsNotInBFC:
-        stream << "grid is not in BFC";
         break;
     case GridAvoidanceReason::GridNeedsBaseline:
         stream << "inline grid needs baseline";


### PR DESCRIPTION
#### 56278cb45475178177d6e7760ff6a2ff274de6fc
<pre>
[GFC] Remove requirement for GFC to be inside a BFC.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300047">https://bugs.webkit.org/show_bug.cgi?id=300047</a>
&lt;<a href="https://rdar.apple.com/161844100">rdar://161844100</a>&gt;

Reviewed by Sammy Gill.

This PR relaxes a requirement for use to use GFC.

Combined changes:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReason):

Canonical link: <a href="https://commits.webkit.org/303706@main">https://commits.webkit.org/303706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5774bd31efdf90965ca82da5aef209456863d124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84347 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101207 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68466 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49262730-5b3f-4a84-b841-7bc2f4c1778a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81998 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cf243ea3-13ce-456e-94ed-c396a46809f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83134 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142559 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4558 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109763 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3445 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114857 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57834 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20630 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4612 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33216 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4703 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4569 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->