### PR TITLE
[threaded-animations] stop scheduling accelerated effect stack updates via the document timeline

### DIFF
--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -37,8 +37,11 @@
 
 namespace WebCore {
 
-void AcceleratedEffectStackUpdater::updateEffectStacks()
+void AcceleratedEffectStackUpdater::update()
 {
+    if (!hasTargetsPendingUpdate())
+        return;
+
     m_timelines.clear();
 
     auto targetsPendingUpdate = std::exchange(m_targetsPendingUpdate, { });
@@ -58,7 +61,7 @@ void AcceleratedEffectStackUpdater::updateEffectStacks()
     }
 }
 
-void AcceleratedEffectStackUpdater::updateEffectStackForTarget(const Styleable& target)
+void AcceleratedEffectStackUpdater::scheduleUpdateForTarget(const Styleable& target)
 {
     m_targetsPendingUpdate.add({ &target.element, target.pseudoElementIdentifier });
 }

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
@@ -42,8 +42,9 @@ class AcceleratedEffectStackUpdater {
 public:
     AcceleratedEffectStackUpdater() = default;
 
-    void updateEffectStacks();
-    void updateEffectStackForTarget(const Styleable&);
+    void update();
+    void scheduleUpdateForTarget(const Styleable&);
+    bool hasTargetsPendingUpdate() const { return !m_targetsPendingUpdate.isEmpty(); }
 
     const HashSet<Ref<AcceleratedTimeline>>& timelines() const { return m_timelines; }
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -43,6 +43,8 @@ class ScrollTimeline;
 class WeakPtrImplWithEventTargetData;
 class WebAnimation;
 
+struct Styleable;
+
 #if ENABLE(THREADED_ANIMATIONS)
 class AcceleratedEffectStackUpdater;
 #endif
@@ -59,7 +61,7 @@ public:
     void removeTimeline(AnimationTimeline&);
     void detachFromDocument();
     void updateAnimationsAndSendEvents(ReducedResolutionSeconds);
-    void updateStaleScrollTimelines();
+    void runPostRenderingUpdateTasks();
     void addPendingAnimation(WebAnimation&);
 
     std::optional<Seconds> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes);
@@ -71,9 +73,8 @@ public:
     bool animationsAreSuspended() const { return m_isSuspended; }
 
 #if ENABLE(THREADED_ANIMATIONS)
-    AcceleratedEffectStackUpdater& acceleratedEffectStackUpdater();
     AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
-    void updateAcceleratedEffectStacks();
+    void scheduleAcceleratedEffectStackUpdateForTarget(const Styleable&);
 #endif
 
 private:

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -89,6 +89,10 @@ public:
 
     std::optional<FramesPerSecond> maximumFrameRate() const;
 
+#if ENABLE(THREADED_ANIMATIONS)
+    void scheduleAcceleratedEffectStackUpdate();
+#endif
+
 private:
     DocumentTimeline(Document&, Seconds);
 

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -266,7 +266,7 @@ private:
     };
 
     bool threadedAnimationsEnabled() const;
-    void updateAssociatedThreadedEffectStack(const std::optional<const Styleable>& = std::nullopt);
+    void scheduleAssociatedAcceleratedEffectStackUpdate(const std::optional<const Styleable>& = std::nullopt);
 #endif
 
     // AnimationEffect

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1624,24 +1624,8 @@ void WebAnimation::setSuspended(bool isSuspended)
 
 void WebAnimation::acceleratedStateDidChange()
 {
-    // FIXME: this would not be necessary if we didn't go through DocumentTimeline to
-    // schedule accelerated animations.
-    auto documentTimeline = [&]() -> DocumentTimeline* {
-        if (auto* timeline = dynamicDowncast<DocumentTimeline>(m_timeline.get()))
-            return timeline;
-        if (RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(m_timeline.get())) {
-            if (RefPtr source = scrollTimeline->source())
-                return &source->protectedDocument()->timeline();
-        }
-        if (RefPtr keyframeEffect = this->keyframeEffect()) {
-            if (RefPtr target = keyframeEffect->target())
-                return &target->protectedDocument()->timeline();
-        }
-        return nullptr;
-    };
-
-    if (RefPtr timeline = documentTimeline())
-        timeline->animationAcceleratedRunningStateDidChange(*this);
+    if (RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline))
+        documentTimeline->animationAcceleratedRunningStateDidChange(*this);
 }
 
 WebAnimation& WebAnimation::readyPromiseResolve()

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10826,10 +10826,8 @@ void Document::updateAnimationsAndSendEvents()
 
 void Document::runPostRenderingUpdateAnimationTasks()
 {
-    if (m_timeline)
-        m_timeline->runPostRenderingUpdateTasks();
     if (CheckedPtr timelinesController = this->timelinesController())
-        timelinesController->updateStaleScrollTimelines();
+        timelinesController->runPostRenderingUpdateTasks();
 }
 
 DocumentTimeline& Document::timeline()


### PR DESCRIPTION
#### 5637407989f35220eb774158c20490e0a3083904
<pre>
[threaded-animations] stop scheduling accelerated effect stack updates via the document timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=302799">https://bugs.webkit.org/show_bug.cgi?id=302799</a>
<a href="https://rdar.apple.com/165060139">rdar://165060139</a>

Reviewed by Simon Fraser.

For historical reasons, scheduling of accelerated animation creation has been performed via the document
timeline. This does not make sense in the context of multiple timeline types and the work to accelerate
scroll-driven animations.

While there is more work required to remove all scheduling from `DocumentTimeline`, we start by moving
the logic relevant to updating the accelerated effect stack to `AnimationTimelinesController`, using an
entirely separate code path to what has been used for non-threaded accelerated animations.

* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::update):
(WebCore::AcceleratedEffectStackUpdater::scheduleUpdateForTarget):
(WebCore::AcceleratedEffectStackUpdater::updateEffectStacks): Deleted.
(WebCore::AcceleratedEffectStackUpdater::updateEffectStackForTarget): Deleted.
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
(WebCore::AcceleratedEffectStackUpdater::hasTargetsPendingUpdate const):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::runPostRenderingUpdateTasks):
(WebCore::AnimationTimelinesController::scheduleAcceleratedEffectStackUpdateForTarget):
(WebCore::AnimationTimelinesController::updateStaleScrollTimelines): Deleted.
(WebCore::AnimationTimelinesController::acceleratedEffectStackUpdater): Deleted.
(WebCore::AnimationTimelinesController::updateAcceleratedEffectStacks): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::shouldRunUpdateAnimationsAndSendEventsIgnoringSuspensionState const):
(WebCore::DocumentTimeline::scheduleAcceleratedEffectStackUpdate):
(WebCore::DocumentTimeline::animationAcceleratedRunningStateDidChange):
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
(WebCore::DocumentTimeline::runPostRenderingUpdateTasks): Deleted.
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateAcceleratedAnimationIfNecessary):
(WebCore::KeyframeEffect::animationSuspensionStateDidChange):
(WebCore::KeyframeEffect::abilityToBeAcceleratedDidChange):
(WebCore::KeyframeEffect::lastStyleChangeEventStyleDidChange):
(WebCore::KeyframeEffect::StackMembershipMutationScope::~StackMembershipMutationScope):
(WebCore::KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate):
(WebCore::KeyframeEffect::updateAssociatedThreadedEffectStack): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::acceleratedStateDidChange):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::runPostRenderingUpdateAnimationTasks):

Canonical link: <a href="https://commits.webkit.org/303279@main">https://commits.webkit.org/303279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ddb1421479ad1bb9b2fca2ff4158a0c7b8242f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4377 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/42941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139397 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9fc9c88a-4aed-4279-a92a-06a1c07f726e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100809 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3355d042-aca0-47a7-976d-cee145155bc9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134831 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81599 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5ac223c-ce77-41e6-b1a7-7f3eefe7caf5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/2976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82617 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142041 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109183 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109349 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3076 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57268 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20505 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4100 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32800 "Unable to confirm if test failures are introduced by change, retrying build") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67547 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->