### PR TITLE
[blocks-in-inline] Caret is too tall

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-caret-height-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-caret-height-expected.html
@@ -1,0 +1,6 @@
+<div contenteditable>
+    <span id=span>span1<div>div<br>div</div>span2</span>
+</div>
+<script>
+getSelection().setPosition(span.lastChild, 3);
+</script>

--- a/LayoutTests/fast/inline/blocks-in-inline-caret-height.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-caret-height.html
@@ -1,0 +1,7 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<div contenteditable>
+    <span id=span>span1<div>div<br>div</div>span2</span>
+</div>
+<script>
+getSelection().setPosition(span.lastChild, 3);
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -68,7 +68,11 @@ LineBox LineBoxBuilder::build(size_t lineIndex)
         auto blockLineLogicalTopLeft = InlineLayoutPoint { lineLayoutResult.lineGeometry.initialLogicalLeft, lineLayoutResult.lineGeometry.logicalTopLeft.y() };
         lineBox.setLogicalRect({ blockLineLogicalTopLeft, lineLayoutResult.lineGeometry.logicalWidth, marginBoxHeight });
         setVerticalPropertiesForInlineLevelBox(lineBox, lineBox.rootInlineBox());
-        lineBox.setHasContent(!!marginBoxHeight);
+        if (marginBoxHeight) {
+            lineBox.setHasContent(true);
+            lineBox.rootInlineBox().setHasContent();
+            lineBox.rootInlineBox().setLogicalHeight(marginBoxHeight);
+        }
     } else {
         constructInlineLevelBoxes(lineBox);
         if (lineBox.hasContent()) {


### PR DESCRIPTION
#### 32928863dd02e00a346ca7b119d331392ffc152d
<pre>
[blocks-in-inline] Caret is too tall
<a href="https://bugs.webkit.org/show_bug.cgi?id=302806">https://bugs.webkit.org/show_bug.cgi?id=302806</a>
<a href="https://rdar.apple.com/problem/165063847">rdar://problem/165063847</a>

Reviewed by NOBODY (OOPS!).

Editing caret can become very tall if there is block content.

Test: fast/inline/blocks-in-inline-caret-height.html
* LayoutTests/fast/inline/blocks-in-inline-caret-height-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-caret-height.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::build):

Take care to also initialize root inline box height and contentful bit.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32928863dd02e00a346ca7b119d331392ffc152d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83787 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba7b3384-ce23-4a26-b9e7-52bfa39c7ffb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81610 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2fe73fdb-53a6-4938-8c86-3f813495833a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2980 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/841 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142053 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4059 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109192 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4140 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3556 "Found 2 new test failures: fast/webgpu/repro_301290.html http/tests/webgpu/webgpu/api/operation/sampling/filter_mode.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109358 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3088 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114409 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57280 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4112 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32809 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4204 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4072 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->