### PR TITLE
Add extra validation when deserializing NSArrays

### DIFF
--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in
@@ -26,7 +26,7 @@ headers: <pal/cocoa/PassKitSoftLink.h>
 
 header: "ApplePayPaymentSetupFeaturesWebKit.h"
 [CustomHeader] class WebKit::PaymentSetupFeatures {
-    Vector<RetainPtr<PKPaymentSetupFeature>> serializableFeatures();
+    [SecureCodingAllowed=[NSArray.class, PAL::getPKPaymentSetupFeatureClassSingleton()], Validator='!arrayContainsAnythingBut<PKPaymentSetupFeature>(*m_platformFeatures)'] RetainPtr<NSArray> m_platformFeatures;
 };
 
 #endif

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -172,6 +172,19 @@ template<typename T> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringA
 
 template<typename T, typename = IsObjCObject<T>> void encode(Encoder&, T *);
 
+#ifdef __OBJC__
+template<typename T> static inline bool arrayContainsAnythingBut(const RetainPtr<NSArray>& array)
+{
+    if (!array)
+        return false;
+    for (id element in array.get()) {
+        if (![element isKindOfClass:getClass<T>()])
+            return true;
+    }
+    return false;
+}
+#endif // __OBJC__
+
 #if ASSERT_ENABLED
 
 static inline bool isObjectClassAllowed(id object, const AllowedClassHashSet& allowedClasses)

--- a/Source/WebKit/Shared/Cocoa/DataDetectionResult.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/DataDetectionResult.serialization.in
@@ -25,7 +25,7 @@ headers: <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #if ENABLE(DATA_DETECTION)
 
 struct WebKit::DataDetectionResult {
-    Vector<RetainPtr<DDScannerResult>> results;
+    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClassSingleton()], Validator='!arrayContainsAnythingBut<DDScannerResult>(*results)'] RetainPtr<NSArray> results;
 };
 
 #endif

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -84,7 +84,7 @@ struct WebKit::InteractionInformationAtPosition {
     RefPtr<WebCore::TextIndicator> textIndicator;
 #if ENABLE(DATA_DETECTION)
     String dataDetectorIdentifier;
-    Vector<RetainPtr<DDScannerResult>> serializableDataDetectorResults();
+    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClassSingleton()], Validator='!arrayContainsAnythingBut<DDScannerResult>(*dataDetectorResults)'] RetainPtr<NSArray> dataDetectorResults;
     WebCore::IntRect dataDetectorBounds;
 #endif
 


### PR DESCRIPTION
#### b22ec681e7a01a614bc59c6467862db42d4b43ef
<pre>
Add extra validation when deserializing NSArrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=298370">https://bugs.webkit.org/show_bug.cgi?id=298370</a>
<a href="https://rdar.apple.com/159206217">rdar://159206217</a>

Reviewed by Abrar Rahman Protyasha.

The SecureCodingAllowed attribute used to tell NSKeyedUnarchiver to only allow the two types.
On new OSes, we no longer use NSKeyedUnarchiver, but we use a variant of types in CoreIPCNSCFObject.
In a few cases, this caused an increase in the types we can decode.  Adding a validator brings
that back down.  This is the cleanest way to support it while still supporting OSes where
we still use NSKeyedUnarchiver.  At some point, we&apos;ll be able to unify and tighten this even more.

* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
(IPC::arrayContainsAnythingBut):
* Source/WebKit/Shared/Cocoa/DataDetectionResult.serialization.in:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:

Originally-landed-as: <a href="https://commits.webkit.org/297297.374@safari-7622-branch">297297.374@safari-7622-branch</a> (bacddb4d7c4a). rdar://164277878
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b22ec681e7a01a614bc59c6467862db42d4b43ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134993 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7410 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46247 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86839 "Built successfully") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8031 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7256 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103155 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70402 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c296fc9-c8cc-42d8-8357-af9e9009d8eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137939 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/8031 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/46247 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84006 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c4d7f442-dfa1-444b-a540-14c65f3bf5ca) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/8031 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/46247 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3098 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/8031 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/46247 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145201 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7086 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/46247 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111532 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7139 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/7256 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111891 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/46247 "Hash b22ec681 for PR 54196 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61021 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7135 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/46247 "Hash b22ec681 for PR 54196 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6908 "Hash b22ec681 for PR 54196 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70707 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7142 "Hash b22ec681 for PR 54196 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7015 "Hash b22ec681 for PR 54196 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->