### PR TITLE
Web Inspector: Breakpoints are misplaced and search results highlight the wrong location

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
@@ -52,7 +52,10 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
         this._basicBlockAnnotator = null;
         this._editingController = null;
 
-        this._autoFormat = false;
+        // If the source code was formatted before (aka pretty-printed), any breakpoint and source code text ranges for search results will use the formatted line and column numbers.
+        // See WI.SourceCodeLocation.prototype._sourceCodeFormatterDidChange()
+        // If this is a new editor view associated with a previously formatted WI.SourceCode, automatically format its contents so the correct locations are highlighted.
+        this._autoFormat = !!this._sourceCode.formatterSourceMap;
         this._isProbablyMinified = false;
 
         this._ignoreContentDidChange = 0;


### PR DESCRIPTION
#### f981173e6b09fa1c7c325c4184bec3be77c667fb
<pre>
Web Inspector: Breakpoints are misplaced and search results highlight the wrong location
<a href="https://bugs.webkit.org/show_bug.cgi?id=302798">https://bugs.webkit.org/show_bug.cgi?id=302798</a>
<a href="https://rdar.apple.com/165059693">rdar://165059693</a>

Reviewed by Devin Rousso.

It is possible to get into a state where a previously formatted (aka pretty-printed) file is rendered again not formatted,
but all source code locations for breakpoints and search results still use the formatted line locations.

There&apos;s no strict dependency between the formatted state of a `WI.SourceCode` and an associated view like `WI.SourceCodeTextEditor`.
The view can get destroyed and re-created as needed, for example in repeated queries in Web Inspector search.
See `WI.ContentViewContainer.prototype.closeAllContentViews()` called by `WI.SearchSidebarPanel.prototype.performSearch()`

When a `WI.SourceCodeLocation` is created, its formatted line / column start off identical to the original line / number.
See `WI.SourceCodeLocation.prototype._resolveFormattedLocation()`.
When `WI.SourceCode` is pretty-printed, the formatted line / column get updated according to
`WI.SourceCode.prototype.formatterSourceMap`. All previous and future breakpoints and source code locations are resolved against it.

`WI.SourceCode` remembers its formatted source map. But its source code editor view might not, for example
when the editor is re-created but its content is not automatically formatted because it fails the necessary conditions.

A re-created editor view (`WI.SourceCodeTextEditor`) and its backing model (`WI.SourceCode`) can get out of sync.

Since breakpoints and search result locations are always resolved against the model and accessed intentionally with
`WI.SourceCodeLocation.prototype.formattedPosition()` (because of the assumption this will point to original locations if unformatted),
existing and new source code locations point to the wrong location the new unformatted editor view.

This patch forces the editor view to automatically format its content if its backing model was previously formatted.

* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js:
(WI.SourceCodeTextEditor):

Canonical link: <a href="https://commits.webkit.org/303327@main">https://commits.webkit.org/303327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f56e818bdf6217a7de229d2b0f4bfdfe28d9d46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139572 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d4d5c6a1-59aa-46c5-85b2-8f908d96195c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4312 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c6dc910-5b43-4303-b1f6-e7f5f4c26b64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135004 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81739 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c989935d-db76-4813-8e91-ce44970a8fd2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82792 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142219 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4220 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36980 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27728 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57450 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4274 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32951 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4105 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4233 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->