### PR TITLE
[JSC] GreedyRegAlloc: introduce gap points between instructions

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -56,11 +56,6 @@ namespace Greedy {
 // Experiments
 static constexpr bool eagerGroupsExhaustiveSearch = false;
 
-// Quickly filters out short ranges from live range splitting consideration.
-static constexpr size_t splitMinRangeSize = 8;
-
-static constexpr unsigned spillCostSizeBias = 50000;
-
 static constexpr float unspillableCost = std::numeric_limits<float>::infinity();
 static constexpr float fastTmpSpillCost = std::numeric_limits<float>::max();
 static constexpr float maxSpillableSpillCost = std::numeric_limits<float>::max();
@@ -78,13 +73,16 @@ static bool verbose() { return Options::airGreedyRegAllocVerbose(); }
 
 // Terminology / core data-structures:
 //
-// Point: a position within the IR stream. There are two points associated with each
-// instruction: early and late. The early point for an instruction occurs immediately
+// Point: a position within the IR stream. There are four points associated with each
+// instruction, see PointOffsets. The early point for an instruction occurs immediately
 // before the instruction and the late occurs immediately following. Early use/defs
 // for that instruction are modeled as occurring at the early point whereas late use/defs
 // are modeled as occurring at the late point. The late point for an instruction and
 // early point for the subsequent instruction are distinct in order to avoid false
-// conflicts, e.g. when a late use is followed by an early def.
+// conflicts, e.g. when a late use is followed by an early def. Two "gap" points, Pre & Post,
+// exist for each instruction to allow distinguishing e.g. a Tmp being live into a block from
+// a Tmp becoming live due to an early def by the first instruction of the block
+// (and sinilarly for block exits and late use).
 //
 // Interval: contiguous set of points, represented by a half open interval [begin, end).
 //
@@ -127,6 +125,20 @@ static bool verbose() { return Options::airGreedyRegAllocVerbose(); }
 
 using Point = uint32_t;
 using Interval = WTF::Range<Point>;
+
+enum PointOffsets {
+    Pre = 0,
+    Early = 1,
+    // Inst lives between the Early and Late points.
+    Late = 2,
+    Post = 3,
+    PointsPerInst
+};
+
+// Quickly filters out short ranges from live range splitting consideration.
+static constexpr size_t splitMinRangeSize = 4 * PointOffsets::PointsPerInst;
+
+static constexpr unsigned spillCostSizeBias = 25000 * PointOffsets::PointsPerInst;
 
 class LiveRange {
 public:
@@ -677,8 +689,6 @@ public:
     }
 
 private:
-    static constexpr Point pointsPerInst = 2;
-
     template<Bank bank>
     void dumpRegRanges(PrintStream& out) const
     {
@@ -707,11 +717,10 @@ private:
                 m_tailPoints[i] = tailPosition;
                 continue;
             }
-            // Two points per instruction: early and late.
-            tailPosition = headPosition + 2 * block->size() - 1;
+            tailPosition = headPosition + block->size() * PointOffsets::PointsPerInst - 1;
             m_blockToHeadPoint[block] = headPosition;
             m_tailPoints[i] = tailPosition;
-            headPosition += block->size() * pointsPerInst;
+            headPosition += block->size() * PointOffsets::PointsPerInst;
         }
     }
 
@@ -732,49 +741,47 @@ private:
 
     Point positionOfTail(BasicBlock* block)
     {
-        return positionOfHead(block) + block->size() * pointsPerInst - 1;
+        return positionOfHead(block) + block->size() * PointOffsets::PointsPerInst - 1;
     }
 
     static size_t instIndex(Point positionOfHead, Point point)
     {
-        return (point - positionOfHead) / pointsPerInst;
+        return (point - positionOfHead) / PointOffsets::PointsPerInst;
+    }
+
+    static Point positionOfEarly(Point positionOfHead, unsigned instIndex)
+    {
+        ASSERT(!(positionOfHead % PointOffsets::PointsPerInst));
+        return positionOfHead + instIndex * PointOffsets::PointsPerInst + PointOffsets::Early;
+    }
+
+    static Point positionOfLate(Point positionOfHead, unsigned instIndex)
+    {
+        ASSERT(!(positionOfHead % PointOffsets::PointsPerInst));
+        return positionOfHead + instIndex * PointOffsets::PointsPerInst + PointOffsets::Late;
     }
 
     static Point positionOfEarly(Interval interval)
     {
-        static_assert(!(pointsPerInst & (pointsPerInst - 1)));
-        return interval.begin() & ~static_cast<Point>(pointsPerInst - 1);
+        static_assert(!(PointOffsets::PointsPerInst & (PointOffsets::PointsPerInst - 1)));
+        return (interval.begin() & ~(PointOffsets::PointsPerInst - 1)) + PointOffsets::Early;
     }
 
     static Interval earlyInterval(Point positionOfEarly)
     {
-        ASSERT(!(positionOfEarly % pointsPerInst));
+        ASSERT((positionOfEarly % PointOffsets::PointsPerInst) == PointOffsets::Early);
         return Interval(positionOfEarly);
     }
 
     static Interval lateInterval(Point positionOfEarly)
     {
-        ASSERT(!(positionOfEarly % pointsPerInst));
-        return Interval(positionOfEarly + 1);
+        ASSERT((positionOfEarly % PointOffsets::PointsPerInst) == PointOffsets::Early);
+        return Interval(positionOfEarly + (PointOffsets::Late - PointOffsets::Early));
     }
 
     static Interval earlyAndLateInterval(Point positionOfEarly)
     {
         return earlyInterval(positionOfEarly) | lateInterval(positionOfEarly);
-    }
-
-    static Interval interval(Point positionOfEarly, Arg::Timing timing)
-    {
-        switch (timing) {
-        case Arg::OnlyEarly:
-            return earlyInterval(positionOfEarly);
-        case Arg::OnlyLate:
-            return lateInterval(positionOfEarly);
-        case Arg::EarlyAndLate:
-            return earlyAndLateInterval(positionOfEarly);
-        }
-        ASSERT_NOT_REACHED();
-        return Interval();
     }
 
     static Interval intervalForSpill(Point positionOfEarly, Arg::Role role)
@@ -1045,8 +1052,8 @@ private:
 
             for (unsigned instIndex = block->size(); instIndex--;) {
                 Inst& inst = block->at(instIndex);
-                Point positionOfEarly = positionOfHead + instIndex * pointsPerInst;
-                Point positionOfLate = positionOfEarly + 1;
+                Point positionOfEarly = this->positionOfEarly(positionOfHead, instIndex);
+                Point positionOfLate = this->positionOfLate(positionOfHead, instIndex);
 
                 lateUses.shrink(0);
                 lateDefs.shrink(0);
@@ -1305,7 +1312,7 @@ private:
             tmpData.useDefCost = useDefCost;
 
             if (cannotSpillInPlace.contains(tmp)
-                && tmpData.liveRange.intervals().size() == 1 && tmpData.liveRange.size() <= pointsPerInst) {
+                && tmpData.liveRange.intervals().size() == 1 && tmpData.liveRange.size() <= PointOffsets::PointsPerInst) {
                 tmpData.spillability = TmpData::Spillability::Unspillable;
                 m_stats[bank].numUnspillableTmps++;
             }
@@ -1823,7 +1830,7 @@ private:
             Point positionOfHead = this->positionOfHead(block);
             for (unsigned instIndex = 0; instIndex < block->size(); ++instIndex) {
                 Inst& inst = block->at(instIndex);
-                unsigned indexOfEarly = positionOfHead + instIndex * 2;
+                unsigned indexOfEarly = positionOfEarly(positionOfHead, instIndex);
 
                 // The TmpWidth analysis will say that a Move only stores 32 bits into the destination,
                 // if the source only had 32 bits worth of non-zero bits. Same for the source: it will


### PR DESCRIPTION
#### 14fcf3754053fb238dfa0a4d0eeddf459afdfd1d
<pre>
[JSC] GreedyRegAlloc: introduce gap points between instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=302815">https://bugs.webkit.org/show_bug.cgi?id=302815</a>
<a href="https://rdar.apple.com/165070452">rdar://165070452</a>

Reviewed by NOBODY (OOPS!).

Currently, there are two points per instruction: Early point which models
early effects and late point which models late effects. This means that
in the case of an early def by the first instruction in a block
or late use by the last instruction in a block, the live ranges
cannot be used to determine whether the range is live into / out of
the block since the first / last points will include the ranges in either
case of the last point def&apos;ing / using the Tmp and/or the Tmp
being live across block boundaries.

Instead, let&apos;s use four points per instruction. Then, for the first
instruction of a block, the Pre point will be included in an interval
if and only if the Tmp is live into the block, and likewise for the
Post point and the block exit.

This will allow for more sophisticated live range splitting to be added
without having to keep around explicit liveness information for the
duration of register allocation by allowing the live ranges to be the
full source of truth.

Bonus: Similarly, because the previous instruction&apos;s late point and next
instruction&apos;s early point are adjacent, the live range intervals
do not indicate kill positions in the case of a late use followed
by early def. However, note that this case is currently handled using
padInterference which inserts Nop instructions at these locations.
So as a bonus, this change removes a dependency on padInterference and
eventually padInterefence can go away.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14fcf3754053fb238dfa0a4d0eeddf459afdfd1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83821 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/197a5bbd-4a7a-46bf-9ec5-f83e37312092) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68238 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61b25855-9a45-404d-b170-d0a10393b825) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134873 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3107 "Found 1 new test failure: fast/forms/ios/file-upload-panel-blur-focus-document-picker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81630 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/33d00b3a-da0c-4040-aff2-ba1fa499927f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2997 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/857 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82659 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/123990 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142084 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130434 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109212 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109381 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3099 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57310 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4142 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32829 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163401 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67589 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42480 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/omg-tail-call-clobber-scratch-register.js.default (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->