### PR TITLE
AX: Refactor some tests to avoid differences with accessibility text stitching when stitching wouldn't be significant to the behavior-under-test

### DIFF
--- a/LayoutTests/accessibility/image-map2-expected.txt
+++ b/LayoutTests/accessibility/image-map2-expected.txt
@@ -1,36 +1,5 @@
-Image map - test 2 - 2 Links (alt tags)
-----------------------
-AXRole: AXGroup
-AXSubrole: (null)
-AXRoleDescription: group
-AXChildren: <array of size 2>
-AXChildrenInNavigationOrder: <array of size 2>
-AXHelp:
-AXParent: <AXGroup>
-AXSize: NSSize: {784, 36}
-AXTitle:
-AXDescription:
-AXValue:
-AXFocused: 0
-AXEnabled: 1
-AXWindow: <AXGroup>
-AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXGroup>
-AXEndTextMarker: <AXGroup>
-AXVisited: 0
-AXLinkedUIElements: <array of size 0>
-AXSelected: 0
-AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXGroup>
-AXLanguage:
-AXDOMIdentifier: result
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXGroup>
-AXEditableAncestor: (null)
-AXHighestEditableAncestor: (null)
-AXElementBusy: 0
+This test ensures proper AX tree output for image map links with alt tags.
 
-------------
 AXRole: AXLink
 AXSubrole: (null)
 AXRoleDescription: link
@@ -102,5 +71,7 @@ AXPath: <AXLink>
 
 ------------
 
+PASS successfullyParsed is true
 
+TEST COMPLETE
 

--- a/LayoutTests/accessibility/image-map2.html
+++ b/LayoutTests/accessibility/image-map2.html
@@ -1,31 +1,27 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<map id="apple" name="imagemap1">
+    <area shape="rect" coords="10,10,133,72" href="http://www.apple.com" alt="Link1" />
+    <area shape="rect" coords="12,74,134,88" href="http://www.apple.com" alt="Link2" />
+</map>
+
+<img src="resources/cake.png"  border="0" align="left" usemap="#imagemap1" vspace="1">
+
 <script>
-    if (window.testRunner)
-        testRunner.dumpAsText();
+var output = "This test ensures proper AX tree output for image map links with alt tags.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    output += webArea.attributesOfChildren();
+    debugEscaped(output);
+}
 </script>
-<body id="body">
-    
-    <div id="result"></div>
-    
-    <!-- Test image map -->
-    <map id="apple" name="imagemap1">
-      <area shape="rect" coords="10,10,133,72" href="http://www.apple.com" alt="Link1" />
-      <area shape="rect" coords="12,74,134,88" href="http://www.apple.com" alt="Link2" />
-    </map>
-
-    <img src="resources/cake.png"  border="0" align="left" usemap="#imagemap1" vspace="1">
-
-     
-    <script>
-        if (window.accessibilityController) {
-            var result = document.getElementById("result");
-
-            var body = document.getElementById("body");
-            body.focus();
-            result.innerText += "Image map - test 2 - 2 Links (alt tags)\n";
-            result.innerText += "----------------------\n";
-            result.innerText += accessibilityController.focusedElement.attributesOfChildren() + "\n\n"; 
-        }
-    </script>
 </body>
 </html>
+

--- a/LayoutTests/accessibility/ios-simulator/suggestion-insertion-deletion-attributes-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/suggestion-insertion-deletion-attributes-expected.txt
@@ -16,4 +16,6 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 inserted textdeleted text
-inserted textdeleted text
+inserted
+text
+deleted text

--- a/LayoutTests/accessibility/ios-simulator/suggestion-insertion-deletion-attributes.html
+++ b/LayoutTests/accessibility/ios-simulator/suggestion-insertion-deletion-attributes.html
@@ -8,7 +8,7 @@
 
 <div id="sug1" role="suggestion"><span id="ins1" role="insertion">inserted text</span><span id="del1" role="deletion">deleted text</span></div>
 
-<div id="sug2" role="suggestion"><span id="ins2" role="insertion"><b>inserted</b> text</span><span id="del2" role="deletion">deleted text</span></div>
+<div id="sug2" role="suggestion"><span id="ins2" role="insertion"><b>inserted</b> <div role="presentation">text</div></span><span id="del2" role="deletion">deleted text</span></div>
 
 
 <script>

--- a/LayoutTests/accessibility/mac/expanded-text-expected.txt
+++ b/LayoutTests/accessibility/mac/expanded-text-expected.txt
@@ -6,4 +6,5 @@ PASS: acronymText.attributedStringForTextMarkerRangeContainsAttribute('AXExpande
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Foo Bar
+Foo
+Bar

--- a/LayoutTests/accessibility/mac/expanded-text.html
+++ b/LayoutTests/accessibility/mac/expanded-text.html
@@ -6,7 +6,10 @@
 </head>
 <body>
 
-<abbr role="group" id="abbr" title="a">Foo</abbr>
+<div>
+    <!-- <div> is added to break text stitching, so the test passes with and without accessibility text-stitching enabled. -->
+    <abbr role="group" id="abbr" title="a">Foo</abbr>
+</div>
 <acronym role="group" id="acronym" title="b">Bar</acronym>
 
 <script>

--- a/LayoutTests/accessibility/mac/mark-role-expected.txt
+++ b/LayoutTests/accessibility/mac/mark-role-expected.txt
@@ -9,4 +9,4 @@ TEST COMPLETE
 This is some
 highlighted
 text.
-This is some highlighted text.
+highlighted text.

--- a/LayoutTests/accessibility/mac/mark-role.html
+++ b/LayoutTests/accessibility/mac/mark-role.html
@@ -7,7 +7,7 @@
 <body>
 
 <div>This is some <div id="highlight1" role="mark">highlighted</div> text.</div>
-<div>This is some <mark id="highlight2">highlighted</mark> text.</div>
+<div><mark id="highlight2">highlighted</mark> text.</div>
 
 <script>
 if (window.accessibilityController) {

--- a/LayoutTests/accessibility/mac/search-predicate-font-change-expected.txt
+++ b/LayoutTests/accessibility/mac/search-predicate-font-change-expected.txt
@@ -4,9 +4,12 @@ PASS: firstText.stringValue === 'AXValue: One'
 PASS: resultText.stringValue === 'AXValue: Two'
 PASS: resultText.stringValue === 'AXValue: Three'
 PASS: resultText.stringValue === 'AXValue: Four'
-PASS: Found #span-4 text after #span-1 after dynamic change.
+PASS: Found #div-4 text after #div-1 after dynamic change.
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
-OneFour Two Three
+One
+Four
+Two
+Three

--- a/LayoutTests/accessibility/mac/search-predicate-font-change.html
+++ b/LayoutTests/accessibility/mac/search-predicate-font-change.html
@@ -6,10 +6,10 @@
 </head>
 <body>
 
-<span id="span-1" style="font-family:sans-serif;">One</span>
-<span style="font-family:serif;">Two</span>
-<span style="font-family:sans-serif;">Three</span>
-<span id="span-4" style="font-family:serif;">Four</span>
+<div role="presentation" id="div-1" style="font-family:sans-serif;">One</div>
+<div role="presentation" style="font-family:serif;">Two</div>
+<div role="presentation" style="font-family:sans-serif;">Three</div>
+<div role="presentation" id="div-4" style="font-family:serif;">Four</div>
 
 <script>
 var output = "This test ensures that the AXFontChangeSearchKey works correctly.\n\n";
@@ -27,14 +27,14 @@ if (window.accessibilityController) {
     var resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXFontChangeSearchKey", "", false);
     output += expect("resultText.stringValue", "'AXValue: Four'");
 
-    // Move the last span to be right after the first.
-    document.getElementById("span-1").after(document.getElementById("span-4"));
+    // Move the last div to be right after the first.
+    document.getElementById("div-1").after(document.getElementById("div-4"));
     setTimeout(async function() {
         await waitFor(() => {
             resultText = webArea.uiElementForSearchPredicate(firstText, true, "AXFontChangeSearchKey", "", false);
             return resultText && resultText.stringValue === "AXValue: Four";
         });
-        output += "PASS: Found #span-4 text after #span-1 after dynamic change.\n";
+        output += "PASS: Found #div-4 text after #div-1 after dynamic change.\n";
 
         debug(output);
         finishJSTest();

--- a/LayoutTests/accessibility/mac/search-predicate-style-change-expected.txt
+++ b/LayoutTests/accessibility/mac/search-predicate-style-change-expected.txt
@@ -14,4 +14,20 @@ PASS: Returned the right element after a dynamic page change.
 PASS successfullyParsed is true
 
 TEST COMPLETE
-OneEight Skip Two Skip Three Skip Four Skip Five Skip Six Skip Seven Skip SkipLast text
+One
+Eight
+Skip
+Two
+Skip
+Three
+Skip
+Four
+Skip
+Five
+Skip
+Six
+Skip
+Seven
+Skip
+Skip
+Last text

--- a/LayoutTests/accessibility/mac/search-predicate-style-change.html
+++ b/LayoutTests/accessibility/mac/search-predicate-style-change.html
@@ -16,29 +16,29 @@
 </head>
 <body>
 
-<span id="span-1" class="font">One</span>
-<span class="font">Skip</span>
+<div role="presentation" id="div-1" class="font">One</div>
+<div role="presentation" class="font">Skip</div>
 
-<span class="text-color">Two</span>
-<span class="text-color">Skip</span>
+<div role="presentation" class="text-color">Two</div>
+<div role="presentation" class="text-color">Skip</div>
 
-<span class="background-color">Three</span>
-<span class="background-color">Skip</span>
+<div role="presentation" class="background-color">Three</div>
+<div role="presentation" class="background-color">Skip</div>
 
-<span class="subscript">Four</span>
-<span class="subscript">Skip</span>
+<div role="presentation" class="subscript">Four</div>
+<div role="presentation" class="subscript">Skip</div>
 
-<span class="superscript">Five</span>
-<span class="superscript">Skip</span>
+<div role="presentation" class="superscript">Five</div>
+<div role="presentation" class="superscript">Skip</div>
 
-<span class="text-shadow">Six</span>
-<span class="text-shadow">Skip</span>
+<div role="presentation" class="text-shadow">Six</div>
+<div role="presentation" class="text-shadow">Skip</div>
 
-<span class="underline">Seven</span>
-<span class="underline">Skip</span>
+<div role="presentation" class="underline">Seven</div>
+<div role="presentation" class="underline">Skip</div>
 
-<span id="span-8" class="linethrough">Eight</span>
-<span class="linethrough">Skip</span>Last text
+<div role="presentation" id="div-8" class="linethrough">Eight</div>
+<div role="presentation" class="linethrough">Skip</div>Last text
     
 <script>
 var output = "This test ensures that our handling of the AXStyleChangeSearchKey behaves correctly.\n\n";
@@ -75,7 +75,7 @@ if (window.accessibilityController) {
     output += expect("resultText.stringValue", "'AXValue: Last text'");
 
     // Ensure we behave correctly after a dynamic change.
-    document.getElementById("span-1").after(document.getElementById("span-8"));
+    document.getElementById("div-1").after(document.getElementById("div-8"));
     setTimeout(async function() {
         await waitFor(() => {
             var resultText = webArea.uiElementForSearchPredicate(startText, true, "AXStyleChangeSearchKey", "", false);

--- a/LayoutTests/platform/glib/accessibility/image-map2-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/image-map2-expected.txt
@@ -1,28 +1,9 @@
-Image map - test 2 - 2 Links (alt tags)
-----------------------
-AXRole: AXSection
-AXParent: AXWebArea
-AXChildren: 0
-AXPosition: { 8.00000, 8.00000 }
-AXSize: { 784.000, 36.0000 }
-AXTitle:
-AXDescription:
-AXValue: Image map - test 2 - 2 Links (alt tags)<\n>----------------------<\n>
-AXFocusable: 0
-AXFocused: 0
-AXSelectable: 0
-AXSelected: 0
-AXMultiSelectable: 0
-AXEnabled: 1
-AXExpanded: 0
-AXRequired: 0
-AXChecked: 0
-AXPlatformAttributes: computed-role:generic, tag:div
-------------
+This test ensures proper AX tree output for image map links with alt tags.
+
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition: { 18.0000, 54.0000 }
+AXPosition:  { 18.0000, 18.0000 }
 AXSize: { 123.000, 62.0000 }
 AXTitle: Link1
 AXDescription:
@@ -42,7 +23,7 @@ AXPlatformAttributes: computed-role:link, tag:area
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition: { 20.0000, 118.000 }
+AXPosition:  { 20.0000, 82.0000 }
 AXSize: { 122.000, 14.0000 }
 AXTitle: Link2
 AXDescription:
@@ -60,5 +41,7 @@ AXURL: http://www.apple.com/
 AXPlatformAttributes: computed-role:link, tag:area
 ------------
 
+PASS successfullyParsed is true
 
+TEST COMPLETE
 


### PR DESCRIPTION
#### 68e5b29ba9b96c8484e6886f055ef3647035d060
<pre>
AX: Refactor some tests to avoid differences with accessibility text stitching when stitching wouldn&apos;t be significant to the behavior-under-test
<a href="https://bugs.webkit.org/show_bug.cgi?id=302816">https://bugs.webkit.org/show_bug.cgi?id=302816</a>
<a href="https://rdar.apple.com/165071062">rdar://165071062</a>

Reviewed by Joshua Hoffman.

In an upcoming PR, I will add a new feature called accessibility text stitching, which stitches adjacent text objects
into one in the outwardly exposed accessibility tree. In preparation for that, this commit modifies tests so that they
behave the same with and without this feature to avoid unnecessary churn when we add it.

* LayoutTests/accessibility/image-map2-expected.txt:
* LayoutTests/accessibility/image-map2.html:
* LayoutTests/accessibility/ios-simulator/suggestion-insertion-deletion-attributes-expected.txt:
* LayoutTests/accessibility/ios-simulator/suggestion-insertion-deletion-attributes.html:
* LayoutTests/accessibility/mac/expanded-text-expected.txt:
* LayoutTests/accessibility/mac/expanded-text.html:
* LayoutTests/accessibility/mac/mark-role-expected.txt:
* LayoutTests/accessibility/mac/mark-role.html:
* LayoutTests/accessibility/mac/search-predicate-font-change-expected.txt:
* LayoutTests/accessibility/mac/search-predicate-font-change.html:
* LayoutTests/accessibility/mac/search-predicate-style-change-expected.txt:
* LayoutTests/accessibility/mac/search-predicate-style-change.html:

Canonical link: <a href="https://commits.webkit.org/303332@main">https://commits.webkit.org/303332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/532adaba077b44c1997f4cd2377882f0b3d601a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83845 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100858 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134894 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81649 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3020 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82680 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142106 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4110 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109230 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109400 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3115 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57331 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4163 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32845 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3995 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4255 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4123 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->