### PR TITLE
[threaded-animations] turning on the "Threaded Scroll-driven Animations" setting should not force monotonic animations to be threaded

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-suspension.html
+++ b/LayoutTests/webanimations/accelerated-animation-suspension.html
@@ -27,8 +27,10 @@ promise_test(async () => {
 
     const initialAnimations = internals.acceleratedAnimationsForElement(target);
     assert_equals(initialAnimations.length, 1, "There should be a single accelerated animation before suspension.");
-    assert_object_equals(initialAnimations[0], { property: "transform", speed: 1 },
-                         'The single accelerated animation before suspension should be running and targeting the "transform" property.');
+    assert_equals(initialAnimations[0].property, "transform",
+                         'The single accelerated animation before suspension should be targeting the "transform" property.');
+    assert_equals(initialAnimations[0].speed, 1,
+                         'The single accelerated animation before suspension should be running.');
 
     internals.suspendAnimations();
 
@@ -36,8 +38,10 @@ promise_test(async () => {
 
     const suspendedAnimations = internals.acceleratedAnimationsForElement(target);
     assert_equals(suspendedAnimations.length, 1, "There should be a single accelerated animation after suspension.");
-    assert_object_equals(suspendedAnimations[0], { property: "transform", speed: 0 },
-                         'The single accelerated animation after suspension should be paused and targeting the "transform" property.');
+    assert_equals(suspendedAnimations[0].property, "transform",
+                         'The single accelerated animation after suspension should be targeting the "transform" property.');
+    assert_equals(suspendedAnimations[0].speed, 0,
+                         'The single accelerated animation after suspension should be paused.');
     internals.resumeAnimations();
 
     await new Promise(setTimeout);

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Scroll-driven animations can be threaded while monotonic animations can be accelerated but not threaded.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+</style>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
+<script>
+
+promise_test(async t => { 
+    const scrollTarget = createDiv(t);
+    const monotonicTarget = createDiv(t);
+    
+    const timeline = new ScrollTimeline({ source : document.documentElement });
+    scrollTarget.animate({ opacity: [0, 1] }, { timeline });
+    monotonicTarget.animate({ opacity: [0, 1] }, 1000 * 1000);
+
+    // Wait a few frames for both animations to be committed.
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+
+    assert_true(window.internals?.acceleratedAnimationsForElement(scrollTarget)[0].isThreaded);
+    assert_false(window.internals?.acceleratedAnimationsForElement(monotonicTarget)[0].isThreaded);
+}, "Scroll-driven animations can be threaded while monotonic animations can be accelerated but not threaded.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -29,6 +29,7 @@
 #include "AnimationEventBase.h"
 #include "CSSAnimation.h"
 #include "CSSTransition.h"
+#include "ContainerNodeInlines.h"
 #include "DocumentEventLoop.h"
 #include "DocumentPage.h"
 #include "DocumentTimeline.h"
@@ -36,9 +37,14 @@
 #include "ElementInlines.h"
 #include "EventLoop.h"
 #include "EventTargetInlines.h"
+#include "GraphicsLayer.h"
 #include "KeyframeEffect.h"
 #include "LocalDOMWindow.h"
 #include "Logging.h"
+#include "RenderBoxModelObject.h"
+#include "RenderLayer.h"
+#include "RenderLayerBacking.h"
+#include "RenderObject.h"
 #include "ScrollTimeline.h"
 #include "Settings.h"
 #include "StyleOriginatedTimelinesController.h"
@@ -392,6 +398,17 @@ void AnimationTimelinesController::scheduleAcceleratedEffectStackUpdateForTarget
         documentTimeline->scheduleAcceleratedEffectStackUpdate();
 }
 #endif
+
+Vector<std::tuple<String, double, bool>> AnimationTimelinesController::acceleratedAnimationsForElement(const Element& element) const
+{
+    CheckedPtr renderer = element.renderer();
+    if (renderer && renderer->isComposited()) {
+        CheckedPtr compositedRenderer = downcast<RenderBoxModelObject>(renderer.get());
+        if (RefPtr graphicsLayer = compositedRenderer->layer()->backing()->graphicsLayer())
+            return graphicsLayer->acceleratedAnimationsForTesting();
+    }
+    return { };
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -77,6 +77,8 @@ public:
     void scheduleAcceleratedEffectStackUpdateForTarget(const Styleable&);
 #endif
 
+    WEBCORE_EXPORT Vector<std::tuple<String, double, bool>> acceleratedAnimationsForElement(const Element&) const;
+
 private:
 
     ReducedResolutionSeconds liveCurrentTime() const;

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -65,7 +65,6 @@ public:
     void transitionDidComplete(Ref<CSSTransition>&&);
 
     void animationAcceleratedRunningStateDidChange(WebAnimation&);
-    void runPostRenderingUpdateTasks();
     void detachFromDocument() override;
 
     void enqueueAnimationEvent(AnimationEventBase&);
@@ -82,7 +81,6 @@ public:
     void suspendAnimations() override;
     void resumeAnimations() override;
     WEBCORE_EXPORT unsigned numberOfActiveAnimationsForTesting() const;
-    WEBCORE_EXPORT Vector<std::pair<String, double>> acceleratedAnimationsForElement(Element&) const;    
     WEBCORE_EXPORT unsigned numberOfAnimationTimelineInvalidationsForTesting() const;
 
     Seconds convertTimelineTimeToOriginRelativeTime(Seconds) const;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1378,7 +1378,7 @@ std::optional<unsigned> KeyframeEffect::transformFunctionListPrefix() const
 {
     auto isTransformFunctionListsMatchPrefixRelevant = [&]() {
 #if ENABLE(THREADED_ANIMATIONS)
-        if (threadedAnimationsEnabled()) {
+        if (canHaveAcceleratedRepresentation()) {
             // The prefix is only relevant if the animation is fully replaced.
             if (m_compositeOperation != CompositeOperation::Replace || m_hasKeyframeComposingAcceleratedProperty)
                 return false;
@@ -1655,7 +1655,7 @@ OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const
 bool KeyframeEffect::isRunningAccelerated() const
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         if (!m_inTargetEffectStack || !canBeAccelerated())
             return false;
         ASSERT(animation());
@@ -1946,13 +1946,8 @@ bool KeyframeEffect::canBeAccelerated() const
     }
 
 #if ENABLE(THREADED_ANIMATIONS)
-    if (RefPtr document = this->document()) {
-        Ref settings = document->settings();
-        if (m_isAssociatedWithProgressBasedTimeline && settings->threadedScrollDrivenAnimationsEnabled())
-            return !animation()->pending();
-        if (!m_isAssociatedWithProgressBasedTimeline && settings->threadedTimeBasedAnimationsEnabled())
-            return true;
-    }
+    if (canHaveAcceleratedRepresentation())
+        return true;
 #endif
 
     if (m_isAssociatedWithProgressBasedTimeline)
@@ -1985,7 +1980,7 @@ bool KeyframeEffect::animatesMotionPath() const
 bool KeyframeEffect::preventsAcceleration() const
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         return false;
 #endif
 
@@ -2010,7 +2005,7 @@ bool KeyframeEffect::preventsAcceleration() const
 void KeyframeEffect::updateAcceleratedActions()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         return;
 #endif
 
@@ -2055,7 +2050,7 @@ void KeyframeEffect::updateAcceleratedActions()
 void KeyframeEffect::addPendingAcceleratedAction(AcceleratedAction action)
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         return;
 #endif
 
@@ -2085,7 +2080,7 @@ void KeyframeEffect::animationDidTick()
 void KeyframeEffect::animationBecameReady()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         updateAcceleratedAnimationIfNecessary();
 #endif
 }
@@ -2100,7 +2095,7 @@ void KeyframeEffect::animationDidChangeTimingProperties()
 void KeyframeEffect::updateAcceleratedAnimationIfNecessary()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         if (canBeAccelerated())
             scheduleAssociatedAcceleratedEffectStackUpdate();
         return;
@@ -2121,7 +2116,7 @@ void KeyframeEffect::updateAcceleratedAnimationIfNecessary()
 void KeyframeEffect::animationDidFinish()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         updateAcceleratedAnimationIfNecessary();
 #endif
 }
@@ -2220,7 +2215,7 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
 void KeyframeEffect::animationWasCanceled()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         updateAcceleratedAnimationIfNecessary();
         return;
     }
@@ -2244,7 +2239,7 @@ void KeyframeEffect::wasRemovedFromEffectStack()
 void KeyframeEffect::willChangeRenderer()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         updateAcceleratedAnimationIfNecessary();
         return;
     }
@@ -2257,7 +2252,7 @@ void KeyframeEffect::willChangeRenderer()
 void KeyframeEffect::animationSuspensionStateDidChange(bool animationIsSuspended)
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         scheduleAssociatedAcceleratedEffectStackUpdate();
         return;
     }
@@ -2270,7 +2265,7 @@ void KeyframeEffect::animationSuspensionStateDidChange(bool animationIsSuspended
 void KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         return;
 #endif
 
@@ -2288,7 +2283,7 @@ void KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties()
 void KeyframeEffect::applyPendingAcceleratedActions()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         return;
 #endif
 
@@ -2624,7 +2619,7 @@ bool KeyframeEffect::ticksContinuouslyWhileActive() const
 
     if (isCompletelyAccelerated() && isRunningAccelerated()) {
 #if ENABLE(THREADED_ANIMATIONS)
-        if (threadedAnimationsEnabled())
+        if (canHaveAcceleratedRepresentation())
             return !m_acceleratedRepresentation || !m_acceleratedRepresentation->disallowedProperties().isEmpty();
 #endif
         return false;
@@ -2670,7 +2665,7 @@ void KeyframeEffect::setComposite(CompositeOperation compositeOperation)
     invalidate();
 
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled())
+    if (canHaveAcceleratedRepresentation())
         updateAcceleratedAnimationIfNecessary();
 #endif
 }
@@ -2898,7 +2893,7 @@ void KeyframeEffect::effectStackNoLongerAllowsAcceleration()
 void KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActionApplication()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         ASSERT_NOT_REACHED();
         return;
     }
@@ -2913,7 +2908,7 @@ void KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActio
 void KeyframeEffect::abilityToBeAcceleratedDidChange()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         scheduleAssociatedAcceleratedEffectStackUpdate();
         return;
     }
@@ -3004,7 +2999,7 @@ static bool acceleratedPropertyDidChange(AnimatableCSSProperty property, const R
 void KeyframeEffect::lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle)
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (threadedAnimationsEnabled()) {
+    if (canHaveAcceleratedRepresentation()) {
         if (!isRunningAccelerated())
             return;
 
@@ -3070,18 +3065,25 @@ KeyframeEffect::StackMembershipMutationScope::~StackMembershipMutationScope()
     }
 }
 
-bool KeyframeEffect::threadedAnimationsEnabled() const
+bool KeyframeEffect::canHaveAcceleratedRepresentation() const
 {
+    if (m_acceleratedRepresentation)
+        return true;
+
     if (RefPtr document = this->document()) {
         Ref settings = document->settings();
-        return settings->threadedScrollDrivenAnimationsEnabled() || settings->threadedTimeBasedAnimationsEnabled();
+        if (m_isAssociatedWithProgressBasedTimeline && settings->threadedScrollDrivenAnimationsEnabled())
+            return true;
+        if (!m_isAssociatedWithProgressBasedTimeline && settings->threadedTimeBasedAnimationsEnabled())
+            return true;
     }
+
     return false;
 }
 
 void KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate(const std::optional<const Styleable>& previousTarget)
 {
-    if (!threadedAnimationsEnabled())
+    if (!canHaveAcceleratedRepresentation())
         return;
 
     ASSERT(document());

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -194,6 +194,7 @@ public:
     WebAnimationType animationType() const { return m_animationType; }
 
 #if ENABLE(THREADED_ANIMATIONS)
+    bool canHaveAcceleratedRepresentation() const;
     const AcceleratedEffect* acceleratedRepresentation() const { return m_acceleratedRepresentation.get(); }
     void setAcceleratedRepresentation(const AcceleratedEffect* acceleratedRepresentation) { m_acceleratedRepresentation = acceleratedRepresentation; }
 #endif
@@ -265,7 +266,6 @@ private:
         std::optional<Style::PseudoElementIdentifier> m_originalPseudoElementIdentifier;
     };
 
-    bool threadedAnimationsEnabled() const;
     void scheduleAssociatedAcceleratedEffectStackUpdate(const std::optional<const Styleable>& = std::nullopt);
 #endif
 

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -28,6 +28,7 @@
 
 #include "AnimationTimelinesController.h"
 #include "ContainerNodeInlines.h"
+#include "Document.h"
 #include "Element.h"
 #include "KeyframeEffect.h"
 #include "RenderElementInlines.h"
@@ -40,6 +41,10 @@
 #include "StylableInlines.h"
 #include "StyleSingleAnimationRange.h"
 #include "WebAnimation.h"
+
+#ifndef NDEBUG
+#include "Settings.h"
+#endif
 
 namespace WebCore {
 
@@ -389,6 +394,7 @@ void ScrollTimeline::animationTimingDidChange(WebAnimation& animation)
 Ref<AcceleratedTimeline> ScrollTimeline::createAcceleratedRepresentation()
 {
     ASSERT(this->source());
+    ASSERT(this->source()->document().settings().threadedScrollDrivenAnimationsEnabled());
     Ref source = *this->source();
     CheckedPtr sourceScrollableArea = scrollableAreaForSourceRenderer(source->renderer(), source->document());
     ASSERT(sourceScrollableArea);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -545,7 +545,7 @@ public:
     WEBCORE_EXPORT virtual void suspendAnimations(MonotonicTime);
     WEBCORE_EXPORT virtual void resumeAnimations();
 
-    virtual Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const { return { }; }
+    virtual Vector<std::tuple<String, double, bool>> acceleratedAnimationsForTesting() const { return { }; }
 
     // Layer contents
     virtual void setContentsToImage(Image*) { }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -226,7 +226,7 @@ public:
 
     WEBCORE_EXPORT TiledBacking* tiledBacking() const override;
 
-    WEBCORE_EXPORT Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const final;
+    WEBCORE_EXPORT Vector<std::tuple<String, double, bool>> acceleratedAnimationsForTesting() const final;
 
     constexpr static CompositingCoordinatesOrientation defaultContentsOrientation = CompositingCoordinatesOrientation::TopDown;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -664,11 +664,11 @@ void GraphicsLayerCoordinated::transformRelatedPropertyDidChange()
         noteLayerPropertyChanged(Change::Animations, ScheduleFlush::Yes);
 }
 
-Vector<std::pair<String, double>> GraphicsLayerCoordinated::acceleratedAnimationsForTesting(const Settings&) const
+Vector<std::tuple<String, double, bool>> GraphicsLayerCoordinated::acceleratedAnimationsForTesting() const
 {
-    Vector<std::pair<String, double>> animations;
+    Vector<std::tuple<String, double, bool>> animations;
     for (auto& animation : m_animations.animations())
-        animations.append({ animatedPropertyIDAsString(animation.keyframes().property()), animation.state() == TextureMapperAnimation::State::Playing ? 1 : 0 });
+        animations.append({ animatedPropertyIDAsString(animation.keyframes().property()), animation.state() == TextureMapperAnimation::State::Playing ? 1 : 0, false });
     return animations;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -114,7 +114,7 @@ private:
     void suspendAnimations(MonotonicTime) override;
     void resumeAnimations() override;
     void transformRelatedPropertyDidChange() override;
-    Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const override;
+    Vector<std::tuple<String, double, bool>> acceleratedAnimationsForTesting() const override;
 
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ShouldClipToLayer::Clip) override;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4465,7 +4465,7 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
         auto animatesWidth = effectStack->containsProperty(CSSPropertyWidth);
         auto animatesHeight = effectStack->containsProperty(CSSPropertyHeight);
         for (const auto& effect : effectStack->sortedEffects()) {
-            if (!effect || !effect->canBeAccelerated())
+            if (!effect || !effect->canHaveAcceleratedRepresentation() || !effect->canBeAccelerated())
                 continue;
             if (animatesWidth || animatesHeight) {
                 auto& blendingKeyframes = effect->blendingKeyframes();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1438,9 +1438,13 @@ ExceptionOr<void> Internals::resumeAnimations() const
 
 Vector<Internals::AcceleratedAnimation> Internals::acceleratedAnimationsForElement(Element& element)
 {
+    CheckedPtr timelinesController = element.document().timelinesController();
+    if (!timelinesController)
+        return { };
+
     Vector<Internals::AcceleratedAnimation> animations;
-    for (const auto& animationAsPair : element.document().timeline().acceleratedAnimationsForElement(element))
-        animations.append({ animationAsPair.first, animationAsPair.second });
+    for (const auto& [property, speed, isThreaded] : timelinesController->acceleratedAnimationsForElement(element))
+        animations.append({ property, speed, isThreaded });
     return animations;
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -326,6 +326,7 @@ public:
     struct AcceleratedAnimation {
         String property;
         double speed;
+        bool isThreaded;
     };
     Vector<AcceleratedAnimation> acceleratedAnimationsForElement(Element&);
     unsigned numberOfAnimationTimelineInvalidations() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -333,6 +333,7 @@ enum AV1ConfigurationRange {
 ] dictionary AcceleratedAnimation {
     DOMString property;
     double speed;
+    boolean isThreaded;
 };
 
 [

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -506,7 +506,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         if (layerTreeHost->threadedAnimationsEnabled()) {
             LOG_WITH_STREAM(Animations, stream << "RemoteLayerTreePropertyApplier::applyProperties() for layer " << layerTreeNode->layerID() << " found " << properties.animationChanges.effects.size() << " effects.");
             layerTreeNode->setAcceleratedEffectsAndBaseValues(properties.animationChanges.effects, properties.animationChanges.baseValues, *layerTreeHost);
-        } else
+        }
 #endif
         PlatformCAAnimationRemote::updateLayerAnimations(layer, layerTreeHost, properties.animationChanges.addedAnimations, properties.animationChanges.keysOfAnimationsToRemove);
     }


### PR DESCRIPTION
#### f47e20b766b4c93246329c7b743b11e17cdf9b70
<pre>
[threaded-animations] turning on the &quot;Threaded Scroll-driven Animations&quot; setting should not force monotonic animations to be threaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=302812">https://bugs.webkit.org/show_bug.cgi?id=302812</a>
<a href="https://rdar.apple.com/165066892">rdar://165066892</a>

Reviewed by Simon Fraser.

We introduced two different settings to control whether to run accelerated animations in the remote
layer tree: &quot;Threaded Scroll-driven Animations&quot; and &quot;Threaded Time-based Animations&quot;. However, we
don&apos;t actually support having one on without the other and thus turning on just &quot;Threaded Scroll-driven
Animations&quot; forces even time-based (ie. monotonic) animations to be accelerated via the remote layer
tree.

In this patch we correctly handle both settings individually. This starts in `KeyframeEffect` where
we introduce a new `canHaveAcceleratedRepresentation()` method which returns true if we can indeed
accelerate this animation via the remote layer tree while honoring the two aforementioned settings
individually. This essentially replaces the previous `threadedAnimationsEnabled()` method which
was the core reason we were in the situation described above.

We also use this new `canHaveAcceleratedRepresentation()` method when considering the creation
of an accelerated representation in `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()`,
ensuring that both the threaded and non-threaded animation flavors may be supported for a given
animation stack. Note that this does not account for the two flavors trying to animate the same
property, which will be handled in a followup patch by turning off acceleration altogether in
this situation.

To ensure that we only ever create accelerated timeline representations for monotonic and progress-based
timelines, we also add debug assertions in `DocumentTimeline` and `ScrollTimeline` to check the
relevant setting is enabled.

On the remote layer tree side, we must also change `RemoteLayerTreePropertyApplier::applyPropertiesToLayer()
in order to allow both animation flavors to be specified on a given remote layer tree node.

Finally, we add a new `isThreaded` member to the `AcceleratedAnimation` dictionary returned by the
`window.internals.acceleratedAnimationsForElement()` method so that we can determine the type of
accelerated animations created for a given element. We take this chance to update this testing-specific
method to be implemented within `AnimationTimelinesController` rather than `DocumentTimeline`
since this method has little to do with the document timeline.

Test: webanimations/threaded-animations/threaded-and-non-threaded-animations.html

* LayoutTests/webanimations/accelerated-animation-suspension.html:
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations.html: Added.
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::acceleratedAnimationsForElement const):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::createAcceleratedRepresentation):
(WebCore::DocumentTimeline::acceleratedAnimationsForElement const): Deleted.
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::transformFunctionListPrefix const):
(WebCore::KeyframeEffect::isRunningAccelerated const):
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::preventsAcceleration const):
(WebCore::KeyframeEffect::updateAcceleratedActions):
(WebCore::KeyframeEffect::addPendingAcceleratedAction):
(WebCore::KeyframeEffect::animationBecameReady):
(WebCore::KeyframeEffect::updateAcceleratedAnimationIfNecessary):
(WebCore::KeyframeEffect::animationDidFinish):
(WebCore::KeyframeEffect::animationWasCanceled):
(WebCore::KeyframeEffect::willChangeRenderer):
(WebCore::KeyframeEffect::animationSuspensionStateDidChange):
(WebCore::KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties):
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
(WebCore::KeyframeEffect::ticksContinuouslyWhileActive const):
(WebCore::KeyframeEffect::setComposite):
(WebCore::KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActionApplication):
(WebCore::KeyframeEffect::abilityToBeAcceleratedDidChange):
(WebCore::KeyframeEffect::lastStyleChangeEventStyleDidChange):
(WebCore::KeyframeEffect::canHaveAcceleratedRepresentation const):
(WebCore::KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate):
(WebCore::KeyframeEffect::threadedAnimationsEnabled const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::createAcceleratedRepresentation):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::acceleratedAnimationsForTesting const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::acceleratedAnimationsForTesting const):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::acceleratedAnimationsForElement):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):

Canonical link: <a href="https://commits.webkit.org/303312@main">https://commits.webkit.org/303312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9c0bec64400199f63f52c735c39da05054753cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132014 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/4506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43030 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/139528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133884 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/4449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/4268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/139528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134960 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/4449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/139528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/4449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/82748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/4449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/142175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/142175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/4257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/4268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/142175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/114512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20525 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/4229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/4061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/4189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->