### PR TITLE
[Filters] Enable CoreGraphics filters for SVGFilters

### DIFF
--- a/LayoutTests/css3/filters/effect-grayscale-hw.html
+++ b/LayoutTests/css3/filters/effect-grayscale-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-33050">
+    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-63800">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-hue-rotate-hw.html
+++ b/LayoutTests/css3/filters/effect-hue-rotate-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-123; totalPixels=0-22400">
+    <meta name="fuzzy" content="maxDifference=0-123; totalPixels=0-57000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-saturate-hw.html
+++ b/LayoutTests/css3/filters/effect-saturate-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-256; totalPixels=0-18900">
+    <meta name="fuzzy" content="maxDifference=0-256; totalPixels=0-34200">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-sepia-hw.html
+++ b/LayoutTests/css3/filters/effect-sepia-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-36800">
+    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-65900">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/svg-blur-filter-clipped.html
+++ b/LayoutTests/css3/filters/svg-blur-filter-clipped.html
@@ -1,3 +1,4 @@
+<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-10000">
 <style>
     .container {
         width: 100px;

--- a/LayoutTests/imported/blink/css3/blending/svg-isolation-add-filter-expected.html
+++ b/LayoutTests/imported/blink/css3/blending/svg-isolation-add-filter-expected.html
@@ -10,7 +10,7 @@
                 </filter>
             </defs>
             <g id="isolator" filter="url(#Blur)">
-                <rect x="0" y="0" width="200" height="200" style="fill: green;"/>
+                <rect x="0" y="0" width="200" height="200" style="fill: green; mix-blend-mode: difference;"/>
             </g>
         </svg>
     </body>

--- a/LayoutTests/imported/mozilla/svg/filters/feGaussianBlur-alpha-01.svg
+++ b/LayoutTests/imported/mozilla/svg/filters/feGaussianBlur-alpha-01.svg
@@ -5,7 +5,7 @@
 <svg xmlns="http://www.w3.org/2000/svg">
 
   <title>SourceAlpha pseudo input test</title>
-
+  <meta name="fuzzy" content="maxDifference=0-24; totalPixels=0-5616" />
   <defs>
     <filter id="alphaBlur">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>

--- a/LayoutTests/svg/filters/svg-gaussianblur-edgeMode-duplicate.svg
+++ b/LayoutTests/svg/filters/svg-gaussianblur-edgeMode-duplicate.svg
@@ -1,11 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <filter id="blur">
+<feGaussianBlur stdDeviation="3"/>
+</filter>
+<filter id="blur-duplicate">
 <feGaussianBlur stdDeviation="3" edgeMode="duplicate"/>
 </filter>
+<clipPath id="clip">
+<rect x="20" y="20" width="140" height="140"/>
+</clipPath>
 </defs>
-<g filter="url(#blur)">
-<rect x="20" y="20" width="140" height="140" fill="green"/>
+<g filter="url(#blur)" clip-path="url(#clip)">
+<rect x="10" y="10" width="160" height="160" fill="green"/>
+<g filter="url(#blur-duplicate)">
 <rect x="40" y="40" width="100" height="100" fill="blue"/>
+</g>
 </g>
 </svg>

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1124,9 +1124,10 @@ void GraphicsContextCG::clearCGDropShadow()
 #if HAVE(CGSTYLE_COLORMATRIX_BLUR)
 void GraphicsContextCG::setCGGaussianBlur(const GraphicsGaussianBlur& gaussianBlur, bool shadowsIgnoreTransforms)
 {
-    CGContextRef context = platformContext();
+    if (gaussianBlur.radius.isEmpty())
+        return;
 
-    ASSERT(gaussianBlur.radius.width() == gaussianBlur.radius.height());
+    CGContextRef context = platformContext();
 
     CGAffineTransform userToBaseCTM = getUserToBaseCTM(context);
     CGFloat blurRadius = scaledBlurRadius(gaussianBlur.radius.width(), userToBaseCTM, shadowsIgnoreTransforms);

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -144,7 +144,8 @@ OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes(Optio
     modes.add(FilterRenderingMode::Accelerated);
 #endif
 #if USE(CG)
-    if (m_stdX == m_stdY)
+    // FIXME: Use GraphicsStyle to draw transparent shadows.
+    if (m_stdX == m_stdY && m_shadowOpacity == 1)
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif
     return modes & preferredFilterRenderingModes;

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -163,7 +163,7 @@ OptionSet<FilterRenderingMode> FEGaussianBlur::supportedFilterRenderingModes(Opt
 #endif
     // FIXME: Ensure the correctness of the CG GaussianBlur filter (http://webkit.org/b/243816).
 #if HAVE(CGSTYLE_COLORMATRIX_BLUR)
-    if (m_stdX == m_stdY && preferredFilterRenderingModes.contains(FilterRenderingMode::GraphicsContext))
+    if (m_stdX == m_stdY && m_edgeMode == EdgeModeType::None && preferredFilterRenderingModes.contains(FilterRenderingMode::GraphicsContext))
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif
     return modes & preferredFilterRenderingModes;

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -24,6 +24,7 @@
 #include "SVGFilterRenderer.h"
 
 #include "ElementChildIteratorInlines.h"
+#include "FEColorMatrix.h"
 #include "FilterResults.h"
 #include "GeometryUtilities.h"
 #include "SVGFilterEffectGraph.h"
@@ -258,8 +259,17 @@ OptionSet<FilterRenderingMode> SVGFilterRenderer::supportedFilterRenderingModes(
 {
     OptionSet<FilterRenderingMode> modes = allFilterRenderingModes;
 
-    for (auto& effect : m_effects)
+    for (auto& term : m_expression) {
+        auto& effect = m_effects[term.index];
+        if (effect->operatingColorSpace() == DestinationColorSpace::LinearSRGB())
+            modes.remove(FilterRenderingMode::GraphicsContext);
+        // FIXME: Use GraphicsStyle to draw FECOLORMATRIX_TYPE_MATRIX filters.
+        if (RefPtr colorMatrix = dynamicDowncast<FEColorMatrix>(effect)) {
+            if (colorMatrix->type() == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX)
+                modes.remove(FilterRenderingMode::GraphicsContext);
+        }
         modes = modes & effect->supportedFilterRenderingModes(preferredFilterRenderingModes);
+    }
 
     ASSERT(modes);
     return modes;


### PR DESCRIPTION
#### 0ff29b2e01ce30e98b624ee4bb573e1e82de0ee1
<pre>
[Filters] Enable CoreGraphics filters for SVGFilters
<a href="https://bugs.webkit.org/show_bug.cgi?id=302822">https://bugs.webkit.org/show_bug.cgi?id=302822</a>
<a href="https://rdar.apple.com/165057553">rdar://165057553</a>

Reviewed by Nikolas Zimmermann.

We loop through all the effects in the SVGFilter graph and check whether each of
them supports CoreGraphics filters or not. If one of them does not support
CoreGraphics filters, we fall back to software filters.

The problem is SourceAlpha has to be in the SVGFilter graph regardless whether it
is used or not. And since SourceAlpha does not support CoreGraphics filters, we
always fallback to software filters.

The fix should be to loop through the effects of the SVGFilter expression.

* LayoutTests/css3/filters/effect-grayscale-hw.html:
* LayoutTests/css3/filters/effect-hue-rotate-hw.html:
* LayoutTests/css3/filters/effect-saturate-hw.html:
* LayoutTests/css3/filters/effect-sepia-hw.html:
* LayoutTests/css3/filters/svg-blur-filter-clipped.html:
* LayoutTests/imported/blink/css3/blending/svg-isolation-add-filter-expected.html:
* LayoutTests/imported/mozilla/svg/filters/feGaussianBlur-alpha-01.svg:
* LayoutTests/svg/filters/svg-gaussianblur-edgeMode-duplicate.svg:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setCGGaussianBlur):
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::supportedFilterRenderingModes const):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::supportedFilterRenderingModes const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff29b2e01ce30e98b624ee4bb573e1e82de0ee1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86861 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/10629511-4f82-4e21-9e6b-e617e9b04ac6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103177 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70427 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4558e037-0c3f-46c4-9afe-b4e905d968b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137971 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5714 "Found 1 new test failure: fast/filter-image/filter-image-blur.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84030 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5532 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3147 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3129 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145232 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111555 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111915 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5373 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117309 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61057 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7161 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35480 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7166 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7041 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->