### PR TITLE
Unreviewed, reverting 303278@main (ddcdf930b1d0)

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -454,12 +454,6 @@ void WebTransport::didFail(std::optional<unsigned>&& code, String&& message)
         cleanupWithSessionError();
 }
 
-void WebTransport::didDrain()
-{
-    m_state = State::Draining;
-    m_draining.second->resolve();
-}
-
 RefPtr<WebTransportSession> WebTransport::protectedSession()
 {
     return m_session;

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -111,7 +111,6 @@ private:
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
     void didFail(std::optional<unsigned>&&, String&&) final;
-    void didDrain() final;
 
     RefPtr<WebTransportSession> protectedSession();
 

--- a/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
@@ -47,7 +47,6 @@ public:
     virtual void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) = 0;
     virtual void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) = 0;
     virtual void didFail(std::optional<unsigned>&&, String&&) = 0;
-    virtual void didDrain() = 0;
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -79,17 +79,6 @@ void WorkerWebTransportSession::didFail(std::optional<unsigned>&& code, String&&
     });
 }
 
-void WorkerWebTransportSession::didDrain()
-{
-    ASSERT(RunLoop::isMain());
-    ScriptExecutionContext::postTaskTo(m_contextID, [weakClient = m_client] (auto&) mutable {
-        RefPtr client = weakClient.get();
-        if (!client)
-            return;
-        client->didDrain();
-    });
-}
-
 void WorkerWebTransportSession::receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier identifier)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -51,7 +51,6 @@ private:
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
     void didFail(std::optional<unsigned>&&, String&&) final;
-    void didDrain() final;
 
     Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final;
     Ref<WritableStreamPromise> createOutgoingUnidirectionalStream() final;

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -83,9 +83,6 @@ const char* nw_webtransport_metadata_get_session_error_message(nw_protocol_metad
 void nw_webtransport_metadata_set_session_error_message(nw_protocol_metadata_t, const char*);
 bool nw_webtransport_metadata_get_session_closed(nw_protocol_metadata_t);
 void nw_webtransport_options_set_allow_joining_before_ready(nw_protocol_options_t, bool);
-typedef void (^nw_webtransport_drain_handler_t)(void);
-void nw_webtransport_metadata_set_remote_drain_handler(nw_protocol_metadata_t, nw_webtransport_drain_handler_t, dispatch_queue_t);
-void nw_webtransport_metadata_set_local_draining(nw_protocol_metadata_t);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -86,7 +86,6 @@ symbols = [
     "nw_webtransport_metadata_get_session_error_message",
     "nw_webtransport_metadata_set_session_error_message",
     "nw_webtransport_metadata_get_session_closed",
-    "nw_webtransport_metadata_set_remote_drain_handler",
     "nw_webtransport_options_add_connect_request_header",
     "nw_webtransport_options_set_allow_joining_before_ready",
     "nw_webtransport_options_set_is_datagram",

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
@@ -38,7 +38,4 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_options_
 // FIXME: Replace this soft linking with a HAVE macro once rdar://164514830 is available on all tested OS builds.
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_get_session_closed, bool, (nw_protocol_metadata_t metadata), (metadata))
 
-// FIXME: Replace this soft linking with a HAVE macro once rdar://164265337 is available on all tested OS builds.
-SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_set_remote_drain_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_drain_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
-
 #endif // HAVE(WEB_TRANSPORT)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
@@ -36,6 +36,4 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_options_
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_get_session_closed, bool, (nw_protocol_metadata_t metadata), (metadata))
 
-SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_set_remote_drain_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_drain_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
-
 #endif // HAVE(AVAUDIOAPPLICATION)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -288,19 +288,8 @@ void NetworkTransportSession::initialize(CompletionHandler<void(bool)>&& complet
         case nw_connection_group_state_waiting:
             return; // We will get another callback with another state change.
         case nw_connection_group_state_ready:
-            if (RefPtr protectedThis = weakThis.get()) {
+            if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_sessionMetadata = nw_connection_group_copy_protocol_metadata(protectedThis->m_connectionGroup.get(), adoptNS(nw_protocol_copy_webtransport_definition()).get());
-                if (RetainPtr metadata = protectedThis->m_sessionMetadata) {
-                    if (canLoad_Network_nw_webtransport_metadata_set_remote_drain_handler()) {
-                        softLink_Network_nw_webtransport_metadata_set_remote_drain_handler(metadata.get(), makeBlockPtr([weakThis = WeakPtr { *protectedThis }] () mutable {
-                            RefPtr protectedThis = weakThis.get();
-                            if (!protectedThis)
-                                return;
-                            protectedThis->send(Messages::WebTransportSession::DidDrain());
-                        }).get(), mainDispatchQueueSingleton());
-                    }
-                }
-            }
             return creationCompletionHandler(true);
         case nw_connection_group_state_failed:
             if (RefPtr protectedThis = weakThis.get()) {

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -126,15 +126,6 @@ void WebTransportSession::didFail(std::optional<unsigned>&& code, String&& messa
         ASSERT_NOT_REACHED();
 }
 
-void WebTransportSession::didDrain()
-{
-    ASSERT(RunLoop::isMain());
-    if (RefPtr strongClient = m_client.get())
-        strongClient->didDrain();
-    else
-        ASSERT_NOT_REACHED();
-}
-
 Ref<WebCore::WebTransportSendPromise> WebTransportSession::sendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier> identifier, std::span<const uint8_t> datagram)
 {
     return sendWithPromisedReply(Messages::NetworkTransportSession::SendDatagram(identifier, datagram))->whenSettled(RunLoop::mainSingleton(), [] (auto&& exception) {

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -72,7 +72,6 @@ public:
     void receiveBidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
     void didFail(std::optional<unsigned>&&, String&&);
-    void didDrain();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
@@ -30,5 +30,4 @@ messages -> WebTransportSession {
     ReceiveBidirectionalStream(WebCore::WebTransportStreamIdentifier identifier)
     StreamReceiveBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, std::optional<WebCore::Exception> exception)
     DidFail(std::optional<unsigned> code, String message)
-    DidDrain()
 }

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -77,7 +77,6 @@ public:
     Connection createWebTransportConnection(ConnectionType) const;
     ReceiveIncomingConnectionOperation receiveIncomingConnection() const;
     void cancel();
-    void drainWebTransportSession();
 
 private:
     friend class WebTransportServer;

--- a/Tools/TestWebKitAPI/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/NetworkConnection.mm
@@ -30,18 +30,12 @@
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/SHA1.h>
-#import <wtf/SoftLinking.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/ThreadSafeRefCounted.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/StringToIntegerConversion.h>
-
-#if HAVE(WEB_TRANSPORT)
-SOFT_LINK_FRAMEWORK(Network)
-SOFT_LINK_MAY_FAIL(Network, nw_webtransport_metadata_set_local_draining, void, (nw_protocol_metadata_t metadata), (metadata))
-#endif
 
 namespace TestWebKitAPI {
 
@@ -276,13 +270,6 @@ void ConnectionGroup::receiveIncomingConnection(Connection connection)
     });
     nw_connection_set_queue(connection.m_connection.get(), mainDispatchQueueSingleton());
     nw_connection_start(connection.m_connection.get());
-}
-
-void ConnectionGroup::drainWebTransportSession()
-{
-    RetainPtr metadata = nw_connection_group_copy_protocol_metadata(m_data->group.get(), adoptNS(nw_protocol_copy_webtransport_definition()).get());
-    if (metadata && canLoadnw_webtransport_metadata_set_local_draining())
-        nw_webtransport_metadata_set_local_draining(metadata.get());
 }
 
 #endif // HAVE(WEB_TRANSPORT)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -47,7 +47,6 @@
 // FIXME: Replace this soft linking with a HAVE macro once rdar://158191390 is available on all tested OS builds.
 SOFT_LINK_FRAMEWORK(Network)
 SOFT_LINK_MAY_FAIL(Network, nw_webtransport_options_set_allow_joining_before_ready, void, (nw_protocol_options_t options, bool allow), (options, allow))
-SOFT_LINK_MAY_FAIL(Network, nw_webtransport_metadata_set_local_draining, void, (nw_protocol_metadata_t metadata), (metadata))
 
 // FIXME: Replace this soft linking with a HAVE macro once rdar://164514830 is available on all tested OS builds.
 SOFT_LINK_MAY_FAIL(Network, nw_webtransport_metadata_get_session_closed, bool, (nw_protocol_metadata_t metadata), (metadata))
@@ -769,42 +768,6 @@ TEST(WebTransport, ServerConnectionTermination)
         "</script>", echoServer.port()];
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], canLoadnw_webtransport_metadata_get_session_closed() ? "successfully read closeInfo (0, )" : "caught WebTransportError");
-}
-
-TEST(WebTransport, ServerDrain)
-{
-    if (!canLoadnw_webtransport_metadata_set_local_draining())
-        return;
-
-    WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
-        auto connection = co_await group.receiveIncomingConnection();
-        auto request = co_await connection.awaitableReceiveBytes();
-        EXPECT_EQ(request.size(), 3u);
-        group.drainWebTransportSession();
-    });
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    [delegate allowAnyTLSCertificate];
-    [webView setNavigationDelegate:delegate.get()];
-
-    NSString *html = [NSString stringWithFormat:@""
-        "<script>async function test() {"
-        "  try {"
-        "    let t = new WebTransport('https://127.0.0.1:%d/');"
-        "    await t.ready;"
-        "    let c = await t.createUnidirectionalStream();"
-        "    let w = c.getWriter();"
-        "    await w.write(new TextEncoder().encode('abc'));"
-        "    await t.draining;"
-        "    alert('successfully receieved draining');"
-        "  } catch (e) { alert('caught ' + e); }"
-        "}; test();"
-        "</script>", echoServer.port()];
-    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully receieved draining");
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 545c79a8d8c7bf1cae13b1f43c2bf87f8eed12c7
<pre>
Unreviewed, reverting 303278@main (ddcdf930b1d0)
<a href="https://rdar.apple.com/165078649">rdar://165078649</a>

Broke multiple builds.

Reverted change:

    WebTransport should resolve the draining promise when the session is draining
    <a href="https://bugs.webkit.org/show_bug.cgi?id=302762">https://bugs.webkit.org/show_bug.cgi?id=302762</a>
    <a href="https://rdar.apple.com/161676172">rdar://161676172</a>
    303278@main (ddcdf930b1d0)

Canonical link: <a href="https://commits.webkit.org/303284@main">https://commits.webkit.org/303284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d341412908913d26fe3e518e04ae843f861a2b3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131939 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/4431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42951 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/139451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4372 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/4193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/139451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134885 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/139451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82671 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142097 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/4182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/4193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/109393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/114442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20508 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/4154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/3986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/4114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->