### PR TITLE
Implement BFCache interoperability for WebTransport

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -93,8 +93,8 @@ public:
     Ref<WebTransportSendGroup> createSendGroup();
 
     RefPtr<WebTransportSession> session();
-
     void datagramsWritableCreated(WebTransportDatagramsWritable&);
+    void cleanupContext(ScriptExecutionContext&);
 
 private:
     WebTransport(ScriptExecutionContext&, JSDOMGlobalObject&, Ref<ReadableStream>&&, Ref<ReadableStream>&&, WebTransportCongestionControl, Ref<WebTransportDatagramDuplexStream>&&, Ref<DatagramSource>&&, Ref<WebTransportReceiveStreamSource>&&, Ref<WebTransportBidirectionalStreamSource>&&);

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -35,6 +35,7 @@
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -101,6 +102,7 @@ class ServiceWorkerContainer;
 class SocketProvider;
 class WeakPtrImplWithEventTargetData;
 class WebCoreOpaqueRoot;
+class WebTransport;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class CrossOriginMode : bool;
 enum class LoadedFromOpaqueSource : bool;
@@ -385,6 +387,8 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
+    void createdWebTransport(WebTransport&);
+
 protected:
     class AddConsoleMessageTask : public Task {
     public:
@@ -465,6 +469,7 @@ private:
 
     RefPtr<GuaranteedSerialFunctionDispatcher> m_nativePromiseDispatcher;
     WeakHashSet<NativePromiseRequest> m_nativePromiseRequests;
+    ThreadSafeWeakHashSet<WebTransport> m_activeWebTransports;
 };
 
 WebCoreOpaqueRoot root(ScriptExecutionContext*);

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -28,6 +28,7 @@
 #import "CoroutineUtilities.h"
 #import <Network/Network.h>
 #import <wtf/CompletionHandler.h>
+#import <wtf/CoroutineUtilities.h>
 
 namespace TestWebKitAPI {
 
@@ -77,6 +78,7 @@ public:
     Connection createWebTransportConnection(ConnectionType) const;
     ReceiveIncomingConnectionOperation receiveIncomingConnection() const;
     void cancel();
+    Awaitable<void> awaitableFailure();
 
 private:
     friend class WebTransportServer;
@@ -84,6 +86,7 @@ private:
     ConnectionGroup(nw_connection_group_t);
     void receiveIncomingConnection(Connection);
     void receiveIncomingConnection(CompletionHandler<void(Connection)>&&);
+    void markAsFailed();
 
     struct Data;
     Ref<Data> m_data;


### PR DESCRIPTION
#### 7c6fd84331d9c12fb903ba57e7c8751f8c27372f
<pre>
Implement BFCache interoperability for WebTransport
<a href="https://bugs.webkit.org/show_bug.cgi?id=255973">https://bugs.webkit.org/show_bug.cgi?id=255973</a>
<a href="https://rdar.apple.com/108827020">rdar://108827020</a>

Reviewed by Matthew Finkel.

In <a href="https://github.com/w3c/webtransport/pull/503">https://github.com/w3c/webtransport/pull/503</a> we agreed it would be best
to clean up all the WebTransport objects when entering the b/f cache.
This implements that proposal.

Tests: Tools/TestWebKitAPI/NetworkConnection.h
       Tools/TestWebKitAPI/NetworkConnection.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
       Tools/TestWebKitAPI/WebTransportServer.mm

* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::WebTransport):
(WebCore::WebTransport::cleanupContext):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::createdWebTransport):
(WebCore::ScriptExecutionContext::suspendActiveDOMObjects):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Tools/TestWebKitAPI/NetworkConnection.h:
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::ConnectionGroup::markAsFailed):
(TestWebKitAPI::ConnectionGroup::awaitableFailure):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, BackForwardCache)):
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::WebTransportServer):

Canonical link: <a href="https://commits.webkit.org/303295@main">https://commits.webkit.org/303295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4728a79dabdab81881da04440da9c466a481bfb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139457 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f55af36c-0fe7-497c-9b44-4ae8a350b6b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100855 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92c706e0-ba86-4f01-99a9-08198c0d2151) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134890 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81646 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82676 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142102 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36868 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109227 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4187 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109397 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114445 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20515 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32842 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/3991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->