### PR TITLE
[git-webkit] Add `git-webkit pull-request --no-update-title` flag

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -125,6 +125,12 @@ class PullRequest(Command):
             action=arguments.NoAction,
         )
         parser.add_argument(
+            '--update-title', '--no-update-title',
+            dest='update_title', default=True,
+            help="When updating a pull request, update (or do not update) its title with the commits' common prefix.",
+            action=arguments.NoAction,
+        )
+        parser.add_argument(
             '--no-issue', '--no-bug',
             dest='update_issue', default=True,
             help='Disable automatic bug creation and updates',
@@ -686,7 +692,7 @@ class PullRequest(Command):
             log.info("Updating pull-request for '{}'...".format(repository.branch))
             pr = remote_repo.pull_requests.update(
                 pull_request=existing_pr,
-                title=cls.title_for(commits),
+                title=cls.title_for(commits) if args.update_title else existing_pr.title,
                 commits=commits,
                 base=branch_point.branch,
                 head=repository.branch,
@@ -699,6 +705,9 @@ class PullRequest(Command):
             print("Updated '{}'!".format(pr))
         else:
             log.info("Creating pull-request for '{}'...".format(repository.branch))
+            if not args.update_title:
+                sys.stderr.write("'--no-update-title' cannot be used when creating a new pull-request.\n")
+                return 1
             pr = remote_repo.pull_requests.create(
                 title=cls.title_for(commits),
                 commits=commits,


### PR DESCRIPTION
#### 287535cb5f154d3a826a36bb93404efad036d042
<pre>
[git-webkit] Add `git-webkit pull-request --no-update-title` flag
<a href="https://rdar.apple.com/165084590">rdar://165084590</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302825">https://bugs.webkit.org/show_bug.cgi?id=302825</a>

Reviewed by Jonathan Bedard.

Implement the --(no-)update-title option for the git-webkit pr command,
only supported when updating a pull request.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.parser):
(PullRequest.create_pull_request):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/303664@main">https://commits.webkit.org/303664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59fe4034cda7bedec1171debb5495364bd52c545

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139464 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43e17a8e-0f43-4381-bedc-e66428a43895) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68255 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69734cc0-5c96-4266-bed2-f39770ecb159) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118171 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81651 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e55c6bb-465b-4702-8274-1f84c6a41da5) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/131300 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/880 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82683 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142109 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109228 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/131379 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4194 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3590 "Found 1 new test failure: http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109398 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27799 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3116 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57334 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20619 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32848 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4126 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->