### PR TITLE
WebTransport should resolve the draining promise when the session is draining

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -470,6 +470,12 @@ void WebTransport::didFail(std::optional<unsigned>&& code, String&& message)
         cleanupWithSessionError();
 }
 
+void WebTransport::didDrain()
+{
+    m_state = State::Draining;
+    m_draining.second->resolve();
+}
+
 RefPtr<WebTransportSession> WebTransport::protectedSession()
 {
     return m_session;

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -111,6 +111,7 @@ private:
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
     void didFail(std::optional<unsigned>&&, String&&) final;
+    void didDrain() final;
 
     RefPtr<WebTransportSession> protectedSession();
 

--- a/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
@@ -47,6 +47,7 @@ public:
     virtual void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) = 0;
     virtual void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) = 0;
     virtual void didFail(std::optional<unsigned>&&, String&&) = 0;
+    virtual void didDrain() = 0;
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -79,6 +79,17 @@ void WorkerWebTransportSession::didFail(std::optional<unsigned>&& code, String&&
     });
 }
 
+void WorkerWebTransportSession::didDrain()
+{
+    ASSERT(RunLoop::isMain());
+    ScriptExecutionContext::postTaskTo(m_contextID, [weakClient = m_client] (auto&) mutable {
+        RefPtr client = weakClient.get();
+        if (!client)
+            return;
+        client->didDrain();
+    });
+}
+
 void WorkerWebTransportSession::receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier identifier)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -51,6 +51,7 @@ private:
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
     void didFail(std::optional<unsigned>&&, String&&) final;
+    void didDrain() final;
 
     Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final;
     Ref<WritableStreamPromise> createOutgoingUnidirectionalStream() final;

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -29,6 +29,8 @@ DECLARE_SYSTEM_HEADER
 
 #import <Network/Network.h>
 
+typedef void (^nw_webtransport_drain_handler_t)(void);
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <nw/private.h>
@@ -83,6 +85,8 @@ const char* nw_webtransport_metadata_get_session_error_message(nw_protocol_metad
 void nw_webtransport_metadata_set_session_error_message(nw_protocol_metadata_t, const char*);
 bool nw_webtransport_metadata_get_session_closed(nw_protocol_metadata_t);
 void nw_webtransport_options_set_allow_joining_before_ready(nw_protocol_options_t, bool);
+void nw_webtransport_metadata_set_remote_drain_handler(nw_protocol_metadata_t, nw_webtransport_drain_handler_t, dispatch_queue_t);
+void nw_webtransport_metadata_set_local_draining(nw_protocol_metadata_t);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -86,6 +86,7 @@ symbols = [
     "nw_webtransport_metadata_get_session_error_message",
     "nw_webtransport_metadata_set_session_error_message",
     "nw_webtransport_metadata_get_session_closed",
+    "nw_webtransport_metadata_set_remote_drain_handler",
     "nw_webtransport_options_add_connect_request_header",
     "nw_webtransport_options_set_allow_joining_before_ready",
     "nw_webtransport_options_set_is_datagram",

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
@@ -38,4 +38,7 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_options_
 // FIXME: Replace this soft linking with a HAVE macro once rdar://164514830 is available on all tested OS builds.
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_get_session_closed, bool, (nw_protocol_metadata_t metadata), (metadata))
 
+// FIXME: Replace this soft linking with a HAVE macro once rdar://164265337 is available on all tested OS builds.
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_set_remote_drain_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_drain_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
+
 #endif // HAVE(WEB_TRANSPORT)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
@@ -36,4 +36,6 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_options_
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_get_session_closed, bool, (nw_protocol_metadata_t metadata), (metadata))
 
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_set_remote_drain_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_drain_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
+
 #endif // HAVE(AVAUDIOAPPLICATION)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -288,8 +288,19 @@ void NetworkTransportSession::initialize(CompletionHandler<void(bool)>&& complet
         case nw_connection_group_state_waiting:
             return; // We will get another callback with another state change.
         case nw_connection_group_state_ready:
-            if (RefPtr protectedThis = weakThis.get())
+            if (RefPtr protectedThis = weakThis.get()) {
                 protectedThis->m_sessionMetadata = nw_connection_group_copy_protocol_metadata(protectedThis->m_connectionGroup.get(), adoptNS(nw_protocol_copy_webtransport_definition()).get());
+                if (RetainPtr metadata = protectedThis->m_sessionMetadata) {
+                    if (canLoad_Network_nw_webtransport_metadata_set_remote_drain_handler()) {
+                        softLink_Network_nw_webtransport_metadata_set_remote_drain_handler(metadata.get(), makeBlockPtr([weakThis = WeakPtr { *protectedThis }] () mutable {
+                            RefPtr protectedThis = weakThis.get();
+                            if (!protectedThis)
+                                return;
+                            protectedThis->send(Messages::WebTransportSession::DidDrain());
+                        }).get(), mainDispatchQueueSingleton());
+                    }
+                }
+            }
             return creationCompletionHandler(true);
         case nw_connection_group_state_failed:
             if (RefPtr protectedThis = weakThis.get()) {

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -126,6 +126,15 @@ void WebTransportSession::didFail(std::optional<unsigned>&& code, String&& messa
         ASSERT_NOT_REACHED();
 }
 
+void WebTransportSession::didDrain()
+{
+    ASSERT(RunLoop::isMain());
+    if (RefPtr strongClient = m_client.get())
+        strongClient->didDrain();
+    else
+        ASSERT_NOT_REACHED();
+}
+
 Ref<WebCore::WebTransportSendPromise> WebTransportSession::sendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier> identifier, std::span<const uint8_t> datagram)
 {
     return sendWithPromisedReply(Messages::NetworkTransportSession::SendDatagram(identifier, datagram))->whenSettled(RunLoop::mainSingleton(), [] (auto&& exception) {

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -72,6 +72,7 @@ public:
     void receiveBidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
     void didFail(std::optional<unsigned>&&, String&&);
+    void didDrain();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
@@ -30,4 +30,5 @@ messages -> WebTransportSession {
     ReceiveBidirectionalStream(WebCore::WebTransportStreamIdentifier identifier)
     StreamReceiveBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, std::optional<WebCore::Exception> exception)
     DidFail(std::optional<unsigned> code, String message)
+    DidDrain()
 }

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -79,6 +79,7 @@ public:
     ReceiveIncomingConnectionOperation receiveIncomingConnection() const;
     void cancel();
     Awaitable<void> awaitableFailure();
+    void drainWebTransportSession();
 
 private:
     friend class WebTransportServer;


### PR DESCRIPTION
#### 1b27bd0b835d0363a21f3b354485422f67fcf6df
<pre>
WebTransport should resolve the draining promise when the session is draining
<a href="https://bugs.webkit.org/show_bug.cgi?id=302762">https://bugs.webkit.org/show_bug.cgi?id=302762</a>
<a href="https://rdar.apple.com/161676172">rdar://161676172</a>

Reviewed by Alex Christensen.

This PR plumbs the session draining signal with didDrain message.

Tests: Tools/TestWebKitAPI/NetworkConnection.h
       Tools/TestWebKitAPI/NetworkConnection.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm

* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::didDrain):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransportSessionClient.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::didDrain):
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::initialize):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::didDrain):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKit/WebProcess/Network/WebTransportSession.messages.in:
* Tools/TestWebKitAPI/NetworkConnection.h:
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::ConnectionGroup::drainWebTransportSession):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, ServerDrain)):

Canonical link: <a href="https://commits.webkit.org/303311@main">https://commits.webkit.org/303311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aa16a428cdd119182ed264b43498ad71083dcd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139493 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100881 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134925 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81672 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142138 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4222 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109423 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3137 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114475 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57362 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20524 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4194 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67641 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->