### PR TITLE
[Site Isolation]

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -382,6 +382,7 @@ class Update;
 enum class PageshowEventPersistence : bool { NotPersisted, Persisted };
 
 enum class EventHandlerRemoval : bool { One, All };
+enum class EventHandlerRemovalReason : bool { RendererDetached, Other };
 using EventTargetSet = WeakHashCountedSet<Node, WeakPtrImplWithEventTargetData>;
 
 struct CachedSetInnerHTML {

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -155,6 +155,9 @@ public:
     bool hasValidQuerySelectorAllResults() const { return hasEventTargetFlag(EventTargetFlag::HasValidQuerySelectorAllResults); }
     void setHasValidQuerySelectorAllResults(bool flag) { setEventTargetFlag(EventTargetFlag::HasValidQuerySelectorAllResults, flag); }
 
+    bool hasInternalTouchEventHandling() const { return hasEventTargetFlag(EventTargetFlag::HasInternalTouchEventHandling); }
+    void setHasInternalTouchEventHandling(bool flag) { setEventTargetFlag(EventTargetFlag::HasInternalTouchEventHandling, flag); }
+
 protected:
     enum ConstructNodeTag { ConstructNode };
     EventTarget() = default;
@@ -183,7 +186,7 @@ protected:
         HasFormAssociatedCustomElementInterface = 1 << 11,
         HasShadowRootContainingSlots = 1 << 12,
         IsInTopLayer = 1 << 13,
-        // 1-bit free
+        HasInternalTouchEventHandling = 1 << 14,
         // SVGElement bits
         HasPendingResources = 1 << 15,
     };

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -320,6 +320,11 @@ void CheckboxInputType::disabledStateChanged()
         stopSwitchAnimation(SwitchAnimationType::Held);
         stopSwitchPointerTracking();
     }
+
+#if ENABLE(TOUCH_EVENTS)
+    if (isSwitch())
+        protectedElement()->updateTouchEventHandler();
+#endif
 }
 
 void CheckboxInputType::willUpdateCheckedness(bool, WasSetByJavaScript wasCheckedByJavaScript)

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -355,6 +355,10 @@ public:
 
     void initializeInputTypeAfterParsingOrCloning();
 
+#if ENABLE(TOUCH_EVENTS)
+    void updateTouchEventHandler();
+#endif
+
 private:
     enum class CreationType : uint8_t { Normal, ByParser, ByCloning };
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, CreationType);
@@ -446,10 +450,6 @@ private:
 
     void updateType(const AtomString& typeAttributeValue);
     void runPostTypeUpdateTasks();
-
-#if ENABLE(TOUCH_EVENTS)
-    void updateTouchEventHandler();
-#endif
 
     void subtreeHasChanged() final;
     void disabledStateChanged() final;

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -1175,8 +1175,10 @@ void InputType::createShadowSubtreeIfNeeded()
 bool InputType::hasTouchEventHandler() const
 {
 #if ENABLE(IOS_TOUCH_EVENTS)
-    if (isSwitch())
-        return true;
+    if (isSwitch()) {
+        ASSERT(element());
+        return !protectedElement()->isDisabledFormControl();
+    }
 #else
     if (isRangeControl())
         return true;

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -267,7 +267,13 @@ void RangeInputType::createShadowSubtree()
     container->appendChild(ContainerNode::ChildChange::Source::Parser, track);
 
     track->setUserAgentPart(UserAgentParts::webkitSliderRunnableTrack());
-    track->appendChild(ContainerNode::ChildChange::Source::Parser, SliderThumbElement::create(document));
+    Ref thumb = SliderThumbElement::create(document);
+    track->appendChild(ContainerNode::ChildChange::Source::Parser, thumb);
+
+#if ENABLE(IOS_TOUCH_EVENTS)
+    // Set up the initial enablement state for the thumb now that it has a parent.
+    thumb->hostDisabledStateChanged();
+#endif
 }
 
 HTMLElement* RangeInputType::sliderTrackElement() const

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -393,7 +393,7 @@ void SliderThumbElement::willDetachRenderers()
             frame->eventHandler().setCapturingMouseEventsElement(nullptr);
     }
 #if ENABLE(IOS_TOUCH_EVENTS)
-    unregisterForTouchEvents();
+    unregisterForTouchEvents(EventHandlerRemovalReason::RendererDetached);
 #endif
 }
 
@@ -493,7 +493,7 @@ void SliderThumbElement::handleTouchEndAndCancel(TouchEvent& touchEvent)
 
 void SliderThumbElement::didAttachRenderers()
 {
-    if (shouldAcceptTouchEvents())
+    if (!isDisabledFormControl())
         registerForTouchEvents();
 }
 
@@ -527,23 +527,18 @@ void SliderThumbElement::handleTouchEvent(TouchEvent& touchEvent)
     HTMLDivElement::defaultEventHandler(touchEvent);
 }
 
-bool SliderThumbElement::shouldAcceptTouchEvents()
-{
-    return renderer() && !isDisabledFormControl();
-}
-
 void SliderThumbElement::registerForTouchEvents()
 {
     if (m_isRegisteredAsTouchEventListener)
         return;
 
-    ASSERT(shouldAcceptTouchEvents());
+    ASSERT(!isDisabledFormControl());
 
     document().addTouchEventHandler(*this);
     m_isRegisteredAsTouchEventListener = true;
 }
 
-void SliderThumbElement::unregisterForTouchEvents()
+void SliderThumbElement::unregisterForTouchEvents(EventHandlerRemovalReason reason)
 {
     if (!m_isRegisteredAsTouchEventListener)
         return;
@@ -551,7 +546,7 @@ void SliderThumbElement::unregisterForTouchEvents()
     clearExclusiveTouchIdentifier();
     stopDragging();
 
-    document().removeTouchEventHandler(*this);
+    document().removeTouchEventHandler(*this, EventHandlerRemoval::One, reason);
     m_isRegisteredAsTouchEventListener = false;
 }
 
@@ -563,7 +558,7 @@ void SliderThumbElement::hostDisabledStateChanged()
         stopDragging();
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-    if (shouldAcceptTouchEvents())
+    if (!isDisabledFormControl())
         registerForTouchEvents();
     else
         unregisterForTouchEvents();

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -88,9 +88,8 @@ private:
     void handleTouchMove(TouchEvent&);
     void handleTouchEndAndCancel(TouchEvent&);
 
-    bool shouldAcceptTouchEvents();
     void registerForTouchEvents();
-    void unregisterForTouchEvents();
+    void unregisterForTouchEvents(EventHandlerRemovalReason = EventHandlerRemovalReason::Other);
 #endif
 
     bool m_inDragMode { false };

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -378,6 +378,13 @@ OptionSet<EventListenerRegionType> Adjuster::computeEventListenerRegionTypes(con
         findListeners(eventNames().gestureendEvent, EventListenerRegionType::GestureEnd, EventListenerRegionType::NonPassiveGestureEnd);
         findListeners(eventNames().gesturestartEvent, EventListenerRegionType::GestureStart, EventListenerRegionType::NonPassiveGestureStart);
     }
+
+    if (eventTarget.hasInternalTouchEventHandling()) {
+        types.add(EventListenerRegionType::NonPassiveTouchStart);
+        types.add(EventListenerRegionType::NonPassiveTouchEnd);
+        types.add(EventListenerRegionType::NonPassiveTouchCancel);
+        types.add(EventListenerRegionType::NonPassiveTouchMove);
+    }
 #endif
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -105,6 +105,7 @@ extern "C" {
     M(FrameTree) \
     M(Fullscreen) \
     M(Gamepad) \
+    M(GestureHandling) \
     M(IPC) \
     M(IPCMessages) \
     M(ITPDebug) \

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -35,7 +35,7 @@ class WebKit::WebEvent {
     WTF::UUID authorizationToken();
 };
 
-enum class WebKit::WebEventType : uint8_t {
+enum class WebKit::WebEventType : uint32_t {
     MouseDown,
     MouseUp,
     MouseMove,

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -46,7 +46,7 @@ namespace WebKit {
 class WebMouseEvent;
 class WebWheelEvent;
 class WebKeyboardEvent;
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 enum class WebMouseEventButton : int8_t;
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/Shared/WebEventType.h
+++ b/Source/WebKit/Shared/WebEventType.h
@@ -27,36 +27,36 @@
 
 namespace WebKit {
 
-enum class WebEventType : uint8_t {
+enum class WebEventType : uint32_t {
     // WebMouseEvent
-    MouseDown,
-    MouseUp,
-    MouseMove,
-    MouseForceChanged,
-    MouseForceDown,
-    MouseForceUp,
+    MouseDown           = 1 << 0,
+    MouseUp             = 1 << 1,
+    MouseMove           = 1 << 2,
+    MouseForceChanged   = 1 << 3,
+    MouseForceDown      = 1 << 4,
+    MouseForceUp        = 1 << 5,
 
     // WebWheelEvent
-    Wheel,
+    Wheel               = 1 << 6,
 
     // WebKeyboardEvent
-    KeyDown,
-    KeyUp,
-    RawKeyDown,
-    Char,
+    KeyDown             = 1 << 7,
+    KeyUp               = 1 << 8,
+    RawKeyDown          = 1 << 9,
+    Char                = 1 << 10,
 
 #if ENABLE(TOUCH_EVENTS)
     // WebTouchEvent
-    TouchStart,
-    TouchMove,
-    TouchEnd,
-    TouchCancel,
+    TouchStart          = 1 << 11,
+    TouchMove           = 1 << 12,
+    TouchEnd            = 1 << 13,
+    TouchCancel         = 1 << 14,
 #endif
 
 #if ENABLE(MAC_GESTURE_EVENTS)
-    GestureStart,
-    GestureChange,
-    GestureEnd,
+    GestureStart        = 1 << 15,
+    GestureChange       = 1 << 16,
+    GestureEnd          = 1 << 17
 #endif
 };
 

--- a/Source/WebKit/Shared/mac/WebGestureEvent.h
+++ b/Source/WebKit/Shared/mac/WebGestureEvent.h
@@ -56,7 +56,7 @@ public:
 
     float gestureScale() const { return m_gestureScale; }
     float gestureRotation() const { return m_gestureRotation; }
-    
+
 private:
     bool isGestureEventType(WebEventType) const;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -645,7 +645,7 @@ enum class UndoOrRedo : bool;
 enum class WasNavigationIntercepted : bool;
 enum class WebContentMode : uint8_t;
 enum class WebEventModifier : uint8_t;
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 enum class WindowKind : uint8_t;
 
 template<typename> class MonotonicObjectIdentifier;
@@ -1410,6 +1410,7 @@ public:
 #if ENABLE(MAC_GESTURE_EVENTS)
     void sendGestureEvent(WebCore::FrameIdentifier, const NativeWebGestureEvent&);
     void handleGestureEvent(const NativeWebGestureEvent&);
+    void processNextQueuedGestureEvent();
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -3164,6 +3165,9 @@ private:
 
     void mouseEventHandlingCompleted(std::optional<WebEventType>, bool handled, std::optional<WebCore::RemoteUserInputEventData>);
     void keyEventHandlingCompleted(std::optional<WebEventType>, bool handled);
+#if ENABLE(MAC_GESTURE_EVENTS)
+    void gestureEventHandlingCompleted(std::optional<WebEventType>, bool handled, std::optional<WebCore::RemoteUserInputEventData>);
+#endif
     void didReceiveEvent(IPC::Connection*, WebEventType, bool handled, std::optional<WebCore::RemoteUserInputEventData>&&);
     void didReceiveEventIPC(IPC::Connection&, WebEventType, bool handled, std::optional<WebCore::RemoteUserInputEventData>&&);
     void didUpdateRenderingAfterCommittingLoad();
@@ -3966,6 +3970,9 @@ private:
     size_t m_suspendMediaPlaybackCounter { 0 };
 
     size_t m_deferredMouseEvents { 0 };
+#if ENABLE(MAC_GESTURE_EVENTS)
+    size_t m_deferredGestureEvents { 0 };
+#endif
 
     bool m_lastNavigationWasAppInitiated { true };
     bool m_isRunningModalJavaScriptDialog { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -36,7 +36,7 @@ messages -> WebPageProxy {
     RunJavaScriptPrompt(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, String message, String defaultValue) -> (String result) Synchronous
     MouseDidMoveOverElement(struct WebKit::WebHitTestResultData hitTestResultData, OptionSet<WebKit::WebEventModifier> modifiers)
 
-    DidReceiveEventIPC(enum:uint8_t WebKit::WebEventType eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
+    DidReceiveEventIPC(enum:uint32_t WebKit::WebEventType eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
     SetCursor(WebCore::Cursor cursor)
     SetCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
     SetFocus(bool focused)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -357,6 +357,7 @@ public:
 
 #if ENABLE(MAC_GESTURE_EVENTS)
     Deque<NativeWebGestureEvent> gestureEventQueue;
+    unsigned droppedGestureEventCount { 0 };
 #endif
 
 #if ENABLE(META_VIEWPORT)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -82,7 +82,7 @@ struct DocumentEditingContext;
 struct PDFContextMenu;
 struct PDFContextMenuItem;
 
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 enum class WebMouseEventButton : int8_t;
 enum class WebEventModifier : uint8_t;
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -30,7 +30,7 @@ messages -> EventDispatcher {
     TouchEvent(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, WebKit::WebTouchEvent event) -> (bool handled, struct std::optional<WebKit::RemoteWebTouchEvent> transformedEvent) MainThreadCallback
 #endif
 #if ENABLE(MAC_GESTURE_EVENTS)
-    GestureEvent(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event) -> (enum:uint8_t std::optional<WebKit::WebEventType> eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) MainThreadCallback
+    GestureEvent(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event) -> (enum:uint32_t std::optional<WebKit::WebEventType> eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) MainThreadCallback
 #endif
 #if HAVE(DISPLAY_LINK)
     DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update, bool sendToMainThread)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -479,7 +479,7 @@ enum class TextInteractionSource : uint8_t;
 enum class TextRecognitionUpdateResult : uint8_t;
 enum class VisitedLinkTableIdentifierType;
 enum class WebEventModifier : uint8_t;
-enum class WebEventType : uint8_t;
+enum class WebEventType : uint32_t;
 
 struct ContentWorldData;
 struct ContentWorldIdentifierType;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -168,7 +168,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     DidBeginTouchPoint(WebCore::FloatPoint locationInRootView)
 #endif
 #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
-    TouchEvent(WebKit::WebTouchEvent event) -> (enum:uint8_t std::optional<WebKit::WebEventType> eventType, bool handled)
+    TouchEvent(WebKit::WebTouchEvent event) -> (enum:uint32_t std::optional<WebKit::WebEventType> eventType, bool handled)
 #endif
 
     CancelPointer(WebCore::PointerID pointerId, WebCore::IntPoint documentPoint)


### PR DESCRIPTION
#### 4a096c0f037d9c0391c705a88b4ab8b3b62713da
<pre>
[Site Isolation] Touch event regions are missing for elements which have touch handlers but no JS listeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=302689">https://bugs.webkit.org/show_bug.cgi?id=302689</a>
<a href="https://rdar.apple.com/164939029">rdar://164939029</a>

Reviewed by NOBODY (OOPS!).

Switch controls, slider thumb elements, and elements with unaccelerated overflow scrolling all
require synchronous touch event handling but do not have JS listeners. The lack of JS listeners
results in us failing to generate touch event regions for these elements.

Fix this issue by introducing a new EventTargetFlag `HasInternalTouchEventHandling` which
is set for these elements. In addition to targeting elements based on JS listeners in
`Adjuster::computeEventListenerRegionTypes`, we now look for the new EventTargetFlag as well.
If present, we add synchronous event listener region types NonPassiveTouchStart,
NonPassiveTouchMove, NonPassiveTouchEnd, &amp; NonPassiveTouchCancel.

In `SliderThumbElement` we no longer check if a renderer is present before registering for
touch events. Elements without a renderer will not get an event region in the first place.

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::disabledStateChanged):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::hasTouchEventHandler const):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::createShadowSubtree):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::willDetachRenderers):
(WebCore::SliderThumbElement::didAttachRenderers):
(WebCore::SliderThumbElement::registerForTouchEvents):
(WebCore::SliderThumbElement::unregisterForTouchEvents):
(WebCore::SliderThumbElement::hostDisabledStateChanged):
(WebCore::SliderThumbElement::shouldAcceptTouchEvents): Deleted.
* Source/WebCore/html/shadow/SliderThumbElement.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::computeEventListenerRegionTypes):
</pre>
----------------------------------------------------------------------
#### 27163e5114ae527074f0307fe3d6bbab4ea948fe
<pre>
[Site Isolation] [macOS] UI Process may crash during gesture event handling for cross-origin frames.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302439">https://bugs.webkit.org/show_bug.cgi?id=302439</a>
<a href="https://rdar.apple.com/164432967">rdar://164432967</a>

Reviewed by NOBODY (OOPS!).

Previously, a race condition could cause the UI process to crash when processing gesture
events due to a mismatch between the type passed to `WebPageProxy::didReceiveEvent` and
the event type of the first event in the gesture event queue. Resolve this issue by
waiting for the web process to handle each gesture event before sending the next one,
just like we do for mouse events.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.h:
* Source/WebKit/Shared/WebEventType.h:
* Source/WebKit/Shared/mac/WebGestureEvent.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::removeOldRedundantEvent):
(WebKit::WebPageProxy::handleMouseEvent):
(WebKit::WebPageProxy::processNextQueuedGestureEvent):
(WebKit::WebPageProxy::handleGestureEvent):
(WebKit::WebPageProxy::gestureEventHandlingCompleted):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a096c0f037d9c0391c705a88b4ab8b3b62713da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131961 "Failed to checkout and rebase branch from PR 54217") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/4453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42974 "Failed to checkout and rebase branch from PR 54217") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139474 "Failed to checkout and rebase branch from PR 54217") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133831 "Failed to checkout and rebase branch from PR 54217") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/4395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/4215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/139474 "Failed to checkout and rebase branch from PR 54217") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134907 "Failed to checkout and rebase branch from PR 54217") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/4395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/42974 "Failed to checkout and rebase branch from PR 54217") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/139474 "Failed to checkout and rebase branch from PR 54217") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/4395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/42974 "Failed to checkout and rebase branch from PR 54217") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82693 "Failed to checkout and rebase branch from PR 54217") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/4395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/42974 "Failed to checkout and rebase branch from PR 54217") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142119 "Failed to checkout and rebase branch from PR 54217") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/42974 "Failed to checkout and rebase branch from PR 54217") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/142119 "Failed to checkout and rebase branch from PR 54217") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/4204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/4215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/142119 "Failed to checkout and rebase branch from PR 54217") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/42974 "Failed to checkout and rebase branch from PR 54217") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/4176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/42974 "Failed to checkout and rebase branch from PR 54217") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/4008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/4136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->