### PR TITLE
[WKCI] filter-test-logs can cause that buildbot ends killing an in-progress step because of no output for more than X seconds

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -25,6 +25,27 @@ import os
 import argparse
 import sys
 import re
+import time
+
+# This prints the progress every interval_seconds to avoid that the step gets killed
+# by buildbot because "command timed out: XXX seconds without output running YYY"
+class KeepAliveStdoutProgress:
+
+    def __init__(self, interval_seconds=300, check_every_n_lines=100):
+        self.line_count = 0
+        self.last_progress_time = time.time()
+        self.interval_seconds = interval_seconds
+        self.check_every_n_lines = check_every_n_lines
+
+    def maybe_update_progress(self):
+        self.line_count += 1
+        # Only check time every N lines to avoid expensive system calls
+        if self.line_count % self.check_every_n_lines == 0:
+            current_time = time.time()
+            if current_time - self.last_progress_time >= self.interval_seconds:
+                print(f'filter-test-logs progress: {self.line_count} lines processed', flush=True)
+                self.last_progress_time = current_time
+
 
 def parser():
     parser = argparse.ArgumentParser(description='filter test output')
@@ -44,6 +65,7 @@ def parser():
 
 def filter_jsc_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
+    keep_alive_stdout = KeepAliveStdoutProgress()
     with open(log_file, 'w') as f:
         print_all_lines = False
         for line in sys.stdin:
@@ -53,10 +75,13 @@ def filter_jsc_tests(log_file_name):
             elif line.startswith('** The following JSC') or line.startswith('Results'):
                 print_all_lines = True
                 print(line, end='')
+            else:
+                keep_alive_stdout.maybe_update_progress()
 
 
 def filter_layout_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
+    keep_alive_stdout = KeepAliveStdoutProgress()
     with open(log_file, 'w') as f:
         print_all_lines = False
         for line in sys.stdin:
@@ -68,61 +93,73 @@ def filter_layout_tests(log_file_name):
             elif line.startswith('=> Results') or 'Exiting early' in line or 'leaks found' in line:
                 print_all_lines = True
                 print(line, end='')
+            else:
+                keep_alive_stdout.maybe_update_progress()
 
 
 def filter_scan_build(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
+    keep_alive_stdout = KeepAliveStdoutProgress()
     with open(log_file, 'w') as f:
         print_all_lines = False
         for line in sys.stdin:
             f.write(line)
-            if line.startswith('====='):
-                print(line, end='')
-            if print_all_lines:
+            if line.startswith('=====') or print_all_lines:
                 print(line, end='')
             # A success or failure is always preceeded by **
-            if line.startswith('**'):
+            elif line.startswith('**'):
                 print_all_lines = True
                 print(line, end='')
+            else:
+                keep_alive_stdout.maybe_update_progress()
 
 
 def filter_webdriver_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
+    keep_alive_stdout = KeepAliveStdoutProgress()
     with open(log_file, 'w') as f:
         print_all_lines = False
         for line in sys.stdin:
             f.write(line)
             if print_all_lines:
                 print(line, end='')
-            if 'tests ran as expected' in line:
+            elif 'tests ran as expected' in line:
                 print_all_lines = True
                 print(line, end='')
+            else:
+                keep_alive_stdout.maybe_update_progress()
 
 
 def filter_test262(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
+    keep_alive_stdout = KeepAliveStdoutProgress()
     with open(log_file, 'w') as f:
         print_all_lines = False
         for line in sys.stdin:
             f.write(line)
             if print_all_lines or line.startswith('! NEW FAIL'):
                 print(line, end='')
-            if 'TESTS SUMMARY---' in line:
+            elif 'TESTS SUMMARY---' in line:
                 print_all_lines = True
                 print(line, end='')
+            else:
+                keep_alive_stdout.maybe_update_progress()
 
 
 def filter_minibrowser_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
+    keep_alive_stdout = KeepAliveStdoutProgress()
     with open(log_file, 'w') as f:
         print_all_lines = False
         for line in sys.stdin:
             f.write(line)
             if print_all_lines:
                 print(line, end='')
-            if 'Bundle passed tests on all this' in line:
+            elif 'Bundle passed tests on all this' in line:
                 print_all_lines = True
                 print(line, end='')
+            else:
+                keep_alive_stdout.maybe_update_progress()
 
 
 def main():


### PR DESCRIPTION
#### 4f8fc62a1b483c3d3e48caaac0face5733e6f436
<pre>
[WKCI] filter-test-logs can cause that buildbot ends killing an in-progress step because of no output for more than X seconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=302827">https://bugs.webkit.org/show_bug.cgi?id=302827</a>

Reviewed by Nikolas Zimmermann.

The python script filter-test-logs used to send the logs directly to S3
instead of letting buildbot process them can cause that a step times out
because of &quot;command timed out: XXX seconds without output running YYY&quot;
when that step was actually working and printing things to stdout.

This patch modifies filter-test-logs to print a status update to stdout
each 5 minutes with the number of lines processed/filtered, in order to
avoid the buildbot no-output timeout.

* Tools/Scripts/filter-test-logs:
(KeepAliveStdoutProgress):
(KeepAliveStdoutProgress.__init__):
(KeepAliveStdoutProgress.maybe_update_progress):
(filter_jsc_tests):
(filter_layout_tests):
(filter_scan_build):
(filter_webdriver_tests):
(filter_test262):
(filter_minibrowser_tests):

Canonical link: <a href="https://commits.webkit.org/303319@main">https://commits.webkit.org/303319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e272a52cc6c62adddb5d80265aaaed21c4d74233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100869 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3023 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82696 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4126 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109241 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4207 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3596 "Found 3 new test failures: http/tests/webgpu/webgpu/api/operation/sampling/sampler_texture.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109411 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3121 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57347 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20526 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4179 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4011 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->