### PR TITLE
[Site Isolation] Touch event regions are missing for elements which have touch handlers but no JS listeners

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -386,6 +386,7 @@ class Update;
 enum class PageshowEventPersistence : bool { NotPersisted, Persisted };
 
 enum class EventHandlerRemoval : bool { One, All };
+enum class EventHandlerRemovalReason : bool { RendererDetached, Other };
 using EventTargetSet = WeakHashCountedSet<Node, WeakPtrImplWithEventTargetData>;
 
 struct CachedSetInnerHTML {

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -155,6 +155,9 @@ public:
     bool hasValidQuerySelectorAllResults() const { return hasEventTargetFlag(EventTargetFlag::HasValidQuerySelectorAllResults); }
     void setHasValidQuerySelectorAllResults(bool flag) { setEventTargetFlag(EventTargetFlag::HasValidQuerySelectorAllResults, flag); }
 
+    bool hasInternalTouchEventHandling() const { return hasEventTargetFlag(EventTargetFlag::HasInternalTouchEventHandling); }
+    void setHasInternalTouchEventHandling(bool flag) { setEventTargetFlag(EventTargetFlag::HasInternalTouchEventHandling, flag); }
+
 protected:
     enum ConstructNodeTag { ConstructNode };
     EventTarget() = default;
@@ -183,7 +186,7 @@ protected:
         HasFormAssociatedCustomElementInterface = 1 << 11,
         HasShadowRootContainingSlots = 1 << 12,
         IsInTopLayer = 1 << 13,
-        // 1-bit free
+        HasInternalTouchEventHandling = 1 << 14,
         // SVGElement bits
         HasPendingResources = 1 << 15,
     };

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -41,6 +41,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "HTMLDivElement.h"
 #include "HTMLInputElement.h"
+#include "HTMLInputElementInlines.h"
 #include "InputTypeNames.h"
 #include "KeyboardEvent.h"
 #include "LayoutPoint.h"
@@ -320,6 +321,11 @@ void CheckboxInputType::disabledStateChanged()
         stopSwitchAnimation(SwitchAnimationType::Held);
         stopSwitchPointerTracking();
     }
+
+#if ENABLE(TOUCH_EVENTS)
+    if (isSwitch())
+        protectedElement()->updateTouchEventHandler();
+#endif
 }
 
 void CheckboxInputType::willUpdateCheckedness(bool, WasSetByJavaScript wasCheckedByJavaScript)

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -55,6 +55,7 @@
 #include "HTMLDataListElement.h"
 #include "HTMLFormElement.h"
 #include "HTMLImageLoader.h"
+#include "HTMLInputElementInlines.h"
 #include "HTMLOptionElement.h"
 #include "HTMLParserIdioms.h"
 #include "IdTargetObserver.h"
@@ -634,29 +635,6 @@ inline void HTMLInputElement::runPostTypeUpdateTasks()
 
     addToRadioButtonGroup();
 }
-
-#if ENABLE(TOUCH_EVENTS)
-inline void HTMLInputElement::updateTouchEventHandler()
-{
-    bool hasTouchEventHandler = m_inputType->hasTouchEventHandler();
-    if (hasTouchEventHandler != m_hasTouchEventHandler) {
-        if (hasTouchEventHandler) {
-#if ENABLE(IOS_TOUCH_EVENTS)
-            document().addTouchEventHandler(*this);
-#else
-            document().didAddTouchEventHandler(*this);
-#endif
-        } else {
-#if ENABLE(IOS_TOUCH_EVENTS)
-            document().removeTouchEventHandler(*this);
-#else
-            document().didRemoveTouchEventHandler(*this);
-#endif
-        }
-        m_hasTouchEventHandler = hasTouchEventHandler;
-    }
-}
-#endif
 
 void HTMLInputElement::subtreeHasChanged()
 {

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -355,6 +355,10 @@ public:
 
     void initializeInputTypeAfterParsingOrCloning();
 
+#if ENABLE(TOUCH_EVENTS)
+    void updateTouchEventHandler();
+#endif
+
 private:
     enum class CreationType : uint8_t { Normal, ByParser, ByCloning };
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, CreationType);
@@ -446,10 +450,6 @@ private:
 
     void updateType(const AtomString& typeAttributeValue);
     void runPostTypeUpdateTasks();
-
-#if ENABLE(TOUCH_EVENTS)
-    void updateTouchEventHandler();
-#endif
 
     void subtreeHasChanged() final;
     void disabledStateChanged() final;

--- a/Source/WebCore/html/HTMLInputElementInlines.h
+++ b/Source/WebCore/html/HTMLInputElementInlines.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Document.h"
+#include "HTMLInputElement.h"
+#include "InputType.h"
+
+namespace WebCore {
+
+#if ENABLE(TOUCH_EVENTS)
+inline void HTMLInputElement::updateTouchEventHandler()
+{
+    bool hasTouchEventHandler = m_inputType->hasTouchEventHandler();
+    if (hasTouchEventHandler != m_hasTouchEventHandler) {
+        if (hasTouchEventHandler) {
+#if ENABLE(IOS_TOUCH_EVENTS)
+            document().addTouchEventHandler(*this);
+#else
+            document().didAddTouchEventHandler(*this);
+#endif
+        } else {
+#if ENABLE(IOS_TOUCH_EVENTS)
+            document().removeTouchEventHandler(*this);
+#else
+            document().didRemoveTouchEventHandler(*this);
+#endif
+        }
+        m_hasTouchEventHandler = hasTouchEventHandler;
+    }
+}
+#endif
+
+}

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -1175,8 +1175,10 @@ void InputType::createShadowSubtreeIfNeeded()
 bool InputType::hasTouchEventHandler() const
 {
 #if ENABLE(IOS_TOUCH_EVENTS)
-    if (isSwitch())
-        return true;
+    if (isSwitch()) {
+        ASSERT(element());
+        return !protectedElement()->isDisabledFormControl();
+    }
 #else
     if (isRangeControl())
         return true;

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -267,7 +267,13 @@ void RangeInputType::createShadowSubtree()
     container->appendChild(ContainerNode::ChildChange::Source::Parser, track);
 
     track->setUserAgentPart(UserAgentParts::webkitSliderRunnableTrack());
-    track->appendChild(ContainerNode::ChildChange::Source::Parser, SliderThumbElement::create(document));
+    Ref thumb = SliderThumbElement::create(document);
+    track->appendChild(ContainerNode::ChildChange::Source::Parser, thumb);
+
+#if ENABLE(IOS_TOUCH_EVENTS)
+    // Set up the initial enablement state for the thumb now that it has a parent.
+    thumb->hostDisabledStateChanged();
+#endif
 }
 
 HTMLElement* RangeInputType::sliderTrackElement() const

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -393,7 +393,7 @@ void SliderThumbElement::willDetachRenderers()
             frame->eventHandler().setCapturingMouseEventsElement(nullptr);
     }
 #if ENABLE(IOS_TOUCH_EVENTS)
-    unregisterForTouchEvents();
+    unregisterForTouchEvents(EventHandlerRemovalReason::RendererDetached);
 #endif
 }
 
@@ -493,7 +493,7 @@ void SliderThumbElement::handleTouchEndAndCancel(TouchEvent& touchEvent)
 
 void SliderThumbElement::didAttachRenderers()
 {
-    if (shouldAcceptTouchEvents())
+    if (!isDisabledFormControl())
         registerForTouchEvents();
 }
 
@@ -527,23 +527,18 @@ void SliderThumbElement::handleTouchEvent(TouchEvent& touchEvent)
     HTMLDivElement::defaultEventHandler(touchEvent);
 }
 
-bool SliderThumbElement::shouldAcceptTouchEvents()
-{
-    return renderer() && !isDisabledFormControl();
-}
-
 void SliderThumbElement::registerForTouchEvents()
 {
     if (m_isRegisteredAsTouchEventListener)
         return;
 
-    ASSERT(shouldAcceptTouchEvents());
+    ASSERT(!isDisabledFormControl());
 
     document().addTouchEventHandler(*this);
     m_isRegisteredAsTouchEventListener = true;
 }
 
-void SliderThumbElement::unregisterForTouchEvents()
+void SliderThumbElement::unregisterForTouchEvents(EventHandlerRemovalReason reason)
 {
     if (!m_isRegisteredAsTouchEventListener)
         return;
@@ -551,7 +546,7 @@ void SliderThumbElement::unregisterForTouchEvents()
     clearExclusiveTouchIdentifier();
     stopDragging();
 
-    document().removeTouchEventHandler(*this);
+    document().removeTouchEventHandler(*this, EventHandlerRemoval::One, reason);
     m_isRegisteredAsTouchEventListener = false;
 }
 
@@ -563,7 +558,7 @@ void SliderThumbElement::hostDisabledStateChanged()
         stopDragging();
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-    if (shouldAcceptTouchEvents())
+    if (!isDisabledFormControl())
         registerForTouchEvents();
     else
         unregisterForTouchEvents();

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -88,9 +88,8 @@ private:
     void handleTouchMove(TouchEvent&);
     void handleTouchEndAndCancel(TouchEvent&);
 
-    bool shouldAcceptTouchEvents();
     void registerForTouchEvents();
-    void unregisterForTouchEvents();
+    void unregisterForTouchEvents(EventHandlerRemovalReason = EventHandlerRemovalReason::Other);
 #endif
 
     bool m_inDragMode { false };

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -378,6 +378,17 @@ OptionSet<EventListenerRegionType> Adjuster::computeEventListenerRegionTypes(con
         findListeners(eventNames().gestureendEvent, EventListenerRegionType::GestureEnd, EventListenerRegionType::NonPassiveGestureEnd);
         findListeners(eventNames().gesturestartEvent, EventListenerRegionType::GestureStart, EventListenerRegionType::NonPassiveGestureStart);
     }
+
+    if (eventTarget.hasInternalTouchEventHandling()) {
+        types.add(EventListenerRegionType::TouchCancel);
+        types.add(EventListenerRegionType::TouchEnd);
+        types.add(EventListenerRegionType::TouchMove);
+        types.add(EventListenerRegionType::TouchStart);
+        types.add(EventListenerRegionType::NonPassiveTouchCancel);
+        types.add(EventListenerRegionType::NonPassiveTouchEnd);
+        types.add(EventListenerRegionType::NonPassiveTouchMove);
+        types.add(EventListenerRegionType::NonPassiveTouchStart);
+    }
 #endif
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)


### PR DESCRIPTION
#### dd0cc81543c22772b348b5d827c8f256437f1ca7
<pre>
[Site Isolation] Touch event regions are missing for elements which have touch handlers but no JS listeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=302689">https://bugs.webkit.org/show_bug.cgi?id=302689</a>
<a href="https://rdar.apple.com/164939029">rdar://164939029</a>

Reviewed by Abrar Rahman Protyasha.

Switch controls, slider thumb elements, and elements with unaccelerated overflow scrolling all
require synchronous touch event handling but do not have JS listeners. The lack of JS listeners
results in us failing to generate touch event regions for these elements.

Fix this issue by introducing a new EventTargetFlag `HasInternalTouchEventHandling` which
is set for these elements. In addition to targeting elements based on JS listeners in
`Adjuster::computeEventListenerRegionTypes`, we now look for the new EventTargetFlag as well.
If present, we add synchronous event listener region types NonPassiveTouchStart,
NonPassiveTouchMove, NonPassiveTouchEnd, &amp; NonPassiveTouchCancel.

In `SliderThumbElement` we no longer check if a renderer is present before registering for
touch events. Elements without a renderer will not get an event region in the first place.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::disabledStateChanged):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateTouchEventHandler): Deleted.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLInputElementInlines.h: Added.
(WebCore::HTMLInputElement::updateTouchEventHandler):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::hasTouchEventHandler const):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::createShadowSubtree):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::willDetachRenderers):
(WebCore::SliderThumbElement::didAttachRenderers):
(WebCore::SliderThumbElement::registerForTouchEvents):
(WebCore::SliderThumbElement::unregisterForTouchEvents):
(WebCore::SliderThumbElement::hostDisabledStateChanged):
(WebCore::SliderThumbElement::shouldAcceptTouchEvents): Deleted.
* Source/WebCore/html/shadow/SliderThumbElement.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::computeEventListenerRegionTypes):

Canonical link: <a href="https://commits.webkit.org/303558@main">https://commits.webkit.org/303558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/667d8595d952e85059ac8d6b3caa9864377bd19a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132711 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84738 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57f2e9be-f0d2-4115-aeb5-62955c355bd2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68758 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76fcd820-6135-482b-bee1-dbad1fc1edd5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135657 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82254 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af7195e4-6d83-4199-aaee-1cc10f0cde0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3798 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1466 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83474 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142900 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4876 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109841 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110018 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3721 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115172 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58358 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20589 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4930 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33519 "Found 1 new test failure: fast/mediastream/granted-denied-request-management1.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68381 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->