### PR TITLE
Empty track elements can prevent media from loading & playing

### DIFF
--- a/LayoutTests/media/track/track-with-no-src-loading-expected.txt
+++ b/LayoutTests/media/track/track-with-no-src-loading-expected.txt
@@ -1,0 +1,5 @@
+
+EVENT(error)
+EXPECTED (document.querySelector('track').readyState == '3') OK
+END OF TEST
+

--- a/LayoutTests/media/track/track-with-no-src-loading.html
+++ b/LayoutTests/media/track/track-with-no-src-loading.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>track-with-no-src-loading</title>
+    <script src=../video-test.js></script>
+    <script>
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+
+    async function runTest() {
+        let trackElement = document.querySelector('track');
+        trackElement.track.mode = 'showing';
+
+        await waitForEventWithTimeout(trackElement, 'error', 1000, 'Failed to fire "error" event');
+        testExpected("document.querySelector('track').readyState", HTMLTrackElement.ERROR);
+    }
+    </script>
+</head>
+<body>
+    <video>
+        <track kind="captions">
+    </video>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -180,11 +180,6 @@ void HTMLTrackElement::scheduleLoad()
 
         SetForScope loadPending { track.m_loadPending, true, false };
 
-        if (!track.hasAttributeWithoutSynchronization(srcAttr)) {
-            track.track().removeAllCues();
-            return;
-        }
-
         // 6. Set the text track readiness state to loading.
         track.setReadyState(HTMLTrackElement::LOADING);
 


### PR DESCRIPTION
#### 16667e0251b6b7ed43163f936641ccb15d34cc9f
<pre>
Empty track elements can prevent media from loading &amp; playing
<a href="https://rdar.apple.com/164125914">rdar://164125914</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302828">https://bugs.webkit.org/show_bug.cgi?id=302828</a>

Reviewed by Jean-Yves Avenard.

The HTML standard requires HTMLTrackElements with an empty trackURL to
generate an &quot;error&quot; event and move to the &quot;ERROR&quot; readyState/readiness
state. However, WebCore is returning early from the resource selection
algorithm when a HTMLTrackElement does not have a src attribute, which
causes the readyState to get stuck at Loading. Additionally, the media
element containing the track cannot progress its own readyState beyond
HAVE_CURRENT_DATA, which blocks play() commands from completing.

Remove the early return from HTMLTrackElement::scheduleLoad().

Test: media/track/track-with-no-src-loading.html

* LayoutTests/media/track/track-with-no-src-loading-expected.txt: Added.
* LayoutTests/media/track/track-with-no-src-loading.html: Added.
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::scheduleLoad):

Canonical link: <a href="https://commits.webkit.org/303314@main">https://commits.webkit.org/303314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1982ed2c6c298e696b539b4ed1435ef5db6f775b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139479 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100870 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/18cd45cc-3bfd-47a1-bb31-d57bf58253fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134912 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81661 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3022 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82698 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142124 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109242 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4209 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3598 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27719 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3124 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57349 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4181 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32891 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->