### PR TITLE
CommandLineAPIHost should use WeakPtr for InstrumentingAgents.

### DIFF
--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -74,7 +74,10 @@ CommandLineAPIHost::CommandLineAPIHost()
 {
 }
 
-CommandLineAPIHost::~CommandLineAPIHost() = default;
+CommandLineAPIHost::~CommandLineAPIHost()
+{
+    RELEASE_ASSERT(!m_instrumentingAgents);
+}
 
 void CommandLineAPIHost::disconnect()
 {

--- a/Source/WebCore/inspector/CommandLineAPIHost.h
+++ b/Source/WebCore/inspector/CommandLineAPIHost.h
@@ -58,9 +58,9 @@ public:
     static Ref<CommandLineAPIHost> create();
     ~CommandLineAPIHost();
 
-    void init(RefPtr<InstrumentingAgents> instrumentingAgents)
+    void init(InstrumentingAgents& instrumentingAgents)
     {
-        m_instrumentingAgents = instrumentingAgents;
+        m_instrumentingAgents = &instrumentingAgents;
     }
 
     void disconnect();
@@ -99,7 +99,7 @@ public:
 private:
     CommandLineAPIHost();
 
-    RefPtr<InstrumentingAgents> m_instrumentingAgents;
+    WeakPtr<InstrumentingAgents> m_instrumentingAgents;
     std::unique_ptr<InspectableObject> m_inspectedObject; // $0
     Inspector::PerGlobalObjectWrapperWorld m_wrappers;
 };

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -110,7 +110,7 @@ void FrameInspectorController::createLazyAgents()
 
     m_injectedScriptManager->connect();
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.copyRef());
+        commandLineAPIHost->init(m_instrumentingAgents.get());
 }
 
 void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& frontendChannel, bool isAutomaticInspection, bool immediatelyPause)

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -197,7 +197,7 @@ void PageInspectorController::createLazyAgents()
     m_agents.append(makeUniqueRef<InspectorAnimationAgent>(pageContext));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.copyRef());
+        commandLineAPIHost->init(m_instrumentingAgents.get());
 }
 
 void PageInspectorController::inspectedPageDestroyed()

--- a/Source/WebCore/inspector/WebInjectedScriptManager.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.cpp
@@ -43,6 +43,12 @@ WebInjectedScriptManager::WebInjectedScriptManager(InspectorEnvironment& environ
 {
 }
 
+WebInjectedScriptManager::~WebInjectedScriptManager()
+{
+    if (isConnected())
+        disconnect();
+}
+
 void WebInjectedScriptManager::connect()
 {
     InjectedScriptManager::connect();

--- a/Source/WebCore/inspector/WebInjectedScriptManager.h
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.h
@@ -39,7 +39,7 @@ class WebInjectedScriptManager final : public Inspector::InjectedScriptManager {
     WTF_MAKE_TZONE_ALLOCATED(WebInjectedScriptManager);
 public:
     WebInjectedScriptManager(Inspector::InspectorEnvironment&, Ref<Inspector::InjectedScriptHost>&&);
-    ~WebInjectedScriptManager() override = default;
+    ~WebInjectedScriptManager() override;
 
     const RefPtr<CommandLineAPIHost>& commandLineAPIHost() const { return m_commandLineAPIHost; }
 
@@ -50,6 +50,7 @@ public:
     void discardInjectedScriptsFor(LocalDOMWindow&);
 
 private:
+    bool isConnected() const { return m_commandLineAPIHost; }
     void didCreateInjectedScript(const Inspector::InjectedScript&) override;
 
     RefPtr<CommandLineAPIHost> m_commandLineAPIHost;

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -249,7 +249,7 @@ void WorkerInspectorController::createLazyAgents()
     m_agents.append(WTFMove(scriptProfilerAgent));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.copyRef());
+        commandLineAPIHost->init(m_instrumentingAgents.get());
 }
 
 WorkerDebuggerAgent& WorkerInspectorController::ensureDebuggerAgent()


### PR DESCRIPTION
#### d3c4861d70b136272b26f7fea2573dbb3f2b1736
<pre>
CommandLineAPIHost should use WeakPtr for InstrumentingAgents.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302829">https://bugs.webkit.org/show_bug.cgi?id=302829</a>
<a href="https://rdar.apple.com/165462131">rdar://165462131</a>

Reviewed by BJ Burg.

CommandLineAPIHost is a garbage-collected object. Using RefPtr to hold InstrumentingAgents
could incorrectly extend its lifetime, as the timing of CommandLineAPIHost&apos;s destruction is
controlled by the garbage collector.

Changed m_instrumentingAgents from RefPtr to WeakPtr. In normal cases, disconnect() is called
before destruction and sets m_instrumentingAgents to nullptr, so this issue shouldn&apos;t occur.

The RELEASE_ASSERT in the destructor verifies this invariant.

To ensure the invariant always holds, WebInjectedScriptManager now calls disconnect() in its
destructor if it is still connected. This prevents the RELEASE_ASSERT from firing in edge cases
where inspector controllers are destroyed without their cleanup methods being called. The
isConnected() helper method provides a clear state check without relying on implementation
details of the parent class or on disconnect() being idempotent across future changes.

* Source/WebCore/inspector/CommandLineAPIHost.cpp:
(WebCore::CommandLineAPIHost::~CommandLineAPIHost):
* Source/WebCore/inspector/CommandLineAPIHost.h:
(WebCore::CommandLineAPIHost::init):
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::createLazyAgents):
(WebCore::FrameInspectorController::disconnectFrontend):
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::createLazyAgents):
(WebCore::PageInspectorController::disconnectFrontend):
* Source/WebCore/inspector/WebInjectedScriptManager.cpp:
(WebCore::WebInjectedScriptManager::~WebInjectedScriptManager):
* Source/WebCore/inspector/WebInjectedScriptManager.h:
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::createLazyAgents):

Canonical link: <a href="https://commits.webkit.org/304055@main">https://commits.webkit.org/304055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/225f8f1f22ccfdd63d8193850e06630a7ab6e37f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86387 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e68bbd0-c601-4a45-8dd8-e168276b9a6d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102728 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83519 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2685 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144624 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111134 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111404 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4897 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60326 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6596 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34923 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6656 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->