### PR TITLE
[JSC] Fold `new Uint8Array(new ArrayBuffer(length)).length` to `length`

### DIFF
--- a/JSTests/stress/bound-check-removal-typed-array-byte-length.js
+++ b/JSTests/stress/bound-check-removal-typed-array-byte-length.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(size) {
+    let result = 0;
+    let ab = new ArrayBuffer(size);
+    let view = new Uint8Array(ab);
+    for (let i = 0; i < size; ++i) {
+        view[i] = i;
+        result += i;
+    }
+    return result;
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(test(128), 8128);

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -398,6 +398,32 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         return Exits;
     }
 
+    case PutByVal: {
+        if (graph.m_form != SSA)
+            return Exits;
+
+        ArrayMode arrayMode = node->arrayMode().modeForPut();
+        if (!arrayMode.isInBounds())
+            return Exits;
+
+        switch (arrayMode.type()) {
+        case Array::Int8Array:
+        case Array::Int16Array:
+        case Array::Int32Array:
+        case Array::Uint8Array:
+        case Array::Uint8ClampedArray:
+        case Array::Uint16Array:
+        case Array::Uint32Array:
+        case Array::Float16Array:
+        case Array::Float32Array:
+        case Array::Float64Array:
+            break;
+        default:
+            return Exits;
+        }
+        break;
+    }
+
     default:
         // If in doubt, return true.
         return Exits;


### PR DESCRIPTION
#### 5659b3ed4152aa7821288fdea285e3adfd1e0ae2
<pre>
[JSC] Fold `new Uint8Array(new ArrayBuffer(length)).length` to `length`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302832">https://bugs.webkit.org/show_bug.cgi?id=302832</a>
<a href="https://rdar.apple.com/165095809">rdar://165095809</a>

Reviewed by Justin Michaud.

We found that this is particularly common since Uint8Array is byte view
to the underlying ArrayBuffer. This patch introduces the above folding
so that we can make GetUndetachedTypeArrayLength non-opaque to the loop
when it is using `length` directly for the loop condition instead of
`view.length`. We also make it more precise about MayExit for PutByVal
with TypedArray in FTL. Since bound-check is already separate, if it is
typed array, then it does not exit within the node.

* JSTests/stress/bound-check-removal-typed-array-byte-length.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/303351@main">https://commits.webkit.org/303351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae05a14ebf98509276863ffb7ba4080e3b9364e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83884 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/220bce1c-1585-43a1-af84-92e5b7a79589) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100887 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/875a144e-161d-4ec8-b754-79fcfb64c030) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81678 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c753a878-dded-493c-ae62-476164742746) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82716 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124047 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111865 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142143 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130491 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109258 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109429 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3133 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57367 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20537 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4199 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163458 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4031 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67646 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42499 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4159 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->