### PR TITLE
Move WTF::Locker specializations to Locker.h

### DIFF
--- a/Source/WTF/wtf/Locker.h
+++ b/Source/WTF/wtf/Locker.h
@@ -38,6 +38,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/Compiler.h>
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/ThreadSafetyAnalysis.h>
 #include <wtf/ThreadSanitizerSupport.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -45,6 +46,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 namespace WTF {
 
 enum NoLockingNecessaryTag { NoLockingNecessary };
+
+class WTF_CAPABILITY_LOCK WordLock;
+class WTF_CAPABILITY_LOCK UnfairLock;
 
 class AbstractLocker {
     WTF_MAKE_NONCOPYABLE(AbstractLocker);
@@ -59,11 +63,86 @@ protected:
     }
 };
 
+template<typename T> class Locker;
 template<typename T> class DropLockForScope;
 
 using AdoptLockTag = std::adopt_lock_t;
 constexpr AdoptLockTag AdoptLock;
 
+// Locker specialization to use with Lock, WordLock, and UnfairLock that integrates with thread safety analysis.
+// Non-movable simple scoped lock holder.
+// Example: Locker locker { m_lock };
+template<typename T>
+#if ENABLE(UNFAIR_LOCK)
+    requires (std::same_as<T, Lock> || std::same_as<T, WordLock> || std::same_as<T, UnfairLock>)
+#else
+    requires (std::same_as<T, Lock> || std::same_as<T, WordLock>)
+#endif
+class WTF_CAPABILITY_SCOPED_LOCK Locker<T> : public AbstractLocker {
+public:
+    explicit Locker(T& lock) WTF_ACQUIRES_LOCK(lock)
+        : m_lock(lock)
+        , m_isLocked(true)
+    {
+        m_lock.lock();
+        TSAN_ANNOTATE_HAPPENS_AFTER(&m_lock);
+    }
+    Locker(AdoptLockTag, T& lock) WTF_REQUIRES_LOCK(lock)
+        : m_lock(lock)
+        , m_isLocked(true)
+    {
+    }
+    ~Locker() WTF_RELEASES_LOCK()
+    {
+        if (m_isLocked) {
+            TSAN_ANNOTATE_HAPPENS_BEFORE(&m_lock);
+            m_lock.unlock();
+        }
+    }
+    void unlockEarly() WTF_RELEASES_LOCK()
+    {
+        ASSERT(m_isLocked);
+        m_isLocked = false;
+        TSAN_ANNOTATE_HAPPENS_BEFORE(&m_lock);
+        m_lock.unlock();
+    }
+    Locker(const Locker<T>&) = delete;
+    Locker& operator=(const Locker<T>&) = delete;
+
+    void assertIsHolding(T& lock) WTF_ASSERTS_ACQUIRED_LOCK(lock)
+    {
+        ASSERT(m_isLocked);
+        ASSERT(&lock == &m_lock);
+        lock.assertIsOwner();
+    }
+
+private:
+    // Support DropLockForScope even though it doesn't support thread safety analysis.
+    template<typename>
+    friend class DropLockForScope;
+
+    // Support Condition class to access private lock/unlock methods
+    friend class Condition;
+
+    void lock() WTF_ACQUIRES_LOCK(m_lock)
+    {
+        m_lock.lock();
+        TSAN_ANNOTATE_HAPPENS_AFTER(&m_lock);
+        compilerFence();
+    }
+
+    void unlock() WTF_RELEASES_LOCK(m_lock)
+    {
+        compilerFence();
+        TSAN_ANNOTATE_HAPPENS_BEFORE(&m_lock);
+        m_lock.unlock();
+    }
+
+    T& m_lock;
+    bool m_isLocked { false };
+};
+
+// Unspecialized Locker that skips thread safety analysis.
 template<typename T>
 class [[nodiscard]] Locker : public AbstractLocker { // NOLINT
 public:
@@ -225,6 +304,17 @@ private:
 
     T* m_lockable;
 };
+
+Locker(Lock&) -> Locker<Lock>;
+Locker(AdoptLockTag, Lock&) -> Locker<Lock>;
+
+Locker(WordLock&) -> Locker<WordLock>;
+Locker(AdoptLockTag, WordLock&) -> Locker<WordLock>;
+
+#if ENABLE(UNFAIR_LOCK)
+Locker(UnfairLock&) -> Locker<UnfairLock>;
+Locker(AdoptLockTag, UnfairLock&) -> Locker<UnfairLock>;
+#endif // ENABLE(UNFAIR_LOCK)
 
 }
 


### PR DESCRIPTION
#### d7b6dda4d2aaa9cd585c2217965dfc747b1c6269
<pre>
Move WTF::Locker specializations to Locker.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302834">https://bugs.webkit.org/show_bug.cgi?id=302834</a>
<a href="https://rdar.apple.com/165097267">rdar://165097267</a>

Reviewed by Chris Dumez.

It took me an embarrassingly long time to realize that the primary Locker&lt;T&gt;
class is not the one in Locker.h, but rather a separate template specialization
in Lock.h.

Moved the specialization to Locker.h.

* Source/WTF/wtf/Lock.h:
* Source/WTF/wtf/Locker.h:

Canonical link: <a href="https://commits.webkit.org/303303@main">https://commits.webkit.org/303303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3042edfdddfe2203c329c3ebb77dd85b941ea5d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139502 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab430cde-2a72-4c4b-b703-b9c8ce4f408f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134934 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a4e3831-0480-42b9-bbc4-4e36a94ef25d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82720 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124051 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142147 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130495 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36911 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4231 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109434 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3143 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114487 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20520 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4203 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/32883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163462 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/4035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67650 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4163 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->