### PR TITLE
[GFC] Add support for fixed grid gaps.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -51,10 +51,15 @@ LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem)
 }
 
 
-LayoutUnit computeTrackSizesBefore(size_t trackIndex, const TrackSizes& trackSizes)
+LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes& trackSizes, LayoutUnit gap)
 {
-    auto trackSizesBefore = trackSizes.subspan(0, trackIndex);
-    return std::reduce(trackSizesBefore.begin(), trackSizesBefore.end());
+    auto trackSizesBefore = trackSizes.subspan(0, gridLineIndex);
+    auto sumOfTrackSizes = std::reduce(trackSizesBefore.begin(), trackSizesBefore.end());
+
+    // For grid line i, there are i-1 gaps before it (between the i tracks)
+    auto numberOfGaps = gridLineIndex > 0 ? gridLineIndex - 1 : 0;
+
+    return sumOfTrackSizes + (numberOfGaps * gap);
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -38,7 +38,7 @@ namespace GridLayoutUtils {
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&);
 
-LayoutUnit computeTrackSizesBefore(size_t trackIndex, const TrackSizes&);
+LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 
 } // namespace GridLayoutUtils
 } // namespace Layout


### PR DESCRIPTION
#### faeb2d14f4c6ae49989c6c792cef152e3c3e2474
<pre>
[GFC] Add support for fixed grid gaps.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302795">https://bugs.webkit.org/show_bug.cgi?id=302795</a>
&lt;<a href="https://rdar.apple.com/165055102">rdar://165055102</a>&gt;

Reviewed by Sammy Gill.

This PR updates GFC to handle fixed grid gaps.

Combined changes:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::layout):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::computeTrackSizesBefore):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReason):

Canonical link: <a href="https://commits.webkit.org/303405@main">https://commits.webkit.org/303405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69e3e79a27a88991a478315c6bf6d22999ff2cc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139637 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4258ce9-b108-4cf2-b42d-67f233ac7a28) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100997 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68340 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b3c927a-003a-4f00-8952-877acaaa72a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a31c941-cdb8-4fb6-866a-bc33f0843081) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/131471 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3127 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1025 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82856 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142283 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109371 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/131550 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27792 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3254 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57530 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33010 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4429 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->