### PR TITLE
Add debug overlay for touch event regions

### DIFF
--- a/Source/WebCore/page/DebugOverlayRegions.h
+++ b/Source/WebCore/page/DebugOverlayRegions.h
@@ -35,6 +35,7 @@ enum class DebugOverlayRegions : uint8_t {
     InteractionRegion = 1 << 4,
     // We must leave 1 << 5 empty due to prior use by SiteIsolation.
     EnhancedSecurity = 1 << 6,
+    TouchEventRegion = 1 << 7,
 };
 
 }

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -147,6 +147,7 @@ public:
 
 #if ENABLE(TOUCH_EVENT_REGIONS)
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegionsEventType, const IntPoint&) const;
+    const EventTrackingRegions& touchEventListenerRegion() const { return m_touchEventListenerRegion; }
 #endif
 
 #if ENABLE(WHEEL_EVENT_REGIONS)

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
@@ -49,6 +49,7 @@ enum WKDebugOverlayRegionFlags {
     kWKWheelEventHandlerRegion = 1 << 1,
     kWKTouchActionRegion = 1 << 2,
     kWKEditableElementRegion = 1 << 3,
+    kWKTouchEventRegion = 1 << 7,
 };
 typedef unsigned WKDebugOverlayRegions;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -40,6 +40,7 @@ typedef NS_OPTIONS(NSUInteger, _WKDebugOverlayRegions) {
     _WKInteractionRegion WK_API_AVAILABLE(macos(13.0), ios(16.0)) = 1 << 4,
     _WKSiteIsolationRegion WK_API_DEPRECATED_WITH_REPLACEMENT("ShowFrameProcessBordersEnabled", macos(15.0, WK_MAC_TBA), ios(18.0, WK_IOS_TBA), visionos(2.0, WK_XROS_TBA)) = 1 << 5,
     _WKEnhancedSecurityRegion WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 6,
+    _WKTouchEventRegion WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 7,
 } WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
 typedef NS_OPTIONS(NSUInteger, _WKJavaScriptRuntimeFlags) {


### PR DESCRIPTION
#### 5d3de8950e69508ca2a3df18cb52c65b4fe0f028
<pre>
Add debug overlay for touch event regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=302833">https://bugs.webkit.org/show_bug.cgi?id=302833</a>
<a href="https://rdar.apple.com/165063365">rdar://165063365</a>

Reviewed by Abrar Rahman Protyasha.

Add a debug overlay for touch event regions.

* Source/WebCore/page/DebugOverlayRegions.h:
* Source/WebCore/rendering/EventRegion.h:
(WebCore::EventRegion::touchEventListenerRegion const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::patternForEventListenerRegionType):
(WebCore::RenderLayerBacking::paintDebugOverlays):
(WebCore::RenderLayerBacking::paintContents):
* Source/WebKit/UIProcess/API/C/WKPreferencesRef.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/303474@main">https://commits.webkit.org/303474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0d1836fe475e333a416e0d8736b3b577a56e229

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84568 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d985caf2-5545-4376-a124-da2784a5e4e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101340 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68636 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/515f2da2-997d-4934-8659-e4bbcfd0955b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135508 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82137 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b17d4ff-ebd4-4f67-9e93-83c6d20b102f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1339 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.PlayAudioInRemoteFrameThenRemove, TestWebKitAPI.NowPlayingSession.HasSessionInSubframe (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83316 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142735 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4727 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109717 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27843 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3596 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58160 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4781 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33367 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4872 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->