### PR TITLE
MediaPlayerPrivateWebM should wait for data being buffered/demuxed before setting readyState to `HAVE_ENOUGH_DATA`

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -555,38 +555,13 @@ bool MediaSource::hasFutureTime()
 
 bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const
 {
-    if (ranges.length() < 1 || isClosed())
+    if (isClosed())
         return true;
-
-    ASSERT(ranges.length() == 1);
 
     Ref msp = protectedPrivate().releaseNonNull();
 
     auto bufferedRanges = msp->buffered();
-    if (!bufferedRanges.length())
-        return false;
-    bufferedRanges.intersectWith(ranges);
-
-    if (!bufferedRanges.length())
-        return false;
-
-    auto hasBufferedTime = [&] (const MediaTime& time) {
-        return abs(bufferedRanges.nearest(time) - time) <= msp->timeFudgeFactor();
-    };
-
-    if (!hasBufferedTime(ranges.minimumBufferedTime()) || !hasBufferedTime(ranges.maximumBufferedTime()))
-        return false;
-
-    if (bufferedRanges.length() == 1)
-        return true;
-
-    // Ensure that if we have a gap in the buffered range, it is smaller than the fudge factor;
-    for (unsigned i = 1; i < bufferedRanges.length(); i++) {
-        if (bufferedRanges.end(i) - bufferedRanges.start(i-1) > msp->timeFudgeFactor())
-            return false;
-    }
-
-    return true;
+    return bufferedRanges.containWithEpsilon(ranges, msp->timeFudgeFactor());
 }
 
 void MediaSource::monitorSourceBuffers()

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -77,6 +77,7 @@ public:
     
     bool contain(const MediaTime&) const;
     bool containWithEpsilon(const MediaTime&, const MediaTime& epsilon) const;
+    bool containWithEpsilon(const PlatformTimeRanges&, const MediaTime& epsilon) const;
 
     size_t find(const MediaTime&) const;
     size_t findWithEpsilon(const MediaTime&, const MediaTime& epsilon) const;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -305,6 +305,8 @@ private:
     void maybeFinishLoading();
     void readyToProcessData();
 
+    void monitorReadyState();
+
     static Ref<AudioVideoRenderer> createRenderer(LoggerHelper&, HTMLMediaElementIdentifier, MediaPlayerIdentifier);
 
     URL m_assetURL;
@@ -359,6 +361,7 @@ private:
     bool m_hasAudio { false };
     bool m_hasVideo { false };
     bool m_hasAvailableVideoFrame { false };
+    bool m_readyStateIsWaitingForAvailableFrame { true };
     bool m_visible { false };
     mutable bool m_loadingProgressed { false };
     bool m_loadFinished { false };


### PR DESCRIPTION
#### 7890b554d51a09386c131c48731f097268cf04cc
<pre>
MediaPlayerPrivateWebM should wait for data being buffered/demuxed before setting readyState to `HAVE_ENOUGH_DATA`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302839">https://bugs.webkit.org/show_bug.cgi?id=302839</a>
<a href="https://rdar.apple.com/165106177">rdar://165106177</a>

Reviewed by Eric Carlson.

The WebM player used to set its readyState to HaveEnoughData immediately
after having the first decoded frame.
Wait until we have 3s of buffered data like we do with MSE.
We will set the readyState to HaveCurrentData only when only a single frame
has been presented and the previous readyState was HaveMetadata.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::isBuffered const): We move this method into PlatformTimeRanges as `containWithEpsilon`
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::containWithEpsilon const):
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::completeSeek):
(WebCore::MediaPlayerPrivateWebM::setBufferedRanges):
(WebCore::MediaPlayerPrivateWebM::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::setReadyState):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
(WebCore::MediaPlayerPrivateWebM::monitorReadyState):

Canonical link: <a href="https://commits.webkit.org/303424@main">https://commits.webkit.org/303424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08f899d90ed1a9f28bba4475f75c9c846c77df99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83911 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3209a0b9-87aa-4dcb-a39f-b66a0f1cd06b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100908 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68287 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6cbd1e07-bf7f-4de6-9b1d-0a91587ca825) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81698 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/15554bf5-8dbc-4cd1-8d3f-c9e08aec1e49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/930 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82742 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111812 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142165 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109278 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4249 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3634 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3156 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57389 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4221 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32924 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->