### PR TITLE
MiniBrowser: Add ability to open a new window with Site Isolation enabled, even if it's otherwise off

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.h
+++ b/Tools/MiniBrowser/mac/AppDelegate.h
@@ -40,6 +40,7 @@
 
     IBOutlet NSMenuItem *_newWebKit1WindowItem;
     IBOutlet NSMenuItem *_newWebKit2WindowItem;
+    IBOutlet NSMenuItem *_newWebKit2SiteIsolateWindowItem;
     IBOutlet NSMenuItem *_newWebKit1EditorItem;
     IBOutlet NSMenuItem *_newWebKit2EditorItem;
     IBOutlet NSMenuItem *_newSwiftUIWindowItem;

--- a/Tools/MiniBrowser/mac/MainMenu.xib
+++ b/Tools/MiniBrowser/mac/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23715.1" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23715.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -79,6 +79,12 @@
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="newWindow:" target="-1" id="572"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="New Site Isolated Window" tag="5" keyEquivalent="n" id="OKy-5P-TL4">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="newWindow:" target="-1" id="PS4-cQ-V4Q"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="New WebKit2 Private Window" tag="2" id="Zqs-AO-XAX">
@@ -940,6 +946,7 @@
                 <outlet property="_newWebKit1EditorItem" destination="jNR-Z3-YWi" id="6wB-Aa-CK7"/>
                 <outlet property="_newWebKit1WindowItem" destination="573" id="ZCj-u2-PU7"/>
                 <outlet property="_newWebKit2EditorItem" destination="IdI-wb-1JD" id="DIr-pe-XI8"/>
+                <outlet property="_newWebKit2SiteIsolateWindowItem" destination="OKy-5P-TL4" id="ISk-zD-pAS"/>
                 <outlet property="_newWebKit2WindowItem" destination="571" id="1Gv-mK-aul"/>
                 <outlet property="_settingsMenu" destination="Egg-52-IiJ" id="JMi-UF-EfK"/>
             </connections>

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -655,6 +655,9 @@ static BOOL areEssentiallyEqual(double a, double b)
     if (_webView._editable)
         [subtitle appendString:@" ✏️"];
 
+    if (_webView.configuration.preferences._siteIsolationEnabled)
+        [subtitle appendString:@" (Site Isolated)"];
+
     self.window.subtitle = subtitle;
 }
 


### PR DESCRIPTION
#### 6789f1ed20e4ebe881730d3f7f269c471a086256
<pre>
MiniBrowser: Add ability to open a new window with Site Isolation enabled, even if it&apos;s otherwise off
<a href="https://rdar.apple.com/165110001">rdar://165110001</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302843">https://bugs.webkit.org/show_bug.cgi?id=302843</a>

Reviewed by Megan Gardner.

Whether you&apos;ve enabled or disabled Site Isolation from the command line, or whether or not you&apos;ve
toggled the _WKFeature for Site Isolation in Settings-&gt;Internal Features, there will always be
a way to create a new WK2 window with site isolation enabled.

This is invaluable for quickly and easily loading the same web content in two different windows,
one with site isolation and the other without.

* Tools/MiniBrowser/mac/AppDelegate.h:
* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate defaultConfigurationForcingSiteIsolation:]):
(-[BrowserAppDelegate createBrowserWindowController:]):
(-[BrowserAppDelegate _updateNewWindowKeyEquivalents]):
* Tools/MiniBrowser/mac/MainMenu.xib:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController updateTitle:]):

Canonical link: <a href="https://commits.webkit.org/303416@main">https://commits.webkit.org/303416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8655ea9f3d23fafff25b7c1acc3df89a6d0ea2b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83923 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100915 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68292 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7489a435-358d-4d92-bd8a-00f3e0070ce0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81705 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3065 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/949 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82750 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142177 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4178 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36939 "Found 1 new test failure: fast/webgpu/nocrash/fuzz-279693.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27802 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3164 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114515 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57399 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32909 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4063 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4323 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->