### PR TITLE
[web-animations] use a dedicated struct instead of a tuple for `GraphicsLayer::acceleratedAnimationsForTesting()`

### DIFF
--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -399,7 +399,7 @@ void AnimationTimelinesController::scheduleAcceleratedEffectStackUpdateForTarget
 }
 #endif
 
-Vector<std::tuple<String, double, bool>> AnimationTimelinesController::acceleratedAnimationsForElement(const Element& element) const
+Vector<GraphicsLayer::AcceleratedAnimationForTesting> AnimationTimelinesController::acceleratedAnimationsForElement(const Element& element) const
 {
     CheckedPtr renderer = element.renderer();
     if (renderer && renderer->isComposited()) {

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/FrameRateAligner.h>
+#include <WebCore/GraphicsLayer.h>
 #include <WebCore/ReducedResolutionSeconds.h>
 #include <WebCore/Timer.h>
 #include <WebCore/WebAnimationTypes.h>
@@ -77,7 +78,7 @@ public:
     void scheduleAcceleratedEffectStackUpdateForTarget(const Styleable&);
 #endif
 
-    WEBCORE_EXPORT Vector<std::tuple<String, double, bool>> acceleratedAnimationsForElement(const Element&) const;
+    WEBCORE_EXPORT Vector<GraphicsLayer::AcceleratedAnimationForTesting> acceleratedAnimationsForElement(const Element&) const;
 
 private:
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -545,7 +545,12 @@ public:
     WEBCORE_EXPORT virtual void suspendAnimations(MonotonicTime);
     WEBCORE_EXPORT virtual void resumeAnimations();
 
-    virtual Vector<std::tuple<String, double, bool>> acceleratedAnimationsForTesting() const { return { }; }
+    struct AcceleratedAnimationForTesting {
+        String property;
+        double speed;
+        bool isThreaded;
+    };
+    virtual Vector<AcceleratedAnimationForTesting> acceleratedAnimationsForTesting() const { return { }; }
 
     // Layer contents
     virtual void setContentsToImage(Image*) { }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -5281,9 +5281,9 @@ double GraphicsLayerCA::backingStoreMemoryEstimate() const
     return layer->backingStoreBytesPerPixel() * size().width() * layer->contentsScale() * size().height() * layer->contentsScale();
 }
 
-Vector<std::tuple<String, double, bool>> GraphicsLayerCA::acceleratedAnimationsForTesting() const
+Vector<GraphicsLayer::AcceleratedAnimationForTesting> GraphicsLayerCA::acceleratedAnimationsForTesting() const
 {
-    Vector<std::tuple<String, double, bool>> animations;
+    Vector<GraphicsLayer::AcceleratedAnimationForTesting> animations;
 
 #if ENABLE(THREADED_ANIMATIONS)
     auto addAcceleratedEffect = [&](const AcceleratedEffect& effect) {
@@ -5305,7 +5305,7 @@ Vector<std::tuple<String, double, bool>> GraphicsLayerCA::acceleratedAnimationsF
         if (auto caAnimation = protectedAnimatedLayer(animation.m_property)->animationForKey(animation.animationIdentifier()))
             animations.append({ animatedPropertyIDAsString(animation.m_property), caAnimation->speed(), false });
         else
-            animations.append({ animatedPropertyIDAsString(animation.m_property), (animation.m_playState == PlayState::Playing || animation.m_playState == PlayState::PlayPending) ? 1 : 0, false });
+            animations.append({ animatedPropertyIDAsString(animation.m_property), (animation.m_playState == PlayState::Playing || animation.m_playState == PlayState::PlayPending) ? 1.0 : 0.0, false });
     }
 
     return animations;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -226,7 +226,7 @@ public:
 
     WEBCORE_EXPORT TiledBacking* tiledBacking() const override;
 
-    WEBCORE_EXPORT Vector<std::tuple<String, double, bool>> acceleratedAnimationsForTesting() const final;
+    WEBCORE_EXPORT Vector<GraphicsLayer::AcceleratedAnimationForTesting> acceleratedAnimationsForTesting() const final;
 
     constexpr static CompositingCoordinatesOrientation defaultContentsOrientation = CompositingCoordinatesOrientation::TopDown;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -664,11 +664,11 @@ void GraphicsLayerCoordinated::transformRelatedPropertyDidChange()
         noteLayerPropertyChanged(Change::Animations, ScheduleFlush::Yes);
 }
 
-Vector<std::tuple<String, double, bool>> GraphicsLayerCoordinated::acceleratedAnimationsForTesting() const
+Vector<GraphicsLayer::AcceleratedAnimationForTesting> GraphicsLayerCoordinated::acceleratedAnimationsForTesting() const
 {
-    Vector<std::tuple<String, double, bool>> animations;
+    Vector<GraphicsLayer::AcceleratedAnimationForTesting> animations;
     for (auto& animation : m_animations.animations())
-        animations.append({ animatedPropertyIDAsString(animation.keyframes().property()), animation.state() == TextureMapperAnimation::State::Playing ? 1 : 0, false });
+        animations.append({ animatedPropertyIDAsString(animation.keyframes().property()), animation.state() == TextureMapperAnimation::State::Playing ? 1.0 : 0.0, false });
     return animations;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -114,7 +114,7 @@ private:
     void suspendAnimations(MonotonicTime) override;
     void resumeAnimations() override;
     void transformRelatedPropertyDidChange() override;
-    Vector<std::tuple<String, double, bool>> acceleratedAnimationsForTesting() const override;
+    Vector<GraphicsLayer::AcceleratedAnimationForTesting> acceleratedAnimationsForTesting() const override;
 
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ShouldClipToLayer::Clip) override;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1443,8 +1443,8 @@ Vector<Internals::AcceleratedAnimation> Internals::acceleratedAnimationsForEleme
         return { };
 
     Vector<Internals::AcceleratedAnimation> animations;
-    for (const auto& [property, speed, isThreaded] : timelinesController->acceleratedAnimationsForElement(element))
-        animations.append({ property, speed, isThreaded });
+    for (const auto& acceleratedAnimation : timelinesController->acceleratedAnimationsForElement(element))
+        animations.append({ acceleratedAnimation.property, acceleratedAnimation.speed, acceleratedAnimation.isThreaded });
     return animations;
 }
 


### PR DESCRIPTION
#### e6a54b2615b179949433a101096aa2ebba31d4e3
<pre>
[web-animations] use a dedicated struct instead of a tuple for `GraphicsLayer::acceleratedAnimationsForTesting()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=302848">https://bugs.webkit.org/show_bug.cgi?id=302848</a>

Reviewed by Anne van Kesteren.

In 303312@main we extended the return type of `GraphicsLayer::acceleratedAnimationsForTesting()` from a pair
to a tuple. It is best to use a dedicated struct for easier expansion in the future.

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::acceleratedAnimationsForElement const):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::acceleratedAnimationsForTesting const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::acceleratedAnimationsForTesting const):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::acceleratedAnimationsForElement):

Canonical link: <a href="https://commits.webkit.org/303326@main">https://commits.webkit.org/303326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e391fc5e944ec69a25d1d19e16e245eb611bab7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139540 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100925 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/88f3de8a-b389-4495-8093-7971b9ec1ef5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134972 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81715 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fe3d9086-02b9-454b-af95-6e972999f0f7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82760 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142187 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4269 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109466 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3174 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57409 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20527 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4242 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32917 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67688 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->