### PR TITLE
Collect PGO profiles from JetStream3 instead of JetStream2

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -75,7 +75,7 @@ else
     echo "Using .app: $APP"
 fi
 
-benchmarks=(jetstream2 speedometer3 motionmark)
+benchmarks=(jetstream3 speedometer3 motionmark)
 
 if [[ -n $APP ]] ; then
    run_benchmark_args=(--browser-path "$APP")

--- a/Tools/Scripts/pgo-profile
+++ b/Tools/Scripts/pgo-profile
@@ -13,7 +13,7 @@ logger = logging.getLogger()
 
 
 PROFILED_DYLIBS = ['JavaScriptCore', 'WebCore', 'WebKit']
-BENCHMARK_GROUP_WEIGHTS = [('speedometer3', 0.6), ('jetstream2', 0.2), ('motionmark', 0.2)]
+BENCHMARK_GROUP_WEIGHTS = [('speedometer3', 0.6), ('jetstream3', 0.2), ('motionmark', 0.2)]
 
 
 def pad(string, max_length):

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/jetstream3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/jetstream3.plan
@@ -1,0 +1,14 @@
+{
+    "timeout": 1200,
+    "count": 5,
+    "git_repository": { "url": "https://github.com/WebKit/JetStream.git", "branch": "main" },
+    "entry_point": "index.html?report=true",
+    "output_file": "jetstream3.result",
+    "subtest_url_format": "test=${TEST}",
+    "subtests": {
+        "": ["WSL","UniPoker","uglify-js-wtb","typescript","tsf-wasm","tfjs-wasm-simd","tfjs-wasm","tagcloud-SP","sync-fs","string-unpack-code-SP","stanford-crypto-sha256","stanford-crypto-pbkdf2","stanford-crypto-aes","sqlite3-wasm","splay","richards-wasm","richards","regexp","regex-dna-SP","raytrace-public-class-fields","raytrace-private-class-fields","raytrace","quicksort-wasm","proxy-vue","proxy-mobx","prepack-wtb","pdfjs","OfflineAssembler","octane-zlib","octane-code-load","navier-stokes","n-body-SP","multi-inspector-code-load","ML","mandreel","lebab-wtb","lazy-collections","json-stringify-inspector","json-parse-inspector","jshint-wtb","js-tokens","HashSet-wasm","hash-map","gcc-loops-wasm","gbemu","gaussian-blur","FlightPlanner","first-inspector-code-load","espree-wtb","earley-boyer","doxbee-promise","doxbee-async","delta-blue","date-format-xparb-SP","date-format-tofte-SP","crypto-sha1-SP","crypto-md5-SP","crypto-aes-SP","crypto","coffeescript-wtb","chai-wtb","cdjs","Box2D","bigint-paillier","bigint-noble-secp256k1","bigint-noble-ed25519","bigint-noble-bls12-381","bigint-bigdenary","Basic","base64-SP","babylon-wtb","Babylon","async-fs","argon2-wasm-simd","argon2-wasm","Air","ai-astar","acorn-wtb","8bitbench-wasm","3d-raytrace-SP","3d-cube-SP"]
+    }
+}
+
+
+


### PR DESCRIPTION
#### efc6bffc4bea93a5db5a930d590c3f6ebe794f98
<pre>
Collect PGO profiles from JetStream3 instead of JetStream2
<a href="https://rdar.apple.com/157814353">rdar://157814353</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302849">https://bugs.webkit.org/show_bug.cgi?id=302849</a>

Reviewed by Keith Miller and Yusuke Suzuki.

Collect PGO profiles from JetStream3 instead of JetStream2 since the former is almost
finalized.

* Tools/Scripts/build-and-collect-pgo-profiles:
* Tools/Scripts/pgo-profile:
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/jetstream3.plan: Added.

Canonical link: <a href="https://commits.webkit.org/303375@main">https://commits.webkit.org/303375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c086ac493bc02c413e4a6c300167705095bd044

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139718 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/70a0ea52-b0eb-454e-ad46-a707437252cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4457 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ada8b77-4e54-45ab-b539-57682c2d0f25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135149 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81846 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc13bd17-2b7d-4960-b359-a83ddd4252c6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/131552 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82938 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37111 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4446 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3305 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114684 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57611 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4419 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4251 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4378 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->