### PR TITLE
Adjust shadowrootcustomelementregistry attribute serialization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/template.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/template.window-expected.txt
@@ -1,10 +1,11 @@
 
 PASS shadowRootCustomElementRegistry reflects as string
-PASS Serializing a ShadowRoot with a null registry
-PASS Serializing a ShadowRoot with a global registry
-PASS Serializing a ShadowRoot with a registry that differs from its host document
-PASS Serializing a ShadowRoot with a null registry with a null registry host document
-PASS Serializing a ShadowRoot with a registry with a null registry host document
-PASS Serializing a ShadowRoot with a null registry with a scoped registry host document
+PASS Serializing a null registry ShadowRoot with a global registry host (document)
+PASS Serializing a global registry ShadowRoot with a global registry host (document)
+PASS Serializing a scoped registry ShadowRoot with a global registry host (document)
+PASS Serializing a null registry ShadowRoot with a null registry host (document)
+PASS Serializing a scoped registry ShadowRoot with a null registry host (document)
+PASS Serializing a null registry ShadowRoot with a scoped registry host (document)
+PASS Serializing a scoped registry ShadowRoot with a scoped registry host (document)
 PASS A declarative shadow root gets its default registry from its node document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/template.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/template.window.js
@@ -10,45 +10,45 @@ test(() => {
 
 test(() => {
   const div = document.createElement("div");
-  div.setHTMLUnsafe(`<div><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></div>`);
+  div.setHTMLUnsafe(`<span><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></span>`);
   assert_equals(div.firstChild.firstChild, null);
-  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<div><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelementregistry=\"\"></template></div>");
-}, "Serializing a ShadowRoot with a null registry");
+  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<span><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelementregistry=\"\"></template></span>");
+}, "Serializing a null registry ShadowRoot with a global registry host (document)");
 
 test(() => {
   const div = document.createElement("div");
-  div.setHTMLUnsafe(`<div><template shadowrootmode=open shadowrootserializable></template></div>`);
+  div.setHTMLUnsafe(`<span><template shadowrootmode=open shadowrootserializable></template></span>`);
   assert_equals(div.firstChild.firstChild, null);
   assert_equals(div.firstChild.shadowRoot.customElementRegistry, customElements);
-  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<div><template shadowrootmode=\"open\" shadowrootserializable=\"\"></template></div>");
-}, "Serializing a ShadowRoot with a global registry");
+  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<span><template shadowrootmode=\"open\" shadowrootserializable=\"\"></template></span>");
+}, "Serializing a global registry ShadowRoot with a global registry host (document)");
 
 test(() => {
   const div = document.createElement("div");
-  div.setHTMLUnsafe(`<div><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></div>`);
+  div.setHTMLUnsafe(`<span><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></span>`);
   const registry = new CustomElementRegistry();
   registry.initialize(div.firstChild.shadowRoot);
   assert_equals(div.firstChild.shadowRoot.customElementRegistry, registry);
-  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<div><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelementregistry=\"\"></template></div>");
-}, "Serializing a ShadowRoot with a registry that differs from its host document");
+  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<span><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelementregistry=\"\"></template></span>");
+}, "Serializing a scoped registry ShadowRoot with a global registry host (document)");
 
 test(() => {
   const div = document.implementation.createHTMLDocument().createElement("div");
   assert_equals(div.customElementRegistry, null);
-  div.setHTMLUnsafe(`<div><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></div>`);
+  div.setHTMLUnsafe(`<span><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></span>`);
   assert_equals(div.firstChild.shadowRoot.customElementRegistry, null);
-  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<div><template shadowrootmode=\"open\" shadowrootserializable=\"\"></template></div>");
-}, "Serializing a ShadowRoot with a null registry with a null registry host document");
+  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<span><template shadowrootmode=\"open\" shadowrootserializable=\"\"></template></span>");
+}, "Serializing a null registry ShadowRoot with a null registry host (document)");
 
 test(() => {
   const div = document.implementation.createHTMLDocument().createElement("div");
   assert_equals(div.customElementRegistry, null);
-  div.setHTMLUnsafe(`<div><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></div>`);
+  div.setHTMLUnsafe(`<span><template shadowrootmode=open shadowrootcustomelementregistry shadowrootserializable></template></span>`);
   const registry = new CustomElementRegistry();
   registry.initialize(div.firstChild.shadowRoot);
   assert_equals(div.firstChild.shadowRoot.customElementRegistry, registry);
-  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<div><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelementregistry=\"\"></template></div>");
-}, "Serializing a ShadowRoot with a registry with a null registry host document");
+  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<span><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelementregistry=\"\"></template></span>");
+}, "Serializing a scoped registry ShadowRoot with a null registry host (document)");
 
 test(() => {
   const registry = new CustomElementRegistry();
@@ -56,9 +56,23 @@ test(() => {
   registry.initialize(hostDocument);
   assert_equals(hostDocument.customElementRegistry, registry);
   const host = hostDocument.createElement('div');
+  assert_equals(host.customElementRegistry, registry);
   const shadow = host.attachShadow({ mode: "closed", serializable: true, customElementRegistry: null });
+  assert_equals(shadow.customElementRegistry, null);
   assert_equals(host.getHTML({ serializableShadowRoots: true }), `<template shadowrootmode="closed" shadowrootserializable="" shadowrootcustomelementregistry=""></template>`);
-}, "Serializing a ShadowRoot with a null registry with a scoped registry host document");
+}, "Serializing a null registry ShadowRoot with a scoped registry host (document)");
+
+test(() => {
+  const registry = new CustomElementRegistry();
+  const hostDocument = document.implementation.createHTMLDocument();
+  registry.initialize(hostDocument);
+  assert_equals(hostDocument.customElementRegistry, registry);
+  const host = hostDocument.createElement('div');
+  assert_equals(host.customElementRegistry, registry);
+  const shadow = host.attachShadow({ mode: "closed", serializable: true, customElementRegistry: registry });
+  assert_equals(shadow.customElementRegistry, registry);
+  assert_equals(host.getHTML({ serializableShadowRoots: true }), `<template shadowrootmode="closed" shadowrootserializable="" shadowrootcustomelementregistry=""></template>`);
+}, "Serializing a scoped registry ShadowRoot with a scoped registry host (document)");
 
 test(() => {
   const registry = new CustomElementRegistry();

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/w3c-import.log
@@ -25,13 +25,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Document-importNode-cross-document.window.js
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Document-importNode.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry-exceptions.html
-/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry-exceptions.html.rej
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry.html
-/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-customElementRegistry.html.rej
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
-/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html.orig
-/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html.rej
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-innerHTML.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/WEB_FEATURES.yml
@@ -48,8 +44,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
-/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria.html.orig
-/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria.html.rej
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-order.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize.html

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -31,6 +31,7 @@
 #include "CDATASection.h"
 #include "Comment.h"
 #include "CommonAtomStrings.h"
+#include "CustomElementRegistry.h"
 #include "DocumentFragment.h"
 #include "DocumentLoader.h"
 #include "DocumentType.h"
@@ -423,7 +424,19 @@ void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespa
             m_markup.append(" shadowrootserializable=\"\""_s);
         if (shadowRoot->isClonable())
             m_markup.append(" shadowrootclonable=\"\""_s);
-        if (shadowRoot->protectedHost()->customElementRegistry() != shadowRoot->registryForBindings())
+        bool shouldAppendRegistryAttribute = [&] {
+            Ref document = shadowRoot->document();
+            if (document->usesNullCustomElementRegistry() && shadowRoot->usesNullCustomElementRegistry())
+                return false;
+
+            RefPtr documentRegistry = document->customElementRegistry();
+            RefPtr shadowRegistry = shadowRoot->customElementRegistry();
+            bool documentHasGlobalRegistry = (documentRegistry && !documentRegistry->isScoped()) || document->window();
+            bool shadowHasGlobalRegistry = (shadowRegistry && !shadowRegistry->isScoped())
+                || (!shadowRegistry && !shadowRoot->usesNullCustomElementRegistry() && document->window());
+            return !(documentHasGlobalRegistry && shadowHasGlobalRegistry);
+        }();
+        if (shouldAppendRegistryAttribute)
             m_markup.append(" shadowrootcustomelementregistry=\"\""_s);
         m_markup.append('>');
     } else


### PR DESCRIPTION
#### 4d68d564249872f4cf9ff099ea1631052e31da36
<pre>
Adjust shadowrootcustomelementregistry attribute serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=302851">https://bugs.webkit.org/show_bug.cgi?id=302851</a>

Reviewed by Ryosuke Niwa.

Since attachShadow() no longer looks at the host&apos;s custom element
registry, but rather the host document registry, we should do something
similar when serializing.

WPT PR: <a href="https://github.com/web-platform-tests/wpt/pull/56419">https://github.com/web-platform-tests/wpt/pull/56419</a>

Canonical link: <a href="https://commits.webkit.org/303841@main">https://commits.webkit.org/303841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bee16da701a6f95df90a3037be2148e708019b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141315 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbe20e2b-bb04-4f98-9d3c-c158593be347) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102306 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9e2b7fb3-dd7d-4d1f-a177-ab90b45917db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136687 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83109 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6520b4ea-8329-4d6a-baed-20accf5ac002) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4661 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2276 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143962 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110684 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110874 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4516 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59666 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20675 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5972 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34449 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69436 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->