### PR TITLE
[GLIB] Move the run loop observer repeating logic to ActivityObserver

### DIFF
--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -216,10 +216,8 @@ void RunLoop::notifyActivity(Activity activity)
 
     // Notify the activity observers, without holding a lock - as mutations
     // to the activity observers are allowed.
-    for (Ref observer : observersToBeNotified) {
-        if (observer->notify() == ActivityObserver::NotifyResult::Stop)
-            observer->stop();
-    }
+    for (Ref observer : observersToBeNotified)
+        observer->notify();
 }
 
 void RunLoop::notifyEvent(RunLoop::Event event, const char* name)

--- a/Source/WebCore/platform/glib/RunLoopObserverGLib.cpp
+++ b/Source/WebCore/platform/glib/RunLoopObserverGLib.cpp
@@ -38,11 +38,8 @@ void RunLoopObserver::schedule(PlatformRunLoop runLoop, OptionSet<Activity> acti
     if (!runLoop)
         runLoop = RunLoop::currentSingleton();
 
-    m_runLoopObserver = ActivityObserver::create(runLoop.releaseNonNull(), static_cast<uint8_t>(m_order), activities, [this]() {
-        if (!isScheduled())
-            return ActivityObserver::NotifyResult::Destroyed;
+    m_runLoopObserver = ActivityObserver::create(runLoop.releaseNonNull(), isRepeating(), static_cast<uint8_t>(m_order), activities, [this]() {
         runLoopObserverFired();
-        return isRepeating() ? ActivityObserver::NotifyResult::Continue : ActivityObserver::NotifyResult::Stop;
     });
 
     m_runLoopObserver->start();

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp
@@ -63,9 +63,8 @@ TEST(WTF_ActivityObserver, Create)
     WTF::initializeMainThread();
 
     bool observerCalled = false;
-    RefPtr observer = ActivityObserver::create(RunLoop::currentSingleton(), 10, { RunLoop::Activity::BeforeWaiting }, [&] {
+    RefPtr observer = ActivityObserver::create(RunLoop::currentSingleton(), true, 10, { RunLoop::Activity::BeforeWaiting }, [&] {
         observerCalled = true;
-        return ActivityObserver::NotifyResult::Continue;
     });
 
     EXPECT_TRUE(observer.get());
@@ -93,9 +92,8 @@ TEST(WTF_ActivityObserver, MatchingActivity)
     RefPtr<ActivityObserver> observer;
 
     runTestWhileRunLoopIsActive([&] {
-        observer = ActivityObserver::create(RunLoop::currentSingleton(), 1, { RunLoop::Activity::BeforeWaiting }, [&] {
+        observer = ActivityObserver::create(RunLoop::currentSingleton(), true, 1, { RunLoop::Activity::BeforeWaiting }, [&] {
             observerCalled = true;
-            return ActivityObserver::NotifyResult::Continue;
         });
 
         observer->start();
@@ -120,17 +118,15 @@ TEST(WTF_ActivityObserver, NonMatchingActivity)
 
     // This observer will fire upon run loop entry, as we observe the Entry activity.
     bool earlyObserverCalled = false;
-    RefPtr<ActivityObserver> earlyObserver = ActivityObserver::create(RunLoop::currentSingleton(), 1, { RunLoop::Activity::Entry }, [&] {
+    RefPtr<ActivityObserver> earlyObserver = ActivityObserver::create(RunLoop::currentSingleton(), true, 1, { RunLoop::Activity::Entry }, [&] {
         earlyObserverCalled = true;
-        return ActivityObserver::NotifyResult::Continue;
     });
 
     earlyObserver->start();
 
     runTestWhileRunLoopIsActive([&] {
-        lateObserver = ActivityObserver::create(RunLoop::currentSingleton(), 1, { RunLoop::Activity::Entry }, [&] {
+        lateObserver = ActivityObserver::create(RunLoop::currentSingleton(), true, 1, { RunLoop::Activity::Entry }, [&] {
             lateObserverCalled = true;
-            return ActivityObserver::NotifyResult::Continue;
         });
 
         lateObserver->start();
@@ -156,9 +152,8 @@ TEST(WTF_ActivityObserver, MultipleActivities)
     RefPtr<ActivityObserver> observer;
 
     runTestWhileRunLoopIsActive([&] {
-        observer = ActivityObserver::create(RunLoop::currentSingleton(), 1, { RunLoop::Activity::BeforeWaiting }, [&] {
+        observer = ActivityObserver::create(RunLoop::currentSingleton(), true, 1, { RunLoop::Activity::BeforeWaiting }, [&] {
             ++observerCallCount;
-            return ActivityObserver::NotifyResult::Continue;
         });
 
         observer->start();
@@ -188,19 +183,16 @@ TEST(WTF_ActivityObserver, Ordering)
     RefPtr<ActivityObserver> observer3;
 
     runTestWhileRunLoopIsActive([&] {
-        observer1 = ActivityObserver::create(RunLoop::currentSingleton(), 30, { RunLoop::Activity::BeforeWaiting }, [&] {
+        observer1 = ActivityObserver::create(RunLoop::currentSingleton(), true, 30, { RunLoop::Activity::BeforeWaiting }, [&] {
             observerExecutionOrder.append(30);
-            return ActivityObserver::NotifyResult::Continue;
         });
 
-        observer2 = ActivityObserver::create(RunLoop::currentSingleton(), 10, { RunLoop::Activity::BeforeWaiting }, [&] {
+        observer2 = ActivityObserver::create(RunLoop::currentSingleton(), true, 10, { RunLoop::Activity::BeforeWaiting }, [&] {
             observerExecutionOrder.append(10);
-            return ActivityObserver::NotifyResult::Continue;
         });
 
-        observer3 = ActivityObserver::create(RunLoop::currentSingleton(), 20, { RunLoop::Activity::BeforeWaiting }, [&] {
+        observer3 = ActivityObserver::create(RunLoop::currentSingleton(), true, 20, { RunLoop::Activity::BeforeWaiting }, [&] {
             observerExecutionOrder.append(20);
-            return ActivityObserver::NotifyResult::Continue;
         });
 
         observer1->start();
@@ -233,14 +225,12 @@ TEST(WTF_ActivityObserver, SameOrder)
     RefPtr<ActivityObserver> observer2;
 
     runTestWhileRunLoopIsActive([&] {
-        observer1 = ActivityObserver::create(RunLoop::currentSingleton(), 10, { RunLoop::Activity::BeforeWaiting }, [&] {
+        observer1 = ActivityObserver::create(RunLoop::currentSingleton(), true, 10, { RunLoop::Activity::BeforeWaiting }, [&] {
             ++observerCallCount1;
-            return ActivityObserver::NotifyResult::Continue;
         });
 
-        observer2 = ActivityObserver::create(RunLoop::currentSingleton(), 10, { RunLoop::Activity::Entry, RunLoop::Activity::BeforeWaiting }, [&] {
+        observer2 = ActivityObserver::create(RunLoop::currentSingleton(), true, 10, { RunLoop::Activity::Entry, RunLoop::Activity::BeforeWaiting }, [&] {
             ++observerCallCount2;
-            return ActivityObserver::NotifyResult::Continue;
         });
 
         observer1->start();


### PR DESCRIPTION
#### 8aa34ebe7063ddcfec42f2268fa999723a5462db
<pre>
[GLIB] Move the run loop observer repeating logic to ActivityObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=302855">https://bugs.webkit.org/show_bug.cgi?id=302855</a>

Reviewed by Nikolas Zimmermann.

This way neither the caller to notify() nor the callback need to check
whether the observer is repeating or not. It&apos;s simpler, but also safer
because ActivityObserver is refcounted and always protected while
notify() is called, so we can safely check if it&apos;s repeating after the
callback is called even if it&apos;s stopped by the callback.

Canonical link: <a href="https://commits.webkit.org/303382@main">https://commits.webkit.org/303382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca27439d2d42e9cbbb1d2b9cc65d29dcc4e2b355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100934 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68305 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3079 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/954 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82769 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124098 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142196 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130542 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4197 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109303 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4278 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3658 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3183 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57422 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20548 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4251 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32930 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163509 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67697 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42507 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->