### PR TITLE
[threaded-animations] disable accelerated animations if threaded and non-threaded animations animate the same underlying property

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Scroll-driven and monotonic animations can be combined on the same element and yield accelerated animations provided they affect different properties.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+</style>
+
+<script src="threaded-animations-utils.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
+<script>
+
+promise_test(async t => { 
+    const target = createDiv(t);
+    
+    const timeline = new ScrollTimeline({ source : document.documentElement });
+    target.animate({ opacity: [0, 1] }, { timeline });
+    target.animate({ translate: '0 100px' }, 1000 * 1000);
+
+    await legacyAnimationCommit();
+
+    const animations = window.internals?.acceleratedAnimationsForElement(target);
+    assert_equals(animations.length, 2, "Both animations are accelerated");
+    assert_equals(animations[0].property, "opacity");
+    assert_true(animations[0].isThreaded, "The scroll-driven animation is threaded");
+    assert_equals(animations[1].property, "transform");
+    assert_false(animations[1].isThreaded, "The time-based animation is not threaded");
+}, "Scroll-driven and monotonic animations can be combined on the same element and yield accelerated animations provided they affect different properties.");
+
+</script>
+</body>

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Adding a monotonic animation on an element that has an accelerated progress-based animation for the same underlying property makes both animations run without acceleration.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic.html
@@ -16,18 +16,17 @@ html {
 <script>
 
 promise_test(async t => { 
-    const scrollTarget = createDiv(t);
-    const monotonicTarget = createDiv(t);
+    const target = createDiv(t);
     
     const timeline = new ScrollTimeline({ source : document.documentElement });
-    scrollTarget.animate({ opacity: [0, 1] }, { timeline });
-    monotonicTarget.animate({ opacity: [0, 1] }, 1000 * 1000);
+    const threadedAnimation = target.animate({ scale: [0, 1] }, { timeline });
+    await animationAcceleration(threadedAnimation);
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1);
 
+    target.animate({ translate: '0 100px' }, 1000 * 1000);
     await legacyAnimationCommit();
-
-    assert_true(window.internals?.acceleratedAnimationsForElement(scrollTarget)[0].isThreaded);
-    assert_false(window.internals?.acceleratedAnimationsForElement(monotonicTarget)[0].isThreaded);
-}, "Scroll-driven animations can be threaded while monotonic animations can be accelerated but not threaded.");
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 0);
+}, "Adding a monotonic animation on an element that has an accelerated progress-based animation for the same underlying property makes both animations run without acceleration.");
 
 </script>
 </body>

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Scroll-driven and monotonic animations on the same element cannot be accelerated if they affect the same underlying property.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property.html
@@ -16,18 +16,17 @@ html {
 <script>
 
 promise_test(async t => { 
-    const scrollTarget = createDiv(t);
-    const monotonicTarget = createDiv(t);
+    const target = createDiv(t);
     
     const timeline = new ScrollTimeline({ source : document.documentElement });
-    scrollTarget.animate({ opacity: [0, 1] }, { timeline });
-    monotonicTarget.animate({ opacity: [0, 1] }, 1000 * 1000);
+    target.animate({ scale: [0, 1] }, { timeline });
+    target.animate({ translate: '0 100px' }, 1000 * 1000);
 
     await legacyAnimationCommit();
 
-    assert_true(window.internals?.acceleratedAnimationsForElement(scrollTarget)[0].isThreaded);
-    assert_false(window.internals?.acceleratedAnimationsForElement(monotonicTarget)[0].isThreaded);
-}, "Scroll-driven animations can be threaded while monotonic animations can be accelerated but not threaded.");
+    const animations = window.internals?.acceleratedAnimationsForElement(target);
+    assert_equals(animations.length, 0);
+}, "Scroll-driven and monotonic animations on the same element cannot be accelerated if they affect the same underlying property.");
 
 </script>
 </body>

--- a/LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js
@@ -13,3 +13,9 @@ const animationAcceleration = async animation => {
     // but after the requestAnimationFrame callbacks have been serviced.
     await new Promise(setTimeout);
 };
+
+const legacyAnimationCommit = async () => {
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+};

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
+#include "KeyframeEffectStack.h"
 #include "RenderElement.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2894,7 +2894,15 @@ void KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActio
 {
 #if ENABLE(THREADED_ANIMATIONS)
     if (canHaveAcceleratedRepresentation()) {
-        ASSERT_NOT_REACHED();
+        ASSERT([&] {
+            if (RefPtr document = this->document()) {
+                Ref settings = document->settings();
+                if (settings->threadedScrollDrivenAnimationsEnabled() && settings->threadedTimeBasedAnimationsEnabled())
+                    return false;
+            }
+            return true;
+        }());
+        scheduleAssociatedAcceleratedEffectStackUpdate();
         return;
     }
 #endif


### PR DESCRIPTION
#### 28045a5b27fe38ad7b575025db2d810e27bce7c3
<pre>
[threaded-animations] disable accelerated animations if threaded and non-threaded animations animate the same underlying property
<a href="https://bugs.webkit.org/show_bug.cgi?id=302856">https://bugs.webkit.org/show_bug.cgi?id=302856</a>
<a href="https://rdar.apple.com/165120183">rdar://165120183</a>

Reviewed by Simon Fraser.

Until we have monotonic and scroll-driven animations all accelerated in the remote layer tree, we need
to ensure the different accelerated approaches can coexist. This means that in the case where a monotonic
and a scroll-driven animation both target the same underlying property, we need to disable accelerated
animations altogether.

To that end, we extend `KeyframeEffectStack::allowsAcceleration()` to identify such cases and return false.
Then, in `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()` we simply ignore targets with an
associated effect stack that is marked as such.

To test this is implemented correctly, we add tests that have two animations that can be accelerated specified
on the same element. In one test, these two animations target different properties and thus allow acceleration
with mixed types. In the other test, these two animations target the same underlying property and thus disallow
acceleration of both types.

Tests: webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property.html
       webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic.html
       webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property.html

* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property.html: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic.html: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property.html: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations.html:
* LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js:
* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActionApplication):
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::allowsAcceleration const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/303444@main">https://commits.webkit.org/303444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e130245c5c08e2983678512bbe66ef2c3b2123c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84395 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/441f3010-da59-427a-a552-5f6653529fff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101245 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef2f08a9-0d4e-44f3-b663-f74f765e55a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135381 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82038 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e6cb3e48-80d3-4dce-a7a8-0d4ee1f1b456) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83180 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4600 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109622 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109802 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3484 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57901 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20571 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4654 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33251 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->