### PR TITLE
Reduce use of raw pointers in containers in BaseAudioContext.h

### DIFF
--- a/Source/WebCore/Modules/webaudio/AnalyserNode.h
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class AnalyserNode final : public AudioBasicInspectorNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AnalyserNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AnalyserNode);
 public:
     static ExceptionOr<Ref<AnalyserNode>> create(BaseAudioContext&, const AnalyserOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h
@@ -33,6 +33,7 @@ namespace WebCore {
 // AudioContext before the end of each render quantum so that it can inspect the audio stream.
 class AudioBasicInspectorNode : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioBasicInspectorNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioBasicInspectorNode);
 public:
     AudioBasicInspectorNode(BaseAudioContext&, NodeType);
 

--- a/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h
@@ -36,6 +36,7 @@ class AudioProcessor;
 // AudioBasicProcessorNode is an AudioNode with one input and one output where the input and output have the same number of channels.
 class AudioBasicProcessorNode : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioBasicProcessorNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioBasicProcessorNode);
 public:
     AudioBasicProcessorNode(BaseAudioContext&, NodeType);
     virtual ~AudioBasicProcessorNode();

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -40,6 +40,7 @@ struct AudioBufferSourceOptions;
 
 class AudioBufferSourceNode final : public AudioScheduledSourceNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioBufferSourceNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioBufferSourceNode);
 public:
     static ExceptionOr<Ref<AudioBufferSourceNode>> create(BaseAudioContext&, AudioBufferSourceOptions&& = { });
 

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
@@ -36,6 +36,7 @@ struct AudioIOPosition;
 
 class AudioDestinationNode : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioDestinationNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioDestinationNode);
 public:
     ~AudioDestinationNode();
     

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -29,6 +29,7 @@
 #include "ChannelInterpretation.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 
@@ -53,12 +54,14 @@ enum class NoiseInjectionPolicy : uint8_t;
 
 class AudioNode
     : public EventTarget
+    , public CanMakeThreadSafeCheckedPtr<AudioNode>
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif
 {
     WTF_MAKE_NONCOPYABLE(AudioNode);
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioNode);
 public:
     enum NodeType {
         NodeTypeDestination,

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -110,7 +110,7 @@ void AudioNodeInput::disable(AudioNodeOutput* output)
     }
 
     // Propagate disabled state to outputs.
-    node()->disableOutputsIfNecessary();
+    checkedNode()->disableOutputsIfNecessary();
 }
 
 void AudioNodeInput::enable(AudioNodeOutput* output)
@@ -134,12 +134,12 @@ void AudioNodeInput::enable(AudioNodeOutput* output)
     m_disabledOutputs.remove(output);
 
     // Propagate enabled state to outputs.
-    node()->enableOutputsIfNecessary();
+    checkedNode()->enableOutputsIfNecessary();
 }
 
 void AudioNodeInput::didUpdate()
 {
-    node()->checkNumberOfChannelsForInput(this);
+    checkedNode()->checkNumberOfChannelsForInput(this);
 }
 
 void AudioNodeInput::updateInternalBus()

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.h
@@ -27,6 +27,7 @@
 #include "AudioBus.h"
 #include "AudioNode.h"
 #include "AudioSummingJunction.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -52,6 +53,7 @@ public:
 
     // Can be called from any thread.
     AudioNode* node() const { return m_node.get(); }
+    CheckedPtr<AudioNode> checkedNode() const { return m_node.get(); }
 
     // Must be called with the context's graph lock.
     void connect(AudioNodeOutput*);

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -101,10 +101,8 @@ void AudioNodeOutput::propagateChannelCount()
     
     if (isChannelCountKnown()) {
         // Announce to any nodes we're connected to that we changed our channel count for its input.
-        for (auto& input : m_inputs.keys()) {
-            AudioNode* connectionNode = input->node();
-            connectionNode->checkNumberOfChannelsForInput(input);
-        }
+        for (auto& input : m_inputs.keys())
+            input->checkedNode()->checkNumberOfChannelsForInput(input);
     }
 }
 
@@ -123,7 +121,7 @@ AudioBus& AudioNodeOutput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
 
     m_inPlaceBus = isInPlace ? inPlaceBus : nullptr;
 
-    node()->processIfNecessary(framesToProcess);
+    checkedNode()->processIfNecessary(framesToProcess);
     return bus();
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -49,7 +49,8 @@ public:
 
     // Can be called from any thread.
     AudioNode* node() const { return m_node.get(); }
-    BaseAudioContext& context() { return m_node->context(); }
+    CheckedPtr<AudioNode> checkedNode() const { return m_node.get(); }
+    BaseAudioContext& context() { return checkedNode()->context(); }
     
     // Causes our AudioNode to process if it hasn't already for this render quantum.
     // It returns the bus containing the processed audio for this output, returning inPlaceBus if in-place processing was possible.

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class AudioScheduledSourceNode : public AudioNode, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioScheduledSourceNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioScheduledSourceNode);
 public:
     // ActiveDOMObject.
     void ref() const final { AudioNode::ref(); }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -51,8 +51,9 @@ struct AudioWorkletNodeOptions;
 template<typename> class AudioArray;
 typedef AudioArray<float> AudioFloatArray;
 
-class AudioWorkletNode : public AudioNode, public ActiveDOMObject {
+class AudioWorkletNode final : public AudioNode, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioWorkletNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioWorkletNode);
 public:
     static ExceptionOr<Ref<AudioWorkletNode>> create(JSC::JSGlobalObject&, BaseAudioContext&, String&& name, AudioWorkletNodeOptions&&);
     ~AudioWorkletNode();

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -316,7 +316,7 @@ private:
     // This is copied to m_nodesToDelete at the end of a render cycle in handlePostRenderTasks(), where we're assured of a stable graph
     // state which will have no references to any of the nodes in m_nodesToDelete once the context lock is released
     // (when handlePostRenderTasks() has completed).
-    Vector<AudioNode*> m_nodesMarkedForDeletion;
+    Vector<CheckedPtr<AudioNode>> m_nodesMarkedForDeletion;
 
     class TailProcessingNode {
     public:
@@ -336,6 +336,7 @@ private:
         }
         TailProcessingNode& operator=(const TailProcessingNode&) = delete;
         TailProcessingNode& operator=(TailProcessingNode&&) = delete;
+        CheckedPtr<AudioNode> checkedNode() const { return m_node.get(); }
         AudioNode* operator->() const { return m_node.get(); }
         friend bool operator==(const TailProcessingNode&, const TailProcessingNode&) = default;
         bool operator==(const AudioNode& node) const { return m_node == &node; }
@@ -350,7 +351,7 @@ private:
     Vector<TailProcessingNode> m_finishedTailProcessingNodes;
 
     // They will be scheduled for deletion (on the main thread) at the end of a render cycle (in realtime thread).
-    Vector<AudioNode*> m_nodesToDelete;
+    Vector<CheckedPtr<AudioNode>> m_nodesToDelete;
 
     // Only accessed when the graph lock is held.
     HashSet<AudioSummingJunction*> m_dirtySummingJunctions;
@@ -358,10 +359,10 @@ private:
 
     // For the sake of thread safety, we maintain a seperate Vector of automatic pull nodes for rendering in m_renderingAutomaticPullNodes.
     // It will be copied from m_automaticPullNodes by updateAutomaticPullNodes() at the very start or end of the rendering quantum.
-    HashSet<AudioNode*> m_automaticPullNodes;
-    Vector<AudioNode*> m_renderingAutomaticPullNodes;
+    HashSet<CheckedPtr<AudioNode>> m_automaticPullNodes;
+    Vector<CheckedPtr<AudioNode>> m_renderingAutomaticPullNodes;
     // Only accessed in the audio thread.
-    Vector<AudioNode*> m_deferredBreakConnectionList;
+    Vector<CheckedPtr<AudioNode>> m_deferredBreakConnectionList;
     Vector<Vector<DOMPromiseDeferred<void>>> m_stateReactions;
 
     const Ref<AudioListener> m_listener;

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
@@ -34,6 +34,7 @@ class AudioParam;
 
 class BiquadFilterNode final : public AudioBasicProcessorNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(BiquadFilterNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BiquadFilterNode);
 public:
     static ExceptionOr<Ref<BiquadFilterNode>> create(BaseAudioContext& context, const BiquadFilterOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/ChannelMergerNode.h
+++ b/Source/WebCore/Modules/webaudio/ChannelMergerNode.h
@@ -37,6 +37,7 @@ class AudioContext;
     
 class ChannelMergerNode final : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ChannelMergerNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ChannelMergerNode);
 public:
     static ExceptionOr<Ref<ChannelMergerNode>> create(BaseAudioContext&, const ChannelMergerOptions& = { });
     

--- a/Source/WebCore/Modules/webaudio/ChannelSplitterNode.h
+++ b/Source/WebCore/Modules/webaudio/ChannelSplitterNode.h
@@ -33,6 +33,7 @@ class AudioContext;
     
 class ChannelSplitterNode final : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ChannelSplitterNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ChannelSplitterNode);
 public:
     static ExceptionOr<Ref<ChannelSplitterNode>> create(BaseAudioContext&, const ChannelSplitterOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class ConstantSourceNode final : public AudioScheduledSourceNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ConstantSourceNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ConstantSourceNode);
 public:
     static ExceptionOr<Ref<ConstantSourceNode>> create(BaseAudioContext&, const ConstantSourceOptions& = { });
     

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.h
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.h
@@ -36,6 +36,7 @@ class Reverb;
     
 class ConvolverNode final : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ConvolverNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ConvolverNode);
 public:
     static ExceptionOr<Ref<ConvolverNode>> create(BaseAudioContext&, ConvolverOptions&& = { });
     

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
@@ -39,6 +39,7 @@ class AudioDestination;
     
 class DefaultAudioDestinationNode final : public AudioDestinationNode, public AudioIOCallback {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DefaultAudioDestinationNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DefaultAudioDestinationNode);
 public:
     explicit DefaultAudioDestinationNode(AudioContext&, std::optional<float> sampleRate = std::nullopt);
     ~DefaultAudioDestinationNode();

--- a/Source/WebCore/Modules/webaudio/DelayNode.h
+++ b/Source/WebCore/Modules/webaudio/DelayNode.h
@@ -32,6 +32,7 @@ struct DelayOptions;
 
 class DelayNode final : public AudioBasicProcessorNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DelayNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DelayNode);
 public:
     static ExceptionOr<Ref<DelayNode>> create(BaseAudioContext&, const DelayOptions&);
 

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
@@ -36,6 +36,7 @@ class DynamicsCompressor;
 
 class DynamicsCompressorNode final : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DynamicsCompressorNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DynamicsCompressorNode);
 public:
     static ExceptionOr<Ref<DynamicsCompressorNode>> create(BaseAudioContext&, const DynamicsCompressorOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/GainNode.h
+++ b/Source/WebCore/Modules/webaudio/GainNode.h
@@ -38,6 +38,7 @@ class AudioContext;
 
 class GainNode final : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GainNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GainNode);
 public:
     static ExceptionOr<Ref<GainNode>> create(BaseAudioContext& context, const GainOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.h
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class IIRFilterNode final : public AudioBasicProcessorNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(IIRFilterNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IIRFilterNode);
 public:
     static ExceptionOr<Ref<IIRFilterNode>> create(ScriptExecutionContext&, BaseAudioContext&, IIRFilterOptions&&);
 

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -41,6 +41,7 @@ struct MediaElementAudioSourceOptions;
     
 class MediaElementAudioSourceNode final : public AudioNode, public AudioSourceProviderClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaElementAudioSourceNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaElementAudioSourceNode);
 public:
     static ExceptionOr<Ref<MediaElementAudioSourceNode>> create(BaseAudioContext&, MediaElementAudioSourceOptions&&);
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.h
@@ -38,6 +38,7 @@ class MediaStreamAudioSource;
 
 class MediaStreamAudioDestinationNode final : public AudioBasicInspectorNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaStreamAudioDestinationNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaStreamAudioDestinationNode);
 public:
     static ExceptionOr<Ref<MediaStreamAudioDestinationNode>> create(BaseAudioContext&, const AudioNodeOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
@@ -41,6 +41,7 @@ class WebAudioSourceProvider;
 
 class MediaStreamAudioSourceNode final : public AudioNode, public AudioSourceProviderClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaStreamAudioSourceNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaStreamAudioSourceNode);
 public:
     static ExceptionOr<Ref<MediaStreamAudioSourceNode>> create(BaseAudioContext&, MediaStreamAudioSourceOptions&&);
 

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
@@ -37,6 +37,7 @@ class OfflineAudioContext;
     
 class OfflineAudioDestinationNode final : public AudioDestinationNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(OfflineAudioDestinationNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(OfflineAudioDestinationNode);
 public:
     OfflineAudioDestinationNode(OfflineAudioContext&, unsigned numberOfChannels, float sampleRate, RefPtr<AudioBuffer>&& renderTarget);
     ~OfflineAudioDestinationNode();

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.h
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.h
@@ -36,6 +36,7 @@ namespace WebCore {
 
 class OscillatorNode final : public AudioScheduledSourceNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(OscillatorNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(OscillatorNode);
 public:
     static ExceptionOr<Ref<OscillatorNode>> create(BaseAudioContext&, const OscillatorOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/PannerNode.h
+++ b/Source/WebCore/Modules/webaudio/PannerNode.h
@@ -53,6 +53,7 @@ class BaseAudioContext;
 
 class PannerNode final : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PannerNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PannerNode);
 public:
     static ExceptionOr<Ref<PannerNode>> create(BaseAudioContext&, const PannerOptions& = { });
 

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
@@ -47,6 +47,7 @@ class AudioProcessingEvent;
 
 class ScriptProcessorNode final : public AudioNode, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ScriptProcessorNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScriptProcessorNode);
 public:
     // bufferSize must be one of the following values: 256, 512, 1024, 2048, 4096, 8192, 16384.
     // This value controls how frequently the onaudioprocess event handler is called and how many sample-frames need to be processed each call.

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.h
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.h
@@ -39,6 +39,7 @@ class AudioContext;
 
 class StereoPannerNode final : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(StereoPannerNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StereoPannerNode);
 public:
     static ExceptionOr<Ref<StereoPannerNode>> create(BaseAudioContext&, const StereoPannerOptions& = { });
     

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.h
@@ -36,6 +36,7 @@ namespace WebCore {
 
 class WaveShaperNode final : public AudioBasicProcessorNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WaveShaperNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WaveShaperNode);
 public:
     static ExceptionOr<Ref<WaveShaperNode>> create(BaseAudioContext&, const WaveShaperOptions& = { });
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -47,14 +47,12 @@ Modules/webaudio/AudioListener.cpp
 Modules/webaudio/AudioNode.cpp
 Modules/webaudio/AudioNodeInput.cpp
 Modules/webaudio/AudioNodeOutput.cpp
-Modules/webaudio/AudioNodeOutput.h
 Modules/webaudio/AudioParam.cpp
 Modules/webaudio/AudioScheduledSourceNode.cpp
 Modules/webaudio/AudioSummingJunction.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/webaudio/AudioWorkletMessagingProxy.cpp
 Modules/webaudio/AudioWorkletNode.cpp
-Modules/webaudio/BaseAudioContext.cpp
 Modules/webaudio/BiquadFilterNode.cpp
 [ iOS ] Modules/webaudio/ChannelMergerNode.cpp
 Modules/webaudio/ConvolverNode.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -20,7 +20,6 @@ Modules/webaudio/AudioNodeOutput.cpp
 Modules/webaudio/AudioParam.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/webaudio/AudioWorkletNode.cpp
-Modules/webaudio/BaseAudioContext.cpp
 Modules/webaudio/ChannelSplitterNode.cpp
 Modules/webaudio/ConstantSourceNode.cpp
 Modules/webaudio/ConvolverNode.cpp


### PR DESCRIPTION
#### 7f8550bf8877aa24a274d6855438444c65309303
<pre>
Reduce use of raw pointers in containers in BaseAudioContext.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302841">https://bugs.webkit.org/show_bug.cgi?id=302841</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/webaudio/AnalyserNode.h:
* Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h:
* Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h:
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
(WebCore::AudioNodeInput::disable):
(WebCore::AudioNodeInput::enable):
(WebCore::AudioNodeInput::didUpdate):
* Source/WebCore/Modules/webaudio/AudioNodeInput.h:
* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::propagateChannelCount):
(WebCore::AudioNodeOutput::pull):
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
(WebCore::AudioNodeOutput::checkedNode const):
(WebCore::AudioNodeOutput::context):
* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
(WebCore::AudioWorkletNode::parameters): Deleted.
(WebCore::AudioWorkletNode::port): Deleted.
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::uninitialize):
At this point, audio rendering is finished since we&apos;re uninitializing.
Therefore, we should clear m_renderingAutomaticPullNodes since those nodes
are no longer rendering. Normally, this would happen at the end of
rendering, in handlePostRenderTasks(). However, handlePostRenderTasks()
uses a tryLock() and returns early if it fails to grab the lock, which
could leave pointers in m_renderingAutomaticPullNodes. After switching
to CheckedPtr, we can see that we could end up in a situation where these
pointers would start pointing to dead nodes.

(WebCore::BaseAudioContext::updateTailProcessingNodes):
(WebCore::BaseAudioContext::disableOutputsForFinishedTailProcessingNodes):
(WebCore::BaseAudioContext::finishTailProcessing):
(WebCore::BaseAudioContext::deleteMarkedNodes):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::TailProcessingNode::checkedNode const):
* Source/WebCore/Modules/webaudio/BiquadFilterNode.h:
* Source/WebCore/Modules/webaudio/ChannelMergerNode.h:
* Source/WebCore/Modules/webaudio/ChannelSplitterNode.h:
* Source/WebCore/Modules/webaudio/ConstantSourceNode.h:
* Source/WebCore/Modules/webaudio/ConvolverNode.h:
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/DelayNode.h:
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h:
* Source/WebCore/Modules/webaudio/GainNode.h:
* Source/WebCore/Modules/webaudio/IIRFilterNode.h:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h:
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/OscillatorNode.h:
* Source/WebCore/Modules/webaudio/PannerNode.h:
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.h:
* Source/WebCore/Modules/webaudio/StereoPannerNode.h:
* Source/WebCore/Modules/webaudio/WaveShaperNode.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/303383@main">https://commits.webkit.org/303383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1714b0b9b75071a4d8dd4824b1cea52951cf064

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2025708e-d85d-414e-a596-d6073755c55b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101046 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d46a0b3-89aa-4016-bf81-9eee52a411d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135136 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81839 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e3707ad-1431-48d8-9624-b84dd11661fd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82925 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109422 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4433 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3772 "Found 1 new test failure: http/tests/webgpu/webgpu/api/validation/encoding/encoder_open_state.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27769 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3295 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57598 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4406 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->