### PR TITLE
[blocks-in-inline] WPT css/css-multicol/spanner-in-child-after-parallel-flow-003.html is failing

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-float-and-spanner-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-float-and-spanner-expected.html
@@ -1,0 +1,6 @@
+<div style="columns:2; width:100px; gap:0; orphans:1; widows:1; background:red;">
+  <div style="float:left; width:50px; height:180px; background:green;"></div>
+  <span>
+    <div style="column-span:all; height:10px; background:green;"></div>
+  </span>
+</div>

--- a/LayoutTests/fast/inline/blocks-in-inline-multicol-float-and-spanner.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-multicol-float-and-spanner.html
@@ -1,0 +1,7 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<div style="columns:2; width:100px; gap:0; orphans:1; widows:1; background:red;">
+  <div style="float:left; width:50px; height:180px; background:green;"></div>
+  <span>
+    <div style="column-span:all; height:10px; background:green;"></div>
+  </span>
+</div>


### PR DESCRIPTION
#### 9a531599df757be7d14ec6925efb13078572c881
<pre>
[blocks-in-inline] WPT css/css-multicol/spanner-in-child-after-parallel-flow-003.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=302867">https://bugs.webkit.org/show_bug.cgi?id=302867</a>
<a href="https://rdar.apple.com/problem/165127526">rdar://problem/165127526</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-multicol-float-and-spanner.html
* LayoutTests/fast/inline/blocks-in-inline-multicol-float-and-spanner-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-multicol-float-and-spanner.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeLineAdjustmentForPagination):

Bail out for block-in-inline before calling updateMinimumPageHeight. That is handled by block layout.
Also remove a big pile of unhelpful prose.

Canonical link: <a href="https://commits.webkit.org/303330@main">https://commits.webkit.org/303330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15afe87b784938b13b58d0603a06189f82633f30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139571 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/83966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d8d9c93-7111-417d-8d2e-2b791cece926) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4311 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/83966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/37b4a58a-009f-4a41-b970-69700160f491) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135003 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81738 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd1e4a02-609b-4147-a8db-1ec0cb257183) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82791 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142218 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4219 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/36983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109317 "Found 1 new test failure: fast/multicol/crash-in-vertical-writing-mode.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4300 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3204 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57449 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4273 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32954 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4104 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4364 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->