### PR TITLE
[threaded-animations] scroll-driven animations stop updating after reaching 100%

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
@@ -47,8 +47,9 @@ const scrollAndCheckTimeline = async (scroller, progress) => {
 
     const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
     assert_equals(remoteAnimationStack.animations.length, 1);
-    const timelineTime = remoteAnimationStack.animations[0].timeline.currentTime;
-    assert_equals(timelineTime, expectedTimelineTime, `After scrolling to ${scrollTop}, the timeline time is ${expectedTimelineTime}`);
+    const remoteAnimation = remoteAnimationStack.animations[0];
+    assert_equals(remoteAnimation.timeline.currentTime, expectedTimelineTime, `After scrolling to ${scrollTop}, the timeline time is ${expectedTimelineTime}`);
+    assert_equals(remoteAnimation.progress, progress, `After scrolling to ${scrollTop}, the animation progress is ${progress}`);
 };
 
 promise_test(async t => { 

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
@@ -40,8 +40,9 @@ const scrollAndCheckTimeline = async (scroller, progress) => {
 
     const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
     assert_equals(remoteAnimationStack.animations.length, 1);
-    const timelineTime = remoteAnimationStack.animations[0].timeline.currentTime;
-    assert_equals(timelineTime, expectedTimelineTime, `After scrolling to ${scrollTop}, the timeline time is ${expectedTimelineTime}`);
+    const remoteAnimation = remoteAnimationStack.animations[0];
+    assert_equals(remoteAnimation.timeline.currentTime, expectedTimelineTime, `After scrolling to ${scrollTop}, the timeline time is ${expectedTimelineTime}`);
+    assert_equals(remoteAnimation.progress, progress, `After scrolling to ${scrollTop}, the animation progress is ${progress}`);
 };
 
 promise_test(async t => { 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2116,7 +2116,7 @@ void KeyframeEffect::updateAcceleratedAnimationIfNecessary()
 void KeyframeEffect::animationDidFinish()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (canHaveAcceleratedRepresentation())
+    if (canHaveAcceleratedRepresentation() && !m_isAssociatedWithProgressBasedTimeline)
         updateAcceleratedAnimationIfNecessary();
 #endif
 }

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -83,6 +83,7 @@ public:
     WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
     WEBCORE_EXPORT void apply(AcceleratedEffectValues&, WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
+    WEBCORE_EXPORT ResolvedEffectTiming resolvedTimingForTesting(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
 
     // Encoding and decoding support
     const AnimationEffectTiming& timing() const { return m_timing; }
@@ -108,6 +109,7 @@ private:
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 
     void validateFilters(const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>&);
+    ResolvedEffectTiming resolvedTiming(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
 
     // KeyframeInterpolation
     bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp
@@ -72,6 +72,8 @@ Ref<JSON::Object> RemoteAnimation::toJSONForTesting() const
         return convertedKeyframes;
     };
 
+    auto resolvedTiming = m_effect->resolvedTimingForTesting(m_timeline->currentTime(), m_timeline->duration());
+
     Ref object = JSON::Object::create();
     object->setValue("composite"_s, WebKit::toJSONForTesting(m_effect->compositeOperation()));
     object->setBoolean("paused"_s, m_effect->paused());
@@ -82,6 +84,8 @@ Ref<JSON::Object> RemoteAnimation::toJSONForTesting() const
     object->setArray("keyframes"_s, convertKeyframes(keyframes()));
     object->setObject("timing"_s, WebKit::toJSONForTesting(m_effect->timing()));
     object->setObject("timeline"_s, m_timeline->toJSONForTesting());
+    if (auto progress = resolvedTiming.transformedProgress)
+        object->setDouble("progress"_s, *progress);
     return object;
 }
 


### PR DESCRIPTION
#### 870d2f5946c851edcc990bae81eef2e84cb4c809
<pre>
[threaded-animations] scroll-driven animations stop updating after reaching 100%
<a href="https://bugs.webkit.org/show_bug.cgi?id=302870">https://bugs.webkit.org/show_bug.cgi?id=302870</a>
<a href="https://rdar.apple.com/165130574">rdar://165130574</a>

Reviewed by Simon Fraser.

Once an accelerated scroll-driven animation reaches 100%, and we update the animation timing
model, `KeyframeEffect::animationDidFinish()` is called and we update the associated accelerated
effect stack for the associated target while the associated animation&apos;s hold time [0] is set,
as the animation is indeed finished.

This yields an update of that animation&apos;s counterpart in the remote layer tree with the
`AcceleratedEffect::m_holdTime` member set to `100%`. From that point on, even though the
associated remote timeline is indeed updated based on the scroll offset, the computed value
for `localTime` in `AcceleratedEffect::apply()` is stuck to `100%` as we assume the hold time
indicates a paused time, not a finished time in that case.

We fix this bug by, first, not triggering an accelerated effect stack update when a scroll-driven
animation is &quot;finished&quot; since it really doesn&apos;t mean much for an animation that is not monotonic.
Additionally, we ensure we only use the hold time when computing the local time [1] if the remote
animation is paused, meaning this bug would have been fixed even if the remote animation had been
updated when reaching 100%.

To check that we indeed update the remote animation&apos;s effect as the remote animation&apos;s timeline
updates, we add a new `progress` property to the JSON object returned via `UIScriptController`
and add assertions to existing tests that check updates occur even after reaching 100%.

[0] <a href="https://drafts.csswg.org/web-animations-1/#animation-hold-time">https://drafts.csswg.org/web-animations-1/#animation-hold-time</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#local-time-section">https://drafts.csswg.org/web-animations-1/#local-time-section</a>

* LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html:
* LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationDidFinish):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::resolvedTimingForTesting const):
(WebCore::AcceleratedEffect::resolvedTiming const):
(WebCore::AcceleratedEffect::apply const):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp:
(WebKit::RemoteAnimation::toJSONForTesting const):

Canonical link: <a href="https://commits.webkit.org/303400@main">https://commits.webkit.org/303400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd70728fcb13b53ad2596e74e240cac891cc1041

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83975 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ed3516a9-e71c-47bf-b8a4-03aa75d1ecce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100954 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68311 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81745 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2940a48-4806-4065-858f-e6b777c61521) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3100 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/983 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82799 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142226 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4227 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109324 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109497 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3210 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57463 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20554 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32958 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4112 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4240 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->