### PR TITLE
[Site isolation] Pipe AudioSession and AudioHardwareListener between RemoteMediaSessionManager and RemoteMediaSessionManagerProxy

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -73,9 +73,9 @@ protected:
     void updateNowPlayingInfo();
     void updateActiveNowPlayingSession(RefPtr<PlatformMediaSessionInterface>);
 
-    void removeSession(PlatformMediaSessionInterface&) final;
-    void addSession(PlatformMediaSessionInterface&) final;
-    void setCurrentSession(PlatformMediaSessionInterface&) final;
+    void removeSession(PlatformMediaSessionInterface&) override;
+    void addSession(PlatformMediaSessionInterface&) override;
+    void setCurrentSession(PlatformMediaSessionInterface&) override;
 
     bool sessionWillBeginPlayback(PlatformMediaSessionInterface&) override;
     void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) override;
@@ -92,18 +92,16 @@ protected:
     void resetHaveEverRegisteredAsNowPlayingApplicationForTesting() final { m_haveEverRegisteredAsNowPlayingApplication = false; };
     void resetSessionState() final;
 
-private:
-#if !RELEASE_LOG_DISABLED
-    ASCIILiteral logClassName() const override { return "MediaSessionManagerCocoa"_s; }
-#endif
-
-    // NowPlayingManagerClient
-    void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType type, const PlatformMediaSession::RemoteCommandArgument& argument) final { processDidReceiveRemoteControlCommand(type, argument); }
+    RefPtr<AudioHardwareListener> audioHardwareListener() const;
 
     // AudioHardwareListenerClient
-    void audioHardwareDidBecomeActive() final { }
-    void audioHardwareDidBecomeInactive() final { }
-    void audioOutputDeviceChanged() final;
+    void audioHardwareDidBecomeActive() override;
+    void audioHardwareDidBecomeInactive() override;
+    void audioOutputDeviceChanged() override;
+
+private:
+    // NowPlayingManagerClient
+    void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) final;
 
     void possiblyChangeAudioCategory();
 
@@ -111,6 +109,10 @@ private:
 
 #if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
     static void updateNowPlayingSuppression(const NowPlayingInfo*);
+#endif
+
+#if !RELEASE_LOG_DISABLED
+    ASCIILiteral logClassName() const override;
 #endif
 
     bool m_nowPlayingActive { false };
@@ -134,6 +136,18 @@ private:
     AudioSession::CategoryType m_previousCategory { AudioSession::CategoryType::None };
     bool m_previousHadAudibleAudioOrVideoMediaType { false };
 };
+
+inline RefPtr<AudioHardwareListener> MediaSessionManagerCocoa::audioHardwareListener() const { return m_audioHardwareListener; }
+
+inline void MediaSessionManagerCocoa::audioHardwareDidBecomeActive() { }
+
+inline void MediaSessionManagerCocoa::audioHardwareDidBecomeInactive() { }
+
+inline void MediaSessionManagerCocoa::didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType type, const PlatformMediaSession::RemoteCommandArgument& argument) { processDidReceiveRemoteControlCommand(type, argument); }
+
+#if !RELEASE_LOG_DISABLED
+inline ASCIILiteral MediaSessionManagerCocoa::logClassName() const { return "MediaSessionManagerCocoa"_s; }
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -82,7 +82,10 @@ private:
     void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<MediaPlaybackTarget>&&) final;
     void isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit) final;
     void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) final;
+
+#if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const override;
+#endif
 
 #if !PLATFORM(WATCHOS)
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
@@ -92,7 +95,9 @@ private:
     bool m_isMonitoringWirelessRoutes { false };
 };
 
+#if !RELEASE_LOG_DISABLED
 inline ASCIILiteral MediaSessionManageriOS::logClassName() const { return "MediaSessionManageriOS"_s; }
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -47,7 +47,7 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSessionProxy);
 
 RemoteAudioSessionProxy::RemoteAudioSessionProxy(GPUConnectionToWebProcess& gpuConnection)
-: m_gpuConnection(gpuConnection)
+    : m_gpuConnection(gpuConnection)
 {
 }
 
@@ -78,6 +78,7 @@ RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
         m_active,
         m_sceneIdentifier,
         m_soundStageSize,
+        session->categoryOverride(),
     };
 }
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.cpp
@@ -69,8 +69,7 @@ void RemoteMediaSessionClientProxy::suspendPlayback()
 
 void RemoteMediaSessionClientProxy::didReceiveRemoteControlCommand(WebCore::PlatformMediaSessionRemoteControlCommandType command, const WebCore::PlatformMediaSessionRemoteCommandArgument& argument)
 {
-    if (RefPtr manager = m_manager.get())
-        manager->send(Messages::RemoteMediaSessionManager::ClientDidReceiveRemoteControlCommand(sessionIdentifier(), command, argument));
+    ASSERT_NOT_REACHED();
 }
 
 bool RemoteMediaSessionClientProxy::shouldOverrideBackgroundPlaybackRestriction(WebCore::PlatformMediaSessionInterruptionType) const

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
@@ -32,6 +32,16 @@ messages -> RemoteMediaSessionManagerProxy {
     void AddMediaSession(struct WebKit::RemoteMediaSessionState session);
     void RemoveMediaSession(struct WebKit::RemoteMediaSessionState session);
     void SetCurrentMediaSession(struct WebKit::RemoteMediaSessionState session);
+
+#if PLATFORM(COCOA)
+    void RemoteAudioHardwareDidBecomeActive();
+    void RemoteAudioHardwareDidBecomeInactive();
+    void RemoteAudioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum);
+#endif
+
+#if USE(AUDIO_SESSION)
+    void RemoteAudioConfigurationChanged(struct WebKit::RemoteAudioSessionConfiguration configuration);
+#endif
 }
 
 #endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -462,6 +462,7 @@
 #endif
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+#include "RemoteAudioSessionConfiguration.h"
 #include "RemoteMediaSessionManagerProxy.h"
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -49,13 +49,13 @@ class RemoteAudioSession final
     , IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioSession);
 public:
-    static Ref<RemoteAudioSession> create();
+    static Ref<RemoteAudioSession> create(WebProcess&);
     ~RemoteAudioSession();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
-    RemoteAudioSession();
+    RemoteAudioSession(WebProcess&);
     IPC::Connection& ensureConnection();
     Ref<IPC::Connection> ensureProtectedConnection();
 
@@ -117,6 +117,7 @@ private:
     void beginAudioSessionInterruption() final;
     void endAudioSessionInterruption(MayResume) final;
 
+    WeakRef<WebProcess> m_webProcess;
     WeakHashSet<WebCore::AudioSessionConfigurationChangeObserver> m_configurationChangeObservers;
     CategoryType m_category { CategoryType::None };
     Mode m_mode { Mode::Default };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
+#if USE(AUDIO_SESSION)
 
 #include <WebCore/AudioSession.h>
 
@@ -43,6 +43,7 @@ struct RemoteAudioSessionConfiguration {
     bool isActive { false };
     String sceneIdentifier;
     WebCore::AudioSessionSoundStageSize soundStageSize { WebCore::AudioSessionSoundStageSize::Automatic };
+    WebCore::AudioSessionCategory categoryOverride { WebCore::AudioSession::CategoryType::None };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
+#if USE(AUDIO_SESSION)
 
 struct WebKit::RemoteAudioSessionConfiguration {
     String routingContextUID;
@@ -34,6 +34,7 @@ struct WebKit::RemoteAudioSessionConfiguration {
     bool isActive;
     String sceneIdentifier;
     WebCore::AudioSessionSoundStageSize soundStageSize;
+    WebCore::AudioSessionCategory categoryOverride;
 };
 
 #endif

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in
@@ -32,7 +32,11 @@ messages -> RemoteMediaSessionManager {
     void ClientMayResumePlayback(WebCore::MediaSessionIdentifier identifier, bool shouldResume)
     void ClientShouldSuspendPlayback(WebCore::MediaSessionIdentifier identifier)
     void ClientSetShouldPlayToPlaybackTarget(WebCore::MediaSessionIdentifier identifier, bool shouldPlay)
-    void ClientDidReceiveRemoteControlCommand(WebCore::MediaSessionIdentifier identifier, enum:uint8_t WebCore::PlatformMediaSessionRemoteControlCommandType command, struct WebCore::PlatformMediaSessionRemoteCommandArgument argument);
+
+#if USE(AUDIO_SESSION)
+    void SetAudioSessionCategory(enum:uint8_t WebCore::AudioSessionCategory type, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
+    void SetAudioSessionPreferredBufferSize(uint64_t preferredBufferSize)
+#endif
 }
 
 #endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -165,6 +165,7 @@ class WebTransportSession;
 struct AccessibilityPreferences;
 struct AdditionalFonts;
 struct ContentWorldIdentifierType;
+struct RemoteAudioSessionConfiguration;
 struct RemoteWorkerInitializationData;
 struct UserMessage;
 struct WebProcessCreationParameters;
@@ -544,6 +545,10 @@ public:
 #if ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)
     void initializeAccessibility(Vector<SandboxExtension::Handle>&&);
     bool shouldInitializeAccessibility() const { return m_shouldInitializeAccessibility; }
+#endif
+
+#if USE(AUDIO_SESSION)
+    void remoteAudioSessionConfigurationChanged(const RemoteAudioSessionConfiguration&);
 #endif
 
 private:


### PR DESCRIPTION
#### b80101a8634c8302d4b3c529bec0327b2e073eee
<pre>
[Site isolation] Pipe AudioSession and AudioHardwareListener between RemoteMediaSessionManager and RemoteMediaSessionManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=302875">https://bugs.webkit.org/show_bug.cgi?id=302875</a>
<a href="https://rdar.apple.com/165134705">rdar://165134705</a>

Reviewed by Jer Noble.

RemoteMediaSessionManagerProxy, the part of media session manager that runs in the UI process,
needs to read and write AudioSession and AudioHardwareListener. Both of these run in the
GPU process and have proxies in the Web process. Add additional proxies in
RemoteMediaSessionManagerProxy in the UI process, and pipe state changes between it and
RemoteMediaSessionManager in the WebProcess so all three processes stay in sync.

No new tests, the remote session manager is disabled by default and is not testable yet.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
(WebCore::MediaSessionManagerCocoa::audioHardwareListener const):
(WebCore::MediaSessionManagerCocoa::audioHardwareDidBecomeActive):
(WebCore::MediaSessionManagerCocoa::audioHardwareDidBecomeInactive):
(WebCore::MediaSessionManagerCocoa::didReceiveRemoteControlCommand):
(WebCore::MediaSessionManagerCocoa::logClassName const):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::RemoteAudioSessionProxy):
(WebKit::RemoteAudioSessionProxy::configuration):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.cpp:
(WebKit::RemoteMediaSessionClientProxy::didReceiveRemoteControlCommand):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioConfigurationChanged):
(WebKit::RemoteMediaSessionManagerProxy::setCategory):
(WebKit::RemoteMediaSessionManagerProxy::tryToSetActiveInternal):
(WebKit::RemoteMediaSessionManagerProxy::setPreferredBufferSize):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive):
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged):
(WebKit::RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
(WebKit::RemoteMediaSessionManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::create):
(WebKit::RemoteAudioSession::RemoteAudioSession):
(WebKit::RemoteAudioSession::configurationChanged):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::RemoteMediaSessionManager):
(WebKit::RemoteMediaSessionManager::addSession):
(WebKit::RemoteMediaSessionManager::removeSession):
(WebKit::RemoteMediaSessionManager::setCurrentSession):
(WebKit::RemoteMediaSessionManager::audioHardwareDidBecomeActive):
(WebKit::RemoteMediaSessionManager::audioHardwareDidBecomeInactive):
(WebKit::RemoteMediaSessionManager::audioOutputDeviceChanged):
(WebKit::RemoteMediaSessionManager::setAudioSessionCategory):
(WebKit::RemoteMediaSessionManager::setAudioSessionPreferredBufferSize):
(WebKit::RemoteMediaSessionManager::tryToSetAudioSessionActive):
(WebKit::RemoteMediaSessionManager::updateCachedSessionState):
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h:
(WebKit::RemoteMediaSessionManager::logClassName const):
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::remoteAudioSessionConfigurationChanged):
(WebKit::WebProcess::setUseGPUProcessForMedia):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/303417@main">https://commits.webkit.org/303417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32ac3d2098a964581e2eda769f9850b23af253bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139841 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f5bb949-9ca7-4975-ae1c-cb5ecfecf531) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6195026a-6e68-48da-b5f5-4d0570d2e4a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135272 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81947 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83066 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142491 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4491 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109535 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109713 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3398 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57767 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4545 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33171 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->