### PR TITLE
[Safer CPP] Address issues in WebCore/xml

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -93,5 +93,4 @@ style/StyleExtractorState.h
 style/StyleScope.h
 style/values/will-change/StyleWillChange.cpp
 testing/Internals.cpp
-xml/XSLStyleSheetLibxslt.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -721,8 +721,4 @@ workers/WorkerThread.cpp
 workers/shared/context/SharedWorkerThreadProxy.cpp
 worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp
-xml/XPathFunctions.cpp
-xml/XSLImportRule.cpp
-xml/XSLStyleSheetLibxslt.cpp
-xml/XSLTProcessorLibxslt.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -984,10 +984,4 @@ workers/shared/SharedWorker.cpp
 worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp
 worklets/WorkletPendingTasks.cpp
-xml/XMLHttpRequest.cpp
-xml/XPathEvaluator.cpp
-xml/XPathFunctions.cpp
-xml/XSLImportRule.cpp
-xml/XSLStyleSheetLibxslt.cpp
-xml/XSLTProcessorLibxslt.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -719,7 +719,7 @@ bool XMLHttpRequest::internalAbort()
     // This would create internalAbort reentrant call.
     // m_loadingActivity is set to std::nullopt before being cancelled to exit early in any reentrant internalAbort() call.
     auto loadingActivity = std::exchange(m_loadingActivity, std::nullopt);
-    loadingActivity->loader->cancel();
+    loadingActivity->protectedLoader()->cancel();
 
     // If window.onload callback calls open() and send() on the same xhr, m_loadingActivity is now set to a new value.
     // The function calling internalAbort() should abort to let the open() and send() calls continue properly.
@@ -1103,7 +1103,7 @@ void XMLHttpRequest::dispatchEvent(Event& event)
 {
     RELEASE_ASSERT(!scriptExecutionContext()->activeDOMObjectsAreSuspended());
 
-    if (m_userGestureToken && m_userGestureToken->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwardingForFetch()))
+    if (m_userGestureToken && RefPtr { m_userGestureToken }->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwardingForFetch()))
         m_userGestureToken = nullptr;
 
     if (readyState() != DONE || !m_userGestureToken || !m_userGestureToken->processingUserGesture()) {
@@ -1132,7 +1132,7 @@ void XMLHttpRequest::timeoutTimerFired()
 {
     if (!m_loadingActivity)
         return;
-    m_loadingActivity->loader->computeIsDone();
+    m_loadingActivity->protectedLoader()->computeIsDone();
 }
 
 void XMLHttpRequest::notifyIsDone(bool isDone)
@@ -1227,6 +1227,11 @@ bool XMLHttpRequest::virtualHasPendingActivity() const
 void XMLHttpRequest::dispatchThrottledProgressEventIfNeeded()
 {
     m_progressEventThrottle->dispatchThrottledProgressEventIfNeeded();
+}
+
+Ref<ThreadableLoader> XMLHttpRequest::LoadingActivity::protectedLoader() const
+{
+    return loader;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -233,6 +233,7 @@ private:
     struct LoadingActivity {
         Ref<XMLHttpRequest> protectedThis; // Keep object alive while loading even if there is no longer a JS wrapper.
         Ref<ThreadableLoader> loader;
+        Ref<ThreadableLoader> protectedLoader() const;
     };
     std::optional<LoadingActivity> m_loadingActivity;
 

--- a/Source/WebCore/xml/XPathEvaluator.cpp
+++ b/Source/WebCore/xml/XPathEvaluator.cpp
@@ -54,7 +54,7 @@ ExceptionOr<Ref<XPathResult>> XPathEvaluator::evaluate(const String& expression,
     if (createResult.hasException())
         return createResult.releaseException();
 
-    return createResult.releaseReturnValue()->evaluate(contextNode, type, result);
+    return RefPtr { createResult.releaseReturnValue() }->evaluate(contextNode, type, result);
 }
 
 }

--- a/Source/WebCore/xml/XPathExpressionNode.h
+++ b/Source/WebCore/xml/XPathExpressionNode.h
@@ -37,8 +37,9 @@ struct EvaluationContext {
     unsigned size;
     unsigned position;
     HashMap<String, String> variableBindings;
-
     bool hadTypeConversionError;
+
+    RefPtr<Node> protectedNode() const { return node; }
 };
 
 class Expression {

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -408,7 +408,7 @@ Value FunLocalName::evaluate() const
         return node ? expandedNameLocalPart(*node) : emptyString();
     }
 
-    return expandedNameLocalPart(*evaluationContext().node);
+    return expandedNameLocalPart(*evaluationContext().protectedNode());
 }
 
 Value FunNamespaceURI::evaluate() const
@@ -422,7 +422,7 @@ Value FunNamespaceURI::evaluate() const
         return node ? node->namespaceURI().string() : emptyString();
     }
 
-    return evaluationContext().node->namespaceURI().string();
+    return evaluationContext().protectedNode()->namespaceURI().string();
 }
 
 Value FunName::evaluate() const
@@ -436,7 +436,7 @@ Value FunName::evaluate() const
         return node ? expandedName(*node) : emptyString();
     }
 
-    return expandedName(*evaluationContext().node);
+    return expandedName(*evaluationContext().protectedNode());
 }
 
 Value FunCount::evaluate() const

--- a/Source/WebCore/xml/XSLImportRule.cpp
+++ b/Source/WebCore/xml/XSLImportRule.cpp
@@ -43,7 +43,7 @@ XSLImportRule::XSLImportRule(XSLStyleSheet& parent, const String& href)
 XSLImportRule::~XSLImportRule()
 {
     if (m_styleSheet)
-        m_styleSheet->setParentStyleSheet(nullptr);
+        protectedStyleSheet()->setParentStyleSheet(nullptr);
 
     if (m_cachedSheet)
         m_cachedSheet->removeClient(*this);
@@ -52,13 +52,13 @@ XSLImportRule::~XSLImportRule()
 void XSLImportRule::setXSLStyleSheet(const String& href, const URL& baseURL, const String& sheet)
 {
     if (m_styleSheet)
-        m_styleSheet->setParentStyleSheet(nullptr);
+        protectedStyleSheet()->setParentStyleSheet(nullptr);
 
     // FIXME: parentStyleSheet() should never be null here.
     RefPtr parent = parentStyleSheet();
     m_styleSheet = XSLStyleSheet::create(parent.get(), href, baseURL);
 
-    m_styleSheet->parseString(sheet);
+    protectedStyleSheet()->parseString(sheet);
     m_loading = false;
 
     if (parent)
@@ -96,7 +96,7 @@ void XSLImportRule::loadSheet()
 
     auto options = CachedResourceLoader::defaultCachedResourceOptions();
     options.mode = FetchOptions::Mode::SameOrigin;
-    m_cachedSheet = cachedResourceLoader->requestXSLStyleSheet({ResourceRequest(cachedResourceLoader->document()->completeURL(absHref)), options}).value_or(nullptr);
+    m_cachedSheet = cachedResourceLoader->requestXSLStyleSheet({ ResourceRequest(cachedResourceLoader->protectedDocument()->completeURL(absHref)), options }).value_or(nullptr);
 
     if (m_cachedSheet) {
         m_cachedSheet->addClient(*this);

--- a/Source/WebCore/xml/XSLImportRule.h
+++ b/Source/WebCore/xml/XSLImportRule.h
@@ -41,6 +41,7 @@ public:
     
     const String& href() const { return m_strHref; }
     XSLStyleSheet* styleSheet() const { return m_styleSheet.get(); }
+    RefPtr<XSLStyleSheet> protectedStyleSheet() const { return styleSheet(); }
 
     XSLStyleSheet* parentStyleSheet() const { return m_parentStyleSheet.get(); }
     void setParentStyleSheet(XSLStyleSheet* styleSheet) { m_parentStyleSheet = styleSheet; }

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -87,8 +87,8 @@ void XSLStyleSheet::checkLoaded()
         return;
     if (RefPtr styleSheet = parentStyleSheet())
         styleSheet->checkLoaded();
-    if (ownerNode())
-        ownerNode()->sheetLoaded();
+    if (RefPtr ownerNode = this->ownerNode())
+        ownerNode->sheetLoaded();
 }
 
 xmlDocPtr XSLStyleSheet::document()
@@ -103,8 +103,8 @@ void XSLStyleSheet::clearDocuments()
     clearXSLStylesheetDocument();
 
     for (auto& import : m_children) {
-        if (import->styleSheet())
-            import->styleSheet()->clearDocuments();
+        if (RefPtr styleSheet = import->styleSheet())
+            styleSheet->clearDocuments();
     }
 }
 
@@ -157,9 +157,9 @@ bool XSLStyleSheet::parseString(const String& string)
         // if a document uses more than one symbol dictionary, so we
         // ensure that all child stylesheets use the same dictionaries as their
         // parents.
-        xmlDictFree(ctxt->dict);
+        SUPPRESS_FORWARD_DECL_ARG xmlDictFree(ctxt->dict);
         ctxt->dict = m_parentStyleSheet->m_stylesheetDoc->dict;
-        xmlDictReference(ctxt->dict);
+        SUPPRESS_FORWARD_DECL_ARG xmlDictReference(ctxt->dict);
     }
 
     m_stylesheetDoc = xmlCtxtReadMemory(ctxt, buffer, size,


### PR DESCRIPTION
#### 75a16623e253de7df3ccbe140ceee1c876ba899f
<pre>
[Safer CPP] Address issues in WebCore/xml
<a href="https://bugs.webkit.org/show_bug.cgi?id=302879">https://bugs.webkit.org/show_bug.cgi?id=302879</a>
<a href="https://rdar.apple.com/165143728">rdar://165143728</a>

Reviewed by Chris Dumez.

Address all Safer CPP issues for several WebCore/xml classes

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::internalAbort):
(WebCore::XMLHttpRequest::dispatchEvent):
(WebCore::XMLHttpRequest::timeoutTimerFired):
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/XPathEvaluator.cpp:
(WebCore::XPathEvaluator::evaluate):
* Source/WebCore/xml/XPathExpressionNode.h:
(WebCore::XPath::EvaluationContext::protectedNode const):
* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::FunLocalName::evaluate const):
(WebCore::XPath::FunNamespaceURI::evaluate const):
(WebCore::XPath::FunName::evaluate const):
* Source/WebCore/xml/XSLImportRule.cpp:
(WebCore::XSLImportRule::~XSLImportRule):
(WebCore::XSLImportRule::setXSLStyleSheet):
(WebCore::XSLImportRule::loadSheet):
* Source/WebCore/xml/XSLImportRule.h:
(WebCore::XSLImportRule::protectedStyleSheet const):
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::checkLoaded):
(WebCore::XSLStyleSheet::clearDocuments):
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc):
(WebCore::xsltStylesheetPointer):
(WebCore::xmlDocPtrFromNode):
(WebCore::XSLTProcessor::transformToString):

Canonical link: <a href="https://commits.webkit.org/303475@main">https://commits.webkit.org/303475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e62a8ab9c812450f9b2a4428d84480c7d6bef4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84486 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/303f8ba2-2ff4-4e41-baec-1a2d025969b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101297 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68567 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a8e37620-22c7-46ee-ac88-7042767ded45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135442 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82091 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be2ff898-ebb7-4ca1-8842-27323c37ac7f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3541 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1280 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83249 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142667 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4661 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109672 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4743 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4027 "Found 1 new test failure: imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3539 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114965 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58034 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4715 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33315 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4806 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4672 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->