### PR TITLE
[EME] Add logging of keyIDs

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2505,6 +2505,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/encryptedmedia/CDMInstance.h
     platform/encryptedmedia/CDMInstanceSession.h
     platform/encryptedmedia/CDMKeyGroupingStrategy.h
+    platform/encryptedmedia/CDMKeyID.h
     platform/encryptedmedia/CDMKeyStatus.h
     platform/encryptedmedia/CDMKeySystemConfiguration.h
     platform/encryptedmedia/CDMMediaCapability.h
@@ -2514,6 +2515,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/encryptedmedia/CDMRequirement.h
     platform/encryptedmedia/CDMRestrictions.h
     platform/encryptedmedia/CDMSessionType.h
+    platform/encryptedmedia/CDMTypesForward.h
     platform/encryptedmedia/CDMUtilities.h
 
     platform/gamepad/GamepadProvider.h

--- a/Source/WebCore/Modules/encryptedmedia/CDMClient.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDMClient.h
@@ -30,8 +30,8 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include <WebCore/CDMTypesForward.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
-#include <wtf/Forward.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -28,10 +28,11 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include "CDMKeyID.h"
 #include "ISOProtectionSystemSpecificHeaderBox.h"
-#include <JavaScriptCore/DataView.h>
 #include "NotImplemented.h"
 #include "SharedBuffer.h"
+#include <JavaScriptCore/DataView.h>
 #include <wtf/JSONValues.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/Base64.h>
@@ -63,7 +64,7 @@ namespace {
     const uint32_t kKeyIdsMaxKeyIdSizeInBytes = 512;
 }
 
-static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsKeyids(const SharedBuffer& buffer)
+static std::optional<CDMKeyIDs> extractKeyIDsKeyids(const SharedBuffer& buffer)
 {
     // 1. Format
     // https://w3c.github.io/encrypted-media/format-registry/initdata/keyids.html#format
@@ -83,7 +84,7 @@ static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsKeyids(const Shared
     if (!kidsArray)
         return std::nullopt;
 
-    Vector<Ref<SharedBuffer>> keyIDs;
+    CDMKeyIDs keyIDs;
     for (auto& value : *kidsArray) {
         auto keyID = value->asString();
         if (!keyID)
@@ -159,9 +160,9 @@ std::optional<Vector<std::unique_ptr<ISOProtectionSystemSpecificHeaderBox>>> Ini
     return psshBoxes;
 }
 
-std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDsCenc(const SharedBuffer& buffer)
+std::optional<CDMKeyIDs> InitDataRegistry::extractKeyIDsCenc(const SharedBuffer& buffer)
 {
-    Vector<Ref<SharedBuffer>> keyIDs;
+    CDMKeyIDs keyIDs;
 
     auto psshBoxes = extractPsshBoxesFromCenc(buffer);
     if (!psshBoxes)
@@ -275,9 +276,9 @@ static RefPtr<SharedBuffer> sanitizeWebM(const SharedBuffer& buffer)
     return buffer.makeContiguous();
 }
 
-static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsWebM(const SharedBuffer& buffer)
+static std::optional<CDMKeyIDs> extractKeyIDsWebM(const SharedBuffer& buffer)
 {
-    Vector<Ref<SharedBuffer>> keyIDs;
+    CDMKeyIDs keyIDs;
     RefPtr<SharedBuffer> sanitizedBuffer = sanitizeWebM(buffer);
     if (!sanitizedBuffer)
         return std::nullopt;
@@ -311,7 +312,7 @@ RefPtr<SharedBuffer> InitDataRegistry::sanitizeInitData(const String& initDataTy
     return iter->value.sanitizeInitData(buffer);
 }
 
-std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDs(const String& initDataType, const SharedBuffer& buffer)
+std::optional<CDMKeyIDs> InitDataRegistry::extractKeyIDs(const String& initDataType, const SharedBuffer& buffer)
 {
     auto iter = m_types.find(initDataType);
     if (iter == m_types.end() || !iter->value.sanitizeInitData)

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include <WebCore/CDMTypesForward.h>
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
@@ -44,11 +45,11 @@ public:
     friend class NeverDestroyed<InitDataRegistry>;
 
     RefPtr<SharedBuffer> sanitizeInitData(const String& initDataType, const SharedBuffer&);
-    WEBCORE_EXPORT std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDs(const String& initDataType, const SharedBuffer&);
+    WEBCORE_EXPORT std::optional<CDMKeyIDs> extractKeyIDs(const String& initDataType, const SharedBuffer&);
 
     struct InitDataTypeCallbacks {
         using SanitizeInitDataCallback = Function<RefPtr<SharedBuffer>(const SharedBuffer&)>;
-        using ExtractKeyIDsCallback = Function<std::optional<Vector<Ref<SharedBuffer>>>(const SharedBuffer&)>;
+        using ExtractKeyIDsCallback = Function<std::optional<CDMKeyIDs>(const SharedBuffer&)>;
 
         SanitizeInitDataCallback sanitizeInitData;
         ExtractKeyIDsCallback extractKeyIDs;
@@ -60,7 +61,7 @@ public:
     static const String& webmName();
 
     static std::optional<Vector<std::unique_ptr<ISOProtectionSystemSpecificHeaderBox>>> extractPsshBoxesFromCenc(const SharedBuffer&);
-    static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsCenc(const SharedBuffer&);
+    static std::optional<CDMKeyIDs> extractKeyIDsCenc(const SharedBuffer&);
     static RefPtr<SharedBuffer> sanitizeCenc(const SharedBuffer&);
 
 private:

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -32,6 +32,7 @@
 
 #include "ActiveDOMObject.h"
 #include "CDMInstanceSession.h"
+#include "CDMKeyID.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
 #include "IDLTypes.h"
@@ -89,7 +90,7 @@ public:
     using ClosedPromise = DOMPromiseProxy<IDLUndefined>;
     ClosedPromise& closed() { return m_closedPromise.get(); }
 
-    const Vector<std::pair<Ref<SharedBuffer>, MediaKeyStatus>>& statuses() const { return m_statuses; }
+    const Vector<std::pair<CDMKeyID, MediaKeyStatus>>& statuses() const { return m_statuses; }
 
     unsigned internalInstanceSessionObjectRefCount() const { return m_instanceSession->refCount(); }
 
@@ -146,7 +147,7 @@ private:
     Vector<Ref<SharedBuffer>> m_recordOfKeyUsage;
     double m_firstDecryptTime { 0 };
     double m_latestDecryptTime { 0 };
-    Vector<std::pair<Ref<SharedBuffer>, MediaKeyStatus>> m_statuses;
+    Vector<std::pair<CDMKeyID, MediaKeyStatus>> m_statuses;
 
     using DisplayChangedObserver = Observer<void(PlatformDisplayID)>;
     const Ref<DisplayChangedObserver> m_displayChangedObserver;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
@@ -31,6 +31,7 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include "BufferSource.h"
+#include "CDMKeyID.h"
 #include "MediaKeyStatus.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h
@@ -30,6 +30,7 @@
 #include <WebCore/CDMKeyStatus.h>
 #include <WebCore/CDMMessageType.h>
 #include <WebCore/CDMSessionType.h>
+#include <WebCore/CDMTypesForward.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Vector.h>
@@ -59,7 +60,7 @@ public:
     virtual ~CDMInstanceSessionClient() = default;
 
     using KeyStatus = CDMKeyStatus;
-    using KeyStatusVector = Vector<std::pair<Ref<SharedBuffer>, KeyStatus>>;
+    using KeyStatusVector = Vector<std::pair<CDMKeyID, KeyStatus>>;
     virtual void updateKeyStatuses(KeyStatusVector&&) = 0;
     virtual void sendMessage(CDMMessageType, Ref<SharedBuffer>&& message) = 0;
     virtual void sessionIdChanged(const String&) = 0;

--- a/Source/WebCore/platform/encryptedmedia/CDMKeyID.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMKeyID.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/SharedBuffer.h>
+#include <wtf/Ref.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+using CDMKeyID = Ref<SharedBuffer>;
+using CDMKeyIDs = Vector<CDMKeyID>;
+
+}

--- a/Source/WebCore/platform/encryptedmedia/CDMLogging.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMLogging.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include "CDMKeyID.h"
 #include "CDMKeySystemConfiguration.h"
 #include "CDMMediaCapability.h"
 #include "CDMMessageType.h"
@@ -152,6 +153,18 @@ String LogArgument<WebCore::CDMRequirement>::toString(const WebCore::CDMRequirem
 String LogArgument<WebCore::CDMSessionType>::toString(const WebCore::CDMSessionType& type)
 {
     return convertEnumerationToString(type);
+}
+
+String LogArgument<WebCore::CDMKeyID>::toString(const WebCore::CDMKeyID& keyID)
+{
+    return keyID->toHexString();
+}
+
+String LogArgument<WebCore::CDMKeyIDs>::toString(const WebCore::CDMKeyIDs& keys)
+{
+    StringBuilder builder;
+    builder.append('[', interleave(keys, LogArgument<WebCore::CDMKeyID>::toString, ", "_s), ']');
+    return builder.toString();
 }
 
 }

--- a/Source/WebCore/platform/encryptedmedia/CDMLogging.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMLogging.h
@@ -27,21 +27,8 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include <WebCore/CDMTypesForward.h>
 #include <wtf/text/WTFString.h>
-
-namespace WebCore {
-
-struct CDMKeySystemConfiguration;
-struct CDMMediaCapability;
-struct CDMRestrictions;
-
-enum class CDMEncryptionScheme : bool;
-enum class CDMKeyStatus : uint8_t;
-enum class CDMMessageType : uint8_t;
-enum class CDMRequirement : uint8_t;
-enum class CDMSessionType : uint8_t;
-
-}
 
 namespace WTF {
 
@@ -86,6 +73,16 @@ struct LogArgument<WebCore::CDMRequirement> {
 template <>
 struct LogArgument<WebCore::CDMSessionType> {
     static String toString(const WebCore::CDMSessionType&);
+};
+
+template <>
+struct LogArgument<WebCore::CDMKeyID> {
+    static String toString(const WebCore::CDMKeyID&);
+};
+
+template <>
+struct LogArgument<WebCore::CDMKeyIDs> {
+    static String toString(const WebCore::CDMKeyIDs&);
 };
 
 }

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -32,6 +32,7 @@
 
 #include <WebCore/CDMInstance.h>
 #include <WebCore/CDMInstanceSession.h>
+#include <WebCore/CDMKeyID.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/BoxPtr.h>
 #include <wtf/CheckedPtr.h>
@@ -70,7 +71,7 @@ public:
 
     virtual ~KeyHandle() { }
 
-    Ref<SharedBuffer> idAsSharedBuffer() const { return SharedBuffer::create(m_id.span()); }
+    CDMKeyID idAsSharedBuffer() const { return SharedBuffer::create(m_id.span()); }
 
     bool takeValueIfDifferent(KeyHandleValueVariant&&);
 

--- a/Source/WebCore/platform/encryptedmedia/CDMTypesForward.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMTypesForward.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class SharedBuffer;
+class CDMInstance;
+
+struct CDMKeySystemConfiguration;
+struct CDMMediaCapability;
+struct CDMRestrictions;
+
+enum class CDMEncryptionScheme : bool;
+enum class CDMKeyStatus : uint8_t;
+enum class CDMMessageType : uint8_t;
+enum class CDMRequirement : uint8_t;
+enum class CDMSessionType : uint8_t;
+
+using CDMKeyID = Ref<SharedBuffer>;
+using CDMKeyIDs = Vector<CDMKeyID>;
+
+}

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -202,7 +202,7 @@ static bool isCencInitData(const SharedBuffer& initData)
     return ((keyIdsMap.first) && (keyIdsMap.second));
 }
 
-static Ref<SharedBuffer> extractKeyidsFromCencInitData(const SharedBuffer& initData)
+static CDMKeyID extractKeyidsFromCencInitData(const SharedBuffer& initData)
 {
     std::pair<unsigned, unsigned> keyIdsMap = extractKeyidsLocationFromCencInitData(initData);
     unsigned keyIdCount = keyIdsMap.first;
@@ -231,7 +231,7 @@ static Ref<SharedBuffer> extractKeyidsFromCencInitData(const SharedBuffer& initD
     return SharedBuffer::create(object->toJSONString().utf8().span());
 }
 
-static Ref<SharedBuffer> extractKeyIdFromWebMInitData(const SharedBuffer& initData)
+static CDMKeyID extractKeyIdFromWebMInitData(const SharedBuffer& initData)
 {
     // Check if initData is a valid WebM initData.
     if (initData.isEmpty() || initData.size() > std::numeric_limits<unsigned>::max())

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -29,6 +29,7 @@
 #import "AudioMediaStreamTrackRenderer.h"
 #import "CDMFairPlayStreaming.h"
 #import "CDMInstanceFairPlayStreamingAVFObjC.h"
+#import "CDMLogging.h"
 #import "CDMSessionAVContentKeySession.h"
 #import "EffectiveRateChangedListener.h"
 #import "FormatDescriptionUtilities.h"
@@ -1719,7 +1720,7 @@ bool AudioVideoRendererAVFObjC::canEnqueueSample(TrackIdentifier trackId, const 
         return true;
     }
 
-    ALWAYS_LOG(LOGIDENTIFIER, "Can't enqueue sample: ", sample, " no suitable CDM");
+    ALWAYS_LOG(LOGIDENTIFIER, "Can't enqueue sample: ", sample, ", no CDM with usable keyIDs: ", sampleAVFObjC->keyIDs());
     return false;
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -29,6 +29,7 @@
 
 #include "CDMInstance.h"
 #include "CDMInstanceSession.h"
+#include "CDMKeyID.h"
 #include "ContentKeyGroupDataSource.h"
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Function.h>
@@ -131,13 +132,12 @@ public:
     void externalProtectionStatusDidChangeForContentKey(AVContentKey *) final;
     void externalProtectionStatusDidChangeForContentKeyRequest(AVContentKeyRequest*) final;
 
-    using Keys = Vector<Ref<SharedBuffer>>;
-    CDMInstanceSessionFairPlayStreamingAVFObjC* sessionForKeyIDs(const Keys&) const;
+    CDMInstanceSessionFairPlayStreamingAVFObjC* sessionForKeyIDs(const CDMKeyIDs&) const;
     CDMInstanceSessionFairPlayStreamingAVFObjC* sessionForGroup(WebAVContentKeyGrouping *) const;
     CDMInstanceSessionFairPlayStreamingAVFObjC* sessionForKey(AVContentKey *) const;
     CDMInstanceSessionFairPlayStreamingAVFObjC* sessionForRequest(AVContentKeyRequest *) const;
 
-    bool isAnyKeyUsable(const Keys&) const;
+    bool isAnyKeyUsable(const CDMKeyIDs&) const;
 
     using KeyStatusesChangedObserver = Observer<void()>;
     void addKeyStatusesChangedObserver(const KeyStatusesChangedObserver&);
@@ -217,8 +217,7 @@ public:
     void externalProtectionStatusDidChangeForContentKey(AVContentKey *) final;
     void externalProtectionStatusDidChangeForContentKeyRequest(AVContentKeyRequest*) final;
 
-    using Keys = CDMInstanceFairPlayStreamingAVFObjC::Keys;
-    Keys keyIDs();
+    CDMKeyIDs keyIDs();
     AVContentKeySession *contentKeySession() { return m_session ? m_session.get() : m_instance->contentKeySession(); }
     WebAVContentKeyGrouping *contentKeyReportGroup() { return m_group.get(); }
 
@@ -230,7 +229,7 @@ public:
 
     bool hasKey(AVContentKey *) const;
     bool hasRequest(AVContentKeyRequest*) const;
-    bool isAnyKeyUsable(const Keys&) const;
+    bool isAnyKeyUsable(const CDMKeyIDs&) const;
 
     const KeyStatusVector& keyStatuses() const { return m_keyStatuses; }
     KeyStatusVector copyKeyStatuses() const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -32,6 +32,10 @@
 #include <wtf/Forward.h>
 #include <wtf/TypeCasts.h>
 
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+#include <WebCore/CDMKeyID.h>
+#endif
+
 typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 namespace WebCore {
@@ -70,10 +74,9 @@ public:
     Vector<Ref<MediaSampleAVFObjC>> divideIntoHomogeneousSamples();
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    using KeyIDs = Vector<Ref<SharedBuffer>>;
-    void setKeyIDs(KeyIDs&& keyIDs) { m_keyIDs = WTFMove(keyIDs); }
-    const KeyIDs& keyIDs() const { return m_keyIDs; }
-    KeyIDs& keyIDs() { return m_keyIDs; }
+    void setKeyIDs(CDMKeyIDs&& keyIDs) { m_keyIDs = WTFMove(keyIDs); }
+    const CDMKeyIDs& keyIDs() const { return m_keyIDs; }
+    CDMKeyIDs& keyIDs() { return m_keyIDs; }
 #endif
 
     static bool isCMSampleBufferNonDisplaying(CMSampleBufferRef);
@@ -94,7 +97,7 @@ protected:
     MediaTime m_duration;
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    Vector<Ref<SharedBuffer>> m_keyIDs;
+    CDMKeyIDs m_keyIDs;
 #endif
 };
 


### PR DESCRIPTION
#### 93ddba07ae8f63eee058dc4aaddae8cb1e5c65dc
<pre>
[EME] Add logging of keyIDs
<a href="https://rdar.apple.com/165148020">rdar://165148020</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302883">https://bugs.webkit.org/show_bug.cgi?id=302883</a>

Reviewed by Eric Carlson.

Log keyIDs in MediaKeySession::updateKeyStatuses() rather than counts of each
status, and also log keyIDs needed for decoding in
AudioVideoRendererAVFObjC::canEnqueueSample().

Add an explicit type declaration for CDMKeyID and CDMKeyIDs rather than using
Ref&lt;SharedBuffer&gt; and Vector&lt;Ref&lt;SharedBuffer&gt;&gt; everywhere.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/encryptedmedia/CDMClient.h:
* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::extractKeyIDsKeyids):
(WebCore::InitDataRegistry::extractKeyIDsCenc):
(WebCore::extractKeyIDsWebM):
(WebCore::InitDataRegistry::extractKeyIDs):
* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::updateKeyStatuses):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h:
* Source/WebCore/platform/encryptedmedia/CDMKeyID.h: Added.
* Source/WebCore/platform/encryptedmedia/CDMLogging.cpp:
(WTF::LogArgument&lt;WebCore::CDMKeyID&gt;::toString):
(WTF::LogArgument&lt;WebCore::CDMKeyIDs&gt;::toString):
* Source/WebCore/platform/encryptedmedia/CDMLogging.h:
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyHandle::idAsSharedBuffer const):
* Source/WebCore/platform/encryptedmedia/CDMTypesForward.h:
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::extractKeyidsFromCencInitData):
(WebCore::extractKeyIdFromWebMInitData):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::canEnqueueSample):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::sessionForKeyIDs const):
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::isAnyKeyUsable const):
(WebCore::keyIDsForRequest):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::keyIDs):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::isAnyKeyUsable const):
(WTF::LogArgument&lt;WebCore::CDMInstanceFairPlayStreamingAVFObjC::Keys&gt;::toString): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h:
(WebCore::MediaSampleAVFObjC::setKeyIDs):
(WebCore::MediaSampleAVFObjC::keyIDs const):
(WebCore::MediaSampleAVFObjC::keyIDs):

Canonical link: <a href="https://commits.webkit.org/304385@main">https://commits.webkit.org/304385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/249f631738d590c1f451047441237b90ac9b5598

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87093 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/14ffa79d-9f96-4dec-b3e4-d00318ccc281) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103454 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/591ada63-b64f-4ce8-a8ee-c2b31b4b9f0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84320 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a2c3bca4-a0cc-4346-be31-bb6ad51cff6d) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5791 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3398 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3675 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145819 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133857 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7437 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111827 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28478 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5641 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61349 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7491 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35764 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71038 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->