### PR TITLE
Avoid moving the same value twice in WebTransport configureTLS

### DIFF
--- a/LayoutTests/ipc/create-webtransport-parameters-expected.txt
+++ b/LayoutTests/ipc/create-webtransport-parameters-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/create-webtransport-parameters.html
+++ b/LayoutTests/ipc/create-webtransport-parameters.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true WebTransportEnabled=true ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+setTimeout(async () => {
+    if (!window.IPC)
+        return testRunner?.notifyDone();
+
+    import('./coreipc.js').then(({ CoreIPC }) => {
+                  CoreIPC.Networking.NetworkConnectionToWebProcess
+                    .InitializeWebTransportSession(
+                      0,
+                      {
+                        identifier : 262146,
+                        url : { string : 'https://127.0.0.1:4443/ws' },
+                        options : {
+                          allowPooling : true,
+                          requireUnreliable : true,
+                          serverCertificateHashes : [
+                            { algorithm :'', value : { span : [90] } },
+                            {
+                              algorithm :'',
+                              value : { span : [ 0, 196, 0, 106 ] }
+                            },
+                            { algorithm :'', value : { span : [218] } },
+                            {
+                              algorithm :'',
+                              value : { span : [ 7, 0, 0, 128, 64, 47, 194 ] }
+                            }
+                          ],
+                          congestionControl : 1
+                        },
+                        pageID : IPC.pageID,
+                        clientOrigin : {
+                          topOrigin : {
+                            data : {
+                              variantType : 'WebCore::SecurityOriginData::Tuple',
+                              variant :
+                                { protocol :'', host : '127.0.0.1', port : {} }
+                            }
+                          },
+                          clientOrigin : {
+                            data : {
+                              variantType : 'WebCore::SecurityOriginData::Tuple',
+                              variant :
+                                { protocol : 'http', host : '127.0.0.1', port : {} }
+                            }
+                          }
+                        }
+                      });
+                });
+    testRunner?.notifyDone();
+}, 10);
+</script>
+<body>
+    <p>This test passes if WebKit does not crash.</p>
+</body>


### PR DESCRIPTION
#### 27b1c63e5a2fb03d12d4e178664d688c325be804
<pre>
Avoid moving the same value twice in WebTransport configureTLS
<a href="https://bugs.webkit.org/show_bug.cgi?id=302885">https://bugs.webkit.org/show_bug.cgi?id=302885</a>
<a href="https://rdar.apple.com/164545506">rdar://164545506</a>

Reviewed by Alex Christensen.

Instead of moving in the configureTLS lambda that can be called multiple times,
we should capture by copying.

Test: ipc/create-webtransport-parameters.html

Test: ipc/create-webtransport-parameters.html
* LayoutTests/ipc/create-webtransport-parameters-expected.txt: Added.
* LayoutTests/ipc/create-webtransport-parameters.html: Added.
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::createParameters):

Canonical link: <a href="https://commits.webkit.org/303346@main">https://commits.webkit.org/303346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3b9842f19019c77ca2c87920cbd9127d3abbdd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139631 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae8a6218-8988-464c-89ea-fbfc142d92e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4370 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/100994 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4b8491c3-ec3f-41dd-9c24-b5e2002454b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135062 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81785 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82850 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142277 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4278 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37033 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109543 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3247 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114609 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57523 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4332 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33002 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4163 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4423 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4291 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->