### PR TITLE
[AutoFill Debugging] Support HTML as a debug text extraction output format

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt
@@ -1,0 +1,69 @@
+<body>
+    <div role='banner'>
+        <h1 aria-label='Main Page Title'>Welcome to Test Page</h1>
+    </div>
+    <nav role='navigation' aria-label='Main navigation'>
+        <ul>
+            <li>
+                <a uid=… href='mailto:wenson_hsieh@apple.com'>Section 1</a>
+            </li>
+            <li>
+                <a uid=… href='https://example.com/'>Section 2</a>
+            </li>
+        </ul>
+    </nav>
+    <main role='main'>
+        <section aria-label='Interactive Elements'>
+            <button uid=… aria-describedby='This <button> does nothing' aria-label='Test button'>Click Me</button>
+            This &lt;button&gt; does nothing
+            <input type='text' uid=… placeholder='Enter text here'>
+            <div uid=… role='button'>Clickable Div</div>
+        </section>
+        <section aria-label='ARIA Labeling Examples'>
+            Name Field           Description
+            <input type='text' uid=… aria-labelledby='Name Field' placeholder='Your name'>
+            <div role='region' aria-labelledby='Description'>This region is labeled by another element.</div>
+            <input type='text' uid=… aria-labelledby='Name Field' placeholder='Full name'>
+            User Profile
+            <div role='group' aria-labelledby='User Profile'>
+                Username:
+                <input type='text' uid=… label='Username:'>
+            </div>
+        </section>
+        <section aria-label='Content with Roles'>
+            <article role='article'>Article Title                   January 1, 2024                            This is some article content with highlighted text.</article>
+            <aside role='complementary' aria-label='Related information'>
+                Related Links
+                <ul>
+                    <li>
+                        <a uid=… href='https://webkit.org/'>Example Link</a>
+                    </li>
+                    <li>
+                        <a uid=… href='https://apple.com/'>Test Link</a>
+                    </li>
+                </ul>
+            </aside>
+            <div role='region'>
+                <div role='status'>Ready</div>
+                <button uid=…>Update Status</button>
+            </div>
+            <div aria-label='Figure 1'>
+                <canvas uid=…>
+            </div>
+            <textarea uid=…>This is a text box</textarea>
+            Price: $11
+            <sup>99</sup>
+            Link to
+            <sub>
+                WebKit home page:
+                <a uid=… href='https://webkit.org/'>
+            </sub>
+        </section>
+    </main>
+    <footer role='contentinfo'>
+        Footer content with
+        <span role='img' aria-label='copyright symbol'>©</span>
+        2024 &amp; 2025
+    </footer>
+</body>
+<!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markup.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markup.html
@@ -1,0 +1,168 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+.clickable {
+    background-color: lightblue;
+    padding: 10px;
+    margin: 5px;
+    cursor: pointer;
+}
+
+.focusable {
+    border: 2px solid green;
+    padding: 5px;
+    margin: 3px;
+}
+
+.interactive {
+    background-color: lightyellow;
+    padding: 8px;
+}
+
+canvas {
+    width: 200px;
+    height: 200px;
+}
+
+.canvas-container {
+    border: 1px dashed gray;
+    padding: 1em;
+}
+
+#error-text {
+    display: none;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div role="banner">
+    <h1 id="main-title" aria-label="Main Page Title">Welcome to Test Page</h1>
+</div>
+<nav role="navigation" aria-label="Main navigation">
+    <ul>
+        <li><a href="mailto:wenson_hsieh@apple.com" onclick="return false;">Section 1</a></li>
+        <li><a href="https://example.com/" onclick="return false;">Section 2</a></li>
+    </ul>
+</nav>
+<main role="main">
+    <section id="section1" aria-label="Interactive Elements">
+        <button class="clickable" onclick="console.log('clicked')" aria-label="Test button" aria-describedby="btn-help">Click Me</button>
+        <div id="btn-help" aria-hidden="true">This &lt;button&gt; does nothing</div>
+        <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
+        <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
+    </section>
+    <section id="section2" aria-label="ARIA Labeling Examples">
+        <div id="label1">Name Field</div>
+        <div id="label2">Description</div>
+        <input type="text" aria-labelledby="label1" placeholder="Your name" />
+        <div aria-labelledby="label2" role="region">
+            <p>This region is labeled by another element.</p>
+        </div>
+        <div id="error-text">Name not found.</div>
+        <input type="text" aria-labelledby="label1" aria-describedby="error-text" placeholder="Full name" />
+        <div id="title-label">User Profile</div>
+        <div role="group" aria-labelledby="title-label">
+            <label for="username">Username:</label>
+            <input type="text" id="username" />
+        </div>
+    </section>
+    <section id="section3" aria-label="Content with Roles">
+        <article role="article">
+            <header>
+                <h3>Article Title</h3>
+                <time datetime="2024-01-01">January 1, 2024</time>
+            </header>
+            <p>This is some article content with <mark>highlighted text</mark>.</p>
+        </article>
+        <aside role="complementary" aria-label="Related information">
+            <h4>Related Links</h4>
+            <ul>
+                <li><a href="https://webkit.org" onmouseover="this.style.color='red'">Example Link</a></li>
+                <li><a href="https://apple.com" onmouseout="this.style.color=''">Test Link</a></li>
+            </ul>
+        </aside>
+        <div role="region">
+            <div role="status" aria-live="polite" id="status-msg">Ready</div>
+            <button onclick="document.getElementById('status-msg').textContent = 'Updated!'">Update Status</button>
+        </div>
+        <div class="canvas-container" aria-label="Figure 1">
+            <canvas width="400" height="400"></canvas>
+        </div>
+        <textarea rows="15" cols="40">This is a text box</textarea>
+        Price: $11<sup>99</sup>
+        Link to <sub>WebKit home page:<a href="https://webkit.org">webkit.org</a></sub>
+    </section>
+</main>
+<footer role="contentinfo">
+    <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024 &amp; 2025</p>
+</footer>
+<div role="dialog" aria-hidden="true" style="display: none;">
+    <p>This dialog is hidden and should not be extracted.</p>
+</div>
+
+<script>
+function paintIntoCanvas() {
+    const context = document.querySelector("canvas").getContext("2d");
+    context.save();
+    context.clearRect(0, 0, 400, 400);
+    context.beginPath();
+    context.strokeStyle = "black";
+    context.rect(20, 20, 160, 160);
+    context.stroke();
+
+    context.beginPath();
+    context.strokeStyle = "red";
+    context.rect(220, 20, 160, 160);
+    context.stroke();
+    context.fillStyle = "red";
+    context.fill();
+
+    context.beginPath();
+    context.rect(20, 220, 160, 160);
+    context.fillStyle = "green";
+    context.fill();
+
+    context.beginPath();
+    context.strokeStyle = "black";
+    context.lineWidth = 20;
+    context.rect(230, 230, 140, 140);
+    context.stroke();
+    context.fillStyle = "gray";
+    context.fill();
+    context.restore();
+}
+
+addEventListener("load", async () => {
+    paintIntoCanvas();
+
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        normalize: true,
+        includeRects: true,
+        includeURLs: true,
+        nodeIdentifierInclusion: "interactive",
+        includeEventListeners: true,
+        includeAccessibilityAttributes: true,
+        includeTextInAutoFilledControls: true,
+        outputFormat: "html",
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -54,6 +54,11 @@ enum class TextExtractionOptionFlag : uint8_t {
     OnlyIncludeText = 1 << 2,
 };
 
+enum class TextExtractionOutputFormat : uint8_t {
+    TextTree,
+    HTMLMarkup
+};
+
 using TextExtractionOptionFlags = OptionSet<TextExtractionOptionFlag>;
 using TextExtractionFilterPromise = NativePromise<String, void>;
 using TextExtractionFilterCallback = Function<Ref<TextExtractionFilterPromise>(const String&, std::optional<WebCore::NodeIdentifier>&&)>;
@@ -65,15 +70,17 @@ struct TextExtractionOptions {
         , replacementStrings(WTFMove(other.replacementStrings))
         , version(other.version)
         , flags(other.flags)
+        , outputFormat(other.outputFormat)
     {
     }
 
-    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags)
+    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat)
         : filterCallbacks(WTFMove(filters))
         , nativeMenuItems(WTFMove(items))
         , replacementStrings(WTFMove(replacementStrings))
         , version(version)
         , flags(flags)
+        , outputFormat(outputFormat)
     {
     }
 
@@ -82,6 +89,7 @@ struct TextExtractionOptions {
     HashMap<String, String> replacementStrings;
     std::optional<TextExtractionVersion> version;
     TextExtractionOptionFlags flags;
+    TextExtractionOutputFormat outputFormat { TextExtractionOutputFormat::TextTree };
 };
 
 struct TextExtractionResult {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6613,6 +6613,19 @@ static HashMap<String, String> extractReplacementStrings(_WKTextExtractionConfig
     }).get()];
 }
 
+static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtractionConfiguration *configuration)
+{
+    switch (configuration.outputFormat) {
+    case _WKTextExtractionOutputFormatTextTree:
+        return WebKit::TextExtractionOutputFormat::TextTree;
+    case _WKTextExtractionOutputFormatHTML:
+        return WebKit::TextExtractionOutputFormat::HTMLMarkup;
+    default:
+        ASSERT_NOT_REACHED();
+        return WebKit::TextExtractionOutputFormat::TextTree;
+    }
+}
+
 - (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(void(^)(_WKTextExtractionResult *))completionHandler
 {
     bool allowFiltering = _page->protectedPreferences()->textExtractionFilterEnabled();
@@ -6642,7 +6655,8 @@ static HashMap<String, String> extractReplacementStrings(_WKTextExtractionConfig
         onlyIncludeText = configuration.onlyIncludeVisibleText,
         maxWordsPerParagraph = WTFMove(maxWordsPerParagraph),
         version,
-        replacementStrings = extractReplacementStrings(configuration)
+        replacementStrings = extractReplacementStrings(configuration),
+        outputFormat = textExtractionOutputFormat(configuration)
     ](auto&& item) mutable {
         RetainPtr strongSelf = weakSelf.get();
         if (!strongSelf)
@@ -6752,7 +6766,8 @@ static HashMap<String, String> extractReplacementStrings(_WKTextExtractionConfig
             [strongSelf _activeNativeMenuItemTitles],
             WTFMove(replacementStrings),
             version,
-            optionFlags
+            optionFlags,
+            outputFormat
         };
         WebKit::convertToText(WTFMove(*item), WTFMove(options), [completionHandler = WTFMove(completionHandler)](auto&& result) {
             auto [text, filteredOutAnyText] = result;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -45,10 +45,22 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionNodeIdentifierInclusion) {
     _WKTextExtractionNodeIdentifierInclusionInteractive
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
+    _WKTextExtractionOutputFormatTextTree = 0,
+    _WKTextExtractionOutputFormatHTML,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
 
 @property (nonatomic, class, copy, readonly) _WKTextExtractionConfiguration *configurationForVisibleTextOnly NS_SWIFT_NAME(visibleTextOnly);
+
+/*!
+ Output format to use when collating extracted elements into the final text output.
+ The default value is `.textTree`, which produces at most 1 element and text node per line,
+ and uses indentation to represent DOM hierarchy.
+ */
+@property (nonatomic) _WKTextExtractionOutputFormat outputFormat;
 
 /*!
  Element extraction is constrained to this rect (in the web view's coordinate space).

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -150,6 +150,13 @@
     _includeTextInAutoFilledControls = value;
 }
 
+- (void)setOutputFormat:(_WKTextExtractionOutputFormat)outputFormat
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(outputFormat != _WKTextExtractionOutputFormatTextTree);
+
+    _outputFormat = outputFormat;
+}
+
 #undef ENSURE_VALID_TEXT_ONLY_CONFIGURATION
 
 @end

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -53,6 +53,7 @@ dictionary TextExtractionTestOptions {
     boolean includeTextInAutoFilledControls = false;
     boolean mergeParagraphs = false;
     boolean skipNearlyTransparentContent = false;
+    DOMString outputFormat;
 };
 
 dictionary TextExtractionInteractionOptions {

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -68,6 +68,7 @@ struct TextExtractionTestOptions {
     bool includeTextInAutoFilledControls { false };
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
+    JSRetainPtr<JSStringRef> outputFormat;
 };
 
 TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef, JSValueRef);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -81,6 +81,7 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
     options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);
     options.nodeIdentifierInclusion = stringProperty(context, (JSObjectRef)argument, "nodeIdentifierInclusion");
+    options.outputFormat = stringProperty(context, (JSObjectRef)argument, "outputFormat");
     return &options;
 }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -361,6 +361,23 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     [configuration setIncludeEventListeners:options && options->includeEventListeners];
     [configuration setIncludeAccessibilityAttributes:options && options->includeAccessibilityAttributes];
     [configuration setIncludeTextInAutoFilledControls:options && options->includeTextInAutoFilledControls];
+
+    auto outputFormat = [&] -> std::optional<_WKTextExtractionOutputFormat> {
+        if (!options)
+            return std::nullopt;
+
+        auto outputFormat = toWTFString(options->outputFormat.get());
+        if (equalLettersIgnoringASCIICase(outputFormat, "html"_s))
+            return _WKTextExtractionOutputFormatHTML;
+
+        if (equalLettersIgnoringASCIICase(outputFormat, "texttree"_s))
+            return _WKTextExtractionOutputFormatTextTree;
+
+        return std::nullopt;
+    }();
+    if (outputFormat)
+        [configuration setOutputFormat:*outputFormat];
+
     if (auto wordLimit = options ? options->wordLimit : 0)
         [configuration setMaxWordsPerParagraph:static_cast<NSUInteger>(wordLimit)];
     [configuration setTargetRect:extractionRect];


### PR DESCRIPTION
#### bb1043813cb24812d98028666485be5357f8969a
<pre>
[AutoFill Debugging] Support HTML as a debug text extraction output format
<a href="https://bugs.webkit.org/show_bug.cgi?id=302886">https://bugs.webkit.org/show_bug.cgi?id=302886</a>
<a href="https://rdar.apple.com/165151498">rdar://165151498</a>

Reviewed by Abrar Rahman Protyasha.

Add support for a new text extraction configuration property, `outputFormat`, which encompasses two
values:

`textTree`:     Existing behavior.
`html`:         Format output in a way that&apos;s *similar* to HTML markup (and importantly, can be
                parsed as markup by clients).

See below for more details.

Test: fast/text-extraction/debug-text-extraction-markup.html

* LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-markup.html: Added.
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::escapeStringForHTML):

Add another version of `escapeString`, which is suitable for use in text content in HTML.

(WebKit::TextExtractionAggregator::addResult):
(WebKit::TextExtractionAggregator::useHTMLOutput const):

Add a helper method on `TextExtractionAggregator` indicating whether or not we should use HTML as
the output format.

(WebKit::TextExtractionAggregator::appendToLine):
(WebKit::TextExtractionAggregator::addLineForVersionNumberIfNeeded):
(WebKit::partsForItem):
(WebKit::addPartsForText):
(WebKit::addPartsForItem):

Avoid including rects and event listeners in the text output for now; we may want to add them back
later down the road, as attributes like `rect=[…]` or `eventListeners=[…]`.

(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(textExtractionOutputFormat):
(-[WKWebView _extractDebugTextWithConfiguration:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration setOutputFormat:]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/303377@main">https://commits.webkit.org/303377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4dac8aed3cd527bba692895e13e47073538824

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139699 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f2667cf-d826-4667-b8b3-fcb41904acce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101040 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3154ad60-6ab6-46ac-bc13-6d8aa7f9067b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135130 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81833 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94488831-99f4-4373-a0d5-9fbd75b8d44d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82919 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142346 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109414 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4427 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109592 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3298 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57592 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4400 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->