### PR TITLE
WebAssemblyGCStructure should retain the transitive closure of all referenced TypeDefinitions

### DIFF
--- a/JSTests/wasm/regress/298963.js
+++ b/JSTests/wasm/regress/298963.js
@@ -1,0 +1,64 @@
+/*
+(module
+    (type $StructB (struct
+        (field i64)
+        (field i64)
+    ))
+
+    (type $StructA (struct
+        (field (ref null $StructB))
+    ))
+
+    (func (export "f") (result (ref $StructA))
+        (struct.new_default $StructA)
+    )
+
+    (func (export "g") (param (ref $StructA))
+
+    )
+)
+*/
+const MODULE_CODE = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x16, 0x04, 0x5f, 0x02, 0x7e, 0x00, 0x7e, 0x00, 0x5f, 0x01, 0x63, 0x00, 0x00, 0x60, 0x00, 0x01, 0x64, 0x01, 0x60, 0x01, 0x64, 0x01, 0x00, 0x03, 0x03, 0x02, 0x02, 0x03, 0x07, 0x09, 0x02, 0x01, 0x66, 0x00, 0x00, 0x01, 0x67, 0x00, 0x01, 0x0a, 0x0a, 0x02, 0x05, 0x00, 0xfb, 0x01, 0x01, 0x0b, 0x02, 0x00, 0x0b]);
+
+function createStructAndAbandonModuleInst() {
+    const module = new WebAssembly.Module(MODULE_CODE);
+    const instance = new WebAssembly.Instance(module);
+
+    return instance.exports.f();
+}
+
+function getFuncAndAbandonModuleInst() {
+    const module = new WebAssembly.Module(MODULE_CODE);
+    const instance = new WebAssembly.Instance(module);
+
+    return instance.exports.g;
+}
+
+function callTypeInformationTryCleanup() {
+    for (let i = 0; i < 5; i++) {
+        {
+            // An empty module.
+            new WebAssembly.Module(new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]));
+        }
+        gc();
+    }
+}
+
+function test() {
+    const s = createStructAndAbandonModuleInst();
+    callTypeInformationTryCleanup();
+
+    // The abandoned module instance in which 's' originated is now garbage-collected and
+    // TypeInformation registry has been cleaned up. Function 'g' will now be extracted
+    // from a different instance of the same module. Calling it with 's' should succeed
+    // because the type it expects is structurally the same and should be recognized as
+    // such.
+    //
+    // See rdar://160601609 for details.
+
+    const g = getFuncAndAbandonModuleInst();
+    callTypeInformationTryCleanup();
+    g(s);
+}
+
+test();


### PR DESCRIPTION
#### 078fa38a67ae5fda4a4183978a1e765401f73999
<pre>
WebAssemblyGCStructure should retain the transitive closure of all referenced TypeDefinitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=298963">https://bugs.webkit.org/show_bug.cgi?id=298963</a>
<a href="https://rdar.apple.com/160601609">rdar://160601609</a>

Reviewed by Daniel Liu.

As the radar demonstrates, there is a fundamental problem in the existing scheme of how GC
objects are associated with TypeDefinitions. A TypeDefinition representing the type of a
GC object is related to a set of other TypeDefinitions: the expanded form of the type as
well as the transitive closure of the types of struct fields and array elements. Because
TypeDefinitions and some other system elements internally use raw pointers to refer to
related TypeDefinitions, this entire set of type dependencies should stay alive while the
GC object is alive.

The existing GC Object/TypeDefinition design uses GC object structures to retain the
declared type of the object. Even if a GC object outlives its original Wasm instance,
the structure stays alive together with the object and keeps the declared type alive.
Unfortunately, as explained above, the declared type may depend on other types, but
instances of those related types are not guaranteed to be around to keep their
TypeDefinitions alive. The radar and the test case of this patch show an example of a
struct A related to struct B, but without a live instance of B to keep struct B&apos;s
TypeDefinition alive.

To address the root cause of this problem, we must make it so that for any GC object type
T, all types T depends on are retained independently of the liveness of their own
instances, for as long as there are live instances of T.

This patch makes WebAssemblyGCStructure collect and retain the set of all relevant
TypeDefinitions. That includes the transitive closure of all TypeDefinitions reachable via
struct fields and array elements, as well as the expanded and unexpanded forms of the
declared type of the GC object. This set of dependencies is collected when the structure
is created together with its Wasm instance, at a small fixed cost and with no runtime
penalty.

(In the future, it might make sense to combine m_type and m_typeDependencies in
WebAssemblyGCStructure and simplify instance creation by not requiring expanded and
unexpanded types separately. However, at this time this code has outstanding parallel
changes in two branches, so it will be easier to do such cleanups after these changes
converge).

Originally-landed-as: 297297.432@safari-7622-branch (0ff0dfde5222). <a href="https://rdar.apple.com/164213794">rdar://164213794</a>
Canonical link: <a href="https://commits.webkit.org/304281@main">https://commits.webkit.org/304281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdbdca5e502e64d62496adf69cb8fa39690603d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86888 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103214 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84067 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5567 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3180 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3167 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127084 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145269 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133560 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111586 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5398 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61084 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7196 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35511 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166440 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70766 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7193 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->