### PR TITLE
Crash under MediaResourceLoader::requestResource()

### DIFF
--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -93,6 +93,17 @@ void MediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<void(Expe
     m_document->protectedFrame()->loader().client().sendH2Ping(url, WTFMove(completionHandler));
 }
 
+static LoadedFromOpaqueSource computeLoadedFromOpaqueSource(const Document& document, const HashSet<URL>& nonOpaqueLoadURLs, const URL& url, const std::optional<LoadedFromOpaqueSource> loadedFromOpaqueSource)
+{
+    if (!document.settings().enableOpaqueLoadingForMedia() || url.isEmpty())
+        return LoadedFromOpaqueSource::No;
+
+    if (loadedFromOpaqueSource.value_or(LoadedFromOpaqueSource::No) == LoadedFromOpaqueSource::No)
+        return LoadedFromOpaqueSource::No;
+
+    return nonOpaqueLoadURLs.contains(url) ? LoadedFromOpaqueSource::No : LoadedFromOpaqueSource::Yes;
+}
+
 RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceRequest&& request, LoadOptions options)
 {
     assertIsMainThread();
@@ -100,6 +111,9 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
     RefPtr document = this->document();
     if (!document)
         return nullptr;
+
+    if (!m_loadedFromOpaqueSource && !request.url().isEmpty())
+        m_nonOpaqueLoadURLs.add(request.url());
 
     DataBufferingPolicy bufferingPolicy = options & LoadOption::BufferData ? DataBufferingPolicy::BufferData : DataBufferingPolicy::DoNotBufferData;
     auto cachingPolicy = options & LoadOption::DisallowCaching ? CachingPolicy::DisallowCaching : CachingPolicy::AllowCaching;
@@ -224,6 +238,13 @@ bool MediaResourceLoader::verifyMediaResponse(const URL& requestURL, const Resou
         return true;
 
     return validationInformation.origin->canRequest(response.url(), OriginAccessPatternsForWebProcess::singleton());
+}
+
+void MediaResourceLoader::redirectReceived(const URL& url)
+{
+    ASSERT(!url.isEmpty());
+    if (!m_loadedFromOpaqueSource)
+        m_nonOpaqueLoadURLs.add(url);
 }
 
 Ref<MediaResource> MediaResource::create(MediaResourceLoader& loader, CachedResourceHandle<CachedRawResource>&& resource)


### PR DESCRIPTION
#### db276a9f20faa8ca3300cbb5abf8ad3d5afb84ed
<pre>
Crash under MediaResourceLoader::requestResource()
<a href="https://rdar.apple.com/161217814">rdar://161217814</a>

Reviewed by Jean-Yves Avenard.

We add checks to protect from empty URLs.

* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::computeLoadedFromOpaqueSource):
(WebCore::MediaResourceLoader::requestResource):
(WebCore::MediaResourceLoader::redirectReceived):

Originally-landed-as: <a href="https://commits.webkit.org/297297.477@safari-7622-branch">297297.477@safari-7622-branch</a> (6cfacf6782cd). rdar://164212243
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db276a9f20faa8ca3300cbb5abf8ad3d5afb84ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135008 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7423 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46263 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142517 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86849 "Hash db276a9f for PR 54275 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b49f0688-7373-4e44-abec-546f8db3eb4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136877 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8044 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7269 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/142517 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/86849 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/660f5c4e-7d54-4f4d-87d6-465970841402) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137954 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/8044 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/46263 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/142517 "Hash db276a9f for PR 54275 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20543c50-b48a-4250-98d9-321eb9d7daf8) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/8044 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/46263 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3112 "Hash db276a9f for PR 54275 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/8044 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/46263 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145215 "Hash db276a9f for PR 54275 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7100 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/46263 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/145215 "Hash db276a9f for PR 54275 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7152 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/7269 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/145215 "Hash db276a9f for PR 54275 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/46263 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61044 "Hash db276a9f for PR 54275 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7148 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/46263 "Hash db276a9f for PR 54275 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6921 "Hash db276a9f for PR 54275 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70722 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7154 "Hash db276a9f for PR 54275 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7028 "Hash db276a9f for PR 54275 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->