### PR TITLE
Stop storing WebAnimations as raw pointers in a HashSet in WebAnimation.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -107,7 +107,6 @@ accessibility/AccessibilityTableHeaderContainer.cpp
 [ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 [ iOS ] accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 animation/AnimationEffectTiming.cpp
-animation/AnimationTimeline.cpp
 animation/BlendingKeyframes.cpp
 animation/DocumentTimeline.cpp
 animation/KeyframeEffect.cpp

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -96,7 +96,7 @@ void AnimationTimeline::detachFromDocument()
 
     auto& animationsToRemove = m_animations;
     while (!animationsToRemove.isEmpty())
-        animationsToRemove.first()->remove();
+        Ref { animationsToRemove.first() }->remove();
 }
 
 void AnimationTimeline::suspendAnimations()

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -38,6 +38,7 @@ class RenderStyle;
 
 class CSSAnimation final : public StyleOriginatedAnimation {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSAnimation);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSAnimation);
 public:
     static Ref<CSSAnimation> create(const Styleable&, Style::Animation&&, const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     ~CSSAnimation() = default;

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -41,6 +41,7 @@ class RenderStyle;
 
 class CSSTransition final : public StyleOriginatedAnimation {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSTransition);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSTransition);
 public:
     static Ref<CSSTransition> create(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Style::Transition&, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double);
 

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -41,6 +41,7 @@ class RenderStyle;
 
 class StyleOriginatedAnimation : public WebAnimation {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(StyleOriginatedAnimation);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleOriginatedAnimation);
 public:
     ~StyleOriginatedAnimation();
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -68,9 +68,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebAnimation);
 
-HashSet<WebAnimation*>& WebAnimation::instances()
+HashSet<CheckedPtr<WebAnimation>>& WebAnimation::instances()
 {
-    static NeverDestroyed<HashSet<WebAnimation*>> instances;
+    static NeverDestroyed<HashSet<CheckedPtr<WebAnimation>>> instances;
     return instances;
 }
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -38,6 +38,7 @@
 #include <WebCore/Styleable.h>
 #include <WebCore/TimelineRangeValue.h>
 #include <WebCore/WebAnimationTypes.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Markable.h>
 #include <wtf/RefCounted.h>
@@ -60,8 +61,9 @@ namespace Style {
 struct ResolutionContext;
 }
 
-class WebAnimation : public RefCounted<WebAnimation>, public EventTarget, public ActiveDOMObject {
+class WebAnimation : public RefCounted<WebAnimation>, public EventTarget, public ActiveDOMObject, public CanMakeCheckedPtr<WebAnimation> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebAnimation);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebAnimation);
 public:
     static Ref<WebAnimation> create(Document&, AnimationEffect*);
     static Ref<WebAnimation> create(Document&, AnimationEffect*, AnimationTimeline*);
@@ -72,7 +74,7 @@ public:
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    WEBCORE_EXPORT static HashSet<WebAnimation*>& instances();
+    WEBCORE_EXPORT static HashSet<CheckedPtr<WebAnimation>>& instances();
 
     virtual bool isStyleOriginatedAnimation() const { return false; }
     virtual bool isCSSAnimation() const { return false; }

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -259,8 +259,8 @@ void ContentVisibilityDocumentState::updateAnimations(const Element& element, Is
 {
     if (wasSkipped == IsSkippedContent::No || becomesSkipped == IsSkippedContent::Yes)
         return;
-    for (RefPtr animation : WebAnimation::instances()) {
-        RefPtr styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation.releaseNonNull());
+    for (auto& animation : WebAnimation::instances()) {
+        RefPtr styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(*animation);
         if (!styleOriginatedAnimation)
             continue;
         auto owningElement = styleOriginatedAnimation->owningElement();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10877,9 +10877,9 @@ Vector<RefPtr<WebAnimation>> Document::matchingAnimations(NOESCAPE const Functio
         return false;
     };
 
-    for (auto* animation : WebAnimation::instances()) {
+    for (auto& animation : WebAnimation::instances()) {
         if (animation->isRelevant() && effectCanBeListed(animation->effect()))
-            animations.append(animation);
+            animations.append(animation.get());
     }
 
     std::ranges::stable_sort(animations, [](auto& lhs, auto& rhs) {
@@ -10891,7 +10891,7 @@ Vector<RefPtr<WebAnimation>> Document::matchingAnimations(NOESCAPE const Functio
 
 void Document::keyframesRuleDidChange(const String& name)
 {
-    for (RefPtr animation : WebAnimation::instances()) {
+    for (auto& animation : WebAnimation::instances()) {
         auto cssAnimation = dynamicDowncast<CSSAnimation>(*animation);
         if (!cssAnimation || !cssAnimation->isRelevant())
             continue;

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -293,7 +293,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::enable()
     };
 
     {
-        for (auto* animation : WebAnimation::instances()) {
+        for (auto& animation : WebAnimation::instances()) {
             if (existsInCurrentPage(animation->scriptExecutionContext()))
                 bindAnimation(*animation, nullptr);
         }
@@ -559,7 +559,7 @@ void InspectorAnimationAgent::didCreateWebAnimation(WebAnimation& animation)
 void InspectorAnimationAgent::animationBindingTimerFired()
 {
     for (auto&& [animation, backtrace] : std::exchange(m_animationsPendingBinding, { }))
-        bindAnimation(animation, WTFMove(backtrace));
+        bindAnimation(Ref { animation }, WTFMove(backtrace));
 }
 
 void InspectorAnimationAgent::willDestroyWebAnimation(WebAnimation& animation)
@@ -582,7 +582,7 @@ void InspectorAnimationAgent::frameNavigated(LocalFrame& frame)
 
     Vector<String> animationIdsToRemove;
     for (auto& [animationId, animation] : m_animationIdMap) {
-        if (RefPtr document = dynamicDowncast<Document>(animation->scriptExecutionContext()); document && document->frame() == &frame)
+        if (RefPtr document = dynamicDowncast<Document>(Ref { animation.get() }->scriptExecutionContext()); document && document->frame() == &frame)
             animationIdsToRemove.append(animationId);
     }
     for (const auto& animationId : animationIdsToRemove)

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
@@ -180,7 +180,7 @@ void CustomPropertyRegistry::invalidate(const AtomString& customProperty)
 void CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration(const AtomString& customProperty)
 {
     auto& document = m_scope.document();
-    for (auto* animation : WebAnimation::instances()) {
+    for (auto& animation : WebAnimation::instances()) {
         if (RefPtr keyframeEffect = animation->keyframeEffect()) {
             if (auto* target = keyframeEffect->target()) {
                 if (&target->document() == &document)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1368,7 +1368,7 @@ ExceptionOr<unsigned> Internals::lastSpatialNavigationCandidateCount() const
 
 bool Internals::animationWithIdExists(const String& id) const
 {
-    for (auto* animation : WebAnimation::instances()) {
+    for (auto& animation : WebAnimation::instances()) {
         if (animation->id() == id)
             return true;
     }


### PR DESCRIPTION
#### 0cc78ca4621b474a727074599a656923635c589f
<pre>
Stop storing WebAnimations as raw pointers in a HashSet in WebAnimation.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=302909">https://bugs.webkit.org/show_bug.cgi?id=302909</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::detachFromDocument):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::instances):
(): Deleted.
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateAnimations):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::matchingAnimations):
(WebCore::Document::keyframesRuleDidChange):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::enable):
(WebCore::InspectorAnimationAgent::animationBindingTimerFired):
(WebCore::InspectorAnimationAgent::frameNavigated):
* Source/WebCore/style/StyleCustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::animationWithIdExists const):

Canonical link: <a href="https://commits.webkit.org/303435@main">https://commits.webkit.org/303435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75baca06b68a15783360e7075ec76b11b34eb237

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139759 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84176 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72abec2f-c887-4843-a5bf-b59299f2da82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101085 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68397 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7389113-2e8c-433b-a97d-fcd276cc6260) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135190 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81880 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/effceff4-bc15-47bc-95d7-81289db04a2b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1108 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82979 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142406 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109463 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109645 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3338 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57658 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4460 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33098 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67906 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->