### PR TITLE
Stop storing raw pointers in a HashMap in WebKitJSHandle.cpp

### DIFF
--- a/Source/WebCore/page/WebKitJSHandle.h
+++ b/Source/WebCore/page/WebKitJSHandle.h
@@ -47,7 +47,7 @@ using JSHandleIdentifier = ProcessQualified<WebProcessJSHandleIdentifier>;
 class WEBCORE_EXPORT WebKitJSHandle : public RefCountedAndCanMakeWeakPtr<WebKitJSHandle> {
 public:
     static Ref<WebKitJSHandle> create(JSC::JSGlobalObject&, JSC::JSObject*);
-    static std::pair<JSC::JSGlobalObject*, JSC::JSObject*> objectForIdentifier(JSHandleIdentifier);
+    static JSC::JSObject* objectForIdentifier(JSHandleIdentifier);
     static void jsHandleDestroyed(JSHandleIdentifier);
     static void jsHandleSentToAnotherProcess(JSHandleIdentifier);
     ~WebKitJSHandle();

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -798,8 +798,8 @@ static void pruneEmptyContainersRecursive(Item& item)
 
 static Node* nodeFromJSHandle(JSHandleIdentifier identifier)
 {
-    auto [globalObject, object] = WebKitJSHandle::objectForIdentifier(identifier);
-    if (!globalObject || !object)
+    auto* object = WebKitJSHandle::objectForIdentifier(identifier);
+    if (!object)
         return nullptr;
 
     if (auto* jsNode = jsDynamicCast<JSNode*>(object))

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -542,11 +542,11 @@ JSValueRef JavaScriptEvaluationResult::JSInserter::toJS(JSGlobalContextRef conte
         ASSERT_NOT_REACHED();
         return JSValueMakeUndefined(context);
     }, [&] (UniqueRef<JSHandleInfo>&& info) -> JSValueRef {
-        auto [originalGlobalObject, object] = WebCore::WebKitJSHandle::objectForIdentifier(info.get().identifier);
+        auto* object = WebCore::WebKitJSHandle::objectForIdentifier(info.get().identifier);
         if (!object)
             return JSValueMakeUndefined(context);
         auto [lexicalGlobalObject, domGlobalObject, document] = globalObjectTuple(context);
-        if (lexicalGlobalObject != originalGlobalObject)
+        if (lexicalGlobalObject != object->globalObject())
             return JSValueMakeUndefined(context);
         return ::toRef(object);
     }, [&] (UniqueRef<WebCore::SerializedNode>&& serializedNode) -> JSValueRef {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1574,8 +1574,8 @@ void WebFrame::takeSnapshotOfNode(JSHandleIdentifier identifier, CompletionHandl
     if (!page)
         return completion({ });
 
-    auto [globalObject, object] = WebKitJSHandle::objectForIdentifier(identifier);
-    if (!globalObject || !object)
+    auto* object = WebKitJSHandle::objectForIdentifier(identifier);
+    if (!object)
         return completion({ });
 
     auto* jsNode = jsDynamicCast<JSNode*>(object);


### PR DESCRIPTION
#### 47a8ec7c7ca35d55eecb1c189081e85bd78a8512
<pre>
Stop storing raw pointers in a HashMap in WebKitJSHandle.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=302910">https://bugs.webkit.org/show_bug.cgi?id=302910</a>

Reviewed by Geoffrey Garen.

Stop storing JSGlobalObject as raw pointer inside a HashMap
in WebKitJSHandle.cpp.

* Source/WebCore/page/WebKitJSHandle.cpp:
(WebCore::WebKitJSHandle::objectForIdentifier):
(WebCore::WebKitJSHandle::WebKitJSHandle):
* Source/WebCore/page/WebKitJSHandle.h:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::nodeFromJSHandle):
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JSInserter::toJS):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::takeSnapshotOfNode):

Canonical link: <a href="https://commits.webkit.org/303442@main">https://commits.webkit.org/303442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa144decb4894990cf4cc2e090d5c3e7d818df61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a8fed3a5-dc19-4690-8d7c-c2321fa766c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101224 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4f046b93-8815-4d54-83e0-398a2ab8cc45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135353 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82016 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/faf7646c-6eca-4ad5-80dd-4b86aa9ca2f0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83148 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142574 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4572 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109600 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109779 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3456 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4626 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33227 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->