### PR TITLE
Create delegate to cache safe browsing results

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -17,6 +17,12 @@ selectors = [
     { name = "_rasterizedImage", class = "UIImage" },
 ]
 
+[[not-web-essential]]
+request = "rdar://165225257"
+selectors = [
+    { name = "lookUpURL:isMainFrame:hasHighConfidenceOfSafety:cachedResult:completionHandler:", class = "SSBLookupContext" },
+]
+
 # Added in rdar://112101742.
 [[equivalent-api]]
 request = "rdar://157876115"

--- a/Source/WebKit/Platform/spi/Cocoa/SafeBrowsingSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/SafeBrowsingSPI.h
@@ -76,6 +76,7 @@ WTF_EXTERN_C_END
 
 - (void)lookUpURL:(NSURL *)URL completionHandler:(void (^)(SSBLookupResult *, NSError *))completionHandler;
 - (void)lookUpURL:(NSURL *)URL isMainFrame:(bool)isMainFrame hasHighConfidenceOfSafety:(BOOL)hasHighConfidenceOfSafety completionHandler:(void (^)(SSBLookupResult *, NSError * _Nullable))completionHandler;
+- (void)lookUpURL:(NSURL *)URL isMainFrame:(bool)isMainFrame hasHighConfidenceOfSafety:(BOOL)hasHighConfidenceOfSafety cachedResult:(SSBLookupResult * _Nullable)cachedResult completionHandler:(void (^)(SSBLookupResult *, NSError * _Nullable))completionHandler;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHistoryDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHistoryDelegatePrivate.h
@@ -29,6 +29,7 @@
 
 @class WKNavigationData;
 @class WKWebView;
+@class SSBLookupResult;
 
 @protocol WKHistoryDelegatePrivate <NSObject>
 
@@ -38,5 +39,8 @@
 - (void)_webView:(WKWebView *)webView didPerformClientRedirectFromURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL;
 - (void)_webView:(WKWebView *)webView didPerformServerRedirectFromURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL;
 - (void)_webView:(WKWebView *)webView didUpdateHistoryTitle:(NSString *)title forURL:(NSURL *)URL;
+
+- (void)_webView:(WKWebView *)webView didReceiveSafeBrowsingResult:(SSBLookupResult *)result forURL:(NSURL *)URL;
+- (void)_webView:(WKWebView *)webView cachedSafeBrowsingResultForURL:(NSURL *)URL completionHandler:(void (^)(SSBLookupResult * _Nullable result, NSError * _Nullable error))completionHandler;
 
 @end


### PR DESCRIPTION
#### c8f97782bb12a0a358e79b6bbc558ec4419cec41
<pre>
Create delegate to cache safe browsing results
<a href="https://rdar.apple.com/163939039">rdar://163939039</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302907">https://bugs.webkit.org/show_bug.cgi?id=302907</a>

Reviewed by Elliott Williams.

Create a delegate so the client can optionally cache safe browsing
results.

* Source/WebKit/Platform/spi/Cocoa/SafeBrowsingSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHistoryDelegatePrivate.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::beginSafeBrowsingCheck):

Canonical link: <a href="https://commits.webkit.org/303683@main">https://commits.webkit.org/303683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f95d931839ccbddb283ce4fb4e44ea2830f8cac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140759 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85250 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/128b9eb2-e5ed-4df8-9171-37f0f6d96089) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69338 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/191557bc-1b58-4435-919a-e660fc799855) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82679 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/120884dd-046c-4d6a-a5f9-b0e7694528cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4291 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1866 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113368 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143407 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5376 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110261 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28008 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4162 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59118 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5431 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34002 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->