### PR TITLE
[GFC] WIP Add support for track sizing with min-content track sizing functions.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -39,6 +39,7 @@
 #include "TrackSizingFunctions.h"
 #include "UnplacedGridItem.h"
 #include "UsedTrackSizes.h"
+#include <wtf/Range.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -249,13 +250,21 @@ TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t implicitGridTra
 
 // https://www.w3.org/TR/css-grid-1/#algo-grid-sizing
 UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& placedGridItems,
-    const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList)
+    const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
 {
-    // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
-    auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, columnTrackSizingFunctionsList);
+    auto& integrationUtils = formattingContext().integrationUtils();
 
+    // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
+    auto columnSpanList = placedGridItems.map([](const PlacedGridItem& gridItem) {
+        return WTF::Range<size_t> { gridItem.columnStartLine(), gridItem.columnEndLine() };
+    });
+    auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, columnSpanList, columnTrackSizingFunctionsList, integrationUtils);
+
+    auto rowSpanList = placedGridItems.map([](const PlacedGridItem& gridItem) {
+        return WTF::Range<size_t> { gridItem.rowStartLine(), gridItem.rowEndLine() };
+    });
     // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
-    auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, rowTrackSizingFunctionsList);
+    auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, rowSpanList, rowTrackSizingFunctionsList, integrationUtils);
 
     // 3. Then, if the min-content contribution of any grid item has changed based on the
     // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -71,7 +71,7 @@ private:
         const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions);
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
-    static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList);
+    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const;
 
     using UsedInlineSizes = Vector<LayoutUnit>;
     using UsedBlockSizes = Vector<LayoutUnit>;

--- a/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+namespace WTF {
+template <typename T>
+class Range;
+}
+
 namespace WebCore {
 
 class LayoutUnit;
@@ -44,6 +49,7 @@ using GridCell = Vector<UnplacedGridItem, 1>;
 using GridItemRects = Vector<GridItemRect>;
 using GridMatrix = Vector<Vector<GridCell>>;
 using PlacedGridItems = Vector<PlacedGridItem>;
+using PlacedGridItemSpanList = Vector<WTF::Range<size_t>>;
 using TrackSizes = Vector<LayoutUnit>;
 using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
 using UnsizedTracks = Vector<UnsizedTrack>;

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -26,9 +26,13 @@
 #include "config.h"
 #include "TrackSizingAlgorithm.h"
 
+#include "LayoutIntegrationUtils.h"
 #include "NotImplemented.h"
+#include "PlacedGridItem.h"
 #include "TrackSizingFunctions.h"
+#include <wtf/Range.h>
 #include <wtf/Vector.h>
+#include <wtf/ZippedRange.h>
 
 namespace WebCore {
 namespace Layout {
@@ -39,17 +43,129 @@ struct UnsizedTrack {
     const TrackSizingFunctions trackSizingFunction;
 };
 
+static auto singleSpanningItemsWithinTrack(size_t trackIndex, const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList)
+{
+    PlacedGridItems nonSpanningItems;
+    for (auto [gridItemIndex, gridItem] : WTF::indexedRange(gridItems)) {
+        auto& gridItemSpan = gridItemSpanList[gridItemIndex];
+        if (gridItemSpan.distance() == 1 && gridItemSpan.begin() == trackIndex)
+            nonSpanningItems.append(gridItem);
+    }
+    return nonSpanningItems;
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-content
+static void resolveIntrinsicTrackSizes(UnsizedTracks& unsizedTracks, const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList,
+    const IntegrationUtils& integrationUtils)
+{
+    // 1. Shim baseline-aligned items so their intrinsic size contributions reflect their
+    // baseline alignment.
+    auto shimBaselineAligedItems = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(shimBaselineAligedItems);
+
+    using IndexedTrackList = Vector<std::pair<unsigned, UnsizedTrack&>>;
+    auto tracksWithIntrinsicSizingFunction = [&] {
+        IndexedTrackList trackList;
+
+        for (auto [index, track] : WTF::indexedRange(unsizedTracks)) {
+            auto& minimumTrackSizingFunction = track.trackSizingFunction.min;
+            auto& maximumTrackSizingFunction = track.trackSizingFunction.max;
+
+            if (minimumTrackSizingFunction.isFlex() || maximumTrackSizingFunction.isFlex())
+                continue;
+            if (minimumTrackSizingFunction.isContentSized() || maximumTrackSizingFunction.isContentSized())
+                trackList.append({ index, track });
+        }
+        return trackList;
+    };
+
+    // 2. Size tracks to fit non-spanning items.
+    // For each track with an intrinsic track sizing function and not a flexible sizing function, consider the items in it with a span of 1:
+    for (auto& [trackIndex, track] : tracksWithIntrinsicSizingFunction()) {
+        auto singleSpanningItems = singleSpanningItemsWithinTrack(trackIndex, gridItems, gridItemSpanList);
+
+        auto& minimumTrackSizingFunction = track.trackSizingFunction.min;
+        track.baseSize = WTF::switchOn(minimumTrackSizingFunction,
+            // If the track has a min-content min track sizing function, set its base size
+            // to the maximum of the items’ min-content contributions, floored at zero.
+            [&](const CSS::Keyword::MinContent&) {
+                auto minContentContributions = singleSpanningItems | std::views::transform([&](const PlacedGridItem& gridItem) {
+                    return integrationUtils.minContentWidth(gridItem.layoutBox());
+                });
+                return std::ranges::max(minContentContributions);
+            },
+            [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            },
+            [&](const CSS::Keyword::Auto&) -> LayoutUnit {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            },
+            [&](const auto&) -> LayoutUnit {
+                ASSERT_NOT_REACHED();
+                return { };
+            }
+        );
+
+        auto& maximumTrackSizingFunction = track.trackSizingFunction.max;
+        track.growthLimit = WTF::switchOn(maximumTrackSizingFunction,
+            [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
+                // If the track has a min-content max track sizing function, set its growth
+                // limit to the maximum of the items’ min-content contributions.
+                auto minContentContributions = singleSpanningItems | std::views::transform([&](const PlacedGridItem& gridItem) {
+                    return integrationUtils.minContentWidth(gridItem.layoutBox());
+                });
+                return std::ranges::max(minContentContributions);
+            },
+            [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            },
+            [&](const CSS::Keyword::Auto&) -> LayoutUnit {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            },
+            [&](const auto&) -> LayoutUnit {
+                ASSERT_NOT_REACHED();
+                return { };
+            }
+        );
+    }
+
+    // 3. Increase sizes to accommodate spanning items crossing content-sized tracks:
+    // Next, consider the items with a span of 2 that do not span a track with a flexible
+    // sizing function.
+    auto increaseSizesToAccommodateSpanningItemsCrosszingContentSizedTracks = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(increaseSizesToAccommodateSpanningItemsCrosszingContentSizedTracks);
+
+    // 4. Increase sizes to accommodate spanning items crossing flexible tracks:
+    auto increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks);
+
+
+    // 5. If any track still has an infinite growth limit, set its growth limit to its base size.
+    auto setInfiniteGrowthLimitsToBaseSize = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(setInfiniteGrowthLimitsToBaseSize);
+}
+
+
 // https://drafts.csswg.org/css-grid-1/#algo-track-sizing
-TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems&, const TrackSizingFunctionsList& trackSizingFunctions)
+TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions, const IntegrationUtils& integrationUtils)
 {
     // 1. Initialize Track Sizes
     auto unsizedTracks = initializeTrackSizes(trackSizingFunctions);
 
     // 2. Resolve Intrinsic Track Sizes
-    auto resolveIntrinsicTrackSizes = [] {
-        notImplemented();
-    };
-    UNUSED_VARIABLE(resolveIntrinsicTrackSizes);
+    resolveIntrinsicTrackSizes(unsizedTracks, gridItems, gridItemSpanList, integrationUtils);
 
     // 3. Maximize Tracks
     auto maximizeTracks = [] {

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -32,9 +32,11 @@ namespace WebCore {
 
 namespace Layout {
 
+class IntegrationUtils;
+
 class TrackSizingAlgorithm {
 public:
-    static TrackSizes sizeTracks(const PlacedGridItems&, const TrackSizingFunctionsList&);
+    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, const IntegrationUtils&);
 
 private:
 


### PR DESCRIPTION
#### 97c90a1ec13bc33ad1efbdd4870b6cc766465366
<pre>
[GFC] WIP Add support for track sizing with min-content track sizing functions.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
(WebCore::Layout::GridLayout::performGridSizingAlgorithm): Deleted.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h:
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::singleSpanningItemsWithinTrack):
(WebCore::Layout::resolveIntrinsicTrackSizes):
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97c90a1ec13bc33ad1efbdd4870b6cc766465366

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84298 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/95ff51b3-a5c8-49df-8a04-bb693514f8e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101171 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68454 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eba6b52a-b6c1-4c0c-a0c5-be473d8beb83) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81962 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/581470c5-9d48-42a8-a250-f1b0cde9de02) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3459 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1170 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83090 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142516 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4515 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109549 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109727 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3412 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57791 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4569 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33182 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4526 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->