### PR TITLE
ASSERTION FAILED: m_outputContext in MediaPlaybackTargetContextCocoa::MediaPlaybackTargetContextCocoa

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
@@ -78,11 +78,14 @@ void RemoteMediaSessionHelper::stopMonitoringWirelessRoutesInternal()
 
 void RemoteMediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo supportsAirPlayVideo, MediaPlaybackTargetContextSerialized&& targetContext)
 {
-    WTF::switchOn(targetContext.platformContext(), [](WebCore::MediaPlaybackTargetContextMock&&) {
-        return;
-    }, [&](WebCore::MediaPlaybackTargetContextCocoa&& context) {
-        WebCore::MediaSessionHelper::activeVideoRouteDidChange(supportsAirPlayVideo, WebCore::MediaPlaybackTargetCocoa::create(WTFMove(context)));
-    });
+    switch (targetContext.targetType()) {
+    case WebCore::MediaPlaybackTargetContextType::AVOutputContext:
+        WebCore::MediaSessionHelper::activeVideoRouteDidChange(supportsAirPlayVideo, MediaPlaybackTargetSerialized::create(WTFMove(targetContext)));
+        break;
+    case WebCore::MediaPlaybackTargetContextType::Mock:
+    case WebCore::MediaPlaybackTargetContextType::Serialized:
+        break;
+    }
 }
 
 void RemoteMediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialAudioPlayback)


### PR DESCRIPTION
#### cf642dec7e61f18c72a31aa01aa692a63578d788
<pre>
ASSERTION FAILED: m_outputContext in MediaPlaybackTargetContextCocoa::MediaPlaybackTargetContextCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=302914">https://bugs.webkit.org/show_bug.cgi?id=302914</a>
<a href="https://rdar.apple.com/165184616">rdar://165184616</a>

Reviewed by Jean-Yves Avenard.

When the WebContent process receives a RemoteMediaSessionHelper::ActiveVideoRouteDidChange message
it attempts to construct an AVOutputContext from the contextID and contextType contained in
MediaPlaybackTargetContextSerialized. AVOutputContext creation involves sending XPC messages that
are blocked by the WebContent sandbox, and therefore creation fails, leading to
ASSERT(m_outputContext) failing in the MediaPlaybackTargetContextCocoa constructor.

Resolved this by creating a MediaPlaybackTargetSerialized rather than a MediaPlaybackTargetCocoa in
RemoteMediaSessionHelper::activeVideoRouteDidChange. The serialized playback target does not
attempt to create an AVOutputContext but does contain the metadata needed by the WebContent process
(e.g., deviceName) as well as the contextID and contextType necessary to re-create an
AVOutputContext in the GPU process when it is sent via
RemoteMediaPlayerProxy::SetWirelessPlaybackTarget.

Tested manually.

* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp:
(WebKit::RemoteMediaSessionHelper::activeVideoRouteDidChange):

Canonical link: <a href="https://commits.webkit.org/303434@main">https://commits.webkit.org/303434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe2d835eb2f9dbb96ac3b651ed57c9fb47c7677

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84134 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101056 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68377 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135155 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81851 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1078 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82944 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111978 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142371 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109434 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4452 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3781 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27816 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3313 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57618 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4425 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67871 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4516 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->