### PR TITLE
Add MacroAssembler emitters for load of 8, 16, and 32 bit values that sign extend into 32 or 64 bit registers.

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -863,6 +863,25 @@ public:
         m_assembler.maskRegister<32>(dest);
     }
 
+    void load8SignedExtendTo64(Address address, RegisterID dest)
+    {
+        auto resolution = resolveAddress(address, lazyTemp<Memory>());
+        m_assembler.lbInsn(dest, resolution.base, Imm::I(resolution.offset));
+    }
+
+    void load8SignedExtendTo64(BaseIndex address, RegisterID dest)
+    {
+        auto resolution = resolveAddress(address, lazyTemp<Memory>());
+        m_assembler.lbInsn(dest, resolution.base, Imm::I(resolution.offset));
+    }
+
+    void load8SignedExtendTo64(const void* address, RegisterID dest)
+    {
+        auto temp = temps<Memory>();
+        loadImmediate(TrustedImmPtr(address), temp.memory());
+        m_assembler.lbInsn(dest, temp.memory(), Imm::I<0>());
+    }
+
     void load16(Address address, RegisterID dest)
     {
         auto resolution = resolveAddress(address, lazyTemp<Memory>());
@@ -921,6 +940,44 @@ public:
         loadImmediate(TrustedImmPtr(address), temp.memory());
         m_assembler.lhInsn(dest, temp.memory(), Imm::I<0>());
         m_assembler.maskRegister<32>(dest);
+    }
+
+    void load16SignedExtendTo64(Address address, RegisterID dest)
+    {
+        auto resolution = resolveAddress(address, lazyTemp<Memory>());
+        m_assembler.lhInsn(dest, resolution.base, Imm::I(resolution.offset));
+    }
+
+    void load16SignedExtendTo64(BaseIndex address, RegisterID dest)
+    {
+        auto resolution = resolveAddress(address, lazyTemp<Memory>());
+        m_assembler.lhInsn(dest, resolution.base, Imm::I(resolution.offset));
+    }
+
+    void load16SignedExtendTo64(const void* address, RegisterID dest)
+    {
+        auto temp = temps<Memory>();
+        loadImmediate(TrustedImmPtr(address), temp.memory());
+        m_assembler.lhInsn(dest, temp.memory(), Imm::I<0>());
+    }
+
+    void load32SignedExtendTo64(Address address, RegisterID dest)
+    {
+        auto resolution = resolveAddress(address, lazyTemp<Memory>());
+        m_assembler.lwInsn(dest, resolution.base, Imm::I(resolution.offset));
+    }
+
+    void load32SignedExtendTo64(BaseIndex address, RegisterID dest)
+    {
+        auto resolution = resolveAddress(address, lazyTemp<Memory>());
+        m_assembler.lwInsn(dest, resolution.base, Imm::I(resolution.offset));
+    }
+
+    void load32SignedExtendTo64(const void* address, RegisterID dest)
+    {
+        auto temp = temps<Memory>();
+        loadImmediate(TrustedImmPtr(address), temp.memory());
+        m_assembler.lwInsn(dest, temp.memory(), Imm::I<0>());
     }
 
     void load32(Address address, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1513,6 +1513,16 @@ public:
         m_assembler.movsbl_mr(address.offset, address.base, dest);
     }
 
+    void load8SignedExtendTo64(BaseIndex address, RegisterID dest)
+    {
+        m_assembler.movsbq_mr(address.offset, address.base, address.index, address.scale, dest);
+    }
+
+    void load8SignedExtendTo64(Address address, RegisterID dest)
+    {
+        m_assembler.movsbq_mr(address.offset, address.base, dest);
+    }
+
     void zeroExtend8To32(RegisterID src, RegisterID dest)
     {
         m_assembler.movzbl_rr(src, dest);
@@ -1541,6 +1551,26 @@ public:
     void load16SignedExtendTo32(Address address, RegisterID dest)
     {
         m_assembler.movswl_mr(address.offset, address.base, dest);
+    }
+
+    void load16SignedExtendTo64(BaseIndex address, RegisterID dest)
+    {
+        m_assembler.movswq_mr(address.offset, address.base, address.index, address.scale, dest);
+    }
+
+    void load16SignedExtendTo64(Address address, RegisterID dest)
+    {
+        m_assembler.movswq_mr(address.offset, address.base, dest);
+    }
+
+    void load32SignedExtendTo64(BaseIndex address, RegisterID dest)
+    {
+        m_assembler.movsxdq_mr(address.offset, address.base, address.index, address.scale, dest);
+    }
+
+    void load32SignedExtendTo64(Address address, RegisterID dest)
+    {
+        m_assembler.movsxdq_mr(address.offset, address.base, dest);
     }
 
     void loadPair32(RegisterID src, RegisterID dest1, RegisterID dest2)
@@ -2787,7 +2817,7 @@ public:
 
     void signExtend32To64(RegisterID src, RegisterID dest)
     {
-        m_assembler.movsxd_rr(src, dest);
+        m_assembler.movsxdq_rr(src, dest);
     }
 
     void signExtend32ToPtr(RegisterID src, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -3167,9 +3167,19 @@ public:
         m_formatter.immediate32(imm);
     }
     
-    void movsxd_rr(RegisterID src, RegisterID dst)
+    void movsxdq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_MOVSXD_GvEv, dst, src);
+    }
+
+    void movsxdq_mr(int offset, RegisterID base, RegisterID dst)
+    {
+        m_formatter.oneByteOp64(OP_MOVSXD_GvEv, dst, base, offset);
+    }
+
+    void movsxdq_mr(int offset, RegisterID base, RegisterID index, int scale, RegisterID dst)
+    {
+        m_formatter.oneByteOp64(OP_MOVSXD_GvEv, dst, base, index, scale, offset);
     }
 
     void movzwl_mr(int offset, RegisterID base, RegisterID dst)
@@ -3192,6 +3202,18 @@ public:
         m_formatter.twoByteOp(OP2_MOVSX_GvEw, dst, base, index, scale, offset);
     }
 
+    void movswq_mr(int offset, RegisterID base, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movsx:movsxd
+        m_formatter.twoByteOp64(OP2_MOVSX_GvEw, dst, base, offset);
+    }
+
+    void movswq_mr(int offset, RegisterID base, RegisterID index, int scale, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movsx:movsxd
+        m_formatter.twoByteOp64(OP2_MOVSX_GvEw, dst, base, index, scale, offset);
+    }
+
     void movzbl_mr(int offset, RegisterID base, RegisterID dst)
     {
         m_formatter.twoByteOp(OP2_MOVZX_GvEb, dst, base, offset);
@@ -3206,10 +3228,22 @@ public:
     {
         m_formatter.twoByteOp(OP2_MOVSX_GvEb, dst, base, offset);
     }
-    
+
     void movsbl_mr(int offset, RegisterID base, RegisterID index, int scale, RegisterID dst)
     {
         m_formatter.twoByteOp(OP2_MOVSX_GvEb, dst, base, index, scale, offset);
+    }
+
+    void movsbq_mr(int offset, RegisterID base, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movsx:movsxd
+        m_formatter.twoByteOp64(OP2_MOVSX_GvEb, dst, base, offset);
+    }
+
+    void movsbq_mr(int offset, RegisterID base, RegisterID index, int scale, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movsx:movsxd
+        m_formatter.twoByteOp64(OP2_MOVSX_GvEb, dst, base, index, scale, offset);
     }
 
     void movzbl_rr(RegisterID src, RegisterID dst)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -383,8 +383,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, 
                 m_jit.load8SignedExtendTo32(location, resultLocation.asGPR());
                 break;
             case LoadOpType::I64Load8S:
-                m_jit.load8SignedExtendTo32(location, resultLocation.asGPR());
-                m_jit.signExtend32To64(resultLocation.asGPR(), resultLocation.asGPR());
+                m_jit.load8SignedExtendTo64(location, resultLocation.asGPR());
                 break;
             case LoadOpType::I32Load8U:
                 m_jit.load8(location, resultLocation.asGPR());
@@ -396,8 +395,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, 
                 m_jit.load16SignedExtendTo32(location, resultLocation.asGPR());
                 break;
             case LoadOpType::I64Load16S:
-                m_jit.load16SignedExtendTo32(location, resultLocation.asGPR());
-                m_jit.signExtend32To64(resultLocation.asGPR(), resultLocation.asGPR());
+                m_jit.load16SignedExtendTo64(location, resultLocation.asGPR());
                 break;
             case LoadOpType::I32Load16U:
                 m_jit.load16(location, resultLocation.asGPR());
@@ -412,8 +410,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, 
                 m_jit.load32(location, resultLocation.asGPR());
                 break;
             case LoadOpType::I64Load32S:
-                m_jit.load32(location, resultLocation.asGPR());
-                m_jit.signExtend32To64(resultLocation.asGPR(), resultLocation.asGPR());
+                m_jit.load32SignedExtendTo64(location, resultLocation.asGPR());
                 break;
             case LoadOpType::I64Load:
                 m_jit.load64(location, resultLocation.asGPR());


### PR DESCRIPTION
#### 466d85255afa476e298a112cf706284a50313326
<pre>
Add MacroAssembler emitters for load of 8, 16, and 32 bit values that sign extend into 32 or 64 bit registers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302915">https://bugs.webkit.org/show_bug.cgi?id=302915</a>
<a href="https://rdar.apple.com/165186300">rdar://165186300</a>

Reviewed by Yusuke Suzuki.

Some of these will currently be used to make WasmBBQJIT64 codegen more efficient,
and enable us to implement other things in the near future.

These emitters were originally written by Yusuke Suzuki in another PR.  I added
tests in testmasm to validate them in this commit in order to land them for use.

Test: Source/JavaScriptCore/assembler/testmasm.cpp
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::load16SignedExtendTo64):
(JSC::MacroAssemblerARM64::load32SignedExtendTo64):
(JSC::MacroAssemblerARM64::load8SignedExtendTo64):
(JSC::MacroAssemblerARM64::loadAcq8SignedExtendTo64):
(JSC::MacroAssemblerARM64::loadAcq16SignedExtendTo64):
(JSC::MacroAssemblerARM64::loadAcq32SignedExtendTo64):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::load8SignedExtendTo64):
(JSC::MacroAssemblerRISCV64::load16SignedExtendTo64):
(JSC::MacroAssemblerRISCV64::load32SignedExtendTo64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::load8SignedExtendTo64):
(JSC::MacroAssemblerX86_64::load16SignedExtendTo64):
(JSC::MacroAssemblerX86_64::load32SignedExtendTo64):
(JSC::MacroAssemblerX86_64::signExtend32To64):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::movsxdq_rr):
(JSC::X86Assembler::movsxdq_mr):
(JSC::X86Assembler::movswq_mr):
(JSC::X86Assembler::movsbq_mr):
(JSC::X86Assembler::movsxd_rr): Deleted.
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testLoadExtend):
(JSC::testLoadExtend_voidp_RegisterID):
(JSC::testLoadAcq8SignedExtendTo32_Address_RegisterID):
(JSC::testLoad8SignedExtendTo32_Address_RegisterID):
(JSC::testLoad8SignedExtendTo32_BaseIndex_RegisterID):
(JSC::testLoad8SignedExtendTo32_voidp_RegisterID):
(JSC::testLoadAcq16SignedExtendTo32_Address_RegisterID):
(JSC::testLoad16SignedExtendTo32_Address_RegisterID):
(JSC::testLoad16SignedExtendTo32_BaseIndex_RegisterID):
(JSC::testLoad16SignedExtendTo32_voidp_RegisterID):
(JSC::testLoadAcq8SignedExtendTo64_Address_RegisterID):
(JSC::testLoad8SignedExtendTo64_Address_RegisterID):
(JSC::testLoad8SignedExtendTo64_BaseIndex_RegisterID):
(JSC::testLoad8SignedExtendTo64_voidp_RegisterID):
(JSC::testLoadAcq16SignedExtendTo64_Address_RegisterID):
(JSC::testLoad16SignedExtendTo64_Address_RegisterID):
(JSC::testLoad16SignedExtendTo64_BaseIndex_RegisterID):
(JSC::testLoad16SignedExtendTo64_voidp_RegisterID):
(JSC::testLoadAcq32SignedExtendTo64_Address_RegisterID):
(JSC::testLoad32SignedExtendTo64_Address_RegisterID):
(JSC::testLoad32SignedExtendTo64_BaseIndex_RegisterID):
(JSC::testLoad32SignedExtendTo64_voidp_RegisterID):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::load):

Canonical link: <a href="https://commits.webkit.org/303414@main">https://commits.webkit.org/303414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91aa4a183406aadcd93af87b8d5c3d790d95e1ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132335 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/4830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139850 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba4847e4-25b3-43a7-ad93-383bbb6fb531) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4589 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8738ef2a-962d-4d29-9183-653a87dbc4d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135281 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81955 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83075 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124403 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142501 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130843 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/4500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37245 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109724 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3406 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114814 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20559 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4554 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163810 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/4386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68004 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42561 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager (failure)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/4645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/4511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->