### PR TITLE
Mac support for extended proofreading.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2952,6 +2952,21 @@ ExtendedAudioDescriptionsEnabled:
     WebCore:
       default: false
 
+ExtendedProofreadingEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Extended Proofreading"
+  humanReadableDescription: "Enable Extended Proofreading"
+  condition: PLATFORM(COCOA)
+  defaultValue:
+    WebCore:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: WebKit::defaultExtendedProofreadingEnabled()
+  sharedPreferenceForWebProcess: true
+
 ExtensibleSSOEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
@@ -29,6 +29,8 @@ DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)
 
+@class NSColor;
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <AppKit/NSTextChecker.h>
@@ -52,6 +54,7 @@ extern NSString *NSTextCompletionAttributeName;
 - (void)showCompletionForCandidate:(NSTextCheckingResult *)candidate selectedRange:(NSRange)selectedRange offset:(NSUInteger)offset inString:(NSString *)string rect:(NSRect)rect view:(NSView *)view client:(id <NSTextInputClient>)client completionHandler:(void (^)(NSDictionary *resultDictionary))completionBlock;
 #endif
 
+- (NSInteger)requestGrammarCheckingOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSInteger sequenceNumber, NSArray<NSTextCheckingResult *> *results))completionHandler;
 - (NSString *)languageForWordRange:(NSRange)range inString:(NSString *)string orthography:(NSOrthography *)orthography;
 - (BOOL)deletesAutospaceBeforeString:(NSString *)string language:(NSString *)language;
 - (void)_preflightChosenSpellServer;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3208,6 +3208,16 @@ void Editor::markAllMisspellingsAndBadGrammarInRanges(OptionSet<TextCheckingType
     Vector<TextCheckingResult> results;
     checkTextOfParagraph(*textChecker(), paragraphToCheck.text(), resolvedOptions, results, document().selection().selection());
     markAndReplaceFor(request.releaseNonNull(), results);
+
+#if PLATFORM(COCOA)
+    bool extendedProofreadingEnabled = document().settings().extendedProofreadingEnabled();
+
+    if (shouldMarkGrammar && extendedProofreadingEnabled) {
+        RefPtr extendedRequest = SpellCheckRequest::create(resolvedOptions, TextCheckingProcessType::TextCheckingProcessIncremental, checkingRange, textReplacementRange, paragraphRange);
+        if (extendedRequest)
+            m_spellChecker->requestExtendedCheckingFor(extendedRequest.releaseNonNull(), results);
+    }
+#endif
 }
 
 static bool isAutomaticTextReplacementType(TextCheckingType type)

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -52,6 +52,7 @@ public:
     Element* rootEditableElement() const { return m_rootEditableElement.get(); }
 
     void setCheckerAndIdentifier(SpellChecker*, TextCheckingRequestIdentifier);
+    void setExistingResults(const Vector<TextCheckingResult>&);
     void requesterDestroyed();
 
     const TextCheckingRequestData& data() const final;
@@ -67,6 +68,7 @@ private:
     SimpleRange m_automaticReplacementRange;
     SimpleRange m_paragraphRange;
     RefPtr<Element> m_rootEditableElement;
+    Vector<TextCheckingResult> m_existingResults;
     TextCheckingRequestData m_requestData;
 };
 
@@ -85,6 +87,7 @@ public:
     bool isCheckable(const SimpleRange&) const;
 
     void requestCheckingFor(Ref<SpellCheckRequest>&&);
+    void requestExtendedCheckingFor(Ref<SpellCheckRequest>&&, const Vector<TextCheckingResult>&);
 
     std::optional<TextCheckingRequestIdentifier> lastRequestIdentifier() const { return m_lastRequestIdentifier; }
     std::optional<TextCheckingRequestIdentifier> lastProcessedIdentifier() const { return m_lastProcessedIdentifier; }
@@ -95,9 +98,9 @@ private:
     void timerFiredToProcessQueuedRequest();
     void invokeRequest(Ref<SpellCheckRequest>&&);
     void enqueueRequest(Ref<SpellCheckRequest>&&);
-    void didCheckSucceed(TextCheckingRequestIdentifier, const Vector<TextCheckingResult>&);
+    void didCheckSucceed(TextCheckingRequestIdentifier, const Vector<TextCheckingResult>&, const Vector<TextCheckingResult>&, const std::optional<SimpleRange>&);
     void didCheckCancel(TextCheckingRequestIdentifier);
-    void didCheck(TextCheckingRequestIdentifier, const Vector<TextCheckingResult>&);
+    void didCheck(TextCheckingRequestIdentifier, const Vector<TextCheckingResult>&, const Vector<TextCheckingResult>&, const std::optional<SimpleRange>&);
 
     Document& document() const;
     Ref<Document> protectedDocument() const;
@@ -110,6 +113,7 @@ private:
 
     RefPtr<SpellCheckRequest> m_processingRequest;
     Deque<Ref<SpellCheckRequest>> m_requestQueue;
+    bool m_inRecheck { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -408,6 +408,7 @@ private:
 
         void getGuessesForWord(const String&, const String&, const VisibleSelection&, Vector<String>&) final { }
         void requestCheckingOfString(TextCheckingRequest&, const VisibleSelection&) final;
+        void requestExtendedCheckingOfString(TextCheckingRequest&, const VisibleSelection&) final;
     };
 
     EmptyTextCheckerClient m_textCheckerClient;
@@ -1165,6 +1166,10 @@ void EmptyFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<void(E
 }
 
 void EmptyEditorClient::EmptyTextCheckerClient::requestCheckingOfString(TextCheckingRequest&, const VisibleSelection&)
+{
+}
+
+void EmptyEditorClient::EmptyTextCheckerClient::requestExtendedCheckingOfString(TextCheckingRequest&, const VisibleSelection&)
 {
 }
 

--- a/Source/WebCore/platform/text/TextCheckerClient.h
+++ b/Source/WebCore/platform/text/TextCheckerClient.h
@@ -52,6 +52,7 @@ public:
     // identification. Noramlly it's the text surrounding the "word" for which we are getting correction suggestions.
     virtual void getGuessesForWord(const String& word, const String& context, const VisibleSelection& currentSelection, Vector<String>& guesses) = 0;
     virtual void requestCheckingOfString(TextCheckingRequest&, const VisibleSelection& currentSelection) = 0;
+    virtual void requestExtendedCheckingOfString(TextCheckingRequest&, const VisibleSelection& currentSelection) = 0;
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -78,6 +78,11 @@ bool defaultScrollAnimatorEnabled()
 }
 #endif
 
+bool defaultExtendedProofreadingEnabled()
+{
+    return os_feature_enabled(TextComposer, PostEditingProofreadingReview);
+}
+
 #if ENABLE(IMAGE_ANALYSIS)
 
 bool defaultTextRecognitionInVideosEnabled()

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -148,6 +148,10 @@ bool defaultVisuallyContiguousBidiTextSelectionEnabled();
 bool defaultBidiContentAwarePasteEnabled();
 #endif
 
+#if PLATFORM(COCOA)
+bool defaultExtendedProofreadingEnabled();
+#endif
+
 bool defaultRunningBoardThrottlingEnabled();
 bool defaultShouldDropNearSuspendedAssertionAfterDelay();
 bool defaultShouldTakeNearSuspendedAssertion();

--- a/Source/WebKit/UIProcess/TextChecker.cpp
+++ b/Source/WebKit/UIProcess/TextChecker.cpp
@@ -145,6 +145,11 @@ void TextChecker::requestCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t)
     notImplemented();
 }
 
+void TextChecker::requestExtendedCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t)
+{
+    notImplemented();
+}
+
 #if USE(UNIFIED_TEXT_CHECKING)
 Vector<TextCheckingResult> TextChecker::checkTextOfParagraph(SpellDocumentTag, StringView, int32_t, OptionSet<TextCheckingType>, bool)
 {

--- a/Source/WebKit/UIProcess/TextChecker.h
+++ b/Source/WebKit/UIProcess/TextChecker.h
@@ -91,6 +91,7 @@ public:
     static void learnWord(SpellDocumentTag, const String& word);
     static void ignoreWord(SpellDocumentTag, const String& word);
     static void requestCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t insertionPoint);
+    static void requestExtendedCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t insertionPoint);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11176,6 +11176,15 @@ void WebPageProxy::requestCheckingOfString(TextCheckerRequestID requestID, const
     TextChecker::requestCheckingOfString(TextCheckerCompletion::create(requestID, request, *this), insertionPoint);
 }
 
+
+void WebPageProxy::requestExtendedCheckingOfString(TextCheckerRequestID requestID, const TextCheckingRequestData& request, int32_t insertionPoint)
+{
+#if PLATFORM(COCOA)
+    TextChecker::requestExtendedCheckingOfString(TextCheckerCompletion::create(requestID, request, *this), insertionPoint);
+#endif
+}
+
+
 void WebPageProxy::didFinishCheckingText(TextCheckerRequestID requestID, const Vector<WebCore::TextCheckingResult>& result)
 {
     send(Messages::WebPage::DidFinishCheckingText(requestID, result));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3179,6 +3179,7 @@ private:
     void learnWord(IPC::Connection&, const String& word);
     void ignoreWord(IPC::Connection&, const String& word);
     void requestCheckingOfString(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, int32_t insertionPoint);
+    void requestExtendedCheckingOfString(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, int32_t insertionPoint);
 
     void takeFocus(WebCore::FocusDirection);
     void setToolTip(const String&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -323,6 +323,7 @@ messages -> WebPageProxy {
     LearnWord(String word)
     IgnoreWord(String word)
     RequestCheckingOfString(WebKit::TextCheckerRequestID requestID, WebCore::TextCheckingRequestData request, int32_t insertionPoint)
+    RequestExtendedCheckingOfString(WebKit::TextCheckerRequestID requestID, WebCore::TextCheckingRequestData request, int32_t insertionPoint)
 
     # Drag and drop messages
 #if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
@@ -366,6 +366,11 @@ void TextChecker::requestCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t)
     notImplemented();
 }
 
+void TextChecker::requestExtendedCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t)
+{
+    notImplemented();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -681,6 +681,17 @@ void WebEditorClient::requestCheckingOfString(TextCheckingRequest& request, cons
     page->send(Messages::WebPageProxy::RequestCheckingOfString(requestID, request.data(), insertionPointFromCurrentSelection(currentSelection)));
 }
 
+void WebEditorClient::requestExtendedCheckingOfString(TextCheckingRequest& request, const WebCore::VisibleSelection& currentSelection)
+{
+    auto requestID = TextCheckerRequestID::generate();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    page->addTextCheckingRequest(requestID, request);
+
+    page->send(Messages::WebPageProxy::RequestExtendedCheckingOfString(requestID, request.data(), insertionPointFromCurrentSelection(currentSelection)));
+}
+
 void WebEditorClient::willChangeSelectionForAccessibility()
 {
     if (RefPtr page = m_page.get())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -177,6 +177,7 @@ private:
     void getGuessesForWord(const String& word, const String& context, const WebCore::VisibleSelection& currentSelection, Vector<String>& guesses) final;
     void setInputMethodState(WebCore::Element*) final;
     void requestCheckingOfString(WebCore::TextCheckingRequest&, const WebCore::VisibleSelection& currentSelection) final;
+    void requestExtendedCheckingOfString(WebCore::TextCheckingRequest&, const WebCore::VisibleSelection& currentSelection) final;
 
 #if PLATFORM(GTK)
     bool shouldShowUnicodeMenu() final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -173,6 +173,7 @@ private:
 
     void setInputMethodState(WebCore::Element*) final;
     void requestCheckingOfString(WebCore::TextCheckingRequest&, const WebCore::VisibleSelection& currentSelection) final;
+    void requestExtendedCheckingOfString(WebCore::TextCheckingRequest&, const WebCore::VisibleSelection& currentSelection) final;
 
 #if PLATFORM(MAC)
     void requestCandidatesForSelection(const WebCore::VisibleSelection&) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -1269,6 +1269,10 @@ void WebEditorClient::requestCheckingOfString(TextCheckingRequest& request, cons
 #endif
 }
 
+void WebEditorClient::requestExtendedCheckingOfString(TextCheckingRequest& request, const VisibleSelection& currentSelection)
+{
+}
+
 #if PLATFORM(IOS_FAMILY)
 bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
 {

--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -29,6 +29,7 @@
 #import "InstanceMethodSwizzler.h"
 #import "JSBasics.h"
 #import <objc/runtime.h>
+#import <pal/spi/mac/NSSpellCheckerSPI.h>
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>
 
@@ -303,6 +304,16 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 
         completion(sequenceNumber, result, orthography, wordCount);
     }];
+}
+
+- (NSInteger)requestGrammarCheckingOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSInteger sequenceNumber, NSArray<NSTextCheckingResult *> *results))completionHandler
+{
+    RetainPtr overrideResult = retainPtr([_results objectForKey:stringToCheck]);
+    if (overrideResult) {
+        completionHandler(0, overrideResult.get());
+        return 0; // Not currently used, so return value doesn't matter. Should be the sequence number.
+    }
+    return [super requestGrammarCheckingOfString:stringToCheck range:range language:language options:options completionHandler:completionHandler];
 }
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 9840948a2ed4bca3b59b39f320610bff4e0133c4
<pre>
Mac support for extended proofreading.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302917">https://bugs.webkit.org/show_bug.cgi?id=302917</a>
<a href="https://rdar.apple.com/165075699">rdar://165075699</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add support for extended proofreading.

Test: editing/input/cocoa/extended-proofreading.html
* LayoutTests/editing/input/cocoa/extended-proofreading-expected.txt: Added.
* LayoutTests/editing/input/cocoa/extended-proofreading.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::markAllMisspellingsAndBadGrammarInRanges):
* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellCheckRequest::didSucceed):
(WebCore::SpellCheckRequest::setExistingResults):
(WebCore::SpellChecker::requestExtendedCheckingFor):
(WebCore::containsGrammarResult):
(WebCore::containsAdditionalGrammarResults):
(WebCore::SpellChecker::didCheck):
(WebCore::SpellChecker::didCheckSucceed):
(WebCore::SpellChecker::didCheckCancel):
* Source/WebCore/editing/SpellChecker.h:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyEditorClient::EmptyTextCheckerClient::requestExtendedCheckingOfString):
* Source/WebCore/platform/text/TextCheckerClient.h:
* Source/WebKit/UIProcess/TextChecker.cpp:
(WebKit::TextChecker::requestExtendedCheckingOfString):
* Source/WebKit/UIProcess/TextChecker.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestExtendedCheckingOfString):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/TextCheckerIOS.mm:
(WebKit::TextChecker::requestExtendedCheckingOfString):
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::convertExtendedCheckingResults):
(WebKit::TextChecker::requestExtendedCheckingOfString):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::requestExtendedCheckingOfString):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(WebEditorClient::requestExtendedCheckingOfString):
* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm:
(-[LayoutTestSpellChecker requestGrammarCheckingOfString:range:language:options:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/303913@main">https://commits.webkit.org/303913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67c10df276c4487b029f26905bb95b48cf1167f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85992 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e076c5eb-1c53-4817-918b-483757161f70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102447 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e705181b-40bf-495f-8d93-b4a16af64804) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136878 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83246 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2397 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126008 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144156 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132445 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6112 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110813 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111022 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4633 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116324 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59859 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6164 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34582 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165408 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69628 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43197 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6255 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->