### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for SVGResourceElementClient

### DIFF
--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -48,6 +48,7 @@ namespace WebCore {
 
 class CSSSVGResourceElementClient final : public SVGResourceElementClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSSVGResourceElementClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSSVGResourceElementClient);
 public:
     CSSSVGResourceElementClient(RenderElement& clientRenderer)
         : m_clientRenderer(clientRenderer)

--- a/Source/WebCore/svg/SVGResourceElementClient.h
+++ b/Source/WebCore/svg/SVGResourceElementClient.h
@@ -25,23 +25,21 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class RenderElement;
-class SVGResourceElementClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SVGResourceElementClient> : std::true_type { };
 }
 
 namespace WebCore {
 
 class SVGElement;
 
-class SVGResourceElementClient : public CanMakeWeakPtr<SVGResourceElementClient> {
+class SVGResourceElementClient : public CanMakeWeakPtr<SVGResourceElementClient>, public CanMakeCheckedPtr<SVGResourceElementClient> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGResourceElementClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGResourceElementClient);
 public:
     virtual ~SVGResourceElementClient() = default;
 


### PR DESCRIPTION
#### 8c578f9c913f2759139361f9cbd446e5603ad808
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for SVGResourceElementClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=302920">https://bugs.webkit.org/show_bug.cgi?id=302920</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/rendering/ReferencedSVGResources.cpp:
* Source/WebCore/svg/SVGResourceElementClient.h:

Canonical link: <a href="https://commits.webkit.org/303436@main">https://commits.webkit.org/303436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d918d081b0742aa1a4750b6ea2a233306dcf83c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132228 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84158 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1684ffd9-c6f2-4509-85b2-b40269b8a6ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101071 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68385 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/675a4ac1-74e3-492b-9609-b5dac7470ee0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81866 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/50b83589-75a6-4272-91c3-2af15d11c3dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1097 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142390 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4390 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27818 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3358 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57637 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4444 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33085 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4403 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->