### PR TITLE
MediaPlayerPrivateWebM will attempt to re-enqueue more samples indefinitely even when the AudioVideoRenderer isn't ready for it

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1024,10 +1024,6 @@ void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId
 
 bool MediaPlayerPrivateWebM::isReadyForMoreSamples(TrackID trackId)
 {
-    if (isEnabledVideoTrackID(trackId)) {
-        if (m_layerRequiresFlush)
-            return false;
-    }
     auto trackIdentifier = maybeTrackIdentifierFor(trackId);
     return trackIdentifier && m_renderer->isReadyForMoreSamples(*trackIdentifier);
 }
@@ -1094,6 +1090,8 @@ void MediaPlayerPrivateWebM::provideMediaData(TrackBuffer& trackBuffer, TrackID 
         return;
 
     if (trackBuffer.needsReenqueueing())
+        return;
+    if (isEnabledVideoTrackID(trackId) && m_layerRequiresFlush)
         return;
 
     unsigned enqueuedSamples = 0;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -94,7 +94,7 @@ private:
     void addTrack(RemoteAudioVideoRendererIdentifier, WebCore::TrackInfo::TrackType, CompletionHandler<void(Expected<TrackIdentifier, WebCore::PlatformMediaError>)>&&);
     void removeTrack(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
 
-    void enqueueSample(RemoteAudioVideoRendererIdentifier, TrackIdentifier, WebCore::MediaSamplesBlock&&, std::optional<MediaTime>);
+    void enqueueSample(RemoteAudioVideoRendererIdentifier, TrackIdentifier, WebCore::MediaSamplesBlock&&, std::optional<MediaTime>, CompletionHandler<void(bool)>&&);
     void requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
     void stopRequestingMediaData(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -40,7 +40,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     AddTrack(WebKit::RemoteAudioVideoRendererIdentifier identifier, enum:uint8_t WebCore::TrackInfoTrackType type) -> (Expected<WebCore::SamplesRendererTrackIdentifier, WebCore::PlatformMediaError> result) Synchronous
     RemoveTrack(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
 
-    EnqueueSample(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier, WebCore::MediaSamplesBlock block, std::optional<MediaTime> upcomingMinimumTime);
+    EnqueueSample(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier, WebCore::MediaSamplesBlock block, std::optional<MediaTime> upcomingMinimumTime) -> (bool readyForMoreData);
     RequestMediaDataWhenReady(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
     StopRequestingMediaData(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
@@ -30,7 +30,7 @@
     DispatchedTo=WebContent
 ]
 messages -> AudioVideoRendererRemoteMessageReceiver {
-    RequestMediaDataWhenReady(WebCore::SamplesRendererTrackIdentifier identifier)
+    ReadyForMoreMediaData(WebCore::SamplesRendererTrackIdentifier identifier)
     FirstFrameAvailable(struct WebKit::RemoteAudioVideoRendererState state)
     HasAvailableVideoFrame(MediaTime time, double clockTime, struct WebKit::RemoteAudioVideoRendererState state)
     RequiresFlushToResume(struct WebKit::RemoteAudioVideoRendererState state)


### PR DESCRIPTION
#### 3484e3687b3ce52e1545a4e764a9176e8bad36da
<pre>
MediaPlayerPrivateWebM will attempt to re-enqueue more samples indefinitely even when the AudioVideoRenderer isn&apos;t ready for it
<a href="https://bugs.webkit.org/show_bug.cgi?id=302918">https://bugs.webkit.org/show_bug.cgi?id=302918</a>
<a href="https://rdar.apple.com/165187226">rdar://165187226</a>

Reviewed by Youenn Fablet.

The earlier iteration attempted for the AudioVideoRendererRemote to always
attempt to guess the state of the GPUP&apos;s renderer without ever querying it.
We would enqueue a maximum of 20 frames and hold until the GPUP sent a message
back later that would reset the state.
The original idea was to reduce two ways traffic between the content process and
the GPUP.
Conditions existed however where the assumptions that we could always guess
the state of the GPUP broke down.
We now have the GPUP send back asynchronously after enqueing each sample
its readyForMoreData state.
This ensures that the two states (CP vs GPUP) are always in sync.

Covered by existing tests; manually verified that lower CPU usage was observed.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::isReadyForMoreSamples): Remove the test if the video track is active.
If a webm had multiple video track, we would have an infinite loop. We move it to provideMediaData instead.
(WebCore::MediaPlayerPrivateWebM::provideMediaData):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady):
(WebKit::RemoteAudioVideoRendererProxyManager::enqueueSample):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in: Rename IPC from requestMediaDataWhenReady to readyForMoreMediaData for clarity
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::enqueueSample):
(WebKit::AudioVideoRendererRemote::isReadyForMoreSamples):
(WebKit::AudioVideoRendererRemote::requestMediaDataWhenReady):
(WebKit::AudioVideoRendererRemote::stopRequestingMediaData):
(WebKit::AudioVideoRendererRemote::readyForMoreDataState):
(WebKit::AudioVideoRendererRemote::resolveRequestMediaDataWhenReadyIfNeeded):
(WebKit::AudioVideoRendererRemote::MessageReceiver::readyForMoreMediaData):
(WebKit::AudioVideoRendererRemote::readyForMoreData): Deleted.
(WebKit::AudioVideoRendererRemote::MessageReceiver::requestMediaDataWhenReady): Deleted.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in:

Canonical link: <a href="https://commits.webkit.org/303386@main">https://commits.webkit.org/303386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32c3dea0330cca3b541af560f77567933255675a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139751 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/12ac5509-615c-4ae4-ad3a-04d2624948e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101078 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c025a38e-4e20-49e9-97b8-4dbceaac500c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81873 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ef8a099-fc2b-4391-bc0d-59d9892c7ac5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82971 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142398 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4398 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109456 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27770 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3329 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114718 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57645 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4452 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33091 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67898 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4543 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4411 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->