### PR TITLE
Fix unsafe use of raw pointers in BaseAudioContext.h

### DIFF
--- a/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
@@ -76,14 +76,14 @@ AnalyserNode::~AnalyserNode()
 
 void AnalyserNode::process(size_t framesToProcess)
 {
-    Ref outputBus = output(0)->bus();
+    Ref outputBus = checkedOutput(0)->bus();
 
     if (!isInitialized()) {
         outputBus->zero();
         return;
     }
 
-    Ref inputBus = input(0)->bus();
+    Ref inputBus = checkedInput(0)->bus();
 
     // Give the analyser the audio which is passing through this AudioNode. This must always
     // be done so that the state of the Analyser reflects the current input.
@@ -154,7 +154,7 @@ void AnalyserNode::updatePullStatus()
 {
     ASSERT(context().isGraphOwner());
 
-    if (output(0)->isConnected()) {
+    if (checkedOutput(0)->isConnected()) {
         // When an AudioBasicInspectorNode is connected to a downstream node, it
         // will get pulled by the downstream node, thus remove it from the context's
         // automatic pull list.

--- a/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
@@ -48,8 +48,8 @@ AudioBasicInspectorNode::AudioBasicInspectorNode(BaseAudioContext& context, Node
 void AudioBasicInspectorNode::pullInputs(size_t framesToProcess)
 {
     // Render input stream - try to render directly into output bus for pass-through processing where process() doesn't need to do anything...
-    auto* output = this->output(0);
-    input(0)->pull(output ? &output->bus() : nullptr, framesToProcess);
+    CheckedPtr output = this->output(0);
+    checkedInput(0)->pull(output ? &output->bus() : nullptr, framesToProcess);
 }
 
 void AudioBasicInspectorNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
@@ -60,7 +60,7 @@ void AudioBasicInspectorNode::checkNumberOfChannelsForInput(AudioNodeInput* inpu
     if (input != this->input(0))
         return;
 
-    if (auto* output = this->output(0)) {
+    if (CheckedPtr output = this->output(0)) {
         unsigned numberOfChannels = input->numberOfChannels();
 
         if (numberOfChannels != output->numberOfChannels()) {
@@ -78,7 +78,7 @@ void AudioBasicInspectorNode::updatePullStatus()
 {
     ASSERT(context().isGraphOwner());
 
-    auto output = this->output(0);
+    CheckedPtr output = this->output(0);
     if (output && output->isConnected()) {
         // When an AudioBasicInspectorNode is connected to a downstream node, it will get pulled by the
         // downstream node, thus remove it from the context's automatic pull list.

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -99,7 +99,8 @@ AudioBufferSourceNode::~AudioBufferSourceNode()
 
 void AudioBufferSourceNode::process(size_t framesToProcess)
 {
-    auto& outputBus = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    auto& outputBus = firstOutput->bus();
 
     if (!isInitialized()) {
         outputBus.zero();
@@ -459,7 +460,7 @@ ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer
         unsigned numberOfChannels = buffer->numberOfChannels();
         ASSERT(numberOfChannels <= AudioContext::maxNumberOfChannels);
 
-        output(0)->setNumberOfChannels(numberOfChannels);
+        checkedOutput(0)->setNumberOfChannels(numberOfChannels);
 
         m_sourceChannels = FixedVector<std::span<const float>>(numberOfChannels);
         m_destinationChannels = FixedVector<std::span<float>>(numberOfChannels);

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -96,7 +96,7 @@ void AudioDestinationNode::renderQuantum(AudioBus& destinationBus, size_t number
 
     // This will cause the node(s) connected to us to process, which in turn will pull on their input(s),
     // all the way backwards through the rendering graph.
-    AudioBus& renderedBus = input(0)->pull(&destinationBus, numberOfFrames);
+    AudioBus& renderedBus = checkedInput(0)->pull(&destinationBus, numberOfFrames);
 
     if (&renderedBus != &destinationBus) {
         // in-place processing was not possible - so copy

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -126,7 +126,9 @@ public:
     unsigned numberOfOutputs() const { return m_outputs.size(); }
 
     AudioNodeInput* input(unsigned);
+    CheckedPtr<AudioNodeInput> checkedInput(unsigned);
     AudioNodeOutput* output(unsigned);
+    CheckedPtr<AudioNodeOutput> checkedOutput(unsigned);
 
     // Called from main thread by corresponding JavaScript methods.
     ExceptionOr<void> connect(AudioNode&, unsigned outputIndex, unsigned inputIndex);
@@ -254,7 +256,7 @@ private:
 
     WeakOrStrongContext m_context;
 
-    Vector<std::unique_ptr<AudioNodeInput>> m_inputs;
+    Vector<Ref<AudioNodeInput>> m_inputs;
     Vector<std::unique_ptr<AudioNodeOutput>> m_outputs;
 
     double m_lastProcessingTime { -1 };

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -40,6 +40,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioNodeInput);
 
+Ref<AudioNodeInput> AudioNodeInput::create(AudioNode* node)
+{
+    return adoptRef(*new AudioNodeInput(node));
+}
+
 AudioNodeInput::AudioNodeInput(AudioNode* node)
     : AudioSummingJunction(node->context())
     , m_node(node, EnableWeakPtrThreadingAssertions::No) // WebAudio code uses locking when accessing the context.
@@ -225,7 +230,7 @@ AudioBus& AudioNodeInput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
     // Handle single connection case.
     if (numberOfRenderingConnections() == 1 && node()->channelCountMode() == ChannelCountMode::Max) {
         // The output will optimize processing using inPlaceBus if it's able.
-        AudioNodeOutput* output = this->renderingOutput(0);
+        CheckedPtr output = this->renderingOutput(0);
         return output->pull(inPlaceBus, framesToProcess);
     }
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -189,7 +189,7 @@ void AudioNodeOutput::disconnectAllInputs()
     
     // AudioNodeInput::disconnect() changes m_inputs by calling removeInput().
     while (!m_inputs.isEmpty()) {
-        AudioNodeInput* input = m_inputs.begin()->key;
+        RefPtr input = m_inputs.begin()->key;
         input->disconnect(this);
     }
 }
@@ -199,10 +199,8 @@ void AudioNodeOutput::addParam(AudioParam* param)
     ASSERT(context().isGraphOwner());
 
     ASSERT(param);
-    if (!param)
-        return;
-
-    m_params.add(param);
+    if (param)
+        m_params.add(*param);
 }
 
 void AudioNodeOutput::removeParam(AudioParam* param)
@@ -210,10 +208,8 @@ void AudioNodeOutput::removeParam(AudioParam* param)
     ASSERT(context().isGraphOwner());
 
     ASSERT(param);
-    if (!param)
-        return;
-
-    m_params.remove(param);
+    if (param)
+        m_params.remove(param);
 }
 
 void AudioNodeOutput::disconnectAllParams()
@@ -222,7 +218,7 @@ void AudioNodeOutput::disconnectAllParams()
 
     // AudioParam::disconnect() changes m_params by calling removeParam().
     while (!m_params.isEmpty()) {
-        AudioParam* param = m_params.begin()->get();
+        Ref param = m_params.begin()->get();
         param->disconnect(this);
     }
 }

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -27,6 +27,7 @@
 #include "AudioBus.h"
 #include "AudioNode.h"
 #include "AudioParam.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -40,9 +41,10 @@ class AudioNodeInput;
 // AudioNodeOutput represents a single output for an AudioNode.
 // It may be connected to one or more AudioNodeInputs.
 
-class AudioNodeOutput {
+class AudioNodeOutput final : public CanMakeThreadSafeCheckedPtr<AudioNodeOutput> {
     WTF_MAKE_TZONE_ALLOCATED(AudioNodeOutput);
     WTF_MAKE_NONCOPYABLE(AudioNodeOutput);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioNodeOutput);
 public:
     // It's OK to pass 0 for numberOfChannels in which case setNumberOfChannels() must be called later on.
     AudioNodeOutput(AudioNode*, unsigned numberOfChannels);
@@ -59,7 +61,7 @@ public:
 
     // bus() will contain the rendered audio after pull() is called for each rendering time quantum.
     // Called from context's audio thread.
-    AudioBus& bus() const;
+    AudioBus& bus() const LIFETIME_BOUND;
 
     // renderingFanOutCount() is the number of AudioNodeInputs that we're connected to during rendering.
     // Unlike fanOutCount() it will not change during the course of a render quantum.
@@ -153,7 +155,7 @@ private:
     unsigned m_renderingFanOutCount { 0 };
     unsigned m_renderingParamFanOutCount { 0 };
 
-    HashSet<RefPtr<AudioParam>> m_params;
+    HashSet<Ref<AudioParam>> m_params;
     typedef HashSet<RefPtr<AudioParam>>::iterator ParamsIterator;
 };
 

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -39,8 +39,11 @@
 #include <algorithm>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioParam);
 
 static void replaceNaNValues(std::span<float> values, float defaultValue)
 {

--- a/Source/WebCore/Modules/webaudio/AudioParam.h
+++ b/Source/WebCore/Modules/webaudio/AudioParam.h
@@ -51,6 +51,8 @@ class AudioParam final
     , private LoggerHelper
 #endif
 {
+    WTF_MAKE_TZONE_ALLOCATED(AudioParam);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioParam);
 public:
     static constexpr double SmoothingConstant = 0.05;
     static constexpr double SnapThreshold = 0.001;

--- a/Source/WebCore/Modules/webaudio/AudioSummingJunction.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioSummingJunction.cpp
@@ -31,8 +31,11 @@
 #include "AudioContext.h"
 #include "AudioNodeOutput.h"
 #include <algorithm>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioSummingJunction);
 
 AudioSummingJunction::AudioSummingJunction(BaseAudioContext& context)
     : m_context(context, EnableWeakPtrThreadingAssertions::No) // WebAudio code uses locking when accessing the context.
@@ -112,7 +115,7 @@ void AudioSummingJunction::updateRenderingState()
 unsigned AudioSummingJunction::maximumNumberOfChannels() const
 {
     unsigned maxChannels = 0;
-    for (auto* output : m_outputs) {
+    for (CheckedPtr output : m_outputs) {
         // Use output()->numberOfChannels() instead of output->bus()->numberOfChannels(),
         // because the calling of AudioNodeOutput::bus() is not safe here.
         maxChannels = std::max(maxChannels, output->numberOfChannels());

--- a/Source/WebCore/Modules/webaudio/AudioSummingJunction.h
+++ b/Source/WebCore/Modules/webaudio/AudioSummingJunction.h
@@ -25,7 +25,9 @@
 #pragma once
 
 #include "AudioBus.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -37,7 +39,9 @@ class WeakPtrImplWithEventTargetData;
 
 // An AudioSummingJunction represents a point where zero, one, or more AudioNodeOutputs connect.
 
-class AudioSummingJunction {
+class AudioSummingJunction : public CanMakeThreadSafeCheckedPtr<AudioSummingJunction> {
+    WTF_MAKE_TZONE_ALLOCATED(AudioSummingJunction);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioSummingJunction);
 public:
     explicit AudioSummingJunction(BaseAudioContext&);
     virtual ~AudioSummingJunction();

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -787,12 +787,12 @@ void BaseAudioContext::deleteMarkedNodes()
         // Before deleting the node, clear out any AudioNodeInputs from m_dirtySummingJunctions.
         unsigned numberOfInputs = node->numberOfInputs();
         for (unsigned i = 0; i < numberOfInputs; ++i)
-            m_dirtySummingJunctions.remove(node->input(i));
+            m_dirtySummingJunctions.remove(node->checkedInput(i).get());
 
         // Before deleting the node, clear out any AudioNodeOutputs from m_dirtyAudioNodeOutputs.
         unsigned numberOfOutputs = node->numberOfOutputs();
         for (unsigned i = 0; i < numberOfOutputs; ++i)
-            m_dirtyAudioNodeOutputs.remove(node->output(i));
+            m_dirtyAudioNodeOutputs.remove(node->checkedOutput(i).get());
 
         ASSERT_WITH_MESSAGE(node->nodeType() != AudioNode::NodeTypeDestination, "Destination node is owned by the BaseAudioContext");
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -190,8 +190,8 @@ public:
     // Thread Safety and Graph Locking:
     //
     
-    void setAudioThread(Thread& thread) { m_audioThread = &thread; } // FIXME: check either not initialized or the same
-    bool isAudioThread() const { return m_audioThread == &Thread::currentSingleton(); }
+    void setAudioThread(Thread& thread) { m_audioThreadUID = thread.uid(); } // FIXME: check either not initialized or the same
+    bool isAudioThread() const { return m_audioThreadUID == Thread::currentSingleton().uid(); }
 
     // Returns true only after the audio thread has been started and then shutdown.
     bool isAudioThreadFinished() const { return m_isAudioThreadFinished; }
@@ -354,8 +354,8 @@ private:
     Vector<CheckedPtr<AudioNode>> m_nodesToDelete;
 
     // Only accessed when the graph lock is held.
-    HashSet<AudioSummingJunction*> m_dirtySummingJunctions;
-    HashSet<AudioNodeOutput*> m_dirtyAudioNodeOutputs;
+    HashSet<CheckedPtr<AudioSummingJunction>> m_dirtySummingJunctions;
+    HashSet<CheckedPtr<AudioNodeOutput>> m_dirtyAudioNodeOutputs;
 
     // For the sake of thread safety, we maintain a seperate Vector of automatic pull nodes for rendering in m_renderingAutomaticPullNodes.
     // It will be copied from m_automaticPullNodes by updateAutomaticPullNodes() at the very start or end of the rendering quantum.
@@ -367,7 +367,7 @@ private:
 
     const Ref<AudioListener> m_listener;
 
-    std::atomic<Thread*> m_audioThread;
+    std::atomic<uint32_t> m_audioThreadUID { 0 };
 
     mutable RecursiveLock m_graphLock;
 

--- a/Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp
@@ -73,14 +73,14 @@ ChannelMergerNode::ChannelMergerNode(BaseAudioContext& context, unsigned numberO
 
 void ChannelMergerNode::process(size_t framesToProcess)
 {
-    AudioNodeOutput* output = this->output(0);
+    CheckedPtr output = this->output(0);
     ASSERT(output);
     ASSERT_UNUSED(framesToProcess, framesToProcess == output->bus().length());
     ASSERT(numberOfInputs() == output->numberOfChannels());
     
     // Merge all the channels from all the inputs into one output.
     for (unsigned i = 0; i < numberOfInputs(); ++i) {
-        AudioNodeInput* input = this->input(i);
+        CheckedPtr input = this->input(i);
         ASSERT(input->numberOfChannels() == 1u);
         auto* outputChannel = output->bus().channel(i);
         if (input->isConnected()) {

--- a/Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp
@@ -66,19 +66,21 @@ ChannelSplitterNode::ChannelSplitterNode(BaseAudioContext& context, unsigned num
 
 void ChannelSplitterNode::process(size_t framesToProcess)
 {
-    AudioBus& source = input(0)->bus();
+    CheckedPtr firstInput = input(0);
+    AudioBus& source = firstInput->bus();
     ASSERT_UNUSED(framesToProcess, framesToProcess == source.length());
 
     unsigned numberOfSourceChannels = source.numberOfChannels();
     
     for (unsigned i = 0; i < numberOfOutputs(); ++i) {
-        AudioBus& destination = output(i)->bus();
+        CheckedPtr currentOutput = output(i);
+        AudioBus& destination = currentOutput->bus();
 
         if (i < numberOfSourceChannels) {
             // Split the channel out if it exists in the source.
             // It would be nice to avoid the copy and simply pass along pointers, but this becomes extremely difficult with fanout and fanin.
             destination.channel(0)->copyFrom(source.channel(i));
-        } else if (output(i)->renderingFanOutCount() > 0) {
+        } else if (currentOutput->renderingFanOutCount() > 0) {
             // Only bother zeroing out the destination if it's connected to anything
             destination.zero();
         }

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
@@ -64,7 +64,8 @@ ConstantSourceNode::~ConstantSourceNode()
 
 void ConstantSourceNode::process(size_t framesToProcess)
 {
-    auto& outputBus = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    auto& outputBus = firstOutput->bus();
     
     if (!isInitialized() || !outputBus.numberOfChannels()) {
         outputBus.zero();

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -91,7 +91,8 @@ ConvolverNode::~ConvolverNode()
 
 void ConvolverNode::process(size_t framesToProcess)
 {
-    AudioBus& outputBus = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    AudioBus& outputBus = firstOutput->bus();
 
     // Synchronize with possible dynamic changes to the impulse response.
     if (!m_processLock.tryLock()) {
@@ -108,7 +109,7 @@ void ConvolverNode::process(size_t framesToProcess)
         // Note that we can handle the case where nothing is connected to the input, in which case we'll just feed silence into the convolver.
         // FIXME: If we wanted to get fancy we could try to factor in the 'tail time' and stop processing once the tail dies down if
         // we keep getting fed silence.
-        m_reverb->process(input(0)->bus(), outputBus, framesToProcess);
+        m_reverb->process(checkedInput(0)->bus(), outputBus, framesToProcess);
     }
 }
 
@@ -155,7 +156,7 @@ ExceptionOr<void> ConvolverNode::setBufferForBindings(RefPtr<AudioBuffer>&& buff
         m_buffer = WTFMove(buffer);
         if (m_buffer) {
             // This will propagate the channel count to any nodes connected further downstream in the graph.
-            output(0)->setNumberOfChannels(computeNumberOfOutputChannels(input(0)->numberOfChannels(), m_buffer->numberOfChannels()));
+            checkedOutput(0)->setNumberOfChannels(computeNumberOfOutputChannels(checkedInput(0)->numberOfChannels(), m_buffer->numberOfChannels()));
         }
     }
 
@@ -233,7 +234,7 @@ void ConvolverNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
         if (!isInitialized()) {
             // This will propagate the channel count to any nodes connected further
             // downstream in the graph.
-            output(0)->setNumberOfChannels(numberOfOutputChannels);
+            checkedOutput(0)->setNumberOfChannels(numberOfOutputChannels);
             initialize();
         }
     }

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -71,7 +71,7 @@ AudioContext& DefaultAudioDestinationNode::context()
 
 bool DefaultAudioDestinationNode::isConnected() const
 {
-    auto* input = const_cast<DefaultAudioDestinationNode*>(this)->input(0);
+    CheckedPtr input = const_cast<DefaultAudioDestinationNode*>(this)->input(0);
     return input ? !!input->numberOfConnections() : false;
 }
 

--- a/Source/WebCore/Modules/webaudio/DelayNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayNode.cpp
@@ -63,7 +63,7 @@ ExceptionOr<Ref<DelayNode>> DelayNode::create(BaseAudioContext& context, const D
     if (result.hasException())
         return result.releaseException();
 
-    delayNode->delayTime().setValue(options.delayTime);
+    delayNode->checkedDelayTime()->setValue(options.delayTime);
 
     return delayNode;
 }
@@ -71,6 +71,11 @@ ExceptionOr<Ref<DelayNode>> DelayNode::create(BaseAudioContext& context, const D
 AudioParam& DelayNode::delayTime()
 {
     return downcast<DelayProcessor>(*m_processor).delayTime();
+}
+
+CheckedRef<AudioParam> DelayNode::checkedDelayTime()
+{
+    return delayTime();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/DelayNode.h
+++ b/Source/WebCore/Modules/webaudio/DelayNode.h
@@ -37,6 +37,7 @@ public:
     static ExceptionOr<Ref<DelayNode>> create(BaseAudioContext&, const DelayOptions&);
 
     AudioParam& delayTime();
+    CheckedRef<AudioParam> checkedDelayTime();
 
 private:
     DelayNode(BaseAudioContext&, double maxDelayTime);

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
@@ -76,7 +76,8 @@ DynamicsCompressorNode::~DynamicsCompressorNode()
 
 void DynamicsCompressorNode::process(size_t framesToProcess)
 {
-    AudioBus& outputBus = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    AudioBus& outputBus = firstOutput->bus();
 
     float threshold = m_threshold->finalValue();
     float knee = m_knee->finalValue();
@@ -90,7 +91,7 @@ void DynamicsCompressorNode::process(size_t framesToProcess)
     m_dynamicsCompressor->setParameterValue(DynamicsCompressor::ParamAttack, attack);
     m_dynamicsCompressor->setParameterValue(DynamicsCompressor::ParamRelease, release);
 
-    m_dynamicsCompressor->process(input(0)->bus(), outputBus, framesToProcess);
+    m_dynamicsCompressor->process(checkedInput(0)->bus(), outputBus, framesToProcess);
 
     setReduction(m_dynamicsCompressor->parameterValue(DynamicsCompressor::ParamReduction));
 }

--- a/Source/WebCore/Modules/webaudio/GainNode.cpp
+++ b/Source/WebCore/Modules/webaudio/GainNode.cpp
@@ -69,12 +69,14 @@ void GainNode::process(size_t framesToProcess)
     // happen in the summing junction input of the AudioNode we're connected to.
     // Then we can avoid all of the following:
 
-    AudioBus& outputBus = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    AudioBus& outputBus = firstOutput->bus();
 
-    if (!isInitialized() || !input(0)->isConnected())
+    CheckedPtr firstInput = input(0);
+    if (!isInitialized() || !firstInput->isConnected())
         outputBus.zero();
     else {
-        AudioBus& inputBus = input(0)->bus();
+        AudioBus& inputBus = firstInput->bus();
 
         if (gain().hasSampleAccurateValues() && gain().automationRate() == AutomationRate::ARate) {
             // Apply sample-accurate gain scaling for precise envelopes, grain windows, etc.
@@ -126,7 +128,7 @@ void GainNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
 
     if (!isInitialized()) {
         // This will propagate the channel count to any nodes connected further downstream in the graph.
-        output(0)->setNumberOfChannels(numberOfChannels);
+        checkedOutput(0)->setNumberOfChannels(numberOfChannels);
         initialize();
     }
 

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -118,7 +118,7 @@ void MediaElementAudioSourceNode::setFormat(size_t numberOfChannels, float sourc
             Locker contextLocker { context().graphLock() };
 
             // Do any necesssary re-configuration to the output's number of channels.
-            output(0)->setNumberOfChannels(numberOfChannels);
+            checkedOutput(0)->setNumberOfChannels(numberOfChannels);
         }
     }
 }
@@ -144,7 +144,7 @@ bool MediaElementAudioSourceNode::wouldTaintOrigin()
 
 void MediaElementAudioSourceNode::process(size_t numberOfFrames)
 {
-    Ref outputBus = output(0)->bus();
+    Ref outputBus = checkedOutput(0)->bus();
 
     // Use tryLock() to avoid contention in the real-time audio thread.
     // If we fail to acquire the lock then the HTMLMediaElement must be in the middle of

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
@@ -121,7 +121,7 @@ void MediaStreamAudioSourceNode::setFormat(size_t numberOfChannels, float source
         Locker contextLocker { context().graphLock() };
 
         // Do any necesssary re-configuration to the output's number of channels.
-        output(0)->setNumberOfChannels(numberOfChannels);
+        checkedOutput(0)->setNumberOfChannels(numberOfChannels);
     }
 }
 
@@ -132,7 +132,7 @@ void MediaStreamAudioSourceNode::provideInput(AudioBus& bus, size_t framesToProc
 
 void MediaStreamAudioSourceNode::process(size_t numberOfFrames)
 {
-    Ref outputBus = output(0)->bus();
+    Ref outputBus = checkedOutput(0)->bus();
 
     // Use tryLock() to avoid contention in the real-time audio thread.
     // If we fail to acquire the lock then the MediaStream must be in the middle of

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -105,7 +105,7 @@ void OfflineAudioContext::increaseNoiseMultiplierIfNeeded()
         auto node = remainingNodes.takeLast();
         target->increaseNoiseInjectionMultiplier(node->noiseInjectionMultiplier());
         for (unsigned i = 0; i < node->numberOfOutputs(); ++i) {
-            auto* output = node->output(i);
+            CheckedPtr output = node->output(i);
             if (!output)
                 continue;
 

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
@@ -340,7 +340,8 @@ double OscillatorNode::processKRate(int n, std::span<float> destination, double 
 
 void OscillatorNode::process(size_t framesToProcess)
 {
-    auto& outputBus = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    auto& outputBus = firstOutput->bus();
 
     if (!isInitialized() || !outputBus.numberOfChannels()) {
         outputBus.zero();

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.h
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.h
@@ -45,8 +45,8 @@ public:
     OscillatorType typeForBindings() const { ASSERT(isMainThread()); return m_type; }
     ExceptionOr<void> setTypeForBindings(OscillatorType);
 
-    AudioParam* frequency() { return m_frequency.get(); }
-    AudioParam* detune() { return m_detune.get(); }
+    AudioParam& frequency() { return m_frequency.get(); }
+    AudioParam& detune() { return m_detune.get(); }
 
     void setPeriodicWave(PeriodicWave&);
 
@@ -72,10 +72,10 @@ private:
     OscillatorType m_type; // Only used on the main thread.
     
     // Frequency value in Hertz.
-    RefPtr<AudioParam> m_frequency;
+    const Ref<AudioParam> m_frequency;
 
     // Detune value (deviating from the frequency) in Cents.
-    RefPtr<AudioParam> m_detune;
+    const Ref<AudioParam> m_detune;
 
     bool m_firstRender { true };
 

--- a/Source/WebCore/Modules/webaudio/PannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/PannerNode.cpp
@@ -109,14 +109,16 @@ PannerNode::~PannerNode()
 
 void PannerNode::process(size_t framesToProcess)
 {
-    AudioBus& destination = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    AudioBus& destination = firstOutput->bus();
 
-    if (!isInitialized() || !input(0)->isConnected()) {
+    CheckedPtr firstInput = input(0);
+    if (!isInitialized() || !firstInput->isConnected()) {
         destination.zero();
         return;
     }
 
-    AudioBus& source = input(0)->bus();
+    AudioBus& source = firstInput->bus();
 
     // The audio thread can't block on this lock, so we use tryLock() instead.
     if (!m_processLock.tryLock()) {

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
@@ -146,8 +146,10 @@ void ScriptProcessorNode::process(size_t framesToProcess)
     // of the buffers for safety reasons.
 
     // Get input and output busses.
-    AudioBus& inputBus = this->input(0)->bus();
-    AudioBus& outputBus = this->output(0)->bus();
+    CheckedPtr firstInput = input(0);
+    AudioBus& inputBus = firstInput->bus();
+    CheckedPtr firstOutput = output(0);
+    AudioBus& outputBus = firstOutput->bus();
 
     // Get input and output buffers. We double-buffer both the input and output sides.
     unsigned bufferIndex = this->bufferIndex();

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
@@ -69,14 +69,16 @@ StereoPannerNode::~StereoPannerNode()
 
 void StereoPannerNode::process(size_t framesToProcess)
 {
-    AudioBus& destination = output(0)->bus();
+    CheckedPtr firstOutput = output(0);
+    AudioBus& destination = firstOutput->bus();
 
-    if (!isInitialized() || !input(0)->isConnected()) {
+    CheckedPtr firstInput = input(0);
+    if (!isInitialized() || !firstInput->isConnected()) {
         destination.zero();
         return;
     }
     
-    AudioBus& source = input(0)->bus();
+    AudioBus& source = firstInput->bus();
 
     if (m_pan->hasSampleAccurateValues() && m_pan->automationRate() == AutomationRate::ARate) {
         auto panValues = m_sampleAccurateValues.span().first(framesToProcess);

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -57,7 +57,6 @@ Modules/webaudio/BiquadFilterNode.cpp
 [ iOS ] Modules/webaudio/ChannelMergerNode.cpp
 Modules/webaudio/ConvolverNode.cpp
 Modules/webaudio/DefaultAudioDestinationNode.cpp
-Modules/webaudio/DelayNode.cpp
 Modules/webaudio/DynamicsCompressorNode.cpp
 Modules/webaudio/MediaElementAudioSourceNode.cpp
 Modules/webaudio/MediaStreamAudioDestinationNode.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -16,7 +16,6 @@ Modules/webaudio/AudioBufferSourceNode.cpp
 Modules/webaudio/AudioDestinationNode.cpp
 Modules/webaudio/AudioNode.cpp
 Modules/webaudio/AudioNodeInput.cpp
-Modules/webaudio/AudioNodeOutput.cpp
 Modules/webaudio/AudioParam.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/webaudio/AudioWorkletNode.cpp


### PR DESCRIPTION
#### 8749eded36e40d597666534cba43339d5284ecad
<pre>
Fix unsafe use of raw pointers in BaseAudioContext.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=302924">https://bugs.webkit.org/show_bug.cgi?id=302924</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/webaudio/AnalyserNode.cpp:
(WebCore::AnalyserNode::process):
(WebCore::AnalyserNode::updatePullStatus):
* Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp:
(WebCore::AudioBasicInspectorNode::pullInputs):
(WebCore::AudioBasicInspectorNode::checkNumberOfChannelsForInput):
(WebCore::AudioBasicInspectorNode::updatePullStatus):
* Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp:
(WebCore::AudioBasicProcessorNode::process):
(WebCore::AudioBasicProcessorNode::pullInputs):
(WebCore::AudioBasicProcessorNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::process):
(WebCore::AudioBufferSourceNode::setBufferForBindings):
* Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp:
(WebCore::AudioDestinationNode::renderQuantum):
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::addInput):
(WebCore::AudioNode::input):
(WebCore::AudioNode::checkedInput):
(WebCore::AudioNode::checkedOutput):
(WebCore::AudioNode::connect):
(WebCore::AudioNode::disconnect):
(WebCore::AudioNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
(WebCore::AudioNodeInput::create):
(WebCore::AudioNodeInput::pull):
* Source/WebCore/Modules/webaudio/AudioNodeInput.h:
* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::disconnectAllInputs):
(WebCore::AudioNodeOutput::addParam):
(WebCore::AudioNodeOutput::removeParam):
(WebCore::AudioNodeOutput::disconnectAllParams):
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
(WebCore::AudioNodeOutput::node const): Deleted.
(WebCore::AudioNodeOutput::checkedNode const): Deleted.
(WebCore::AudioNodeOutput::context): Deleted.
(WebCore::AudioNodeOutput::numberOfChannels const): Deleted.
(WebCore::AudioNodeOutput::isChannelCountKnown const): Deleted.
(WebCore::AudioNodeOutput::isConnected): Deleted.
(WebCore::AudioNodeOutput::isConnectedTo const): Deleted.
(WebCore::AudioNodeOutput::isEnabled const): Deleted.
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
* Source/WebCore/Modules/webaudio/AudioParam.h:
* Source/WebCore/Modules/webaudio/AudioSummingJunction.cpp:
(WebCore::AudioSummingJunction::maximumNumberOfChannels const):
* Source/WebCore/Modules/webaudio/AudioSummingJunction.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
(WebCore::AudioWorkletNode::updatePullStatus):
(WebCore::AudioWorkletNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::deleteMarkedNodes):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::setAudioThread):
(WebCore::BaseAudioContext::isAudioThread const):
* Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp:
(WebCore::ChannelMergerNode::process):
* Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp:
(WebCore::ChannelSplitterNode::process):
* Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp:
(WebCore::ConstantSourceNode::process):
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
(WebCore::ConvolverNode::process):
(WebCore::ConvolverNode::setBufferForBindings):
(WebCore::ConvolverNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::DefaultAudioDestinationNode::isConnected const):
* Source/WebCore/Modules/webaudio/DelayNode.cpp:
(WebCore::DelayNode::create):
(WebCore::DelayNode::checkedDelayTime):
* Source/WebCore/Modules/webaudio/DelayNode.h:
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp:
(WebCore::DynamicsCompressorNode::process):
* Source/WebCore/Modules/webaudio/GainNode.cpp:
(WebCore::GainNode::process):
(WebCore::GainNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::setFormat):
(WebCore::MediaElementAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp:
(WebCore::MediaStreamAudioSourceNode::setFormat):
(WebCore::MediaStreamAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::increaseNoiseMultiplierIfNeeded):
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::OscillatorNode::process):
* Source/WebCore/Modules/webaudio/OscillatorNode.h:
* Source/WebCore/Modules/webaudio/PannerNode.cpp:
(WebCore::PannerNode::process):
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp:
(WebCore::ScriptProcessorNode::process):
* Source/WebCore/Modules/webaudio/StereoPannerNode.cpp:
(WebCore::StereoPannerNode::process):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/303454@main">https://commits.webkit.org/303454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a4a8a67813db185bf867e58f8095fc7a73b533b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132433 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84393 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3bcd133b-0692-4cb7-91cf-afba14e64db3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101244 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68496 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/31ae2434-7b80-4c59-8284-742202df0963) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135379 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b2418a0-9633-48d6-942c-1f9dcefaa3dc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142602 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109620 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27829 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3482 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57899 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4652 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33252 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->