### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for TextTrackRepresentationCocoa

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h
@@ -30,6 +30,7 @@
 
 #include <QuartzCore/CALayer.h>
 #include <WebCore/TextTrackRepresentation.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -38,19 +39,15 @@ namespace WebCore {
 class TextTrackRepresentationCocoa;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TextTrackRepresentationCocoa> : std::true_type { };
-}
-
 @class WebCoreTextTrackRepresentationCocoaHelper;
 
 namespace WebCore {
 
 class HTMLMediaElement;
 
-class TextTrackRepresentationCocoa : public TextTrackRepresentation, public CanMakeWeakPtr<TextTrackRepresentationCocoa, WeakPtrFactoryInitialization::Eager> {
+class TextTrackRepresentationCocoa : public TextTrackRepresentation, public CanMakeWeakPtr<TextTrackRepresentationCocoa, WeakPtrFactoryInitialization::Eager>, public CanMakeCheckedPtr<TextTrackRepresentationCocoa> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(TextTrackRepresentationCocoa, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextTrackRepresentationCocoa);
 public:
     WEBCORE_EXPORT explicit TextTrackRepresentationCocoa(TextTrackRepresentationClient&);
     WEBCORE_EXPORT virtual ~TextTrackRepresentationCocoa();

--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
@@ -43,7 +43,7 @@
 
 
 @interface WebCoreTextTrackRepresentationCocoaHelper : NSObject <CALayerDelegate> {
-    WebCore::TextTrackRepresentationCocoa* _parent;
+    CheckedPtr<WebCore::TextTrackRepresentationCocoa> _parent;
 }
 - (id)initWithParent:(WebCore::TextTrackRepresentationCocoa*)parent;
 @property (assign) WebCore::TextTrackRepresentationCocoa* parent;
@@ -79,7 +79,7 @@
 
 - (WebCore::TextTrackRepresentationCocoa*)parent
 {
-    return _parent;
+    return _parent.get();
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
@@ -93,7 +93,7 @@
     });
 #else
     if (_parent && [keyPath isEqual:@"bounds"] && object == _parent->platformLayer())
-        _parent->boundsChanged();
+        CheckedPtr { _parent }->boundsChanged();
 #endif
 }
 
@@ -170,8 +170,8 @@ IntRect TextTrackRepresentationCocoa::bounds() const
 void TextTrackRepresentationCocoa::boundsChanged()
 {
     callOnMainThread([weakThis = WeakPtr { *this }] {
-        if (weakThis)
-            weakThis->client().textTrackRepresentationBoundsChanged(weakThis->bounds());
+        if (CheckedPtr checkedThis = weakThis.get())
+            checkedThis->client().textTrackRepresentationBoundsChanged(checkedThis->bounds());
     });
 }
 

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
@@ -39,6 +39,8 @@ namespace WebKit {
 class WebPage;
 
 class WebTextTrackRepresentationCocoa final : public WebCore::TextTrackRepresentationCocoa {
+    WTF_MAKE_TZONE_ALLOCATED(WebTextTrackRepresentationCocoa);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebTextTrackRepresentationCocoa);
 public:
     explicit WebTextTrackRepresentationCocoa(WebCore::TextTrackRepresentationClient&, WebCore::HTMLMediaElement&);
     virtual ~WebTextTrackRepresentationCocoa() = default;

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -37,8 +37,11 @@
 #import <WebCore/NativeImage.h>
 #import <WebCore/NodeDocument.h>
 #import <WebCore/Page.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebTextTrackRepresentationCocoa);
 
 WebTextTrackRepresentationCocoa::WebTextTrackRepresentationCocoa(WebCore::TextTrackRepresentationClient& client, WebCore::HTMLMediaElement& mediaElement)
     : WebCore::TextTrackRepresentationCocoa(client)


### PR DESCRIPTION
#### c26e67282fd109aa8c9964ec527ca94d5101b0c2
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for TextTrackRepresentationCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=302926">https://bugs.webkit.org/show_bug.cgi?id=302926</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h:
* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm:
(-[WebCoreTextTrackRepresentationCocoaHelper parent]):
(-[WebCoreTextTrackRepresentationCocoaHelper observeValueForKeyPath:ofObject:change:context:]):
(WebCore::TextTrackRepresentationCocoa::boundsChanged):
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h:
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/303455@main">https://commits.webkit.org/303455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afe7cb1b1373f1123875c7781299c7791cdfeef6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84383 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76281aac-31a2-47d8-9578-b0c48ef1c807) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101236 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68491 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/efb72c41-e79d-4577-a6cc-500e012c31fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135370 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82028 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cedd0ad5-da5a-4a2c-94be-eeb2b1aaad85) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83166 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142591 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109611 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109790 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3476 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57875 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4643 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33245 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4734 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->