### PR TITLE
MediaStreamTrackProcessor does not respect track.enabled = false

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker-expected.txt
@@ -1,3 +1,4 @@
 
 PASS Tests that multiple read requests are eventually settled
+PASS Tests that MediaStreamTrackProcess respects track.enabled
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -103,7 +103,7 @@ void MediaStreamTrackProcessor::tryEnqueueingVideoFrame()
     if (!context || !videoFrameObserverWrapper || !m_readable)
         return;
 
-    if (m_readableStreamSource->isCancelled())
+    if (m_readableStreamSource->isCancelled() || !m_readableStreamSource->isEnabled())
         return;
 
     // FIXME: If the stream is waiting, we might want to buffer based on

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -71,6 +71,7 @@ public:
         Source(Ref<MediaStreamTrackPrivate>&&, MediaStreamTrackProcessor&);
         ~Source();
 
+        bool isEnabled() const { return m_privateTrack->enabled(); }
         bool isWaiting() const { return m_isWaiting; }
         bool isCancelled() const { return m_isCancelled; }
         void close();


### PR DESCRIPTION
#### d70198894a34b66b97df3c0c8b1dbeb8da0ddd77
<pre>
MediaStreamTrackProcessor does not respect track.enabled = false
<a href="https://rdar.apple.com/165199900">rdar://165199900</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302930">https://bugs.webkit.org/show_bug.cgi?id=302930</a>

Reviewed by Jean-Yves Avenard.

Add a check to track.enabled before enqueuing video frames.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker.js:
(promise_test.async t):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::tryEnqueueingVideoFrame):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:

Canonical link: <a href="https://commits.webkit.org/303389@main">https://commits.webkit.org/303389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/012da2c760f288eed0f0a658a9c0a706f16077e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84183 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/772d0bf3-f46d-4034-9d03-a656da36b73e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101091 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135196 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81886 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82985 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142412 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4493 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109652 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3345 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114735 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57668 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4466 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33107 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67912 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4557 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->