### PR TITLE
[blocks-in-inline] Compute first and last line baselines for blocks

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-list-marker-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-list-marker-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<ul>
+  <li>
+    <div style="display: inline-block;"><span><div>line1<br>line2</div></span></div>
+  </li>
+</ul>
+

--- a/LayoutTests/fast/inline/blocks-in-inline-list-marker.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-list-marker.html
@@ -1,0 +1,7 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE html>
+<ul>
+  <li>
+    <div style="display: inline-block;"><span><div>line1<br>line2</div></span></div>
+  </li>
+</ul>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -145,6 +145,13 @@ std::optional<size_t> InlineContent::firstBoxIndexForLayoutBox(const Layout::Box
     return it->value;
 }
 
+// Returns a block level box if the line is for block-in-inline.
+const InlineDisplay::Box* InlineContent::blockLevelBoxForLine(const InlineDisplay::Line& line) const
+{
+    auto& lastBox = displayContent().boxes[line.lastBoxIndex()];
+    return lastBox.isBlockLevelBox() ? &lastBox : nullptr;
+}
+
 const Vector<size_t>& InlineContent::nonRootInlineBoxIndexesForLayoutBox(const Layout::Box& layoutBox) const
 {
     ASSERT(layoutBox.isElementBox());

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -88,6 +88,9 @@ public:
     const InlineDisplay::Box* firstBoxForLayoutBox(const Layout::Box&) const;
     std::optional<size_t> firstBoxIndexForLayoutBox(const Layout::Box&) const;
 
+    // Returns a block level box if the line is for block-in-inline.
+    const InlineDisplay::Box* blockLevelBoxForLine(const InlineDisplay::Line&) const;
+
     template<typename Function> void traverseNonRootInlineBoxes(const Layout::Box&, Function&&);
     template<typename Function> void traverseDescendantBlockLevelBoxes(const Layout::Box&, Function&&);
 


### PR DESCRIPTION
#### c23a3e4b0af49d829fc1441ca860416df7e08195
<pre>
[blocks-in-inline] Compute first and last line baselines for blocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=302927">https://bugs.webkit.org/show_bug.cgi?id=302927</a>
<a href="https://rdar.apple.com/165198637">rdar://165198637</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-list-marker.html
* LayoutTests/fast/inline/blocks-in-inline-list-marker-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-list-marker.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
(WebCore::LayoutIntegration::InlineContent::blockLevelBoxForLine const):

Add a helper.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::firstLineBaseline const):
(WebCore::LayoutIntegration::LineLayout::lastLineBaseline const):

In case of a block-in-inline return the relevant block baseline.

Canonical link: <a href="https://commits.webkit.org/303391@main">https://commits.webkit.org/303391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55ed77320fc76cc2568a42b04fd75dd59c593be6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84187 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f46cfa7-8ce9-4b57-81c3-9810f6aee9d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101096 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/530e19c3-264a-4cb0-b138-91db08c0337d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135200 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81891 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82989 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142416 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109472 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27777 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3349 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57673 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4470 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33108 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67916 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->