### PR TITLE
[WTF] Fix behavioral issues in searching in spans

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1073,10 +1073,10 @@ template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
     requires(TriviallyComparableOneByteCodeUnits<T, U>)
 size_t find(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
 {
-#if !HAVE(MEMMEM)
     if (needle.empty())
         return 0;
 
+#if !HAVE(MEMMEM)
     if (haystack.size() < needle.size())
         return notFound;
 

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -494,16 +494,9 @@ template<typename SearchCharacterType, typename MatchCharacterType>
     requires(TriviallyComparableCodeUnits<SearchCharacterType, MatchCharacterType>)
 size_t findIgnoringASCIICase(std::span<const SearchCharacterType> source, std::span<const MatchCharacterType> matchCharacters, size_t startOffset = 0)
 {
-    ASSERT(source.size() >= matchCharacters.size());
-
-    auto startSearchedCharacters = source.subspan(startOffset);
-
-    // delta is the number of additional times to test; delta == 0 means test only once.
-    size_t delta = startSearchedCharacters.size() - matchCharacters.size();
-
-    for (size_t i = 0; i <= delta; ++i) {
-        if (equalIgnoringASCIICaseWithLength(startSearchedCharacters.subspan(i), matchCharacters, matchCharacters.size()))
-            return startOffset + i;
+    for (size_t offset = startOffset; offset <= source.size() && source.size() - offset >= matchCharacters.size(); ++offset) {
+        if (equalIgnoringASCIICaseWithLength(source.subspan(offset), matchCharacters, matchCharacters.size()))
+            return offset;
     }
     return notFound;
 }
@@ -804,6 +797,9 @@ inline bool contains(std::span<const CharacterType> characters, ASCIILiteral mat
 template <typename SearchCharacterType, typename MatchCharacterType>
 ALWAYS_INLINE static size_t reverseFindInner(std::span<const SearchCharacterType> searchCharacters, std::span<const MatchCharacterType> matchCharacters, size_t start)
 {
+    if (searchCharacters.size() < matchCharacters.size())
+        return notFound;
+
     // Optimization: keep a running hash of the strings,
     // only call equal if the hashes match.
 
@@ -830,9 +826,9 @@ ALWAYS_INLINE static size_t reverseFindInner(std::span<const SearchCharacterType
 
 template<typename SearchCharacterType, typename MatchCharacterType>
     requires(TriviallyComparableCodeUnits<SearchCharacterType, MatchCharacterType>)
-ALWAYS_INLINE static size_t reverseFind(std::span<const SearchCharacterType> searchCharacters, std::span<const MatchCharacterType> matchCharacters, size_t start = std::numeric_limits<size_t>::max())
+ALWAYS_INLINE static size_t reverseFind(std::span<const SearchCharacterType> searchCharacters, std::span<const MatchCharacterType> matchCharacters)
 {
-    return reverseFindInner(searchCharacters, matchCharacters, start);
+    return reverseFindInner(searchCharacters, matchCharacters, std::numeric_limits<size_t>::max());
 }
 
 template<OneByteCharacterType CharacterType>

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -111,6 +111,14 @@ TEST(WTF_StringCommon, Equal)
 {
     EXPECT_TRUE(WTF::equal(u8"Water🍉Melon"_span, u8"Water🍉Melon"_span));
     EXPECT_FALSE(WTF::equal(u8"Water🍉Melon"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::equal(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::equal(std::span<const char8_t>(), u8""_span));
+    EXPECT_FALSE(WTF::equal(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::equal(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::equal(u8""_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_FALSE(WTF::equal(u8"🍉"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::equal(u8"Water🍉Melon"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::equal(u8"Water🍉Melon"_span, u8""_span));
     // EXPECT_TRUE(WTF::equal("test"_span, "test"_span8)); // This should not compile.
     String string(u8"Water🍉Melon"_span);
     EXPECT_FALSE(string.is8Bit());
@@ -122,6 +130,15 @@ TEST(WTF_StringCommon, EqualIgnoringASCIICase)
 {
     EXPECT_TRUE(WTF::equalIgnoringASCIICase(u8"Test"_span, u8"test"_span));
     EXPECT_FALSE(WTF::equalIgnoringASCIICase(u8"another test"_span, u8"test"_span));
+    EXPECT_TRUE(WTF::equalIgnoringASCIICase(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::equalIgnoringASCIICase(std::span<const char8_t>(), u8""_span));
+    EXPECT_TRUE(WTF::equalIgnoringASCIICase(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::equalIgnoringASCIICase(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span));
+    EXPECT_FALSE(WTF::equalIgnoringASCIICase(u8""_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_FALSE(WTF::equalIgnoringASCIICase(u8"🍉"_span, std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::equalIgnoringASCIICase(u8"🍉Watermelon🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_FALSE(WTF::equalIgnoringASCIICase(u8"🍉Watermelon🍉"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::equalIgnoringASCIICase(u8"🍉Watermelon🍉"_span, u8""_span));
     // EXPECT_TRUE(WTF::equalIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
@@ -132,6 +149,16 @@ TEST(WTF_StringCommon, StartsWith)
     EXPECT_FALSE(WTF::startsWith(u8"🍉WaterMelon🍉"_span, "Water"_s));
     EXPECT_TRUE(WTF::startsWith(u8"🍉WaterMelon🍉"_span, u8"🍉"_span));
     EXPECT_FALSE(WTF::startsWith(u8"Water🍉Melon"_span, u8"🍉"_span));
+    EXPECT_TRUE(WTF::startsWith(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::startsWith(std::span<const char8_t>(), u8""_span));
+    EXPECT_FALSE(WTF::startsWith(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::startsWith(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::startsWith(u8""_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::startsWith(u8"🍉"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::startsWith(u8"🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::startsWith(u8"🍉WaterMelon🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::startsWith(u8"🍉WaterMelon🍉"_span, std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::startsWith(u8"🍉WaterMelon🍉"_span, u8""_span));
     // EXPECT_TRUE(WTF::startsWith(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
@@ -142,6 +169,16 @@ TEST(WTF_StringCommon, EndsWith)
     EXPECT_FALSE(WTF::endsWith(u8"🍉WaterMelon🍉"_span, "Melon"_s));
     EXPECT_TRUE(WTF::endsWith(u8"🍉WaterMelon🍉"_span, u8"🍉"_span));
     EXPECT_FALSE(WTF::endsWith(u8"Water🍉Melon"_span, u8"🍉"_span));
+    EXPECT_TRUE(WTF::endsWith(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::endsWith(std::span<const char8_t>(), u8""_span));
+    EXPECT_FALSE(WTF::endsWith(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::endsWith(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::endsWith(u8""_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::endsWith(u8"🍉"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::endsWith(u8"🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::endsWith(u8"🍉WaterMelon🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::endsWith(u8"🍉WaterMelon🍉"_span, std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::endsWith(u8"🍉WaterMelon🍉"_span, u8""_span));
     // EXPECT_TRUE(WTF::endsWith(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
@@ -151,7 +188,17 @@ TEST(WTF_StringCommon, Find)
     EXPECT_EQ(WTF::find(u8"🍉WaterMelon🍉"_span, "ter"_s), 6UZ);
     EXPECT_EQ(WTF::find(u8"Water🍉Melon"_span, u8"🍉"_span), 5UZ);
     EXPECT_EQ(WTF::find(u8"🍉WaterMelon🍉"_span, u8"🍉"_span), 0UZ);
-    // EXPECT_NEQ(WTF::find(u8"test"_span, "test"_span8), notFound); // This should not compile.
+    EXPECT_EQ(WTF::find(std::span<const char8_t>(), std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::find(std::span<const char8_t>(), u8""_span), 0UZ);
+    EXPECT_EQ(WTF::find(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::find(u8""_span, std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::find(u8""_span, u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::find(u8"🍉"_span, std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::find(u8"🍉"_span, u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::find(u8"🍉WaterMelon🍉"_span, u8"🍉WaterMelon🍉"_span), 0UZ);
+    EXPECT_EQ(WTF::find(u8"🍉WaterMelon🍉"_span, std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::find(u8"🍉WaterMelon🍉"_span, u8""_span), 0UZ);
+    // EXPECT_NE(WTF::find(u8"test"_span, "test"_span8), notFound); // This should not compile.
 }
 
 TEST(WTF_StringCommon, ReverseFind)
@@ -160,7 +207,17 @@ TEST(WTF_StringCommon, ReverseFind)
     EXPECT_EQ(WTF::reverseFind(u8"🍉WaterMelon🍉"_span, "ter"_s), 6UZ);
     EXPECT_EQ(WTF::reverseFind(u8"Water🍉Melon"_span, u8"🍉"_span), 5UZ);
     EXPECT_EQ(WTF::reverseFind(u8"🍉WaterMelon🍉"_span, u8"🍉"_span), 14UZ);
-    // EXPECT_NEQ(WTF::reverseFind(u8"test"_span, "test"_span8), notFound); // This should not compile.
+    EXPECT_EQ(WTF::reverseFind(std::span<const char8_t>(), std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::reverseFind(std::span<const char8_t>(), u8""_span), 0UZ);
+    EXPECT_EQ(WTF::reverseFind(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::reverseFind(u8""_span, std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::reverseFind(u8""_span, u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::reverseFind(u8"🍉"_span, std::span<const char8_t>()), 4UZ);
+    EXPECT_EQ(WTF::reverseFind(u8"🍉"_span, u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::reverseFind(u8"🍉WaterMelon🍉"_span, u8"🍉WaterMelon🍉"_span), 0UZ);
+    EXPECT_EQ(WTF::reverseFind(u8"🍉WaterMelon🍉"_span, std::span<const char8_t>()), 18UZ);
+    EXPECT_EQ(WTF::reverseFind(u8"🍉WaterMelon🍉"_span, u8""_span), 18UZ);
+    // EXPECT_NE(WTF::reverseFind(u8"test"_span, "test"_span8), notFound); // This should not compile.
 }
 
 TEST(WTF_StringCommon, Contains)
@@ -173,6 +230,16 @@ TEST(WTF_StringCommon, Contains)
     EXPECT_FALSE(WTF::contains(u8"🍉WaterMelon🍉"_span, "pear"_s));
     EXPECT_FALSE(WTF::contains(u8"Water🍉Melon"_span, u8"🍈"_span));
     EXPECT_FALSE(WTF::contains(u8"🍉WaterMelon🍉"_span, u8"🍈"_span));
+    EXPECT_TRUE(WTF::contains(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::contains(std::span<const char8_t>(), u8""_span));
+    EXPECT_FALSE(WTF::contains(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::contains(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::contains(u8""_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::contains(u8"🍉"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::contains(u8"🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::contains(u8"🍉WaterMelon🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::contains(u8"🍉WaterMelon🍉"_span, std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::contains(u8"🍉WaterMelon🍉"_span, u8""_span));
     // EXPECT_TRUE(WTF::contains(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
@@ -180,6 +247,16 @@ TEST(WTF_StringCommon, StartsWithLettersIgnoringASCIICase)
 {
     EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"Water🍉Melon"_span, "water"_s));
     EXPECT_FALSE(WTF::startsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "water"_s));
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(std::span<const char8_t>(), u8""_span));
+    EXPECT_FALSE(WTF::startsWithLettersIgnoringASCIICase(std::span<const char8_t>(), u8"watermelon"_span));
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::startsWithLettersIgnoringASCIICase(u8""_span, u8"watermelon"_span));
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"Water"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::startsWithLettersIgnoringASCIICase(u8"Water"_span, u8"watermelon"_span));
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"WaterMelon"_span, u8"watermelon"_span));
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, u8""_span));
     // EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
@@ -187,6 +264,16 @@ TEST(WTF_StringCommon, EndsWithLettersIgnoringASCIICase)
 {
     EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"Water🍉Melon"_span, "melon"_s));
     EXPECT_FALSE(WTF::endsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "melon"_s));
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(std::span<const char8_t>(), u8""_span));
+    EXPECT_FALSE(WTF::endsWithLettersIgnoringASCIICase(std::span<const char8_t>(), u8"watermelon"_span));
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::endsWithLettersIgnoringASCIICase(u8""_span, u8"watermelon"_span));
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"Water"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::endsWithLettersIgnoringASCIICase(u8"Water"_span, u8"watermelon"_span));
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"WaterMelon"_span, u8"watermelon"_span));
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, u8""_span));
     // EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
@@ -196,7 +283,18 @@ TEST(WTF_StringCommon, FindIgnoringASCIICase)
     EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "water"_s), 4UZ);
     EXPECT_EQ(WTF::findIgnoringASCIICase(u8"Water🍉Melon"_span, u8"🍉"_span), 5UZ);
     EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, u8"🍉"_span), 0UZ);
-    // EXPECT_NEQ(WTF::findIgnoringASCIICase(u8"test"_span, "test"_span8), notFound); // This should not compile.
+    EXPECT_EQ(WTF::findIgnoringASCIICase(std::span<const char8_t>(), std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(std::span<const char8_t>(), u8""_span), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8""_span, std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8""_span, u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉"_span, std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉"_span, u8"🍉WaterMelon🍉"_span), notFound);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉Watermelon🍉"_span, u8"🍉WaterMelon🍉"_span), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉Watermelon🍉"_span, u8"🍉WaterMelon🍉"_span, 5UZ), notFound);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉Watermelon🍉"_span, std::span<const char8_t>()), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉Watermelon🍉"_span, u8""_span), 0UZ);
+    // EXPECT_NE(WTF::findIgnoringASCIICase(u8"test"_span, "test"_span8), notFound); // This should not compile.
 }
 
 TEST(WTF_StringCommon, ContainsIgnoringASCIICase)
@@ -205,14 +303,25 @@ TEST(WTF_StringCommon, ContainsIgnoringASCIICase)
     EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "melon"_s));
     EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"Water🍉Melon"_span, u8"🍉"_span));
     EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, u8"🍉"_span));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(std::span<const char8_t>(), std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(std::span<const char8_t>(), u8""_span));
+    EXPECT_FALSE(WTF::containsIgnoringASCIICase(std::span<const char8_t>(), u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8""_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::containsIgnoringASCIICase(u8""_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉"_span, std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::containsIgnoringASCIICase(u8"🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉Watermelon🍉"_span, u8"🍉WaterMelon🍉"_span));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉Watermelon🍉"_span, std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉Watermelon🍉"_span, u8""_span));
     // EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, CharactersAreAllASCII)
 {
     EXPECT_TRUE(WTF::charactersAreAllASCII(u8"Test"_span));
-    EXPECT_TRUE(WTF::charactersAreAllASCII(std::span<const char8_t>()));
     EXPECT_FALSE(WTF::charactersAreAllASCII(u8"🍉"_span));
+    EXPECT_TRUE(WTF::charactersAreAllASCII(std::span<const char8_t>()));
+    EXPECT_TRUE(WTF::charactersAreAllASCII(u8""_span));
 }
 
 TEST(WTF_StringCommon, CopyElements64To8)


### PR DESCRIPTION
#### 647785e34521e96ba37dab6bbd61a29ff2172666
<pre>
[WTF] Fix behavioral issues in searching in spans
<a href="https://bugs.webkit.org/show_bug.cgi?id=302925">https://bugs.webkit.org/show_bug.cgi?id=302925</a>

Reviewed by Darin Adler.

There were several cases where we were not handling properly certain cases when inspecting spans for data and some
codepaths that had different behaviors. Fixed them and improved test coverage. reverseFind lost the starting offset that
was not used anywhere and for coherence with the find counterpart.

Test: Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
* Source/WTF/wtf/StdLibExtras.h:
(WTF::find):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::findIgnoringASCIICase):
(WTF::reverseFindInner):
(WTF::reverseFind):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, Equal)):
(TestWebKitAPI::TEST(WTF_StringCommon, EqualIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, StartsWith)):
(TestWebKitAPI::TEST(WTF_StringCommon, EndsWith)):
(TestWebKitAPI::TEST(WTF_StringCommon, Find)):
(TestWebKitAPI::TEST(WTF_StringCommon, ReverseFind)):
(TestWebKitAPI::TEST(WTF_StringCommon, Contains)):
(TestWebKitAPI::TEST(WTF_StringCommon, StartsWithLettersIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, EndsWithLettersIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, FindIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, ContainsIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, CharactersAreAllASCII)):

Canonical link: <a href="https://commits.webkit.org/303965@main">https://commits.webkit.org/303965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8834ecb9bd338084650567b919eabcff546ab80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102453 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69756 "Too many flaky failures: compositing/layer-creation/multiple-keyframes-individual-transform-properties-animation-overlap.html, compositing/layer-creation/scale-rotation-individual-properties-animation-overlap.html, compositing/layer-creation/translate-scale-individual-properties-animation-overlap.html, css3/unicode-bidi-float-crash.html, fast/css/content-visibility-zoom.html, fast/forms/input-number-click.html, fast/html/crash-marquee-fullscreen.html, fast/line-grid/line-align-right-edges.html, fast/rendering/missing-selection-with-sibling-table.html, http/tests/security/offscreen-canvas-remote-read-remote-image.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83252 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2398 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126009 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144157 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132446 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4635 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6165 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34584 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165409 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6011 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69629 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43198 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->