### PR TITLE
[threaded-animations] https://scroll-driven-animations.style/demos/contact-list/css/ asserts with "Threaded Scroll-driven Animations" enabled

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<style>
+
+body {
+    height: 2000px;
+}
+
+@keyframes anim {
+	entry 0% { transform: translateY(100px) }
+}
+
+div {
+	animation: anim;
+	animation-timeline: view();
+}
+
+</style>
+
+<div>PASS if this does not crash.</div>
+
+<script>
+
+window.testRunner?.dumpAsText();
+
+</script>


### PR DESCRIPTION
#### 07e87d550ef2eccca07a0dc80b721ff0907e40a2
<pre>
[threaded-animations] <a href="https://scroll-driven-animations.style/demos/contact-list/css/">https://scroll-driven-animations.style/demos/contact-list/css/</a> asserts with &quot;Threaded Scroll-driven Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=302940">https://bugs.webkit.org/show_bug.cgi?id=302940</a>
<a href="https://rdar.apple.com/165207414">rdar://165207414</a>

Reviewed by Alan Baradlay.

In 303045@main we updated our transform animation extent computation code to iterate over
an effect&apos;s keyframes to compute their respective animated style and build up the bounds
union for all keyframes. However, in the case of scroll-driven animations, we could hit
`ASSERT(computedTiming.progress)` under `KeyframeEffect::setAnimatedPropertiesInStyle()`
because the keyframe&apos;s offset may not have been computed for view timelines using one of
view timeline range keywords [0].

This issue was actually already fixed in 303410@main by ensuring we don&apos;t accelerate
pending animations [1], but we add a test that would have caught this particular assertion
being hit.

[0] <a href="https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges">https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-pending">https://drafts.csswg.org/web-animations-1/#dom-animation-pending</a>

Test: webanimations/threaded-animations/transform-animation-extent-crash.html

* LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash.html: Added.

Canonical link: <a href="https://commits.webkit.org/303443@main">https://commits.webkit.org/303443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90d7961722dad05bf8cfce969688a769ce8aa4a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84396 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101246 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135382 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82039 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83181 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142605 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4601 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109621 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3969 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109801 "Found 1 new API test failure: TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3485 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57906 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20570 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4655 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33253 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4489 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4612 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->