### PR TITLE
Nest modules in WebKit internal modulemap

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -1,10 +1,13 @@
+// FIXME: this modulemap needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
 module WebKit_Internal {
-    header "WebKitInternal.h"
-    export *
-    requires objc
-}
-
-module WebKit_Internal_Cxx {
-    header "WebKitInternalCxx.h"
-    export *
+    module WebKit_Internal_Objc {
+        header "WebKitInternal.h"
+        export *
+        requires objc
+    }
+    module WebKit_Internal_Cxx {
+        header "WebKitInternalCxx.h"
+        export *
+        requires cplusplus20
+    }
 }

--- a/Source/WebKit/UIProcess/SwiftDemoLogo.swift
+++ b/Source/WebKit/UIProcess/SwiftDemoLogo.swift
@@ -24,7 +24,7 @@
 #if ENABLE_SWIFT_DEMO_URI_SCHEME
 
 import Foundation
-internal import WebKit_Internal_Cxx
+internal import WebKit_Internal
 
 extension Data {
     var bytes: [UInt8] {


### PR DESCRIPTION
#### bc49cd45def20ba9ac94af8aabe10b900a3f40d6
<pre>
Nest modules in WebKit internal modulemap
<a href="https://bugs.webkit.org/show_bug.cgi?id=302948">https://bugs.webkit.org/show_bug.cgi?id=302948</a>
<a href="https://rdar.apple.com/165212021">rdar://165212021</a>

Reviewed by Richard Robinson.

Previously, two top-level modules were given in the WebKit internal modulemap.
This appears to have caused clang some parsing confusion - the &apos;requires objc&apos;
directive of the first module was taken to apply to the second. (This issue is
known as <a href="https://rdar.apple.com/165045205">rdar://165045205</a> but is probably working as designed).

This commit adjusts the modulemap to nest them in a top-level module. Because
the submodules do not contain the &apos;explicit&apos; keyword this also means we do not
need to spell out the full path to each module in users; the Swift demo logo
code is duly adjusted.

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/UIProcess/SwiftDemoLogo.swift:

Canonical link: <a href="https://commits.webkit.org/303747@main">https://commits.webkit.org/303747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864fbde40e4a1440ca7c4de943ac329bfd82b425

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141063 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2f6cb795-5a06-4ea6-9fe8-00ff71a0f5eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5873 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/333480e7-a043-4bea-9243-6466112fdc45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136454 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82924 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/294e44da-e999-4ad8-956c-ba096d61627d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2099 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113621 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143710 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38381 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5760 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110686 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28052 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4361 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115943 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5733 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34255 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5822 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5689 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->