### PR TITLE
Template document should share its event loop with the context document

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context-expected.txt
@@ -1,0 +1,4 @@
+
+PASS MutationObserver callback should be called in the order
+PASS "close" event on a dialog element should fire in the order
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+
+function timeout(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+promise_test(async function () {
+  const events = [];
+  const mo1 = new MutationObserver(() => { events.push('mo1'); });
+  const element1 = document.createElement('div');
+  mo1.observe(element1, {subtree: true, childList: true, attributes: true, characterData: true});
+  element1.appendChild(document.createElement('span'));
+
+  const doc2 = document.createElement('template').content.ownerDocument;
+  const mo2 = new MutationObserver(() => { events.push('mo2'); });
+  const element2 = doc2.createElement('div');
+  mo2.observe(element2, {subtree: true, childList: true, attributes: true, characterData: true});
+  element2.appendChild(doc2.createElement('span'));
+
+  const mo3 = new MutationObserver(() => { events.push('mo3'); });
+  const element3 = document.createElement('div');
+  mo3.observe(element3, {subtree: true, childList: true, attributes: true, characterData: true});
+  element3.appendChild(document.createElement('span'));
+
+  await timeout(0);
+
+  assert_array_equals(events, ['mo1', 'mo2', 'mo3']);
+}, 'MutationObserver callback should be called in the order');
+
+promise_test(async function () {
+  const events = [];
+  const dialog1 = document.createElement('dialog');
+  dialog1.show();
+  assert_true(dialog1.hasAttribute('open'));
+  dialog1.close();
+  dialog1.addEventListener('close', () => events.push('close1'));
+
+  const doc2 = document.createElement('template').content.ownerDocument;
+  const dialog2 = doc2.createElement('dialog');
+  dialog2.show();
+  assert_true(dialog2.hasAttribute('open'));
+  dialog2.close();
+  dialog2.addEventListener('close', () => events.push('close2'));
+
+  const dialog3 = document.createElement('dialog');
+  dialog3.show();
+  assert_true(dialog3.hasAttribute('open'));
+  dialog3.close();
+  dialog3.addEventListener('close', () => events.push('close3'));
+
+  await timeout(0);
+
+  assert_array_equals(events, ['close1', 'close2', 'close3']);
+}, '"close" event on a dialog element should fire in the order');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8748,7 +8748,7 @@ WindowEventLoop& Document::windowEventLoop()
 {
     ASSERT(isMainThread());
     if (!m_eventLoop) [[unlikely]] {
-        m_eventLoop = WindowEventLoop::eventLoopForSecurityOrigin(securityOrigin());
+        m_eventLoop = WindowEventLoop::eventLoopForSecurityOrigin(contextDocument().securityOrigin());
         m_eventLoop->addAssociatedContext(*this);
     }
     return *m_eventLoop;


### PR DESCRIPTION
#### e1aba52cfc1434f637d01551d4eebca59002d39c
<pre>
Template document should share its event loop with the context document
<a href="https://bugs.webkit.org/show_bug.cgi?id=302951">https://bugs.webkit.org/show_bug.cgi?id=302951</a>

Reviewed by Sam Weinig.

Fixed the bug that template document had its own WindowEventLoop instead of sharing it with the context document.
Use given document&apos;s context document&apos;s security origin to obtain WindowEventLoop.

Test: imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context.html

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context.html: Added.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::windowEventLoop): Fixed the bug.

Canonical link: <a href="https://commits.webkit.org/303438@main">https://commits.webkit.org/303438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fafcd771055abfa37918659d6711343f73b0be9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139943 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101237 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135374 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82030 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83170 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36738 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_keyPath.any.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142595 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109613 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109792 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57885 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20568 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4647 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33247 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4738 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->