### PR TITLE
[threaded-animations] https://scroll-driven-animations.style/demos/scroll-shadows/css/ asserts with "Threaded Scroll-driven Animations" enabled

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/pending-animation-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/pending-animation-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/threaded-animations/pending-animation-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/pending-animation-crash.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<style>
+
+@keyframes fade {
+	0% { opacity: 0 }
+	100% { opacity: 1 }
+}
+
+div {
+	animation-name: fade;
+	animation-timeline: scroll();
+}
+
+</style>
+
+<div>PASS if this does not crash.</div>
+
+<script>
+
+(async function () {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    await new Promise(requestAnimationFrame);
+    await new Promise(setTimeout);
+
+    window.testRunner?.notifyDone();
+})();
+
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1947,7 +1947,7 @@ bool KeyframeEffect::canBeAccelerated() const
 
 #if ENABLE(THREADED_ANIMATIONS)
     if (canHaveAcceleratedRepresentation())
-        return true;
+        return !animation()->pending();
 #endif
 
     if (m_isAssociatedWithProgressBasedTimeline)


### PR DESCRIPTION
#### fc9b2b2ae777519d8dcaa78e5e8e252b5f36c458
<pre>
[threaded-animations] <a href="https://scroll-driven-animations.style/demos/scroll-shadows/css/">https://scroll-driven-animations.style/demos/scroll-shadows/css/</a> asserts with &quot;Threaded Scroll-driven Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=302953">https://bugs.webkit.org/show_bug.cgi?id=302953</a>

Reviewed by Alan Baradlay.

We made a mistake in 303312@main and removed the requirement that an effect&apos;s
associated animation not be pending to qualify for acceleration and as a result
we hit the `ASSERT(!animation-&gt;pending())` assertion in the `AcceleratedEffect`
constructor.

We simply reinstate this requirement in `KeyframeEffect::canBeAccelerated()`
for threaded animations.

Test: webanimations/threaded-animations/pending-animation-crash.html

* LayoutTests/webanimations/threaded-animations/pending-animation-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/pending-animation-crash.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canBeAccelerated const):

Canonical link: <a href="https://commits.webkit.org/303410@main">https://commits.webkit.org/303410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fcb1221e45166003ab083bb362a4d2c34288de7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139817 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101138 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135248 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81928 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83040 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142467 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4467 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109518 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4549 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/3866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109696 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3384 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114777 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57743 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20558 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33147 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4478 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->