### PR TITLE
[Swift in WebKit] Continue work towards modularizing WebCore (part 1)

### DIFF
--- a/Source/WebCore/Modules/Model/InternalAPI/DDMaterialDescriptor.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDMaterialDescriptor.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "DDVertexAttributeFormat.h"
-#include "DDVertexLayout.h"
+#include <WebCore/DDVertexAttributeFormat.h>
+#include <WebCore/DDVertexLayout.h>
 
 namespace WebCore::DDModel {
 

--- a/Source/WebCore/Modules/Model/InternalAPI/DDTextureDescriptor.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDTextureDescriptor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "DDImageAsset.h"
+#include <WebCore/DDImageAsset.h>
 
 namespace WebCore::DDModel {
 

--- a/Source/WebCore/Modules/Model/InternalAPI/DDUpdateTextureDescriptor.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDUpdateTextureDescriptor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "DDImageAsset.h"
+#include <WebCore/DDImageAsset.h>
 
 namespace WebCore::DDModel {
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -30,8 +30,8 @@
 
 #include "FetchBodySource.h"
 #include "FormDataConsumer.h"
+#include "ReadableStreamToSharedBufferSink.h"
 #include <WebCore/JSDOMPromiseDeferredForward.h>
-#include <WebCore/ReadableStreamToSharedBufferSink.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/UserGestureIndicator.h>

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -32,8 +32,8 @@
 #include <wtf/WeakPtr.h>
 
 #if ENABLE(THREADED_ANIMATIONS)
-#include "AcceleratedTimeline.h"
-#include "TimelineIdentifier.h"
+#include <WebCore/AcceleratedTimeline.h>
+#include <WebCore/TimelineIdentifier.h>
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/platform/TextRecognitionResult.h
+++ b/Source/WebCore/platform/TextRecognitionResult.h
@@ -37,8 +37,7 @@ OBJC_CLASS VKCImageAnalysis;
 OBJC_CLASS DDScannerResult;
 #endif
 
-#include "AttributedString.h"
-
+#include <WebCore/AttributedString.h>
 #include <WebCore/FloatQuad.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/platform/animation/AcceleratedTimeline.h
+++ b/Source/WebCore/platform/animation/AcceleratedTimeline.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-#include "ProgressResolutionData.h"
-#include "TimelineIdentifier.h"
+#include <WebCore/ProgressResolutionData.h>
+#include <WebCore/TimelineIdentifier.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Variant.h>

--- a/Source/WebCore/platform/animation/ProgressResolutionData.h
+++ b/Source/WebCore/platform/animation/ProgressResolutionData.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-#include "ScrollingNodeID.h"
-#include "WebAnimationTime.h"
+#include <WebCore/ScrollingNodeID.h>
+#include <WebCore/WebAnimationTime.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/angle/ANGLEUtilities.h
+++ b/Source/WebCore/platform/graphics/angle/ANGLEUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBGL)
 
 #include <WebCore/GraphicsContextGL.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -79,7 +79,7 @@ private:
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "SourceBufferParserAVFObjC"_s; }
-    WTFLogChannel& logChannel() const final { return LogMedia; }
+    WTFLogChannel& logChannel() const final;
 #endif
 
     RetainPtr<AVStreamDataParser> m_parser;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -375,6 +375,13 @@ void SourceBufferParserAVFObjC::didProvideContentKeyRequestSpecifierForTrackID(N
     });
 }
 
+#if !RELEASE_LOG_DISABLED
+WTFLogChannel& SourceBufferParserAVFObjC::logChannel() const
+{
+    return LogMedia;
+}
+#endif // !RELEASE_LOG_DISABLED
+
 }
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/mac/WebCoreObjCExtras.h
+++ b/Source/WebCore/platform/mac/WebCoreObjCExtras.h
@@ -28,10 +28,11 @@
 
 #pragma once
 
-#if __has_feature(objc_arc)
-#error Do not use these functions in ARC-enabled code, as they conflict with ARC's automatic memory management.
-#endif
+// Do not use these functions in ARC-enabled code, as they conflict with ARC's automatic memory management.
+#if !__has_feature(objc_arc)
 
 // The class passed here is the class that implements the dealloc method that this function is called from.
 WEBCORE_EXPORT bool WebCoreObjCScheduleDeallocateOnMainThread(Class, id);
 WEBCORE_EXPORT bool WebCoreObjCScheduleDeallocateOnMainRunLoop(Class, id);
+
+#endif // !__has_feature(objc_arc)

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -20,12 +20,14 @@
 #pragma once
 
 #include <WebCore/BlobData.h>
+#include <optional>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
+#include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
 namespace PAL {

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -32,10 +32,12 @@
 #include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/ResourceLoadPriority.h>
+#include <optional>
 #include <wtf/EnumTraits.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
+#include <wtf/WallTime.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -32,11 +32,13 @@
 #include <WebCore/IPAddressSpace.h>
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/ParsedContentRange.h>
+#include <optional>
 #include <span>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Box.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/Markable.h>
+#include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WallTime.h>

--- a/Source/WebCore/platform/network/cf/ResourceRequest.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequest.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/ResourceRequestBase.h>
+#include <optional>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "LayoutUnit.h"
+#include <WebCore/LayoutUnit.h>
 
 #include <WebCore/StylePrimitiveNumeric.h>
 #include <WebCore/StyleZoomPrimitives.h>

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -42,6 +42,10 @@
 #include <wtf/Vector.h>
 #include <wtf/text/ASCIILiteral.h>
 
+#if PLATFORM(COCOA)
+#include "ClassStructPtr.h"
+#endif
+
 #if PLATFORM(MAC)
 #include "ImportanceAssertion.h"
 #endif
@@ -49,12 +53,6 @@
 #if !USE(SYSTEM_MALLOC)
 #include <bmalloc/TZoneHeap.h>
 #include <bmalloc/bmalloc.h>
-#endif
-
-#ifdef __OBJC__
-typedef Class ClassStructPtr;
-#else
-typedef struct objc_class* ClassStructPtr;
 #endif
 
 namespace IPC {

--- a/Source/WebKit/Platform/cocoa/ClassStructPtr.h
+++ b/Source/WebKit/Platform/cocoa/ClassStructPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,52 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef BlobDataFileReference_h
-#define BlobDataFileReference_h
+#pragma once
 
-#include <optional>
-#include <wtf/Markable.h>
-#include <wtf/RefCounted.h>
-#include <wtf/WallTime.h>
-#include <wtf/text/WTFString.h>
-
-namespace WebCore {
-
-class WEBCORE_EXPORT BlobDataFileReference : public RefCounted<BlobDataFileReference> {
-public:
-    static Ref<BlobDataFileReference> create(const String& path, const String& replacementPath = { })
-    {
-        return adoptRef(*new BlobDataFileReference(path, replacementPath));
-    }
-
-    virtual ~BlobDataFileReference();
-
-    void startTrackingModifications();
-
-    const String& path();
-    unsigned long long size();
-    std::optional<WallTime> expectedModificationTime();
-
-    virtual void prepareForFileAccess();
-    virtual void revokeFileAccess();
-
-protected:
-    BlobDataFileReference(const String& path, const String& replacementPath);
-
-private:
-#if ENABLE(FILE_REPLACEMENT)
-    void generateReplacementFile();
+#ifdef __OBJC__
+typedef Class ClassStructPtr;
+#else
+typedef struct objc_class* ClassStructPtr;
 #endif
-
-    String m_path;
-    String m_replacementPath;
-#if ENABLE(FILE_REPLACEMENT)
-    bool m_replacementShouldBeGenerated { false };
-#endif
-    unsigned long long m_size { 0 };
-    Markable<WallTime> m_expectedModificationTime;
-};
-
-}
-
-#endif // BlobDataFileReference_h

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "WebPreferencesDefaultValues.h"
+#include "WebPreferencesDefinitions.h"
 #include "WebURLSchemeHandler.h"
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/FrameIdentifier.h>
@@ -41,6 +42,14 @@
 #include <wtf/Markable.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/text/WTFString.h>
+
+#if PLATFORM(COCOA)
+#include "ClassStructPtr.h"
+#endif
+
+#if ENABLE(DATA_DETECTION)
+#include <WebCore/DataDetectorType.h>
+#endif
 
 #if PLATFORM(IOS_FAMILY)
 OBJC_PROTOCOL(_UIClickInteractionDriving);

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.h
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include "APIObject.h"
-#include "WebProcessProxy.h"
+#include "WebPageProxyIdentifier.h"
+#include <WebCore/PageIdentifier.h>
+#include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
@@ -35,6 +37,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/RunLoop.h>
 
 namespace API {
 class FrameInfo;
@@ -42,7 +45,6 @@ class FrameInfo;
 
 namespace WebCore {
 class ResourceError;
-class ResourceResponse;
 }
 
 namespace WebKit {
@@ -50,6 +52,7 @@ namespace WebKit {
 struct URLSchemeTaskParameters;
 class WebURLSchemeHandler;
 class WebPageProxy;
+class WebProcessProxy;
 
 using SyncLoadCompletionHandler = CompletionHandler<void(const WebCore::ResourceResponse&, const WebCore::ResourceError&, Vector<uint8_t>&&)>;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		07AF79DF2D693BAA004E8D3A /* SwiftUI+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF79DE2D693BAA004E8D3A /* SwiftUI+Extras.swift */; };
 		07AF79E12D693DD7004E8D3A /* WKScrollGeometryAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF79E02D693DD7004E8D3A /* WKScrollGeometryAdapter.swift */; };
 		07AF79E92D695195004E8D3A /* WKUIDelegateInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07AF79E82D695195004E8D3A /* WKUIDelegateInternal.h */; };
+		07BAEEA12ED056EE00251691 /* WebURLSchemeTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D124271E6D3F1F002B2820 /* WebURLSchemeTask.h */; };
 		07CB79962CE9435700199C49 /* WebPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CB79952CE9435700199C49 /* WebPage.swift */; };
 		07CB79982CE943E400199C49 /* WKNavigationDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CB79972CE943E400199C49 /* WKNavigationDelegateAdapter.swift */; };
 		07CF2D512C2147A50064DF23 /* PlatformWritingToolsUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */; };
@@ -213,10 +214,10 @@
 		07E2AD972CF42302000844EA /* WebPage+BackForwardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E2AD962CF42302000844EA /* WebPage+BackForwardList.swift */; };
 		07E4BDC72A3A7089000D5509 /* _WKWebViewTextInputNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E4BDC52A3A7089000D5509 /* _WKWebViewTextInputNotifications.h */; };
 		07E4BDC82A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E4BDC62A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm */; };
-		07EF24BF2E309EFE004429B6 /* WebKitInternalCxx.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EF24BE2E309EFE004429B6 /* WebKitInternalCxx.h */; };
 		07F327F22CB09B74006D9918 /* _WKTextPreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 07F327F02CB085A4006D9918 /* _WKTextPreview.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07F6B5592D719323009F206D /* _WKRectEdge+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */; };
 		07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */; };
+		07FE63E82ED11D5900D5ED9E /* ClassStructPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 07FE63E72ED11D5900D5ED9E /* ClassStructPtr.h */; };
 		07FEBC9A2E035A8B004A6D5D /* WKMouseDeviceObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FEBC992E035950004A6D5D /* WKMouseDeviceObserver.swift */; };
 		0D4599052C86B00F00435F48 /* WKDigitalCredentialsPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D9D28E72C81473B002CB4C7 /* WKDigitalCredentialsPicker.h */; };
 		0D9649182E7489AF000F9CDA /* ModelDowncastConvertToBackingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D9649122E748610000F9CDA /* ModelDowncastConvertToBackingContext.h */; };
@@ -3419,6 +3420,7 @@
 		07F327F12CB085A4006D9918 /* _WKTextPreview.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKTextPreview.mm; sourceTree = "<group>"; };
 		07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_WKRectEdge+Extras.swift"; sourceTree = "<group>"; };
 		07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Navigation.swift"; sourceTree = "<group>"; };
+		07FE63E72ED11D5900D5ED9E /* ClassStructPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ClassStructPtr.h; sourceTree = "<group>"; };
 		07FEBC992E035950004A6D5D /* WKMouseDeviceObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKMouseDeviceObserver.swift; sourceTree = "<group>"; };
 		07FEBC9C2E036C6D004A6D5D /* WKMouseDeviceObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKMouseDeviceObserver.mm; sourceTree = "<group>"; };
 		0867D6A5FE840307C02AAC07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
@@ -13242,6 +13244,7 @@
 				A1D615662B06BBAB002D0E19 /* AssertionCapability.h */,
 				A1D615632B06BBAB002D0E19 /* AssertionCapability.mm */,
 				7121A3CE2B73727B00C8F7A4 /* CAFrameRateRangeUtilities.h */,
+				07FE63E72ED11D5900D5ED9E /* ClassStructPtr.h */,
 				1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */,
 				1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */,
 				4482734624528F6000A95493 /* CocoaImage.h */,
@@ -17657,6 +17660,7 @@
 				935BF8072936C9FD00B41326 /* CacheStorageRegistry.h in Headers */,
 				935BF7FF2936BF1A00B41326 /* CacheStorageStore.h in Headers */,
 				7121A3CF2B73728B00C8F7A4 /* CAFrameRateRangeUtilities.h in Headers */,
+				07FE63E82ED11D5900D5ED9E /* ClassStructPtr.h in Headers */,
 				57B4B46020B504AC00D4AD79 /* ClientCertificateAuthenticationXPCConstants.h in Headers */,
 				1C62747D288B4C3E00CED3A2 /* CocoaHelpers.h in Headers */,
 				4482734724528F6000A95493 /* CocoaImage.h in Headers */,
@@ -18507,7 +18511,6 @@
 				BCB63478116BF10600603215 /* WebKit2_C.h in Headers */,
 				BC9BA5051697C45300E44616 /* WebKit2Initialize.h in Headers */,
 				0744DA552CE05FE400AACC81 /* WebKitInternal.h in Headers */,
-				07EF24BF2E309EFE004429B6 /* WebKitInternalCxx.h in Headers */,
 				E3DCC9AB2DA08079008712FE /* WebKitServiceNames.h in Headers */,
 				DD4BDE9C2CA73B60001A3339 /* WebKitSwiftOverlayMacros.h in Headers */,
 				BC032D7F10F4378D0058C15A /* WebLocalFrameLoaderClient.h in Headers */,
@@ -18650,6 +18653,7 @@
 				515262BC1FB9515D0070E579 /* WebSWServerToContextConnectionMessages.h in Headers */,
 				6D9A666E2A27FAE300BD68A0 /* WebTouchEvent.h in Headers */,
 				BCA0EF7F12331E78007D3CFB /* WebUndoStep.h in Headers */,
+				07BAEEA12ED056EE00251691 /* WebURLSchemeTask.h in Headers */,
 				1AAF08AE1926936700B6390C /* WebUserContentController.h in Headers */,
 				7C065F2C1C8CD95F00C2D950 /* WebUserContentControllerDataTypes.h in Headers */,
 				1AAF08B819269E6D00B6390C /* WebUserContentControllerMessages.h in Headers */,


### PR DESCRIPTION
#### dba962b2a56d30037022920c5467fe3e4e176512
<pre>
[Swift in WebKit] Continue work towards modularizing WebCore (part 1)
<a href="https://rdar.apple.com/165217840">rdar://165217840</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302959">https://bugs.webkit.org/show_bug.cgi?id=302959</a>

Reviewed by Mike Wyrzykowski.

Fix some more module related issues before introducing the WebCore module.

* Source/WebCore/animation/AnimationTimeline.h:
* Source/WebCore/platform/animation/AcceleratedTimeline.h:
* Source/WebCore/platform/animation/ProgressResolutionData.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/Model/InternalAPI/DDMaterialDescriptor.h:
* Source/WebCore/Modules/Model/InternalAPI/DDTextureDescriptor.h:
* Source/WebCore/Modules/Model/InternalAPI/DDUpdateTextureDescriptor.h:
* Source/WebCore/platform/TextRecognitionResult.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:

- Fix quoted header imports

* Source/WebCore/platform/graphics/angle/ANGLEUtilities.h:
* Source/WebCore/platform/network/cf/ResourceRequest.h:
* Source/WebCore/platform/network/BlobDataFileReference.h:
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/ResourceResponseBase.h:

- Add missing includes

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::logChannel const):

- Fix `logChannel` definition to be properly defined in the implementation file like all other definitions of it.

* Source/WebCore/platform/mac/WebCoreObjCExtras.h:

- Allow this file to be included anywhere, just guard the contents

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

- Make some private headers project, and vice versa

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::attachmentFileWrapperClassSingleton const):
(API::PageConfiguration::setAttachmentFileWrapperClass):

- Do not rely on a (transitive) dependency on `Decoder.h` just for `ClassStructPtr`,
especially since it&apos;s never used in APIPageConfiguration in a non-objc context

* Source/WebKit/UIProcess/WebURLSchemeTask.h:

- Forward declare `WebProcessProxy` instead of including it, and instead include only
the headers that are actually needed.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

- Let Xcode sort some stuff, and also add some missing headers to the xcode project.

Canonical link: <a href="https://commits.webkit.org/303439@main">https://commits.webkit.org/303439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9602043caff91c3e7c860d78a9ec62d34113337f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84373 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101228 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f192705-abd7-4e3a-a6d5-6ba4f9e7578a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135362 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82020 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cddad0f4-c30a-49d2-ba6e-f512a193bc1c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83158 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142583 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4581 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109604 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3468 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57857 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4635 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33236 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68086 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->