### PR TITLE
MiniBrowser: Add back/forward menus to the back/forward buttons

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -175,7 +175,6 @@ bool WebBackForwardListFrameItem::sharesAncestor(WebBackForwardListFrameItem& fr
     return false;
 }
 
-#if !LOG_DISABLED
 String WebBackForwardListFrameItem::loggingString()
 {
     return loggingStringAtIndent(1);
@@ -197,11 +196,13 @@ String WebBackForwardListFrameItem::loggingStringAtIndent(size_t indent)
         builder.append('\n');
     }
 
-    for (size_t i = 0; i < m_children.size(); ++i)
-        builder.append(makeString(indentString, String::number(i), " - "_s, m_children[i]->loggingStringAtIndent(indent + 1)));
+    for (size_t i = 0; i < m_children.size(); ++i) {
+        Ref child = m_children[i];
+        auto childString = child->loggingStringAtIndent(indent + 1);
+        builder.append(makeString(indentString, String::number(i), " - "_s, childString));
+    }
 
     return builder.toString();
 }
-#endif // !LOG_DISABLED
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -71,16 +71,12 @@ public:
 
     void setWasRestoredFromSession();
 
-#if !LOG_DISABLED
     String loggingString();
-#endif
 
 private:
     WebBackForwardListFrameItem(WebBackForwardListItem&, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&&);
 
-#if !LOG_DISABLED
     String loggingStringAtIndent(size_t);
-#endif
 
     static HashMap<std::pair<WebCore::BackForwardFrameItemIdentifier, WebCore::BackForwardItemIdentifier>, WeakRef<WebBackForwardListFrameItem>>& allItems();
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -225,11 +225,9 @@ Ref<WebBackForwardListFrameItem> WebBackForwardListItem::protectedMainFrameItem(
     return m_mainFrameItem;
 }
 
-#if !LOG_DISABLED
 String WebBackForwardListItem::loggingString()
 {
     return m_mainFrameItem->loggingString();
 }
-#endif // !LOG_DISABLED
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -99,9 +99,7 @@ public:
 
     void setWasRestoredFromSession();
 
-#if !LOG_DISABLED
     String loggingString();
-#endif
 
 private:
     WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, BrowsingContextGroup*);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -103,4 +103,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     self._protectedList->clear();
 }
 
+- (NSString *)_loggingStringForTesting
+{
+    return self._protectedList->loggingString().createNSString().autorelease();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListPrivate.h
@@ -32,4 +32,6 @@
 // Removes all items except the current one.
 - (void)_clear;
 
+- (NSString *)_loggingStringForTesting;
+
 @end

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -796,8 +796,6 @@ void WebBackForwardList::backForwardListCounts(CompletionHandler<void(WebBackFor
     completionHandler(counts());
 }
 
-#if !LOG_DISABLED
-
 String WebBackForwardList::loggingString()
 {
     StringBuilder builder;
@@ -805,13 +803,13 @@ String WebBackForwardList::loggingString()
     builder.append("\nWebBackForwardList 0x"_s, hex(reinterpret_cast<uintptr_t>(this)), " - "_s, m_entries.size(), " entries, has current index "_s, m_currentIndex ? "YES"_s : "NO"_s, " ("_s, m_currentIndex ? *m_currentIndex : 0, ")\n"_s);
 
     for (size_t i = 0; i < m_entries.size(); ++i) {
+        Ref entry = m_entries[i];
         ASCIILiteral prefix = (m_currentIndex && *m_currentIndex == i) ? " * "_s : " - "_s;
-        builder.append(prefix, m_entries[i]->loggingString());
+        auto entryString = entry->loggingString();
+        builder.append(prefix, entryString);
     }
 
     return builder.toString();
 }
-
-#endif // !LOG_DISABLED
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -96,9 +96,7 @@ public:
     void backForwardAddItemShared(IPC::Connection&, Ref<FrameState>&&, LoadedWebArchive);
     void backForwardGoToItemShared(WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
 
-#if !LOG_DISABLED
     String loggingString();
-#endif
 
 private:
     explicit WebBackForwardList(WebPageProxy&);

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		256AC3DA0F4B6AC300CF3369 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 256AC3D90F4B6AC300CF3369 /* AppDelegate.m */; };
 		2DC37343198B62D300EC33E9 /* SettingsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DC37342198B62D300EC33E9 /* SettingsController.m */; };
 		511AAEB72A8C1E77007ECBEE /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 511AAEB62A8C1E77007ECBEE /* UserNotifications.framework */; };
+		513EA7BF2ECFE34900828F2A /* HistoryButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 513EA7BE2ECFE34900828F2A /* HistoryButton.m */; };
 		51E244FA11EFCE07008228D1 /* MBToolbarItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 51E244F911EFCE07008228D1 /* MBToolbarItem.m */; };
 		5C9332AF24C1349C0036DECE /* SecurityInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9332AE24C1349C0036DECE /* SecurityInterface.framework */; };
 		72945D0229B7F204006ACF75 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72945D0129B7F204006ACF75 /* QuartzCore.framework */; };
@@ -65,6 +66,8 @@
 		2DC37342198B62D300EC33E9 /* SettingsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SettingsController.m; path = mac/SettingsController.m; sourceTree = "<group>"; };
 		37BAF90620218053000EA879 /* MiniBrowser.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MiniBrowser.entitlements; sourceTree = "<group>"; };
 		511AAEB62A8C1E77007ECBEE /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
+		513EA7BD2ECFE34900828F2A /* HistoryButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HistoryButton.h; path = mac/HistoryButton.h; sourceTree = "<group>"; };
+		513EA7BE2ECFE34900828F2A /* HistoryButton.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = HistoryButton.m; path = mac/HistoryButton.m; sourceTree = "<group>"; };
 		51E244F811EFCE07008228D1 /* MBToolbarItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBToolbarItem.h; sourceTree = "<group>"; };
 		51E244F911EFCE07008228D1 /* MBToolbarItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBToolbarItem.m; sourceTree = "<group>"; };
 		5C9332AE24C1349C0036DECE /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = System/Library/Frameworks/SecurityInterface.framework; sourceTree = SDKROOT; };
@@ -107,6 +110,8 @@
 				0FE643A0161FA8940059E3FF /* BrowserWindowController.m */,
 				7CA3793F1AC381C10079DC37 /* ExtensionManagerWindowController.h */,
 				7CA379401AC381C10079DC37 /* ExtensionManagerWindowController.m */,
+				513EA7BD2ECFE34900828F2A /* HistoryButton.h */,
+				513EA7BE2ECFE34900828F2A /* HistoryButton.m */,
 				BC72B89A11E57E8A001EB4EA /* Info.plist */,
 				BC329486116A92E2008635D0 /* main.m */,
 				51E244F811EFCE07008228D1 /* MBToolbarItem.h */,
@@ -265,6 +270,7 @@
 				256AC3DA0F4B6AC300CF3369 /* AppDelegate.m in Sources */,
 				0FE643A1161FA8940059E3FF /* BrowserWindowController.m in Sources */,
 				7CA379421AC381C10079DC37 /* ExtensionManagerWindowController.m in Sources */,
+				513EA7BF2ECFE34900828F2A /* HistoryButton.m in Sources */,
 				BC329487116A92E2008635D0 /* main.m in Sources */,
 				51E244FA11EFCE07008228D1 /* MBToolbarItem.m in Sources */,
 				2DC37343198B62D300EC33E9 /* SettingsController.m in Sources */,

--- a/Tools/MiniBrowser/mac/BrowserWindow.xib
+++ b/Tools/MiniBrowser/mac/BrowserWindow.xib
@@ -45,7 +45,7 @@
                         <nil key="toolTip"/>
                         <size key="minSize" width="32" height="25"/>
                         <size key="maxSize" width="32" height="25"/>
-                        <button key="view" verticalHuggingPriority="750" id="40">
+                        <button key="view" verticalHuggingPriority="750" id="40" customClass="HistoryButton">
                             <rect key="frame" x="10" y="14" width="32" height="25"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="chevron.left" catalog="system" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="41">
@@ -61,7 +61,7 @@
                         <nil key="toolTip"/>
                         <size key="minSize" width="32" height="25"/>
                         <size key="maxSize" width="32" height="27"/>
-                        <button key="view" verticalHuggingPriority="750" id="42">
+                        <button key="view" verticalHuggingPriority="750" id="42" customClass="HistoryButton">
                             <rect key="frame" x="18" y="14" width="32" height="25"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="chevron.right" catalog="system" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="43">

--- a/Tools/MiniBrowser/mac/HistoryButton.h
+++ b/Tools/MiniBrowser/mac/HistoryButton.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,13 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WebKit.h>
-#import "BrowserWindowController.h"
-
-@interface WK2BrowserWindowController : BrowserWindowController
-
-@property (readonly) WKWebView *webView;
-
-- (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration;
-
+@interface HistoryButton : NSButton
 @end
+

--- a/Tools/MiniBrowser/mac/HistoryButton.m
+++ b/Tools/MiniBrowser/mac/HistoryButton.m
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "HistoryButton.h"
+
+#import "WK2BrowserWindowController.h"
+#import <WebKit/WKBackForwardListPrivate.h>
+
+@implementation HistoryButton {
+    NSTimer *_holdTimer;
+    NSEvent *_mouseDownEvent;
+}
+
+- (void)mouseDown:(NSEvent *)event
+{
+    if (self->_mouseDownEvent)
+        return;
+
+    [self highlight:YES];
+    self->_mouseDownEvent = event;
+    self->_holdTimer = [NSTimer scheduledTimerWithTimeInterval:0.5 repeats:NO block:^(NSTimer *timer) {
+        [self _showMenuTimerFired];
+    }];
+}
+
+- (void)mouseUp:(NSEvent *)event
+{
+    if (!self->_mouseDownEvent)
+        return;
+
+    [self _cleanup];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [self.target performSelector:self.action withObject:self];
+#pragma clang diagnostic pop
+}
+
+- (void)_cleanup
+{
+    [self->_holdTimer invalidate];
+    self->_holdTimer = nil;
+    [self highlight:NO];
+    self->_mouseDownEvent = nil;
+}
+
+- (void)_itemSelected:(NSMenuItem *)item
+{
+    [((WK2BrowserWindowController *)self.target).webView goToBackForwardListItem:item.representedObject];
+}
+
+- (void)_showMenuTimerFired
+{
+    WKBackForwardList *backForwardList = ((WK2BrowserWindowController *)self.target).webView.backForwardList;
+    NSArray<WKBackForwardListItem *> *items;
+    NSString *menuTitle;
+    BOOL pruned = NO;
+    if (self.action == @selector(goBack:)) {
+        items = [[backForwardList.backList reverseObjectEnumerator] allObjects];
+        menuTitle = @"Back list";
+    } else {
+        items = backForwardList.forwardList;
+        menuTitle = @"Forward list";
+    }
+
+    if (items.count > 15) {
+        pruned = YES;
+        items = [items subarrayWithRange:NSMakeRange(0, 15)];
+    }
+
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:menuTitle];
+    for (WKBackForwardListItem *item in items) {
+        NSString *title = item.title;
+        if (title.length > 0)
+            title = [title stringByAppendingFormat:@" (%@)", item.URL.absoluteString];
+        else
+            title = item.URL.absoluteString;
+
+        NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:title action:@selector(_itemSelected:) keyEquivalent:@""];
+        menuItem.representedObject = item;
+        [menu addItem:menuItem];
+    }
+
+    if (pruned) {
+        NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:@"<pruned>" action:nil keyEquivalent:@""];
+        menuItem.enabled = NO;
+        [menu addItem:menuItem];
+    }
+
+    if (self->_mouseDownEvent.modifierFlags & NSEventModifierFlagOption)
+        NSLog(@"Showing back/forward menu:%@", backForwardList._loggingStringForTesting);
+
+    [NSMenu popUpContextMenu:menu withEvent:self->_mouseDownEvent forView:self];
+    [self _cleanup];
+}
+
+@end

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -880,17 +880,20 @@ static BOOL isJavaScriptURL(NSURL *url)
     }
 
     decisionHandler(WKNavigationActionPolicyCancel, preferences);
+    [self validateToolbar];
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler
 {
     LOG(@"decidePolicyForNavigationResponse");
     decisionHandler(WKNavigationResponsePolicyAllow);
+    [self validateToolbar];
 }
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation
 {
     LOG(@"didStartProvisionalNavigation: %@", navigation);
+    [self validateToolbar];
 }
 
 - (void)webView:(WKWebView *)webView didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation


### PR DESCRIPTION
#### 2924745ed44fec69be0d1c58ee77e72817e5111f
<pre>
MiniBrowser: Add back/forward menus to the back/forward buttons
<a href="https://rdar.apple.com/165217446">rdar://165217446</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302957">https://bugs.webkit.org/show_bug.cgi?id=302957</a>

Reviewed by Alex Christensen.

Browsers usually let you long press the back/forward buttons to see a back/forward list,
and allow you to choose an item that is farther away than 1 in either direction.

So let&apos;s add &quot;long press for back/forward list&quot; to MiniBrowser.

I do this by adding an NSButton subclass that tracks `mouseDown:`, `mouseUp:`, and detects
long-press with a timer.

As an added development feature if you hold `option` while clicking to bring up the full
back/forward list, the list&apos;s logging string will dump to the system console, with frame tree.

This is particularly useful while working on site isolation.

This is enabled by always compiling in the `loggingString` functionality for back/forward
list objects and exposing that string as a test-only SPI on `WKBackForwardList`

* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::loggingStringAtIndent):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::loggingString):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
(-[WKBackForwardList _loggingStringForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListPrivate.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::loggingString):
* Source/WebKit/UIProcess/WebBackForwardList.h:

* Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/mac/BrowserWindow.xib:
* Tools/MiniBrowser/mac/HistoryButton.h: Copied from Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListPrivate.h.
* Tools/MiniBrowser/mac/HistoryButton.m: Added.
(-[HistoryButton mouseDown:]):
(-[HistoryButton mouseUp:]):
(-[HistoryButton _cleanup]):
(-[HistoryButton _itemSelected:]):
(-[HistoryButton _showMenuTimerFired]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.h:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):
(-[WK2BrowserWindowController webView:decidePolicyForNavigationResponse:decisionHandler:]):
(-[WK2BrowserWindowController webView:didStartProvisionalNavigation:]):

Canonical link: <a href="https://commits.webkit.org/303433@main">https://commits.webkit.org/303433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/269387f7e76b151644597529c4749cda98285309

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132401 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139916 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f5a976ca-1549-48d8-a071-c41d80ebcf24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101216 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/add11156-a1b6-448a-9ce6-58b14824969d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135347 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82008 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d1d10b9-10b7-463b-8cec-668a2bc51ed7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83142 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142568 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4566 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109592 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109771 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3455 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57842 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4620 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4452 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4711 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/4577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->