### PR TITLE
ASAN_ILL | WebCore::XMLDocumentParser::detach; WebCore::Document::removedLastRef; WebCore::HTMLCollection::~HTMLCollection

### DIFF
--- a/LayoutTests/fast/parser/xml-parser-detach-crash-expected.txt
+++ b/LayoutTests/fast/parser/xml-parser-detach-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/parser/xml-parser-detach-crash.html
+++ b/LayoutTests/fast/parser/xml-parser-detach-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+Test passes if it does not crash.
+<script src="../../resources/gc.js"></script>
+<script>
+  testRunner?.dumpAsText();
+  var doc = new DOMParser().parseFromString("<svg xmlns='http://www.w3.org/2000/svg'><glypRef xlink:href='#foo' ></svg>", "application/xml");
+  doc.documentElement.innerHTML = "foo";
+  gc();
+</script>
+</html>

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -98,8 +98,10 @@ void XMLDocumentParser::clearCurrentNodeStack()
     m_leafTextNode = nullptr;
 
     if (m_currentNodeStack.size()) { // Aborted parsing.
-        for (size_t i = m_currentNodeStack.size() - 1; i != 0; --i)
-            m_currentNodeStack[i]->deref();
+        for (size_t i = m_currentNodeStack.size() - 1; i != 0; --i) {
+            if (m_currentNodeStack[i])
+                m_currentNodeStack[i]->deref();
+        }
         if (m_currentNodeStack[0] && m_currentNodeStack[0] != document())
             m_currentNodeStack[0]->deref();
         m_currentNodeStack.clear();
@@ -148,7 +150,8 @@ void XMLDocumentParser::createLeafTextNode()
     ASSERT(m_bufferedText.size() == 0);
     ASSERT(!m_leafTextNode);
     m_leafTextNode = Text::create(m_currentNode->protectedDocument(), String { emptyString() });
-    CheckedPtr { m_currentNode }->parserAppendChild(*protectedLeafTextNode());
+    if (RefPtr currentNode = m_currentNode.get())
+        currentNode->parserAppendChild(*protectedLeafTextNode());
 }
 
 bool XMLDocumentParser::updateLeafTextNode()

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -166,8 +166,8 @@ private:
     const UniqueRef<PendingCallbacks> m_pendingCallbacks;
     Vector<xmlChar> m_bufferedText;
 
-    CheckedPtr<ContainerNode> m_currentNode;
-    Vector<CheckedPtr<ContainerNode>> m_currentNodeStack;
+    WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_currentNode;
+    Vector<WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData>> m_currentNodeStack;
 
     RefPtr<Text> m_leafTextNode;
 


### PR DESCRIPTION
#### 479cba7de88ccd438fc40c4b44fff6c1d19e91bd
<pre>
ASAN_ILL | WebCore::XMLDocumentParser::detach; WebCore::Document::removedLastRef; WebCore::HTMLCollection::~HTMLCollection
<a href="https://bugs.webkit.org/show_bug.cgi?id=302967">https://bugs.webkit.org/show_bug.cgi?id=302967</a>

Reviewed by Ryosuke Niwa.

The xml document can have a parse error in which case insertErrorMessageBlock is called.
This will replace the existing DOM tree and elements in the node stack and current node
may end up with a reference count of just one. The CheckedPtr based logic in clearCurrentNodeStack
will further deref and the CheckedPtr will have a release assert on destruction of the CheckedPtr.

To fix this, convert the node stack and current node member variables to use a WeakPtr instead.

Test: fast/parser/xml-parser-detach-crash.html

* LayoutTests/fast/parser/xml-parser-detach-crash-expected.txt: Added.
* LayoutTests/fast/parser/xml-parser-detach-crash.html: Added.
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::clearCurrentNodeStack):
(WebCore::XMLDocumentParser::createLeafTextNode):
* Source/WebCore/xml/parser/XMLDocumentParser.h:

Originally-landed-as: <a href="https://commits.webkit.org/302196.3@webkit-2025.11-embargoed">https://commits.webkit.org/302196.3@webkit-2025.11-embargoed</a> (2157624f4f2c).
Canonical link: <a href="https://commits.webkit.org/303426@main">https://commits.webkit.org/303426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8d3988b3c7ae4c3460224897c5c79cb18baf283

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132346 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139861 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101168 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135292 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81959 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83086 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142512 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4511 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109547 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109725 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27808 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3415 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57787 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4565 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33181 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68015 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->