### PR TITLE
Add an event that fires for user text input

### DIFF
--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -325,6 +325,7 @@
     "webkitsourceclose": { },
     "webkitsourceended": { },
     "webkitsourceopen": { },
+    "webkitusertextinput": { },
     "wheel": { "categories": ["Wheel"], "defaultEventHandler": true },
     "write": { },
     "writeend": { },

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -147,6 +147,14 @@ void HTMLTextFormControlElement::dispatchBlurEvent(RefPtr<Element>&& newFocusedE
     HTMLFormControlElement::dispatchBlurEvent(WTFMove(newFocusedElement));
 }
 
+void HTMLTextFormControlElement::dispatchUserTextInputEvent()
+{
+    Ref event = Event::create(eventNames().webkitusertextinputEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes);
+    event->setIsAutofillEvent();
+    event->setTarget(this);
+    dispatchEvent(event);
+}
+
 void HTMLTextFormControlElement::didEditInnerTextValue(bool wasUserEdit)
 {
     if (!renderer() || !isTextField())

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -118,6 +118,8 @@ public:
 
     bool canContainRangeEndPoint() const override { return false; }
 
+    WEBCORE_EXPORT void dispatchUserTextInputEvent();
+
 protected:
     HTMLTextFormControlElement(const QualifiedName&, Document&, HTMLFormElement*);
     bool isPlaceholderEmpty() const;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -456,6 +456,9 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
 
     if (RefPtr page = m_page.get())
         page->injectedBundleFormClient().textDidChangeInTextField(page.get(), *inputElement, webFrame.get(), initiatedByUserTyping);
+
+    if (initiatedByUserTyping)
+        inputElement->dispatchUserTextInputEvent();
 }
 
 void WebEditorClient::textDidChangeInTextArea(Element& element)
@@ -469,6 +472,9 @@ void WebEditorClient::textDidChangeInTextArea(Element& element)
 
     if (RefPtr page = m_page.get())
         page->injectedBundleFormClient().textDidChangeInTextArea(page.get(), *textAreaElement, webFrame.get());
+
+    if (UserTypingGestureIndicator::processingUserTypingGesture())
+        textAreaElement->dispatchUserTextInputEvent();
 }
 
 #if !PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 590c0256ba490bfb57dd3fd7e8dc21712d41b3a9
<pre>
Add an event that fires for user text input
<a href="https://bugs.webkit.org/show_bug.cgi?id=302969">https://bugs.webkit.org/show_bug.cgi?id=302969</a>
<a href="https://rdar.apple.com/problem/165226356">rdar://problem/165226356</a>

Reviewed by Per Arne Vollan.

Some use cases want an event that only fires when real user typing occurs (i.e. not synthetic
modifications to input or textarea via JS). Adding an event handler for the input event that checks
for isTrusted events mostly accomplishes this. But it still has some overhead that we don&apos;t want to
pay for (e.g. an untrusted click event on a checkbox causes a trusted input event to fire, which
then spuriously invokes the code that only cares about real user typing).

To help with this, add a webkitusertextinput event that only fires when real user typing occurs
which modifies a text field or text area. This is analogous to the behavior of the
textDidChangeInTextField and textDidChangeInTextArea APIs that we offer to the injected bundle.

For now, this event is only available to autofill worlds.

Test: Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::dispatchUserTextInputEvent):
* Source/WebCore/html/HTMLTextFormControlElement.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::textDidChangeInTextField):
(WebKit::WebEditorClient::textDidChangeInTextArea):
* Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm:
(TestWebKitAPI::TEST(KeyboardEventTests, UserTextInputEvent)):

Canonical link: <a href="https://commits.webkit.org/303685@main">https://commits.webkit.org/303685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6041ba90b76293ccd00ecad898cf70791d9a023

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85308 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbedbe4c-9e85-4388-9e25-48e01e572465) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69399 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b6f86cdb-3813-4b1b-9aa5-119b77df9a1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82733 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4da19ce2-8ca1-422e-99d0-7a70cdc81efc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4340 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1920 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143464 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5433 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110314 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110498 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28011 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4206 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59183 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5488 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34061 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5334 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68940 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->