### PR TITLE
Remove excessive documentation of YarrSyntaxCheckable concept and update the concept

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -76,6 +76,8 @@ template <class T> concept YarrSyntaxCheckable = requires (T& checker, Vector<Ve
     { checker.atomNamedForwardReference(subpatternName) } -> std::same_as<void>;
     { checker.quantifyAtom(unsigned { }, unsigned { }, bool { }) } -> std::same_as<void>;
     { checker.disjunction(CreateDisjunctionPurpose { }) } -> std::same_as<void>;
+    { checker.abortedDueToError() } -> std::same_as<bool>;
+    { checker.abortErrorCode() } -> std::same_as<ErrorCode>;
     { checker.resetForReparsing() } -> std::same_as<void>;
 };
 
@@ -2219,39 +2221,8 @@ private:
  * Yarr::parse() returns null on success, or a const C string providing an error
  * message where a parse error occurs.
  *
- * The Delegate must implement `YarrSyntaxCheckable` concept.
- * The Delegate must implement the following interface:
- *
- *    void assertionBOL();
- *    void assertionEOL();
- *    void assertionWordBoundary(bool invert);
- *
- *    void atomPatternCharacter(char32_t ch);
- *    void atomBuiltInCharacterClass(BuiltInCharacterClassID classID, bool invert);
- *    void atomCharacterClassBegin(bool invert)
- *    void atomCharacterClassAtom(char32_t ch)
- *    void atomCharacterClassRange(char32_t begin, char32_t end)
- *    void atomCharacterClassBuiltIn(BuiltInCharacterClassID classID, bool invert)
- *    void atomClassStringDisjunction(Vector<Vector<char32_t>>&)
- *    void atomCharacterClassSetOp(CharacterClassSetOp setOp)
- *    void atomCharacterClassPushNested(bool invert)
- *    void atomCharacterClassPopNested(bool invert)
- *    void atomCharacterClassEnd()
- *    void atomParenthesesSubpatternBegin(bool capture = true, std::optional<String> groupName);
- *    void atomParentheticalAssertionBegin(bool invert, MatchDirection matchDirection);
- *    void atomParenthesesEnd();
- *    void atomBackReference(unsigned subpatternId);
- *    void atomNamedBackReference(const String& subpatternName);
- *    void atomNamedForwardReference(const String& subpatternName);
- *
- *    void quantifyAtom(unsigned min, unsigned max, bool greedy);
- *
- *    void disjunction(CreateDisjunctionPurpose purpose);
- *
- *    bool abortedDueToError() const;
- *    ErrorCode abortErrorCode() const;
- *
- *    void resetForReparsing();
+ * The Delegate must implement `YarrSyntaxCheckable` concept. Don't forget to
+ * modify the concept if adding new methods.
  *
  * The regular expression is described by a sequence of assertion*() and atom*()
  * callbacks to the delegate, describing the terms in the regular expression.


### PR DESCRIPTION
#### 30064b62dc4d1f90147930214300e27c376dbacf
<pre>
Remove excessive documentation of YarrSyntaxCheckable concept and update the concept
<a href="https://bugs.webkit.org/show_bug.cgi?id=302968">https://bugs.webkit.org/show_bug.cgi?id=302968</a>

Reviewed by Yusuke Suzuki.

This comment is no longer necessary since 290702@main, when it was
originally removed at the same time the YarrSyntaxCheckable concept was
added. The concept enforces at compile time that the type must be as
expected.

The comment was reintroduced in 293609@main but I&apos;m not sure why. The
comment already has the wrong parameter types in atomCharacterClassAtom
and atomCharacterClassRange, since it&apos;s not possible to enforce that the
comment is updated when the concept changes. It&apos;s probably better to
just refer to the concept instead.

Canonical link: <a href="https://commits.webkit.org/303499@main">https://commits.webkit.org/303499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4c0e0ae0f0c8ad944d3f90c5950f9c7f42332bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84320 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101179 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68458 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3380 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83096 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124426 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142522 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130864 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4521 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109733 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3421 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57797 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4575 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33187 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163831 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4407 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68026 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42564 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/omg-tail-call-clobber-scratch-register.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->