### PR TITLE
Remove staging code for 105286196.

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
@@ -35,6 +35,8 @@ DECLARE_SYSTEM_HEADER
 
 #else
 
+@class NSColor;
+
 extern NSString *NSTextCheckingInsertionPointKey;
 extern NSString *NSTextCheckingSuppressInitialCapitalizationKey;
 #if HAVE(INLINE_PREDICTIONS)
@@ -56,6 +58,10 @@ extern NSString *NSTextCompletionAttributeName;
 
 + (BOOL)grammarCheckingEnabled;
 
+#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
++ (NSColor *)correctionIndicatorUnderlineColor;
+#endif
+
 @end
 
 #if HAVE(INLINE_PREDICTIONS)
@@ -67,13 +73,8 @@ typedef NS_OPTIONS(uint64_t, NSTextCheckingTypeAppKitTemporary) {
 };
 #endif
 
-#endif // USE(APPLE_INTERNAL_SDK)
 
-#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
-// FIXME: rdar://105853874 Remove staging code.
-@interface NSSpellChecker (Staging_105286196)
-+ (NSColor *)correctionIndicatorUnderlineColor;
-@end
-#endif
+
+#endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 32e8eb0835dee5ace91685e20a86982f821dc545
<pre>
Remove staging code for 105286196.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302972">https://bugs.webkit.org/show_bug.cgi?id=302972</a>
<a href="https://rdar.apple.com/105853874">rdar://105853874</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h:

Canonical link: <a href="https://commits.webkit.org/303430@main">https://commits.webkit.org/303430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65bbdcbabc1c7d997ebe36e87951a91b6b705634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139874 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d59847ca-6c67-454f-8704-58ddcdb87017) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101180 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c14594ec-cb35-4da1-bbd3-e4cc7489192e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135305 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81971 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b64a7792-c0ce-408e-b8d3-478f66760b4e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83099 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142525 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4524 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109559 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109736 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3422 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57800 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4578 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33192 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4410 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4535 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->