### PR TITLE
ASAN_ILL | WebCore::RenderText::computePreferredLogicalWidths; WebCore::RenderText::trimmedPreferredWidths; WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths

### DIFF
--- a/LayoutTests/fast/css/letter-spacing-with-compounded-zoom-factor-crash-expected.txt
+++ b/LayoutTests/fast/css/letter-spacing-with-compounded-zoom-factor-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/letter-spacing-with-compounded-zoom-factor-crash.html
+++ b/LayoutTests/fast/css/letter-spacing-with-compounded-zoom-factor-crash.html
@@ -1,0 +1,18 @@
+<style>
+.content {
+  width: fit-content;
+  zoom: 100000000000;
+}
+
+.content::first-letter {
+  float: left;
+}
+
+.container {
+  letter-spacing: 1000px;
+}
+</style>
+<div class=container><div class="content"><div class="content"><div class="content"><div class="content">PASS if no crash.
+<script>
+window.testRunner?.dumpAsText();
+</script>

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
  * Copyright (C) 2000 Antti Koivisto (koivisto@kde.org)
  * Copyright (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  * Copyright (C) 2014-2021 Google Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
@@ -275,7 +275,11 @@ inline bool RenderStyle::setWritingMode(StyleWritingMode mode)
 
 inline bool RenderStyle::setZoom(float zoomLevel)
 {
-    setUsedZoom(clampTo<float>(usedZoom() * zoomLevel, std::numeric_limits<float>::epsilon(), std::numeric_limits<float>::max()));
+    // Clamp the effective zoom value to avoid overflow in derived computations.
+    // This matches other engines values for compatbility.
+    constexpr float minEffectiveZoom = 1e-6f;
+    constexpr float maxEffectiveZoom = 1e6f;
+    setUsedZoom(clampTo<float>(usedZoom() * zoomLevel, minEffectiveZoom, maxEffectiveZoom));
     if (compareEqual(m_nonInheritedData->rareData->zoom, zoomLevel))
         return false;
     m_nonInheritedData.access().rareData.access().zoom = zoomLevel;


### PR DESCRIPTION
#### e718add89ed69e33354f3348a34afcd1549cb648
<pre>
ASAN_ILL | WebCore::RenderText::computePreferredLogicalWidths; WebCore::RenderText::trimmedPreferredWidths; WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths
<a href="https://bugs.webkit.org/show_bug.cgi?id=302954">https://bugs.webkit.org/show_bug.cgi?id=302954</a>
<a href="https://rdar.apple.com/164952578">rdar://164952578</a>

Reviewed by Brent Fulgham, Simon Fraser, and Alan Baradlay.

Clamp effective zoom to prevent arithmetic overflow in layout computations.

When zoom compounds through nested elements, the effective zoom can overflow
to infinity, causing failures in width calculations.

Clamp usedZoom to [1e-6, 1e6] to prevent overflow while maintaining
compatibility with other engines.

Test: fast/css/letter-spacing-with-compounded-zoom-factor-crash.html
* LayoutTests/fast/css/letter-spacing-with-compounded-zoom-factor-crash-expected.txt: Added.
* LayoutTests/fast/css/letter-spacing-with-compounded-zoom-factor-crash.html: Added.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setZoom):

Canonical link: <a href="https://commits.webkit.org/303808@main">https://commits.webkit.org/303808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402c973b541149a209f8b3cd85dfcc39c5d2f929

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141238 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d33bc872-d893-4ede-bed2-c7ed844b9445) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136612 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83042 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f1f67fdb-e9c1-46a9-95fa-5a3838ee9288) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143884 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5842 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110623 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28098 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116076 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59591 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5897 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34387 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69367 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5851 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->