### PR TITLE
Add webkitTrustedOnly event listener option

### DIFF
--- a/Source/WebCore/dom/AddEventListenerOptions.h
+++ b/Source/WebCore/dom/AddEventListenerOptions.h
@@ -35,15 +35,16 @@ namespace WebCore {
 class AbortSignal;
 
 struct AddEventListenerOptions : EventListenerOptions {
-    inline AddEventListenerOptions(bool capture = false, std::optional<bool> passive = std::nullopt, bool once = false);
+    inline AddEventListenerOptions(bool capture = false, std::optional<bool> passive = std::nullopt, bool once = false, bool webkitTrustedOnly = false);
 
-    inline AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, RefPtr<AbortSignal>&&);
+    inline AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, RefPtr<AbortSignal>&&, bool webkitTrustedOnly);
 
     inline ~AddEventListenerOptions();
 
     std::optional<bool> passive;
     bool once { false };
     RefPtr<AbortSignal> signal;
+    bool webkitTrustedOnly { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/AddEventListenerOptions.idl
+++ b/Source/WebCore/dom/AddEventListenerOptions.idl
@@ -27,4 +27,5 @@ dictionary AddEventListenerOptions : EventListenerOptions {
     boolean passive;
     boolean once = false;
     AbortSignal signal;
+    boolean webkitTrustedOnly = false;
 };

--- a/Source/WebCore/dom/AddEventListenerOptionsInlines.h
+++ b/Source/WebCore/dom/AddEventListenerOptionsInlines.h
@@ -31,18 +31,20 @@
 
 namespace WebCore {
 
-inline AddEventListenerOptions::AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, RefPtr<AbortSignal>&& signal)
+inline AddEventListenerOptions::AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, RefPtr<AbortSignal>&& signal, bool webkitTrustedOnly)
     : EventListenerOptions(capture)
     , passive(passive)
     , once(once)
     , signal(WTFMove(signal))
+    , webkitTrustedOnly(webkitTrustedOnly)
 {
 }
 
-inline AddEventListenerOptions::AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once)
+inline AddEventListenerOptions::AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, bool webkitTrustedOnly)
     : EventListenerOptions(capture)
     , passive(passive)
     , once(once)
+    , webkitTrustedOnly(webkitTrustedOnly)
 {
 }
 

--- a/Source/WebCore/dom/RegisteredEventListener.h
+++ b/Source/WebCore/dom/RegisteredEventListener.h
@@ -36,15 +36,17 @@ namespace WebCore {
 class RegisteredEventListener : public RefCounted<RegisteredEventListener> {
 public:
     struct Options {
-        Options(bool capture = false, bool passive = false, bool once = false)
+        Options(bool capture = false, bool passive = false, bool once = false, bool trustedOnly = false)
             : capture(capture)
             , passive(passive)
             , once(once)
+            , trustedOnly(trustedOnly)
         { }
 
         bool capture;
         bool passive;
         bool once;
+        bool trustedOnly;
     };
 
     static Ref<RegisteredEventListener> create(Ref<EventListener>&& listener, const Options& options)
@@ -57,6 +59,7 @@ public:
     bool isPassive() const { return m_isPassive; }
     bool isOnce() const { return m_isOnce; }
     bool wasRemoved() const { return m_wasRemoved; }
+    bool trustedOnly() const { return m_trustedOnly; }
 
     void markAsRemoved() { m_wasRemoved = true; }
 
@@ -66,6 +69,7 @@ private:
         , m_isPassive(options.passive)
         , m_isOnce(options.once)
         , m_wasRemoved(false)
+        , m_trustedOnly(options.trustedOnly)
         , m_callback(WTFMove(listener))
     {
     }
@@ -74,6 +78,7 @@ private:
     bool m_isPassive : 1;
     bool m_isOnce : 1;
     bool m_wasRemoved : 1;
+    bool m_trustedOnly : 1;
     const Ref<EventListener> m_callback;
 };
 


### PR DESCRIPTION
#### 462dacaed0ffc2326494a5299c23f613fd9d8653
<pre>
Add webkitTrustedOnly event listener option
<a href="https://bugs.webkit.org/show_bug.cgi?id=302977">https://bugs.webkit.org/show_bug.cgi?id=302977</a>
<a href="https://rdar.apple.com/165233141">rdar://165233141</a>

Reviewed by Sihui Liu.

This adds a webkitTrustedOnly option to addEventListener, which is similar to the wantsUntrusted
option supported by Gecko, except that Gecko&apos;s default for that option is context-dependent
(e.g. depends on whether the event listener is in a browser chrome or page context), whereas
webkitTrustedOnly always defaults to false (which seemed easier to reason about and also seemed
important for backwards compatibility).

The option prevents event listeners from firing for untrusted events. Scripts can already achieve a
similar effect with an early return if `!event.isTrusted`, but in some cases we want to avoid even
that overhead.

Currently we only support this option in the autofill world.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
* Source/WebCore/dom/AddEventListenerOptions.h:
* Source/WebCore/dom/AddEventListenerOptions.idl:
* Source/WebCore/dom/AddEventListenerOptionsInlines.h:
(WebCore::AddEventListenerOptions::AddEventListenerOptions):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::addEventListener):
(WebCore::EventTarget::innerInvokeEventListeners):
* Source/WebCore/dom/RegisteredEventListener.h:
(WebCore::RegisteredEventListener::Options::Options):
(WebCore::RegisteredEventListener::trustedOnly const):
(WebCore::RegisteredEventListener::RegisteredEventListener):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, AutoFillWorldTrustedEventHandler)):

Canonical link: <a href="https://commits.webkit.org/303686@main">https://commits.webkit.org/303686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d4cb233dd6983c5cd58743609af0ae4639ebfb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85301 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e29f77f1-3bbc-48b2-baf2-497e3c8942be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101933 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69396 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f45dc74a-c161-4c56-af40-74ea6a3c352b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e06707b-271f-48fc-a0bf-4560dd7983d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4336 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143457 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110310 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4204 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115701 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59176 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5481 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34055 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68933 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->