### PR TITLE
[GFC][Cleanup] Move grid item rects computation to its own function.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -83,14 +83,11 @@ private:
 
     static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList);
 
-    using UsedInlineSizes = Vector<LayoutUnit>;
-    using UsedBlockSizes = Vector<LayoutUnit>;
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const UsedTrackSizes&) const;
 
     static Vector<UsedMargins> computeInlineMargins(const PlacedGridItems&, const Style::ZoomFactor&);
     static Vector<UsedMargins> computeBlockMargins(const PlacedGridItems&, const Style::ZoomFactor&);
 
-    using BorderBoxPositions = Vector<LayoutUnit>;
     static BorderBoxPositions performInlineAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
     static BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
@@ -39,6 +39,7 @@ struct GridItemRect;
 struct TrackSizingFunctions;
 struct UnsizedTrack;
 
+using BorderBoxPositions = Vector<LayoutUnit>;
 using GridAreas = HashMap<UnplacedGridItem, GridAreaLines>;
 using GridCell = Vector<UnplacedGridItem, 1>;
 using GridItemRects = Vector<GridItemRect>;
@@ -47,5 +48,7 @@ using PlacedGridItems = Vector<PlacedGridItem>;
 using TrackSizes = Vector<LayoutUnit>;
 using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
 using UnsizedTracks = Vector<UnsizedTrack>;
+using UsedBlockSizes = Vector<LayoutUnit>;
+using UsedInlineSizes = Vector<LayoutUnit>;
 } // namespace Layout
 } // namespace WebCore


### PR DESCRIPTION
#### 9b856c67d85184b03ecd0e893760f79b10fff69f
<pre>
[GFC][Cleanup] Move grid item rects computation to its own function.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302985">https://bugs.webkit.org/show_bug.cgi?id=302985</a>
<a href="https://rdar.apple.com/problem/165241488">rdar://problem/165241488</a>

Reviewed by Brandon Stewart.

The last step of GridLayout::layout is to map the various geometry we
computed during layout to a list of GridItemRects that will be used by
the formatting context and integration to map geometry back to the
renderers. Since this really isn&apos;t a part of grid layout strictly we can
move all of this logic to a dedicated function that we just call at the
end of layout. This improves the clarity of GridLayout::layout when you
want to read what this function is doing in regards to grid layout
specifically.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::computeGridItemRects):
(WebCore::Layout::GridLayout::layout):
(WebCore::Layout::GridLayout::performInlineAxisSelfAlignment):
(WebCore::Layout::GridLayout::performBlockAxisSelfAlignment):
(WebCore::Layout::GridLayout::layoutGridItems const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h:

Canonical link: <a href="https://commits.webkit.org/303464@main">https://commits.webkit.org/303464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56f532202eac6a2675ace1bdf665101727581b01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb6571c3-9a1f-45d5-981e-904c08103f18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101218 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68475 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8f7ae48-eaad-400c-9f66-d20bc493afc1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82010 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1cc7aac3-ac45-4b9b-9512-7a10f90e6d23) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1201 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83144 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142570 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4568 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37294 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109594 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109773 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3459 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114862 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57844 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4622 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4454 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68073 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4713 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->