### PR TITLE
Adopt smart pointers in AXIsolatedObjectMac.mm and CSSVariableReferenceValue.cpp

### DIFF
--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -545,7 +545,7 @@ template<typename C> using EachTakingAccumulatorAndValueFunction = void(&)(Strin
 
 template<typename C, std::invocable<decltype(*std::begin(std::declval<C>()))> E, StringTypeAdaptable B>
     requires EachTakingValue<C, E>
-decltype(auto) interleave(const C& container, E each, const B& between)
+decltype(auto) interleave(const C& container, NOESCAPE E&& each, const B& between)
 {
     return Interleave {
         container,
@@ -556,7 +556,7 @@ decltype(auto) interleave(const C& container, E each, const B& between)
 
 template<typename C, std::invocable<decltype(std::declval<StringBuilder&>()), decltype(*std::begin(std::declval<C>()))> E, StringTypeAdaptable B>
     requires EachTakingAccumulatorAndValue<C, E>
-decltype(auto) interleave(const C& container, E each, const B& between)
+decltype(auto) interleave(const C& container, NOESCAPE E&& each, const B& between)
 {
     return Interleave {
         container,

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -91,7 +91,6 @@ css/CSSStyleProperties.cpp
 css/CSSStyleSheet.cpp
 css/CSSStyleSheetObservableArray.cpp
 css/CSSToLengthConversionData.cpp
-css/CSSVariableReferenceValue.cpp
 css/MediaQueryList.cpp
 css/MediaQueryMatcher.cpp
 css/SelectorChecker.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -19,13 +19,11 @@ Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webdatabase/DatabaseThread.cpp
 [ Mac ] accessibility/isolatedtree/AXIsolatedObject.cpp
 [ Mac ] accessibility/isolatedtree/AXIsolatedObject.h
-[ Mac ] accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
 animation/KeyframeEffect.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp
 css/CSSValue.cpp
-css/CSSVariableReferenceValue.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
 dom/RejectedPromiseTracker.cpp
@@ -80,7 +78,6 @@ style/StyleCustomProperty.cpp
 style/Styleable.cpp
 style/values/StyleValueTypes.h
 style/values/backgrounds/StyleFillLayers.h
-style/values/fonts/StyleFontVariationSettings.cpp
 style/values/images/StyleGradient.cpp
 style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h
 style/values/primitives/StylePrimitiveKeyword+Serialization.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -109,7 +109,6 @@ css/CSSStyleSheetObservableArray.cpp
 css/CSSValue.cpp
 css/CSSValueList.cpp
 css/CSSValueList.h
-css/CSSVariableReferenceValue.cpp
 css/DeprecatedCSSOMPrimitiveValue.cpp
 css/FontFaceSet.cpp
 css/ImmutableStyleProperties.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -8,7 +8,6 @@ Modules/WebGPU/GPUQueue.cpp
 [ iOS ] accessibility/ios/AXObjectCacheIOS.mm
 [ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
 [ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-[ Mac ] accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
 [ Mac ] accessibility/mac/AXObjectCacheMac.mm
 [ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -168,7 +168,7 @@ FloatRect AXIsolatedObject::convertRectToPlatformSpace(const FloatRect& rect, Ac
     if (space == AccessibilityConversionSpace::Screen)
         return convertFrameToSpace(rect, space);
 
-    return Accessibility::retrieveValueFromMainThread<FloatRect>([&rect, &space, this] () -> FloatRect {
+    return Accessibility::retrieveValueFromMainThread<FloatRect>([&rect, &space, this, protectedThis = Ref { *this }] () -> FloatRect {
         if (RefPtr axObject = associatedAXObject())
             return axObject->convertRectToPlatformSpace(rect, space);
         return { };
@@ -177,7 +177,8 @@ FloatRect AXIsolatedObject::convertRectToPlatformSpace(const FloatRect& rect, Ac
 
 bool AXIsolatedObject::isDetached() const
 {
-    return !wrapper() || [wrapper() axBackingObject] != this;
+    RetainPtr retainedWrapper = wrapper();
+    return !retainedWrapper || [retainedWrapper axBackingObject] != this;
 }
 
 void AXIsolatedObject::attachPlatformWrapper(AccessibilityObjectWrapper* wrapper)
@@ -198,7 +199,8 @@ void AXIsolatedObject::attachPlatformWrapper(AccessibilityObjectWrapper* wrapper
 
 void AXIsolatedObject::detachPlatformWrapper(AccessibilityDetachmentType detachmentType)
 {
-    [wrapper() detachIsolatedObject:detachmentType];
+    RetainPtr retainedWrapper = wrapper();
+    [retainedWrapper detachIsolatedObject:detachmentType];
 }
 
 AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::allSortedLiveRegions() const
@@ -353,7 +355,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([this] () {
+    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([this, protectedThis = Ref { *this }] () {
         RefPtr axObject = associatedAXObject();
         return axObject ? axObject->textMarkerRange() : AXTextMarkerRange();
     });
@@ -382,7 +384,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRangeForNSRange(const NSRange& ran
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([&range, this] () -> AXTextMarkerRange {
+    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([&range, this, protectedThis = Ref { *this }] () -> AXTextMarkerRange {
         RefPtr axObject = associatedAXObject();
         return axObject ? axObject->textMarkerRangeForNSRange(range) : AXTextMarkerRange();
     });
@@ -445,7 +447,7 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
     attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXProperty::AttributedText);
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
     if (!isConfined || !attributedText) {
-        return Accessibility::retrieveValueFromMainThread<RetainPtr<NSAttributedString>>([markerRange = WTFMove(markerRange), &spellCheck, this] () mutable -> RetainPtr<NSAttributedString> {
+        return Accessibility::retrieveValueFromMainThread<RetainPtr<NSAttributedString>>([markerRange = WTFMove(markerRange), &spellCheck, this, protectedThis = Ref { *this }] () mutable -> RetainPtr<NSAttributedString> {
             if (RefPtr axObject = associatedAXObject())
                 return axObject->attributedStringForTextMarkerRange(WTFMove(markerRange), spellCheck);
             return { };
@@ -514,7 +516,7 @@ IntPoint AXIsolatedObject::clickPoint()
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<IntPoint>([this] () -> IntPoint {
+    return Accessibility::retrieveValueFromMainThread<IntPoint>([this, protectedThis = Ref { *this }] () -> IntPoint {
         if (RefPtr object = associatedAXObject())
             return object->clickPoint();
         return { };
@@ -525,7 +527,7 @@ bool AXIsolatedObject::pressedIsPresent() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<bool>([this] () -> bool {
+    return Accessibility::retrieveValueFromMainThread<bool>([this, protectedThis = Ref { *this }] () -> bool {
         if (RefPtr object = associatedAXObject())
             return object->pressedIsPresent();
         return false;
@@ -536,7 +538,7 @@ Vector<String> AXIsolatedObject::determineDropEffects() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<Vector<String>>([this] () -> Vector<String> {
+    return Accessibility::retrieveValueFromMainThread<Vector<String>>([this, protectedThis = Ref { * this }] () -> Vector<String> {
         if (RefPtr object = associatedAXObject())
             return object->determineDropEffects();
         return { };
@@ -547,7 +549,7 @@ int AXIsolatedObject::layoutCount() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<int>([this] () -> int {
+    return Accessibility::retrieveValueFromMainThread<int>([this, protectedThis = Ref { *this }] () -> int {
         if (RefPtr object = associatedAXObject())
             return object->layoutCount();
         return { };
@@ -569,7 +571,7 @@ String AXIsolatedObject::computedRoleString() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<String>([this] () -> String {
+    return Accessibility::retrieveValueFromMainThread<String>([this, protectedThis = Ref { *this }] () -> String {
         if (RefPtr object = associatedAXObject())
             return object->computedRoleString().isolatedCopy();
         return { };

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "FontTaggedSettings.h"
 #include "PropertyCascade.h"
+#include "RenderStyle.h"
 #include "RuleSet.h"
 #include "SelectorChecker.h"
 #include "StyleForVisitedLink.h"
@@ -109,6 +110,7 @@ public:
 
     RenderStyle& style() { return m_style; }
     const RenderStyle& style() const { return m_style; }
+    CheckedRef<const RenderStyle> checkedStyle() const { return style(); }
 
     const RenderStyle& parentStyle() const { return *m_context.parentStyle; }
     const RenderStyle* rootElementStyle() const { return m_context.rootElementStyle; }


### PR DESCRIPTION
#### fc05be64ea55db58c24524a81dce28e0acf9fbf7
<pre>
Adopt smart pointers in AXIsolatedObjectMac.mm and CSSVariableReferenceValue.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=302990">https://bugs.webkit.org/show_bug.cgi?id=302990</a>
<a href="https://rdar.apple.com/165245900">rdar://165245900</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

No new tests needed.

* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::std::invocable&lt;decltype):
(WTF::decltype):
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::convertRectToPlatformSpace const):
(WebCore::AXIsolatedObject::isDetached const):
(WebCore::AXIsolatedObject::detachPlatformWrapper):
(WebCore::AXIsolatedObject::textMarkerRange const):
(WebCore::AXIsolatedObject::textMarkerRangeForNSRange const):
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
(WebCore::AXIsolatedObject::clickPoint):
(WebCore::AXIsolatedObject::pressedIsPresent const):
(WebCore::AXIsolatedObject::determineDropEffects const):
(WebCore::AXIsolatedObject::layoutCount const):
(WebCore::AXIsolatedObject::computedRoleString const):
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::propertyValueForVariableName):
(WebCore::CSSVariableReferenceValue::resolveVariableReference const):
(WebCore::CSSVariableReferenceValue::tryResolveSimpleReference const):
(WebCore::CSSVariableReferenceValue::resolveSingleValue const):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::checkedStyle const):

Canonical link: <a href="https://commits.webkit.org/304101@main">https://commits.webkit.org/304101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3fc1d92c8d425fbcf62132626b858d17f355ae0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86375 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2fb8b87b-2e85-4fe7-a7ba-3266bac43f45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102721 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69980 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83512 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5057 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2678 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126442 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144610 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132894 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111127 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111396 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4891 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60314 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20775 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6584 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34914 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165825 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70153 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43345 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6644 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6520 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->