### PR TITLE
Adopt safer CPP in AudioWorkletThread, SQLTransactionCoordinator, CSSPendingSubstitutionValue, CDMClearKey, SVGAltGlyphElement

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp
@@ -69,8 +69,12 @@ WorkerDebuggerProxy* AudioWorkletThread::workerDebuggerProxy() const
 
 Ref<Thread> AudioWorkletThread::createThread()
 {
-    return Thread::create("WebCore: AudioWorklet"_s, [this] {
-        workerOrWorkletThread();
+    return Thread::create("WebCore: AudioWorklet"_s, [weakThis = ThreadSafeWeakPtr { *this }] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        protectedThis->workerOrWorkletThread();
     }, ThreadType::Audio, m_parameters.isAudioContextRealTime ? Thread::QOS::UserInteractive : Thread::QOS::Default);
 }
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCoordinator.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCoordinator.cpp
@@ -123,8 +123,8 @@ void SQLTransactionCoordinator::shutdown()
         // Clean up transactions that have reached "lockAcquired":
         // Transaction phase 4 cleanup. See comment on "What happens if a
         // transaction is interrupted?" at the top of SQLTransactionBackend.cpp.
-        if (info.activeWriteTransaction)
-            info.activeWriteTransaction->notifyDatabaseThreadIsShuttingDown();
+        if (RefPtr transaction = info.activeWriteTransaction)
+            transaction->notifyDatabaseThreadIsShuttingDown();
         for (auto& transaction : info.activeReadTransactions)
             transaction->notifyDatabaseThreadIsShuttingDown();
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -80,7 +80,6 @@ Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
 Modules/webdatabase/SQLStatement.cpp
 Modules/webdatabase/SQLTransaction.cpp
 Modules/webdatabase/SQLTransactionBackend.cpp
-Modules/webdatabase/SQLTransactionCoordinator.cpp
 Modules/webtransport/WebTransport.cpp
 accessibility/AXLogger.cpp
 accessibility/AXObjectCache.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -9,7 +9,6 @@ Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/RTCRtpSender.cpp
 Modules/paymentrequest/PaymentRequest.cpp
 Modules/push-api/PushDatabase.cpp
-Modules/webaudio/AudioWorkletThread.cpp
 Modules/webaudio/OfflineAudioContext.cpp
 Modules/webaudio/OfflineAudioDestinationNode.cpp
 Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -25,7 +24,6 @@ animation/KeyframeEffect.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp
-css/CSSPendingSubstitutionValue.cpp
 css/CSSValue.cpp
 css/CSSVariableReferenceValue.cpp
 dom/ContentVisibilityDocumentState.cpp
@@ -47,14 +45,12 @@ page/writing-tools/WritingToolsController.mm
 platform/ScrollableArea.cpp
 platform/cocoa/NetworkExtensionContentFilter.mm
 platform/encryptedmedia/CDMProxy.cpp
-platform/encryptedmedia/clearkey/CDMClearKey.cpp
 platform/graphics/ShadowBlur.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
 [ iOS ] platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
-platform/graphics/filters/FilterOperation.cpp
 [ iOS ] platform/ios/DragImageIOS.mm
 platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
 platform/mediastream/RealtimeVideoCaptureSource.cpp

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
@@ -33,17 +33,14 @@ namespace WebCore {
 
 RefPtr<CSSValue> CSSPendingSubstitutionValue::resolveValue(Style::Builder& builder, CSSPropertyID propertyID) const
 {
-    auto cacheValue = [&](auto data) {
+    if (!m_shorthandValue->resolveAndCacheValue(builder, [this](auto data) {
         ParsedPropertyVector parsedProperties;
         if (!CSSPropertyParser::parseValue(m_shorthandPropertyId, IsImportant::No, data->tokens(), data->context(), parsedProperties, StyleRuleType::Style)) {
             m_cachedPropertyValues = { };
             return;
         }
 
-        m_cachedPropertyValues = parsedProperties;
-    };
-
-    if (!m_shorthandValue->resolveAndCacheValue(builder, cacheValue))
+        m_cachedPropertyValues = parsedProperties; }))
         return nullptr;
 
     for (auto& property : m_cachedPropertyValues) {

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -461,11 +461,8 @@ void CDMInstanceSessionClearKey::requestLicense(LicenseType, KeyGroupingStrategy
         initData = extractKeyIdFromWebMInitData(initData.get());
 
     callOnMainThread(
-        [this, weakThis = WeakPtr { *this }, callback = WTFMove(callback), initData = WTFMove(initData)]() mutable {
-            if (!weakThis)
-                return;
-
-            callback(WTFMove(initData), m_sessionID, false, Succeeded);
+        [sessionID = m_sessionID, callback = WTFMove(callback), initData = WTFMove(initData)]() mutable {
+            callback(WTFMove(initData), sessionID, false, Succeeded);
         });
 }
 

--- a/Source/WebCore/platform/graphics/ColorUtilities.h
+++ b/Source/WebCore/platform/graphics/ColorUtilities.h
@@ -46,7 +46,7 @@ uint8_t convertPrescaledSRGBAFloatToSRGBAByte(float);
 template<typename T> T convertByteAlphaTo(uint8_t);
 template<typename T> T convertFloatAlphaTo(float);
 
-template<typename ColorType, typename Functor> auto colorByModifingEachNonAlphaComponent(const ColorType&, Functor&&);
+template<typename ColorType, typename Functor> auto colorByModifingEachNonAlphaComponent(const ColorType&, NOESCAPE Functor&&);
 
 template<typename ColorType> constexpr auto colorWithOverriddenAlpha(const ColorType&, uint8_t overrideAlpha);
 template<typename ColorType> auto colorWithOverriddenAlpha(const ColorType&, float overrideAlpha);
@@ -119,7 +119,7 @@ template<> inline float convertFloatAlphaTo<float>(float value)
     return clampedAlpha(value);
 }
 
-template<typename ColorType, typename Functor> auto colorByModifingEachNonAlphaComponent(const ColorType& color, Functor&& functor)
+template<typename ColorType, typename Functor> auto colorByModifingEachNonAlphaComponent(const ColorType& color, NOESCAPE Functor&& functor)
 {
     auto components = asColorComponents(color.resolved());
     auto copy = components;


### PR DESCRIPTION
#### 28f408c82d9e05b448ba4efc98077f12ed144f6b
<pre>
Adopt safer CPP in AudioWorkletThread, SQLTransactionCoordinator, CSSPendingSubstitutionValue, CDMClearKey, SVGAltGlyphElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=302993">https://bugs.webkit.org/show_bug.cgi?id=302993</a>
<a href="https://rdar.apple.com/165248345">rdar://165248345</a>

Reviewed by Per Arne Vollan.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

No new tests needed.

* Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp:
(WebCore::AudioWorkletThread::createThread):
* Source/WebCore/Modules/webdatabase/SQLTransactionCoordinator.cpp:
(WebCore::SQLTransactionCoordinator::shutdown):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/css/CSSPendingSubstitutionValue.cpp:
(WebCore::CSSPendingSubstitutionValue::resolveValue const):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::CDMInstanceSessionClearKey::requestLicense):
* Source/WebCore/platform/graphics/ColorUtilities.h:
(WebCore::colorByModifingEachNonAlphaComponent):

Canonical link: <a href="https://commits.webkit.org/303999@main">https://commits.webkit.org/303999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bc131521e5af2a5a320d4ad1846be11fd05f877

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86239 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/830c25bf-fcdd-4c80-9753-0c30a66e9ea1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102602 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/945932f1-6fc6-4808-ba37-ed6c4f1dc87f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83396 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2557 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1572 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144403 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6358 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110976 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111223 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4781 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116538 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60129 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20734 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6410 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6500 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->