### PR TITLE
Adopt Safer CPP in BiquadFilterNode.cpp, ScrollAnimator.cpp, CDMProxy.cpp

### DIFF
--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
@@ -45,10 +45,10 @@ ExceptionOr<Ref<BiquadFilterNode>> BiquadFilterNode::create(BaseAudioContext& co
         return result.releaseException();
 
     node->setType(options.type);
-    node->q().setValue(options.Q);
-    node->detune().setValue(options.detune);
-    node->frequency().setValue(options.frequency);
-    node->gain().setValue(options.gain);
+    Ref { node->q() }->setValue(options.Q);
+    Ref { node->detune() }->setValue(options.detune);
+    Ref { node->frequency() }->setValue(options.frequency);
+    Ref { node->gain() }->setValue(options.gain);
 
     return node;
 }
@@ -70,7 +70,7 @@ BiquadFilterType BiquadFilterNode::type() const
 
 void BiquadFilterNode::setType(BiquadFilterType type)
 {
-    biquadProcessor()->setType(type);
+    checkedBiquadProcessor()->setType(type);
 }
 
 ExceptionOr<void> BiquadFilterNode::getFrequencyResponse(const Ref<Float32Array>& frequencyHz, const Ref<Float32Array>& magResponse, const Ref<Float32Array>& phaseResponse)
@@ -80,7 +80,7 @@ ExceptionOr<void> BiquadFilterNode::getFrequencyResponse(const Ref<Float32Array>
         return Exception { ExceptionCode::InvalidAccessError, "The arrays passed as arguments must have the same length"_s };
 
     if (length)
-        biquadProcessor()->getFrequencyResponse(length, frequencyHz->typedSpan(), magResponse->typedMutableSpan(), phaseResponse->typedMutableSpan());
+        checkedBiquadProcessor()->getFrequencyResponse(length, frequencyHz->typedSpan(), magResponse->typedMutableSpan(), phaseResponse->typedMutableSpan());
     return { };
 }
 

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
@@ -54,6 +54,7 @@ private:
     explicit BiquadFilterNode(BaseAudioContext&);
 
     BiquadProcessor* biquadProcessor() { return downcast<BiquadProcessor>(processor()); }
+    CheckedPtr<BiquadProcessor> checkedBiquadProcessor() { return biquadProcessor(); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -43,7 +43,6 @@ page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingTreeGestureState.h
 platform/PODInterval.h
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
-platform/encryptedmedia/CDMProxy.h
 platform/graphics/GraphicsLayer.h
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -12,7 +12,6 @@ Modules/push-api/PushManager.cpp
 Modules/push-api/PushSubscription.cpp
 Modules/remoteplayback/RemotePlayback.cpp
 Modules/storage/StorageManager.cpp
-Modules/webaudio/BiquadFilterNode.cpp
 Modules/webaudio/DefaultAudioDestinationNode.cpp
 Modules/webaudio/IIRFilterNode.cpp
 Modules/webaudio/MediaStreamAudioDestinationNode.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -53,7 +53,6 @@ Modules/webaudio/AudioSummingJunction.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/webaudio/AudioWorkletMessagingProxy.cpp
 Modules/webaudio/AudioWorkletNode.cpp
-Modules/webaudio/BiquadFilterNode.cpp
 [ iOS ] Modules/webaudio/ChannelMergerNode.cpp
 Modules/webaudio/ConvolverNode.cpp
 Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -602,7 +601,6 @@ page/text-extraction/TextExtraction.cpp
 page/writing-tools/WritingToolsController.mm
 platform/DragImage.cpp
 platform/ScrollAnimationSmooth.cpp
-platform/ScrollAnimator.cpp
 platform/ScrollView.cpp
 platform/ScrollableArea.cpp
 platform/Widget.cpp
@@ -612,7 +610,6 @@ platform/audio/cocoa/AudioFileReaderCocoa.cpp
 [ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
-platform/encryptedmedia/CDMProxy.cpp
 platform/encryptedmedia/CDMProxy.h
 platform/graphics/BitmapImage.cpp
 platform/graphics/BitmapImage.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -42,7 +42,6 @@ page/writing-tools/WritingToolsController.mm
 [ iOS ] platform/PreviewConverter.cpp
 platform/ScrollableArea.cpp
 platform/cocoa/NetworkExtensionContentFilter.mm
-platform/encryptedmedia/CDMProxy.cpp
 platform/graphics/ShadowBlur.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -306,7 +306,6 @@ page/scrolling/ScrollingTreeStickyNode.cpp
 page/text-extraction/TextExtraction.cpp
 platform/DictationCaretAnimator.cpp
 platform/KeyboardScrollingAnimator.cpp
-platform/ScrollAnimator.cpp
 platform/ScrollView.cpp
 platform/ScrollableArea.cpp
 platform/ScrollbarsController.cpp

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -193,8 +193,8 @@ bool ScrollAnimator::handleSteppedScrolling(const PlatformWheelEvent& wheelEvent
     }
 #endif
 
-    auto* horizontalScrollbar = scrollableArea->horizontalScrollbar();
-    auto* verticalScrollbar = scrollableArea->verticalScrollbar();
+    RefPtr horizontalScrollbar = scrollableArea->horizontalScrollbar();
+    RefPtr verticalScrollbar = scrollableArea->verticalScrollbar();
 
     // Accept the event if we have a scrollbar in that direction and can still
     // scroll any further.
@@ -409,18 +409,14 @@ void ScrollAnimator::stopAnimationCallback(ScrollingEffectsController&)
 
 void ScrollAnimator::deferWheelEventTestCompletionForReason(ScrollingNodeID identifier, WheelEventTestMonitor::DeferReason reason) const
 {
-    if (!m_wheelEventTestMonitor)
-        return;
-
-    m_wheelEventTestMonitor->deferForReason(identifier, reason);
+    if (RefPtr monitor = m_wheelEventTestMonitor)
+        monitor->deferForReason(identifier, reason);
 }
 
 void ScrollAnimator::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID identifier, WheelEventTestMonitor::DeferReason reason) const
 {
-    if (!m_wheelEventTestMonitor)
-        return;
-    
-    m_wheelEventTestMonitor->removeDeferralForReason(identifier, reason);
+    if (RefPtr monitor = m_wheelEventTestMonitor)
+        monitor->removeDeferralForReason(identifier, reason);
 }
 
 #if USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -53,6 +53,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMFactoryClearKey);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMPrivateClearKey);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMInstanceClearKey);
 
 static std::optional<Vector<RefPtr<KeyHandle>>> parseLicenseFormat(const JSON::Object& root)
 {

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
@@ -97,6 +97,8 @@ public:
 };
 
 class CDMInstanceClearKey final : public CDMInstanceProxy {
+    WTF_MAKE_TZONE_ALLOCATED(CDMInstanceClearKey);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMInstanceClearKey);
 public:
     CDMInstanceClearKey();
     virtual ~CDMInstanceClearKey();

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -80,6 +80,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMFactoryThunder);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMPrivateThunder);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMInstanceThunder);
 
 static CDMInstanceSession::SessionLoadFailure sessionLoadFailureFromThunder(const StringView& loadStatus)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -110,6 +110,8 @@ private:
 };
 
 class CDMInstanceThunder final : public CDMInstanceProxy {
+    WTF_MAKE_TZONE_ALLOCATED(CDMInstanceThunder);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMInstanceThunder);
 public:
     CDMInstanceThunder(const String& keySystem);
     virtual ~CDMInstanceThunder() = default;


### PR DESCRIPTION
#### 65e001848f1e0a00d0590e503e308d3028a70482
<pre>
Adopt Safer CPP in BiquadFilterNode.cpp, ScrollAnimator.cpp, CDMProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=302996">https://bugs.webkit.org/show_bug.cgi?id=302996</a>
<a href="https://rdar.apple.com/165251539">rdar://165251539</a>

Reviewed by Chris Dumez and Per Arne Vollan.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

No new tests needed.
* Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp:
(WebCore::BiquadFilterNode::create):
(WebCore::BiquadFilterNode::setType):
(WebCore::BiquadFilterNode::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadFilterNode.h:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::handleSteppedScrolling):
(WebCore::ScrollAnimator::deferWheelEventTestCompletionForReason const):
(WebCore::ScrollAnimator::removeWheelEventTestCompletionDeferralForReason const):
* Source/WebCore/platform/encryptedmedia/CDMProxy.cpp:
(WebCore::CDMProxy::instance const):
(WebCore::CDMProxy::startedWaitingForKey const):
(WebCore::CDMProxy::stoppedWaitingForKey const):
(WebCore::CDMProxy::tryWaitForKeyHandle const):
(WebCore::CDMInstanceProxy::mergeKeysFrom):
(WebCore::CDMInstanceProxy::unrefAllKeysFrom):
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::CDMInstanceProxy::~CDMInstanceProxy):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h:
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h:

Canonical link: <a href="https://commits.webkit.org/304121@main">https://commits.webkit.org/304121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfe406685269a6a7c1af30f60249dcf68c9d58ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c6fd61ae-0d83-4a71-b084-d53292fe1ede) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102704 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69963 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/285c3a60-f1be-452b-b6bc-6c66ecfe21e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eb50dbd7-cf29-48e0-8760-cbd31dfc1f7d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2663 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114246 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.PageOverlayLayerPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144583 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6512 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111369 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4876 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60294 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20789 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6564 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34890 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70129 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6501 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->