### PR TITLE
MiniBrowser: Add menu option to clone the current WK2 window, both with and without site isolation

### DIFF
--- a/Tools/MiniBrowser/mac/BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.h
@@ -47,6 +47,9 @@
 
 - (IBAction)openLocation:(id)sender;
 
+- (IBAction)cloneSiteIsolatedWindow:(id)sender;
+- (IBAction)cloneNonIsolatedWindow:(id)sender;
+
 - (IBAction)saveAsPDF:(id)sender;
 - (IBAction)saveAsImage:(id)sender;
 - (IBAction)saveAsWebArchive:(id)sender;

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -114,6 +114,16 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+- (IBAction)cloneSiteIsolatedWindow:(id)sender
+{
+    [self doesNotRecognizeSelector:_cmd];
+}
+
+- (IBAction)cloneNonIsolatedWindow:(id)sender
+{
+    [self doesNotRecognizeSelector:_cmd];
+}
+
 - (IBAction)saveAsPDF:(id)sender
 {
     [self doesNotRecognizeSelector:_cmd];

--- a/Tools/MiniBrowser/mac/MainMenu.xib
+++ b/Tools/MiniBrowser/mac/MainMenu.xib
@@ -123,6 +123,20 @@
                             <menuItem isSeparatorItem="YES" id="79">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
+                            <menuItem title="Clone Site Isolated Window" tag="4" keyEquivalent="i" id="ka5-QP-WgC">
+                                <connections>
+                                    <action selector="cloneSiteIsolatedWindow:" target="-1" id="fSF-Rg-NSY"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Clone Non-isolated Window" tag="4" keyEquivalent="i" id="TOF-K0-SlE">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="cloneNonIsolatedWindow:" target="-1" id="qDa-CW-kBR"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Rug-SG-b5b">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
                             <menuItem title="Close" keyEquivalent="w" id="73">
                                 <connections>
                                     <action selector="performClose:" target="-1" id="193"/>

--- a/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
@@ -148,6 +148,10 @@ static BOOL areEssentiallyEqual(double a, double b)
 {
     SEL action = [menuItem action];
 
+    if (action == @selector(cloneSiteIsolatedWindow:))
+        return NO;
+    if (action == @selector(cloneNonIsolatedWindow:))
+        return NO;
     if (action == @selector(saveAsPDF:))
         return NO;
     if (action == @selector(saveAsImage:))

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -279,6 +279,10 @@ static BOOL areEssentiallyEqual(double a, double b)
 {
     SEL action = menuItem.action;
 
+    if (action == @selector(cloneSiteIsolatedWindow:))
+        return YES;
+    if (action == @selector(cloneNonIsolatedWindow:))
+        return YES;
     if (action == @selector(saveAsPDF:))
         return YES;
     if (action == @selector(saveAsImage:))
@@ -1026,6 +1030,31 @@ static BOOL isJavaScriptURL(NSURL *url)
 
 - (void)findBarViewDidChangeHeight
 {
+}
+
+- (void)_cloneWindowSiteIsolated:(BOOL)siteIsolated
+{
+    _WKSessionState *sessionState = [_webView _sessionState];
+
+    WKWebViewConfiguration *configuration = _webView.configuration;
+    _configuration.preferences._siteIsolationEnabled = siteIsolated;
+
+    WK2BrowserWindowController *controller = [[WK2BrowserWindowController alloc] initWithConfiguration:configuration];
+    [controller.window makeKeyAndOrderFront:self];
+
+    [[[NSApplication sharedApplication] browserAppDelegate] didCreateBrowserWindowController:controller];
+
+    [controller->_webView _restoreSessionState:sessionState andNavigate:YES];
+}
+
+- (IBAction)cloneSiteIsolatedWindow:(id)sender
+{
+    [self _cloneWindowSiteIsolated:YES];
+}
+
+- (IBAction)cloneNonIsolatedWindow:(id)sender
+{
+    [self _cloneWindowSiteIsolated:NO];
 }
 
 - (IBAction)saveAsPDF:(id)sender


### PR DESCRIPTION
#### e1740c6b6a3b99ba3c86d3e98664e6ce13ebbeb8
<pre>
MiniBrowser: Add menu option to clone the current WK2 window, both with and without site isolation
<a href="https://rdar.apple.com/165252135">rdar://165252135</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302997">https://bugs.webkit.org/show_bug.cgi?id=302997</a>

Reviewed by Richard Robinson and Megan Gardner.

It&apos;s useful for various WebKit development tasks to be able to make a clone of the existing browser window,
session history included.

For site isolation, it&apos;s particular useful to be able to clone the current non-isolated window as an
isolated window.

And vice versa.

* Tools/MiniBrowser/mac/BrowserWindowController.h:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController cloneSiteIsolatedWindow:]):
(-[BrowserWindowController cloneNonIsolatedWindow:]):
* Tools/MiniBrowser/mac/MainMenu.xib:
* Tools/MiniBrowser/mac/WK1BrowserWindowController.m:
(-[WK1BrowserWindowController validateMenuItem:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController validateMenuItem:]):
(-[WK2BrowserWindowController _cloneWindowSiteIsolated:]):
(-[WK2BrowserWindowController cloneSiteIsolatedWindow:]):
(-[WK2BrowserWindowController cloneNonIsolatedWindow:]):

Canonical link: <a href="https://commits.webkit.org/303775@main">https://commits.webkit.org/303775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db50338f45be5436eba2e459fdc1eacdbdfda15f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84401 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4df041f5-2068-48ea-98fa-12a2b1f4f575) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101233 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68501 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82025 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a89eb1ee-dfb7-4fba-a404-ea864ed668af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1215 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83163 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142588 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4586 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109609 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109788 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3472 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57867 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4640 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33241 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4473 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->