### PR TITLE
[Safe CPP] Address warnings in InlineLine.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -56,9 +56,7 @@ inspector/PageInspectorController.h
 inspector/UserGestureEmulationScope.h
 inspector/agents/InspectorNetworkAgent.h
 inspector/agents/InspectorPageAgent.h
-layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
-layout/formattingContexts/inline/InlineLine.h
 layout/integration/inline/LayoutIntegrationLineLayout.h
 layout/layouttree/LayoutElementBox.h
 page/DOMWindow.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -17,7 +17,6 @@ layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineFormattingUtils.cpp
 layout/formattingContexts/inline/InlineItem.h
 layout/formattingContexts/inline/InlineItemsBuilder.h
-layout/formattingContexts/inline/InlineLine.h
 layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
 layout/integration/LayoutIntegrationBoxTreeUpdater.h
 layout/integration/inline/LayoutIntegrationInlineContentBuilder.h

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -27,6 +27,7 @@
 
 #include "FormattingContext.h"
 #include <WebCore/LayoutElementBox.h>
+#include <WebCore/LayoutState.h>
 #include <WebCore/PlacedFloats.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
@@ -32,6 +32,7 @@
 #include <WebCore/InlineLayoutState.h>
 #include <WebCore/InlineQuirks.h>
 #include <WebCore/LayoutIntegrationUtils.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -54,8 +55,9 @@ struct InlineLayoutResult {
 
 // This class implements the layout logic for inline formatting context.
 // https://www.w3.org/TR/CSS22/visuren.html#inline-formatting
-class InlineFormattingContext {
+class InlineFormattingContext : public CanMakeCheckedPtr<InlineFormattingContext> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(InlineFormattingContext);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InlineFormattingContext);
 public:
     InlineFormattingContext(const ElementBox& formattingContextRoot, LayoutState&, BlockLayoutState& parentBlockLayoutState);
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
@@ -27,13 +27,13 @@
 
 #include "InlineLine.h"
 #include "InlineLineBuilder.h"
+#include <WebCore/InlineFormattingContext.h>
 #include <WebCore/InlineLineTypes.h>
 
 namespace WebCore {
 namespace Layout {
 
 class FloatingContext;
-class InlineFormattingContext;
 class InlineLevelBox;
 
 class InlineFormattingUtils {
@@ -82,7 +82,7 @@ private:
     const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
 
 private:
-    const InlineFormattingContext& m_inlineFormattingContext;
+    CheckedRef<const InlineFormattingContext> m_inlineFormattingContext;
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -690,7 +690,7 @@ bool Line::hasTrailingForcedLineBreak(const RunList& runs)
 
 const InlineFormattingContext& Line::formattingContext() const
 {
-    return m_inlineFormattingContext;
+    return m_inlineFormattingContext.get();
 }
 
 Line::TrimmableTrailingContent::TrimmableTrailingContent(RunList& runs)
@@ -947,7 +947,7 @@ InlineLayoutUnit Line::Run::removeTrailingWhitespace()
         auto endPosition = m_textContent->start + m_textContent->length;
         RELEASE_ASSERT(startPosition < endPosition - trailingTrimmableContentLength);
         if (inlineTextBox.content()[endPosition - 1] == space)
-            trimmedWidth = TextUtil::trailingWhitespaceWidth(inlineTextBox, m_style.fontCascade(), startPosition, endPosition);
+            trimmedWidth = TextUtil::trailingWhitespaceWidth(inlineTextBox, m_style->fontCascade(), startPosition, endPosition);
     }
     m_textContent->length -= trailingTrimmableContentLength;
     m_trailingWhitespace = { };
@@ -981,12 +981,12 @@ bool Line::Run::isContentfulOrHasDecoration(const Run& run, const InlineFormatti
 
 bool Line::Run::hasTextCombine() const
 {
-    return m_style.hasTextCombine();
+    return m_style->hasTextCombine();
 }
 
 InlineLayoutUnit Line::Run::letterSpacing() const
 {
-    return m_style.usedLetterSpacing();
+    return m_style->usedLetterSpacing();
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
@@ -201,8 +201,8 @@ public:
         InlineLayoutUnit removeTrailingLetterSpacing();
 
         Type m_type { Type::Text };
-        const Box* m_layoutBox { nullptr };
-        const RenderStyle& m_style;
+        const CheckedPtr<const Box> m_layoutBox;
+        const CheckedRef<const RenderStyle> m_style;
         InlineLayoutUnit m_logicalLeft { 0 };
         InlineLayoutUnit m_logicalWidth { 0 };
         InlineDisplay::Box::Expansion m_expansion;
@@ -310,7 +310,7 @@ private:
         std::optional<TrailingContent> m_trailingContent { };
     };
 
-    const InlineFormattingContext& m_inlineFormattingContext;
+    const CheckedRef<const InlineFormattingContext> m_inlineFormattingContext;
     RunList m_runs;
     TrimmableTrailingContent m_trimmableTrailingContent;
     HangingContent m_hangingContent;
@@ -389,7 +389,7 @@ inline void Line::Run::setNeedsHyphen(InlineLayoutUnit hyphenLogicalWidth)
 
 inline TextDirection Line::Run::inlineDirection() const
 {
-    return m_style.writingMode().bidiDirection();
+    return m_style->writingMode().bidiDirection();
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
@@ -29,6 +29,7 @@
 #include <WebCore/InlineLayoutState.h>
 #include "InlineLineBuilder.h"
 #include <WebCore/TextUtil.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 namespace Layout {
@@ -70,7 +71,7 @@ private:
     const BlockLayoutState& blockLayoutState() const { return layoutState().parentBlockLayoutState(); }
 
 private:
-    const InlineFormattingContext& m_inlineFormattingContext;
+    CheckedRef<const InlineFormattingContext> m_inlineFormattingContext;
     LineLayoutResult& m_lineLayoutResult;
     bool m_fallbackFontRequiresIdeographicBaseline { false };
     bool m_lineHasNonLineSpanningRubyContent { false };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
@@ -65,7 +65,7 @@ private:
     const InlineLayoutState& layoutState() const { return formattingContext().layoutState(); }
 
 private:
-    const InlineFormattingContext& m_inlineFormattingContext;
+    CheckedRef<const InlineFormattingContext> m_inlineFormattingContext;
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
@@ -25,12 +25,13 @@
 
 #pragma once
 
+#include <WebCore/InlineFormattingContext.h>
 #include <WebCore/InlineLineBox.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 namespace Layout {
 
-class InlineFormattingContext;
 class LineBox;
 
 class InlineQuirks {
@@ -50,7 +51,7 @@ private:
     const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
 
 private:
-    const InlineFormattingContext& m_inlineFormattingContext;
+    const CheckedRef<const InlineFormattingContext> m_inlineFormattingContext;
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -91,7 +91,7 @@ InlineDisplayContentBuilder::InlineDisplayContentBuilder(InlineFormattingContext
     , m_lineBox(lineBox)
     , m_displayLine(displayLine)
 {
-    auto& initialContainingBlockGeometry = m_formattingContext.geometryForBox(FormattingContext::initialContainingBlock(root()), InlineFormattingContext::EscapeReason::InkOverflowNeedsInitialContiningBlockForStrokeWidth);
+    auto& initialContainingBlockGeometry = m_formattingContext->geometryForBox(FormattingContext::initialContainingBlock(root()), InlineFormattingContext::EscapeReason::InkOverflowNeedsInitialContiningBlockForStrokeWidth);
     m_initialContaingBlockSize = ceiledIntSize(LayoutSize { initialContainingBlockGeometry.contentBoxWidth(), initialContainingBlockGeometry.contentBoxHeight() });
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -28,6 +28,7 @@
 #include "InlineFormattingContext.h"
 #include "InlineLineBuilder.h"
 #include <WebCore/LayoutUnits.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Range.h>
 
 namespace WebCore {
@@ -85,13 +86,13 @@ private:
     const LineBox& lineBox() const { return m_lineBox; }
     size_t lineIndex() const { return lineBox().lineIndex(); }
     const ConstraintsForInlineContent& constraints() const { return m_constraints; }
-    const ElementBox& root() const { return m_formattingContext.root(); }
+    const ElementBox& root() const { return m_formattingContext->root(); }
     const RenderStyle& rootStyle() const { return lineIndex() ? root().style() : root().firstLineStyle(); }
     InlineFormattingContext& formattingContext() { return m_formattingContext; }
     const InlineFormattingContext& formattingContext() const { return m_formattingContext; }
 
 private:
-    InlineFormattingContext& m_formattingContext;
+    CheckedRef<InlineFormattingContext> m_formattingContext;
     const ConstraintsForInlineContent& m_constraints;
     const LineBox& m_lineBox;
     const InlineDisplay::Line& m_displayLine;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -372,13 +372,13 @@ void LineLayout::updateOverflow()
 std::pair<LayoutUnit, LayoutUnit> LineLayout::computeIntrinsicWidthConstraints()
 {
     auto parentBlockLayoutState = Layout::BlockLayoutState { m_blockFormattingState.placedFloats(), { } };
-    auto inlineFormattingContext = Layout::InlineFormattingContext { rootLayoutBox(), layoutState(), parentBlockLayoutState };
+    auto inlineFormattingContext = makeUnique<Layout::InlineFormattingContext>(rootLayoutBox(), layoutState(), parentBlockLayoutState);
     if (m_lineDamage)
         m_inlineContentCache.resetMinimumMaximumContentSizes();
     // FIXME: This is where we need to switch between minimum and maximum box geometries.
     // Currently we only support content where min == max.
     m_boxGeometryUpdater.setFormattingContextContentGeometry({ }, Layout::IntrinsicWidthMode::Minimum);
-    auto [minimumContentSize, maximumContentSize] = inlineFormattingContext.minimumMaximumContentSize(m_lineDamage.get());
+    auto [minimumContentSize, maximumContentSize] = inlineFormattingContext->minimumMaximumContentSize(m_lineDamage.get());
     return { minimumContentSize, maximumContentSize };
 }
 
@@ -483,18 +483,18 @@ std::optional<LayoutRect> LineLayout::layout(RenderBlockFlow::MarginInfo& margin
         intrusiveInitialLetterBottom(),
         lineGrid(flow())
     };
-    auto inlineFormattingContext = Layout::InlineFormattingContext { rootLayoutBox(), layoutState(), parentBlockLayoutState };
+    auto inlineFormattingContext = makeUnique<Layout::InlineFormattingContext>(rootLayoutBox(), layoutState(), parentBlockLayoutState);
     // Temporary, integration only.
-    inlineFormattingContext.layoutState().setNestedListMarkerOffsets(m_boxGeometryUpdater.takeNestedListMarkerOffsets());
+    inlineFormattingContext->layoutState().setNestedListMarkerOffsets(m_boxGeometryUpdater.takeNestedListMarkerOffsets());
 
-    auto layoutResult = inlineFormattingContext.layout(inlineContentConstraints(), m_lineDamage.get());
-    auto repaintRect = LayoutRect { constructContent(inlineFormattingContext.layoutState(), WTFMove(layoutResult)) };
+    auto layoutResult = inlineFormattingContext->layout(inlineContentConstraints(), m_lineDamage.get());
+    auto repaintRect = LayoutRect { constructContent(inlineFormattingContext->layoutState(), WTFMove(layoutResult)) };
 
     m_lineDamage = { };
 
     auto adjustments = adjustContentForPagination(parentBlockLayoutState, isPartialLayout);
 
-    updateRenderTreePositions(adjustments, inlineFormattingContext.layoutState(), layoutResult.didDiscardContent);
+    updateRenderTreePositions(adjustments, inlineFormattingContext->layoutState(), layoutResult.didDiscardContent);
 
     if (m_lineDamage) {
         // Pagination may require another layout pass.


### PR DESCRIPTION
#### d3c00af8594113a25b17ac65d8d1776754e93ddb
<pre>
[Safe CPP] Address warnings in InlineLine.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=303012">https://bugs.webkit.org/show_bug.cgi?id=303012</a>
<a href="https://rdar.apple.com/165277374">rdar://165277374</a>

Reviewed by NOBODY (OOPS!).

Address safer cpp warnings in InlineLine.h.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/layout/floats/FloatingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::formattingContext const):
(WebCore::Layout::Line::Run::removeTrailingWhitespace):
(WebCore::Layout::Line::Run::hasTextCombine const):
(WebCore::Layout::Line::Run::letterSpacing const):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.h:
(WebCore::Layout::Line::Run::inlineDirection const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::InlineDisplayContentBuilder):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
(WebCore::Layout::InlineDisplayContentBuilder::root const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::computeIntrinsicWidthConstraints):
(WebCore::LayoutIntegration::LineLayout::layout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3c00af8594113a25b17ac65d8d1776754e93ddb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132989 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5490 "Hash d3c00af8 for PR 54372 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85020 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134859 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5922 "Hash d3c00af8 for PR 54372 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5353 "Hash d3c00af8 for PR 54372 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101696 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69021 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e9ff87b-340b-4811-85f7-554dd8f4d6fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135935 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/5922 "Hash d3c00af8 for PR 54372 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82495 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c1528be5-4887-4f87-95c4-61e3ce859057) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/5922 "Hash d3c00af8 for PR 54372 does not build (failure)") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83759 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/5922 "Hash d3c00af8 for PR 54372 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143178 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5159 "Hash d3c00af8 for PR 54372 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110075 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5241 "Hash d3c00af8 for PR 54372 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/5353 "Hash d3c00af8 for PR 54372 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110255 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58730 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5213 "Hash d3c00af8 for PR 54372 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33776 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5054 "Hash d3c00af8 for PR 54372 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68665 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5303 "Hash d3c00af8 for PR 54372 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5171 "Hash d3c00af8 for PR 54372 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->