### PR TITLE
AudioVideoRenderer will constantly request for more data even if earlier request not serviced.

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -158,6 +158,8 @@ private:
     void updateAllRenderersHaveAvailableSamples();
     void setHasAvailableVideoFrame(bool);
     void setHasAvailableAudioSample(TrackIdentifier, bool);
+    void setHasRequestedAudioDataWhenReady(TrackIdentifier, bool);
+    bool hasRequestedAudioDataWhenReady(TrackIdentifier);
 
     std::optional<TrackType> typeOf(TrackIdentifier) const;
 
@@ -300,9 +302,11 @@ private:
 
     struct AudioTrackProperties {
         bool hasAudibleSample { false };
+        bool hasRequestedAudioDataWhenReady { false };
         Function<void(TrackIdentifier, const MediaTime&)> callbackForReenqueuing;
     };
     HashMap<TrackIdentifier, AudioTrackProperties> m_audioTracksMap;
+    bool m_hasRequestedVideoDataWhenReady { false };
     bool m_readyToRequestVideoData { true };
     bool m_readyToRequestAudioData { true };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -666,11 +666,6 @@ void SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples(TrackID trackId)
 {
     INFO_LOG(LOGIDENTIFIER, trackId);
 
-    if (auto trackIdentifier = trackIdentifierFor(trackId))
-        protectedRenderer()->stopRequestingMediaData(*trackIdentifier);
-    else
-        return;
-
     provideMediaData(trackId);
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1050,7 +1050,6 @@ void MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples(TrackID trackId)
     INFO_LOG(LOGIDENTIFIER, trackId);
 
     m_requestReadyForMoreSamplesSetMap[trackId] = false;
-    m_renderer->stopRequestingMediaData(trackIdentifierFor(trackId));
 
     provideMediaData(trackId);
 }


### PR DESCRIPTION
#### 2a2382187dbc549550ac8a4ca11a0a0f8672b0a6
<pre>
AudioVideoRenderer will constantly request for more data even if earlier request not serviced.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303001">https://bugs.webkit.org/show_bug.cgi?id=303001</a>
<a href="https://rdar.apple.com/165259808">rdar://165259808</a>

Reviewed by Eric Carlson.

The AVSampleBufferAudioRenderer can call the callback provided to `requestMediaDataWhenReadyOnQueue`
multiple times before stopRequestingMediaData is called.
When used across processes, it may call spuriously the callback before the
message to stop the request comes back.
There should be no need for the AudioVideoRenderer to ask to stop the requestMediaDataWhenReadyOnQueue
after each callback. So we make it part of the API.
The callback will now be called once, until the next requestMediaDataWhenReadyOnQueue
is issued.

Fly-By: Typo (m_readyToRequestVideoData vs m_readyToRequestAudioData) could
have caused audio callback to not be called if we were waiting on a video
flush.

* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::requestMediaDataWhenReady):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples):

Canonical link: <a href="https://commits.webkit.org/303456@main">https://commits.webkit.org/303456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31c2599401cbb5a5943ec7b8204415c79c92e39d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84468 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69de2f86-7ee4-493c-9b36-668326cef780) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101289 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68550 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0970fe27-c383-49c8-b2c9-3a0988dbfc27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135435 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82082 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8b9e6fa-3f84-4ccb-89db-66fafb8f4e1f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1273 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83239 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142659 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4654 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109664 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4020 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/109846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3533 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58021 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4708 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33308 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4665 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->