### PR TITLE
[GTK][WPE] Add CompositionReason enum and pass it to ThreadedCompositor when requesting a composition

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -89,7 +89,7 @@ void ScrollingTreeCoordinated::applyLayerPositionsInternal()
 
     if (ScrollingThread::isCurrentThread()) {
         auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();
-        rootContentsLayer->requestComposition();
+        rootContentsLayer->requestComposition(CompositionReason::AsyncScrolling);
     }
 }
 

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -88,6 +88,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+        platform/graphics/texmap/coordinated/CoordinatedCompositionReason.h
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedCompositionReason.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedCompositionReason.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+#include <wtf/EnumTraits.h>
+
+namespace WebCore {
+
+enum class CompositionReason : uint32_t {
+    RenderingUpdate = 1 << 0,
+    VideoFrame = 1 << 1,
+    Animation = 1 << 2,
+    AsyncScrolling = 1 << 3,
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::CompositionReason> {
+    using values = EnumValues<
+        WebCore::CompositionReason,
+        WebCore::CompositionReason::RenderingUpdate,
+        WebCore::CompositionReason::VideoFrame,
+        WebCore::CompositionReason::Animation,
+        WebCore::CompositionReason::AsyncScrolling
+    >;
+};
+
+} // namespace WTF
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -810,10 +810,10 @@ bool CoordinatedPlatformLayer::isCompositionRequiredOrOngoing() const
     return m_client ? m_client->isCompositionRequiredOrOngoing() : false;
 }
 
-void CoordinatedPlatformLayer::requestComposition()
+void CoordinatedPlatformLayer::requestComposition(CompositionReason reason)
 {
     if (m_client)
-        m_client->requestComposition();
+        m_client->requestComposition(reason);
 }
 
 RunLoop* CoordinatedPlatformLayer::compositingRunLoop() const

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
+#include "CoordinatedCompositionReason.h"
 #include "Damage.h"
 #include "FloatPoint.h"
 #include "FloatPoint3D.h"
@@ -74,7 +75,7 @@ public:
         virtual Ref<CoordinatedImageBackingStore> imageBackingStore(Ref<NativeImage>&&) = 0;
         virtual void notifyCompositionRequired() = 0;
         virtual bool isCompositionRequiredOrOngoing() const = 0;
-        virtual void requestComposition() = 0;
+        virtual void requestComposition(CompositionReason) = 0;
         virtual RunLoop* compositingRunLoop() const = 0;
         virtual int maxTextureSize() const = 0;
     };
@@ -181,7 +182,7 @@ public:
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
     bool isCompositionRequiredOrOngoing() const;
-    void requestComposition();
+    void requestComposition(CompositionReason);
     RunLoop* compositingRunLoop() const;
     int maxTextureSize() const;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
@@ -99,7 +99,7 @@ void CoordinatedPlatformLayerBufferProxy::setDisplayBuffer(std::unique_ptr<Coord
         Locker layerLocker { layer->lock() };
         layer->setContentsBuffer(WTFMove(buffer), std::nullopt, CoordinatedPlatformLayer::RequireComposition::No);
     }
-    layer->requestComposition();
+    layer->requestComposition(CompositionReason::VideoFrame);
 }
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -226,7 +226,7 @@ void LayerTreeHost::updateRendering()
 
     bool didChangeSceneState = m_sceneState->flush();
     if (m_compositionRequired || m_pendingResize || m_forceFrameSync || didChangeSceneState)
-        commitSceneState();
+        requestCompositionForRenderingUpdate();
 
     m_compositionRequired = false;
     m_pendingResize = false;
@@ -407,7 +407,7 @@ bool LayerTreeHost::isCompositionRequiredOrOngoing() const
     return m_compositionRequired || m_forceFrameSync || m_compositor->isActive();
 }
 
-void LayerTreeHost::requestComposition()
+void LayerTreeHost::requestComposition(CompositionReason reason)
 {
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {
@@ -417,7 +417,7 @@ void LayerTreeHost::requestComposition()
     }
 #endif
 
-    m_compositor->scheduleUpdate();
+    m_compositor->requestComposition(reason);
 }
 
 RunLoop* LayerTreeHost::compositingRunLoop() const
@@ -467,7 +467,7 @@ void LayerTreeHost::didRenderFrame()
     }
 }
 
-void LayerTreeHost::commitSceneState()
+void LayerTreeHost::requestCompositionForRenderingUpdate()
 {
     m_isWaitingForRenderer = true;
     m_compositor->requestCompositionForRenderingUpdate([this] {
@@ -490,7 +490,7 @@ void LayerTreeHost::commitSceneState()
 
         WTFEndSignpost(this, DidComposite);
     });
-    WTFEmitSignpost(this, CommitSceneState);
+    WTFEmitSignpost(this, RequestCompositionForRenderingUpdate);
 }
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -126,7 +126,7 @@ private:
     void invalidateRenderingUpdateRunLoopObserver();
     void renderingUpdateRunLoopObserverFired();
     void updateRendering();
-    void commitSceneState();
+    void requestCompositionForRenderingUpdate();
 
     // CoordinatedPlatformLayer::Client
 #if USE(CAIRO)
@@ -140,7 +140,7 @@ private:
     void detachLayer(WebCore::CoordinatedPlatformLayer&) override;
     void notifyCompositionRequired() override;
     bool isCompositionRequiredOrOngoing() const override;
-    void requestComposition() override;
+    void requestComposition(WebCore::CompositionReason) override;
     RunLoop* compositingRunLoop() const override;
     int maxTextureSize() const override;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -404,7 +404,7 @@ bool LayerTreeHost::isCompositionRequiredOrOngoing() const
     return m_compositionRequired || m_forceFrameSync || m_compositor->isActive();
 }
 
-void LayerTreeHost::requestComposition()
+void LayerTreeHost::requestComposition(CompositionReason)
 {
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
@@ -150,7 +150,7 @@ private:
     void detachLayer(WebCore::CoordinatedPlatformLayer&) override;
     void notifyCompositionRequired() override;
     bool isCompositionRequiredOrOngoing() const override;
-    void requestComposition() override;
+    void requestComposition(WebCore::CompositionReason) override;
     RunLoop* compositingRunLoop() const override;
     int maxTextureSize() const override;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
+#include <WebCore/CoordinatedCompositionReason.h>
 #include <WebCore/Damage.h>
 #include <WebCore/DisplayUpdate.h>
 #include <WebCore/GLContext.h>
@@ -71,7 +72,7 @@ public:
 
     void setSize(const WebCore::IntSize&, float);
     void requestCompositionForRenderingUpdate(Function<void()>&&);
-    void scheduleUpdate();
+    void requestComposition(CompositionReason);
     RunLoop* runLoop();
 
     void invalidate();
@@ -129,6 +130,7 @@ private:
     struct {
         mutable Lock lock;
         State state WTF_GUARDED_BY_LOCK(lock) { State::Idle };
+        OptionSet<WebCore::CompositionReason> reasons WTF_GUARDED_BY_LOCK(lock);
         Function<void()> didCompositeRenderinUpdateFunction WTF_GUARDED_BY_LOCK(lock);
     } m_state;
 


### PR DESCRIPTION
#### 558de671b9bb49c5e6074093d10dff5c656edb19
<pre>
[GTK][WPE] Add CompositionReason enum and pass it to ThreadedCompositor when requesting a composition
<a href="https://bugs.webkit.org/show_bug.cgi?id=303021">https://bugs.webkit.org/show_bug.cgi?id=303021</a>

Reviewed by Miguel Gomez.

This way the compositor can know the reasons why it&apos;s compositing. For
now it&apos;s only used to show the reasons in sysprof, but it will be used
to decide how to update the layers depending on the pending changes.

Canonical link: <a href="https://commits.webkit.org/303479@main">https://commits.webkit.org/303479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7e6922efb157432bc7e133d74c155db6a3a4ba6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84479 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4752 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101298 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68559 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135444 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3547 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142669 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109673 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109855 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3541 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58036 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4717 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33316 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4551 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68168 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->