### PR TITLE
AudioVideoRenderer::requestMediaDataWhenReady should return a NativePromise

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -144,8 +144,8 @@ public:
 
     virtual void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime> = std::nullopt) = 0;
     virtual bool isReadyForMoreSamples(TrackIdentifier) = 0;
-    virtual void requestMediaDataWhenReady(TrackIdentifier, Function<void(TrackIdentifier)>&&) = 0;
-    virtual void stopRequestingMediaData(TrackIdentifier) = 0;
+    using RequestPromise = NativePromise<TrackIdentifier, PlatformMediaError>;
+    virtual Ref<RequestPromise> requestMediaDataWhenReady(TrackIdentifier) = 0;
     virtual void notifyTrackNeedsReenqueuing(TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>&&) { }
 
     virtual bool timeIsProgressing() const = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -739,13 +739,9 @@ void SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples(TrackID trackId)
 void SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples(TrackID trackId)
 {
     if (auto trackIdentifier = trackIdentifierFor(trackId)) {
-        protectedRenderer()->requestMediaDataWhenReady(*trackIdentifier, [weakThis = ThreadSafeWeakPtr { *this }, trackId](auto) {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-            protectedThis->ensureWeakOnDispatcher<SourceBufferPrivateAVFObjC>([trackId](auto& buffer) {
-                buffer.didBecomeReadyForMoreSamples(trackId);
-            });
+        protectedRenderer()->requestMediaDataWhenReady(*trackIdentifier)->whenSettled(m_dispatcher, [weakThis = ThreadSafeWeakPtr { *this }, trackId](auto&& result) {
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && result)
+                protectedThis->didBecomeReadyForMoreSamples(trackId);
         });
     }
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1031,11 +1031,9 @@ void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId
     auto trackIdentifier = maybeTrackIdentifierFor(trackId);
     if (!trackIdentifier)
         return; // track hasn't been enabled yet.
-    m_renderer->requestMediaDataWhenReady(*trackIdentifier, [weakThis = ThreadSafeWeakPtr { *this }, trackId](AudioVideoRenderer::TrackIdentifier) {
-        ensureOnMainThread([weakThis, trackId] {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->didBecomeReadyForMoreSamples(trackId);
-        });
+    m_renderer->requestMediaDataWhenReady(*trackIdentifier)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, trackId](auto&& result) {
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && result)
+            protectedThis->didBecomeReadyForMoreSamples(trackId);
     });
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -96,7 +96,6 @@ private:
 
     void enqueueSample(RemoteAudioVideoRendererIdentifier, TrackIdentifier, WebCore::MediaSamplesBlock&&, std::optional<MediaTime>, CompletionHandler<void(bool)>&&);
     void requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
-    void stopRequestingMediaData(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
 
     void notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier, const MediaTime&);
     void cancelTimeReachedAction(RemoteAudioVideoRendererIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -42,7 +42,6 @@ messages -> RemoteAudioVideoRendererProxyManager {
 
     EnqueueSample(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier, WebCore::MediaSamplesBlock block, std::optional<MediaTime> upcomingMinimumTime) -> (bool readyForMoreData);
     RequestMediaDataWhenReady(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
-    StopRequestingMediaData(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
 
     NotifyTimeReachedAndStall(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime time)
     CancelTimeReachedAction(WebKit::RemoteAudioVideoRendererIdentifier identifier)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -514,24 +514,17 @@ bool AudioVideoRendererRemote::isReadyForMoreSamples(TrackIdentifier trackIdenti
     return readyForMoreDataState(trackIdentifier).isReadyForMoreData();
 }
 
-void AudioVideoRendererRemote::requestMediaDataWhenReady(TrackIdentifier trackIdentifier, Function<void(TrackIdentifier)>&& callback)
+Ref<AudioVideoRenderer::RequestPromise> AudioVideoRendererRemote::requestMediaDataWhenReady(TrackIdentifier trackIdentifier)
 {
-    ensureOnDispatcherWithConnection([trackIdentifier, callback = WTFMove(callback)](auto& renderer, auto& connection) mutable {
+    return invokeAsync(queueSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, trackIdentifier] {
         assertIsCurrent(queueSingleton());
-        if (renderer.isReadyForMoreSamples(trackIdentifier)) {
-            callback(trackIdentifier);
-            return;
-        }
-        auto addResult = renderer.m_requestMediaDataWhenReadyDataCallbacks.add(trackIdentifier, nullptr);
-        addResult.iterator->value = WTFMove(callback);
-    });
-}
-
-void AudioVideoRendererRemote::stopRequestingMediaData(TrackIdentifier trackIdentifier)
-{
-    ensureOnDispatcherWithConnection([trackIdentifier](auto& renderer, auto& connection) {
-        assertIsCurrent(queueSingleton());
-        renderer.m_requestMediaDataWhenReadyDataCallbacks.remove(trackIdentifier);
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return RequestPromise::createAndReject(PlatformMediaError::Cancelled);
+        if (protectedThis->isReadyForMoreSamples(trackIdentifier))
+            return RequestPromise::createAndResolve(trackIdentifier);
+        auto addResult = protectedThis->m_requestMediaDataWhenReadyDataPromises.set(trackIdentifier, makeUnique<RequestPromise::AutoRejectProducer>(PlatformMediaError::Cancelled));
+        return addResult.iterator->value->promise();
     });
 }
 
@@ -687,10 +680,10 @@ void AudioVideoRendererRemote::resolveRequestMediaDataWhenReadyIfNeeded(TrackIde
 
     if (!isReadyForMoreSamples(trackIdentifier))
         return;
-    auto iterator = m_requestMediaDataWhenReadyDataCallbacks.find(trackIdentifier);
-    if (iterator == m_requestMediaDataWhenReadyDataCallbacks.end() || !iterator->value)
+    auto iterator = m_requestMediaDataWhenReadyDataPromises.find(trackIdentifier);
+    if (iterator == m_requestMediaDataWhenReadyDataPromises.end())
         return;
-    iterator->value(trackIdentifier);
+    m_requestMediaDataWhenReadyDataPromises.take(iterator)->resolve(trackIdentifier);
 }
 
 void AudioVideoRendererRemote::requestHostingContext(LayerHostingContextCallback&& completionHandler)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -157,8 +157,7 @@ private:
 
     void enqueueSample(TrackIdentifier, Ref<WebCore::MediaSample>&&, std::optional<MediaTime>) final;
     bool isReadyForMoreSamples(TrackIdentifier) final;
-    void requestMediaDataWhenReady(TrackIdentifier, Function<void(TrackIdentifier)>&&) final;
-    void stopRequestingMediaData(TrackIdentifier) final;
+    Ref<RequestPromise> requestMediaDataWhenReady(TrackIdentifier) final;
     void notifyTrackNeedsReenqueuing(TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>&&) final;
 
     bool timeIsProgressing() const final;
@@ -257,7 +256,7 @@ private:
     Function<void(const MediaTime&, WebCore::FloatSize)> m_videoLayerSizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
 
     HashMap<TrackIdentifier, ReadyForMoreDataState> m_readyForMoreDataStates WTF_GUARDED_BY_LOCK(m_lock);
-    HashMap<TrackIdentifier, Function<void(TrackIdentifier)>> m_requestMediaDataWhenReadyDataCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    HashMap<TrackIdentifier, std::unique_ptr<RequestPromise::AutoRejectProducer>> m_requestMediaDataWhenReadyDataPromises WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     HashMap<TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>> m_trackNeedsReenqueuingCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
 
     Vector<LayerHostingContextCallback> m_layerHostingContextRequests WTF_GUARDED_BY_CAPABILITY(queueSingleton());


### PR DESCRIPTION
#### 53acf55d821f527c352c60180d58a03631c612d5
<pre>
AudioVideoRenderer::requestMediaDataWhenReady should return a NativePromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=303017">https://bugs.webkit.org/show_bug.cgi?id=303017</a>
<a href="https://rdar.apple.com/165288972">rdar://165288972</a>

Reviewed by Gerald Squelart.

Following 303456@main, AudioVideoRenderer::requestMediaDataWhenReady will
only ever call once the callback provided. To enforce it at the API level
we make it return a `RequestPromise` instead.
NativePromise also ensures that the callback is always executed on the expected
workqueue/thread.

Remove AudioVideoRenderer::stopRequestingMediaData API as it&apos;s no longer
used.

No change in existing behaviour. Covered by existing tests.
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::requestMediaDataWhenReady):
(WebCore::AudioVideoRendererAVFObjC::audioTrackPropertiesFor):
(WebCore::AudioVideoRendererAVFObjC::stopRequestingMediaData): Deleted.
(WebCore::AudioVideoRendererAVFObjC::setHasRequestedAudioDataWhenReady): Deleted.
(WebCore::AudioVideoRendererAVFObjC::hasRequestedAudioDataWhenReady): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady):
(WebKit::RemoteAudioVideoRendererProxyManager::stopRequestingMediaData): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::requestMediaDataWhenReady):
(WebKit::AudioVideoRendererRemote::resolveRequestMediaDataWhenReadyIfNeeded):
(WebKit::AudioVideoRendererRemote::stopRequestingMediaData): Deleted.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h: HashMap doesn&apos;t
play well with object (AutoRejectProducer) that have a delete copy constructor.
AutoRejectProducer contains a LogSiteIdentifier which has const member. So we have to use an std::unique_ptr instead.

Canonical link: <a href="https://commits.webkit.org/303486@main">https://commits.webkit.org/303486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50bce613d55b872890c9c18d59ca794ad5df59fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140131 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87d48a2a-bc7e-4bc2-8a67-57e35f8a9e99) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4864 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ccb3be14-35e8-4df3-a2d5-b9664d6a9a1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135556 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2374c455-41f9-4fda-a813-2331c8fa4246) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83366 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142786 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4775 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37498 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4857 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109937 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27853 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3633 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58215 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4829 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4920 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->