### PR TITLE
[Safe CPP] Address warnings in RenderIterator.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -66,7 +66,6 @@ platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 rendering/BidiRun.cpp
 rendering/BidiRun.h
 rendering/RenderAncestorIterator.h
-rendering/RenderIterator.h
 rendering/RenderMultiColumnSet.h
 rendering/cocoa/RenderThemeCocoa.mm
 rendering/svg/RenderSVGResourcePattern.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -52,7 +52,6 @@ rendering/RenderDescendantIterator.h
 rendering/RenderFlexibleBox.cpp
 rendering/RenderFragmentContainer.h
 rendering/RenderGeometryMap.h
-rendering/RenderIterator.h
 rendering/RenderLayer.h
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerBacking.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -505,7 +505,6 @@ rendering/RenderImageResource.cpp
 rendering/RenderImageResourceStyleImage.cpp
 rendering/RenderImageResourceStyleImage.h
 rendering/RenderInline.cpp
-rendering/RenderIterator.h
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerBacking.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -339,7 +339,6 @@ rendering/RenderGrid.cpp
 rendering/RenderImage.cpp
 rendering/RenderImageResourceStyleImage.cpp
 rendering/RenderInline.cpp
-rendering/RenderIterator.h
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp

--- a/Source/WebCore/rendering/RenderIterator.h
+++ b/Source/WebCore/rendering/RenderIterator.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "RenderElement.h"
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -52,7 +53,7 @@ public:
     RenderIterator& traverseAncestor();
 
 private:
-    const RenderElement* m_root;
+    CheckedPtr<const RenderElement> m_root;
     T* m_current;
 };
 
@@ -76,7 +77,7 @@ public:
     RenderConstIterator& traverseAncestor();
 
 private:
-    const RenderElement* m_root;
+    CheckedPtr<const RenderElement> m_root;
     const T* m_current;
 };
 
@@ -96,7 +97,7 @@ public:
     RenderPostOrderIterator& traverseNext();
 
 private:
-    const RenderElement* m_root;
+    CheckedPtr<const RenderElement> m_root;
     T* m_current;
 };
 
@@ -116,7 +117,7 @@ public:
     RenderPostOrderConstIterator& traverseNext();
 
 private:
-    const RenderElement* m_root;
+    CheckedPtr<const RenderElement> m_root;
     const T* m_current;
 };
 
@@ -320,7 +321,7 @@ template <typename T>
 inline RenderIterator<T>& RenderIterator<T>::traverseNext()
 {
     ASSERT(m_current);
-    m_current = RenderTraversal::next<T>(*m_current, m_root);
+    m_current = RenderTraversal::next<T>(*m_current, m_root.get());
     return *this;
 }
 
@@ -328,7 +329,7 @@ template <typename T>
 inline RenderIterator<T>& RenderIterator<T>::traverseNextSkippingChildren()
 {
     ASSERT(m_current);
-    m_current = RenderObjectTraversal::nextSkippingChildren(*m_current, m_root);
+    m_current = RenderObjectTraversal::nextSkippingChildren(*m_current, m_root.get());
     return *this;
 }
 
@@ -344,7 +345,7 @@ template <typename T>
 inline RenderIterator<T>& RenderIterator<T>::traverseAncestor()
 {
     ASSERT(m_current);
-    ASSERT(m_current != m_root);
+    ASSERT(m_current != m_root.get());
     m_current = RenderTraversal::findAncestorOfType<T>(*m_current);
     return *this;
 }
@@ -398,7 +399,7 @@ template <typename T>
 inline RenderConstIterator<T>& RenderConstIterator<T>::traverseNext()
 {
     ASSERT(m_current);
-    m_current = RenderTraversal::next<T>(*m_current, m_root);
+    m_current = RenderTraversal::next<T>(*m_current, m_root.get());
     return *this;
 }
 
@@ -406,7 +407,7 @@ template <typename T>
 inline RenderConstIterator<T>& RenderConstIterator<T>::traverseNextSkippingChildren()
 {
     ASSERT(m_current);
-    m_current = RenderObjectTraversal::nextSkippingChildren(*m_current, m_root);
+    m_current = RenderObjectTraversal::nextSkippingChildren(*m_current, m_root.get());
     return *this;
 }
 
@@ -423,7 +424,7 @@ template <typename T>
 inline RenderConstIterator<T>& RenderConstIterator<T>::traverseAncestor()
 {
     ASSERT(m_current);
-    ASSERT(m_current != m_root);
+    ASSERT(m_current != m_root.get());
     m_current = RenderTraversal::findAncestorOfType<const T>(*m_current);
     return *this;
 }
@@ -469,7 +470,7 @@ template <typename T>
 inline RenderPostOrderIterator<T>& RenderPostOrderIterator<T>::traverseNext()
 {
     ASSERT(m_current);
-    m_current = RenderPostOrderTraversal::next<T>(*m_current, m_root);
+    m_current = RenderPostOrderTraversal::next<T>(*m_current, m_root.get());
     return *this;
 }
 
@@ -514,7 +515,7 @@ template <typename T>
 inline RenderPostOrderConstIterator<T>& RenderPostOrderConstIterator<T>::traverseNext()
 {
     ASSERT(m_current);
-    m_current = RenderPostOrderTraversal::next<T>(*m_current, m_root);
+    m_current = RenderPostOrderTraversal::next<T>(*m_current, m_root.get());
     return *this;
 }
 


### PR DESCRIPTION
#### a16e36139da27b4ddd765c2adff8d518d6755264
<pre>
[Safe CPP] Address warnings in RenderIterator.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=303026">https://bugs.webkit.org/show_bug.cgi?id=303026</a>
<a href="https://rdar.apple.com/problem/165305239">rdar://problem/165305239</a>

Reviewed by NOBODY (OOPS!).

Address safer cpp warnings in RenderIterator.h

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/rendering/RenderIterator.h:
(WebCore::RenderIterator&lt;T&gt;::traverseNext):
(WebCore::RenderIterator&lt;T&gt;::traverseNextSkippingChildren):
(WebCore::RenderIterator&lt;T&gt;::traverseAncestor):
(WebCore::RenderConstIterator&lt;T&gt;::traverseNext):
(WebCore::RenderConstIterator&lt;T&gt;::traverseNextSkippingChildren):
(WebCore::RenderConstIterator&lt;T&gt;::traverseAncestor):
(WebCore::RenderPostOrderIterator&lt;T&gt;::traverseNext):
(WebCore::RenderPostOrderConstIterator&lt;T&gt;::traverseNext):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a16e36139da27b4ddd765c2adff8d518d6755264

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84525 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d5c69d40-8962-495f-aa06-59759e4ec225) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101321 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68601 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fab00956-f28f-40ce-b001-e09bca7d339d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82116 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3576349-3df8-4cc0-966f-ba90e53ae436) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3854 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83284 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142702 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109697 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109879 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3570 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58107 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4750 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33341 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4585 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68201 "Found 29 new failures in rendering/RenderIterator.h") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4841 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->