### PR TITLE
Streamline handling of null-terminated strings to improve clarity and safety

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -44,17 +44,8 @@ JSStringRef JSStringCreateWithCharacters(const JSChar* chars, size_t numChars)
 JSStringRef JSStringCreateWithUTF8CString(const char* string)
 {
     JSC::initialize();
-    if (string) {
-        auto stringSpan = unsafeSpan8(string);
-        Vector<char16_t, 1024> buffer(stringSpan.size());
-        auto result = WTF::Unicode::convert(spanReinterpretCast<const char8_t>(stringSpan), buffer.mutableSpan());
-        if (result.code == WTF::Unicode::ConversionResultCode::Success) {
-            if (result.isAllASCII)
-                return &OpaqueJSString::create(stringSpan).leakRef();
-            return &OpaqueJSString::create(result.buffer).leakRef();
-        }
-    }
-
+    if (auto result = OpaqueJSString::tryCreate(byteCast<char8_t>(unsafeSpan(string))))
+        return result.leakRef();
     return &OpaqueJSString::create().leakRef();
 }
 

--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1285,7 +1285,7 @@ static StructHandlers* createStructHandlerMap()
             return;
         {
             auto type = adoptSystemMalloc(method_copyArgumentType(method, 2));
-            structHandlers->add(StringImpl::createFromCString(type.get()), (StructTagHandler) { selector, 0 });
+            structHandlers->add(byteCast<Latin1Character>(unsafeSpan(type.get())), StructTagHandler { selector, nullptr });
         }
     });
 

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -144,11 +144,7 @@ public:
     bool isPrivateName() const { return isSymbol() && static_cast<const SymbolImpl*>(impl())->isPrivate(); }
 
     friend bool operator==(const Identifier&, const Identifier&);
-    friend bool operator==(const Identifier&, const Latin1Character*);
-    friend bool operator==(const Identifier&, const char*);
 
-    static bool equal(const StringImpl*, const Latin1Character*);
-    static inline bool equal(const StringImpl* a, const char* b) { return Identifier::equal(a, byteCast<Latin1Character>(b)); };
     static bool equal(const StringImpl*, std::span<const Latin1Character>);
     static bool equal(const StringImpl*, std::span<const char16_t>);
     static bool equal(const StringImpl* a, const StringImpl* b) { return ::equal(a, b); }
@@ -175,7 +171,6 @@ private:
     { }
 
     static bool equal(const Identifier& a, const Identifier& b) { return a.m_string.impl() == b.m_string.impl(); }
-    static bool equal(const Identifier& a, const Latin1Character* b) { return equal(a.m_string.impl(), b); }
 
     template <typename T> inline static Ref<AtomStringImpl> add(VM&, std::span<const T>); // Defined in IdentifierInlines.h
     static Ref<AtomStringImpl> add8(VM&, std::span<const char16_t>);
@@ -205,21 +200,6 @@ template <> ALWAYS_INLINE constexpr bool Identifier::canUseSingleCharacterString
 inline bool operator==(const Identifier& a, const Identifier& b)
 {
     return Identifier::equal(a, b);
-}
-
-inline bool operator==(const Identifier& a, const Latin1Character* b)
-{
-    return Identifier::equal(a, b);
-}
-
-inline bool operator==(const Identifier& a, const char* b)
-{
-    return Identifier::equal(a, byteCast<Latin1Character>(b));
-}
-
-inline bool Identifier::equal(const StringImpl* r, const Latin1Character* s)
-{
-    return WTF::equal(r, s);
 }
 
 inline bool Identifier::equal(const StringImpl* r, std::span<const Latin1Character> s)

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1452,7 +1452,7 @@ void Option::dump(StringBuilder& builder) const
         builder.append(unsafeSpan(m_optionRange.rangeString()));
         break;
     case Options::Type::OptionString:
-        builder.append('"', m_optionString ? unsafeSpan8(m_optionString) : ""_span8, '"');
+        builder.append('"', m_optionString ? unsafeSpan(m_optionString) : ""_span, '"');
         break;
     case Options::Type::GCLogLevel:
         builder.append(m_gcLogLevel);

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -184,7 +184,7 @@ ALWAYS_INLINE bool ParserBase::consumeUTF8String(Name& result, size_t stringLeng
     if (!result.tryReserveCapacity(stringLength))
         return false;
 
-    auto string = spanReinterpretCast<const char8_t>(m_source.subspan(m_offset, stringLength));
+    auto string = byteCast<char8_t>(m_source.subspan(m_offset, stringLength));
     if (auto checkResult = WTF::Unicode::checkUTF8(string); checkResult.characters.size() != string.size())
         return false;
 

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -67,7 +67,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 static String fromStdFileSystemPath(const std::filesystem::path& path)
 {
 #if HAVE(MISSING_U8STRING)
-    return String::fromUTF8(unsafeSpan8(path.u8string().c_str()));
+    // FIXME: This uses u8string so how can it be correct inside HAVE(MISSING_U8STRING)?
+    return String::fromUTF8(unsafeSpan(path.u8string().c_str()));
 #else
     return String::fromUTF8(span(path.u8string()));
 #endif

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -77,7 +77,6 @@ public:
     constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
     constexpr std::span<const char> span() const { return m_charactersWithNullTerminator.first(length()); }
     std::span<const Latin1Character> span8() const { return byteCast<Latin1Character>(m_charactersWithNullTerminator.first(length())); }
-    std::span<const char8_t> spanChar8() const { return byteCast<char8_t>(m_charactersWithNullTerminator.first(length())); }
     std::span<const char> spanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
     size_t isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
@@ -173,14 +172,9 @@ constexpr std::span<const Latin1Character> operator""_span8(const char* characte
     return span;
 }
 
-constexpr std::span<const char8_t> operator""_spanChar8(const char* characters, size_t n)
+constexpr std::span<const char8_t> operator""_span(const char8_t* characters, size_t n)
 {
-    auto span = byteCast<char8_t>(unsafeMakeSpan(characters, n));
-#if ASSERT_ENABLED
-    for (size_t i = 0, size = span.size(); i < size; ++i)
-        ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(span[i]));
-#endif
-    return span;
+    return unsafeMakeSpan(characters, n);
 }
 
 } // inline StringLiterals

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -52,27 +52,6 @@ inline std::span<const char16_t> span(const char16_t& character)
     return unsafeMakeSpan(&character, 1);
 }
 
-inline std::span<const Latin1Character> unsafeSpan8(const char* string)
-{
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return unsafeMakeSpan(byteCast<Latin1Character>(string), string ? strlen(string) : 0);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
-inline std::span<const char8_t> unsafeSpanChar8(const char* string)
-{
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return unsafeMakeSpan(byteCast<char8_t>(string), string ? strlen(string) : 0);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
-inline std::span<const Latin1Character> unsafeSpan8IncludingNullTerminator(const char* string)
-{
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return unsafeMakeSpan(byteCast<Latin1Character>(string), string ? strlen(string) + 1 : 0);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
 inline std::span<const char> unsafeSpan(const char* string)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -84,13 +63,6 @@ inline std::span<const char> unsafeSpanIncludingNullTerminator(const char* strin
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(string, string ? strlen(string) + 1 : 0);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
-inline std::span<const Latin1Character> unsafeSpan(const Latin1Character* string)
-{
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return unsafeMakeSpan(string, string ? strlen(byteCast<char>(string)) : 0);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
@@ -510,7 +482,7 @@ bool equalIgnoringASCIICaseCommon(const StringClassA& a, const StringClassB& b)
 
 template<typename StringClassA> bool equalIgnoringASCIICaseCommon(const StringClassA& a, const char* b)
 {
-    auto bSpan = unsafeSpan8(b);
+    auto bSpan = unsafeSpan(b);
     if (a.length() != bSpan.size())
         return false;
     if (a.is8Bit())
@@ -1033,7 +1005,7 @@ template<typename StringClass> inline bool startsWithLettersIgnoringASCIICaseCom
 
 inline bool equalIgnoringASCIICase(const char* a, const char* b)
 {
-    return equalIgnoringASCIICase(unsafeSpan8(a), unsafeSpan8(b));
+    return equalIgnoringASCIICase(unsafeSpan(a), unsafeSpan(b));
 }
 
 inline bool equalLettersIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
@@ -1043,7 +1015,7 @@ inline bool equalLettersIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
 
 inline bool equalIgnoringASCIICase(const char* string, ASCIILiteral literal)
 {
-    return equalIgnoringASCIICase(unsafeSpan8(string), literal.span8());
+    return equalIgnoringASCIICase(unsafeSpan(string), literal.span());
 }
 
 inline bool equalIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
@@ -1470,7 +1442,4 @@ using WTF::startsWith;
 using WTF::startsWithLettersIgnoringASCIICase;
 using WTF::strlenSpan;
 using WTF::unsafeSpan;
-using WTF::unsafeSpan8;
-using WTF::unsafeSpanChar8;
 using WTF::unsafeSpanIncludingNullTerminator;
-using WTF::unsafeSpan8IncludingNullTerminator;

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -120,22 +120,6 @@ private:
     char32_t m_character;
 };
 
-template<> class StringTypeAdapter<const Latin1Character*> {
-public:
-    StringTypeAdapter(const Latin1Character* characters)
-        : m_characters { unsafeSpan(characters) }
-    {
-        RELEASE_ASSERT(m_characters.size() <= String::MaxLength);
-    }
-
-    unsigned length() const { return m_characters.size(); }
-    bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_characters); }
-
-private:
-    std::span<const Latin1Character> m_characters;
-};
-
 template<> class StringTypeAdapter<const char16_t*> {
 public:
     StringTypeAdapter(const char16_t* characters)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -264,9 +264,6 @@ public:
     // Construct a string with UTF-8 data, null if it contains invalid UTF-8 sequences.
     WTF_EXPORT_PRIVATE static RefPtr<StringImpl> create(std::span<const char8_t>);
 
-    // Not using create() naming to encourage developers to call create(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(unsafeSpan8(characters)); }
-
     static Ref<StringImpl> createSubstringSharingImpl(StringImpl&, unsigned offset, unsigned length);
 
     ALWAYS_INLINE static Ref<StringImpl> create(ASCIILiteral literal) { return createWithoutCopying(literal.span8()); }
@@ -622,11 +619,11 @@ template<> struct ValueCheck<StringImpl*> {
 
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const StringImpl*);
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, std::span<const Latin1Character>);
-inline bool equal(const StringImpl* a, const char* b) { return equal(a, unsafeSpan8(b)); }
+inline bool equal(const StringImpl* a, const char* b) { return equal(a, byteCast<Latin1Character>(unsafeSpan(b))); }
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, std::span<const char16_t>);
 ALWAYS_INLINE bool equal(const StringImpl* a, ASCIILiteral b) { return equal(a, b.span8()); }
 inline bool equal(const StringImpl* a, std::span<const char> b) { return equal(a, byteCast<Latin1Character>(b)); }
-inline bool equal(const char* a, StringImpl* b) { return equal(b, unsafeSpan8(a)); }
+inline bool equal(const char* a, StringImpl* b) { return equal(b, byteCast<Latin1Character>(unsafeSpan(a))); }
 WTF_EXPORT_PRIVATE bool equal(const StringImpl& a, const StringImpl& b);
 
 WTF_EXPORT_PRIVATE bool equalIgnoringNullity(StringImpl*, StringImpl*);

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -65,7 +65,7 @@ String::String(std::span<const char> characters)
 
 // Construct a string with Latin-1 data, from a null-terminated source.
 String::String(const char* nullTerminatedString)
-    : m_impl(nullTerminatedString ? RefPtr { StringImpl::createFromCString(nullTerminatedString) } : nullptr)
+    : m_impl(nullTerminatedString ? RefPtr { StringImpl::create(byteCast<Latin1Character>(unsafeSpan(nullTerminatedString))) } : nullptr)
 {
 }
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -272,14 +272,18 @@ public:
     WTF_EXPORT_PRIVATE void convertTo16Bit();
 
     // String::fromUTF8 will return a null string if the input data contains invalid UTF-8 sequences.
+    // FIXME: Deprecated: Use constructor that takes span<const char8_t>.
     WTF_EXPORT_PRIVATE static String fromUTF8(std::span<const char8_t>);
-    static String fromUTF8(std::span<const Latin1Character> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
-    static String fromUTF8(std::span<const char> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
-    static String fromUTF8(const char* string) { return fromUTF8(unsafeSpan8(string)); }
+    static String fromUTF8(std::span<const Latin1Character> characters) { return byteCast<char8_t>(characters); }
+    static String fromUTF8(std::span<const char> characters) { return byteCast<char8_t>(characters); }
+    static String fromUTF8(const char* string) { return byteCast<char8_t>(unsafeSpan(string)); }
+
+    // Convert each invalid UTF-8 sequence into a replacement character.
     static String fromUTF8ReplacingInvalidSequences(std::span<const char8_t>);
     static String fromUTF8ReplacingInvalidSequences(std::span<const Latin1Character> characters) { return fromUTF8ReplacingInvalidSequences(byteCast<char8_t>(characters)); }
 
     // Tries to convert the passed in string to UTF-8, but will fall back to Latin-1 if the string is not valid UTF-8.
+    // FIXME: Deprecated: Use fromUTF8ReplacingInvalidSequences.
     WTF_EXPORT_PRIVATE static String fromUTF8WithLatin1Fallback(std::span<const char8_t>);
     static String fromUTF8WithLatin1Fallback(std::span<const Latin1Character> characters) { return fromUTF8WithLatin1Fallback(byteCast<char8_t>(characters)); }
     static String fromUTF8WithLatin1Fallback(std::span<const char> characters) { return fromUTF8WithLatin1Fallback(byteCast<char8_t>(characters)); }

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -198,12 +198,12 @@ bool GraphicsContextGLANGLE::initialize()
         return false;
 
     {
-        StringView extensionsString { unsafeSpan8(byteCast<char>(GL_GetString(GL_EXTENSIONS))) };
+        StringView extensionsString { unsafeSpan(byteCast<char>(GL_GetString(GL_EXTENSIONS))) };
         for (auto extension : extensionsString.split(' '))
             m_extensions.add(extension.span8());
     }
     {
-        StringView extensionsString { unsafeSpan8(byteCast<char>(GL_GetString(GL_REQUESTABLE_EXTENSIONS_ANGLE))) };
+        StringView extensionsString { unsafeSpan(byteCast<char>(GL_GetString(GL_REQUESTABLE_EXTENSIONS_ANGLE))) };
         for (auto extension : extensionsString.split(' '))
             m_allRequestableExtensions.add(extension.span8());
     }

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -111,7 +111,7 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     }
 
 #if ASSERT_ENABLED
-    auto clientExtensions = unsafeSpan8(EGL_QueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS));
+    auto clientExtensions = unsafeSpan(EGL_QueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS));
     ASSERT(clientExtensions.data());
 #endif
 
@@ -159,7 +159,7 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     LOG(WebGL, "ANGLE initialised Major: %d Minor: %d", majorVersion, minorVersion);
 
 #if ASSERT_ENABLED
-    auto displayExtensions = unsafeSpan8(EGL_QueryString(display, EGL_EXTENSIONS));
+    auto displayExtensions = unsafeSpan(EGL_QueryString(display, EGL_EXTENSIONS));
     ASSERT(WTF::contains(displayExtensions, "EGL_ANGLE_metal_shared_event_sync"_span));
 #endif
 
@@ -268,7 +268,7 @@ bool GraphicsContextGLCocoa::platformInitializeContext()
     eglContextAttributes.append(EGL_FALSE);
 
 #if HAVE(TASK_IDENTITY_TOKEN)
-    auto displayExtensions = unsafeSpan8(EGL_QueryString(m_displayObj, EGL_EXTENSIONS));
+    auto displayExtensions = unsafeSpan(EGL_QueryString(m_displayObj, EGL_EXTENSIONS));
     bool supportsOwnershipIdentity = WTF::contains(displayExtensions, "EGL_ANGLE_metal_create_context_ownership_identity"_span);
     if (m_resourceOwner && supportsOwnershipIdentity) {
         eglContextAttributes.append(EGL_CONTEXT_METAL_OWNERSHIP_IDENTITY_ANGLE);

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -205,7 +205,7 @@ String FontPlatformData::familyName() const
 {
     FcChar8* family = nullptr;
     FcPatternGetString(m_pattern.get(), FC_FAMILY, 0, &family);
-    return String::fromUTF8(unsafeSpan8(reinterpret_cast<const char*>(family)));
+    return byteCast<char8_t>(unsafeSpan(byteCast<char>(family)));
 }
 
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames shouldLocalizeAxisNames) const

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -63,7 +63,6 @@ private:
 #ifndef GST_DISABLE_GST_DEBUG
     static const char * streamTypeToString(StreamType);
 #endif
-    static const char * streamTypeToStringLower(StreamType);
 
     struct Track {
         // Track objects are created on pad-added for the first initialization segment, and destroyed after

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3504,7 +3504,7 @@ void webkit_web_view_load_plain_text(WebKitWebView* webView, const gchar* plainT
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
     g_return_if_fail(plainText);
 
-    getPage(webView).loadData(WebCore::SharedBuffer::create(unsafeSpan8(plainText)), "text/plain"_s, "UTF-8"_s, aboutBlankURL().string());
+    getPage(webView).loadData(WebCore::SharedBuffer::create(byteCast<uint8_t>(unsafeSpan(plainText))), "text/plain"_s, "UTF-8"_s, aboutBlankURL().string());
 }
 
 /**

--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -193,7 +193,7 @@ void SystemSettingsManagerProxy::updateFontProperties(const String& fontName, We
     // If the size of the font is in points, we need to convert it to pixels.
     if (!pango_font_description_get_size_is_absolute(pangoDescription))
         size = size * (WebCore::fontDPI() / 72.0);
-    changedState.fontFamily = String::fromUTF8(unsafeSpan8(pango_font_description_get_family(pangoDescription)));
+    changedState.fontFamily = String { byteCast<char8_t>(unsafeSpan(pango_font_description_get_family(pangoDescription))) };
     changedState.fontSize = static_cast<float>(size);
     changedState.fontWeight = pango_font_description_get_weight(pangoDescription);
     pango_font_description_free(pangoDescription);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -168,7 +168,7 @@ void RemoteVideoCodecFactory::createEncoder(const String& codec, const WebCore::
     std::map<std::string, std::string> parameters;
     if (type == WebCore::VideoCodecType::H264) {
         if (auto position = codec.find('.');position != notFound && position != codec.length()) {
-            auto profileLevelId = spanReinterpretCast<const char>(codec.span8().subspan(position + 1));
+            auto profileLevelId = byteCast<char>(codec.span8().subspan(position + 1));
             parameters["profile-level-id"] = std::string(profileLevelId.data(), profileLevelId.size());
         }
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
@@ -32,7 +32,7 @@ GObjectEventListener::GObjectEventListener(GObject* target, EventTarget* coreTar
     : EventListener(GObjectEventListenerType)
     , m_target(target)
     , m_coreTarget(coreTarget)
-    , m_domEventName(domEventName)
+    , m_eventType(byteCast<Latin1Character>(unsafeSpan(domEventName)))
     , m_handler(handler)
     , m_capture(capture)
 {
@@ -58,7 +58,7 @@ void GObjectEventListener::gobjectDestroyed()
     // and later use-after-free with the m_handler = 0; assignment.
     RefPtr<GObjectEventListener> protectedThis(this);
 
-    m_coreTarget->removeEventListener(AtomString(m_domEventName.span()), *this, m_capture);
+    m_coreTarget->removeEventListener(m_eventType, *this, m_capture);
     m_coreTarget = nullptr;
     m_handler = nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
@@ -32,17 +32,17 @@ namespace WebKit {
 
 class GObjectEventListener : public WebCore::EventListener {
 public:
-
     static bool addEventListener(GObject* target, WebCore::EventTarget* coreTarget, const char* domEventName, GClosure* handler, bool useCapture)
     {
         Ref<GObjectEventListener> listener(adoptRef(*new GObjectEventListener(target, coreTarget, domEventName, handler, useCapture)));
-        return coreTarget->addEventListener(AtomString(unsafeSpan8(domEventName)), WTFMove(listener), useCapture);
+        auto type = listener->m_eventType;
+        return coreTarget->addEventListener(type, WTFMove(listener), useCapture);
     }
 
     static bool removeEventListener(GObject* target, WebCore::EventTarget* coreTarget, const char* domEventName, GClosure* handler, bool useCapture)
     {
         GObjectEventListener key(target, coreTarget, domEventName, handler, useCapture);
-        return coreTarget->removeEventListener(AtomString(unsafeSpan8(domEventName)), key, useCapture);
+        return coreTarget->removeEventListener(key.m_eventType, key, useCapture);
     }
 
     static void gobjectDestroyedCallback(GObjectEventListener* listener, GObject*)
@@ -70,7 +70,7 @@ private:
     // We do not need to keep a reference to the m_coreTarget, because
     // we only use it when the GObject and thus the m_coreTarget object is alive.
     WebCore::EventTarget* m_coreTarget;
-    CString m_domEventName;
+    AtomString m_eventType;
     GRefPtr<GClosure> m_handler;
     bool m_capture;
 };

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -842,9 +842,9 @@ static void prewarmLogs()
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-static bool shouldIgnoreLogMessage(std::span<const Latin1Character> logChannel)
+static bool shouldIgnoreLogMessage(std::span<const char> logChannel)
 {
-    return equalSpans(logChannel, "com.apple.xpc\0"_span8) || equalSpans(logChannel, "com.apple.CoreAnalytics\0"_span8);
+    return equalSpans(logChannel, "com.apple.xpc\0"_span) || equalSpans(logChannel, "com.apple.CoreAnalytics\0"_span);
 }
 
 static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogClient>&& newLogClient)
@@ -879,12 +879,12 @@ static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogCli
         if (Thread::currentThreadIsRealtime())
             return;
 
-        auto logChannel = unsafeSpan8IncludingNullTerminator(msg->subsystem);
+        auto logChannel = unsafeSpanIncludingNullTerminator(msg->subsystem);
         if (logChannel.size() > logSubsystemMaxSize)
             return;
         if (shouldIgnoreLogMessage(logChannel))
             return;
-        auto logCategory = unsafeSpan8IncludingNullTerminator(msg->category);
+        auto logCategory = unsafeSpanIncludingNullTerminator(msg->category);
         if (logCategory.size() > logCategoryMaxSize)
             return;
 
@@ -892,7 +892,7 @@ static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogCli
             type = OS_LOG_TYPE_ERROR;
 
         if (auto messageString = adoptSystemMalloc(os_log_copy_message_string(msg))) {
-            auto logString = spanConstCast<Latin1Character>(unsafeSpan8IncludingNullTerminator(messageString.get()));
+            auto logString = spanConstCast<char>(unsafeSpanIncludingNullTerminator(messageString.get()));
             if (logString.size() > logStringMaxSize) {
                 logString = logString.first(logStringMaxSize);
                 logString.back() = 0;

--- a/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
@@ -262,12 +262,12 @@ TEST(WTF, CStringStdStringInterop)
 
 TEST(WTF, CStringViewASCIICaseConversions)
 {
-    EXPECT_EQ(WTF::convertToASCIILowercase("Test"_spanChar8), CString("test"));
-    EXPECT_EQ(WTF::convertToASCIIUppercase("Test"_spanChar8), CString("TEST"));
-    EXPECT_EQ(WTF::convertToASCIILowercase(unsafeSpanChar8("Water🍉Melon")), CString("water🍉melon"));
-    EXPECT_EQ(WTF::convertToASCIIUppercase(unsafeSpanChar8("Water🍉Melon")), CString("WATER🍉MELON"));
+    EXPECT_EQ(WTF::convertToASCIILowercase(u8"Test"_span), CString("test"));
+    EXPECT_EQ(WTF::convertToASCIIUppercase(u8"Test"_span), CString("TEST"));
+    EXPECT_EQ(WTF::convertToASCIILowercase(u8"Water🍉Melon"_span), CString("water🍉melon"));
+    EXPECT_EQ(WTF::convertToASCIIUppercase(u8"Water🍉Melon"_span), CString("WATER🍉MELON"));
     EXPECT_EQ(WTF::convertToASCIILowercase(std::span<const char8_t>()), CString(""_s));
     EXPECT_EQ(WTF::convertToASCIIUppercase(std::span<const char8_t>()), CString(""_s));
-    EXPECT_EQ(WTF::convertToASCIILowercase(""_spanChar8), CString(""_s));
-    EXPECT_EQ(WTF::convertToASCIIUppercase(""_spanChar8), CString(""_s));
+    EXPECT_EQ(WTF::convertToASCIILowercase(u8""_span), CString(""_s));
+    EXPECT_EQ(WTF::convertToASCIIUppercase(u8""_span), CString(""_s));
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -122,8 +122,8 @@ TEST(StringBuilderTest, Append)
 
     {
         StringBuilder builder;
-        builder.append(unsafeSpanChar8("Water🍉Melon"));
-        EXPECT_EQ(builder.toString(), unsafeSpanChar8("Water🍉Melon"));
+        builder.append(u8"Water🍉Melon"_span);
+        EXPECT_EQ(builder.toString(), u8"Water🍉Melon"_span);
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -109,110 +109,110 @@ TEST(WTF_StringCommon, FindIgnoringASCIICaseWithoutLengthIdentical)
 
 TEST(WTF_StringCommon, Equal)
 {
-    EXPECT_TRUE(WTF::equal(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("Water🍉Melon")));
-    EXPECT_FALSE(WTF::equal(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉WaterMelon🍉")));
-    // EXPECT_TRUE(WTF::equal("test"_spanChar8, "test"_span8)); // This should not compile.
-    String string(unsafeSpanChar8("Water🍉Melon"));
+    EXPECT_TRUE(WTF::equal(u8"Water🍉Melon"_span, u8"Water🍉Melon"_span));
+    EXPECT_FALSE(WTF::equal(u8"Water🍉Melon"_span, u8"🍉WaterMelon🍉"_span));
+    // EXPECT_TRUE(WTF::equal("test"_span, "test"_span8)); // This should not compile.
+    String string(u8"Water🍉Melon"_span);
     EXPECT_FALSE(string.is8Bit());
-    EXPECT_TRUE(WTF::equal(string, unsafeSpanChar8("Water🍉Melon")));
-    EXPECT_FALSE(WTF::equal(string, unsafeSpanChar8("🍉WaterMelon🍉")));
+    EXPECT_TRUE(WTF::equal(string, u8"Water🍉Melon"_span));
+    EXPECT_FALSE(WTF::equal(string, u8"🍉WaterMelon🍉"_span));
 }
 
 TEST(WTF_StringCommon, EqualIgnoringASCIICase)
 {
-    EXPECT_TRUE(WTF::equalIgnoringASCIICase("Test"_spanChar8, "test"_spanChar8));
-    EXPECT_FALSE(WTF::equalIgnoringASCIICase("another test"_spanChar8, "test"_spanChar8));
-    // EXPECT_TRUE(WTF::equalIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+    EXPECT_TRUE(WTF::equalIgnoringASCIICase(u8"Test"_span, u8"test"_span));
+    EXPECT_FALSE(WTF::equalIgnoringASCIICase(u8"another test"_span, u8"test"_span));
+    // EXPECT_TRUE(WTF::equalIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, StartsWith)
 {
-    EXPECT_TRUE(WTF::startsWith(unsafeSpanChar8("Water🍉Melon"), "Water"_s));
-    EXPECT_FALSE(WTF::startsWith(unsafeSpanChar8("Water🍉Melon"), "water"_s));
-    EXPECT_FALSE(WTF::startsWith(unsafeSpanChar8("🍉WaterMelon🍉"), "Water"_s));
-    EXPECT_TRUE(WTF::startsWith(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
-    EXPECT_FALSE(WTF::startsWith(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
-    // EXPECT_TRUE(WTF::startsWith("test"_spanChar8, "test"_span8)); // This should not compile.
+    EXPECT_TRUE(WTF::startsWith(u8"Water🍉Melon"_span, "Water"_s));
+    EXPECT_FALSE(WTF::startsWith(u8"Water🍉Melon"_span, "water"_s));
+    EXPECT_FALSE(WTF::startsWith(u8"🍉WaterMelon🍉"_span, "Water"_s));
+    EXPECT_TRUE(WTF::startsWith(u8"🍉WaterMelon🍉"_span, u8"🍉"_span));
+    EXPECT_FALSE(WTF::startsWith(u8"Water🍉Melon"_span, u8"🍉"_span));
+    // EXPECT_TRUE(WTF::startsWith(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, EndsWith)
 {
-    EXPECT_TRUE(WTF::endsWith(unsafeSpanChar8("Water🍉Melon"), "Melon"_s));
-    EXPECT_FALSE(WTF::endsWith(unsafeSpanChar8("Water🍉Melon"), "melon"_s));
-    EXPECT_FALSE(WTF::endsWith(unsafeSpanChar8("🍉WaterMelon🍉"), "Melon"_s));
-    EXPECT_TRUE(WTF::endsWith(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
-    EXPECT_FALSE(WTF::endsWith(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
-    // EXPECT_TRUE(WTF::endsWith("test"_spanChar8, "test"_span8)); // This should not compile.
+    EXPECT_TRUE(WTF::endsWith(u8"Water🍉Melon"_span, "Melon"_s));
+    EXPECT_FALSE(WTF::endsWith(u8"Water🍉Melon"_span, "melon"_s));
+    EXPECT_FALSE(WTF::endsWith(u8"🍉WaterMelon🍉"_span, "Melon"_s));
+    EXPECT_TRUE(WTF::endsWith(u8"🍉WaterMelon🍉"_span, u8"🍉"_span));
+    EXPECT_FALSE(WTF::endsWith(u8"Water🍉Melon"_span, u8"🍉"_span));
+    // EXPECT_TRUE(WTF::endsWith(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, Find)
 {
-    EXPECT_EQ(WTF::find(unsafeSpanChar8("Water🍉Melon"), "ter"_s), 2UZ);
-    EXPECT_EQ(WTF::find(unsafeSpanChar8("🍉WaterMelon🍉"), "ter"_s), 6UZ);
-    EXPECT_EQ(WTF::find(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")), 5UZ);
-    EXPECT_EQ(WTF::find(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")), 0UZ);
-    // EXPECT_NEQ(WTF::find("test"_spanChar8, "test"_span8), notFound); // This should not compile.
+    EXPECT_EQ(WTF::find(u8"Water🍉Melon"_span, "ter"_s), 2UZ);
+    EXPECT_EQ(WTF::find(u8"🍉WaterMelon🍉"_span, "ter"_s), 6UZ);
+    EXPECT_EQ(WTF::find(u8"Water🍉Melon"_span, u8"🍉"_span), 5UZ);
+    EXPECT_EQ(WTF::find(u8"🍉WaterMelon🍉"_span, u8"🍉"_span), 0UZ);
+    // EXPECT_NEQ(WTF::find(u8"test"_span, "test"_span8), notFound); // This should not compile.
 }
 
 TEST(WTF_StringCommon, ReverseFind)
 {
-    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("Water🍉Melon"), "ter"_s), 2UZ);
-    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("🍉WaterMelon🍉"), "ter"_s), 6UZ);
-    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")), 5UZ);
-    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")), 14UZ);
-    // EXPECT_NEQ(WTF::reverseFind("test"_spanChar8, "test"_span8), notFound); // This should not compile.
+    EXPECT_EQ(WTF::reverseFind(u8"Water🍉Melon"_span, "ter"_s), 2UZ);
+    EXPECT_EQ(WTF::reverseFind(u8"🍉WaterMelon🍉"_span, "ter"_s), 6UZ);
+    EXPECT_EQ(WTF::reverseFind(u8"Water🍉Melon"_span, u8"🍉"_span), 5UZ);
+    EXPECT_EQ(WTF::reverseFind(u8"🍉WaterMelon🍉"_span, u8"🍉"_span), 14UZ);
+    // EXPECT_NEQ(WTF::reverseFind(u8"test"_span, "test"_span8), notFound); // This should not compile.
 }
 
 TEST(WTF_StringCommon, Contains)
 {
-    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), "Water"_s));
-    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), "Water"_s));
-    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
-    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
-    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), "pear"_s));
-    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), "pear"_s));
-    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍈")));
-    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍈")));
-    // EXPECT_TRUE(WTF::contains("test"_spanChar8, "test"_span8)); // This should not compile.
+    EXPECT_TRUE(WTF::contains(u8"Water🍉Melon"_span, "Water"_s));
+    EXPECT_TRUE(WTF::contains(u8"🍉WaterMelon🍉"_span, "Water"_s));
+    EXPECT_TRUE(WTF::contains(u8"Water🍉Melon"_span, u8"🍉"_span));
+    EXPECT_TRUE(WTF::contains(u8"🍉WaterMelon🍉"_span, u8"🍉"_span));
+    EXPECT_FALSE(WTF::contains(u8"Water🍉Melon"_span, "pear"_s));
+    EXPECT_FALSE(WTF::contains(u8"🍉WaterMelon🍉"_span, "pear"_s));
+    EXPECT_FALSE(WTF::contains(u8"Water🍉Melon"_span, u8"🍈"_span));
+    EXPECT_FALSE(WTF::contains(u8"🍉WaterMelon🍉"_span, u8"🍈"_span));
+    // EXPECT_TRUE(WTF::contains(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, StartsWithLettersIgnoringASCIICase)
 {
-    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "water"_s));
-    EXPECT_FALSE(WTF::startsWithLettersIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "water"_s));
-    // EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"Water🍉Melon"_span, "water"_s));
+    EXPECT_FALSE(WTF::startsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "water"_s));
+    // EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, EndsWithLettersIgnoringASCIICase)
 {
-    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "melon"_s));
-    EXPECT_FALSE(WTF::endsWithLettersIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "melon"_s));
-    // EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"Water🍉Melon"_span, "melon"_s));
+    EXPECT_FALSE(WTF::endsWithLettersIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "melon"_s));
+    // EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, FindIgnoringASCIICase)
 {
-    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "water"_s), 0UZ);
-    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "water"_s), 4UZ);
-    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")), 5UZ);
-    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")), 0UZ);
-    // EXPECT_NEQ(WTF::findIgnoringASCIICase("test"_spanChar8, "test"_span8), notFound); // This should not compile.
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"Water🍉Melon"_span, "water"_s), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "water"_s), 4UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"Water🍉Melon"_span, u8"🍉"_span), 5UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, u8"🍉"_span), 0UZ);
+    // EXPECT_NEQ(WTF::findIgnoringASCIICase(u8"test"_span, "test"_span8), notFound); // This should not compile.
 }
 
 TEST(WTF_StringCommon, ContainsIgnoringASCIICase)
 {
-    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "melon"_s));
-    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "melon"_s));
-    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
-    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
-    // EXPECT_TRUE(WTF::containsIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"Water🍉Melon"_span, "melon"_s));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, "melon"_s));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"Water🍉Melon"_span, u8"🍉"_span));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"🍉WaterMelon🍉"_span, u8"🍉"_span));
+    // EXPECT_TRUE(WTF::containsIgnoringASCIICase(u8"test"_span, "test"_span8)); // This should not compile.
 }
 
 TEST(WTF_StringCommon, CharactersAreAllASCII)
 {
-    EXPECT_TRUE(WTF::charactersAreAllASCII("Test"_spanChar8));
+    EXPECT_TRUE(WTF::charactersAreAllASCII(u8"Test"_span));
     EXPECT_TRUE(WTF::charactersAreAllASCII(std::span<const char8_t>()));
-    EXPECT_FALSE(WTF::charactersAreAllASCII(unsafeSpanChar8("🍉")));
+    EXPECT_FALSE(WTF::charactersAreAllASCII(u8"🍉"_span));
 }
 
 TEST(WTF_StringCommon, CopyElements64To8)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleEditingDelegatePlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleEditingDelegatePlugIn.mm
@@ -86,7 +86,7 @@
 
 - (NSDictionary<NSString *, NSData *> *)_webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController *)controller pasteboardDataForRange:(WKWebProcessPlugInRangeHandle *)range
 {
-    return @{ @"org.webkit.data" : _shouldWriteEmptyData ? NSData.data : toNSDataNoCopy("hello"_span8, FreeWhenDone::No).autorelease() };
+    return @{ @"org.webkit.data" : [(_shouldWriteEmptyData ? @"" : @"hello") dataUsingEncoding:NSASCIIStringEncoding] };
 }
 
 - (void)_webProcessPlugInBrowserContextControllerDidWriteToPasteboard:(WKWebProcessPlugInBrowserContextController *)controller

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -3051,10 +3051,9 @@ static bool didStartURLSchemeTaskForImportedScript = false;
 
     if (auto data = _dataMappings.get([finalURL absoluteString]))
         [task didReceiveData:data.get()];
-    else if (_bytes) {
-        RetainPtr data = toNSDataNoCopy(unsafeSpan8(_bytes), FreeWhenDone::No);
-        [task didReceiveData:data.get()];
-    } else
+    else if (_bytes)
+        [task didReceiveData:toNSData(byteCast<uint8_t>(unsafeSpan(_bytes))).get()];
+    else
         [task didReceiveData:[@"Hello" dataUsingEncoding:NSUTF8StringEncoding]];
 
     [task didFinish];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -1096,15 +1096,15 @@ static unsigned loadCount;
     HashMap<String, RetainPtr<NSData>> _dataMappings;
     Function<void(id <WKURLSchemeTask>)> _taskHandler;
 }
-- (void)addMappingFromURLString:(NSString *)urlString toData:(const char*)data;
+- (void)addMappingFromURLString:(NSString *)urlString toData:(ASCIILiteral)data;
 - (void)setTaskHandler:(Function<void(id <WKURLSchemeTask>)>&&)handler;
 @end
 
 @implementation DataMappingSchemeHandler
 
-- (void)addMappingFromURLString:(NSString *)urlString toData:(const char*)data
+- (void)addMappingFromURLString:(NSString *)urlString toData:(ASCIILiteral)data
 {
-    _dataMappings.set(urlString, toNSDataNoCopy(unsafeSpan8(data), FreeWhenDone::No));
+    _dataMappings.set(urlString, toNSData(data.span8()));
 }
 
 - (void)setTaskHandler:(Function<void(id <WKURLSchemeTask>)>&&)handler
@@ -1136,7 +1136,7 @@ static unsigned loadCount;
 
 @end
 
-constexpr const char* customUserAgent = "Foo Custom UserAgent";
+constexpr auto customUserAgent = "Foo Custom UserAgent"_s;
 
 @interface CustomUserAgentDelegate : NSObject <WKNavigationDelegate> {
 }
@@ -1160,7 +1160,7 @@ constexpr const char* customUserAgent = "Foo Custom UserAgent";
 
 @end
 
-static const char* customUserAgentMainFrameTestBytes = R"TESTRESOURCE(
+constexpr auto customUserAgentMainFrameTestBytes = R"TESTRESOURCE(
 <script src="test://www.webkit.org/script.js"></script>
 <img src="test://www.webkit.org/image.png"></img>
 <iframe src="test://www.apple.com/subframe.html"></iframe>
@@ -1174,9 +1174,9 @@ onmessage = (event) => {
     window.subframeUserAgent = event.data;
 }
 </script>
-)TESTRESOURCE";
+)TESTRESOURCE"_s;
 
-static const char* customUserAgentSubFrameTestBytes = R"TESTRESOURCE(
+constexpr auto customUserAgentSubFrameTestBytes = R"TESTRESOURCE(
 <script src="test://www.apple.com/script.js"></script>
 <img src="test://www.apple.com/image.png"></img>
 <iframe src="test://www.apple.com/subframe2.html"></iframe>
@@ -1188,7 +1188,7 @@ onload = () => {
     top.postMessage(navigator.userAgent, '*');
 }
 </script>
-)TESTRESOURCE";
+)TESTRESOURCE"_s;
 
 TEST(WebpagePreferences, WebsitePoliciesCustomUserAgent)
 {
@@ -1228,7 +1228,7 @@ TEST(WebpagePreferences, WebsitePoliciesCustomUserAgent)
     loadCount = 0;
 }
 
-constexpr const char* customUserAgentAsSiteSpecificQuirk = "Foo Site Specific Quirks UserAgent";
+constexpr auto customUserAgentAsSiteSpecificQuirk = "Foo Site Specific Quirks UserAgent"_s;
 
 @interface CustomJavaScriptUserAgentDelegate : NSObject <WKNavigationDelegate>
 @property (nonatomic) BOOL setCustomUserAgent;
@@ -1399,13 +1399,13 @@ TEST(WebpagePreferences, WebsitePoliciesCustomNavigatorPlatform)
 
 #if PLATFORM(IOS_FAMILY)
 
-static const char* deviceOrientationEventTestBytes = R"TESTRESOURCE(
+static constexpr auto deviceOrientationEventTestBytes = R"TESTRESOURCE(
 <script>
 addEventListener("deviceorientation", (event) => {
     webkit.messageHandlers.testHandler.postMessage("received-device-orientation-event");
 });
 </script>
-)TESTRESOURCE";
+)TESTRESOURCE"_s;
 
 @interface WebsitePoliciesDeviceOrientationDelegate : NSObject <WKNavigationDelegate> {
     _WKWebsiteDeviceOrientationAndMotionAccessPolicy _accessPolicy;

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
@@ -33,19 +33,20 @@
 static NSString *MainFrameIconKeyPath = @"mainFrameIcon";
 static bool messageReceived = false;
 
-static const char defaultFaviconHTML[] =
+static constexpr auto defaultFaviconHTML =
 "<html>" \
-"</html>";
+"</html>"_s;
 
-static const char customFaviconHTML[] =
+static constexpr auto customFaviconHTML =
 "<head>" \
 "<link rel=\"icon\" href=\"custom.ico\">" \
-"</head>";
+"</head>"_s;
 
-static const char* currentMainHTML;
+static const ASCIILiteral* currentMainHTML;
+
 static RetainPtr<NSData> mainResourceData()
 {
-    return toNSDataNoCopy(unsafeSpan8(currentMainHTML), FreeWhenDone::No);
+    return toNSData(byteCast<uint8_t>(currentMainHTML->span()));
 }
 
 static NSData *defaultFaviconData()
@@ -63,9 +64,7 @@ static NSData *customFaviconData()
 static NSImage *imageFromData(NSData *data)
 {
     auto image = adoptNS([[NSImage alloc] initWithData:data]);
-
     [image setSize:NSMakeSize(16, 16)];
-
     return image.autorelease();
 }
 
@@ -155,7 +154,7 @@ TEST(WebKitLegacy, IconLoadingDelegateDefaultFirst)
 {
     [NSURLProtocol registerClass:[IconLoadingProtocol class]];
 
-    currentMainHTML = defaultFaviconHTML;
+    currentMainHTML = &defaultFaviconHTML;
     @autoreleasepool {
         auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
         auto frameLoadDelegate = adoptNS([[IconLoadingFrameLoadDelegate alloc] init]);
@@ -178,7 +177,7 @@ TEST(WebKitLegacy, IconLoadingDelegateDefaultFirst)
         messageReceived = false;
         kvo->oldImage = imageFromData(defaultFaviconData());
         kvo->expectedImage = imageFromData(customFaviconData());
-        currentMainHTML = customFaviconHTML;
+        currentMainHTML = &customFaviconHTML;
         [webView.get().mainFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://testserver/2/main"]]];
 
         Util::run(&messageReceived);
@@ -196,7 +195,7 @@ TEST(WebKitLegacy, IconLoadingDelegateCustomFirst)
 {
     [NSURLProtocol registerClass:[IconLoadingProtocol class]];
 
-    currentMainHTML = customFaviconHTML;
+    currentMainHTML = &customFaviconHTML;
     @autoreleasepool {
         auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
         auto frameLoadDelegate = adoptNS([[IconLoadingFrameLoadDelegate alloc] init]);
@@ -219,7 +218,7 @@ TEST(WebKitLegacy, IconLoadingDelegateCustomFirst)
         messageReceived = false;
         kvo->oldImage = imageFromData(customFaviconData());
         kvo->expectedImage = imageFromData(defaultFaviconData());
-        currentMainHTML = defaultFaviconHTML;
+        currentMainHTML = &defaultFaviconHTML;
         [webView.get().mainFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://testserver/2/main"]]];
 
         Util::run(&messageReceived);


### PR DESCRIPTION
#### 26dd620584929051fb686703df2da90997db739c
<pre>
Streamline handling of null-terminated strings to improve clarity and safety
<a href="https://rdar.apple.com/165305546">rdar://165305546</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303027">https://bugs.webkit.org/show_bug.cgi?id=303027</a>

Reviewed by Sam Weinig.

Eliminated other members of the unsafeSpan function family, leaving only
unsafeSpan and unsafeSpanIncludingNullTerminator.

Eliminated some functions that take null-terminated strings, such as
String::createFromCString. Changed callers to safe interfaces that pass
lengths and sizes instead or to call unsafeSpan.

Redid the UTF-8 span literal operator so we can use it in constant expressions.
Syntax is now u8&quot;&quot;_span instead of &quot;&quot;_spanChar8.

Simplified test code that was unnecessarily using null-terminated strings
to instead use ASCIILiteral or similar. Also used toNSData in test code
rather than toNSDataNoCopy; the &quot;no copy&quot; optimization is unnecessary for tests.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringCreateWithUTF8CString): Use unsafeSpan. Use conversion from UTF-8
built into the String class. Take advantage of null handling built into the
function so we don&apos;t need a special case for the null pointer.

* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap): Use unsafeSpan.

* Source/JavaScriptCore/runtime/Identifier.h: Removed overloads of
the == operator and the equal function that take null-terminated strings.

(JSC::Identifier::equal):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::OptionsHelper::Option::dump const): Use unsafeSpan.

* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::consumeUTF8String): Use byteCast.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::fromStdFileSystemPath): Use unsafeSpan.

* Source/WTF/wtf/text/ASCIILiteral.h: Added u8&quot;&quot;_span. Removed &quot;&quot;_spanChar8.

* Source/WTF/wtf/text/StringCommon.h:
Deleted the unsafeSpan overload that takes const Latin1Character*.
(WTF::unsafeSpan8): Deleted.
(WTF::unsafeSpanChar8): Deleted.
(WTF::unsafeSpan8IncludingNullTerminator): Deleted.

* Source/WTF/wtf/text/StringConcatenate.h: Deleted the StringTypeAdapter
that takes const Latin1Character*.

* Source/WTF/wtf/text/StringImpl.h: Use unsafeSpan.
(WTF::StringImpl::createFromCString): Deleted.

* Source/WTF/wtf/text/StringView.h: Use unsafeSpan.
Replaced the equal function that takes const Latin1Character* with one
that takes span&lt;const Latin1Character&gt;.

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::String): Use unsafeSpan.

* Source/WTF/wtf/text/WTFString.h: Use unsafeSpan.
Some updates to the fromUTF8 family of functions, clarifying deprecation.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize): Use unsafeSpan.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::initializeEGLDisplay): Use unsafeSpan.
(WebCore::GraphicsContextGLCocoa::platformInitializeContext): Ditto.

* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
(WebCore::FontPlatformData::familyName const): Use unsafeSpan.

* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer): Use unsafeSpan.
(WebCore::TrackPrivateBaseGStreamer::setPad): Ditto.
(WebCore::TrackPrivateBaseGStreamer::getLanguageCode): Ditto.
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged): Ditto.
(WebCore::TrackPrivateBaseGStreamer::updateTrackIDFromTags): Ditto.

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::recycleTrackForPad): Use unsafeSpan.
(WebCore::serializeLowercase): Moved this function up in the file, changed it
to return ASCIILiteral, and made it a non-member function so it can be internal
to the file rather than in the header.
(WebCore::AppendPipeline::Track::emplaceOptionalElementsForFormat): Use
serializeLowercase.

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
Removed now-unused streamTypeToStringLower.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_load_plain_text): Use unsafeSpan.

* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::updateFontProperties): Use unsafeSpan.

* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createEncoder): Use byteCast.

* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp:
(WebKit::GObjectEventListener::GObjectEventListener): Store event type as
m_eventType AtomString instead of m_domEventName CString, previously we converted
it to an AtomString any time it is used. Also, used the term event type from
the DOM rather than coining a different name for the same concept.
(WebKit::GObjectEventListener::gobjectDestroyed): Use m_eventType.

* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h:
(WebKit::GObjectEventListener::addEventListener): Use m_eventType instead of
converting to AtomString.
(WebKit::GObjectEventListener::removeEventListener): Ditto.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement): Use unsafeSpanIncludingNullTerminator.

* Tools/TestWebKitAPI/Tests/WTF/CString.cpp:
(TEST(WTF, CStringViewASCIICaseConversions)): Use u8&quot;&quot;_span.

* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp:
(TestWebKitAPI::TEST(StringBuilderTest, Append)): Use u8&quot;&quot;_span.

* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, Equal)): Use u8&quot;&quot;_span.
(TestWebKitAPI::TEST(WTF_StringCommon, EqualIgnoringASCIICase)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, StartsWith)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, EndsWith)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, Find)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, ReverseFind)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, Contains)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, StartsWithLettersIgnoringASCIICase)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, EndsWithLettersIgnoringASCIICase)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, FindIgnoringASCIICase)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, ContainsIgnoringASCIICase)): Ditto.
(TestWebKitAPI::TEST(WTF_StringCommon, CharactersAreAllASCII)): Ditto.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleEditingDelegatePlugIn.mm:
(-[BundleEditingDelegatePlugIn _webProcessPlugInBrowserContextController:pasteboardDataForRange:]):
Use [NSData dataUsingEncoding:].

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[PSONScheme initWithBytes:]): Use ASCIILiteral.
(-[PSONScheme addMappingFromURLString:toData:]): Ditto.
(-[PSONScheme webView:startURLSchemeTask:]): Ditto.
((ProcessSwap, HistoryNavigationToFragmentURL)): Ditto.
((ProcessSwap, PolicyCancelAfterServerRedirect)): Ditto.
((ProcessSwap, SameOriginSystemPreview)): Ditto.
((ProcessSwap, SessionStorage)): Ditto.
((ProcessSwap, ReuseSuspendedProcessEvenIfPageCacheFails)): Ditto.
((ProcessSwap, HistoryItemIDConfusion)): Ditto.
((ProcessSwap, MainFramesOnly)): Ditto.
((ProcessSwap, MediaTypeAfterSwap)): Ditto.
((ProcessSwap, NavigateCrossSiteBeforePageLoadEnd)): Ditto.
((ProcessSwap, PageShowHide)): Ditto.
((ProcessSwap, LoadUnload)): Ditto.
((ProcessSwap, SameOriginBlobNavigation)): Ditto.
((ProcessSwap, NavigateToDataURLThenBack)): Ditto.
((ProcessSwap, SwapOnFormSubmission)): Ditto.
((ProcessSwap, OpenerLinkAfterAPIControlledProcessSwappingOfOpener)): Ditto.
((ProcessSwap, NavigateCrossOriginWithOpener)): Ditto.
((ProcessSwap, ContentBlockingAfterProcessSwap)): Ditto.
((ProcessSwap, ContentExtensionBlocksMainLoadThenReloadWithoutExtensions)): Ditto.
((ProcessSwap, GetUserMediaCaptureState)): Ditto.
((ProcessSwap, PassMinimumDeviceWidthOnNewWebView)): Ditto.
((ProcessSwap, ResizeWebViewDuringCrossSiteProvisionalNavigation)): Ditto.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[ServiceWorkerSchemeHandler webView:startURLSchemeTask:]): Use unsafeSpan.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
(mainBytesData): Added.
(TEST(URLSchemeHandler, Basic)): Use ASCIILiteral.
(TEST(URLSchemeHandler, BasicWithHTTPS)): Ditto.
(TEST(URLSchemeHandler, BasicWithAsyncPolicyDelegate)): Ditto.
(TEST(URLSchemeHandler, NoMIMEType)): Ditto.
(-[SyncScheme webView:startURLSchemeTask:]): Ditto.
(-[SyncErrorScheme webView:startURLSchemeTask:]): Ditto.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(-[DataMappingSchemeHandler addMappingFromURLString:toData:]): Use ASCIILiteral.
((WebpagePreferences, WebsitePoliciesCustomUserAgent)): Ditto.

* Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm:
(mainResourceData): Use ASCIILiteral.
(imageFromData): Ditto.
(TestWebKitAPI::TEST(WebKitLegacy, IconLoadingDelegateDefaultFirst)): Ditto.
(TestWebKitAPI::TEST(WebKitLegacy, IconLoadingDelegateCustomFirst)): Ditto.

Canonical link: <a href="https://commits.webkit.org/303520@main">https://commits.webkit.org/303520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd758fc5db715b3ec3259c74b97e666278f2d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84661 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb565641-1196-457e-8a9f-d671e7a04e6f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101403 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68693 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a48ef54-aac2-45ef-b41e-474151b7355b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135584 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82196 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a59d816-7311-4b1e-a7b0-c62d3a41c79b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1401 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83395 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124708 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142817 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131146 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4803 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109778 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4885 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3656 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58258 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4857 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33437 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164113 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68308 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42624 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->