### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for FontLoadRequestClient

### DIFF
--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -621,7 +621,7 @@ void CSSFontFace::opportunisticallyStartFontDataURLLoading()
 {
     // We don't want to go crazy here and blow the cache. Usually these data URLs are the first item in the src: list, so let's just check that one.
     if (!m_sources.isEmpty())
-        m_sources[0]->opportunisticallyStartFontDataURLLoading();
+        CheckedRef { *m_sources[0] }->opportunisticallyStartFontDataURLLoading();
 }
 
 size_t CSSFontFace::pump(ExternalResourceDownloadPolicy policy)
@@ -756,12 +756,9 @@ void CSSFontFace::updateStyleIfNeeded()
 
 bool CSSFontFace::hasSVGFontFaceSource() const
 {
-    size_t size = m_sources.size();
-    for (size_t i = 0; i < size; i++) {
-        if (m_sources[i]->isSVGFontFaceSource())
-            return true;
-    }
-    return false;
+    return m_sources.containsIf([](auto& source) {
+        return CheckedRef { *source }->isSVGFontFaceSource();
+    });
 }
 
 void CSSFontFace::setErrorState()

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -47,6 +47,7 @@ struct FontCustomPlatformData;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFaceSource);
 class CSSFontFaceSource final : public FontLoadRequestClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSFontFaceSource, CSSFontFaceSource);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFontFaceSource);
 public:
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName);
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName, SVGFontFaceElement&);

--- a/Source/WebCore/loader/FontLoadRequest.h
+++ b/Source/WebCore/loader/FontLoadRequest.h
@@ -27,17 +27,10 @@
 #pragma once
 
 #include <WebCore/FontTaggedSettings.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
-
-namespace WebCore {
-class FontLoadRequestClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::FontLoadRequestClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -47,7 +40,9 @@ class FontDescription;
 class FontLoadRequest;
 struct FontSelectionSpecifiedCapabilities;
 
-class FontLoadRequestClient : public CanMakeWeakPtr<FontLoadRequestClient> {
+class FontLoadRequestClient : public CanMakeWeakPtr<FontLoadRequestClient>, public CanMakeCheckedPtr<FontLoadRequestClient> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FontLoadRequestClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FontLoadRequestClient);
 public:
     virtual ~FontLoadRequestClient() = default;
     virtual void fontLoaded(FontLoadRequest&) { }

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -82,9 +82,7 @@ private:
 
     void setClient(FontLoadRequestClient* client) final
     {
-        WeakPtr oldClient = m_fontLoadRequestClient;
-        m_fontLoadRequestClient = client;
-
+        WeakPtr oldClient = std::exchange(m_fontLoadRequestClient, client);
         if (!client && oldClient)
             protectedCachedFont()->removeClient(*this);
         else if (client && !oldClient)
@@ -100,8 +98,8 @@ private:
 
         m_fontLoadedProcessed = true;
         ASSERT_UNUSED(font, &font == m_font.get());
-        if (m_fontLoadRequestClient)
-            m_fontLoadRequestClient->fontLoaded(*this); // fontLoaded() might destroy this object. Don't deref its members after it.
+        if (CheckedPtr client = m_fontLoadRequestClient.get())
+            client->fontLoaded(*this); // fontLoaded() might destroy this object. Don't deref its members after it.
     }
 
     CachedResourceHandle<CachedFont> m_font;

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -110,7 +110,7 @@ void WorkerFontLoadRequest::setClient(FontLoadRequestClient* client)
 
     if (m_notifyOnClientSet) {
         m_notifyOnClientSet = false;
-        m_fontLoadRequestClient->fontLoaded(*this);
+        client->fontLoaded(*this);
     }
 }
 
@@ -133,8 +133,8 @@ void WorkerFontLoadRequest::didFinishLoading(ScriptExecutionContextIdentifier, s
     m_isLoading = false;
 
     if (!m_errorOccurred) {
-        if (m_fontLoadRequestClient)
-            m_fontLoadRequestClient->fontLoaded(*this);
+        if (CheckedPtr client = m_fontLoadRequestClient.get())
+            client->fontLoaded(*this);
         else
             m_notifyOnClientSet = true;
     }
@@ -143,8 +143,8 @@ void WorkerFontLoadRequest::didFinishLoading(ScriptExecutionContextIdentifier, s
 void WorkerFontLoadRequest::didFail(std::optional<ScriptExecutionContextIdentifier>, const ResourceError&)
 {
     m_errorOccurred = true;
-    if (m_fontLoadRequestClient)
-        m_fontLoadRequestClient->fontLoaded(*this);
+    if (CheckedPtr client = m_fontLoadRequestClient.get())
+        client->fontLoaded(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -74,7 +74,7 @@ private:
     bool m_isLoading { false };
     bool m_notifyOnClientSet { false };
     bool m_errorOccurred { false };
-    FontLoadRequestClient* m_fontLoadRequestClient { nullptr };
+    WeakPtr<FontLoadRequestClient> m_fontLoadRequestClient;
 
     WeakPtr<ScriptExecutionContext> m_context;
     SharedBufferBuilder m_data;


### PR DESCRIPTION
#### 6566d039c12058f0b40cfba7b00cab99b7d7e29c
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for FontLoadRequestClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303030">https://bugs.webkit.org/show_bug.cgi?id=303030</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::opportunisticallyStartFontDataURLLoading):
(WebCore::CSSFontFace::hasSVGFontFaceSource const):
* Source/WebCore/css/CSSFontFaceSource.h:
* Source/WebCore/loader/FontLoadRequest.h:
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::setClient):
(WebCore::WorkerFontLoadRequest::didFinishLoading):
(WebCore::WorkerFontLoadRequest::didFail):
* Source/WebCore/workers/WorkerFontLoadRequest.h:

Canonical link: <a href="https://commits.webkit.org/303516@main">https://commits.webkit.org/303516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c4ebb2abf52a1f3db5df37a27e9834525cf95c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132585 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84597 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b58c39d3-9188-410e-a389-ad28b66725e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101361 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68657 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f95c43e3-4dc1-4e48-ac00-b7e7bb6b6c55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135531 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3712 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 2 new passes 35 flakes; Uploaded test results; 2 new passes 35 flakes; Compiled WebKit (warnings); layout-tests (cancelled)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82159 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/129b9c01-b16d-4a52-8e37-07f061d98f22) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3599 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83341 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142759 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109919 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3614 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115040 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4804 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33389 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68255 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->