### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for LinkLoaderClient

### DIFF
--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -104,6 +104,13 @@ public:
     // Otherwise checks if any Element in the tree does.
     void processInternalResourceLink(Element* = nullptr);
 
+    // AbstractCanMakeCheckedPtr.
+    uint32_t checkedPtrCount() const final { return HTMLElement::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return HTMLElement::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { HTMLElement::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { HTMLElement::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { HTMLElement::setDidBeginCheckedPtrDeletion(); }
+
 private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -89,7 +89,7 @@ private:
     static std::unique_ptr<LinkPreloadResourceClient> preloadIfNeeded(const LinkLoadParameters&, Document&, LinkLoader*);
     void prefetchIfNeeded(const LinkLoadParameters&, Document&);
 
-    WeakRef<LinkLoaderClient> m_client;
+    const CheckedRef<LinkLoaderClient> m_client;
     CachedResourceHandle<CachedResource> m_cachedLinkResource;
     std::unique_ptr<LinkPreloadResourceClient> m_preloadResourceClient;
 };

--- a/Source/WebCore/loader/LinkLoaderClient.h
+++ b/Source/WebCore/loader/LinkLoaderClient.h
@@ -31,20 +31,11 @@
 
 #pragma once
 
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class LinkLoaderClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::LinkLoaderClient> : std::true_type { };
-}
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 
 namespace WebCore {
 
-class LinkLoaderClient : public CanMakeWeakPtr<LinkLoaderClient> {
+class LinkLoaderClient : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~LinkLoaderClient() = default;
 


### PR DESCRIPTION
#### e238f47d550f11106b64168e787780ff1ef196e7
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for LinkLoaderClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303031">https://bugs.webkit.org/show_bug.cgi?id=303031</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/loader/LinkLoader.h:
* Source/WebCore/loader/LinkLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/303515@main">https://commits.webkit.org/303515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d6761aa48825ffbeba00b8cf66cf2eb221f1516

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84556 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba285bc9-2bb5-425d-bdff-d2f85d72cba9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101336 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68629 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41c61268-3210-4afb-8a2d-29ecbce62dd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82133 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29c2d083-b7f3-40da-b826-7c3b811a2253) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3633 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83307 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142726 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109712 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3589 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115025 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58149 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4772 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33375 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4863 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->