### PR TITLE
Sync `MediaDeviceInfo` interface with Web Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-SecureContext-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-SecureContext-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL MediaDevices and SecureContext assert_false: MediaDeviceInfo is not exposed expected false got true
+PASS MediaDevices and SecureContext
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-SecureContext-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-SecureContext-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL MediaDevices and SecureContext assert_false: MediaDeviceInfo is not exposed expected false got true
-

--- a/Source/WebCore/Modules/mediastream/MediaDeviceInfo.idl
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceInfo.idl
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2015 Apple Inc. All rights reserved.
+* Copyright (C) 2015-2025 Apple Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -23,9 +23,12 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/mediacapture-main/#device-info
+
 [
     Conditional=MEDIA_STREAM,
-    Exposed=Window
+    Exposed=Window,
+    SecureContext
 ] interface MediaDeviceInfo {
     readonly attribute DOMString deviceId;
     readonly attribute MediaDeviceKind kind;
@@ -33,6 +36,8 @@
     readonly attribute DOMString groupId;
     [Default] object toJSON();
 };
+
+// https://w3c.github.io/mediacapture-main/#dom-mediadevicekind
 
 enum MediaDeviceKind {
     "audioinput",

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -307,6 +307,7 @@ namespace WebCore {
     macro(MediaCapabilities) \
     macro(MediaCapabilitiesInfo) \
     macro(MediaDevices) \
+    macro(MediaDeviceInfo) \
     macro(MediaElementAudioSourceNode) \
     macro(MediaEncryptedEvent) \
     macro(MediaKeyMessageEvent) \


### PR DESCRIPTION
#### 997b7babcdeb68f85f9f7375ab3055cb9644f2bf
<pre>
Sync `MediaDeviceInfo` interface with Web Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=303033">https://bugs.webkit.org/show_bug.cgi?id=303033</a>
<a href="https://rdar.apple.com/165318702">rdar://165318702</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Blink / Chromium, Gecko / Firefox and
Web Specification [1]:

[1] <a href="https://w3c.github.io/mediacapture-main/#device-info">https://w3c.github.io/mediacapture-main/#device-info</a>

This patch adds missing `SecureContext`, which leads to progressing WPT.

* Source/WebCore/Modules/mediastream/MediaDeviceInfo.idl:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-SecureContext-expected.txt: Progression
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-SecureContext-expected.txt: Removed Stale Expectation.

Canonical link: <a href="https://commits.webkit.org/303512@main">https://commits.webkit.org/303512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/183719bc782669e74038f2424342bf3dfaa42d13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84686 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d09466f-7448-4d41-ae17-e53a52fddfc9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4913 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/12365d6b-6fad-4ec2-90d5-a2b8f1245e3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135605 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82213 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c0e9895b-7a0c-4008-926e-235f2327b14b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83419 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142840 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37542 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109796 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4906 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109973 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27873 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3674 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115110 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58283 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4878 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68329 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4969 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->