### PR TITLE
Resync `mediacapture-streams` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https-expected.txt
@@ -1,0 +1,5 @@
+When prompted, accept to share your audio stream.
+
+
+FAIL getUserMedia suports "all" assert_equals: expected (string) "all" but got (boolean) true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<title>getUserMedia echoCancellation remote-only</title>
+<p class="instructions">When prompted, accept to share your audio stream.</p>
+<meta name=timeout content=long>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=permission-helper.js></script>
+<script>
+  'use strict'
+
+  // https://w3c.github.io/mediacapture-main/#dom-echocancellationmodeenum-all
+
+  promise_test(async t => {
+    await setMediaPermission("granted", ["microphone"]);
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: false,
+      audio: {echoCancellation: {exact: "all"}},
+    });
+    const track = stream.getAudioTracks()[0];
+    t.add_cleanup(() => track.stop());
+    const settings = track.getSettings();
+    assert_equals(settings.echoCancellation, "all");
+  }, 'getUserMedia suports "all"');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https-expected.txt
@@ -1,0 +1,6 @@
+When prompted, accept to share your audio stream.
+
+
+PASS getUserMedia suports true
+PASS getUserMedia suports false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<title>getUserMedia echoCancellation remote-only</title>
+<p class="instructions">When prompted, accept to share your audio stream.</p>
+<meta name=timeout content=long>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=permission-helper.js></script>
+<script>
+  'use strict'
+
+  // https://w3c.github.io/mediacapture-main/#dfn-echocancellation
+
+  promise_test(async t => {
+    await setMediaPermission("granted", ["microphone"]);
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: false,
+      audio: {echoCancellation: {exact: true}},
+    });
+    const track = stream.getAudioTracks()[0];
+    t.add_cleanup(() => track.stop());
+    const settings = track.getSettings();
+    assert_equals(settings.echoCancellation, true);
+  }, 'getUserMedia suports true');
+
+  promise_test(async t => {
+    await setMediaPermission("granted", ["microphone"]);
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: false,
+      audio: {echoCancellation: {exact: false}},
+    });
+    const track = stream.getAudioTracks()[0];
+    t.add_cleanup(() => track.stop());
+    const settings = track.getSettings();
+    assert_equals(settings.echoCancellation, false);
+  }, 'getUserMedia suports false');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https-expected.txt
@@ -1,0 +1,5 @@
+When prompted, accept to share your audio stream.
+
+
+FAIL getUserMedia suports "remote-only" assert_equals: expected (string) "remote-only" but got (boolean) true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<title>getUserMedia echoCancellation remote-only</title>
+<p class="instructions">When prompted, accept to share your audio stream.</p>
+<meta name=timeout content=long>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=permission-helper.js></script>
+<script>
+  'use strict'
+
+  // https://w3c.github.io/mediacapture-main/#dom-echocancellationmodeenum-remote-only
+
+  promise_test(async t => {
+    await setMediaPermission("granted", ["microphone"]);
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: false,
+      audio: {echoCancellation: {exact: "remote-only"}},
+    });
+    const track = stream.getAudioTracks()[0];
+    t.add_cleanup(() => track.stop());
+    const settings = track.getSettings();
+    assert_equals(settings.echoCancellation, "remote-only");
+  }, 'getUserMedia suports "remote-only"');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-permissions-query.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-permissions-query.https-expected.txt
@@ -1,0 +1,10 @@
+When prompted, accept to share your camera or microphone.
+
+Description
+
+This test checks that permissions.query() of camera and microphone produce "granted" after successful calls to getUserMedia for the respective device kinds.
+
+
+FAIL camera is granted after getUserMedia, according to permissions.query() assert_true: status.onchange fired for camera permission change expected true got false
+FAIL microphone is granted after getUserMedia, according to permissions.query() assert_true: status.onchange fired for microphone permission change expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-permissions-query.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-permissions-query.https.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+<title>Check permissions.query with getUserMedia</title>
+</head>
+<body>
+<p class="instructions">When prompted, accept to share your camera or microphone.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that permissions.query() of camera and
+microphone produce "granted" after successful calls to getUserMedia for the
+respective device kinds.</p>
+<div id='log'></div>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=permission-helper.js></script>
+<script>
+promise_test(async t => {
+  let status = await navigator.permissions.query({name: "camera"});
+  assert_equals(status.state, "prompt", "initial camera state is prompt");
+
+  let eventFired = false;
+  status.onchange = () => eventFired = true;
+
+  // state is set by setMediaPermission in automation & by gUM when run manually
+  await setMediaPermission("granted", ["camera"]);
+  const stream = await navigator.mediaDevices.getUserMedia({video: true});
+  t.add_cleanup(() => stream.getTracks()[0].stop());
+  status.onchange = null; // defer assert to not overshadow main assert below
+
+  status = await navigator.permissions.query({name: "camera"});
+  assert_equals(status.state, "granted", "camera is granted after getUserMedia");
+  assert_true(eventFired, "status.onchange fired for camera permission change");
+}, "camera is granted after getUserMedia, according to permissions.query()");
+
+promise_test(async t => {
+  let status = await navigator.permissions.query({name: "microphone"});
+  assert_equals(status.state, "prompt", "initial microphone state is prompt");
+  let eventFired = false;
+  status.onchange = () => eventFired = true;
+
+  // state is set by setMediaPermission in automation & by gUM when run manually
+  await setMediaPermission("granted", ["microphone"]);
+  const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+  t.add_cleanup(() => stream.getTracks()[0].stop());
+  status.onchange = null; // defer assert to not overshadow main assert below
+
+  status = await navigator.permissions.query({name: "microphone"});
+  assert_equals(status.state, "granted", "microphone is granted after getUserMedia");
+  assert_true(eventFired, "status.onchange fired for microphone permission change");
+}, "microphone is granted after getUserMedia, according to permissions.query()");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices-per-origin-ids.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices-per-origin-ids.sub.https.html
@@ -9,8 +9,8 @@
 <script src=permission-helper.js></script>
 </head>
 <body>
-  <iframe allow="camera 'src';microphone 'src'" id=same src="/mediacapture-streams/iframe-enumerate.html"></iframe>
-<iframe allow="camera 'src';microphone 'src'" id=cross src="https://{{hosts[][www1]}}:{{ports[https][0]}}/mediacapture-streams/iframe-enumerate.html"></iframe>
+  <iframe allow="camera 'src';microphone 'src';speaker-selection 'src'" id=same src="/mediacapture-streams/iframe-enumerate.html"></iframe>
+<iframe allow="camera 'src';microphone 'src';speaker-selection 'src'" id=cross src="https://{{hosts[][www1]}}:{{ports[https][0]}}/mediacapture-streams/iframe-enumerate.html"></iframe>
 <script>
 
   let deviceList;

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
@@ -7,6 +7,8 @@ PASS mediaDevices.getUserMedia() is present on navigator
 PASS groupId is correctly supported by getUserMedia() for video devices
 PASS groupId is correctly supported by getUserMedia() for audio devices
 FAIL getUserMedia() supports setting none as resizeMode. assert_true: resizeMode should be supported expected true got undefined
-FAIL getUserMedia() supports setting crop-and-scale as resizeMode. assert_true: resizeMode should be supported expected true got undefined
+FAIL getUserMedia() supports setting crop-and-scale as resizeMode without downscaling. assert_true: resizeMode should be supported expected true got undefined
+FAIL getUserMedia() supports setting crop-and-scale as resizeMode with downscaling. assert_true: resizeMode should be supported expected true got undefined
+FAIL getUserMedia() supports setting crop-and-scale as resizeMode with decimation. assert_true: resizeMode should be supported expected true got undefined
 FAIL getUserMedia() fails with exact invalid resizeMode. assert_true: resizeMode should be supported expected true got undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https.html
@@ -114,7 +114,29 @@ promise_test(async t => {
   const [track] = stream.getVideoTracks();
   t.add_cleanup(() => track.stop());
   assert_equals(track.getSettings().resizeMode, 'crop-and-scale');
-}, 'getUserMedia() supports setting crop-and-scale as resizeMode.');
+}, 'getUserMedia() supports setting crop-and-scale as resizeMode without downscaling.');
+
+promise_test(async t => {
+  assert_true(navigator.mediaDevices.getSupportedConstraints()["resizeMode"],
+    "resizeMode should be supported");
+  const stream = await navigator.mediaDevices.getUserMedia(
+      { video: {resizeMode: {exact: 'crop-and-scale'}, width: {max: 30}}});
+  const [track] = stream.getVideoTracks();
+  t.add_cleanup(() => track.stop());
+  assert_equals(track.getSettings().resizeMode, 'crop-and-scale');
+  assert_less_than_equal(track.getSettings().width, 30);
+}, 'getUserMedia() supports setting crop-and-scale as resizeMode with downscaling.');
+
+promise_test(async t => {
+  assert_true(navigator.mediaDevices.getSupportedConstraints()["resizeMode"],
+    "resizeMode should be supported");
+  const stream = await navigator.mediaDevices.getUserMedia(
+      { video: {resizeMode: {exact: 'crop-and-scale'}, frameRate: {max: 5}}});
+  const [track] = stream.getVideoTracks();
+  t.add_cleanup(() => track.stop());
+  assert_equals(track.getSettings().resizeMode, 'crop-and-scale');
+  assert_less_than_equal(track.getSettings().frameRate, 5);
+}, 'getUserMedia() supports setting crop-and-scale as resizeMode with decimation.');
 
 promise_test(async t => {
   assert_true(navigator.mediaDevices.getSupportedConstraints()["resizeMode"],

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getCapabilities.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getCapabilities.https.html
@@ -10,7 +10,7 @@
 const audioProperties = [
   {name: "sampleRate", type: "number"},
   {name: "sampleSize", type: "number"},
-  {name: "echoCancellation", type: "boolean"},
+  {name: "echoCancellation", type: "boolean or string", validValues: [true, false, "all", "remote-only"]},
   {name: "autoGainControl", type: "boolean"},
   {name: "noiseSuppression", type: "boolean"},
   {name: "voiceIsolation", type: "boolean"},
@@ -62,6 +62,13 @@ function verifyEnumAllCapability(capability, enumMembers, testNamePrefix) {
   });
 }
 
+function verifyBooleanOrStringCapability(capability, validMembers) {
+  capability.forEach(c => {
+    assert_true(typeof c == "boolean" || typeof c == "string");
+    assert_in_array(c, validMembers);
+  });
+}
+
 function testCapabilities(capabilities, property, testNamePrefix) {
   let testName = testNamePrefix + " " + property.name;
   test(() => {
@@ -79,6 +86,12 @@ function testCapabilities(capabilities, property, testNamePrefix) {
   if (property.type == "boolean") {
     test(() => {
       verifyBooleanCapability(capability);
+    }, testName);
+  }
+
+  if (property.type == "boolean or string") {
+    test(() => {
+      verifyBooleanOrStringCapability(capability, property.validValues);
     }, testName);
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt
@@ -3,9 +3,7 @@ When prompted, accept to share your video stream.
 
 PASS A device can be opened twice and have the same device ID
 PASS A device can be opened twice with different resolutions requested
-PASS groupId is correctly reported by getSettings() for all input devices
-PASS deviceId is reported by getSettings() for getUserMedia() audio tracks
-PASS groupId is reported by getSettings() for getUserMedia() audio tracks
+PASS deviceId and groupId are correctly reported by getSettings() for all input devices
 PASS sampleRate is reported by getSettings() for getUserMedia() audio tracks
 FAIL sampleSize is reported by getSettings() for getUserMedia() audio tracks assert_equals: sampleSize should exist and it should be a number. expected "number" but got "undefined"
 PASS echoCancellation is reported by getSettings() for getUserMedia() audio tracks
@@ -14,8 +12,6 @@ FAIL noiseSuppression is reported by getSettings() for getUserMedia() audio trac
 FAIL voiceIsolation is reported by getSettings() for getUserMedia() audio tracks assert_equals: voiceIsolation should exist and it should be a boolean. expected "boolean" but got "undefined"
 FAIL latency is reported by getSettings() for getUserMedia() audio tracks assert_equals: latency should exist and it should be a number. expected "number" but got "undefined"
 FAIL channelCount is reported by getSettings() for getUserMedia() audio tracks assert_equals: channelCount should exist and it should be a number. expected "number" but got "undefined"
-PASS deviceId is reported by getSettings() for getUserMedia() video tracks
-PASS groupId is reported by getSettings() for getUserMedia() video tracks
 PASS width is reported by getSettings() for getUserMedia() video tracks
 PASS height is reported by getSettings() for getUserMedia() video tracks
 PASS aspectRatio is reported by getSettings() for getUserMedia() video tracks

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https.html
@@ -71,11 +71,25 @@
     const afterGum = await navigator.mediaDevices.getUserMedia({
       video: true, audio: true
     });
-    afterGum.getTracks().forEach(track => track.stop());
-
     const devices = await navigator.mediaDevices.enumerateDevices();
     const inputDevices = devices.filter(({kind}) => kind != "audiooutput");
     assert_greater_than(inputDevices.length, 1, "have at least 2 test devices");
+
+    // first check the default tracks from the already called getUserMedia()
+    for (const track of afterGum.getTracks()) {
+      const settings = track.getSettings();
+      const device = inputDevices.find(({deviceId}) => deviceId == settings.deviceId);
+      assert_not_equals(device, undefined, `track was from an enumerated device`);
+      assert_equals(`${track.kind}input`, device.kind, `default track is the right kind.`);
+      track.stop();
+      assert_equals(typeof settings.deviceId, "string", "default deviceId is a string");
+      assert_greater_than(settings.deviceId.length, 0, "default deviceId is not empty");
+      assert_equals(settings.deviceId, device.deviceId, "default track deviceId matches device");
+      assert_equals(typeof settings.groupId, "string", "default groupId is a string.");
+      assert_greater_than(settings.groupId.length, 0, "default groupId is not empty");
+      assert_equals(settings.groupId, device.groupId, "default track groupId matches device");
+    }
+    // then check explicitly requesting each input device
     for (const {kind, deviceId, groupId} of inputDevices) {
       const type = {videoinput: "video", audioinput: "audio"}[kind];
       const stream = await navigator.mediaDevices.getUserMedia({
@@ -84,22 +98,15 @@
       const [track] = stream.getTracks();
       const settings = track.getSettings();
       track.stop();
-      assert_true(settings.groupId == groupId, "device groupId");
+      assert_equals(`${track.kind}input`, kind, `track is of the right kind.`);
+      assert_equals(typeof settings.deviceId, "string", "deviceId is a string.");
+      assert_greater_than(settings.deviceId.length, 0, "deviceId is not empty");
+      assert_equals(settings.deviceId, deviceId, "track and device deviceIds match");
+      assert_equals(typeof settings.groupId, "string", "groupId is a string.");
       assert_greater_than(settings.groupId.length, 0, "groupId is not empty");
+      assert_equals(settings.groupId, groupId, "track and device groupId match");
     }
-  }, 'groupId is correctly reported by getSettings() for all input devices');
-
-  promise_test(async t => {
-    const settings = await createTrackAndGetSettings(t, "audio");
-    assert_equals(typeof(settings.deviceId), "string",
-                  "deviceId should exist and it should be a string.");
-  }, 'deviceId is reported by getSettings() for getUserMedia() audio tracks');
-
-  promise_test(async t => {
-    const settings = await createTrackAndGetSettings(t, "audio");
-    assert_equals(typeof(settings.groupId), "string",
-                  "groupId should exist and it should be a string.");
-  }, 'groupId is reported by getSettings() for getUserMedia() audio tracks');
+  }, 'deviceId and groupId are correctly reported by getSettings() for all input devices');
 
   promise_test(async t => {
     const settings = await createTrackAndGetSettings(t, "audio");
@@ -152,18 +159,6 @@
                   "channelCount should exist and it should be a number.");
     assert_greater_than(settings.channelCount, 0);
   }, 'channelCount is reported by getSettings() for getUserMedia() audio tracks');
-
-  promise_test(async t => {
-    const settings = await createTrackAndGetSettings(t, "video");
-    assert_equals(typeof(settings.deviceId), "string",
-                  "deviceId should exist and it should be a string.");
-  }, 'deviceId is reported by getSettings() for getUserMedia() video tracks');
-
-  promise_test(async t => {
-    const settings = await createTrackAndGetSettings(t, "video");
-    assert_equals(typeof(settings.groupId), "string",
-                  "groupId should exist and it should be a string.");
-  }, 'groupId is reported by getSettings() for getUserMedia() video tracks');
 
   promise_test(async t => {
     const settings = await createTrackAndGetSettings(t, "video");

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/permission-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/permission-helper.js
@@ -7,7 +7,7 @@ async function setMediaPermission(status="granted", scope=["camera", "microphone
       await test_driver.set_permission({ name: s }, status);
     }
   } catch (e) {
-    const noSetPermissionSupport = typeof e === "string" && e.match(/set_permission not implemented/);
+    const noSetPermissionSupport = typeof e === "string" && (e.match(/set_permission not implemented/) || e.match(/Unknown permission name/));
     if (!(noSetPermissionSupport ||
           (e instanceof Error && e.message.match("unimplemented")) )) {
       throw e;

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/w3c-import.log
@@ -18,11 +18,15 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/BrowserCaptureMediaStreamTrack-restrictTo.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-api.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-deny.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-empty-option-param.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-impossible-constraint.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-invalid-facing-mode.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-non-applicable-constraint.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-optional-constraint.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-permissions-query.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-required-constraint-with-ideal-value.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-trivial-constraint.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-unknownkey-option-param.https.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -4649,6 +4649,15 @@
     "imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 5e283cb75c33e5ae56526de6b1d609702768fc3a
<pre>
Resync `mediacapture-streams` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=303037">https://bugs.webkit.org/show_bug.cgi?id=303037</a>
<a href="https://rdar.apple.com/165324576">rdar://165324576</a>

Reviewed by Youenn Fablet.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3c78379a9191bc582cb55b10185d4863347df55a">https://github.com/web-platform-tests/wpt/commit/3c78379a9191bc582cb55b10185d4863347df55a</a>

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-all.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-boolean.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-echoCancellation-remote-only.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-permissions-query.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/GUM-permissions-query.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices-per-origin-ids.sub.https.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getCapabilities.https.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/permission-helper.js:
(async setMediaPermission):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/w3c-import.log:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/303506@main">https://commits.webkit.org/303506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2f4a5865dfd51e15efa7417eb286cf3dfbe813a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84575 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/047476a8-107e-4560-902b-fbc3f4a09730) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101347 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68641 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5441d6b-0ebd-4452-82c7-751d1abf68c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135512 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82144 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d4082be-5063-41f9-884b-cb28cd9f34ac) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83320 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142739 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4731 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109723 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3600 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58165 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4785 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33384 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4621 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->