### PR TITLE
Regression(303442@main) TestWebKitAPI.JSHandle.Basic is asserting in debug

### DIFF
--- a/Source/WebCore/page/WebKitJSHandle.cpp
+++ b/Source/WebCore/page/WebKitJSHandle.cpp
@@ -46,9 +46,9 @@ static HandleMap& handleMap()
     return map.get();
 }
 
-Ref<WebKitJSHandle> WebKitJSHandle::create(JSC::JSGlobalObject& globalObject, JSC::JSObject* object)
+Ref<WebKitJSHandle> WebKitJSHandle::create(JSC::JSObject* object)
 {
-    return adoptRef(*new WebKitJSHandle(globalObject, object));
+    return adoptRef(*new WebKitJSHandle(object));
 }
 
 WebKitJSHandle::~WebKitJSHandle()
@@ -97,19 +97,18 @@ static Markable<FrameIdentifier> windowFrameIdentifier(JSC::JSObject* object)
     return std::nullopt;
 }
 
-WebKitJSHandle::WebKitJSHandle(JSC::JSGlobalObject& globalObject, JSC::JSObject* object)
+WebKitJSHandle::WebKitJSHandle(JSC::JSObject* object)
     : m_identifier(JSHandleIdentifier(WebProcessJSHandleIdentifier(reinterpret_cast<uintptr_t>(object)), Process::identifier()))
     , m_windowFrameIdentifier(WebCore::windowFrameIdentifier(object))
 {
     auto addResult = handleMap().ensure(m_identifier, [&] {
         return JSHandleData {
-            JSC::Strong<JSC::JSObject> { globalObject.vm(), object },
+            JSC::Strong<JSC::JSObject> { object->globalObject()->vm(), object },
             0 // Immediately incremented.
         };
     });
     auto& data = addResult.iterator->value;
     data.refCount++;
-    ASSERT(data.strongReference->globalObject() == &globalObject);
 }
 
 }

--- a/Source/WebCore/page/WebKitJSHandle.h
+++ b/Source/WebCore/page/WebKitJSHandle.h
@@ -46,7 +46,7 @@ using JSHandleIdentifier = ProcessQualified<WebProcessJSHandleIdentifier>;
 
 class WEBCORE_EXPORT WebKitJSHandle : public RefCountedAndCanMakeWeakPtr<WebKitJSHandle> {
 public:
-    static Ref<WebKitJSHandle> create(JSC::JSGlobalObject&, JSC::JSObject*);
+    static Ref<WebKitJSHandle> create(JSC::JSObject*);
     static JSC::JSObject* objectForIdentifier(JSHandleIdentifier);
     static void jsHandleDestroyed(JSHandleIdentifier);
     static void jsHandleSentToAnotherProcess(JSHandleIdentifier);
@@ -56,7 +56,7 @@ public:
     Markable<FrameIdentifier> windowFrameIdentifier() const { return m_windowFrameIdentifier; }
 
 private:
-    WebKitJSHandle(JSC::JSGlobalObject&, JSC::JSObject*);
+    WebKitJSHandle(JSC::JSObject*);
 
     const JSHandleIdentifier m_identifier;
     const Markable<FrameIdentifier> m_windowFrameIdentifier;

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -76,9 +76,9 @@ WebKitBufferNamespace& WebKitNamespace::buffers()
     return m_buffers;
 }
 
-Ref<WebKitJSHandle> WebKitNamespace::createJSHandle(JSC::JSGlobalObject& globalObject, JSC::Strong<JSC::JSObject> object)
+Ref<WebKitJSHandle> WebKitNamespace::createJSHandle(JSC::Strong<JSC::JSObject> object)
 {
-    return WebKitJSHandle::create(globalObject, object.get());
+    return WebKitJSHandle::create(object.get());
 }
 
 ExceptionOr<Ref<WebKitSerializedNode>> WebKitNamespace::serializeNode(Node& node, SerializedNodeInit&& init)

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -56,7 +56,7 @@ public:
 
     UserMessageHandlersNamespace* messageHandlers();
     WebKitBufferNamespace& buffers();
-    Ref<WebKitJSHandle> createJSHandle(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>);
+    Ref<WebKitJSHandle> createJSHandle(JSC::Strong<JSC::JSObject>);
 
     struct SerializedNodeInit {
         bool deep { false };

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -32,7 +32,7 @@
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
     readonly attribute WebKitBufferNamespace buffers;
-    [EnabledForGlobalObject=allowsJSHandleCreation, CallWith=CurrentGlobalObject] WebKitJSHandle createJSHandle(object object);
+    [EnabledForGlobalObject=allowsJSHandleCreation] WebKitJSHandle createJSHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9850,7 +9850,7 @@ void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoi
         RELEASE_ASSERT(lexicalGlobalObject->template inherits<WebCore::JSDOMGlobalObject>());
         auto* domGlobalObject = jsCast<WebCore::JSDOMGlobalObject*>(lexicalGlobalObject);
         JSLockHolder locker(lexicalGlobalObject);
-        return WebCore::WebKitJSHandle::create(*lexicalGlobalObject, WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
+        return WebCore::WebKitJSHandle::create(WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
     }();
     WebCore::WebKitJSHandle::jsHandleSentToAnotherProcess(nodeHandle->identifier());
     completionHandler({ JSHandleInfo { nodeHandle->identifier(), pageContentWorldIdentifier(), nodeWebFrame->info(), nodeHandle->windowFrameIdentifier() } });


### PR DESCRIPTION
#### bccdf740c57ef597a1e70cb3cb1fe88df97e35a4
<pre>
Regression(303442@main) TestWebKitAPI.JSHandle.Basic is asserting in debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=303038">https://bugs.webkit.org/show_bug.cgi?id=303038</a>

Reviewed by Geoffrey Garen.

Stop passing the lexicalGlobalObject as a parameter to the
WebKitJSHandle constructor and instead rely on the object&apos;s globalObject.

The implementation expected the lexicalGlobalObject to always be the same
as the object&apos;s globalObject, which wasn&apos;t always true in practice.

* Source/WebCore/page/WebKitJSHandle.cpp:
(WebCore::WebKitJSHandle::create):
(WebCore::WebKitJSHandle::WebKitJSHandle):
* Source/WebCore/page/WebKitJSHandle.h:
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::createJSHandle):
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hitTestAtPoint):

Canonical link: <a href="https://commits.webkit.org/303478@main">https://commits.webkit.org/303478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/984ec2c4d7a44d9ccbfa94676579733e08212497

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84576 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1f7c5c03-e69a-4ca0-9932-4f4150563fa8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101353 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68642 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a6c6cdc3-b131-4da7-99cc-8b0b8d22aff8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135513 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82151 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b511a92-f2b9-4e03-9db1-fbf2c0817b71) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1345 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83321 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142740 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109727 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109908 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3601 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58166 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4786 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33376 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4622 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->