### PR TITLE
[WPE] Right mouse button click stops further mouse button processing

### DIFF
--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -283,6 +283,7 @@ UIProcess/wpe/WPEUtilities.cpp
 UIProcess/wpe/WebPageProxyWPE.cpp
 UIProcess/wpe/WebPasteboardProxyWPE.cpp
 UIProcess/wpe/WebPreferencesWPE.cpp
+UIProcess/wpe/WebContextMenuProxyWPE.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
 UIProcess/XR/openxr/OpenXRInput.cpp

--- a/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -10,7 +10,7 @@
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
  * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
@@ -23,26 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "WebContextMenuProxy.h"
+#include "config.h"
+#include "WebContextMenuProxyWPE.h"
 
 #if ENABLE(CONTEXT_MENUS)
 
 namespace WebKit {
+using namespace WebCore;
 
-class WebContextMenuProxyWPE final : public WebContextMenuProxy {
-public:
-    static auto create(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
-    {
-        return adoptRef(*new WebContextMenuProxyWPE(page, WTFMove(context), userData));
-    }
+WebContextMenuProxyWPE::WebContextMenuProxyWPE(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
+    : WebContextMenuProxy(page, WTFMove(context), userData)
+{
+}
 
-private:
-    WebContextMenuProxyWPE(WebPageProxy&, ContextMenuContextData&&, const UserData&);
-    void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
-};
+void WebContextMenuProxyWPE::showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&& items)
+{
+    notImplemented();
+}
 
 } // namespace WebKit
-
 #endif // ENABLE(CONTEXT_MENUS)


### PR DESCRIPTION
#### d811b2767c100458dc9b72a7c4c30de7a483948d
<pre>
[WPE] Right mouse button click stops further mouse button processing

<a href="https://bugs.webkit.org/show_bug.cgi?id=272354">https://bugs.webkit.org/show_bug.cgi?id=272354</a>

Reviewed by Adrian Perez de Castro.

The context menu request was not followed by any
implementation logic. As a result, WebPageProxy::
clearWaitingForContextMenuToShow() was never called,
leaving the page stuck in a state where mouse click
events were not processed.

This patch introduces the initial plumbing for WPE
context menu handling. Follow-up patches will impl-
ement the full public API to expose hit-test results
and context-menu item information to the application.

This patch is based on the original work by
chrisduerr@. I have updated the work for the WPE port.

Co-authored-by: Christian Duerr(chrisduerr@)&lt;contact@christianduerr.com&gt;

* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp: Copied from Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h.
(WebKit::WebContextMenuProxyWPE::WebContextMenuProxyWPE):
(WebKit::WebContextMenuProxyWPE::showContextMenuWithItems):
* Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h:

Canonical link: <a href="https://commits.webkit.org/303518@main">https://commits.webkit.org/303518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a7c5b0df667e20dd2d60f2c46fbeb8a7a36f75c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84651 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135576 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118809 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82191 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1391 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83386 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142807 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4795 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109772 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109949 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3648 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115081 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/58240 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20583 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4849 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68300 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->