### PR TITLE
[AutoFill Debugging] Add basic support for markdown as an output format

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
@@ -1,0 +1,9 @@
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes.
+[T\[e\]st link](https://www.apple.com/)
+You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things.
+![Purposefully broken image](file:///fake/image.png)
+This is a list:
+- foo
+- bar
+- baz
+<!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
@@ -1,0 +1,39 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes.</p>
+<a href="https://www.apple.com">T[e]st link</a>
+<div>You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things.</div>
+<img src="file:///fake/image.png" alt="Purposefully broken image"></img>
+<p>This is a list:</p>
+<ul>
+    <li>foo</li>
+    <li>bar</li>
+    <li>baz</li>
+</ul>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({ outputFormat: "markdown" });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -56,7 +56,8 @@ enum class TextExtractionOptionFlag : uint8_t {
 
 enum class TextExtractionOutputFormat : uint8_t {
     TextTree,
-    HTMLMarkup
+    HTMLMarkup,
+    Markdown
 };
 
 using TextExtractionOptionFlags = OptionSet<TextExtractionOptionFlag>;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6620,6 +6620,8 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         return WebKit::TextExtractionOutputFormat::TextTree;
     case _WKTextExtractionOutputFormatHTML:
         return WebKit::TextExtractionOutputFormat::HTMLMarkup;
+    case _WKTextExtractionOutputFormatMarkdown:
+        return WebKit::TextExtractionOutputFormat::Markdown;
     default:
         ASSERT_NOT_REACHED();
         return WebKit::TextExtractionOutputFormat::TextTree;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionNodeIdentifierInclusion) {
 typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
     _WKTextExtractionOutputFormatTextTree = 0,
     _WKTextExtractionOutputFormatHTML,
+    _WKTextExtractionOutputFormatMarkdown,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -370,6 +370,9 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
         if (equalLettersIgnoringASCIICase(outputFormat, "html"_s))
             return _WKTextExtractionOutputFormatHTML;
 
+        if (equalLettersIgnoringASCIICase(outputFormat, "markdown"_s))
+            return _WKTextExtractionOutputFormatMarkdown;
+
         if (equalLettersIgnoringASCIICase(outputFormat, "texttree"_s))
             return _WKTextExtractionOutputFormatTextTree;
 


### PR DESCRIPTION
#### acacf10b8aee54863e1ec73bf4a1c1dc860da4b0
<pre>
[AutoFill Debugging] Add basic support for markdown as an output format
<a href="https://bugs.webkit.org/show_bug.cgi?id=303032">https://bugs.webkit.org/show_bug.cgi?id=303032</a>
<a href="https://rdar.apple.com/165316390">rdar://165316390</a>

Reviewed by Richard Robinson.

Add basic support for markdown as an output format. This covers support
for `a` and `img` tags in `[]()` notation, along with unodered lists
prefixed with `-`.

Test: fast/text-extraction/debug-text-extraction-markdown.html

* LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html: Added.
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::escapeStringForMarkdown):
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::addResult):
(WebKit::TextExtractionAggregator::useMarkdownOutput const):
(WebKit::TextExtractionAggregator::pushURLString):

Add a mechanism to keep track of the current URL string when traversing
into a link item. This allows us to insert markdown links as
[text](<a href="http://url)">http://url)</a> when appending text inside of the link.

(WebKit::TextExtractionAggregator::currentURLString const):
(WebKit::TextExtractionAggregator::popURLString):
(WebKit::TextExtractionAggregator::addLineForVersionNumberIfNeeded):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(textExtractionOutputFormat):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/303514@main">https://commits.webkit.org/303514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44fbe9b60e0533a3d0f203403e7d69f8dc3c7038

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84679 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/742c0679-0bb7-477d-8382-1f2fb10a6640) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101413 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68702 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/82dbf549-0099-4e98-a66f-062b2b29c0f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135598 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82206 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6baa593-3e78-4e97-ae8b-bc0bda0ce6e9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83412 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142833 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109787 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109964 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3666 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115105 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58276 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4871 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33453 "Found 1 new test failure: fast/mediastream/granted-denied-request-management1.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4962 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->