### PR TITLE
media/media-source/media-source-allowed-codecs.html is a permanent failure when MediaPlayerPrivateMediaSourceAVFObjC runs in the content process.

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2415,4 +2415,4 @@ webkit.org/b/302174 [ Tahoe Debug arm64 ] platform/mac/media/encrypted-media/fps
 [ Tahoe Debug arm64 ] fast/webgpu/nocrash/ [ Skip ]
 [ Tahoe Debug arm64 ] fast/selectors/is-backtracking.html [ Skip ]
 
-webkit.org/b/302935 [ Sonoma ] media/media-source/media-source-allowed-codecs.html [ Failure ]
+webkit.org/b/302935 [ x86_64 ] media/media-source/media-source-allowed-codecs.html [ Failure ]

--- a/Source/WebCore/platform/MediaStrategy.cpp
+++ b/Source/WebCore/platform/MediaStrategy.cpp
@@ -108,6 +108,11 @@ void MediaStrategy::enableRemoteRenderer(MediaPlayerMediaEngineIdentifier type, 
 {
     m_remoteRenderersEnabled.set(static_cast<uint16_t>(type), enabled);
 }
+
+MediaPlayerEnums::SupportsType MediaStrategy::supportsType(const MediaEngineSupportParameters&) const
+{
+    return MediaPlayerEnums::SupportsType::IsNotSupported;
+}
 #endif
 
 }

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -45,6 +45,7 @@ class AudioDestination;
 class AudioIOCallback;
 class AudioVideoRenderer;
 class CDMFactory;
+struct MediaEngineSupportParameters;
 class NowPlayingManager;
 class VideoFrame;
 
@@ -61,6 +62,7 @@ public:
     virtual RefPtr<AudioVideoRenderer> createAudioVideoRenderer(WTF::LoggerHelper*, HTMLMediaElementIdentifier, MediaPlayerIdentifier) const;
     bool hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier) const;
     void enableRemoteRenderer(MediaPlayerMediaEngineIdentifier, bool);
+    virtual MediaPlayerEnums::SupportsType supportsType(const MediaEngineSupportParameters&) const;
 #endif
     virtual std::unique_ptr<NowPlayingManager> createNowPlayingManager() const;
     void resetMediaEngines();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -188,8 +188,10 @@ MediaPlayer::SupportsType MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndC
 
     auto supported = SourceBufferParser::isContentTypeSupported(parameters.type);
 
-    if (supported != MediaPlayer::SupportsType::IsSupported)
-        return supported;
+    if (supported != MediaPlayer::SupportsType::IsSupported) {
+        if (!hasPlatformStrategies() || platformStrategies()->mediaStrategy()->supportsType(parameters) != MediaPlayer::SupportsType::IsSupported)
+            return supported;
+    }
 
     if (!contentTypeMeetsHardwareDecodeRequirements(parameters.type, parameters.contentTypesRequiringHardwareSupport))
         return MediaPlayer::SupportsType::IsNotSupported;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -80,6 +80,7 @@ private:
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
     friend class MediaPlayerRemoteFactory;
+    friend class WebMediaStrategy;
     void getSupportedTypes(WebCore::MediaPlayerEnums::MediaEngineIdentifier, HashSet<String>&);
     WebCore::MediaPlayer::SupportsType supportsTypeAndCodecs(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const WebCore::MediaEngineSupportParameters&);
     bool supportsKeySystem(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const String& keySystem, const String& mimeType);

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -76,6 +76,17 @@ RefPtr<AudioVideoRenderer> WebMediaStrategy::createAudioVideoRenderer(LoggerHelp
 {
     return AudioVideoRendererRemote::create(loggerHelper, mediaElementIdentifier, playerIdentifier, WebProcess::singleton().ensureProtectedGPUProcessConnection());
 }
+
+MediaPlayerEnums::SupportsType WebMediaStrategy::supportsType(const MediaEngineSupportParameters& parameters) const
+{
+#if USE(AVFOUNDATION)
+    Ref mediaPlayerManager = WebProcess::singleton().protectedRemoteMediaPlayerManager();
+    if (parameters.isMediaSource)
+        return mediaPlayerManager->supportsTypeAndCodecs(MediaPlayerMediaEngineIdentifier::AVFoundationMSE, parameters);
+#endif
+    return MediaStrategy::supportsType(parameters);
+}
+
 #endif
 
 std::unique_ptr<WebCore::NowPlayingManager> WebMediaStrategy::createNowPlayingManager() const

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -48,6 +48,7 @@ private:
 #endif
 #if ENABLE(VIDEO) && ENABLE(GPU_PROCESS)
     RefPtr<WebCore::AudioVideoRenderer> createAudioVideoRenderer(LoggerHelper*, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier) const final;
+    WebCore::MediaPlayerEnums::SupportsType supportsType(const WebCore::MediaEngineSupportParameters&) const final;
 #endif
     std::unique_ptr<WebCore::NowPlayingManager> createNowPlayingManager() const final;
     bool hasThreadSafeMediaSourceSupport() const final;


### PR DESCRIPTION
#### eb1aa3ea4642440dd0c42963a6507902976b9fbd
<pre>
media/media-source/media-source-allowed-codecs.html is a permanent failure when MediaPlayerPrivateMediaSourceAVFObjC runs in the content process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302935">https://bugs.webkit.org/show_bug.cgi?id=302935</a>
<a href="https://rdar.apple.com/165203312">rdar://165203312</a>

Reviewed by NOBODY (OOPS!).

On some systems (macOS Sonoma), [AVStreamDataParser canParseExtendedMIMEType] will not work when used in the content process
due to the sandbox. When add a fallback that should `SourceBufferParser::isContentTypeSupported`
returns false, we will query the GPU process&apos; MediaPlayer as a fallback.

Covered by existing test.
* Source/WebCore/platform/MediaStrategy.cpp:
(WebCore::MediaStrategy::supportsType const):
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndCodecs):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::supportsType const):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638d8115ef4404c2a6dcf41a33042a95e7073670

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84759 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68772 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82267 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3915 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83495 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142917 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4897 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37608 "Found 2 new test failures: fast/images/individual-animation-toggle.html media/media-source/media-source-allowed-codecs.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109852 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110029 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3734 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115176 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58380 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4951 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33523 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4789 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->