### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for CachedResourceClient

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -53,15 +53,25 @@ NavigatorBeacon::~NavigatorBeacon()
         beacon->removeClient(*this);
 }
 
-NavigatorBeacon* NavigatorBeacon::from(Navigator& navigator)
+void NavigatorBeacon::ref() const
 {
-    auto* supplement = downcast<NavigatorBeacon>(Supplement<Navigator>::from(&navigator, supplementName()));
+    m_navigator->ref();
+}
+
+void NavigatorBeacon::deref() const
+{
+    m_navigator->deref();
+}
+
+Ref<NavigatorBeacon> NavigatorBeacon::from(Navigator& navigator)
+{
+    RefPtr supplement = downcast<NavigatorBeacon>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
-        auto newSupplement = makeUnique<NavigatorBeacon>(navigator);
+        auto newSupplement = makeUniqueWithoutRefCountedCheck<NavigatorBeacon>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }
-    return supplement;
+    return supplement.releaseNonNull();
 }
 
 void NavigatorBeacon::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.h
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.h
@@ -50,7 +50,11 @@ public:
 
     size_t inflightBeaconsCount() const { return m_inflightBeacons.size(); }
 
-    WEBCORE_EXPORT static NavigatorBeacon* from(Navigator&);
+    WEBCORE_EXPORT static Ref<NavigatorBeacon> from(Navigator&);
+
+    // CachedResourceClient.
+    WEBCORE_EXPORT void ref() const final;
+    WEBCORE_EXPORT void deref() const final;
 
 private:
     ExceptionOr<bool> sendBeacon(Document&, const String& url, std::optional<FetchBody::Init>&&);

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -2,7 +2,6 @@ Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
-Modules/mediasession/MediaMetadata.cpp
 Modules/mediastream/RTCController.cpp
 Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -349,7 +348,6 @@ loader/SubresourceLoader.cpp
 loader/ThreadableLoaderClientWrapper.h
 loader/WorkerThreadableLoader.cpp
 loader/archive/cf/LegacyWebArchive.cpp
-loader/cache/CachedImage.cpp
 mathml/MathMLElement.cpp
 mathml/MathMLMathElement.cpp
 mathml/MathMLOperatorElement.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -231,7 +231,6 @@ loader/DocumentLoader.cpp
 loader/EmptyClients.cpp
 loader/FrameLoader.cpp
 loader/archive/cf/LegacyWebArchive.cpp
-loader/cache/CachedImage.cpp
 loader/cache/MemoryCache.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -51,6 +51,10 @@ public:
 
     virtual ~CachedModuleScriptLoader();
 
+    // CachedResourceClient.
+    void ref() const final { ModuleScriptLoader::ref(); }
+    void deref() const final { ModuleScriptLoader::deref(); }
+
     bool load(Document&, URL&& sourceURL, std::optional<ServiceWorkersMode>);
 
     CachedScript* cachedScript() { return m_cachedScript.get(); }

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -43,8 +43,12 @@ public:
         m_cachedScript->removeClient(*this);
     }
 
-    unsigned hash() const override;
-    StringView source() const override;
+    // CachedResourceClient.
+    void ref() const final { JSC::SourceProvider::ref(); }
+    void deref() const final { JSC::SourceProvider::deref(); }
+
+    unsigned hash() const final;
+    StringView source() const final;
 
     JSC::CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, JSC::CodeSpecializationKind kind) override
     {

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -51,6 +51,10 @@ public:
         m_cachedScript->removeClient(*this);
     }
 
+    // CachedResourceClient.
+    void ref() const final { JSC::BaseWebAssemblySourceProvider::ref(); }
+    void deref() const final { JSC::BaseWebAssemblySourceProvider::deref(); }
+
     unsigned hash() const final { return m_cachedScript->scriptHash(); }
     StringView source() const final { return m_cachedScript->script(); }
     size_t size() const final { return m_buffer ? m_buffer->size() : 0; }

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -73,7 +73,7 @@ void CSSFontFace::appendSources(CSSFontFace& fontFace, CSSValueList& srcList, Sc
         } else {
             if (allowDownloading) {
                 if (auto request = downcast<CSSFontFaceSrcResourceValue>(const_cast<CSSValue&>(src)).fontLoadRequest(*context, isInitiatingElementInUserAgentShadowTree))
-                    fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, *context->cssFontSelector(), makeUniqueRefFromNonNullUniquePtr(WTFMove(request))));
+                    fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, *context->cssFontSelector(), request.releaseNonNull()));
             }
         }
     }

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -74,10 +74,10 @@ CSSFontFaceSource::CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName
 {
 }
 
-CSSFontFaceSource::CSSFontFaceSource(CSSFontFace& owner, CSSFontSelector& fontSelector, UniqueRef<FontLoadRequest> request)
+CSSFontFaceSource::CSSFontFaceSource(CSSFontFace& owner, CSSFontSelector& fontSelector, Ref<FontLoadRequest>&& request)
     : m_owningCSSFontFace(owner)
     , m_fontSelector(fontSelector)
-    , m_fontRequest(request.moveToUniquePtr())
+    , m_fontRequest(WTFMove(request))
 {
     // This may synchronously call fontLoaded().
     m_fontRequest->setClient(this);

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -51,7 +51,7 @@ class CSSFontFaceSource final : public FontLoadRequestClient {
 public:
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName);
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName, SVGFontFaceElement&);
-    CSSFontFaceSource(CSSFontFace& owner, CSSFontSelector&, UniqueRef<FontLoadRequest>);
+    CSSFontFaceSource(CSSFontFace& owner, CSSFontSelector&, Ref<FontLoadRequest>&&);
     CSSFontFaceSource(CSSFontFace& owner, Ref<JSC::ArrayBufferView>&&);
     virtual ~CSSFontFaceSource();
 
@@ -90,7 +90,7 @@ private:
     AtomString m_fontFaceName; // Font name for local fonts
     WeakRef<CSSFontFace> m_owningCSSFontFace; // Our owning font face.
     WeakPtr<CSSFontSelector> m_fontSelector; // For remote fonts, to orchestrate loading.
-    const std::unique_ptr<FontLoadRequest> m_fontRequest; // Also for remote fonts, a pointer to the resource request.
+    const RefPtr<FontLoadRequest> m_fontRequest; // Also for remote fonts, a pointer to the resource request.
 
     RefPtr<SharedBuffer> m_generatedOTFBuffer;
     RefPtr<JSC::ArrayBufferView> m_immediateSource;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -87,10 +87,10 @@ Ref<CSSFontFaceSrcResourceValue> CSSFontFaceSrcResourceValue::create(CSS::URL lo
     return adoptRef(*new CSSFontFaceSrcResourceValue { WTFMove(location), WTFMove(format), WTFMove(technologies) });
 }
 
-std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(ScriptExecutionContext& context, bool isInitiatingElementInUserAgentShadowTree)
+RefPtr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(ScriptExecutionContext& context, bool isInitiatingElementInUserAgentShadowTree)
 {
     if (m_cachedFont)
-        return makeUnique<CachedFontLoadRequest>(*m_cachedFont, context);
+        return CachedFontLoadRequest::create(*m_cachedFont, context);
 
     bool isFormatSVG;
     if (m_format.isEmpty()) {
@@ -112,8 +112,8 @@ std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(Sc
         }
     }
 
-    auto request = context.fontLoadRequest(m_location.resolved.string(), isFormatSVG, isInitiatingElementInUserAgentShadowTree, m_location.modifiers.loadedFromOpaqueSource);
-    if (auto* cachedRequest = dynamicDowncast<CachedFontLoadRequest>(request.get()))
+    RefPtr request = context.fontLoadRequest(m_location.resolved.string(), isFormatSVG, isInitiatingElementInUserAgentShadowTree, m_location.modifiers.loadedFromOpaqueSource);
+    if (RefPtr cachedRequest = dynamicDowncast<CachedFontLoadRequest>(request.get()))
         m_cachedFont = &cachedRequest->cachedFont();
 
     return request;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -111,7 +111,7 @@ public:
     static Ref<CSSFontFaceSrcResourceValue> create(CSS::URL, String format, Vector<FontTechnology>&&);
 
     bool isEmpty() const { return m_location.specified.isEmpty(); }
-    std::unique_ptr<FontLoadRequest> fontLoadRequest(ScriptExecutionContext&, bool isInitiatingElementInUserAgentShadowTree);
+    RefPtr<FontLoadRequest> fontLoadRequest(ScriptExecutionContext&, bool isInitiatingElementInUserAgentShadowTree);
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&) const;

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -44,7 +44,7 @@ Ref<StyleRuleImport> StyleRuleImport::create(const String& href, MQ::MediaQueryL
 
 StyleRuleImport::StyleRuleImport(const String& href, MQ::MediaQueryList&& mediaQueries, std::optional<CascadeLayerName>&& cascadeLayerName, SupportsCondition&& supportsCondition)
     : StyleRuleBase(StyleRuleType::Import)
-    , m_styleSheetClient(this)
+    , m_styleSheetClient(*this)
     , m_strHref(href)
     , m_mediaQueries(WTFMove(mediaQueries))
     , m_cascadeLayerName(WTFMove(cascadeLayerName))

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -156,7 +156,7 @@ private:
     IntPoint m_dragLocation;
     CachedResourceHandle<CachedImage> m_dragImage;
     RefPtr<Element> m_dragImageElement;
-    std::unique_ptr<DragImageLoader> m_dragImageLoader;
+    RefPtr<DragImageLoader> m_dragImageLoader;
 #endif
 };
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4195,10 +4195,12 @@ void Document::implicitOpen()
     setReadyState(ReadyState::Loading);
 }
 
-std::unique_ptr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
+RefPtr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
     CachedResourceHandle cachedFont = protectedFontLoader()->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
-    return cachedFont ? makeUnique<CachedFontLoadRequest>(*cachedFont, *this) : nullptr;
+    if (!cachedFont)
+        return nullptr;
+    return CachedFontLoadRequest::create(*cachedFont, *this);
 }
 
 void Document::beginLoadingFontSoon(FontLoadRequest& request)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2139,7 +2139,7 @@ private:
 
     // ScriptExecutionContext
     CSSFontSelector* cssFontSelector() final;
-    std::unique_ptr<FontLoadRequest> fontLoadRequest(const String&, bool, bool, LoadedFromOpaqueSource) final;
+    RefPtr<FontLoadRequest> fontLoadRequest(const String&, bool, bool, LoadedFromOpaqueSource) final;
     void beginLoadingFontSoon(FontLoadRequest&) final;
 
     // FontSelectorClient

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -45,6 +45,10 @@ class LoadableNonModuleScriptBase : public LoadableScript, protected CachedResou
 public:
     virtual ~LoadableNonModuleScriptBase();
 
+    // CachedResourceClient.
+    void ref() const final { LoadableScript::ref(); }
+    void deref() const final { LoadableScript::deref(); }
+
     bool isLoaded() const final;
     bool hasError() const final;
     std::optional<Error> takeError() final;

--- a/Source/WebCore/dom/LoadableSpeculationRules.h
+++ b/Source/WebCore/dom/LoadableSpeculationRules.h
@@ -48,6 +48,10 @@ public:
     static Ref<LoadableSpeculationRules> create(Document&, const URL&);
     ~LoadableSpeculationRules();
 
+    // CachedResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     bool load(Document&, const URL&);
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) final;
 

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -40,6 +40,10 @@ public:
     static Ref<ProcessingInstruction> create(Document&, String&& target, String&& data);
     virtual ~ProcessingInstruction();
 
+    // CachedResourceClient.
+    void ref() const final { CharacterData::ref(); }
+    void deref() const final { CharacterData::deref(); }
+
     const String& target() const { return m_target; }
 
     void setCreatedByParser(bool createdByParser) { m_createdByParser = createdByParser; }

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -286,7 +286,7 @@ CSSValuePool& ScriptExecutionContext::cssValuePool()
     return CSSValuePool::singleton();
 }
 
-std::unique_ptr<FontLoadRequest> ScriptExecutionContext::fontLoadRequest(const String&, bool, bool, LoadedFromOpaqueSource)
+RefPtr<FontLoadRequest> ScriptExecutionContext::fontLoadRequest(const String&, bool, bool, LoadedFromOpaqueSource)
 {
     return nullptr;
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -232,7 +232,7 @@ public:
 
     virtual CSSFontSelector* cssFontSelector() { return nullptr; }
     virtual CSSValuePool& cssValuePool();
-    virtual std::unique_ptr<FontLoadRequest> fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource);
+    virtual RefPtr<FontLoadRequest> fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource);
     virtual void beginLoadingFontSoon(FontLoadRequest&) { }
 
     WEBCORE_EXPORT static void setCrossOriginMode(CrossOriginMode);

--- a/Source/WebCore/html/HTMLImageLoader.h
+++ b/Source/WebCore/html/HTMLImageLoader.h
@@ -29,7 +29,6 @@ namespace WebCore {
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HTMLImageLoader);
 class HTMLImageLoader final : public ImageLoader {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLImageLoader, HTMLImageLoader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLImageLoader);
 public:
     explicit HTMLImageLoader(Element&);
     virtual ~HTMLImageLoader();

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -118,7 +118,7 @@ void ExpectIdTargetObserver::idTargetChanged(Element& element)
 
 inline HTMLLinkElement::HTMLLinkElement(const QualifiedName& tagName, Document& document, bool createdByParser)
     : HTMLElement(tagName, document)
-    , m_linkLoader(*this)
+    , m_linkLoader(LinkLoader::create(*this))
     , m_disabledState(Unset)
     , m_loading(false)
     , m_createdByParser(createdByParser)
@@ -333,7 +333,7 @@ void HTMLLinkElement::process()
         fetchPriority(),
     };
 
-    m_linkLoader.loadLink(params, document);
+    m_linkLoader->loadLink(params, document);
 
     bool treatAsStyleSheet = false;
     if (m_relAttribute.isStyleSheet) {
@@ -539,7 +539,7 @@ void HTMLLinkElement::removedFromAncestor(RemovalType removalType, ContainerNode
     if (!removalType.disconnectedFromDocument)
         return;
 
-    m_linkLoader.cancelLoad();
+    m_linkLoader->cancelLoad();
 
     bool wasLoading = styleSheetIsLoading();
 

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -55,6 +55,10 @@ public:
     static Ref<HTMLLinkElement> create(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLLinkElement();
 
+    // CachedResourceClient.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
+
     URL href() const;
     WEBCORE_EXPORT const AtomString& rel() const;
 
@@ -104,13 +108,6 @@ public:
     // Otherwise checks if any Element in the tree does.
     void processInternalResourceLink(Element* = nullptr);
 
-    // AbstractCanMakeCheckedPtr.
-    uint32_t checkedPtrCount() const final { return HTMLElement::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return HTMLElement::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { HTMLElement::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { HTMLElement::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { HTMLElement::setDidBeginCheckedPtrDeletion(); }
-
 private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
@@ -159,7 +156,7 @@ private:
 
     CheckedPtr<Style::Scope> checkedStyleScope();
 
-    LinkLoader m_linkLoader;
+    const Ref<LinkLoader> m_linkLoader;
     CheckedPtr<Style::Scope> m_styleScope;
     CachedResourceHandle<CachedCSSStyleSheet> m_cachedSheet;
     RefPtr<CSSStyleSheet> m_sheet;

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -185,7 +185,7 @@ unsigned ImageInputType::height() const
         return optionalHeight.value();
 
     // If the image is available, use its height.
-    CheckedPtr imageLoader = element->imageLoader();
+    RefPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
         return imageLoader->image()->imageSizeForRenderer(renderer.get(), 1).height().toUnsigned();
 
@@ -208,7 +208,7 @@ unsigned ImageInputType::width() const
         return optionalWidth.value();
 
     // If the image is available, use its width.
-    CheckedPtr imageLoader = element->imageLoader();
+    RefPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
         return imageLoader->image()->imageSizeForRenderer(renderer.get(), 1).width().toUnsigned();
 

--- a/Source/WebCore/html/track/LoadableTextTrack.cpp
+++ b/Source/WebCore/html/track/LoadableTextTrack.cpp
@@ -91,7 +91,7 @@ void LoadableTextTrack::scheduleLoad(const URL& url)
         // 4. Download: If URL is not the empty string, perform a potentially CORS-enabled fetch of URL, with the
         // mode being the state of the media element's crossorigin content attribute, the origin being the
         // origin of the media element's Document, and the default origin behaviour set to fail.
-        m_loader = makeUnique<TextTrackLoader>(static_cast<TextTrackLoaderClient&>(*this), m_trackElement->document());
+        m_loader = TextTrackLoader::create(static_cast<TextTrackLoaderClient&>(*this), m_trackElement->document());
         if (!m_loader->load(m_url, *m_trackElement))
             m_trackElement->didCompleteLoad(HTMLTrackElement::Failure);
     });

--- a/Source/WebCore/html/track/LoadableTextTrack.h
+++ b/Source/WebCore/html/track/LoadableTextTrack.h
@@ -65,7 +65,7 @@ private:
 #endif
 
     WeakPtr<HTMLTrackElement, WeakPtrImplWithEventTargetData> m_trackElement;
-    std::unique_ptr<TextTrackLoader> m_loader;
+    RefPtr<TextTrackLoader> m_loader;
     URL m_url;
     bool m_loadPending { false };
 };

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -50,7 +50,12 @@ using namespace Inspector;
 
 InspectorAuditResourcesObject::InspectorAuditResourcesObject(InspectorAuditAgent& auditAgent)
     : m_auditAgent(auditAgent)
-    , m_cachedImageClient(makeUniqueRef<InspectorAuditCachedImageClient>())
+    , m_cachedResourceClient(*this)
+    , m_cachedFontClient(*this)
+    , m_cachedImageClient(*this)
+    , m_cachedRawResourceClient(*this)
+    , m_cachedSVGDocumentClient(*this)
+    , m_cachedStyleSheetClient(*this)
 {
 }
 
@@ -117,7 +122,7 @@ ExceptionOr<InspectorAuditResourcesObject::ResourceContent> InspectorAuditResour
     return resourceContent;
 }
 
-CachedResourceClient& InspectorAuditResourcesObject::clientForResource(const CachedResource& cachedResource)
+Ref<CachedResourceClient> InspectorAuditResourcesObject::clientForResource(const CachedResource& cachedResource)
 {
     if (is<CachedCSSStyleSheet>(cachedResource))
         return m_cachedStyleSheetClient;
@@ -126,7 +131,7 @@ CachedResourceClient& InspectorAuditResourcesObject::clientForResource(const Cac
         return m_cachedFontClient;
 
     if (is<CachedImage>(cachedResource))
-        return m_cachedImageClient.get();
+        return m_cachedImageClient;
 
     if (is<CachedRawResource>(cachedResource))
         return m_cachedRawResourceClient;

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.h
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.h
@@ -43,7 +43,7 @@ class CachedResource;
 class Document;
 template<typename> class ExceptionOr;
 
-class InspectorAuditResourcesObject : public RefCounted<InspectorAuditResourcesObject> {
+class InspectorAuditResourcesObject : public RefCountedAndCanMakeWeakPtr<InspectorAuditResourcesObject> {
 public:
     static Ref<InspectorAuditResourcesObject> create(Inspector::InspectorAuditAgent& auditAgent)
     {
@@ -69,29 +69,98 @@ public:
 private:
     explicit InspectorAuditResourcesObject(Inspector::InspectorAuditAgent&);
 
-    CachedResourceClient& clientForResource(const CachedResource&);
+    Ref<CachedResourceClient> clientForResource(const CachedResource&);
 
     Inspector::InspectorAuditAgent& m_auditAgent;
 
-    class InspectorAuditCachedResourceClient : public CachedResourceClient { };
+    class InspectorAuditCachedResourceClient : public CachedResourceClient {
+    public:
+        explicit InspectorAuditCachedResourceClient(InspectorAuditResourcesObject& owner)
+            : m_owner(owner)
+        { }
+
+    private:
+        // CachedResourceClient.
+        void ref() const final { m_owner->ref(); }
+        void deref() const final { m_owner->deref(); }
+
+        WeakRef<InspectorAuditResourcesObject> m_owner;
+    };
     InspectorAuditCachedResourceClient m_cachedResourceClient;
 
-    class InspectorAuditCachedFontClient : public CachedFontClient { };
+    class InspectorAuditCachedFontClient : public CachedFontClient {
+    public:
+        explicit InspectorAuditCachedFontClient(InspectorAuditResourcesObject& owner)
+            : m_owner(owner)
+        { }
+
+    private:
+        // CachedResourceClient.
+        void ref() const final { m_owner->ref(); }
+        void deref() const final { m_owner->deref(); }
+
+        WeakRef<InspectorAuditResourcesObject> m_owner;
+    };
     InspectorAuditCachedFontClient m_cachedFontClient;
 
     class InspectorAuditCachedImageClient final : public CachedImageClient {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(InspectorAuditCachedImageClient);
-        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedImageClient);
-    };
-    UniqueRef<InspectorAuditCachedImageClient> m_cachedImageClient;
+    public:
+        explicit InspectorAuditCachedImageClient(InspectorAuditResourcesObject& owner)
+            : m_owner(owner)
+        { }
 
-    class InspectorAuditCachedRawResourceClient : public CachedRawResourceClient { };
+    private:
+        // CachedResourceClient.
+        void ref() const final { m_owner->ref(); }
+        void deref() const final { m_owner->deref(); }
+
+        WeakRef<InspectorAuditResourcesObject> m_owner;
+    };
+    InspectorAuditCachedImageClient m_cachedImageClient;
+
+    class InspectorAuditCachedRawResourceClient : public CachedRawResourceClient {
+    public:
+        explicit InspectorAuditCachedRawResourceClient(InspectorAuditResourcesObject& owner)
+            : m_owner(owner)
+        { }
+
+    private:
+        // CachedResourceClient.
+        void ref() const final { m_owner->ref(); }
+        void deref() const final { m_owner->deref(); }
+
+        WeakRef<InspectorAuditResourcesObject> m_owner;
+    };
     InspectorAuditCachedRawResourceClient m_cachedRawResourceClient;
 
-    class InspectorAuditCachedSVGDocumentClient : public CachedSVGDocumentClient { };
+    class InspectorAuditCachedSVGDocumentClient : public CachedSVGDocumentClient {
+    public:
+        explicit InspectorAuditCachedSVGDocumentClient(InspectorAuditResourcesObject& owner)
+            : m_owner(owner)
+        { }
+
+    private:
+        // CachedResourceClient.
+        void ref() const final { m_owner->ref(); }
+        void deref() const final { m_owner->deref(); }
+
+        WeakRef<InspectorAuditResourcesObject> m_owner;
+    };
     InspectorAuditCachedSVGDocumentClient m_cachedSVGDocumentClient;
 
-    class InspectorAuditCachedStyleSheetClient : public CachedStyleSheetClient { };
+    class InspectorAuditCachedStyleSheetClient : public CachedStyleSheetClient {
+    public:
+        explicit InspectorAuditCachedStyleSheetClient(InspectorAuditResourcesObject& owner)
+            : m_owner(owner)
+        { }
+
+    private:
+        // CachedResourceClient.
+        void ref() const final { m_owner->ref(); }
+        void deref() const final { m_owner->deref(); }
+
+        WeakRef<InspectorAuditResourcesObject> m_owner;
+    };
     InspectorAuditCachedStyleSheetClient m_cachedStyleSheetClient;
 
     MemoryCompactRobinHoodHashMap<String, CachedResource*> m_resources;

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -38,6 +38,11 @@
 
 namespace WebCore {
 
+Ref<ApplicationManifestLoader> ApplicationManifestLoader::create(DocumentLoader& documentLoader, const URL& url, bool useCredentials)
+{
+    return adoptRef(*new ApplicationManifestLoader(documentLoader, url, useCredentials));
+}
+
 ApplicationManifestLoader::ApplicationManifestLoader(DocumentLoader& documentLoader, const URL& url, bool useCredentials)
     : m_documentLoader(documentLoader)
     , m_url(url)
@@ -53,7 +58,7 @@ ApplicationManifestLoader::~ApplicationManifestLoader()
 bool ApplicationManifestLoader::startLoading()
 {
     ASSERT(!m_resource);
-    RefPtr frame = m_documentLoader->frame();
+    RefPtr frame = m_documentLoader ? m_documentLoader->frame() : nullptr;
     if (!frame)
         return false;
 
@@ -121,7 +126,8 @@ std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
 void ApplicationManifestLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
-    Ref { m_documentLoader.get() }->finishedLoadingApplicationManifest(*this);
+    if (RefPtr documentLoader = m_documentLoader.get())
+        documentLoader->finishedLoadingApplicationManifest(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -187,11 +187,6 @@ class DocumentLoader
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentLoader, DocumentLoader);
     friend class ContentFilter;
 public:
-#if ENABLE(CONTENT_FILTERING)
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-#endif
-
     static Ref<DocumentLoader> create(ResourceRequest&& request, SubstituteData&& data)
     {
         return adoptRef(*new DocumentLoader(WTFMove(request), WTFMove(data)));
@@ -202,6 +197,10 @@ public:
     WEBCORE_EXPORT static DocumentLoader* fromScriptExecutionContextIdentifier(ScriptExecutionContextIdentifier);
 
     WEBCORE_EXPORT virtual ~DocumentLoader();
+
+    // CachedResourceClient, ContentFilterClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void attachToFrame(LocalFrame&);
 
@@ -712,11 +711,11 @@ private:
     Markable<ResourceLoaderIdentifier> m_identifierForLoadWithoutResourceLoader;
 
     HashMap<uint64_t, LinkIcon> m_iconsPendingLoadDecision;
-    HashMap<std::unique_ptr<IconLoader>, CompletionHandler<void(FragmentedSharedBuffer*)>> m_iconLoaders;
+    HashMap<RefPtr<IconLoader>, CompletionHandler<void(FragmentedSharedBuffer*)>> m_iconLoaders;
     Vector<LinkIcon> m_linkIcons;
 
 #if ENABLE(APPLICATION_MANIFEST)
-    std::unique_ptr<ApplicationManifestLoader> m_applicationManifestLoader;
+    RefPtr<ApplicationManifestLoader> m_applicationManifestLoader;
     Vector<CompletionHandler<void(const std::optional<ApplicationManifest>&)>> m_loadApplicationManifestCallbacks;
 #endif
 

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -51,8 +51,11 @@ public:
         Box<NetworkLoadMetrics> metrics;
     };
     static Ref<DocumentPrefetcher> create(FrameLoader& frameLoader) { return adoptRef(*new DocumentPrefetcher(frameLoader)); }
-    explicit DocumentPrefetcher(FrameLoader&);
     ~DocumentPrefetcher();
+
+    // CachedResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void prefetch(const URL&, const Vector<String>& tags, std::optional<ReferrerPolicy>, bool lowPriority = false);
     bool wasPrefetched(const URL&) const;
@@ -65,6 +68,8 @@ public:
 
 
 private:
+    explicit DocumentPrefetcher(FrameLoader&);
+
     WeakRef<FrameLoader> m_frameLoader;
     HashMap<URL, PrefetchedResourceData> m_prefetchedData;
 };

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -69,8 +69,9 @@ class CachedRawResource;
         friend class InspectorInstrumentation;
         friend class InspectorNetworkAgent;
 
-        using RefCounted<DocumentThreadableLoader>::ref;
-        using RefCounted<DocumentThreadableLoader>::deref;
+        // CachedResourceClient.
+        void ref() const final { RefCounted::ref(); }
+        void deref() const final { RefCounted::deref(); }
 
     protected:
         void refThreadableLoader() override { ref(); }
@@ -148,7 +149,7 @@ class CachedRawResource;
         bool m_delayCallbacksForIntegrityCheck;
         std::unique_ptr<ContentSecurityPolicy> m_contentSecurityPolicy;
         std::optional<CrossOriginEmbedderPolicy> m_crossOriginEmbedderPolicy;
-        std::optional<CrossOriginPreflightChecker> m_preflightChecker;
+        RefPtr<CrossOriginPreflightChecker> m_preflightChecker;
         std::optional<HTTPHeaderMap> m_originalHeaders;
         URL m_responseURL;
 

--- a/Source/WebCore/loader/FontLoadRequest.h
+++ b/Source/WebCore/loader/FontLoadRequest.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/FontTaggedSettings.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
@@ -48,7 +49,7 @@ public:
     virtual void fontLoaded(FontLoadRequest&) { }
 };
 
-class FontLoadRequest {
+class FontLoadRequest : public AbstractRefCounted {
 public:
     virtual ~FontLoadRequest() = default;
 

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -49,12 +49,12 @@ enum class LazyImageLoadState : uint8_t { None, Deferred, LoadImmediately, FullI
 
 class ImageLoader : public CachedImageClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ImageLoader, Loader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ImageLoader);
 public:
     virtual ~ImageLoader();
 
-    void ref() const;
-    void deref() const;
+    // CachedResourceClient.
+    void ref() const final;
+    void deref() const final;
 
     // This function should be called when the element is attached to a document; starts
     // loading if a load hasn't already been started.

--- a/Source/WebCore/loader/LinkLoaderClient.h
+++ b/Source/WebCore/loader/LinkLoaderClient.h
@@ -31,11 +31,11 @@
 
 #pragma once
 
-#include <wtf/AbstractCanMakeCheckedPtr.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
-class LinkLoaderClient : public AbstractCanMakeCheckedPtr {
+class LinkLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<LinkLoaderClient> {
 public:
     virtual ~LinkLoaderClient() = default;
 

--- a/Source/WebCore/loader/LinkPreloadResourceClients.cpp
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.cpp
@@ -39,8 +39,8 @@ LinkPreloadResourceClient::LinkPreloadResourceClient(LinkLoader& loader, CachedR
 
 void LinkPreloadResourceClient::triggerEvents(const CachedResource& resource)
 {
-    if (m_loader)
-        m_loader->triggerEvents(resource);
+    if (RefPtr loader = m_loader.get())
+        loader->triggerEvents(resource);
 }
 
 }

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -37,13 +37,15 @@
 #include "CachedScript.h"
 #include <WebCore/CachedStyleSheetClient.h>
 #include "CachedTextTrack.h"
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class LinkLoader;
 
-class LinkPreloadResourceClient {
+class LinkPreloadResourceClient : public AbstractRefCounted {
 public:
     virtual ~LinkPreloadResourceClient() = default;
 
@@ -75,31 +77,49 @@ private:
     CachedResourceHandle<CachedResource> m_resource;
 };
 
-class LinkPreloadDefaultResourceClient : public LinkPreloadResourceClient, CachedResourceClient {
+class LinkPreloadDefaultResourceClient : public LinkPreloadResourceClient, CachedResourceClient, public RefCounted<LinkPreloadDefaultResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadDefaultResourceClient, Loader);
 public:
+    static Ref<LinkPreloadDefaultResourceClient> create(LinkLoader& loader, CachedResource& resource)
+    {
+        return adoptRef(*new LinkPreloadDefaultResourceClient(loader, resource));
+    }
+
+    // LinkPreloadResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
     LinkPreloadDefaultResourceClient(LinkLoader& loader, CachedResource& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
 
-private:
     void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadStyleResourceClient : public LinkPreloadResourceClient, public CachedStyleSheetClient {
+class LinkPreloadStyleResourceClient : public LinkPreloadResourceClient, public CachedStyleSheetClient, public RefCounted<LinkPreloadStyleResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadStyleResourceClient, Loader);
 public:
+    static Ref<LinkPreloadStyleResourceClient> create(LinkLoader& loader, CachedCSSStyleSheet& resource)
+    {
+        return adoptRef(*new LinkPreloadStyleResourceClient(loader, resource));
+    }
+
+    // LinkPreloadResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
     LinkPreloadStyleResourceClient(LinkLoader& loader, CachedCSSStyleSheet& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
 
-private:
     void setCSSStyleSheet(const String&, const URL&, ASCIILiteral, const CachedCSSStyleSheet* resource) final
     {
         ASSERT(resource);
@@ -111,32 +131,49 @@ private:
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadImageResourceClient : public LinkPreloadResourceClient, public CachedImageClient {
+class LinkPreloadImageResourceClient : public LinkPreloadResourceClient, public CachedImageClient, public RefCounted<LinkPreloadImageResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadImageResourceClient, Loader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkPreloadImageResourceClient);
 public:
+    static Ref<LinkPreloadImageResourceClient> create(LinkLoader& loader, CachedImage& resource)
+    {
+        return adoptRef(*new LinkPreloadImageResourceClient(loader, resource));
+    }
+
+    // LinkPreloadResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
     LinkPreloadImageResourceClient(LinkLoader& loader, CachedImage& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
 
-private:
     void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadFontResourceClient : public LinkPreloadResourceClient, public CachedFontClient {
+class LinkPreloadFontResourceClient : public LinkPreloadResourceClient, public CachedFontClient, public RefCounted<LinkPreloadFontResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadFontResourceClient, Loader);
 public:
+    static Ref<LinkPreloadFontResourceClient> create(LinkLoader& loader, CachedFont& resource)
+    {
+        return adoptRef(*new LinkPreloadFontResourceClient(loader, resource));
+    }
+
+    // LinkPreloadResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
     LinkPreloadFontResourceClient(LinkLoader& loader, CachedFont& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
 
-private:
     void fontLoaded(CachedFont& resource) final
     {
         ASSERT(ownedResource() == &resource);
@@ -147,16 +184,25 @@ private:
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadRawResourceClient : public LinkPreloadResourceClient, public CachedRawResourceClient {
+class LinkPreloadRawResourceClient : public LinkPreloadResourceClient, public CachedRawResourceClient, public RefCounted<LinkPreloadRawResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadRawResourceClient, Loader);
 public:
+    static Ref<LinkPreloadRawResourceClient> create(LinkLoader& loader, CachedRawResource& resource)
+    {
+        return adoptRef(*new LinkPreloadRawResourceClient(loader, resource));
+    }
+
+    // LinkPreloadResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
     LinkPreloadRawResourceClient(LinkLoader& loader, CachedRawResource& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
 
-private:
     void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -104,6 +104,8 @@ public:
     bool didPassAccessControlCheck() const override { return m_didPassAccessControlCheck.load(); }
 
     // CachedRawResourceClient
+    void ref() const final { PlatformMediaResource::ref(); }
+    void deref() const final { PlatformMediaResource::deref(); }
     void responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;
     void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) override;
     bool shouldCacheResponse(CachedResource&, const ResourceResponse&) override;

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -137,8 +137,8 @@ void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&, LoadWillContinu
         return;
 
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
-    while (CachedStyleSheetClient* c = walker.next())
-        c->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), protectedDecoder()->encoding().name(), this);
+    while (RefPtr client = walker.next())
+        client->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), protectedDecoder()->encoding().name(), this);
 }
 
 String CachedCSSStyleSheet::responseMIMEType() const

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -222,7 +222,7 @@ void CachedFont::checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnothe
         return;
 
     CachedResourceClientWalker<CachedFontClient> walker(*this);
-    while (CachedFontClient* client = walker.next())
+    while (RefPtr client = walker.next())
         client->fontLoaded(*this);
 }
 

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -186,7 +186,7 @@ void CachedImage::addClientWaitingForAsyncDecoding(CachedImageClient& client)
         // to cancel the repaint optimization we do in CachedImage::imageFrameAvailable() by adding
         // all the m_clients to m_clientsWaitingForAsyncDecoding.
         CachedResourceClientWalker<CachedImageClient> walker(*this);
-        while (auto* client = walker.next())
+        while (RefPtr client = walker.next())
             m_clientsWaitingForAsyncDecoding.add(*client);
     } else
         m_clientsWaitingForAsyncDecoding.add(client);
@@ -202,8 +202,8 @@ void CachedImage::removeAllClientsWaitingForAsyncDecoding()
         return;
     bitmapImage->stopDecodingWorkQueue();
 
-    for (auto& client : m_clientsWaitingForAsyncDecoding)
-        client.imageChanged(this);
+    for (Ref client : m_clientsWaitingForAsyncDecoding)
+        client->imageChanged(this);
     m_clientsWaitingForAsyncDecoding.clear();
 }
 
@@ -374,8 +374,8 @@ bool CachedImage::hasHDRContent() const
 void CachedImage::notifyObservers(const IntRect* changeRect)
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);
-    while (CachedImageClient* c = walker.next())
-        c->imageChanged(this, changeRect);
+    while (RefPtr client = walker.next())
+        client->imageChanged(this, changeRect);
 }
 
 void CachedImage::checkShouldPaintBrokenImage()
@@ -688,7 +688,7 @@ bool CachedImage::canDestroyDecodedData(const Image& image) const
         return false;
 
     CachedResourceClientWalker<CachedImageClient> walker(*this);
-    while (CachedImageClient* client = walker.next()) {
+    while (RefPtr client = walker.next()) {
         if (!client->canDestroyDecodedData())
             return false;
     }
@@ -704,7 +704,7 @@ void CachedImage::imageFrameAvailable(const Image& image, ImageAnimatingState an
     CachedResourceClientWalker<CachedImageClient> walker(*this);
     VisibleInViewportState visibleState = VisibleInViewportState::No;
 
-    while (CachedImageClient* client = walker.next()) {
+    while (RefPtr client = walker.next()) {
         // All the clients of animated images have to be notified. The new frame has to be drawn in all of them.
         if (animatingState == ImageAnimatingState::No && !m_clientsWaitingForAsyncDecoding.contains(*client))
             continue;
@@ -732,7 +732,7 @@ void CachedImage::imageContentChanged(const Image& image)
         return;
 
     CachedResourceClientWalker<CachedImageClient> walker(*this);
-    while (auto* client = walker.next())
+    while (RefPtr client = walker.next())
         client->imageContentChanged(*this);
 }
 
@@ -742,7 +742,7 @@ void CachedImage::scheduleRenderingUpdate(const Image& image)
         return;
 
     CachedResourceClientWalker<CachedImageClient> walker(*this);
-    while (auto* client = walker.next())
+    while (RefPtr client = walker.next())
         client->scheduleRenderingUpdateForImage(*this);
 }
 
@@ -755,7 +755,7 @@ bool CachedImage::allowsAnimation(const Image& image) const
         return true;
 
     CachedResourceClientWalker<CachedImageClient> walker(*this);
-    while (auto* client = walker.next()) {
+    while (RefPtr client = walker.next()) {
         if (!client->allowsAnimation())
             return false;
     }
@@ -808,7 +808,7 @@ bool CachedImage::canSkipRevalidation(const CachedResourceLoader& loader, const 
 bool CachedImage::isVisibleInViewport(const Document& document) const
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);
-    while (auto* client = walker.next()) {
+    while (RefPtr client = walker.next()) {
         if (client->imageVisibleInViewport(document) == VisibleInViewportState::Yes)
             return true;
     }

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -34,9 +34,8 @@ class IntRect;
 
 enum class VisibleInViewportState { Unknown, Yes, No };
 
-class WEBCORE_EXPORT CachedImageClient : public CachedResourceClient, public CanMakeCheckedPtr<CachedImageClient> {
+class WEBCORE_EXPORT CachedImageClient : public CachedResourceClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CachedImageClient);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedImageClient);
 public:
     virtual ~CachedImageClient() = default;
     static CachedResourceClientType expectedType() { return ImageType; }

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -141,8 +141,8 @@ void CachedRawResource::notifyClientsDataWasReceived(const SharedBuffer& buffer)
 
     CachedResourceHandle protectedThis { this };
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->dataReceived(*this, buffer);
+    while (RefPtr client = walker.next())
+        client->dataReceived(*this, buffer);
 }
 
 static void iterateRedirects(CachedResourceHandle<CachedRawResource>&& handle, CachedRawResourceClient& client, Vector<std::pair<ResourceRequest, ResourceResponse>>&& redirectsInReverseOrder, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
@@ -207,7 +207,7 @@ void CachedRawResource::allClientsRemoved()
 
 static void iterateClients(CachedResourceClientWalker<CachedRawResourceClient>&& walker, CachedResourceHandle<CachedRawResource>&& handle, ResourceRequest&& request, std::unique_ptr<ResourceResponse>&& response, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
-    auto client = walker.next();
+    RefPtr client = walker.next();
     if (!client)
         return completionHandler(WTFMove(request));
     const ResourceResponse& responseReference = *response;
@@ -236,15 +236,15 @@ void CachedRawResource::responseReceived(ResourceResponse&& newResponse)
         m_resourceLoaderIdentifier = m_loader->identifier();
     CachedResource::responseReceived(WTFMove(newResponse));
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->responseReceived(*this, response(), nullptr);
+    while (RefPtr client = walker.next())
+        client->responseReceived(*this, response(), nullptr);
 }
 
 bool CachedRawResource::shouldCacheResponse(const ResourceResponse& response)
 {
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next()) {
-        if (!c->shouldCacheResponse(*this, response))
+    while (RefPtr client = walker.next()) {
+        if (!client->shouldCacheResponse(*this, response))
             return false;
     }
     return true;
@@ -253,15 +253,15 @@ bool CachedRawResource::shouldCacheResponse(const ResourceResponse& response)
 void CachedRawResource::didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent)
 {
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->dataSent(*this, bytesSent, totalBytesToBeSent);
+    while (RefPtr client = walker.next())
+        client->dataSent(*this, bytesSent, totalBytesToBeSent);
 }
 
 void CachedRawResource::finishedTimingForWorkerLoad(ResourceTiming&& resourceTiming)
 {
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->finishedTimingForWorkerLoad(*this, resourceTiming);
+    while (RefPtr client = walker.next())
+        client->finishedTimingForWorkerLoad(*this, resourceTiming);
 }
 
 void CachedRawResource::switchClientsToRevalidatedResource()

--- a/Source/WebCore/loader/cache/CachedRawResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedRawResourceClient.h
@@ -26,15 +26,6 @@
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
-class CachedRawResourceClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedRawResourceClient> : std::true_type { };
-}
-
-namespace WebCore {
 
 class CachedResource;
 class ResourceRequest;

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -316,7 +316,7 @@ void CachedResource::checkNotify(const NetworkLoadMetrics& metrics, LoadWillCont
         return;
 
     CachedResourceClientWalker<CachedResourceClient> walker(*this);
-    while (CachedResourceClient* client = walker.next())
+    while (RefPtr client = walker.next())
         client->notifyFinished(*this, metrics, loadWillContinueInAnotherProcess);
 }
 
@@ -782,10 +782,10 @@ void CachedResource::switchClientsToRevalidatedResource()
 
     Vector<SingleThreadWeakPtr<CachedResourceClient>> clientsToMove;
     for (auto entry : m_clients) {
-        auto& client = entry.key;
+        Ref client = entry.key;
         unsigned count = entry.value;
         while (count) {
-            clientsToMove.append(client);
+            clientsToMove.append(client.get());
             --count;
         }
     }

--- a/Source/WebCore/loader/cache/CachedResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedResourceClient.h
@@ -25,25 +25,17 @@
 #pragma once
 
 #include <WebCore/FrameLoaderTypes.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class CachedResourceClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedResourceClient> : std::true_type { };
-}
 
 namespace WebCore {
 
 class CachedResource;
 class NetworkLoadMetrics;
 
-class WEBCORE_EXPORT CachedResourceClient : public CanMakeSingleThreadWeakPtr<CachedResourceClient> {
+class WEBCORE_EXPORT CachedResourceClient : public CanMakeSingleThreadWeakPtr<CachedResourceClient>, public AbstractRefCounted {
     WTF_MAKE_NONCOPYABLE(CachedResourceClient);
 public:
     enum CachedResourceClientType {

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -233,6 +233,7 @@ CachedResourceLoader::CachedResourceLoader(DocumentLoader* documentLoader)
     : m_documentLoader(documentLoader)
     , m_unusedPreloadsTimer(*this, &CachedResourceLoader::warnUnusedPreloads)
     , m_garbageCollectDocumentResourcesTimer(*this, &CachedResourceLoader::garbageCollectDocumentResources)
+    , m_keepaliveRequestTracker(KeepaliveRequestTracker::create())
 {
 }
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -175,7 +175,7 @@ public:
 
     ResourceTimingInformation& resourceTimingInformation() { return m_resourceTimingInfo; }
 
-    KeepaliveRequestTracker& keepaliveRequestTracker() { return m_keepaliveRequestTracker; }
+    KeepaliveRequestTracker& keepaliveRequestTracker() { return m_keepaliveRequestTracker.get(); }
 
     Vector<CachedResourceHandle<CachedResource>> visibleResourcesToPrioritize();
 
@@ -231,7 +231,7 @@ private:
     Timer m_garbageCollectDocumentResourcesTimer;
 
     ResourceTimingInformation m_resourceTimingInfo;
-    KeepaliveRequestTracker m_keepaliveRequestTracker;
+    const Ref<KeepaliveRequestTracker> m_keepaliveRequestTracker;
 
     bool m_autoLoadImages { true };
     bool m_imagesEnabled { true };

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
@@ -35,6 +35,11 @@
 
 namespace WebCore {
 
+Ref<CachedSVGDocumentReference> CachedSVGDocumentReference::create(const Style::URL& location)
+{
+    return adoptRef(*new CachedSVGDocumentReference(location));
+}
+
 CachedSVGDocumentReference::CachedSVGDocumentReference(const Style::URL& location)
     : m_location { location }
 {

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
@@ -37,12 +37,16 @@ class CachedSVGDocument;
 class CachedResourceLoader;
 struct ResourceLoaderOptions;
 
-class CachedSVGDocumentReference final : public CachedSVGDocumentClient {
+class CachedSVGDocumentReference final : public CachedSVGDocumentClient, public RefCounted<CachedSVGDocumentReference> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CachedSVGDocumentReference, Loader);
 public:
-    CachedSVGDocumentReference(const Style::URL&);
+    static Ref<CachedSVGDocumentReference> create(const Style::URL&);
 
     virtual ~CachedSVGDocumentReference();
+
+    // CachedResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void load(CachedResourceLoader&, const ResourceLoaderOptions&);
     bool loadRequested() const { return m_loadRequested; }
@@ -50,6 +54,8 @@ public:
     CachedSVGDocument* document() { return m_document.get(); }
 
 private:
+    explicit CachedSVGDocumentReference(const Style::URL&);
+
     Style::URL m_location;
     CachedResourceHandle<CachedSVGDocument> m_document;
     bool m_loadRequested { false };

--- a/Source/WebCore/loader/cache/CachedTextTrack.cpp
+++ b/Source/WebCore/loader/cache/CachedTextTrack.cpp
@@ -49,7 +49,7 @@ void CachedTextTrack::doUpdateBuffer(const FragmentedSharedBuffer* data)
     setEncodedSize(data ? data->size() : 0);
 
     CachedResourceClientWalker<CachedResourceClient> walker(*this);
-    while (CachedResourceClient* client = walker.next())
+    while (RefPtr client = walker.next())
         client->deprecatedDidReceiveCachedResource(*this);
 }
 

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -87,8 +87,8 @@ void CachedXSLStyleSheet::checkNotify(const NetworkLoadMetrics&, LoadWillContinu
         return;
     
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
-    while (CachedStyleSheetClient* c = walker.next())
-        c->setXSLStyleSheet(m_resourceRequest.url().string(), response().url(), m_sheet);
+    while (RefPtr client = walker.next())
+        client->setXSLStyleSheet(m_resourceRequest.url().string(), response().url(), m_sheet);
 }
 
 #endif

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -28,7 +28,12 @@
 
 namespace WebCore {
 
-const uint64_t maxInflightKeepaliveBytes { 65536 }; // 64 kibibytes as per Fetch specification.
+constexpr uint64_t maxInflightKeepaliveBytes { 65536 }; // 64 kibibytes as per Fetch specification.
+
+Ref<KeepaliveRequestTracker> KeepaliveRequestTracker::create()
+{
+    return adoptRef(*new KeepaliveRequestTracker);
+}
 
 KeepaliveRequestTracker::~KeepaliveRequestTracker()
 {

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
@@ -32,12 +32,20 @@
 
 namespace WebCore {
 
-class KeepaliveRequestTracker final : public CachedRawResourceClient {
+class KeepaliveRequestTracker final : public CachedRawResourceClient, public RefCounted<KeepaliveRequestTracker> {
 public:
+    static Ref<KeepaliveRequestTracker> create();
     ~KeepaliveRequestTracker();
+
     bool tryRegisterRequest(CachedResource&);
 
+    // CachedResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    KeepaliveRequestTracker() = default;
+
     // CachedRawResourceClient.
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -42,6 +42,11 @@
 
 namespace WebCore {
 
+Ref<IconLoader> IconLoader::create(DocumentLoader& documentLoader, const URL& url)
+{
+    return adoptRef(*new IconLoader(documentLoader, url));
+}
+
 IconLoader::IconLoader(DocumentLoader& documentLoader, const URL& url)
     : m_documentLoader(documentLoader)
     , m_url(url)
@@ -58,7 +63,7 @@ void IconLoader::startLoading()
     if (m_resource)
         return;
 
-    RefPtr frame = m_documentLoader->frame();
+    RefPtr frame = m_documentLoader ? m_documentLoader->frame() : nullptr;
     if (!frame)
         return;
 
@@ -122,7 +127,8 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
 
     // DocumentLoader::finishedLoadingIcon destroys this IconLoader as it finishes. This will automatically
     // trigger IconLoader::stopLoading() during destruction, so we should just return here.
-    Ref { m_documentLoader.get() }->finishedLoadingIcon(*this, data.get());
+    if (RefPtr documentLoader = m_documentLoader.get())
+        documentLoader->finishedLoadingIcon(*this, data.get());
 }
 
 }

--- a/Source/WebCore/loader/icon/IconLoader.h
+++ b/Source/WebCore/loader/icon/IconLoader.h
@@ -30,6 +30,7 @@
 #include "LoaderMalloc.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
 #include <wtf/URL.h>
 #include <wtf/WeakRef.h>
 
@@ -39,19 +40,25 @@ class CachedRawResource;
 class DocumentLoader;
 class LocalFrame;
 
-class IconLoader final : private CachedRawResourceClient {
+class IconLoader final : public RefCounted<IconLoader>, private CachedRawResourceClient {
     WTF_MAKE_NONCOPYABLE(IconLoader); WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(IconLoader, Loader);
 public:
-    IconLoader(DocumentLoader&, const URL&);
+    static Ref<IconLoader> create(DocumentLoader&, const URL&);
     virtual ~IconLoader();
+
+    // CachedResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void startLoading();
     void stopLoading();
 
 private:
+    IconLoader(DocumentLoader&, const URL&);
+
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
-    SingleThreadWeakRef<DocumentLoader> m_documentLoader;
+    SingleThreadWeakPtr<DocumentLoader> m_documentLoader;
     URL m_url;
     CachedResourceHandle<CachedRawResource> m_resource;
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h
@@ -75,7 +75,7 @@ private:
     ThreadSafeWeakPtr<MediaPlayerPrivateAVFoundationObjC> m_parent;
     RetainPtr<AVAssetResourceLoadingRequest> m_avRequest;
     std::unique_ptr<DataURLResourceMediaLoader> m_dataURLMediaLoader;
-    std::unique_ptr<CachedResourceMediaLoader> m_resourceMediaLoader;
+    RefPtr<CachedResourceMediaLoader> m_resourceMediaLoader;
     RefPtr<PlatformResourceMediaLoader> m_platformMediaLoader;
     bool m_isBlob { false };
     size_t m_responseOffset { 0 };

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -231,7 +231,7 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
     }
 
     if (context.invalidatingImagesWithAsyncDecodes()) {
-        if (shouldPaintBackgroundImage && bgImage->cachedImage()->isClientWaitingForAsyncDecoding(m_renderer))
+        if (shouldPaintBackgroundImage && bgImage->cachedImage()->isClientWaitingForAsyncDecoding(m_renderer.cachedImageClient()))
             bgImage->cachedImage()->removeAllClientsWaitingForAsyncDecoding();
         return;
     }
@@ -531,7 +531,7 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
             auto drawResult = context.drawTiledImage(*image, geometry.destinationRect, toLayoutPoint(geometry.relativePhase()), geometry.tileSize, geometry.spaceSize, options);
             if (drawResult == ImageDrawResult::DidRequestDecoding) {
                 ASSERT(bgImage->hasCachedImage());
-                bgImage->cachedImage()->addClientWaitingForAsyncDecoding(m_renderer);
+                bgImage->cachedImage()->addClientWaitingForAsyncDecoding(m_renderer.cachedImageClient());
             }
 
             if (!context.paintingDisabled()) {

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -516,7 +516,7 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
 
     GraphicsContext& context = paintInfo.context();
     if (context.invalidatingImagesWithAsyncDecodes()) {
-        if (cachedImage() && cachedImage()->isClientWaitingForAsyncDecoding(*this))
+        if (cachedImage() && cachedImage()->isClientWaitingForAsyncDecoding(cachedImageClient()))
             cachedImage()->removeAllClientsWaitingForAsyncDecoding();
         return;
     }
@@ -775,7 +775,7 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
         drawResult = paintInfo.context().drawImage(*img, rect, options);
 
     if (drawResult == ImageDrawResult::DidRequestDecoding)
-        imageResource().cachedImage()->addClientWaitingForAsyncDecoding(*this);
+        imageResource().cachedImage()->addClientWaitingForAsyncDecoding(cachedImageClient());
 
 #if USE(SYSTEM_PREVIEW)
     auto* imageElement = dynamicDowncast<HTMLImageElement>(element());

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -65,7 +65,7 @@ void RenderImageResource::setCachedImage(CachedResourceHandle<CachedImage>&& new
         return;
 
     if (m_cachedImage && m_renderer && m_cachedImageRemoveClientIsNeeded)
-        m_cachedImage->removeClient(*m_renderer);
+        m_cachedImage->removeClient(m_renderer->protectedCachedImageClient());
     if (!m_renderer) {
         // removeClient may have destroyed the renderer.
         return;
@@ -75,7 +75,7 @@ void RenderImageResource::setCachedImage(CachedResourceHandle<CachedImage>&& new
     if (!m_cachedImage)
         return;
 
-    m_cachedImage->addClient(*renderer());
+    m_cachedImage->addClient(renderer()->protectedCachedImageClient());
     if (m_cachedImage->errorOccurred())
         renderer()->imageChanged(m_cachedImage.get());
 }
@@ -112,7 +112,7 @@ void RenderImageResource::setContainerContext(const IntSize& imageContainerSize,
 {
     if (!m_cachedImage || !m_renderer)
         return;
-    m_cachedImage->setContainerContextForClient(*m_renderer, imageContainerSize, m_renderer->style().usedZoom(), imageURL);
+    m_cachedImage->setContainerContextForClient(m_renderer->protectedCachedImageClient(), imageContainerSize, m_renderer->style().usedZoom(), imageURL);
 }
 
 LayoutSize RenderImageResource::imageSize(float multiplier, CachedImage::SizeType type) const

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6367,14 +6367,15 @@ RenderLayerFilters& RenderLayer::ensureLayerFilters()
     if (m_filters)
         return *m_filters;
     
-    m_filters = makeUnique<RenderLayerFilters>(*this);
+    m_filters = RenderLayerFilters::create(*this);
     m_filters->setFilterScale({ page().deviceScaleFactor(), page().deviceScaleFactor() });
     return *m_filters;
 }
 
 void RenderLayer::clearLayerFilters()
 {
-    m_filters = nullptr;
+    if (RefPtr filters = std::exchange(m_filters, nullptr))
+        filters->detachFromLayer();
 }
 
 RenderLayerScrollableArea* RenderLayer::ensureLayerScrollableArea()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1465,7 +1465,7 @@ private:
 
     IntRect m_blockSelectionGapsBounds;
 
-    std::unique_ptr<RenderLayerFilters> m_filters;
+    RefPtr<RenderLayerFilters> m_filters;
     std::unique_ptr<RenderLayerBacking> m_backing;
     std::unique_ptr<RenderLayerScrollableArea> m_scrollableArea;
 

--- a/Source/WebCore/rendering/style/ReferenceFilterOperation.cpp
+++ b/Source/WebCore/rendering/style/ReferenceFilterOperation.cpp
@@ -70,7 +70,7 @@ void ReferenceFilterOperation::loadExternalDocumentIfNeeded(CachedResourceLoader
         return;
     if (!SVGURIReference::isExternalURIReference(m_url.resolved.string(), *cachedResourceLoader.protectedDocument()))
         return;
-    m_cachedSVGDocumentReference = makeUnique<CachedSVGDocumentReference>(m_url);
+    lazyInitialize(m_cachedSVGDocumentReference, CachedSVGDocumentReference::create(m_url));
     m_cachedSVGDocumentReference->load(cachedResourceLoader, options);
 }
 

--- a/Source/WebCore/rendering/style/ReferenceFilterOperation.h
+++ b/Source/WebCore/rendering/style/ReferenceFilterOperation.h
@@ -75,7 +75,7 @@ private:
     URL m_url;
     AtomString m_fragment;
 
-    std::unique_ptr<CachedSVGDocumentReference> m_cachedSVGDocumentReference;
+    const RefPtr<CachedSVGDocumentReference> m_cachedSVGDocumentReference;
 };
 
 } // Style

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -286,7 +286,7 @@ void StyleCachedImage::setContainerContextForRenderer(const RenderElement& rende
     m_containerSize = containerSize;
     if (!m_cachedImage)
         return;
-    m_cachedImage->setContainerContextForClient(renderer, LayoutSize(containerSize), containerZoom, m_url.resolved);
+    m_cachedImage->setContainerContextForClient(renderer.cachedImageClient(), LayoutSize(containerSize), containerZoom, m_url.resolved);
 }
 
 void StyleCachedImage::addClient(RenderElement& renderer)
@@ -294,7 +294,7 @@ void StyleCachedImage::addClient(RenderElement& renderer)
     ASSERT(!m_isPending);
     if (!m_cachedImage)
         return;
-    m_cachedImage->addClient(renderer);
+    m_cachedImage->addClient(renderer.cachedImageClient());
 }
 
 void StyleCachedImage::removeClient(RenderElement& renderer)
@@ -302,7 +302,7 @@ void StyleCachedImage::removeClient(RenderElement& renderer)
     ASSERT(!m_isPending);
     if (!m_cachedImage)
         return;
-    m_cachedImage->removeClient(renderer);
+    m_cachedImage->removeClient(renderer.cachedImageClient());
 }
 
 bool StyleCachedImage::hasClient(RenderElement& renderer) const
@@ -310,7 +310,7 @@ bool StyleCachedImage::hasClient(RenderElement& renderer) const
     ASSERT(!m_isPending);
     if (!m_cachedImage)
         return false;
-    return m_cachedImage->hasClient(renderer);
+    return m_cachedImage->hasClient(renderer.cachedImageClient());
 }
 
 bool StyleCachedImage::hasImage() const

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.h
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.h
@@ -36,13 +36,16 @@ struct BlendingContext;
 
 class StyleCrossfadeImage final : public StyleGeneratedImage, private CachedImageClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StyleCrossfadeImage);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleCrossfadeImage);
 public:
     static Ref<StyleCrossfadeImage> create(RefPtr<StyleImage> from, RefPtr<StyleImage> to, double percentage, bool isPrefixed)
     {
         return adoptRef(*new StyleCrossfadeImage(WTFMove(from), WTFMove(to), percentage, isPrefixed));
     }
     virtual ~StyleCrossfadeImage();
+
+    // CachedResourceClient.
+    void ref() const final { StyleGeneratedImage::ref(); }
+    void deref() const final { StyleGeneratedImage::deref(); }
 
     RefPtr<StyleCrossfadeImage> blend(const StyleCrossfadeImage&, const BlendingContext&) const;
 

--- a/Source/WebCore/rendering/style/StyleCursorImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCursorImage.cpp
@@ -159,7 +159,7 @@ void StyleCursorImage::setContainerContextForRenderer(const RenderElement& rende
 {
     if (!hasCachedImage())
         return;
-    cachedImage()->setContainerContextForClient(renderer, LayoutSize(containerSize), containerZoom, m_originalURL.resolved);
+    cachedImage()->setContainerContextForClient(renderer.cachedImageClient(), LayoutSize(containerSize), containerZoom, m_originalURL.resolved);
 }
 
 bool StyleCursorImage::usesDataProtocol() const

--- a/Source/WebCore/rendering/style/StyleFilterImage.h
+++ b/Source/WebCore/rendering/style/StyleFilterImage.h
@@ -35,13 +35,16 @@ namespace WebCore {
 
 class StyleFilterImage final : public StyleGeneratedImage, private CachedImageClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StyleFilterImage);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleFilterImage);
 public:
     static Ref<StyleFilterImage> create(RefPtr<StyleImage> image, Style::Filter filter)
     {
         return adoptRef(*new StyleFilterImage(WTFMove(image), WTFMove(filter)));
     }
     virtual ~StyleFilterImage();
+
+    // CachedResourceClient.
+    void ref() const final { StyleGeneratedImage::ref(); }
+    void deref() const final { StyleGeneratedImage::deref(); }
 
     bool operator==(const StyleImage& other) const final;
     bool equals(const StyleFilterImage&) const;

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -185,7 +185,7 @@ ImageDrawResult RenderSVGImage::paintIntoRect(PaintInfo& paintInfo, const FloatR
 
     auto drawResult = paintInfo.context().drawImage(*image, rect, sourceRect, options);
     if (drawResult == ImageDrawResult::DidRequestDecoding)
-        imageResource().cachedImage()->addClientWaitingForAsyncDecoding(*this);
+        imageResource().cachedImage()->addClientWaitingForAsyncDecoding(cachedImageClient());
 
     return drawResult;
 }
@@ -194,7 +194,7 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 {
     GraphicsContext& context = paintInfo.context();
     if (context.invalidatingImagesWithAsyncDecodes()) {
-        if (cachedImage() && cachedImage()->isClientWaitingForAsyncDecoding(*this))
+        if (cachedImage() && cachedImage()->isClientWaitingForAsyncDecoding(cachedImageClient()))
             cachedImage()->removeAllClientsWaitingForAsyncDecoding();
         return;
     }

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -37,16 +37,9 @@ public:
 
     virtual ~SVGFEImageElement();
 
-    // CheckedPtr interface
-    uint32_t checkedPtrCount() const { return SVGFilterPrimitiveStandardAttributes::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return SVGFilterPrimitiveStandardAttributes::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion()
-    {
-        SVGFilterPrimitiveStandardAttributes::setDidBeginCheckedPtrDeletion();
-        CachedImageClient::setDidBeginCheckedPtrDeletion();
-    }
+    // CachedResourceClient.
+    void ref() const final { SVGFilterPrimitiveStandardAttributes::ref(); }
+    void deref() const final { SVGFilterPrimitiveStandardAttributes::deref(); }
 
     bool renderingTaintsOrigin() const;
 

--- a/Source/WebCore/svg/SVGFontFaceUriElement.h
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.h
@@ -35,6 +35,10 @@ public:
 
     virtual ~SVGFontFaceUriElement();
 
+    // CachedResourceClient.
+    void ref() const final { SVGElement::ref(); }
+    void deref() const final { SVGElement::deref(); }
+
     Ref<CSSFontFaceSrcResourceValue> createSrcValue() const;
 
 private:

--- a/Source/WebCore/svg/SVGImageLoader.h
+++ b/Source/WebCore/svg/SVGImageLoader.h
@@ -28,7 +28,6 @@ class SVGImageElement;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SVGImageLoader);
 class SVGImageLoader final : public ImageLoader {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SVGImageLoader, SVGImageLoader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGImageLoader);
 public:
     explicit SVGImageLoader(SVGImageElement&);
     virtual ~SVGImageLoader();

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -39,6 +39,10 @@ public:
     static Ref<SVGUseElement> create(const QualifiedName&, Document&);
     virtual ~SVGUseElement();
 
+    // CachedResourceClient.
+    void ref() const final { SVGGraphicsElement::ref(); }
+    void deref() const final { SVGGraphicsElement::deref(); }
+
     void invalidateShadowTree();
     void updateUserAgentShadowTree() final;
 

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -69,7 +69,7 @@ void SVGImageCache::setContainerContextForClient(const CachedImageClient& client
 
 Image* SVGImageCache::findImageForRenderer(const RenderObject* renderer) const
 {
-    return renderer ? m_imageForContainerMap.get(renderer) : nullptr;
+    return renderer ? m_imageForContainerMap.get(&renderer->cachedImageClient()) : nullptr;
 }
 
 RefPtr<SVGImage> SVGImageCache::protectedSVGImage() const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7594,7 +7594,7 @@ void Internals::loadArtworkImage(String&& url, ArtworkImagePromise&& promise)
         return;
     }
     m_artworkImagePromise = makeUnique<ArtworkImagePromise>(WTFMove(promise));
-    m_artworkLoader = makeUnique<ArtworkImageLoader>(*contextDocument(), url, [weakThis = WeakPtr { *this }](Image* image) {
+    m_artworkLoader = ArtworkImageLoader::create(*contextDocument(), url, [weakThis = WeakPtr { *this }](Image* image) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1701,7 +1701,7 @@ private:
     int m_trackVideoRotation { 0 };
 #endif
 #if ENABLE(MEDIA_SESSION) && ENABLE(WEB_CODECS)
-    std::unique_ptr<ArtworkImageLoader> m_artworkLoader;
+    RefPtr<ArtworkImageLoader> m_artworkLoader;
     std::unique_ptr<ArtworkImagePromise> m_artworkImagePromise;
 #endif
     std::unique_ptr<InspectorStubFrontend> m_inspectorFrontend;

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -43,6 +43,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerFontLoadRequest);
 
+Ref<WorkerFontLoadRequest> WorkerFontLoadRequest::create(URL&& url, LoadedFromOpaqueSource loadedFromOpaqueSource)
+{
+    return adoptRef(*new WorkerFontLoadRequest(WTFMove(url), loadedFromOpaqueSource));
+}
+
 WorkerFontLoadRequest::WorkerFontLoadRequest(URL&& url, LoadedFromOpaqueSource loadedFromOpaqueSource)
     : m_url(WTFMove(url))
     , m_loadedFromOpaqueSource(loadedFromOpaqueSource)

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -42,15 +42,21 @@ class WorkerGlobalScope;
 
 struct FontCustomPlatformData;
 
-class WorkerFontLoadRequest final : public FontLoadRequest, public ThreadableLoaderClient {
+class WorkerFontLoadRequest final : public FontLoadRequest, public ThreadableLoaderClient, public RefCounted<WorkerFontLoadRequest> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerFontLoadRequest);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerFontLoadRequest);
 public:
-    WorkerFontLoadRequest(URL&&, LoadedFromOpaqueSource);
+    static Ref<WorkerFontLoadRequest> create(URL&&, LoadedFromOpaqueSource);
 
     void load(WorkerGlobalScope&);
 
+    // FontLoadRequest.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    WorkerFontLoadRequest(URL&&, LoadedFromOpaqueSource);
+
     const URL& url() const final { return m_url; }
     bool isPending() const final { return !m_isLoading && !m_errorOccurred && !m_data; }
     bool isLoading() const final { return m_isLoading; }

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -628,9 +628,9 @@ Ref<FontFaceSet> WorkerGlobalScope::fonts()
     return cssFontSelector()->fontFaceSet();
 }
 
-std::unique_ptr<FontLoadRequest> WorkerGlobalScope::fontLoadRequest(const String& url, bool, bool, LoadedFromOpaqueSource loadedFromOpaqueSource)
+RefPtr<FontLoadRequest> WorkerGlobalScope::fontLoadRequest(const String& url, bool, bool, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
-    return makeUnique<WorkerFontLoadRequest>(completeURL(url), loadedFromOpaqueSource);
+    return WorkerFontLoadRequest::create(completeURL(url), loadedFromOpaqueSource);
 }
 
 void WorkerGlobalScope::beginLoadingFontSoon(FontLoadRequest& request)

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -159,7 +159,7 @@ public:
     CSSValuePool& cssValuePool() final;
     CSSFontSelector* cssFontSelector() final;
     Ref<FontFaceSet> fonts();
-    std::unique_ptr<FontLoadRequest> fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource) final;
+    RefPtr<FontLoadRequest> fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource) final;
     void beginLoadingFontSoon(FontLoadRequest&) final;
 
     const SettingsValues& settingsValues() const final { return m_settingsValues; }

--- a/Source/WebCore/xml/XSLImportRule.cpp
+++ b/Source/WebCore/xml/XSLImportRule.cpp
@@ -34,6 +34,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XSLImportRule);
 
+Ref<XSLImportRule> XSLImportRule::create(XSLStyleSheet& parentSheet, const String& href)
+{
+    return adoptRef(*new XSLImportRule(parentSheet, href));
+}
+
 XSLImportRule::XSLImportRule(XSLStyleSheet& parent, const String& href)
     : m_parentStyleSheet(parent)
     , m_strHref(href)

--- a/Source/WebCore/xml/XSLImportRule.h
+++ b/Source/WebCore/xml/XSLImportRule.h
@@ -33,10 +33,10 @@ namespace WebCore {
 
 class CachedXSLStyleSheet;
 
-class XSLImportRule : private CachedStyleSheetClient {
+class XSLImportRule : public RefCounted<XSLImportRule>, private CachedStyleSheetClient {
     WTF_MAKE_TZONE_ALLOCATED(XSLImportRule);
 public:
-    XSLImportRule(XSLStyleSheet& parentSheet, const String& href);
+    static Ref<XSLImportRule> create(XSLStyleSheet& parentSheet, const String& href);
     virtual ~XSLImportRule();
     
     const String& href() const { return m_strHref; }
@@ -48,8 +48,14 @@ public:
 
     bool isLoading();
     void loadSheet();
+
+    // CachedResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
     
 private:
+    XSLImportRule(XSLStyleSheet& parentSheet, const String& href);
+
     void setXSLStyleSheet(const String& href, const URL& baseURL, const String& sheet) override;
     
     WeakPtr<XSLStyleSheet> m_parentStyleSheet;

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -111,7 +111,7 @@ private:
     URL m_finalURL;
     bool m_isDisabled { false };
 
-    Vector<std::unique_ptr<XSLImportRule>> m_children;
+    Vector<Ref<XSLImportRule>> m_children;
 
     bool m_embedded;
     bool m_processed;

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -228,9 +228,9 @@ void XSLStyleSheet::loadChildSheets()
 
 void XSLStyleSheet::loadChildSheet(const String& href)
 {
-    auto childRule = makeUnique<XSLImportRule>(*this, href);
-    m_children.append(childRule.release());
-    m_children.last()->loadSheet();
+    Ref rule = XSLImportRule::create(*this, href);
+    m_children.append(rule.copyRef());
+    rule->loadSheet();
 }
 
 xsltStylesheetPtr XSLStyleSheet::compileStyleSheet()

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -160,6 +160,7 @@
 #import <wtf/RunLoop.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/SystemTracing.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -829,10 +830,23 @@ const float _WebHTMLViewPrintingMaximumShrinkFactor = WebCore::PrintContext::max
 @implementation WebCoreScrollView
 @end
 
+class EmptyCachedImageClient : public WebCore::CachedImageClient, public RefCounted<EmptyCachedImageClient> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EmptyCachedImageClient);
+public:
+    static Ref<EmptyCachedImageClient> create() { return adoptRef(*new EmptyCachedImageClient); }
+
+    // CachedResourceClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    EmptyCachedImageClient() = default;
+};
+
 // We need this to be able to safely reference the CachedImage for the promised drag data
 static WebCore::CachedImageClient& promisedDataClient()
 {
-    static NeverDestroyed<WebCore::CachedImageClient> staticCachedResourceClient;
+    static NeverDestroyed<Ref<EmptyCachedImageClient>> staticCachedResourceClient = EmptyCachedImageClient::create();
     return staticCachedResourceClient.get();
 }
 


### PR DESCRIPTION
#### 4c281591ca8b9afa56ba5eea72528ceb6de5c505
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for CachedResourceClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=300775">https://bugs.webkit.org/show_bug.cgi?id=300775</a>
<a href="https://rdar.apple.com/163168617">rdar://163168617</a>

Reviewed by Geoffrey Garen.

In an earlier PR, I had tried to use CanMakeCheckedPtr but this did not
work out since quite a few clients destroy themselves when one of their
virtual function overrides get called. I am therefore making CachedResourceClient
ref-counted instead. However, since RenderObject is a CachedImageClient
and I do not want to make all RenderObjects ref-counted, I&apos;m using a
ref-counted trampoline object to forward the calls to the RenderObject.

* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::ref const):
(WebCore::NavigatorBeacon::deref const):
(WebCore::NavigatorBeacon::from):
* Source/WebCore/Modules/beacon/NavigatorBeacon.h:
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::create):
(WebCore::ArtworkImageLoader::requestImageResource):
(WebCore::MediaMetadata::tryNextArtworkImage):
* Source/WebCore/Modules/mediasession/MediaMetadata.h:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/bindings/js/CachedModuleScriptLoader.h:
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
* Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::appendSources):
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::CSSFontFaceSource):
* Source/WebCore/css/CSSFontFaceSource.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::fontLoadRequest):
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::StyleRuleImport):
* Source/WebCore/css/StyleRuleImport.h:
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::~DataTransfer):
(WebCore::DataTransfer::setDragImage):
(WebCore::DragImageLoader::create):
(WebCore::DragImageLoader::imageChanged):
(WebCore::DataTransfer::moveDragState):
* Source/WebCore/dom/DataTransfer.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::fontLoadRequest):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableSpeculationRules.h:
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::fontLoadRequest):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/html/HTMLImageLoader.h:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::HTMLLinkElement):
(WebCore::HTMLLinkElement::process):
(WebCore::HTMLLinkElement::removedFromAncestor):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::height const):
(WebCore::ImageInputType::width const):
* Source/WebCore/html/track/LoadableTextTrack.cpp:
(WebCore::LoadableTextTrack::scheduleLoad):
* Source/WebCore/html/track/LoadableTextTrack.h:
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
(WebCore::InspectorAuditResourcesObject::InspectorAuditResourcesObject):
(WebCore::InspectorAuditResourcesObject::clientForResource):
* Source/WebCore/inspector/InspectorAuditResourcesObject.h:
(WebCore::InspectorAuditResourcesObject::InspectorAuditCachedResourceClient::InspectorAuditCachedResourceClient):
(WebCore::InspectorAuditResourcesObject::InspectorAuditCachedFontClient::InspectorAuditCachedFontClient):
(WebCore::InspectorAuditResourcesObject::InspectorAuditCachedRawResourceClient::InspectorAuditCachedRawResourceClient):
(WebCore::InspectorAuditResourcesObject::InspectorAuditCachedSVGDocumentClient::InspectorAuditCachedSVGDocumentClient):
(WebCore::InspectorAuditResourcesObject::InspectorAuditCachedStyleSheetClient::InspectorAuditCachedStyleSheetClient):
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::create):
(WebCore::ApplicationManifestLoader::startLoading):
(WebCore::ApplicationManifestLoader::notifyFinished):
* Source/WebCore/loader/ApplicationManifestLoader.h:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::create):
(WebCore::CrossOriginPreflightChecker::notifyFinished):
(WebCore::CrossOriginPreflightChecker::redirectReceived):
(WebCore::CrossOriginPreflightChecker::startPreflight):
(WebCore::CrossOriginPreflightChecker::protectedLoader const): Deleted.
* Source/WebCore/loader/CrossOriginPreflightChecker.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadApplicationManifest):
(WebCore::DocumentLoader::notifyFinishedLoadingApplicationManifest):
(WebCore::DocumentLoader::didGetLoadDecisionForIcon):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/DocumentPrefetcher.h:
(WebCore::DocumentPrefetcher::create):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequestWithPreflight):
(WebCore::DocumentThreadableLoader::clearResource):
(WebCore::DocumentThreadableLoader::preflightSuccess):
(WebCore::DocumentThreadableLoader::preflightFailure):
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/FontLoadRequest.h:
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::create):
(WebCore::LinkLoader::~LinkLoader):
(WebCore::LinkLoader::triggerEvents):
(WebCore::LinkLoader::triggerError):
(WebCore::createLinkPreloadResourceClient):
(WebCore::LinkLoader::preloadIfNeeded):
(WebCore::LinkLoader::cancelLoad):
(WebCore::LinkLoader::loadLink):
* Source/WebCore/loader/LinkLoader.h:
* Source/WebCore/loader/LinkLoaderClient.h:
* Source/WebCore/loader/LinkPreloadResourceClients.cpp:
(WebCore::LinkPreloadResourceClient::triggerEvents):
* Source/WebCore/loader/LinkPreloadResourceClients.h:
(WebCore::LinkPreloadDefaultResourceClient::create):
(WebCore::LinkPreloadStyleResourceClient::create):
(WebCore::LinkPreloadImageResourceClient::create):
(WebCore::LinkPreloadFontResourceClient::create):
(WebCore::LinkPreloadRawResourceClient::create):
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/loader/TextTrackLoader.cpp:
(WebCore::TextTrackLoader::create):
(WebCore::TextTrackLoader::cueLoadTimerFired):
(WebCore::TextTrackLoader::processNewCueData):
(WebCore::TextTrackLoader::corsPolicyPreventedLoad):
(WebCore::TextTrackLoader::load):
(WebCore::TextTrackLoader::newRegionsParsed):
(WebCore::TextTrackLoader::newStyleSheetsParsed):
(WebCore::TextTrackLoader::getNewCues):
(WebCore::TextTrackLoader::protectedDocument const): Deleted.
* Source/WebCore/loader/TextTrackLoader.h:
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::checkNotify):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::checkNotify):
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::addClientWaitingForAsyncDecoding):
(WebCore::CachedImage::removeAllClientsWaitingForAsyncDecoding):
(WebCore::CachedImage::notifyObservers):
(WebCore::CachedImage::canDestroyDecodedData const):
(WebCore::CachedImage::imageFrameAvailable):
(WebCore::CachedImage::imageContentChanged):
(WebCore::CachedImage::scheduleRenderingUpdate):
(WebCore::CachedImage::allowsAnimation const):
(WebCore::CachedImage::isVisibleInViewport const):
* Source/WebCore/loader/cache/CachedImageClient.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::notifyClientsDataWasReceived):
(WebCore::iterateClients):
(WebCore::CachedRawResource::responseReceived):
(WebCore::CachedRawResource::shouldCacheResponse):
(WebCore::CachedRawResource::didSendData):
(WebCore::CachedRawResource::finishedTimingForWorkerLoad):
* Source/WebCore/loader/cache/CachedRawResourceClient.h:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::checkNotify):
(WebCore::CachedResource::switchClientsToRevalidatedResource):
* Source/WebCore/loader/cache/CachedResourceClient.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::CachedResourceLoader):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
(WebCore::CachedResourceLoader::keepaliveRequestTracker):
* Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp:
(WebCore::CachedSVGDocumentReference::create):
* Source/WebCore/loader/cache/CachedSVGDocumentReference.h:
* Source/WebCore/loader/cache/CachedTextTrack.cpp:
(WebCore::CachedTextTrack::doUpdateBuffer):
* Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp:
(WebCore::CachedXSLStyleSheet::checkNotify):
* Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp:
(WebCore::KeepaliveRequestTracker::create):
* Source/WebCore/loader/cache/KeepaliveRequestTracker.h:
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::create):
(WebCore::IconLoader::startLoading):
(WebCore::IconLoader::notifyFinished):
* Source/WebCore/loader/icon/IconLoader.h:
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h:
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::CachedResourceMediaLoader::create):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayerImpl const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintReplaced):
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/RenderImageResource.cpp:
(WebCore::RenderImageResource::setCachedImage):
(WebCore::RenderImageResource::setContainerContext):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::create):
(WebCore::RenderLayerFilters::RenderLayerFilters):
(WebCore::RenderLayerFilters::notifyFinished):
(WebCore::RenderLayerFilters::updateReferenceFilterClients):
(WebCore::RenderLayerFilters::removeReferenceFilterClients):
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::RenderObject):
(WebCore::RenderObject::CachedImageListener::create):
(WebCore::RenderObject::CachedImageListener::CachedImageListener):
(WebCore::RenderObject::CachedImageListener::notifyFinished):
(WebCore::RenderObject::CachedImageListener::imageChanged):
(WebCore::RenderObject::CachedImageListener::allowsAnimation const):
(WebCore::RenderObject::CachedImageListener::canDestroyDecodedData const):
(WebCore::RenderObject::CachedImageListener::imageFrameAvailable):
(WebCore::RenderObject::CachedImageListener::imageVisibleInViewport const):
(WebCore::RenderObject::CachedImageListener::didRemoveCachedImageClient):
(WebCore::RenderObject::CachedImageListener::imageContentChanged):
(WebCore::RenderObject::CachedImageListener::scheduleRenderingUpdateForImage):
(WebCore::RenderObject::imageFrameAvailable):
(WebCore::RenderObject::imageChanged): Deleted.
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::notifyFinished):
(WebCore::RenderObject::allowsAnimation const):
(WebCore::RenderObject::canDestroyDecodedData const):
(WebCore::RenderObject::imageVisibleInViewport const):
(WebCore::RenderObject::didRemoveCachedImageClient):
(WebCore::RenderObject::imageContentChanged):
(WebCore::RenderObject::scheduleRenderingUpdateForImage):
(WebCore::RenderObject::protectedCachedImageClient const):
(WebCore::RenderObject::cachedImageClient const):
* Source/WebCore/rendering/style/ReferenceFilterOperation.cpp:
(WebCore::Style::ReferenceFilterOperation::loadExternalDocumentIfNeeded):
* Source/WebCore/rendering/style/ReferenceFilterOperation.h:
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
(WebCore::StyleCachedImage::setContainerContextForRenderer):
(WebCore::StyleCachedImage::addClient):
(WebCore::StyleCachedImage::removeClient):
(WebCore::StyleCachedImage::hasClient const):
* Source/WebCore/rendering/style/StyleCrossfadeImage.h:
* Source/WebCore/rendering/style/StyleCursorImage.cpp:
(WebCore::StyleCursorImage::setContainerContextForRenderer):
* Source/WebCore/rendering/style/StyleFilterImage.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintIntoRect):
(WebCore::RenderSVGImage::paintForeground):
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFontFaceUriElement.h:
* Source/WebCore/svg/SVGImageLoader.h:
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/svg/graphics/SVGImageCache.cpp:
(WebCore::SVGImageCache::findImageForRenderer const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::loadArtworkImage):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::create):
* Source/WebCore/workers/WorkerFontLoadRequest.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::fontLoadRequest):
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/xml/XSLImportRule.cpp:
(WebCore::XSLImportRule::create):
* Source/WebCore/xml/XSLImportRule.h:
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::loadChildSheet):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(EmptyCachedImageClient::create):
(promisedDataClient):

Canonical link: <a href="https://commits.webkit.org/303654@main">https://commits.webkit.org/303654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e8d151767201763b4c94e7717b8f43f07423142

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84711 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ea35a38-781f-482f-b4e3-3b42583fff4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101442 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68745 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/805d77c0-0fb0-45f2-80d7-0903e4f0568f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82235 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2548823d-ff9b-4814-8314-cbc4e34e4075) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4182 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1442 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83446 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4849 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109818 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109995 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3700 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58324 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4903 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33483 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4741 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->