### PR TITLE
ASSERTION: ASSERT(isMainThread()); when watching protected content with MediaSourceUseRemoteAudioVideoRenderer enabled

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -303,7 +303,7 @@ InitDataRegistry::InitDataRegistry()
 
 InitDataRegistry::~InitDataRegistry() = default;
 
-RefPtr<SharedBuffer> InitDataRegistry::sanitizeInitData(const AtomString& initDataType, const SharedBuffer& buffer)
+RefPtr<SharedBuffer> InitDataRegistry::sanitizeInitData(const String& initDataType, const SharedBuffer& buffer)
 {
     auto iter = m_types.find(initDataType);
     if (iter == m_types.end() || !iter->value.sanitizeInitData)
@@ -311,7 +311,7 @@ RefPtr<SharedBuffer> InitDataRegistry::sanitizeInitData(const AtomString& initDa
     return iter->value.sanitizeInitData(buffer);
 }
 
-std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDs(const AtomString& initDataType, const SharedBuffer& buffer)
+std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDs(const String& initDataType, const SharedBuffer& buffer)
 {
     auto iter = m_types.find(initDataType);
     if (iter == m_types.end() || !iter->value.sanitizeInitData)
@@ -319,28 +319,28 @@ std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDs(const A
     return iter->value.extractKeyIDs(buffer);
 }
 
-void InitDataRegistry::registerInitDataType(const AtomString& initDataType, InitDataTypeCallbacks&& callbacks)
+void InitDataRegistry::registerInitDataType(const String& initDataType, InitDataTypeCallbacks&& callbacks)
 {
     ASSERT(!m_types.contains(initDataType));
     m_types.set(initDataType, WTFMove(callbacks));
 }
 
-const AtomString& InitDataRegistry::cencName()
+const String& InitDataRegistry::cencName()
 {
-    static MainThreadNeverDestroyed<const AtomString> sinf { MAKE_STATIC_STRING_IMPL("cenc") };
-    return sinf;
+    static NeverDestroyed<const String> staticCencName(MAKE_STATIC_STRING_IMPL("cenc"));
+    return staticCencName;
 }
 
-const AtomString& InitDataRegistry::keyidsName()
+const String& InitDataRegistry::keyidsName()
 {
-    static MainThreadNeverDestroyed<const AtomString> sinf { MAKE_STATIC_STRING_IMPL("keyids") };
-    return sinf;
+    static NeverDestroyed<const String> staticKeyidsName(MAKE_STATIC_STRING_IMPL("keyids"));
+    return staticKeyidsName;
 }
 
-const AtomString& InitDataRegistry::webmName()
+const String& InitDataRegistry::webmName()
 {
-    static MainThreadNeverDestroyed<const AtomString> sinf { MAKE_STATIC_STRING_IMPL("webm") };
-    return sinf;
+    static NeverDestroyed<const String> staticWebmName(MAKE_STATIC_STRING_IMPL("webm"));
+    return staticWebmName;
 }
 
 }

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h
@@ -32,8 +32,6 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomString.h>
-#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 
@@ -45,8 +43,8 @@ public:
     WEBCORE_EXPORT static InitDataRegistry& singleton();
     friend class NeverDestroyed<InitDataRegistry>;
 
-    RefPtr<SharedBuffer> sanitizeInitData(const AtomString& initDataType, const SharedBuffer&);
-    WEBCORE_EXPORT std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDs(const AtomString& initDataType, const SharedBuffer&);
+    RefPtr<SharedBuffer> sanitizeInitData(const String& initDataType, const SharedBuffer&);
+    WEBCORE_EXPORT std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDs(const String& initDataType, const SharedBuffer&);
 
     struct InitDataTypeCallbacks {
         using SanitizeInitDataCallback = Function<RefPtr<SharedBuffer>(const SharedBuffer&)>;
@@ -55,11 +53,11 @@ public:
         SanitizeInitDataCallback sanitizeInitData;
         ExtractKeyIDsCallback extractKeyIDs;
     };
-    void registerInitDataType(const AtomString& initDataType, InitDataTypeCallbacks&&);
+    void registerInitDataType(const String& initDataType, InitDataTypeCallbacks&&);
 
-    static const AtomString& cencName();
-    static const AtomString& keyidsName();
-    static const AtomString& webmName();
+    static const String& cencName();
+    static const String& keyidsName();
+    static const String& webmName();
 
     static std::optional<Vector<std::unique_ptr<ISOProtectionSystemSpecificHeaderBox>>> extractPsshBoxesFromCenc(const SharedBuffer&);
     static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsCenc(const SharedBuffer&);
@@ -69,7 +67,7 @@ private:
     InitDataRegistry();
     ~InitDataRegistry();
 
-    MemoryCompactRobinHoodHashMap<AtomString, InitDataTypeCallbacks> m_types;
+    MemoryCompactRobinHoodHashMap<String, InitDataTypeCallbacks> m_types;
 };
 
 }

--- a/Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h
@@ -99,7 +99,7 @@ public:
     };
 
     using LicenseCallback = CompletionHandler<void(Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, SuccessValue succeeded)>;
-    virtual void requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) = 0;
+    virtual void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) = 0;
 
     using KeyStatusVector = CDMInstanceSessionClient::KeyStatusVector;
     using Message = std::pair<MessageType, Ref<SharedBuffer>>;

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
@@ -82,11 +82,11 @@ public:
     using SupportedConfigurationCallback = Function<void(std::optional<CDMKeySystemConfiguration>)>;
     WEBCORE_EXPORT virtual void getSupportedConfiguration(CDMKeySystemConfiguration&& candidateConfiguration, LocalStorageAccess, SupportedConfigurationCallback&&);
 
-    virtual Vector<AtomString> supportedInitDataTypes() const = 0;
+    virtual Vector<String> supportedInitDataTypes() const = 0;
     virtual bool supportsConfiguration(const CDMKeySystemConfiguration&) const = 0;
     virtual bool supportsConfigurationWithRestrictions(const CDMKeySystemConfiguration&, const CDMRestrictions&) const = 0;
     virtual bool supportsSessionTypeWithConfiguration(const CDMSessionType&, const CDMKeySystemConfiguration&) const = 0;
-    virtual Vector<AtomString> supportedRobustnesses() const = 0;
+    virtual Vector<String> supportedRobustnesses() const = 0;
     virtual CDMRequirement distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const = 0;
     virtual CDMRequirement persistentStateRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const = 0;
     virtual bool distinctiveIdentifiersAreUniquePerOriginAndClearable(const CDMKeySystemConfiguration&) const = 0;
@@ -94,7 +94,7 @@ public:
     virtual void loadAndInitialize() = 0;
     virtual bool supportsServerCertificates() const = 0;
     virtual bool supportsSessions() const = 0;
-    virtual bool supportsInitData(const AtomString&, const SharedBuffer&) const = 0;
+    virtual bool supportsInitData(const String&, const SharedBuffer&) const = 0;
     virtual RefPtr<SharedBuffer> sanitizeResponse(const SharedBuffer&) const = 0;
     virtual std::optional<String> sanitizeSessionId(const String&) const = 0;
 

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -276,7 +276,7 @@ bool CDMFactoryClearKey::supportsKeySystem(const String& keySystem)
 CDMPrivateClearKey::CDMPrivateClearKey() = default;
 CDMPrivateClearKey::~CDMPrivateClearKey() = default;
 
-Vector<AtomString> CDMPrivateClearKey::supportedInitDataTypes() const
+Vector<String> CDMPrivateClearKey::supportedInitDataTypes() const
 {
     return {
         InitDataRegistry::keyidsName(),
@@ -333,10 +333,10 @@ bool CDMPrivateClearKey::supportsSessionTypeWithConfiguration(const CDMSessionTy
     return supportsConfiguration(configuration);
 }
 
-Vector<AtomString> CDMPrivateClearKey::supportedRobustnesses() const
+Vector<String> CDMPrivateClearKey::supportedRobustnesses() const
 {
     // Only empty `robustness` string is supported.
-    return { emptyAtom() };
+    return { emptyString() };
 }
 
 CDMRequirement CDMPrivateClearKey::distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions& restrictions) const
@@ -382,7 +382,7 @@ bool CDMPrivateClearKey::supportsSessions() const
     return true;
 }
 
-bool CDMPrivateClearKey::supportsInitData(const AtomString& initDataType, const SharedBuffer& initData) const
+bool CDMPrivateClearKey::supportsInitData(const String& initDataType, const SharedBuffer& initData) const
 {
     // Validate the initData buffer as an JSON object in keyids case.
     if (equalLettersIgnoringASCIICase(initDataType, "keyids"_s) && CDMUtilities::parseJSONObject(initData))
@@ -447,7 +447,7 @@ RefPtr<CDMInstanceSession> CDMInstanceClearKey::createSession()
     return adoptRef(new CDMInstanceSessionClearKey(*this));
 }
 
-void CDMInstanceSessionClearKey::requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
+void CDMInstanceSessionClearKey::requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
     if (RefPtr parentInstance = this->parentInstance())
         m_sessionID = String::number(parentInstance->getNextSessionIdValue());

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
@@ -78,8 +78,8 @@ public:
     CDMPrivateClearKey();
     virtual ~CDMPrivateClearKey();
 
-    Vector<AtomString> supportedInitDataTypes() const final;
-    Vector<AtomString> supportedRobustnesses() const final;
+    Vector<String> supportedInitDataTypes() const final;
+    Vector<String> supportedRobustnesses() const final;
     bool supportsConfiguration(const CDMKeySystemConfiguration&) const final;
     bool supportsConfigurationWithRestrictions(const CDMKeySystemConfiguration&, const CDMRestrictions&) const final;
     bool supportsSessionTypeWithConfiguration(const CDMSessionType&, const CDMKeySystemConfiguration&) const final;
@@ -90,7 +90,7 @@ public:
     void loadAndInitialize() final;
     bool supportsServerCertificates() const final;
     bool supportsSessions() const final;
-    bool supportsInitData(const AtomString&, const SharedBuffer&) const final;
+    bool supportsInitData(const String&, const SharedBuffer&) const final;
     RefPtr<SharedBuffer> sanitizeResponse(const SharedBuffer&) const final;
     std::optional<String> sanitizeSessionId(const String&) const final;
 };
@@ -118,7 +118,7 @@ class CDMInstanceSessionClearKey final : public CDMInstanceSessionProxy {
 public:
     CDMInstanceSessionClearKey(CDMInstanceClearKey& parent)
         : CDMInstanceSessionProxy(parent) { }
-    void requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
+    void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
     void updateLicense(const String&, LicenseType, Ref<SharedBuffer>&&, LicenseUpdateCallback&&) final;
     void loadSession(LicenseType, const String&, const String&, LoadSessionCallback&&) final;
     void closeSession(const String&, CloseSessionCallback&&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -1639,12 +1639,9 @@ Ref<MediaPromise> AudioVideoRendererAVFObjC::setInitData(Ref<SharedBuffer> initD
     }
 #endif
     auto keyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsSinf(initData);
-    AtomString initDataType = CDMPrivateFairPlayStreaming::sinfName();
 #if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)
-    if (!keyIDs) {
+    if (!keyIDs)
         keyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsMpts(initData);
-        initDataType = CDMPrivateFairPlayStreaming::mptsName();
-    }
 #endif
     if (!keyIDs)
         return MediaPromise::createAndResolve();

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -79,16 +79,16 @@ const Vector<FourCC>& CDMPrivateFairPlayStreaming::validFairPlayStreamingSchemes
     return validSchemes;
 }
 
-const AtomString& CDMPrivateFairPlayStreaming::sinfName()
+const String& CDMPrivateFairPlayStreaming::sinfName()
 {
-    static MainThreadNeverDestroyed<const AtomString> sinf { MAKE_STATIC_STRING_IMPL("sinf") };
-    return sinf;
+    static NeverDestroyed<const String> staticSinfName(MAKE_STATIC_STRING_IMPL("sinf"));
+    return staticSinfName;
 }
 
-const AtomString& CDMPrivateFairPlayStreaming::skdName()
+const String& CDMPrivateFairPlayStreaming::skdName()
 {
-    static MainThreadNeverDestroyed<const AtomString> skd { MAKE_STATIC_STRING_IMPL("skd") };
-    return skd;
+    static NeverDestroyed<const String> staticSkdName(MAKE_STATIC_STRING_IMPL("skd"));
+    return staticSkdName;
 }
 
 static Vector<Ref<SharedBuffer>> extractSinfData(const SharedBuffer& buffer)
@@ -206,10 +206,10 @@ std::optional<Vector<Ref<SharedBuffer>>> CDMPrivateFairPlayStreaming::extractKey
 }
 
 #if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)
-const AtomString& CDMPrivateFairPlayStreaming::mptsName()
+const String& CDMPrivateFairPlayStreaming::mptsName()
 {
-    static MainThreadNeverDestroyed<const AtomString> mpts { MAKE_STATIC_STRING_IMPL("mpts") };
-    return mpts;
+    static NeverDestroyed<const String> staticMptsName(MAKE_STATIC_STRING_IMPL("mpts"));
+    return staticMptsName;
 }
 
 std::optional<Vector<Ref<SharedBuffer>>> CDMPrivateFairPlayStreaming::extractKeyIDsMpts(const SharedBuffer& buffer)
@@ -256,9 +256,9 @@ const Vector<Ref<SharedBuffer>>& CDMPrivateFairPlayStreaming::mptsKeyIDs() {
 }
 #endif
 
-static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& validInitDataTypes()
+static const MemoryCompactLookupOnlyRobinHoodHashSet<String>& validInitDataTypes()
 {
-    static NeverDestroyed<MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>> validTypes(std::initializer_list<AtomString> {
+    static NeverDestroyed<MemoryCompactLookupOnlyRobinHoodHashSet<String>> validTypes(std::initializer_list<String> {
         CDMPrivateFairPlayStreaming::sinfName(),
         CDMPrivateFairPlayStreaming::skdName(),
 #if HAVE(FAIRPLAYSTREAMING_CENC_INITDATA)
@@ -320,7 +320,7 @@ CDMPrivateFairPlayStreaming::CDMPrivateFairPlayStreaming(const String& mediaKeys
 
 CDMPrivateFairPlayStreaming::~CDMPrivateFairPlayStreaming() = default;
 
-Vector<AtomString> CDMPrivateFairPlayStreaming::supportedInitDataTypes() const
+Vector<String> CDMPrivateFairPlayStreaming::supportedInitDataTypes() const
 {
     return copyToVector(validInitDataTypes());
 }
@@ -399,10 +399,10 @@ bool CDMPrivateFairPlayStreaming::supportsSessionTypeWithConfiguration(const CDM
     return supportsConfiguration(configuration);
 }
 
-Vector<AtomString> CDMPrivateFairPlayStreaming::supportedRobustnesses() const
+Vector<String> CDMPrivateFairPlayStreaming::supportedRobustnesses() const
 {
     // FIXME: Determine an enumerated list of robustness values supported by FPS.
-    return { emptyAtom() };
+    return { emptyString() };
 }
 
 CDMRequirement CDMPrivateFairPlayStreaming::distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const
@@ -448,7 +448,7 @@ bool CDMPrivateFairPlayStreaming::supportsSessions() const
     return true;
 }
 
-bool CDMPrivateFairPlayStreaming::supportsInitData(const AtomString& initDataType, const SharedBuffer& initData) const
+bool CDMPrivateFairPlayStreaming::supportsInitData(const String& initDataType, const SharedBuffer& initData) const
 {
     if (!validInitDataTypes().contains(initDataType))
         return false;

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
@@ -69,11 +69,11 @@ public:
     ASCIILiteral logClassName() const { return "CDMPrivateFairPlayStreaming"_s; }
 #endif
 
-    Vector<AtomString> supportedInitDataTypes() const override;
+    Vector<String> supportedInitDataTypes() const override;
     bool supportsConfiguration(const CDMKeySystemConfiguration&) const override;
     bool supportsConfigurationWithRestrictions(const CDMKeySystemConfiguration&, const CDMRestrictions&) const override;
     bool supportsSessionTypeWithConfiguration(const CDMSessionType&, const CDMKeySystemConfiguration&) const override;
-    Vector<AtomString> supportedRobustnesses() const override;
+    Vector<String> supportedRobustnesses() const override;
     CDMRequirement distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const override;
     CDMRequirement persistentStateRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const override;
     bool distinctiveIdentifiersAreUniquePerOriginAndClearable(const CDMKeySystemConfiguration&) const override;
@@ -81,20 +81,20 @@ public:
     void loadAndInitialize() override;
     bool supportsServerCertificates() const override;
     bool supportsSessions() const override;
-    bool supportsInitData(const AtomString&, const SharedBuffer&) const override;
+    bool supportsInitData(const String&, const SharedBuffer&) const override;
     RefPtr<SharedBuffer> sanitizeResponse(const SharedBuffer&) const override;
     std::optional<String> sanitizeSessionId(const String&) const override;
 
-    static const AtomString& sinfName();
+    static const String& sinfName();
     static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsSinf(const SharedBuffer&);
     static RefPtr<SharedBuffer> sanitizeSinf(const SharedBuffer&);
 
-    static const AtomString& skdName();
+    static const String& skdName();
     static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsSkd(const SharedBuffer&);
     static RefPtr<SharedBuffer> sanitizeSkd(const SharedBuffer&);
 
 #if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)
-    static const AtomString& mptsName();
+    static const String& mptsName();
     static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsMpts(const SharedBuffer&);
     static RefPtr<SharedBuffer> sanitizeMpts(const SharedBuffer&);
     static const Vector<Ref<SharedBuffer>>& mptsKeyIDs();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -119,7 +119,7 @@ public:
     SharedBuffer* serverCertificate() const { return m_serverCertificate.get(); }
     AVContentKeySession *contentKeySession();
 
-    RetainPtr<AVContentKeyRequest> takeUnexpectedKeyRequestForInitializationData(const AtomString& initDataType, SharedBuffer& initData);
+    RetainPtr<AVContentKeyRequest> takeUnexpectedKeyRequestForInitializationData(const String& initDataType, SharedBuffer& initData);
 
     // AVContentKeySessionDelegateClient
     void didProvideRequest(AVContentKeyRequest*) final;
@@ -191,7 +191,7 @@ public:
     virtual ~CDMInstanceSessionFairPlayStreamingAVFObjC();
 
     // CDMInstanceSession
-    void requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
+    void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
     void updateLicense(const String&, LicenseType, Ref<SharedBuffer>&&, LicenseUpdateCallback&&) final;
     void loadSession(LicenseType, const String&, const String&, LoadSessionCallback&&) final;
     void closeSession(const String&, CloseSessionCallback&&) final;
@@ -221,7 +221,7 @@ public:
     WebAVContentKeyGrouping *contentKeyReportGroup() { return m_group.get(); }
 
     struct Request {
-        AtomString initType;
+        String initType;
         Vector<RetainPtr<AVContentKeyRequest>> requests;
         friend bool operator==(const Request&, const Request&) = default;
     };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -220,7 +220,7 @@ namespace WebCore {
 static WTFLogChannel& logChannel() { return LogEME; }
 #endif
 
-static AtomString initTypeForRequest(AVContentKeyRequest* request)
+static String initTypeForRequest(AVContentKeyRequest* request)
 {
     if ([request.identifier isKindOfClass:NSString.class] && [request.identifier hasPrefix:@"skd://"])
         return CDMPrivateFairPlayStreaming::skdName();
@@ -233,7 +233,7 @@ static AtomString initTypeForRequest(AVContentKeyRequest* request)
         return CDMPrivateFairPlayStreaming::sinfName();
     }
 
-    return AtomString(nsInitType);
+    return String(nsInitType);
 }
 
 static Ref<SharedBuffer> initializationDataForRequest(AVContentKeyRequest* request)
@@ -279,7 +279,7 @@ AVContentKeySession* CDMInstanceFairPlayStreamingAVFObjC::contentKeySession()
     return m_session.get();
 }
 
-RetainPtr<AVContentKeyRequest> CDMInstanceFairPlayStreamingAVFObjC::takeUnexpectedKeyRequestForInitializationData(const AtomString& initDataType, SharedBuffer& initData)
+RetainPtr<AVContentKeyRequest> CDMInstanceFairPlayStreamingAVFObjC::takeUnexpectedKeyRequestForInitializationData(const String& initDataType, SharedBuffer& initData)
 {
     for (auto requestIter = m_unexpectedKeyRequests.begin(); requestIter != m_unexpectedKeyRequests.end(); ++requestIter) {
         auto& request = *requestIter;
@@ -752,7 +752,7 @@ Keys CDMInstanceSessionFairPlayStreamingAVFObjC::keyIDs()
     return keyIDs;
 }
 
-void CDMInstanceSessionFairPlayStreamingAVFObjC::requestLicense(LicenseType licenseType, KeyGroupingStrategy keyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
+void CDMInstanceSessionFairPlayStreamingAVFObjC::requestLicense(LicenseType licenseType, KeyGroupingStrategy keyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
     if (!isLicenseTypeSupported(licenseType)) {
         ERROR_LOG(LOGIDENTIFIER, " false, licenseType \"", licenseType, "\" not supported");
@@ -1154,7 +1154,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::clearClient()
 void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequest(AVContentKeyRequest *request)
 {
     auto initDataType = initTypeForRequest(request);
-    if (initDataType == emptyAtom()) {
+    if (initDataType.isEmpty()) {
         ERROR_LOG(LOGIDENTIFIER, "- request has empty initDataType");
         return;
     }
@@ -1359,7 +1359,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest(AVCon
 {
     ASSERT(!m_requestLicenseCallback);
     auto initDataType = initTypeForRequest(request);
-    if (initDataType == emptyAtom())
+    if (initDataType.isEmpty())
         return;
 
     Request currentRequest = { initDataType, { request } };

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -151,10 +151,10 @@ CDMPrivateThunder::CDMPrivateThunder(const String& keySystem)
 {
 };
 
-Vector<AtomString> CDMPrivateThunder::supportedInitDataTypes() const
+Vector<String> CDMPrivateThunder::supportedInitDataTypes() const
 {
     static std::once_flag onceFlag;
-    static Vector<AtomString> supportedInitDataTypes;
+    static Vector<String> supportedInitDataTypes;
     std::call_once(onceFlag, [] {
         supportedInitDataTypes.appendList({ "keyids"_s, "cenc"_s, "webm"_s, "cbcs"_s });
     });
@@ -174,9 +174,9 @@ bool CDMPrivateThunder::supportsConfiguration(const CDMKeySystemConfiguration& c
     return true;
 }
 
-Vector<AtomString> CDMPrivateThunder::supportedRobustnesses() const
+Vector<String> CDMPrivateThunder::supportedRobustnesses() const
 {
-    return { emptyAtom(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
+    return { emptyString(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
 }
 
 CDMRequirement CDMPrivateThunder::distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const
@@ -217,7 +217,7 @@ bool CDMPrivateThunder::supportsSessions() const
     return true;
 }
 
-bool CDMPrivateThunder::supportsInitData(const AtomString& initDataType, const SharedBuffer& initData) const
+bool CDMPrivateThunder::supportsInitData(const String& initDataType, const SharedBuffer& initData) const
 {
     // Validate the initData buffer as an JSON object in keyids case.
     if (equalLettersIgnoringASCIICase(initDataType, "keyids"_s) && CDMUtilities::parseJSONObject(initData))
@@ -494,7 +494,7 @@ void CDMInstanceSessionThunder::errorCallback(RefPtr<SharedBuffer>&& message)
     m_sessionChangedCallbacks.clear();
 }
 
-void CDMInstanceSessionThunder::requestLicense(LicenseType licenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initDataSharedBuffer,
+void CDMInstanceSessionThunder::requestLicense(LicenseType licenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initDataSharedBuffer,
     LicenseCallback&& callback)
 {
     ASSERT(isMainThread());
@@ -513,7 +513,7 @@ void CDMInstanceSessionThunder::requestLicense(LicenseType licenseType, KeyGroup
     GST_MEMDUMP("init data", payloadData.span().data(), payloadData.size());
 
     OpenCDMSession* session = nullptr;
-    opencdm_construct_session(&instance->thunderSystem(), thunderLicenseType(licenseType), initDataType.string().utf8().data(),
+    opencdm_construct_session(&instance->thunderSystem(), thunderLicenseType(licenseType), initDataType.utf8().data(),
         payloadData.span().data(), payloadData.size(), nullptr, 0, &m_thunderSessionCallbacks, this, &session);
     if (!session) {
         GST_ERROR("Could not create session");

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -81,7 +81,7 @@ public:
     CDMPrivateThunder(const String& keySystem);
     virtual ~CDMPrivateThunder() = default;
 
-    Vector<AtomString> supportedInitDataTypes() const final;
+    Vector<String> supportedInitDataTypes() const final;
     bool supportsConfiguration(const CDMKeySystemConfiguration&) const final;
     bool supportsConfigurationWithRestrictions(const CDMKeySystemConfiguration& configuration, const CDMRestrictions&) const final
     {
@@ -91,7 +91,7 @@ public:
     {
         return supportsConfiguration(configuration);
     }
-    Vector<AtomString> supportedRobustnesses() const final;
+    Vector<String> supportedRobustnesses() const final;
     CDMRequirement distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const final;
     CDMRequirement persistentStateRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const final;
     bool distinctiveIdentifiersAreUniquePerOriginAndClearable(const CDMKeySystemConfiguration&) const final;
@@ -99,7 +99,7 @@ public:
     void loadAndInitialize() final;
     bool supportsServerCertificates() const final;
     bool supportsSessions() const final;
-    bool supportsInitData(const AtomString&, const SharedBuffer&) const final;
+    bool supportsInitData(const String&, const SharedBuffer&) const final;
     RefPtr<SharedBuffer> sanitizeResponse(const SharedBuffer&) const final;
     std::optional<String> sanitizeSessionId(const String&) const final;
 
@@ -132,7 +132,7 @@ class CDMInstanceSessionThunder final : public CDMInstanceSessionProxy {
 public:
     CDMInstanceSessionThunder(CDMInstanceThunder&);
 
-    void requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
+    void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
     void updateLicense(const String&, LicenseType, Ref<SharedBuffer>&&, LicenseUpdateCallback&&) final;
     void loadSession(LicenseType, const String&, const String&, LoadSessionCallback&&) final;
     void closeSession(const String&, CloseSessionCallback&&) final;

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -127,14 +127,14 @@ MockCDM::MockCDM(WeakPtr<MockCDMFactory> factory, const String& mediaKeysHashSal
 {
 }
 
-Vector<AtomString> MockCDM::supportedInitDataTypes() const
+Vector<String> MockCDM::supportedInitDataTypes() const
 {
     if (m_factory)
         return m_factory->supportedDataTypes();
     return { };
 }
 
-Vector<AtomString> MockCDM::supportedRobustnesses() const
+Vector<String> MockCDM::supportedRobustnesses() const
 {
     if (m_factory)
         return m_factory->supportedRobustness();
@@ -216,7 +216,7 @@ bool MockCDM::supportsSessions() const
     return m_factory && m_factory->supportsSessions();
 }
 
-bool MockCDM::supportsInitData(const AtomString& initDataType, const SharedBuffer& initData) const
+bool MockCDM::supportsInitData(const String& initDataType, const SharedBuffer& initData) const
 {
     if (!supportedInitDataTypes().contains(initDataType))
         return false;
@@ -311,11 +311,11 @@ MockCDMInstanceSession::MockCDMInstanceSession(WeakPtr<MockCDMInstance>&& instan
 {
 }
 
-void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
+void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
     MockCDMFactory* factory = m_instance ? m_instance->factory() : nullptr;
     if (!factory) {
-        callback(SharedBuffer::create(), emptyAtom(), false, SuccessValue::Failed);
+        callback(SharedBuffer::create(), emptyString(), false, SuccessValue::Failed);
         return;
     }
 

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -59,14 +59,14 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const Vector<AtomString>& supportedDataTypes() const { return m_supportedDataTypes; }
+    const Vector<String>& supportedDataTypes() const { return m_supportedDataTypes; }
     void setSupportedDataTypes(Vector<String>&&);
 
     const Vector<MediaKeySessionType>& supportedSessionTypes() const { return m_supportedSessionTypes; }
     void setSupportedSessionTypes(Vector<MediaKeySessionType>&& types) { m_supportedSessionTypes = WTFMove(types); }
 
-    const Vector<AtomString>& supportedRobustness() const { return m_supportedRobustness; }
-    void setSupportedRobustness(Vector<AtomString>&& supportedRobustness) { m_supportedRobustness = WTFMove(supportedRobustness); }
+    const Vector<String>& supportedRobustness() const { return m_supportedRobustness; }
+    void setSupportedRobustness(Vector<String>&& supportedRobustness) { m_supportedRobustness = WTFMove(supportedRobustness); }
 
     MediaKeysRequirement distinctiveIdentifiersRequirement() const { return m_distinctiveIdentifiersRequirement; }
     void setDistinctiveIdentifiersRequirement(MediaKeysRequirement requirement) { m_distinctiveIdentifiersRequirement = requirement; }
@@ -101,9 +101,9 @@ private:
 
     MediaKeysRequirement m_distinctiveIdentifiersRequirement { MediaKeysRequirement::Optional };
     MediaKeysRequirement m_persistentStateRequirement { MediaKeysRequirement::Optional };
-    Vector<AtomString> m_supportedDataTypes;
+    Vector<String> m_supportedDataTypes;
     Vector<MediaKeySessionType> m_supportedSessionTypes;
-    Vector<AtomString> m_supportedRobustness;
+    Vector<String> m_supportedRobustness;
     Vector<MediaKeyEncryptionScheme> m_supportedEncryptionSchemes;
     bool m_registered { true };
     bool m_canCreateInstances { true };
@@ -123,8 +123,8 @@ public:
 private:
     friend class MockCDMInstance;
 
-    Vector<AtomString> supportedInitDataTypes() const final;
-    Vector<AtomString> supportedRobustnesses() const final;
+    Vector<String> supportedInitDataTypes() const final;
+    Vector<String> supportedRobustnesses() const final;
     bool supportsConfiguration(const MediaKeySystemConfiguration&) const final;
     bool supportsConfigurationWithRestrictions(const MediaKeySystemConfiguration&, const MediaKeysRestrictions&) const final;
     bool supportsSessionTypeWithConfiguration(const MediaKeySessionType&, const MediaKeySystemConfiguration&) const final;
@@ -135,7 +135,7 @@ private:
     void loadAndInitialize() final;
     bool supportsServerCertificates() const final;
     bool supportsSessions() const final;
-    bool supportsInitData(const AtomString&, const SharedBuffer&) const final;
+    bool supportsInitData(const String&, const SharedBuffer&) const final;
     RefPtr<SharedBuffer> sanitizeResponse(const SharedBuffer&) const final;
     std::optional<String> sanitizeSessionId(const String&) const final;
 
@@ -169,7 +169,7 @@ public:
     MockCDMInstanceSession(WeakPtr<MockCDMInstance>&&);
 
 private:
-    void requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
+    void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
     void updateLicense(const String&, LicenseType, Ref<SharedBuffer>&&, LicenseUpdateCallback&&) final;
     void loadSession(LicenseType, const String&, const String&, LoadSessionCallback&&) final;
     void closeSession(const String&, CloseSessionCallback&&) final;

--- a/Source/WebCore/testing/MockCDMFactory.idl
+++ b/Source/WebCore/testing/MockCDMFactory.idl
@@ -29,7 +29,7 @@
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
 ] interface MockCDMFactory {
     attribute sequence<DOMString> supportedDataTypes;
-    attribute sequence<[AtomString] DOMString> supportedRobustness;
+    attribute sequence<DOMString> supportedRobustness;
     attribute sequence<MediaKeySessionType> supportedSessionTypes;
     attribute MediaKeysRequirement distinctiveIdentifiersRequirement;
     attribute MediaKeysRequirement persistentStateRequirement;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -65,7 +65,7 @@ void RemoteCDMInstanceSessionProxy::setLogIdentifier(uint64_t logIdentifier)
 #endif
 }
 
-void RemoteCDMInstanceSessionProxy::requestLicense(LicenseType type, KeyGroupingStrategy keyGroupingStrategy, AtomString initDataType, RefPtr<WebCore::SharedBuffer>&& initData, LicenseCallback&& completion)
+void RemoteCDMInstanceSessionProxy::requestLicense(LicenseType type, KeyGroupingStrategy keyGroupingStrategy, String initDataType, RefPtr<WebCore::SharedBuffer>&& initData, LicenseCallback&& completion)
 {
     if (!initData) {
         completion({ }, emptyString(), false, false);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -73,7 +73,7 @@ private:
 
     // Messages
     void setLogIdentifier(uint64_t);
-    void requestLicense(LicenseType, KeyGroupingStrategy, AtomString initDataType, RefPtr<WebCore::SharedBuffer>&& initData, LicenseCallback&&);
+    void requestLicense(LicenseType, KeyGroupingStrategy, String initDataType, RefPtr<WebCore::SharedBuffer>&& initData, LicenseCallback&&);
     void updateLicense(String sessionId, LicenseType, RefPtr<WebCore::SharedBuffer>&& response, LicenseUpdateCallback&&);
     void loadSession(LicenseType, String sessionId, String origin, LoadSessionCallback&&);
     void closeSession(const String& sessionId, CloseSessionCallback&&);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
@@ -32,7 +32,7 @@
 ]
 messages -> RemoteCDMInstanceSessionProxy {
     SetLogIdentifier(uint64_t logIdentifier)
-    RequestLicense(enum:uint8_t WebCore::CDMSessionType type, enum:bool WebCore::CDMKeyGroupingStrategy keyGroupingStrategy, AtomString initDataType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> message, String sessionId, bool needsIndividualization, bool succeeded)
+    RequestLicense(enum:uint8_t WebCore::CDMSessionType type, enum:bool WebCore::CDMKeyGroupingStrategy keyGroupingStrategy, String initDataType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> message, String sessionId, bool needsIndividualization, bool succeeded)
     UpdateLicense(String sessionId, enum:uint8_t WebCore::CDMSessionType type, RefPtr<WebCore::SharedBuffer> response) -> (bool sessionWasClosed, std::optional<Vector<std::pair<Ref<WebCore::SharedBuffer>, WebCore::CDMKeyStatus>>> changedKeys, std::optional<double> changedExpiration, std::optional<std::pair<WebCore::CDMMessageType, Ref<WebCore::SharedBuffer>>> message, bool succeeded)
     LoadSession(enum:uint8_t WebCore::CDMSessionType type, String sessionId, String origin) -> (std::optional<Vector<std::pair<Ref<WebCore::SharedBuffer>, WebCore::CDMKeyStatus>>> changedKeys, std::optional<double> changedExpiration, std::optional<std::pair<WebCore::CDMMessageType, Ref<WebCore::SharedBuffer>>> message, bool succeeded, enum:uint8_t WebCore::CDMInstanceSessionLoadFailure loadFailure)
     CloseSession(String sessionId) -> ()

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -66,7 +66,7 @@ RemoteCDMProxy::RemoteCDMProxy(RemoteCDMFactoryProxy& factory, std::unique_ptr<C
 
 RemoteCDMProxy::~RemoteCDMProxy() = default;
 
-bool RemoteCDMProxy::supportsInitData(const AtomString& type, const SharedBuffer& data)
+bool RemoteCDMProxy::supportsInitData(const String& type, const SharedBuffer& data)
 {
     return m_private->supportsInitData(type, data);
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -63,7 +63,7 @@ public:
     RemoteCDMFactoryProxy* factory() const { return m_factory.get(); }
     RefPtr<RemoteCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
 
-    bool supportsInitData(const AtomString&, const WebCore::SharedBuffer&);
+    bool supportsInitData(const String&, const WebCore::SharedBuffer&);
     RefPtr<WebCore::SharedBuffer> sanitizeResponse(const WebCore::SharedBuffer& response);
     std::optional<String> sanitizeSessionId(const String& sessionId);
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
@@ -92,7 +92,7 @@ bool RemoteCDM::supportsSessionTypeWithConfiguration(const CDMSessionType&, cons
     return false;
 }
 
-bool RemoteCDM::supportsInitData(const AtomString& type, const SharedBuffer& data) const
+bool RemoteCDM::supportsInitData(const String& type, const SharedBuffer& data) const
 {
     // This check will be done, later, inside RemoteCDMInstanceSessionProxy::requestLicense().
     return true;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
@@ -52,7 +52,7 @@ private:
     bool supportsConfiguration(const WebCore::CDMKeySystemConfiguration&) const final;
     bool supportsConfigurationWithRestrictions(const WebCore::CDMKeySystemConfiguration&, const WebCore::CDMRestrictions&) const final;
     bool supportsSessionTypeWithConfiguration(const WebCore::CDMSessionType&, const WebCore::CDMKeySystemConfiguration&) const final;
-    bool supportsInitData(const AtomString&, const WebCore::SharedBuffer&) const final;
+    bool supportsInitData(const String&, const WebCore::SharedBuffer&) const final;
     WebCore::CDMRequirement distinctiveIdentifiersRequirement(const WebCore::CDMKeySystemConfiguration&, const WebCore::CDMRestrictions&) const final;
     WebCore::CDMRequirement persistentStateRequirement(const WebCore::CDMKeySystemConfiguration&, const WebCore::CDMRestrictions&) const final;
     bool distinctiveIdentifiersAreUniquePerOriginAndClearable(const WebCore::CDMKeySystemConfiguration&) const final;
@@ -61,8 +61,8 @@ private:
     RefPtr<WebCore::SharedBuffer> sanitizeResponse(const WebCore::SharedBuffer&) const final;
     std::optional<String> sanitizeSessionId(const String&) const final;
 
-    Vector<AtomString> supportedInitDataTypes() const final { return m_configuration.supportedInitDataTypes; }
-    Vector<AtomString> supportedRobustnesses() const final { return m_configuration.supportedRobustnesses; }
+    Vector<String> supportedInitDataTypes() const final { return m_configuration.supportedInitDataTypes; }
+    Vector<String> supportedRobustnesses() const final { return m_configuration.supportedRobustnesses; }
     bool supportsServerCertificates() const final { return m_configuration.supportsServerCertificates; }
     bool supportsSessions() const final { return m_configuration.supportsSessions; }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMConfiguration.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMConfiguration.h
@@ -32,8 +32,8 @@
 namespace WebKit {
 
 struct RemoteCDMConfiguration {
-    Vector<AtomString> supportedInitDataTypes;
-    Vector<AtomString> supportedRobustnesses;
+    Vector<String> supportedInitDataTypes;
+    Vector<String> supportedRobustnesses;
     bool supportsServerCertificates;
     bool supportsSessions;
     uint64_t logIdentifier { 0 };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMConfiguration.serialization.in
@@ -23,11 +23,11 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
 struct WebKit::RemoteCDMConfiguration {
-    Vector<AtomString> supportedInitDataTypes;
-    Vector<AtomString> supportedRobustnesses;
+    Vector<String> supportedInitDataTypes;
+    Vector<String> supportedRobustnesses;
     bool supportsServerCertificates;
     bool supportsSessions;
     uint64_t logIdentifier;
 };
-    
+
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
@@ -65,7 +65,7 @@ void RemoteCDMInstanceSession::setLogIdentifier(uint64_t logIdentifier)
 }
 #endif
 
-void RemoteCDMInstanceSession::requestLicense(LicenseType type, KeyGroupingStrategy keyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
+void RemoteCDMInstanceSession::requestLicense(LicenseType type, KeyGroupingStrategy keyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
     RefPtr factory = m_factory.get();
     if (!factory) {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
@@ -67,7 +67,7 @@ private:
 
     void setClient(WeakPtr<WebCore::CDMInstanceSessionClient>&& client) final { m_client = WTFMove(client); }
     void clearClient() final { m_client = nullptr; }
-    void requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<WebCore::SharedBuffer>&& initData, LicenseCallback&&) final;
+    void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<WebCore::SharedBuffer>&& initData, LicenseCallback&&) final;
     void updateLicense(const String& sessionId, LicenseType, Ref<WebCore::SharedBuffer>&& response, LicenseUpdateCallback&&) final;
     void loadSession(LicenseType, const String& sessionId, const String& origin, LoadSessionCallback&&) final;
     void closeSession(const String& sessionId, CloseSessionCallback&&) final;


### PR DESCRIPTION
#### 07e98f6bcf9a5d101f9539b657a005d96151a865
<pre>
ASSERTION: ASSERT(isMainThread()); when watching protected content with MediaSourceUseRemoteAudioVideoRenderer enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=303035">https://bugs.webkit.org/show_bug.cgi?id=303035</a>
<a href="https://rdar.apple.com/165322277">rdar://165322277</a>

Reviewed by Youenn Fablet.

The SourceBufferParser runs in a dedicated WorkQueue ; if the CDMPrivateFairPlayStreaming::sinfName, sdkName, mptsName
were first accessed on that queue, their MainThreadNeverDestroyed container&apos;s constructor would assert.

Due to the multi-threaded nature of the SourceBufferParser / SourceBufferPrivate / MediaPlayerPrivate
we replace the use of AtomString with String. Almost all CDMs were using Strings in
their API but the initialisation, so using String isn&apos;t much of a jump.

No change in observable behaviours. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/303490@main">https://commits.webkit.org/303490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9473047f4cb3695680006055c1ca473cd3cbc482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140136 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/366599bc-b735-409a-b642-16f72f8aae62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101382 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b28132c9-f052-463c-a4c7-01cdeef2f53b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135561 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82179 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7faa8cc6-eacd-4635-80ea-bf9e7ab791cf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83371 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142791 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109758 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109939 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27855 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3637 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58220 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4834 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33413 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68285 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4925 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4791 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->