### PR TITLE
StabilityTracer: com.apple.WebKit.GPU.Development at com.apple.WebKit:  IPC::MessageReceiver::~MessageReceiver

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2051,8 +2051,6 @@ webkit.org/b/289200 imported/w3c/web-platform-tests/fullscreen/rendering/backdro
 
 webkit.org/b/289211 [ Sequoia Release x86_64 ] imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html [ Failure ]
 
-webkit.org/b/289254 [ Debug ] imported/w3c/web-platform-tests/mediacapture-streams/historical.https.html [ Pass Crash ]
-
 # webkit.org/b/289272 [ macOS wk2 arm64 ] 2x imported/w3c/web-platform-tests/editing/other/delete-in-child-of-head.tentative.html?designMode=on&method=* are flaky failures.
 [ arm64 ] imported/w3c/web-platform-tests/editing/other/delete-in-child-of-head.tentative.html?designMode=on&method=forwarddelete [ Pass Failure ]
 [ arm64 ] imported/w3c/web-platform-tests/editing/other/delete-in-child-of-head.tentative.html?designMode=on&method=backspace [ Pass Failure ]

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -441,7 +441,7 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 #endif
 #if ENABLE(VIDEO)
     protectedVideoFrameObjectHeap()->close();
-    protectedRemoteMediaPlayerManagerProxy()->clear();
+    protectedRemoteMediaPlayerManagerProxy()->connectionToWebProcessClosed();
 #endif
     // RemoteRenderingBackend objects ref their GPUConnectionToWebProcess so we need to make sure
     // to break the reference cycle by destroying them.

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -74,6 +74,7 @@ public:
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
     void clear();
+    void connectionToWebProcessClosed();
 
 #if !RELEASE_LOG_DISABLED
     Logger& logger() { return m_logger; }
@@ -120,7 +121,7 @@ private:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 
 #if ENABLE(MEDIA_SOURCE)
-    HashMap<RemoteMediaSourceIdentifier, RefPtr<RemoteMediaSourceProxy>> m_pendingMediaSources;
+    HashMap<RemoteMediaSourceIdentifier, Ref<RemoteMediaSourceProxy>> m_pendingMediaSources;
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -127,6 +127,14 @@ RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy()
     setShouldEnableAudioSourceProvider(false);
 }
 
+void RemoteMediaPlayerProxy::connectionToWebProcessClosed()
+{
+#if ENABLE(MEDIA_SOURCE)
+    if (RefPtr mediaSource = m_mediaSourceProxy)
+        mediaSource->connectionToWebProcessClosed();
+#endif
+}
+
 void RemoteMediaPlayerProxy::invalidate()
 {
     m_updateCachedStateMessageTimer.stop();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -127,6 +127,7 @@ public:
 
     WebCore::MediaPlayerIdentifier identifier() const { return m_id; }
     void invalidate();
+    void connectionToWebProcessClosed();
 
     // Ensure that all previously queued messages to the content process have completed.
     Ref<WebCore::MediaPromise> commitAllTransactions();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -51,7 +51,7 @@ RemoteMediaSourceProxy::RemoteMediaSourceProxy(RemoteMediaPlayerManagerProxy& ma
     , m_identifier(identifier)
     , m_remoteMediaPlayerProxy(remoteMediaPlayerProxy)
 {
-    ASSERT(RunLoop::isMain());
+    assertIsMainRunLoop();
 
     connectionToWebProcess()->messageReceiverMap().addMessageReceiver(Messages::RemoteMediaSourceProxy::messageReceiverName(), m_identifier.toUInt64(), *this);
     manager.registerMediaSource(m_identifier, *this);
@@ -179,7 +179,7 @@ void RemoteMediaSourceProxy::attached()
 
 void RemoteMediaSourceProxy::shutdown()
 {
-    ASSERT(RunLoop::isMain());
+    assertIsMainRunLoop();
 
     disconnect();
 
@@ -189,7 +189,7 @@ void RemoteMediaSourceProxy::shutdown()
 
 RefPtr<GPUConnectionToWebProcess> RemoteMediaSourceProxy::connectionToWebProcess() const
 {
-    ASSERT(RunLoop::isMain());
+    assertIsMainRunLoop();
 
     RefPtr manager = m_manager.get();
     return manager ? manager->gpuConnectionToWebProcess() : nullptr;
@@ -201,6 +201,13 @@ std::optional<SharedPreferencesForWebProcess> RemoteMediaSourceProxy::sharedPref
         return connection->sharedPreferencesForWebProcess();
 
     return std::nullopt;
+}
+
+void RemoteMediaSourceProxy::connectionToWebProcessClosed()
+{
+    assertIsMainRunLoop();
+    for (RefPtr sourceBuffer : std::exchange(m_sourceBuffers, { }))
+        sourceBuffer->connectionToWebProcessClosed();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -80,6 +80,8 @@ public:
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+    void connectionToWebProcessClosed();
+
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -417,6 +417,12 @@ std::optional<SharedPreferencesForWebProcess> RemoteSourceBufferProxy::sharedPre
     return std::nullopt;
 }
 
+void RemoteSourceBufferProxy::connectionToWebProcessClosed()
+{
+    ASSERT(isMainRunLoop());
+    disconnect();
+}
+
 #undef MESSAGE_CHECK
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -70,6 +70,8 @@ public:
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+    void connectionToWebProcessClosed();
+
 private:
     RemoteSourceBufferProxy(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
 


### PR DESCRIPTION
#### 17afe2b0d011864b2a6333836f06adab43d06e66
<pre>
StabilityTracer: com.apple.WebKit.GPU.Development at com.apple.WebKit:  IPC::MessageReceiver::~MessageReceiver
<a href="https://bugs.webkit.org/show_bug.cgi?id=303040">https://bugs.webkit.org/show_bug.cgi?id=303040</a>
<a href="https://rdar.apple.com/148660972">rdar://148660972</a>

Reviewed by Youenn Fablet.

If the web content process got terminated before the RemoteSourceBufferProxy&apos;s
destruction, we would get an assertion as `disconnect()` would have been
a no-op and it didn&apos;t remove itself from the connection&apos;s messageReceiverMap.

We now invalidate all RemoteMediaSource and their RemoteSourceBufferProxy when the connection
to the content process is terminated.

Canonical link: <a href="https://commits.webkit.org/303561@main">https://commits.webkit.org/303561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bde4508b568bac770bff2afdcf6b1e5a5159bc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84829 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f05bfde7-b194-4c45-896a-a032973b6b50) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5629 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/5077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101539 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9af66d7-908a-48e3-926b-05cbcbf86e12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135747 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82331 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1087f7dc-ff77-4999-a945-6e09ae728cc0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83566 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142988 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5060 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/5077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110090 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27915 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58481 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5029 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33597 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68486 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->