### PR TITLE
Use OSObjectPtr consistently for libdispatch objects

### DIFF
--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -54,7 +54,7 @@ public:
 
 #if USE(COCOA_EVENT_LOOP)
     dispatch_queue_t dispatchQueue() const { return m_dispatchQueue.get(); }
-    RetainPtr<dispatch_queue_t> protectedDispatchQueue() const { return dispatchQueue(); }
+    OSObjectPtr<dispatch_queue_t> protectedDispatchQueue() const { return dispatchQueue(); }
 #endif
 
     virtual void ref() const = 0;

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -32,6 +32,7 @@
 
 #include <wtf/BlockPtr.h>
 #include <wtf/Forward.h>
+#include <wtf/OSObjectPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/cocoa/SpanCocoa.h>
 #include <wtf/darwin/DispatchExtras.h>
@@ -113,11 +114,11 @@ inline Vector<uint8_t> makeVector(NSData *data)
 }
 
 template<typename T>
-inline RetainPtr<dispatch_data_t> makeDispatchData(Vector<T>&& vector)
+inline OSObjectPtr<dispatch_data_t> makeDispatchData(Vector<T>&& vector)
 {
     auto buffer = vector.releaseBuffer();
     auto span = buffer.span();
-    return adoptNS(dispatch_data_create(span.data(), span.size_bytes(), mainDispatchQueueSingleton(), makeBlockPtr([buffer = WTFMove(buffer)] { }).get()));
+    return adoptOSObject(dispatch_data_create(span.data(), span.size_bytes(), mainDispatchQueueSingleton(), makeBlockPtr([buffer = WTFMove(buffer)] { }).get()));
 }
 
 } // namespace WTF

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -91,7 +91,7 @@ public:
 
 #if PLATFORM(COCOA)
     dispatch_data_t dispatchData() const { return m_dispatchData.get(); }
-    RetainPtr<dispatch_data_t> protectedDispatchData() const;
+    OSObjectPtr<dispatch_data_t> protectedDispatchData() const;
 #endif
 
 #if USE(GLIB)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -53,7 +53,7 @@ Data::Data(Vector<uint8_t>&& data)
 {
 }
 
-RetainPtr<dispatch_data_t> Data::protectedDispatchData() const
+OSObjectPtr<dispatch_data_t> Data::protectedDispatchData() const
 {
     return dispatchData();
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -192,7 +192,7 @@ void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<vo
         m_clearCacheDispatchGroup = adoptOSObject(dispatch_group_create());
 
     RetainPtr group = m_clearCacheDispatchGroup.get();
-    dispatch_group_async(group.get(), RetainPtr { mainDispatchQueueSingleton() }.get(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {
+    dispatch_group_async(group.get(), mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {
         auto aggregator = CallbackAggregator::create(WTFMove(completionHandler));
         forEachNetworkSession([modifiedSince, &aggregator](NetworkSession& session) {
             if (RefPtr cache = session.cache())

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -53,7 +53,7 @@ using namespace WebCore;
 
 static dispatch_queue_t tcpSocketQueueSingleton()
 {
-    static NeverDestroyed<OSObjectPtr<dispatch_queue_t>> queue = adoptOSObject(dispatch_queue_create("WebRTC TCP socket queue", RetainPtr { DISPATCH_QUEUE_CONCURRENT }.get()));
+    static NeverDestroyed<OSObjectPtr<dispatch_queue_t>> queue = adoptOSObject(dispatch_queue_create("WebRTC TCP socket queue", OSObjectPtr { DISPATCH_QUEUE_CONCURRENT }.get()));
     return queue.get().get();
 }
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -106,7 +106,7 @@ private:
 
 static dispatch_queue_t udpSocketQueueSingleton()
 {
-    static NeverDestroyed<OSObjectPtr<dispatch_queue_t>> queue = adoptOSObject(dispatch_queue_create("WebRTC UDP socket queue", RetainPtr { DISPATCH_QUEUE_CONCURRENT }.get()));
+    static NeverDestroyed<OSObjectPtr<dispatch_queue_t>> queue = adoptOSObject(dispatch_queue_create("WebRTC UDP socket queue", OSObjectPtr { DISPATCH_QUEUE_CONCURRENT }.get()));
     return queue.get().get();
 }
 
@@ -425,7 +425,7 @@ void NetworkRTCUDPSocketCocoaConnections::sendTo(std::span<const uint8_t> data, 
         }).iterator->value.first.get();
     }
 
-    RetainPtr value = adoptNS(dispatch_data_create(data.data(), data.size(), nullptr, DISPATCH_DATA_DESTRUCTOR_DEFAULT));
+    OSObjectPtr value = adoptOSObject(dispatch_data_create(data.data(), data.size(), nullptr, DISPATCH_DATA_DESTRUCTOR_DEFAULT));
     nw_connection_send(nwConnection.get(), value.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([identifier = m_identifier, connection = m_connection.copyRef(), options](_Nullable nw_error_t error) {
         RELEASE_LOG_ERROR_IF(error, WebRTC, "NetworkRTCUDPSocketCocoaConnections::sendTo failed with error %d", error ? nw_error_get_error_code(error) : 0);
         connection->send(Messages::LibWebRTCNetwork::SignalSentPacket { identifier, options.packet_id, webrtc::TimeMillis() }, 0);

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
@@ -91,7 +91,7 @@ XPCObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&& encoder)
 {
     __block auto blockEncoder = WTFMove(encoder);
     auto buffer = blockEncoder->span();
-    auto dispatchData = adoptNS(dispatch_data_create(buffer.data(), buffer.size(), mainDispatchQueueSingleton(), ^{
+    auto dispatchData = adoptOSObject(dispatch_data_create(buffer.data(), buffer.size(), mainDispatchQueueSingleton(), ^{
         // Explicitly clear out the encoder, destroying it.
         blockEncoder.moveToUniquePtr();
     }));

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -36,6 +36,7 @@
 #import <WebCore/SecurityOrigin.h>
 #import <pal/spi/cocoa/NSFileManagerSPI.h>
 #import <wtf/Deque.h>
+#import <wtf/OSObjectPtr.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/NotificationCenterCF.h>
@@ -108,7 +109,7 @@ struct PermissionRequest {
 
 @implementation WKWebGeolocationPolicyDecider {
 @private
-    RetainPtr<dispatch_queue_t> _diskDispatchQueue;
+    OSObjectPtr<dispatch_queue_t> _diskDispatchQueue;
     RetainPtr<NSMutableDictionary> _sites;
     Deque<std::unique_ptr<PermissionRequest>> _challenges;
     std::unique_ptr<PermissionRequest> _activeChallenge;
@@ -128,7 +129,7 @@ struct PermissionRequest {
     if (!self)
         return nil;
 
-    _diskDispatchQueue = adoptNS(dispatch_queue_create("com.apple.WebKit.WKWebGeolocationPolicyDecider", DISPATCH_QUEUE_SERIAL));
+    _diskDispatchQueue = adoptOSObject(dispatch_queue_create("com.apple.WebKit.WKWebGeolocationPolicyDecider", DISPATCH_QUEUE_SERIAL));
 
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenterSingleton(), self, clearGeolocationCache, CLAppResetChangedNotification, NULL, CFNotificationSuspensionBehaviorCoalesce);
 

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -60,7 +60,7 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
     if (!self)
         return nil;
 
-    m_queue = adoptOSObject(dispatch_queue_create(nullptr, retainPtr(DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL).get()));
+    m_queue = adoptOSObject(dispatch_queue_create(nullptr, OSObjectPtr { DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL }.get()));
     m_bundleIdentifier = bundleIdentifier;
     m_notifications = adoptNS([[NSMutableArray alloc] init]);
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -52,6 +52,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/Compiler.h>
 #import <wtf/MainThread.h>
+#import <wtf/OSObjectPtr.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
@@ -200,13 +201,13 @@ struct WebPreferencesPrivate
 public:
     WebPreferencesPrivate()
 #if PLATFORM(IOS_FAMILY)
-        : readWriteQueue { adoptNS(dispatch_queue_create("com.apple.WebPreferences.ReadWriteQueue", DISPATCH_QUEUE_CONCURRENT)) }
+        : readWriteQueue { adoptOSObject(dispatch_queue_create("com.apple.WebPreferences.ReadWriteQueue", DISPATCH_QUEUE_CONCURRENT)) }
 #endif
     {
     }
 
 #if PLATFORM(IOS_FAMILY)
-    RetainPtr<dispatch_queue_t> readWriteQueue;
+    OSObjectPtr<dispatch_queue_t> readWriteQueue;
 #endif
     RetainPtr<NSMutableDictionary> values;
     RetainPtr<NSString> identifier;

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2974,6 +2974,35 @@ def check_wtf_never_destroyed(clean_lines, line_number, file_state, error):
         error(line_number, 'runtime/wtf_never_destroyed', 4, "Use 'static Lock/Condition' instead of 'NeverDestroyed<Lock/Condition>'.")
 
 
+def check_wtf_os_object_ptr(clean_lines, line_number, file_state, error):
+    """Looks for usage of RetainPtr with OS objects, which should be replaced with OSObjectPtr.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+    dispatch_object_using_retain_ptr = search(r'RetainPtr<dispatch_', line)
+    if dispatch_object_using_retain_ptr:
+        error(line_number, 'runtime/wtf_os_object_ptr', 4, "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects.")
+        return
+    dispatch_constant_using_retain_ptr = search(r'RetainPtr { DISPATCH_', line)
+    if dispatch_constant_using_retain_ptr:
+        error(line_number, 'runtime/wtf_os_object_ptr', 4, "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects.")
+        return
+    dispatch_constant_using_retainptr = search(r'retainPtr\(DISPATCH_', line)
+    if dispatch_constant_using_retainptr:
+        error(line_number, 'runtime/wtf_os_object_ptr', 4, "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects.")
+        return
+    dispatch_object_using_adoptns = search(r'adoptNS\(dispatch_', line)
+    if dispatch_object_using_adoptns:
+        error(line_number, 'runtime/wtf_os_object_ptr', 4, "Use 'adoptOSObject()' instead of 'adoptNS()' for dispatch objects.")
+        return
+
 def check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error):
     """Looks for usage of RetainPtr / OSObjectPtr with XPC objects, which should be replaced with XPCObjectPtr.
 
@@ -3803,6 +3832,7 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_unsafe_get(clean_lines, line_number, file_state, error)
     check_wtf_make_unique(clean_lines, line_number, file_state, error)
     check_wtf_never_destroyed(clean_lines, line_number, file_state, error)
+    check_wtf_os_object_ptr(clean_lines, line_number, file_state, error)
     check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error)
     check_lock_guard(clean_lines, line_number, file_state, error)
     check_log(clean_lines, line_number, file_state, error)
@@ -5084,6 +5114,7 @@ class CppChecker(object):
         'runtime/wtf_make_unique',
         'runtime/wtf_move',
         'runtime/wtf_never_destroyed',
+        'runtime/wtf_os_object_ptr',
         'runtime/wtf_xpc_object_ptr',
         'safercpp/atoi',
         'safercpp/checked_getter_for_init',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6186,6 +6186,74 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [runtime/wtf_never_destroyed] [4]",
             'foo.mm')
 
+    def test_wtf_os_object_ptr(self):
+        self.assert_lint(
+            'auto queue = adoptOSObject(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
+            '',
+            'foo.cpp')
+        self.assert_lint(
+            'OSObjectPtr queue = adoptOSObject(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
+            '',
+            'foo.cpp')
+        self.assert_lint(
+            'OSObjectPtr<dispatch_queue_t> queue = adoptOSObject(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
+            '',
+            'foo.cpp')
+        self.assert_lint(
+            'auto group = adoptOSObject(dispatch_group_create());',
+            '',
+            'foo.cpp')
+        self.assert_lint(
+            'RetainPtr<dispatch_queue_t> m_queue;',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'RetainPtr<dispatch_group_t> m_group;',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'RetainPtr<dispatch_queue_t> queue;',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'RetainPtr<dispatch_group_t> group;',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'auto queue = adoptNS(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
+            "Use 'adoptOSObject()' instead of 'adoptNS()' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'auto group = adoptNS(dispatch_group_create());',
+            "Use 'adoptOSObject()' instead of 'adoptNS()' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'auto queue = adoptOSObject(dispatch_queue_create("foo", RetainPtr { DISPATCH_QUEUE_CONCURRENT }.get()));',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'auto queue = adoptOSObject(dispatch_queue_create("foo", RetainPtr { DISPATCH_QUEUE_SERIAL }.get()));',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'auto queue = adoptOSObject(dispatch_queue_create("foo", retainPtr(DISPATCH_QUEUE_CONCURRENT).get()));',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'auto queue = adoptOSObject(dispatch_queue_create("foo", retainPtr(DISPATCH_QUEUE_SERIAL).get()));',
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
+            "  [runtime/wtf_os_object_ptr] [4]",
+            'foo.mm')
+
     def test_wtf_xpc_object_ptr(self):
         self.assert_lint(
             'XPCObjectPtr<xpc_connection_t> connection = adoptXPCObject(xpc_connection_create_from_endpoint(endpoint));',

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -29,6 +29,7 @@
 #import <Network/Network.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/CoroutineUtilities.h>
+#import <wtf/OSObjectPtr.h>
 
 namespace TestWebKitAPI {
 
@@ -44,10 +45,10 @@ class Connection {
 public:
     void send(String&&, CompletionHandler<void()>&& = nullptr) const;
     void send(Vector<uint8_t>&&, CompletionHandler<void()>&& = nullptr) const;
-    void send(RetainPtr<dispatch_data_t>&&, CompletionHandler<void(bool)>&& = nullptr) const;
+    void send(OSObjectPtr<dispatch_data_t>&&, CompletionHandler<void(bool)>&& = nullptr) const;
     SendOperation awaitableSend(Vector<uint8_t>&&);
     SendOperation awaitableSend(String&&);
-    SendOperation awaitableSend(RetainPtr<dispatch_data_t>&&);
+    SendOperation awaitableSend(OSObjectPtr<dispatch_data_t>&&);
     void sendAndReportError(Vector<uint8_t>&&, CompletionHandler<void(bool)>&&) const;
     void receiveBytes(CompletionHandler<void(Vector<uint8_t>&&)>&&, size_t minimumSize = 1) const;
     ReceiveBytesOperation awaitableReceiveBytes() const;
@@ -133,14 +134,14 @@ private:
 
 class SendOperation {
 public:
-    SendOperation(RetainPtr<dispatch_data_t>&& data, const Connection& connection)
+    SendOperation(OSObjectPtr<dispatch_data_t>&& data, const Connection& connection)
         : m_data(WTFMove(data))
         , m_connection(connection) { }
     bool await_ready() { return false; }
     void await_suspend(std::coroutine_handle<>);
     void await_resume() { }
 private:
-    RetainPtr<dispatch_data_t> m_data;
+    OSObjectPtr<dispatch_data_t> m_data;
     Connection m_connection;
 };
 

--- a/Tools/TestWebKitAPI/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/NetworkConnection.mm
@@ -56,12 +56,12 @@ static Vector<uint8_t> vectorFromData(dispatch_data_t content)
     return request;
 }
 
-static RetainPtr<dispatch_data_t> dataFromString(String&& s)
+static OSObjectPtr<dispatch_data_t> dataFromString(String&& s)
 {
     auto impl = s.releaseImpl();
     ASSERT(impl->is8Bit());
     auto characters = impl->span8();
-    return adoptNS(dispatch_data_create(characters.data(), characters.size(), mainDispatchQueueSingleton(), ^{
+    return adoptOSObject(dispatch_data_create(characters.data(), characters.size(), mainDispatchQueueSingleton(), ^{
         (void)impl;
     }));
 }
@@ -135,7 +135,7 @@ SendOperation Connection::awaitableSend(String&& message)
     return { dataFromString(WTFMove(message)), *this };
 }
 
-SendOperation Connection::awaitableSend(RetainPtr<dispatch_data_t>&& data)
+SendOperation Connection::awaitableSend(OSObjectPtr<dispatch_data_t>&& data)
 {
     return { WTFMove(data), *this };
 }
@@ -161,7 +161,7 @@ void Connection::sendAndReportError(Vector<uint8_t>&& message, CompletionHandler
     send(makeDispatchData(WTFMove(message)), WTFMove(completionHandler));
 }
 
-void Connection::send(RetainPtr<dispatch_data_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
+void Connection::send(OSObjectPtr<dispatch_data_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
 {
     nw_connection_send(m_connection.get(), message.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTFMove(completionHandler)](nw_error_t error) mutable {
         if (completionHandler)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -246,7 +246,7 @@ TEST(WebKit, LoadMoreThan4GB)
         else {
             co_await connection.awaitableSend("HTTP/1.1 200 OK\r\nContent-type: application/octet-stream\r\n\r\n"_s);
             for (size_t i = 0; i < 16; ++i)
-                co_await connection.awaitableSend(RetainPtr { longData.get() });
+                co_await connection.awaitableSend(OSObjectPtr { longData.get() });
             connection.terminate();
         }
     } });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -445,7 +445,7 @@ XPCObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryF
 
     __block auto blockBytes = encoder.takeBytes();
     auto buffer = blockBytes.span();
-    auto dispatchData = adoptNS(dispatch_data_create(buffer.data(), buffer.size(), mainDispatchQueueSingleton(), ^{
+    auto dispatchData = adoptOSObject(dispatch_data_create(buffer.data(), buffer.size(), mainDispatchQueueSingleton(), ^{
         blockBytes.clear();
     }));
     // FIXME: This is a false positive. <rdar://164843889>

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -82,7 +82,7 @@ static RetainPtr<nw_protocol_definition_t> proxyDefinition(HTTPServer::Protocol 
                         "Proxy-Authenticate: Basic realm=\"testrealm\"\r\n"
                         "Content-Length: 0\r\n"
                         "\r\n";
-                    auto response = adoptNS(dispatch_data_create(challengeResponse, strlen(challengeResponse), nullptr, nullptr));
+                    auto response = adoptOSObject(dispatch_data_create(challengeResponse, strlen(challengeResponse), nullptr, nullptr));
                     nw_framer_write_output_data(retainedFramer.get(), response.get());
                     state = State::DidRequestCredentials;
                     break;
@@ -94,7 +94,7 @@ static RetainPtr<nw_protocol_definition_t> proxyDefinition(HTTPServer::Protocol 
                     const char* negotiationResponse = ""
                         "HTTP/1.1 200 Connection Established\r\n"
                         "Connection: close\r\n\r\n";
-                    auto response = adoptNS(dispatch_data_create(negotiationResponse, strlen(negotiationResponse), nullptr, nullptr));
+                    auto response = adoptOSObject(dispatch_data_create(negotiationResponse, strlen(negotiationResponse), nullptr, nullptr));
                     nw_framer_write_output_data(retainedFramer.get(), response.get());
                     nw_framer_mark_ready(retainedFramer.get());
                     state = State::PassThrough;


### PR DESCRIPTION
#### 6f96a5e9095ce22ee33d52ea3715219e6782e2a4
<pre>
Use OSObjectPtr consistently for libdispatch objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=303041">https://bugs.webkit.org/show_bug.cgi?id=303041</a>

Reviewed by Geoffrey Garen.

Use OSObjectPtr consistently for libdispatch objects. We would sometimes
use RetainPtr in the codebase. libdispatch seems to rely on os_retain
os_release internally.

* Source/WTF/wtf/WorkQueue.h:
(WTF::WorkQueueBase::protectedDispatchQueue const):
* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::makeDispatchData):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::protectedDispatchData const):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::clearDiskCache):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::tcpSocketQueueSingleton):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::udpSocketQueueSingleton):
(WebKit::NetworkRTCUDPSocketCocoaConnections::sendTo):
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::encoderToXPCData):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(-[WKWebGeolocationPolicyDecider init]):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter initWithBundleIdentifierInternal:]):
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(WebPreferencesPrivate::WebPreferencesPrivate):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_wtf_os_object_ptr):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_wtf_os_object_ptr):
* Tools/TestWebKitAPI/NetworkConnection.h:
(TestWebKitAPI::SendOperation::SendOperation):
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::dataFromString):
(TestWebKitAPI::Connection::awaitableSend):
(TestWebKitAPI::Connection::send const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm:
(TEST(WebKit, LoadMoreThan4GB)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::proxyDefinition):

Canonical link: <a href="https://commits.webkit.org/303517@main">https://commits.webkit.org/303517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7166b2a5a76140ff082a2409434df5d9b1cd85a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/39d2b094-35e2-43ba-a927-cbeebf5781f5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101363 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68661 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae6236cb-6a3c-496d-a687-cf77bf490d70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135537 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3723 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 2 new passes 33 flakes; Uploaded test results; layout-tests (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82161 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eaa2888c-9195-40ae-92a9-99fc7546538f) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/131940 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3611 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1361 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83347 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124661 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142766 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131099 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109740 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3619 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58196 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4810 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33393 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164066 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68261 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42615 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->