### PR TITLE
[blocks-in-inline] Don't paint inline boxes around the block

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-layout-3-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-layout-3-expected.html
@@ -5,7 +5,7 @@ div {
   height: 100px;
 }
 span {
-  border-top: 10px solid transparent;
+  border-top: 10px solid green;
 }
 </style>
 <span>span start<div>div line 1<br>div line 2</div>span end</span>

--- a/LayoutTests/fast/inline/blocks-in-inline-layout-3.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-layout-3.html
@@ -6,7 +6,7 @@ div {
   height: 100px;
 }
 span {
-  border-top: 10px solid transparent;
+  border-top: 10px solid green;
 }
 </style>
 <span>span start<div>div line 1<br>div line 2</div>span end</span>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -114,6 +114,8 @@ struct Box {
 
     bool hasContent() const { return m_hasContent; }
     inline bool isVisible() const;
+    // Inline boxes around blocks are visible to hit testing but don't paint.
+    bool suppressesPaintingForBlockInInline() const { return m_suppressesPaintingForBlockInInline; }
     bool isVisibleIgnoringUsedVisibility() const { return !isFullyTruncated() && style().visibility() == Visibility::Visible; }
     bool isFullyTruncated() const { return m_isFullyTruncated; } 
 
@@ -142,6 +144,7 @@ struct Box {
     void setRect(const FloatRect&, const FloatRect& inkOverflow);
     void setHasContent() { m_hasContent = true; }
     void setIsFullyTruncated() { m_isFullyTruncated = true; }
+    void setSuppressesPaintingForBlockInInline() { m_suppressesPaintingForBlockInInline = true; }
 
     Text& text() { ASSERT(isTextOrSoftLineBreak()); return m_text; }
     const Text& text() const { ASSERT(isTextOrSoftLineBreak()); return m_text; }
@@ -191,6 +194,7 @@ private:
     bool m_isFullyTruncated : 1 { false };
     bool m_isInGlyphDisplayListCache : 1 { false };
     bool m_isFirstFormattedLine : 1 { false };
+    bool m_suppressesPaintingForBlockInInline : 1 { false };
 
     Text m_text;
 };

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -58,7 +58,7 @@ private:
     void appendAtomicInlineLevelDisplayBox(const Line::Run&, const InlineRect&, InlineDisplay::Boxes&);
     void appendBlockLevelDisplayBox(const Line::Run&, const InlineRect&, InlineDisplay::Boxes&);
     void appendRootInlineBoxDisplayBox(const InlineRect&, bool lineHasContent, InlineDisplay::Boxes&);
-    void appendInlineBoxDisplayBox(const Line::Run&, const InlineLevelBox&, const InlineRect&, InlineDisplay::Boxes&);
+    void appendInlineBoxDisplayBox(const Line::Run&, const InlineLevelBox&, const InlineRect&, bool lineHasBlockContent, InlineDisplay::Boxes&);
     void appendInlineDisplayBoxAtBidiBoundary(const Box&, InlineDisplay::Boxes&);
     void insertRubyAnnotationBox(const Box& annotationBox, size_t insertionPosition, const InlineRect&, InlineDisplay::Boxes&);
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -85,7 +85,7 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
     }
 
     if (box.isInlineBox()) {
-        if (!box.isVisible() || !hasDamage(box))
+        if (!box.isVisible() || box.suppressesPaintingForBlockInInline() || !hasDamage(box))
             return;
 
         auto canSkipInlineBoxPainting = [&]() {


### PR DESCRIPTION
#### 4cc512b709037ee3dd82c8cd05bc89d3cf04315d
<pre>
[blocks-in-inline] Don&apos;t paint inline boxes around the block
<a href="https://bugs.webkit.org/show_bug.cgi?id=303047">https://bugs.webkit.org/show_bug.cgi?id=303047</a>
<a href="https://rdar.apple.com/165339764">rdar://165339764</a>

Reviewed by Alan Baradlay.

They are useful for hit testing but shouldn&apos;t paint.

* LayoutTests/fast/inline/blocks-in-inline-layout-3-expected.html:
* LayoutTests/fast/inline/blocks-in-inline-layout-3.html:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::suppressesPaintingForBlockInInline const):
(WebCore::InlineDisplay::Box::setSuppressesPaintingForBlockInInline):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::appendInlineBoxDisplayBox):
(WebCore::Layout::InlineDisplayContentBuilder::processNonBidiContent):
(WebCore::Layout::InlineDisplayContentBuilder::processBidiContent):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):

Canonical link: <a href="https://commits.webkit.org/303492@main">https://commits.webkit.org/303492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f613124b480975603a0b5950a28bf3dc0fa0c037

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84638 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/89279f54-9316-4233-a564-1c2e86a9ab09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eb1cd3cf-8d9f-4c6f-859f-0b99110b2ee3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82184 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbfd48a9-dbb0-4cfc-b31d-e768cd0bbce8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83375 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112557 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142796 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109760 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27859 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3640 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115070 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58224 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4838 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68289 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->