### PR TITLE
[WPE] WPE Platform: add disconnected signal to WPEDisplay

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -86,6 +86,8 @@ enum {
     SCREEN_ADDED,
     SCREEN_REMOVED,
 
+    DISCONNECTED,
+
     LAST_SIGNAL
 };
 
@@ -205,6 +207,22 @@ static void wpe_display_class_init(WPEDisplayClass* displayClass)
         g_cclosure_marshal_generic,
         G_TYPE_NONE, 1,
         WPE_TYPE_SCREEN);
+
+    /**
+     * WPEDisplay::disconnected:
+     * @display: a #WPEDisplay
+     * @error: (nullable): a #GError or %NULL
+     *
+     * Emitted when the @display is disconnected from the platform display.
+     */
+    signals[DISCONNECTED] = g_signal_new(
+        "disconnected",
+        G_TYPE_FROM_CLASS(displayClass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 1,
+        G_TYPE_ERROR);
 }
 
 WPEView* wpeDisplayCreateView(WPEDisplay* display)
@@ -320,6 +338,23 @@ gboolean wpe_display_connect(WPEDisplay* display, GError** error)
 
     auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
     return wpeDisplayClass->connect(display, error);
+}
+
+/**
+ * wpe_display_disconnected:
+ * @display: a #WPEDisplay
+ * @error: (nullable): a #GError or %NULL
+ *
+ * Emit the signal #WPEDisplay::disconnected with the given @error
+ *
+ * This function should only be called by platform implementations.
+ */
+void wpe_display_disconnected(WPEDisplay* display, GError* error)
+{
+    g_return_if_fail(WPE_IS_DISPLAY(display));
+    g_return_if_fail(!error || g_error_matches(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_LOST));
+
+    g_signal_emit(display, signals[DISCONNECTED], 0, error);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -91,7 +91,8 @@ struct _WPEDisplayClass
  */
 typedef enum {
     WPE_DISPLAY_ERROR_NOT_SUPPORTED,
-    WPE_DISPLAY_ERROR_CONNECTION_FAILED
+    WPE_DISPLAY_ERROR_CONNECTION_FAILED,
+    WPE_DISPLAY_ERROR_CONNECTION_LOST
 } WPEDisplayError;
 
 WPE_API GQuark                   wpe_display_error_quark                   (void);
@@ -100,6 +101,8 @@ WPE_API WPEDisplay              *wpe_display_get_primary                   (void
 WPE_API void                     wpe_display_set_primary                   (WPEDisplay *display);
 WPE_API gboolean                 wpe_display_connect                       (WPEDisplay *display,
                                                                             GError    **error);
+WPE_API void                     wpe_display_disconnected                  (WPEDisplay *display,
+                                                                            GError     *error);
 WPE_API gpointer                 wpe_display_get_egl_display               (WPEDisplay *display,
                                                                             GError    **error);
 WPE_API WPEKeymap               *wpe_display_get_keymap                    (WPEDisplay *display);

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -265,6 +265,15 @@ static void webViewTitleChanged(WebKitWebView* webView, GParamSpec*, WPEView* vi
     wpe_toplevel_set_title(wpe_view_get_toplevel(view), privateTitle ? privateTitle : title);
     g_free(privateTitle);
 }
+
+static void displayDisconnected(WPEDisplay*, GError* error)
+{
+    if (error)
+        g_warning("WPE display disconnected: %s", error->message);
+    else
+        g_warning("WPE display disconnected");
+    _exit(1);
+}
 #endif
 
 
@@ -617,6 +626,7 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
 
 #if ENABLE_WPE_PLATFORM
     if (auto* wpeView = webkit_web_view_get_wpe_view(webView)) {
+        g_signal_connect(wpe_view_get_display(wpeView), "disconnected", G_CALLBACK(displayDisconnected), nullptr);
         auto* wpeToplevel = wpe_view_get_toplevel(wpeView);
         if (windowWidth > 0 && windowHeight > 0)
             wpe_toplevel_resize(wpeToplevel, windowWidth, windowHeight);

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
@@ -212,6 +212,14 @@ void wpeDisplayMockRegister(GIOModule* ioModule)
     g_io_extension_point_implement(WPE_DISPLAY_EXTENSION_POINT_NAME, WPE_TYPE_DISPLAY_MOCK, "wpe-display-mock", G_MAXINT32);
 }
 
+void wpeDisplayMockDisconnect(WPEDisplayMock* mock)
+{
+    mock->isConnected = FALSE;
+    GError* error = g_error_new_literal(WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_LOST, "Display disconnected");
+    wpe_display_disconnected(WPE_DISPLAY(mock), error);
+    g_error_free(error);
+}
+
 void wpeDisplayMockUseFakeDRMNodes(WPEDisplayMock* mock, gboolean useFakeDRMNodes)
 {
     if (!useFakeDRMNodes) {

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.h
@@ -36,6 +36,7 @@ G_DECLARE_FINAL_TYPE(WPEDisplayMock, wpe_display_mock, WPE, DISPLAY_MOCK, WPEDis
 
 void wpeDisplayMockRegister(GIOModule*);
 WPEDisplay* wpeDisplayMockNew();
+void wpeDisplayMockDisconnect(WPEDisplayMock*);
 void wpeDisplayMockUseFakeDRMNodes(WPEDisplayMock*, gboolean);
 void wpeDisplayMockUseFakeDMABufFormats(WPEDisplayMock*, gboolean);
 void wpeDisplayMockSetUseExplicitSync(WPEDisplayMock*, gboolean);


### PR DESCRIPTION
#### d2d8024107d14d4a11c3d8d597d4ad428cbb9e0e
<pre>
[WPE] WPE Platform: add disconnected signal to WPEDisplay
<a href="https://bugs.webkit.org/show_bug.cgi?id=303050">https://bugs.webkit.org/show_bug.cgi?id=303050</a>

Reviewed by Adrian Perez de Castro.

Emitted when the connection to the native display is lost.

Tests: Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
Canonical link: <a href="https://commits.webkit.org/303531@main">https://commits.webkit.org/303531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/424d2f22aed6cea6ef8ed89a5282239dd075d7cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101396 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135574 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82189 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83384 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142805 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109948 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3647 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58238 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20584 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4847 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33426 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68298 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->