### PR TITLE
[blocks-in-inline] Client rects for inline box don't require special casing

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-client-rects-expected.txt
+++ b/LayoutTests/fast/inline/blocks-in-inline-client-rects-expected.txt
@@ -1,0 +1,6 @@
+non-empty
+
+PASS t1.getBoundingClientRect().width
+PASS t2.getBoundingClientRect().width
+PASS t3.getBoundingClientRect().width
+

--- a/LayoutTests/fast/inline/blocks-in-inline-client-rects.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-client-rects.html
@@ -1,0 +1,70 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+div {
+  width: 500px;
+}
+.inline-block {
+  display: inline-block;
+  width: 100px;
+  height: 1px;
+  background: blue;
+}
+.w200 {
+  width: 200px;
+}
+</style>
+<body>
+  <!-- The `<span>` contains an empty block child -->
+  <div>
+    <span id="t1" class="target">
+      <div class="inline-block"></div>
+      <div></div>
+      <div class="inline-block w200"></div>
+    </span>
+  </div>
+
+  <!-- The `<span>` contains non-empty block child -->
+  <div>
+    <span id="t2" class="target">
+      <div class="inline-block"></div>
+      <div>non-empty</div>
+      <div class="inline-block w200"></div>
+    </span>
+  </div>
+
+  <!-- The `<span>` contains empty but non-zero height block child -->
+  <div>
+    <span id="t3" class="target">
+      <div class="inline-block"></div>
+      <div style="height: 100px"></div>
+      <div class="inline-block w200"></div>
+    </span>
+  </div>
+<script>
+// The `getBoundingClientRect` spec[1] says to ignore rects "of which the
+// height or width is not zero."
+// [1] https://www.w3.org/TR/cssom-view-1/#dom-range-getboundingclientrect
+function testGetBoundingClientRect() {
+  test(()=> { assert_equals(t1.getBoundingClientRect().width, 200); },
+                            `t1.getBoundingClientRect().width`);
+  test(()=> { assert_equals(t2.getBoundingClientRect().width, 500); },
+                            `t2.getBoundingClientRect().width`);
+  test(()=> { assert_equals(t3.getBoundingClientRect().width, 500); },
+                            `t3.getBoundingClientRect().width`);
+}
+testGetBoundingClientRect();
+
+// Skip testing `offsetWidth` because the 3 implementations return different
+// values for these cases, and the expectations aren't clear from the spec.
+// https://github.com/w3c/csswg-drafts/issues/6588
+function testOffsetWidth() {
+  test(()=> { assert_equals(t1.offsetWidth, 200); }, `t1.offsetWidth`);
+  test(()=> { assert_equals(t2.offsetWidth, 500); }, `t2.offsetWidth`);
+  test(()=> { assert_equals(t3.offsetWidth, 500); }, `t3.offsetWidth`);
+}
+// testOffsetWidth();
+</script>
+</body>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -92,7 +92,6 @@ public:
     const InlineDisplay::Box* blockLevelBoxForLine(const InlineDisplay::Line&) const;
 
     template<typename Function> void traverseNonRootInlineBoxes(const Layout::Box&, Function&&);
-    template<typename Function> void traverseDescendantBlockLevelBoxes(const Layout::Box&, Function&&);
 
     const RenderBlockFlow& formattingContextRoot() const;
 
@@ -140,21 +139,6 @@ template<typename Function> void InlineContent::traverseNonRootInlineBoxes(const
 {
     for (auto index : nonRootInlineBoxIndexesForLayoutBox(layoutBox))
         function(displayContent().boxes[index]);
-}
-
-template<typename Function> void InlineContent::traverseDescendantBlockLevelBoxes(const Layout::Box& ancestor, Function&& function)
-{
-    if (!m_hasBlockLevelBoxes)
-        return;
-
-    for (auto& box : m_displayContent.boxes) {
-        if (!box.isBlockLevelBox())
-            continue;
-        CheckedRef layoutBox = box.layoutBox();
-        if (!layoutBox->isDescendantOfWithinFormattingContext(ancestor))
-            continue;
-        function(box);
-    }
 }
 
 }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1114,9 +1114,6 @@ LayoutRect LineLayout::inkOverflowBoundingBoxRectFor(const RenderInline& renderI
     m_inlineContent->traverseNonRootInlineBoxes(layoutBox, [&](auto& inlineBox) {
         result.unite(Layout::toLayoutRect(inlineBox.inkOverflow()));
     });
-    m_inlineContent->traverseDescendantBlockLevelBoxes(layoutBox, [&](auto& inlineBox) {
-        result.unite(Layout::toLayoutRect(inlineBox.inkOverflow()));
-    });
     return result;
 }
 
@@ -1129,11 +1126,8 @@ Vector<FloatRect> LineLayout::collectInlineBoxRects(const RenderInline& renderIn
 
     Vector<FloatRect> result;
     m_inlineContent->traverseNonRootInlineBoxes(layoutBox, [&](auto& inlineBox) {
-        result.append(inlineBox.visualRectIgnoringBlockDirection());
-    });
-    m_inlineContent->traverseDescendantBlockLevelBoxes(layoutBox, [&](auto& inlineBox) {
         auto rect = inlineBox.visualRectIgnoringBlockDirection();
-        if (!rect.isEmpty())
+        if (result.isEmpty() || !rect.isEmpty())
             result.append(rect);
     });
     return result;


### PR DESCRIPTION
#### adee794250caf17bd412ab2ad27802050d9f4dc8
<pre>
[blocks-in-inline] Client rects for inline box don&apos;t require special casing
<a href="https://bugs.webkit.org/show_bug.cgi?id=303051">https://bugs.webkit.org/show_bug.cgi?id=303051</a>
<a href="https://rdar.apple.com/165346690">rdar://165346690</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-client-rects.html
* LayoutTests/fast/inline/blocks-in-inline-client-rects-expected.txt: Added.
* LayoutTests/fast/inline/blocks-in-inline-client-rects.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
(WebCore::LayoutIntegration::InlineContent::traverseDescendantBlockLevelBoxes): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::inkOverflowBoundingBoxRectFor const):
(WebCore::LayoutIntegration::LineLayout::collectInlineBoxRects const):

We now have inline boxes on block lines. Remove the special case for getting them.
Ensure that empty &lt;span&gt;&lt;/span&gt; still returns a rect.

Canonical link: <a href="https://commits.webkit.org/303496@main">https://commits.webkit.org/303496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee289efe922ffcd44ae19d1529ee30c061bf9649

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84656 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ecbd062c-67e8-4500-9403-a9ad2eb18a96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b7c878e-a585-4dd9-b2d9-282467d04c12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135575 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82190 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49a15363-8c3c-49d0-82b5-3cedeac98049) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1392 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83385 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142806 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4794 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37512 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27861 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3650 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58239 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4848 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33428 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4805 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->