### PR TITLE
WebRTC types should be serialized using CoreIPC primitive Strings instead of raw bytes

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -224,7 +224,7 @@ bool NetworkRTCMonitor::sortNetworks(const RTCNetwork& a, const RTCNetwork& b)
     if (precedenceA != precedenceB)
         return precedenceA < precedenceB;
 
-    return codePointCompare(StringView { a.description.span() }, StringView { b.description.span() }) < 0;
+    return codePointCompare(StringView { a.description }, StringView { b.description }) < 0;
 }
 
 NetworkRTCMonitor::NetworkRTCMonitor(NetworkRTCProvider& rtcProvider)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -266,12 +266,6 @@
     [NotSentFromWebContent] MessageParamReply NetworkConnectionToWebProcess.PerformSynchronousLoad data
 }
 
-[UnsafeWrapper] Vector<char> {
-    [Legacy] StructureParam WebKit::RTCNetwork.description
-    [Legacy] StructureParam WebKit::RTCNetwork.name
-    [Legacy] StructureParam WebKit::WebRTCNetwork::SocketAddress.hostname
-}
-
 [UnsafeWrapper] Vector<unsigned char> {
     [Legacy] StructureParam WebCore::SVGPathByteStream.bytes()
 }

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -45,7 +45,7 @@ static_assert
 
  */
 
-RTCNetwork::RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips)
+RTCNetwork::RTCNetwork(String&& name, String&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips)
     : name(WTFMove(name))
     , description(WTFMove(description))
     , prefix(prefix)
@@ -60,7 +60,9 @@ RTCNetwork::RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddres
 
 webrtc::Network RTCNetwork::value() const
 {
-    webrtc::Network network({ name.span().data(), name.size() }, { description.span().data(), description.size() }, prefix.rtcAddress(), prefixLength, webrtc::AdapterType(type));
+    auto nameUTF8 = name.utf8();
+    auto descriptionUTF8 = description.utf8();
+    webrtc::Network network({ nameUTF8.span().data(), nameUTF8.span().size() }, { descriptionUTF8.span().data(), descriptionUTF8.span().size() }, prefix.rtcAddress(), prefixLength, webrtc::AdapterType(type));
     network.set_id(id);
     network.set_preference(preference);
     network.set_active(active);
@@ -100,7 +102,8 @@ webrtc::SocketAddress SocketAddress::rtcAddress() const
     webrtc::SocketAddress result;
     result.SetPort(port);
     result.SetScopeID(scopeID);
-    result.SetIP({ hostname.span().data(), hostname.size() });
+    auto hostnameUTF8 = hostname.utf8();
+    result.SetIP({ hostnameUTF8.span().data(), hostnameUTF8.span().size() });
     if (ipAddress)
         result.SetResolvedIP(ipAddress->rtcAddress());
     return result;
@@ -109,7 +112,7 @@ webrtc::SocketAddress SocketAddress::rtcAddress() const
 SocketAddress::SocketAddress(const webrtc::SocketAddress& value)
     : port(value.port())
     , scopeID(value.scope_id())
-    , hostname(std::span { value.hostname() })
+    , hostname(value.hostname())
     , ipAddress(value.IsUnresolvedIP() ? std::nullopt : std::optional(IPAddress(value.ipaddr())))
 {
 }

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -31,6 +31,7 @@
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -87,7 +88,7 @@ struct InterfaceAddress {
 
 struct SocketAddress {
     explicit SocketAddress(const webrtc::SocketAddress&);
-    explicit SocketAddress(uint16_t port, int scopeID, Vector<char>&& hostname, std::optional<IPAddress> ipAddress)
+    explicit SocketAddress(uint16_t port, int scopeID, String&& hostname, std::optional<IPAddress> ipAddress)
         : port(port)
         , scopeID(scopeID)
         , hostname(WTFMove(hostname))
@@ -97,7 +98,7 @@ struct SocketAddress {
 
     uint16_t port;
     int scopeID;
-    Vector<char> hostname;
+    String hostname;
     std::optional<IPAddress> ipAddress;
 };
 
@@ -109,13 +110,13 @@ struct RTCNetwork {
     using InterfaceAddress = WebRTCNetwork::InterfaceAddress;
 
     RTCNetwork() = default;
-    explicit RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips);
+    explicit RTCNetwork(String&& name, String&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips);
     RTCNetwork isolatedCopy() const;
 
     webrtc::Network value() const;
 
-    Vector<char> name;
-    Vector<char> description;
+    String name;
+    String description;
     IPAddress prefix;
     int prefixLength { 0 };
     int type { 0 };

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -45,13 +45,13 @@ enum class WebKit::WebRTCNetwork::EcnMarking : int {
 [CustomHeader] struct WebKit::WebRTCNetwork::SocketAddress {
     uint16_t port;
     int scopeID;
-    Vector<char> hostname;
+    String hostname;
     std::optional<WebKit::WebRTCNetwork::IPAddress> ipAddress;
 };
 
 struct WebKit::RTCNetwork {
-    Vector<char> name;
-    Vector<char> description;
+    String name;
+    String description;
     WebKit::WebRTCNetwork::IPAddress prefix;
     int prefixLength;
     int type;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -179,7 +179,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         }
 #endif
         for (auto& network : networks) {
-            if (std::ranges::any_of(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name))))
+            if (std::ranges::any_of(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(network.name)))
                 filteredNetworks.append(network);
         }
     }


### PR DESCRIPTION
#### 6ed6b6a4c121b050e54bedea8db4a811aa6fa323
<pre>
WebRTC types should be serialized using CoreIPC primitive Strings instead of raw bytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=303055">https://bugs.webkit.org/show_bug.cgi?id=303055</a>
<a href="https://rdar.apple.com/165358157">rdar://165358157</a>

Reviewed by Youenn Fablet.

Ports WebRTC strings from ODTs to native serializable
CoreIPC primitive Strings.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkRTCMonitor::sortNetworks):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::RTCNetwork):
(WebKit::RTCNetwork::value const):
(WebKit::WebRTCNetwork::SocketAddress::rtcAddress const):
(WebKit::WebRTCNetwork::SocketAddress::SocketAddress):
(WebKit::WebRTCNetwork::ipAddress): Deleted.
* Source/WebKit/Shared/RTCNetwork.h:
(WebKit::WebRTCNetwork::SocketAddress::SocketAddress):
* Source/WebKit/Shared/RTCNetwork.serialization.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):

Canonical link: <a href="https://commits.webkit.org/303624@main">https://commits.webkit.org/303624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc6d58e3108c652eabb5a7f1ee334aa17098d100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140516 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85011 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94101906-aac2-42a1-ba32-25ff302591c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101688 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69016 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d3a54ac2-d300-448f-9366-3e5ea7ebfc62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135926 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82487 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54b40589-28c5-4781-93cb-fb1584964123) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132329 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4109 "Found unexpected failure with change (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1669 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83750 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113171 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143169 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5150 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110064 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110244 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3949 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115436 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58721 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5204 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33787 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68656 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5294 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->