### PR TITLE
Remove unnecessary `toInt()` in fallback baseline calculation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
@@ -23,7 +23,7 @@ PASS Appending and removing children to mtable
 PASS Appending and removing children to mtext
 PASS Appending and removing children to munder
 PASS Appending and removing children to munderover
-FAIL Appending and removing children to semantics assert_approx_equals: block position (child 0) expected -362.890625 +/- 1 but got -380.890625
+FAIL Appending and removing children to semantics assert_approx_equals: block position (child 0) expected -363.890625 +/- 1 but got -381.890625
 maction:
 msqrt:
 semantics:

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
@@ -44,7 +44,7 @@ inline RenderMathMLTable::RenderMathMLTable(MathMLElement& element, RenderStyle&
 
 inline LayoutUnit RenderMathMLBlock::ascentForChild(const RenderBox& child)
 {
-    return child.firstLineBaseline().value_or(child.logicalHeight().toInt());
+    return child.firstLineBaseline().value_or(child.logicalHeight());
 }
 
 inline LayoutUnit RenderMathMLBlock::mirrorIfNeeded(LayoutUnit horizontalOffset, const RenderBox& child) const


### PR DESCRIPTION
#### 64101eaeeb4dc0e011bba9167bd37583dbbfa7eb
<pre>
Remove unnecessary `toInt()` in fallback baseline calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=303062">https://bugs.webkit.org/show_bug.cgi?id=303062</a>
<a href="https://rdar.apple.com/165366161">rdar://165366161</a>

Reviewed by NOBODY (OOPS!).

RenderMathMLBlock::ascentForChild() previously used child.logicalHeight().toInt()
as a fallback when firstLineBaseline() was missing. Since LayoutUnit can be
returned directly and callers expect a LayoutUnit, the integer conversion is
unnecessary and loses precision.

This patch removes the toInt() call and returns child.logicalHeight()
directly, preserving full LayoutUnit precision and avoiding an unnecessary
fixed-point to integer conversion.

* Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h:
(WebCore::RenderMathMLBlock::ascentForChild):

* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt: Rebaseline
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64101eaeeb4dc0e011bba9167bd37583dbbfa7eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84684 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bbbb648f-de35-4d9b-94ac-b1c54057a9e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101418 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68708 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/52100ed1-181c-417b-ab60-2f064ffc815d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82211 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9beaac95-aeec-4095-8f43-2d4253ec9b3c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3725 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83417 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142838 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109794 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109971 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3675 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58281 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4876 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33459 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4967 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->