### PR TITLE
Reduce use of std::call_once() / dispatch_once() further now that statics initialization is thread safe

### DIFF
--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -99,11 +99,7 @@ const unsigned long long quotaIncreaseSize = 5 * 1024 * 1024;
 
 static const String& fullyQualifiedInfoTableName()
 {
-    static LazyNeverDestroyed<String> qualifiedName;
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        qualifiedName.construct(MAKE_STATIC_STRING_IMPL("main.__WebKitDatabaseInfoTable__"));
-    });
+    static NeverDestroyed<String> qualifiedName { MAKE_STATIC_STRING_IMPL("main.__WebKitDatabaseInfoTable__") };
     return qualifiedName;
 }
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5965,12 +5965,7 @@ void AXObjectCache::onWidgetVisibilityChanged(RenderWidget& widget)
 #if PLATFORM(MAC)
 bool AXObjectCache::isAppleInternalInstall()
 {
-    static bool isInternal = false;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        isInternal = os_variant_allows_internal_security_policies("com.apple.Accessibility");
-    });
-
+    static bool isInternal = os_variant_allows_internal_security_policies("com.apple.Accessibility");
     return isInternal;
 }
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/page/NavigatorUAData.cpp
+++ b/Source/WebCore/page/NavigatorUAData.cpp
@@ -95,9 +95,7 @@ const Vector<NavigatorUABrandVersion>& NavigatorUAData::brands() const
     if (overrideFromUserAgentString)
         return NavigatorUAData::m_brands;
 
-    static LazyNeverDestroyed<Vector<NavigatorUABrandVersion>> brandVersion;
-    static std::once_flag onceKey;
-    std::call_once(onceKey, [] {
+    static NeverDestroyed<Vector<NavigatorUABrandVersion>> brandVersion = [] {
         Vector<NavigatorUABrandVersion> temp = {
             NavigatorUABrandVersion {
                 .brand = "AppleWebKit"_s,
@@ -109,8 +107,8 @@ const Vector<NavigatorUABrandVersion>& NavigatorUAData::brands() const
 
         auto rng = std::default_random_engine { };
         std::ranges::shuffle(temp, rng);
-        brandVersion.construct(temp);
-    });
+        return temp;
+    }();
 
     return brandVersion;
 }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2301,23 +2301,9 @@ std::optional<Quirks::TikTokOverflowingContentQuirkType> Quirks::needsTikTokOver
     if (!element.elementData() || !element.hasClass())
         return { };
 
-    static LazyNeverDestroyed<AtomString> contentContainerSubstring;
-    static std::once_flag contentContainerSubstringOnceKey;
-    std::call_once(contentContainerSubstringOnceKey, [&] {
-        contentContainerSubstring.construct("DivContentContainer"_s);
-    });
-
-    static LazyNeverDestroyed<AtomString> videoContainerSubstring;
-    static std::once_flag videoContainerSubstringOnceKey;
-    std::call_once(videoContainerSubstringOnceKey, [&] {
-        videoContainerSubstring.construct("DivVideoContainer"_s);
-    });
-
-    static LazyNeverDestroyed<AtomString> browserModeContainerSubstring;
-    static std::once_flag browserModeContainerSubstringOnceKey;
-    std::call_once(browserModeContainerSubstringOnceKey, [&] {
-        browserModeContainerSubstring.construct("DivBrowserModeContainer"_s);
-    });
+    static NeverDestroyed<AtomString> contentContainerSubstring { "DivContentContainer"_s };
+    static NeverDestroyed<AtomString> videoContainerSubstring { "DivVideoContainer"_s };
+    static NeverDestroyed<AtomString> browserModeContainerSubstring { "DivBrowserModeContainer"_s };
 
     auto parentElementClassNamesContainsBrowserModeContainerSubstring = [&] {
         RefPtr parentElement = element.parentElement();

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -516,13 +516,7 @@ bool isVorbisDecoderAvailable()
 bool registerVorbisDecoderIfNeeded()
 {
 #if ENABLE(VORBIS)
-    static bool available;
-
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        available = registerDecoderFactory("ACVorbisDecoderFactory"_s, kAudioFormatVorbis);
-    });
-
+    static bool available = registerDecoderFactory("ACVorbisDecoderFactory"_s, kAudioFormatVorbis);
     return available;
 #else
     return false;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -49,6 +49,7 @@
 #import <objc/runtime.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/Scope.h>
 #import <wtf/WorkQueue.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -114,12 +115,8 @@ static CMVideoDimensions toCMVideoDimensions(const IntSize& size)
 
 static dispatch_queue_t globaVideoCaptureSerialQueue()
 {
-    static dispatch_queue_t globalQueue;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        globalQueue = dispatch_queue_create_with_target("WebCoreAVVideoCaptureSource video capture queue", DISPATCH_QUEUE_SERIAL, globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_HIGH, 0));
-    });
-    return globalQueue;
+    static NeverDestroyed<OSObjectPtr<dispatch_queue_t>> globalQueue = adoptOSObject(dispatch_queue_create_with_target("WebCoreAVVideoCaptureSource video capture queue", DISPATCH_QUEUE_SERIAL, globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_HIGH, 0)));
+    return globalQueue.get().get();
 }
 
 static FillLightMode toFillLightMode(AVCaptureTorchMode mode)

--- a/Source/WebCore/platform/text/BidiContext.cpp
+++ b/Source/WebCore/platform/text/BidiContext.cpp
@@ -59,36 +59,20 @@ Ref<BidiContext> BidiContext::create(unsigned char level, UCharDirection directi
     ASSERT(level <= 1);
     if (!level) {
         if (!override) {
-            static NeverDestroyed<RefPtr<BidiContext>> ltrContext;
-            static std::once_flag ltrContextOnceFlag;
-            std::call_once(ltrContextOnceFlag, [&]() {
-                ltrContext.get() = createUncached(0, U_LEFT_TO_RIGHT, false, FromStyleOrDOM, 0);
-            });
+            static NeverDestroyed<RefPtr<BidiContext>> ltrContext = createUncached(0, U_LEFT_TO_RIGHT, false, FromStyleOrDOM, 0);
             return *ltrContext.get();
         }
 
-        static NeverDestroyed<RefPtr<BidiContext>> ltrOverrideContext;
-        static std::once_flag ltrOverrideContextOnceFlag;
-        std::call_once(ltrOverrideContextOnceFlag, [&]() {
-            ltrOverrideContext.get() = createUncached(0, U_LEFT_TO_RIGHT, true, FromStyleOrDOM, 0);
-        });
+        static NeverDestroyed<RefPtr<BidiContext>> ltrOverrideContext = createUncached(0, U_LEFT_TO_RIGHT, true, FromStyleOrDOM, 0);
         return *ltrOverrideContext.get();
     }
 
     if (!override) {
-        static NeverDestroyed<RefPtr<BidiContext>> rtlContext;
-        static std::once_flag rtlContextOnceFlag;
-        std::call_once(rtlContextOnceFlag, [&]() {
-            rtlContext.get() = createUncached(1, U_RIGHT_TO_LEFT, false, FromStyleOrDOM, 0);
-        });
+        static NeverDestroyed<RefPtr<BidiContext>> rtlContext = createUncached(1, U_RIGHT_TO_LEFT, false, FromStyleOrDOM, 0);
         return *rtlContext.get();
     }
 
-    static NeverDestroyed<RefPtr<BidiContext>> rtlOverrideContext;
-    static std::once_flag rtlOverrideContextOnceFlag;
-    std::call_once(rtlOverrideContextOnceFlag, [&]() {
-        rtlOverrideContext.get() = createUncached(1, U_RIGHT_TO_LEFT, true, FromStyleOrDOM, 0);
-    });
+    static NeverDestroyed<RefPtr<BidiContext>> rtlOverrideContext = createUncached(1, U_RIGHT_TO_LEFT, true, FromStyleOrDOM, 0);
     return *rtlOverrideContext.get();
 }
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -930,15 +930,11 @@ static Style::PreferredSizePair checkboxSize(const Style::PreferredSizePair& zoo
 
 static const std::span<const IntSize, 4> radioSizes()
 {
-    static std::array<IntSize, 4> sizes;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        if (supportsLargeFormControls()) {
-            sizes = { { IntSize(14, 14), IntSize(12, 12), IntSize(10, 10), IntSize(16, 16) } };
-            return;
-        }
-        sizes = { { IntSize(16, 16), IntSize(12, 12), IntSize(10, 10), IntSize(0, 0) } };
-    });
+    static std::array<IntSize, 4> sizes = [] {
+        if (supportsLargeFormControls())
+            return std::array<IntSize, 4> { { IntSize(14, 14), IntSize(12, 12), IntSize(10, 10), IntSize(16, 16) } };
+        return std::array<IntSize, 4> { { IntSize(16, 16), IntSize(12, 12), IntSize(10, 10), IntSize(0, 0) } };
+    }();
     return sizes;
 }
 

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -228,10 +228,9 @@ bool isWebGPUSwiftEnabled()
 #elif !ENABLE(WEBGPU_SWIFT)
     return false;
 #else
-    static std::once_flag onceFlag;
-    static bool isWebGPUSwiftEnabled;
-    std::call_once(onceFlag, [&] {
+    static bool isWebGPUSwiftEnabled = [&] {
         NSNumber* object = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitWebGPUSwiftEnabled"];
+        bool isWebGPUSwiftEnabled;
         if (object)
             isWebGPUSwiftEnabled = object.boolValue;
         else
@@ -241,7 +240,8 @@ bool isWebGPUSwiftEnabled()
             WTFLogAlways("WebGPU: using SWIFT backend"); // NOLINT
         else
             WTFLogAlways("WebGPU: using C++ backend"); // NOLINT
-    });
+        return isWebGPUSwiftEnabled;
+    }();
     return isWebGPUSwiftEnabled;
 #endif
 }

--- a/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
@@ -103,14 +103,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 + (WebIconDatabase *)sharedIconDatabase
 {
-    static NeverDestroyed<RetainPtr<WebIconDatabase>> database;
-    static dispatch_once_t once;
-    dispatch_once(&once, ^ {
+    static NeverDestroyed<RetainPtr<WebIconDatabase>> database = [] {
         if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::WebIconDatabaseWarning))
             NSLog(@"+[WebIconDatabase sharedIconDatabase] is not API and should not be used. WebIconDatabase no longer handles icon loading and it will be removed in a future release.");
 
-        database.get() = adoptNS([[WebIconDatabase alloc] init]);
-    });
+        return adoptNS([[WebIconDatabase alloc] init]);
+    }();
 
     return database.get().get();
 }
@@ -135,13 +133,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSImage *)defaultIconWithSize:(NSSize)size
 {
-    static NeverDestroyed<RetainPtr<NSImage>> defaultImage;
-
-    static dispatch_once_t once;
-    dispatch_once(&once, ^ {
-        auto imageData = adoptNS([[NSData alloc] initWithBytes:defaultIconData length:sizeof(defaultIconData)]);
-        defaultImage.get() = adoptNS([[NSImage alloc] initWithData:imageData.get()]);
-    });
+    static NeverDestroyed<RetainPtr<NSImage>> defaultImage = [] {
+        RetainPtr imageData = adoptNS([[NSData alloc] initWithBytes:defaultIconData length:sizeof(defaultIconData)]);
+        return adoptNS([[NSImage alloc] initWithData:imageData.get()]);
+    }();
     
     return defaultImage.get().get();
 }

--- a/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
@@ -96,9 +96,7 @@ NSString * const WebStorageDidModifyOriginNotification = @"WebStorageDidModifyOr
 
 + (NSString *)_storageDirectoryPath
 {
-    static NeverDestroyed<RetainPtr<NSString>> sLocalStoragePath;
-    static dispatch_once_t flag;
-    dispatch_once(&flag, ^{
+    static NeverDestroyed<RetainPtr<NSString>> sLocalStoragePath = [] {
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         RetainPtr<NSString> localStoragePath = [defaults objectForKey:WebStorageDirectoryDefaultsKey];
         if (!localStoragePath || ![localStoragePath isKindOfClass:[NSString class]]) {
@@ -106,8 +104,8 @@ NSString * const WebStorageDidModifyOriginNotification = @"WebStorageDidModifyOr
             NSString *libraryDirectory = [paths objectAtIndex:0];
             localStoragePath = [libraryDirectory stringByAppendingPathComponent:@"WebKit/LocalStorage"];
         }
-        sLocalStoragePath.get() = [localStoragePath stringByStandardizingPath];
-    });
+        return [localStoragePath stringByStandardizingPath];
+    }();
     return sLocalStoragePath.get().get();
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1808,11 +1808,7 @@ static BOOL isQuickLookEvent(NSEvent *event)
         return owner;
 
     for (NSTrackingArea *trackingArea in self.trackingAreas) {
-        static Class managerClass;
-        static std::once_flag onceFlag;
-        std::call_once(onceFlag, [] {
-            managerClass = NSClassFromString(@"NSToolTipManager");
-        });
+        static Class managerClass = NSClassFromString(@"NSToolTipManager");
 
         id owner = trackingArea.owner;
         if ([owner class] == managerClass)

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -106,12 +106,10 @@ static void WebAVPlayerView_exitFullScreen(id aSelf, SEL, id sender)
 
 static WebAVPlayerView *allocWebAVPlayerViewInstance()
 {
-    static Class theClass = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+    static Class theClass = [] {
         ASSERT(getAVPlayerViewClassSingleton());
         Class aClass = objc_allocateClassPair(getAVPlayerViewClassSingleton(), "WebAVPlayerView", 0);
-        theClass = aClass;
+        Class theClass = aClass;
         class_addMethod(theClass, @selector(setWebDelegate:), (IMP)WebAVPlayerView_setWebDelegate, "v@:@");
         class_addMethod(theClass, @selector(webDelegate), (IMP)WebAVPlayerView_webDelegate, "@@:");
         class_addMethod(theClass, @selector(isFullScreen), (IMP)WebAVPlayerView_isFullScreen, "B@:");
@@ -122,7 +120,8 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
         class_addIvar(theClass, "_webIsFullScreen", sizeof(BOOL), log2(sizeof(BOOL)), "B");
 
         objc_registerClassPair(theClass);
-    });
+        return theClass;
+    }();
     return (WebAVPlayerView *)[theClass alloc];
 }
 


### PR DESCRIPTION
#### aff336649076fd0fee9341bbfc77e6ce5745a25d
<pre>
Reduce use of std::call_once() / dispatch_once() further now that statics initialization is thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=303070">https://bugs.webkit.org/show_bug.cgi?id=303070</a>

Reviewed by Gerald Squelart.

Reduce use of std::call_once() / dispatch_once() further now that statics
initialization is thread safe everywhere except JSC and bmalloc.

* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::fullyQualifiedInfoTableName):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::isAppleInternalInstall):
* Source/WebCore/page/NavigatorUAData.cpp:
(WebCore::NavigatorUAData::brands const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsTikTokOverflowingContentQuirk const):
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::hostTime const):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::registerVorbisDecoderIfNeeded):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::bufferForType const):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::globaVideoCaptureSerialQueue):
* Source/WebCore/platform/text/BidiContext.cpp:
(WebCore::BidiContext::create):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::radioSizes):
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::isWebGPUSwiftEnabled):
* Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm:
(+[WebIconDatabase sharedIconDatabase]):
(-[WebIconDatabase defaultIconWithSize:]):
* Source/WebKitLegacy/mac/Storage/WebStorageManager.mm:
(+[WebStorageManager _storageDirectoryPath]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _toolTipOwnerForSendingMouseEvents]):
* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm:
(allocWebAVPlayerViewInstance):

Canonical link: <a href="https://commits.webkit.org/303523@main">https://commits.webkit.org/303523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b88b988c73e585f2c4d8a03ffc3c66a20e6558d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84708 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a534ac9a-ad29-4653-b519-e0f861ef0407) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68734 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ac3f6941-dd28-422c-843a-06f01cd1c87c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135627 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82231 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/288a3eb5-a25b-46c6-9299-97be4637a83b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1441 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83443 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112658 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/36991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142864 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4846 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109814 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27882 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4900 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33495 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4738 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68351 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->