### PR TITLE
SVGAnimatedNumber properties should handle attribute removal and invalid values correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (invalid value) assert_equals: initial after expected 1 but got 0
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (remove)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.intercept (remove)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.intercept (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (invalid value) assert_equals: initial after expected 1 but got 0
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (remove)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (remove)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.offset (remove)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.offset (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFECompositeElement.prototype.k1 (remove)
@@ -25,36 +25,36 @@ PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.ker
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthX (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEDisplacementMapElement.prototype.scale (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEDisplacementMapElement.prototype.scale (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.azimuth (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.azimuth (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.elevation (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.elevation (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (remove) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (invalid value) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (remove) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (invalid value) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (remove) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (invalid value) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (remove) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (invalid value) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEOffsetElement.prototype.dx (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEOffsetElement.prototype.dx (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEOffsetElement.prototype.dy (remove)
@@ -65,16 +65,16 @@ PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.y (remo
 PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.y (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.z (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.z (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.x (remove)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.x (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.y (remove)
@@ -91,10 +91,10 @@ FAIL SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.specular
 FAIL SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.specularExponent (invalid value) assert_equals: initial after expected 1 but got 0
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.limitingConeAngle (remove)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.limitingConeAngle (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.seed (remove)
 PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.seed (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGGeometryElement.prototype.pathLength (remove)

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -62,19 +62,19 @@ void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& 
         m_tableValues->baseVal()->parse(newValue);
         break;
     case AttributeNames::slopeAttr:
-        m_slope->setBaseValInternal(newValue.toFloat());
+        m_slope->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::interceptAttr:
-        m_intercept->setBaseValInternal(newValue.toFloat());
+        m_intercept->setBaseValInternal(parseNumber(newValue).value_or(0));
         break;
     case AttributeNames::amplitudeAttr:
-        m_amplitude->setBaseValInternal(newValue.toFloat());
+        m_amplitude->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::exponentAttr:
-        m_exponent->setBaseValInternal(newValue.toFloat());
+        m_exponent->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::offsetAttr:
-        m_offset->setBaseValInternal(newValue.toFloat());
+        m_offset->setBaseValInternal(parseNumber(newValue).value_or(0));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Oliver Hunt <ojh16@student.canterbury.ac.nz>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -62,15 +62,18 @@ void SVGFEDiffuseLightingElement::attributeChanged(const QualifiedName& name, co
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::surfaceScaleAttr:
-        Ref { m_surfaceScale }->setBaseValInternal(newValue.toFloat());
+        Ref { m_surfaceScale }->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::diffuseConstantAttr:
-        Ref { m_diffuseConstant }->setBaseValInternal(newValue.toFloat());
+        Ref { m_diffuseConstant }->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             Ref { m_kernelUnitLengthX }->setBaseValInternal(result->first);
             Ref { m_kernelUnitLengthY }->setBaseValInternal(result->second);
+        } else {
+            Ref { m_kernelUnitLengthX }->setBaseValInternal(0);
+            Ref { m_kernelUnitLengthY }->setBaseValInternal(0);
         }
         break;
     default:

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -68,16 +68,19 @@ void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const A
         if (auto result = parseNumberOptionalNumber(newValue)) {
             Ref { m_stdDeviationX }->setBaseValInternal(result->first);
             Ref { m_stdDeviationY }->setBaseValInternal(result->second);
+        } else {
+            Ref { m_stdDeviationX }->setBaseValInternal(2);
+            Ref { m_stdDeviationY }->setBaseValInternal(2);
         }
         break;
     case AttributeNames::inAttr:
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::dxAttr:
-        Ref { m_dx }->setBaseValInternal(newValue.toFloat());
+        Ref { m_dx }->setBaseValInternal(parseNumber(newValue).value_or(2));
         break;
     case AttributeNames::dyAttr:
-        Ref { m_dy }->setBaseValInternal(newValue.toFloat());
+        Ref { m_dy }->setBaseValInternal(parseNumber(newValue).value_or(2));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -69,6 +69,9 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
         if (auto result = parseNumberOptionalNumber(newValue)) {
             Ref { m_stdDeviationX }->setBaseValInternal(result->first);
             Ref { m_stdDeviationY }->setBaseValInternal(result->second);
+        } else {
+            Ref { m_stdDeviationX }->setBaseValInternal(0);
+            Ref { m_stdDeviationY }->setBaseValInternal(0);
         }
         break;
     case AttributeNames::inAttr:

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -68,6 +68,9 @@ void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const A
         if (auto result = parseNumberOptionalNumber(newValue)) {
             Ref { m_radiusX }->setBaseValInternal(result->first);
             Ref { m_radiusY }->setBaseValInternal(result->second);
+        } else {
+            Ref { m_radiusX }->setBaseValInternal(0);
+            Ref { m_radiusY }->setBaseValInternal(0);
         }
         break;
     default:

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
  * Copyright (C) 2005 Oliver Hunt <oliver@nerget.com>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -65,18 +65,21 @@ void SVGFESpecularLightingElement::attributeChanged(const QualifiedName& name, c
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::surfaceScaleAttr:
-        Ref { m_surfaceScale }->setBaseValInternal(newValue.toFloat());
+        Ref { m_surfaceScale }->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::specularConstantAttr:
-        Ref { m_specularConstant }->setBaseValInternal(newValue.toFloat());
+        Ref { m_specularConstant }->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::specularExponentAttr:
-        Ref { m_specularExponent }->setBaseValInternal(newValue.toFloat());
+        Ref { m_specularExponent }->setBaseValInternal(parseNumber(newValue).value_or(1));
         break;
     case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             Ref { m_kernelUnitLengthX }->setBaseValInternal(result->first);
             Ref { m_kernelUnitLengthY }->setBaseValInternal(result->second);
+        } else {
+            Ref { m_kernelUnitLengthX }->setBaseValInternal(0);
+            Ref { m_kernelUnitLengthY }->setBaseValInternal(0);
         }
         break;
     default:

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -75,6 +75,9 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
         if (auto result = parseNumberOptionalNumber(newValue)) {
             Ref { m_baseFrequencyX }->setBaseValInternal(result->first);
             Ref { m_baseFrequencyY }->setBaseValInternal(result->second);
+        } else {
+            Ref { m_baseFrequencyX }->setBaseValInternal(0);
+            Ref { m_baseFrequencyY }->setBaseValInternal(0);
         }
         break;
     case AttributeNames::seedAttr:


### PR DESCRIPTION
#### b99448c4aa6398dfad09cb896386e02ee1f49b70
<pre>
SVGAnimatedNumber properties should handle attribute removal and invalid values correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=303073">https://bugs.webkit.org/show_bug.cgi?id=303073</a>
<a href="https://rdar.apple.com/165378154">rdar://165378154</a>

Reviewed by NOBODY (OOPS!).

When SVG number attributes are removed or set to invalid values, they should
reset to their specified default values rather than 0. Previously, the code
used toFloat() which returns 0 for invalid input, causing properties with
non-zero defaults (e.g., slope=1, amplitude=1) to incorrectly become 0.

This patch switches to using parseNumber() which returns std::optional&lt;float&gt;,
allowing proper detection of parse failures and fallback to the correct default
values.

Additionally, for attributes parsed with parseNumberOptionalNumber() (like
baseFrequency, stdDeviation, kernelUnitLength), the code now explicitly handles
the parse failure case by resetting both X and Y components to their default values.

Affected elements and their defaults:
- SVGComponentTransferFunctionElement: slope/amplitude/exponent (default: 1),
  intercept/offset (default: 0)
- SVGFEDiffuseLightingElement: surfaceScale/diffuseConstant (default: 1),
  kernelUnitLengthX/Y (default: 0)
- SVGFEDropShadowElement: dx/dy/stdDeviationX/Y (default: 2)
- SVGFEGaussianBlurElement: stdDeviationX/Y (default: 0)
- SVGFEMorphologyElement: radiusX/Y (default: 0)
- SVGFETurbulenceElement: baseFrequencyX/Y (default: 0)
- SVGFESpecularLightingElement: surfaceScale/specularConstant/specularExponent (default: 1),
  kernelUnitLengthX/Y (default: 0)

* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::attributeChanged):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::attributeChanged):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::attributeChanged):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::attributeChanged):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::attributeChanged):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt: Progressions
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b99448c4aa6398dfad09cb896386e02ee1f49b70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84715 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa8aee58-7a83-4f3c-a49e-359184f1a211) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68741 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e44d47a2-a35e-4256-965a-21b4284baf07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82237 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0148ab4-71dc-4e53-8cd5-06f4aa584950) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1445 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83450 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142871 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109820 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109997 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3698 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115139 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58330 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4907 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33487 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4745 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->