### PR TITLE
[JSC] Add fast path for `Array.from(arguments)` in strict mode

### DIFF
--- a/JSTests/microbenchmarks/array-from-cloned-arguments.js
+++ b/JSTests/microbenchmarks/array-from-cloned-arguments.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function test() {
+    const args = Array.from(arguments);
+    return args;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+  test(i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6);
+}

--- a/JSTests/stress/array-from-cloned-arguments.js
+++ b/JSTests/stress/array-from-cloned-arguments.js
@@ -1,0 +1,50 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+"use strict";
+
+function test() {
+  return Array.from(arguments);
+}
+noInline(test);
+
+
+// contiguous
+{
+  const value1 = { value: 1 };
+  const value2 = { value: 2 };
+  const value3 = { value: 3 };
+  const value4 = { value: 4 };
+  const value5 = { value: 5 };
+  const array = test(value1, value2, value3, value4, value5);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], value1);
+  shouldBe(array[1], value2);
+  shouldBe(array[2], value3);
+  shouldBe(array[3], value4);
+  shouldBe(array[4], value5);
+}
+
+// double
+{
+  const array = test(1.1, 2.1, 3.1, 4.1, 5.1);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1.1);
+  shouldBe(array[1], 2.1);
+  shouldBe(array[2], 3.1);
+  shouldBe(array[3], 4.1);
+  shouldBe(array[4], 5.1);
+}
+
+// int32
+{
+  const array = test(1, 2, 3, 4, 5);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3);
+  shouldBe(array[3], 4);
+  shouldBe(array[4], 5);
+}


### PR DESCRIPTION
#### 118076d88138bd4aa22ab1a27737765d4524ca39
<pre>
[JSC] Add fast path for `Array.from(arguments)` in strict mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=303074">https://bugs.webkit.org/show_bug.cgi?id=303074</a>

Reviewed by Yusuke Suzuki.

This patch changes to add fast path for `Array.from(arguments)` in strict mode.

                                     TipOfTree                  Patched

array-from-cloned-arguments        8.3149+-0.0485     ^      4.0432+-0.1304        ^ definitely 2.0565x faster

Tests: JSTests/microbenchmarks/array-from-cloned-arguments.js
       JSTests/stress/array-from-cloned-arguments.js

* JSTests/microbenchmarks/array-from-cloned-arguments.js: Added.
(test):
* JSTests/stress/array-from-cloned-arguments.js: Added.
(shouldBe):
(test):
(noInline):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::getArgumentsLength):
(JSC::tryCreateArrayFromArguments):
(JSC::tryCreateArrayFromClonedArguments):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/304978@main">https://commits.webkit.org/304978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98a036531a24627959cb371377af24595b0fa4f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84716 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101445 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68743 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135635 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4151 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4046 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1444 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124759 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142872 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131197 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109821 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4196 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109998 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3702 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115137 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58333 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4908 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33485 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164164 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68359 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42634 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->