### PR TITLE
[JSC] Fix UBSan crash for null butterfly

### DIFF
--- a/JSTests/stress/null-butterfly-checking.js
+++ b/JSTests/stress/null-butterfly-checking.js
@@ -1,0 +1,13 @@
+// https://bugs.webkit.org/show_bug.cgi?id=303015
+
+const v3 = {
+  p() {
+    try {
+      this.p();
+    } catch (e) {}
+    delete this.g;
+    this.g = this;
+  },
+};
+v3.p();
+v3.p();

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1038,11 +1038,12 @@ Structure* Structure::flattenDictionaryStructure(VM& vm, JSObject* object)
             object->inlineStorageUnsafe() + inlineSize(),
             (inlineCapacity() - inlineSize()) * sizeof(EncodedJSValue));
 
-        Butterfly* butterfly = object->butterfly();
-        size_t preCapacity = butterfly->indexingHeader()->preCapacity(this);
-        void* base = butterfly->base(preCapacity, beforeOutOfLineCapacity);
-        void* startOfPropertyStorageSlots = reinterpret_cast<EncodedJSValue*>(base) + preCapacity;
-        gcSafeZeroMemory(static_cast<JSValue*>(startOfPropertyStorageSlots), (beforeOutOfLineCapacity - outOfLineSize()) * sizeof(EncodedJSValue));
+        if (Butterfly* butterfly = object->butterfly()) {
+            size_t preCapacity = butterfly->indexingHeader()->preCapacity(this);
+            void* base = butterfly->base(preCapacity, beforeOutOfLineCapacity);
+            void* startOfPropertyStorageSlots = reinterpret_cast<EncodedJSValue*>(base) + preCapacity;
+            gcSafeZeroMemory(static_cast<JSValue*>(startOfPropertyStorageSlots), (beforeOutOfLineCapacity - outOfLineSize()) * sizeof(EncodedJSValue));
+        }
         checkOffsetConsistency();
     }
 


### PR DESCRIPTION
#### 8fbefe5287a878076ed350832298646d80944e2f
<pre>
[JSC] Fix UBSan crash for null butterfly
<a href="https://bugs.webkit.org/show_bug.cgi?id=303015">https://bugs.webkit.org/show_bug.cgi?id=303015</a>

Reviewed by Yusuke Suzuki.

This patch changes to add null checking for butterfly for fixing UBSan crash like:

```
runtime/Structure.cpp:1042:41: runtime error: member call on null pointer of type &apos;JSC::Butterfly&apos;
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior runtime/Structure.cpp:1042:41
/Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/Butterfly.h:182:21: runtime error: member call on null pointer of type &apos;JSC::Butterfly *&apos;
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/Butterfly.h:182:21
/Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/IndexingHeader.h:74:61: runtime error: applying non-zero offset 18446744073709551608 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/IndexingHeader.h:74:61
runtime/Structure.cpp:1043:33: runtime error: member call on null pointer of type &apos;JSC::Butterfly&apos;
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior runtime/Structure.cpp:1043:33
/Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/Butterfly.h:222:11: runtime error: member call on null pointer of type &apos;JSC::Butterfly *&apos;
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/Butterfly.h:222:11
/Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/Butterfly.h:184:21: runtime error: member call on null pointer of type &apos;JSC::Butterfly *&apos;
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/sosukesuzuki/ghq/github.com/WebKit/WebKit/Source/JavaScriptCore/runtime/Butterfly.h:184:21
```

* JSTests/stress/null-butterfly-checking.js: Added.
(const.v3.p):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::flattenDictionaryStructure):

Canonical link: <a href="https://commits.webkit.org/303524@main">https://commits.webkit.org/303524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/847429bb92054c072d0c79b171a0ed192576e6af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84722 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101448 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135641 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82241 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1449 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83457 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124765 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142878 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131203 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4860 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109822 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109999 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27884 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3704 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4914 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33493 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164170 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68365 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42636 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->