### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MediaCaptureStatusBarManager

### DIFF
--- a/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.h
+++ b/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.h
@@ -28,6 +28,7 @@
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -35,28 +36,15 @@
 OBJC_CLASS WebCoreMediaCaptureStatusBarHandler;
 
 namespace WebCore {
-class MediaCaptureStatusBarManager;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaCaptureStatusBarManager> : std::true_type { };
-}
-
-namespace WebCore {
-
-class MediaCaptureStatusBarManager : public CanMakeWeakPtr<MediaCaptureStatusBarManager> {
+class MediaCaptureStatusBarManager : public RefCountedAndCanMakeWeakPtr<MediaCaptureStatusBarManager> {
     WTF_MAKE_TZONE_ALLOCATED(MediaCaptureStatusBarManager);
 public:
     static bool hasSupport();
 
     using TapCallback = Function<void(CompletionHandler<void()>&&)>;
     using ErrorCallback = Function<void()>;
-    MediaCaptureStatusBarManager(TapCallback&& callback, ErrorCallback&& errorCallback)
-        : m_tapCallback(WTFMove(callback))
-        , m_errorCallback(WTFMove(errorCallback))
-    {
-    }
+    static Ref<MediaCaptureStatusBarManager> create(TapCallback&&, ErrorCallback&&);
     ~MediaCaptureStatusBarManager();
 
     void start();
@@ -66,6 +54,8 @@ public:
     void didTap(CompletionHandler<void()>&& completionHandler) { m_tapCallback(WTFMove(completionHandler)); }
 
 private:
+    MediaCaptureStatusBarManager(TapCallback&&, ErrorCallback&&);
+
     RetainPtr<WebCoreMediaCaptureStatusBarHandler> m_handler;
     TapCallback m_tapCallback;
     ErrorCallback m_errorCallback;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
@@ -229,7 +229,7 @@ private:
     CoreAudioSpeakerSamplesProducer* m_speakerSamplesProducer WTF_GUARDED_BY_LOCK(m_speakerSamplesProducerLock) { nullptr };
 
 #if PLATFORM(IOS_FAMILY)
-    std::unique_ptr<MediaCaptureStatusBarManager> m_statusBarManager;
+    RefPtr<MediaCaptureStatusBarManager> m_statusBarManager;
     Function<void(CompletionHandler<void()>&&)> m_statusBarWasTappedCallback;
 #endif
 


### PR DESCRIPTION
#### f12f8770d3d849022529ca7529d73195ce0c2ed0
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MediaCaptureStatusBarManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=303077">https://bugs.webkit.org/show_bug.cgi?id=303077</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.h:
(WebCore::MediaCaptureStatusBarManager::MediaCaptureStatusBarManager): Deleted.
* Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm:
(-[WebCoreMediaCaptureStatusBarHandler start]):
(-[WebCoreMediaCaptureStatusBarHandler statusBarCoordinator:receivedTapWithContext:completionBlock:]):
(-[WebCoreMediaCaptureStatusBarHandler statusBarCoordinator:invalidatedRegistrationWithError:]):
(WebCore::MediaCaptureStatusBarManager::create):
(WebCore::MediaCaptureStatusBarManager::MediaCaptureStatusBarManager):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.cpp:
(WebCore::CoreAudioCaptureUnit::setIsInBackground):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h:

Canonical link: <a href="https://commits.webkit.org/303554@main">https://commits.webkit.org/303554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30d24c8c99e8ad7d32a98b98e30230cfa3819ee9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84735 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a0c9d0e-e34a-4573-ae0b-2b5bc569989a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68755 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2a31a4e2-76aa-4ee2-aab8-98c53576ceac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82251 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/99fca0ec-bd0a-41f1-a131-580a90d2357a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1463 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83471 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142892 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109833 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3718 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58355 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33503 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5018 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->