### PR TITLE
[appearance: base] Add -internal-auto-base() and resolve it by substitution

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics-expected.html
@@ -1,0 +1,42 @@
+<style>
+    .checkable {
+        width: 200px;
+        height: 200px;
+        margin: 2px;
+        display: inline-block;
+        border: 0.3em solid currentColor;
+        background: transparent;
+        font: 11px system-ui;
+        box-sizing: border-box;
+    }
+
+    .radio {
+        border-radius: 100%;
+    }
+
+    .checkbox {
+        border-radius: 0.5em;
+    }
+
+    .enabled .checkable {
+        color: darkblue;
+        margin-top: 3px;
+    }
+
+    .disabled .checkable {
+        color: darkgreen;
+        margin-top: 4px;
+        border-color: color-mix(in srgb, currentColor 30%, transparent);
+        background-color: color-mix(in srgb, currentColor 10%, transparent);
+    }
+</style>
+<body>
+    <div class="enabled container">
+        <div class="checkable checkbox"></div>
+        <div class="checkable radio"></div>
+    </div>
+    <div class="disabled container">
+        <div class="checkable checkbox"></div>
+        <div class="checkable radio"></div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<style>
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        font: 11px system-ui;
+        height: -internal-auto-base(unset, 2em);
+        width: -internal-auto-base(unset, 2em);
+        border: -internal-auto-base(unset, 0.3em solid currentColor);
+        background-color: -internal-auto-base(unset, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
+    }
+
+    input[type=radio] {
+        border-radius: -internal-auto-base(unset, 100%);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+    }
+
+    .enabled input:is([type=checkbox]:not([switch]), [type=radio]) {
+        color: darkblue;
+    }
+
+    .disabled input:is([type=checkbox]:not([switch]), [type=radio]) {
+        color: darkgreen;
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        appearance: base;
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<body>
+    <div class="enabled">
+        <input type="checkbox">
+        <input type="radio">
+    </div>
+    <div class="disabled">
+        <input type="checkbox" disabled>
+        <input type="radio" disabled>
+    </div>
+</body>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1252,6 +1252,20 @@ CSSInputSecurityEnabled:
     WebCore:
       default: false
 
+CSSInternalAutoBaseParsingEnabled:
+  type: bool
+  status: internal
+  category: css
+  humanReadableName: "CSS -internal-auto-base() in author sheet"
+  humanReadableDescription: "Enable parsing -internal-auto-base() in author sheet"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSLineClampEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -67,6 +67,12 @@ public:
     {
     }
 
+    CSSProperty(const StylePropertyMetadata& metadata, Ref<CSSValue>&& value)
+        : m_metadata(metadata)
+        , m_value(WTFMove(value))
+    {
+    }
+
     CSSPropertyID id() const { return static_cast<CSSPropertyID>(m_metadata.m_propertyID); }
     bool isSetFromShorthand() const { return m_metadata.m_isSetFromShorthand; };
     CSSPropertyID shorthandID() const { return m_metadata.shorthandID(); };

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -929,6 +929,7 @@ attachment enable-if=ENABLE_ATTACHMENT_ELEMENT
 borderless-attachment enable-if=ENABLE_ATTACHMENT_ELEMENT
 textarea
 textfield
+-internal-auto-base
 
 //
 // CSS_PROP_BORDER_IMAGE

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -59,6 +59,7 @@ static void applyUASheetBehaviorsToContext(CSSParserContext& context)
     context.propertySettings.useSystemAppearance = true;
 #endif
     context.thumbAndTrackPseudoElementsEnabled = true;
+    context.cssInternalAutoBaseParsingEnabled = true;
 }
 
 CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
@@ -115,6 +116,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssDynamicRangeLimitMixEnabled { document.settings().cssDynamicRangeLimitMixEnabled() }
     , cssConstrainedDynamicRangeLimitEnabled { document.settings().cssConstrainedDynamicRangeLimitEnabled() }
     , cssTextTransformMathAutoEnabled { document.settings().cssTextTransformMathAutoEnabled() }
+    , cssInternalAutoBaseParsingEnabled { document.settings().cssInternalAutoBaseParsingEnabled() }
     , webkitMediaTextTrackDisplayQuirkEnabled { document.quirks().needsWebKitMediaTextTrackDisplayQuirk() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
@@ -156,7 +158,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssDynamicRangeLimitMixEnabled            << 27
         | context.cssConstrainedDynamicRangeLimitEnabled    << 28
         | context.cssTextDecorationLineErrorValues          << 29
-        | context.cssTextTransformMathAutoEnabled           << 30;
+        | context.cssTextTransformMathAutoEnabled           << 30
+        | context.cssInternalAutoBaseParsingEnabled         << 31;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -87,6 +87,7 @@ struct CSSParserContext {
     bool cssDynamicRangeLimitMixEnabled : 1 { false };
     bool cssConstrainedDynamicRangeLimitEnabled : 1 { false };
     bool cssTextTransformMathAutoEnabled : 1 { false };
+    bool cssInternalAutoBaseParsingEnabled : 1 { false };
     bool webkitMediaTextTrackDisplayQuirkEnabled : 1 { false };
 
     // Settings, those affecting properties.

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp
@@ -58,5 +58,33 @@ CSSParserTokenRange consumeFunction(CSSParserTokenRange& range)
     return contents;
 }
 
+std::optional<CSSParserTokenRange> consumeArgument(CSSParserTokenRange& range, unsigned index)
+{
+    if (range.atEnd())
+        return std::nullopt;
+
+    if (index) {
+        ASSERT(range.peek().type() == CommaToken);
+        range.consume();
+    }
+
+    range.consumeWhitespace();
+
+    auto argumentStart = range;
+    while (!range.atEnd()) {
+        if (range.peek().type() == CommaToken)
+            break;
+
+        if (range.peek().getBlockType() == CSSParserToken::BlockStart) {
+            range.consumeBlock();
+            continue;
+        }
+
+        range.consume();
+    }
+
+    return argumentStart.rangeUntil(range);
+}
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.h
@@ -42,5 +42,7 @@ bool consumeSlashIncludingWhitespace(CSSParserTokenRange&);
 // NOTE: consumeFunction expects the range starts with a FunctionToken.
 CSSParserTokenRange consumeFunction(CSSParserTokenRange&);
 
+std::optional<CSSParserTokenRange> consumeArgument(CSSParserTokenRange&, unsigned index);
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserResult.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserResult.cpp
@@ -34,6 +34,11 @@
 namespace WebCore {
 namespace CSS {
 
+void PropertyParserResult::addProperty(CSSProperty&& property)
+{
+    parsedProperties.append(WTFMove(property));
+}
+
 void PropertyParserResult::addProperty([[maybe_unused]] CSS::PropertyParserState& state, CSSPropertyID property, CSSPropertyID currentShorthand, RefPtr<CSSValue>&& value, IsImportant important, IsImplicit implicit)
 {
     int shorthandIndex = 0;
@@ -53,10 +58,10 @@ void PropertyParserResult::addProperty([[maybe_unused]] CSS::PropertyParserState
     ASSERT(isExposed(property, &state.context.propertySettings) || setFromShorthand || isInternal(property));
 
     if (value && !value->isImplicitInitialValue())
-        parsedProperties.append(CSSProperty(property, value.releaseNonNull(), important, setFromShorthand, shorthandIndex, implicit));
+        addProperty(CSSProperty(property, value.releaseNonNull(), important, setFromShorthand, shorthandIndex, implicit));
     else {
         ASSERT(setFromShorthand);
-        parsedProperties.append(CSSProperty(property, Ref { CSSPrimitiveValue::implicitInitialValue() }, important, setFromShorthand, shorthandIndex, IsImplicit::Yes));
+        addProperty(CSSProperty(property, Ref { CSSPrimitiveValue::implicitInitialValue() }, important, setFromShorthand, shorthandIndex, IsImplicit::Yes));
     }
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserResult.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserResult.h
@@ -38,6 +38,8 @@ struct PropertyParserState;
 struct PropertyParserResult {
     Vector<CSSProperty, 256>& parsedProperties;
 
+    void addProperty(CSSProperty&&);
+
     // Bottleneck where the CSSValue is added to the CSSProperty vector.
     void addProperty(PropertyParserState&, CSSPropertyID longhand, CSSPropertyID shorthand, RefPtr<CSSValue>&&, IsImportant, IsImplicit = IsImplicit::No);
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -75,6 +75,7 @@ private:
     void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, PropertyCascade::Origin);
     void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&);
 
+    Ref<CSSValue> resolveInternalAutoBaseFunction(CSSValue&);
     Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
     std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> resolveCustomPropertyValue(CSSCustomPropertyValue&);
 


### PR DESCRIPTION
#### 04ea7c36cab8de930b1477f15e9fc921380e080c
<pre>
[appearance: base] Add -internal-auto-base() and resolve it by substitution
<a href="https://bugs.webkit.org/show_bug.cgi?id=303078">https://bugs.webkit.org/show_bug.cgi?id=303078</a>
<a href="https://rdar.apple.com/165381349">rdar://165381349</a>

Reviewed by Tim Nguyen.

To add support for `appearance: base` a new internal function `-internal-auto-base()`
is added. This functional will resolve and substitute itself with one of two values
depending on whether the style has `appearance: base` or not.

No UA style sheet changes will be added in this PR. An internal setting which
enables parsing `-internal-auto-base()` on regular author style will be added for
now. This setting will be used to write layout tests until default properties for
`appearance: base` form controls are added in the UA style sheet.

Test: fast/forms/appearance-base/appearance-base-checkable-basics.html

* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperty.h:
(WebCore::CSSProperty::CSSProperty):
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::applyUASheetBehaviorsToContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeFunctionArgument):
(WebCore::consumeInternalAutoBaseFunction):
(WebCore::consumeStyleProperty):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp:
(WebCore::CSSPropertyParserHelpers::consumeArgument):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.h:
* Source/WebCore/css/parser/CSSPropertyParserResult.cpp:
(WebCore::CSS::PropertyParserResult::addProperty):
* Source/WebCore/css/parser/CSSPropertyParserResult.h:
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::isValidDashedFunction):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::resolveInternalAutoBaseFunction):
* Source/WebCore/style/StyleBuilder.h:

Canonical link: <a href="https://commits.webkit.org/303693@main">https://commits.webkit.org/303693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3be4e48335adf0568ffb61842f16575cd579adaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140926 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e2e5315-1517-4bc0-b044-e611c4afc0b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a563f111-3f9c-41ee-898f-27fc174d0469) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136318 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82820 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7df78ba-1da2-4c2a-8a54-29f3574d24fb) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132720 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125443 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113504 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143573 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131883 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5542 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/132799 "Build is in progress. Recent messages:") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110582 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28014 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115810 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5597 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164847 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69049 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43070 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5686 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->