### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for DataDetectorHighlightClient

### DIFF
--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -611,7 +611,7 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
 
     if (!result.dataDetectors.isEmpty()) {
         RefPtr page = document->page();
-        if (auto* overlayController = page ? page->imageOverlayControllerIfExists() : nullptr)
+        if (RefPtr overlayController = page ? page->imageOverlayControllerIfExists() : nullptr)
             overlayController->textRecognitionResultsChanged(element);
     }
 #endif // ENABLE(DATA_DETECTION)

--- a/Source/WebCore/editing/SelectionGeometryGatherer.cpp
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.cpp
@@ -79,7 +79,7 @@ SelectionGeometryGatherer::Notifier::~Notifier()
         return;
 
     page->protectedServicesOverlayController()->selectionRectsDidChange(m_gatherer.boundingRects(), m_gatherer.m_gapRects, m_gatherer.isTextOnly());
-    page->imageOverlayController().selectionQuadsDidChange(frame, m_gatherer.m_quads);
+    page->protectedImageOverlayController()->selectionQuadsDidChange(frame, m_gatherer.m_quads);
 }
 
 Vector<LayoutRect> SelectionGeometryGatherer::boundingRects() const

--- a/Source/WebCore/page/ImageOverlayController.cpp
+++ b/Source/WebCore/page/ImageOverlayController.cpp
@@ -63,7 +63,7 @@ ImageOverlayController::ImageOverlayController(Page& page)
 
 void ImageOverlayController::selectionQuadsDidChange(LocalFrame& frame, const Vector<FloatQuad>& quads)
 {
-    if (!m_page || !protectedPage()->chrome().client().needsImageOverlayControllerForSelectionPainting())
+    if (!protectedPage()->chrome().client().needsImageOverlayControllerForSelectionPainting())
         return;
 
     if (frame.editor().ignoreSelectionChanges() || frame.editor().isGettingDictionaryPopupInfo())
@@ -151,15 +151,25 @@ void ImageOverlayController::uninstallPageOverlay()
 #endif
 
     auto overlayToUninstall = std::exchange(m_overlay, nullptr);
-    if (!m_page || !overlayToUninstall)
+    if (!overlayToUninstall)
         return;
 
     protectedPage()->pageOverlayController().uninstallPageOverlay(*overlayToUninstall, PageOverlay::FadeMode::DoNotFade);
 }
 
-RefPtr<Page> ImageOverlayController::protectedPage() const
+Ref<Page> ImageOverlayController::protectedPage() const
 {
     return m_page.get();
+}
+
+void ImageOverlayController::ref() const
+{
+    m_page->ref();
+}
+
+void ImageOverlayController::deref() const
+{
+    m_page->deref();
 }
 
 void ImageOverlayController::uninstallPageOverlayIfNeeded()

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -66,6 +66,15 @@ public:
     void selectionQuadsDidChange(LocalFrame&, const Vector<FloatQuad>&);
     void elementUnderMouseDidChange(LocalFrame&, Element*);
 
+#if PLATFORM(MAC)
+    // DataDetectorHighlightClient.
+    void ref() const final;
+    void deref() const final;
+#else
+    void ref() const;
+    void deref() const;
+#endif
+
 #if ENABLE(DATA_DETECTION)
     WEBCORE_EXPORT bool hasActiveDataDetectorHighlightForTesting() const;
     void textRecognitionResultsChanged(HTMLElement&);
@@ -102,10 +111,10 @@ private:
     void platformUpdateElementUnderMouse(LocalFrame&, Element* elementUnderMouse);
     bool platformHandleMouseEvent(const PlatformMouseEvent&);
 
-    RefPtr<Page> protectedPage() const;
+    Ref<Page> protectedPage() const;
     RefPtr<PageOverlay> protectedOverlay() const { return m_overlay; }
 
-    WeakPtr<Page> m_page;
+    WeakRef<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hostElementForSelection;
     Vector<FloatQuad> m_selectionQuads;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5086,8 +5086,13 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
 ImageOverlayController& Page::imageOverlayController()
 {
     if (!m_imageOverlayController)
-        m_imageOverlayController = makeUnique<ImageOverlayController>(*this);
+        lazyInitialize(m_imageOverlayController, makeUniqueWithoutRefCountedCheck<ImageOverlayController>(*this));
     return *m_imageOverlayController;
+}
+
+Ref<ImageOverlayController> Page::protectedImageOverlayController()
+{
+    return imageOverlayController();
 }
 
 Page* Page::serviceWorkerPage(ScriptExecutionContextIdentifier serviceWorkerPageIdentifier)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -755,6 +755,7 @@ public:
     Ref<ServicesOverlayController> protectedServicesOverlayController();
 #endif
     ImageOverlayController& imageOverlayController();
+    Ref<ImageOverlayController> protectedImageOverlayController();
     ImageOverlayController* imageOverlayControllerIfExists() { return m_imageOverlayController.get(); }
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -145,9 +145,6 @@ bool ImageOverlayController::platformHandleMouseEvent(const PlatformMouseEvent& 
 
 bool ImageOverlayController::handleDataDetectorAction(const HTMLElement& element, const IntPoint& locationInContents)
 {
-    if (!m_page)
-        return false;
-
     RefPtr frame = element.document().frame();
     if (!frame)
         return false;
@@ -249,25 +246,16 @@ void ImageOverlayController::elementUnderMouseDidChange(LocalFrame& frame, Eleme
 
 void ImageOverlayController::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps)
 {
-    if (!m_page)
-        return;
-
     protectedPage()->scheduleRenderingUpdate(requestedSteps);
 }
 
 float ImageOverlayController::deviceScaleFactor() const
 {
-    if (!m_page)
-        return 1;
-
     return protectedPage()->deviceScaleFactor();
 }
 
 RefPtr<GraphicsLayer> ImageOverlayController::createGraphicsLayer(GraphicsLayerClient& client)
 {
-    if (!m_page)
-        return nullptr;
-
     return GraphicsLayer::create(protectedPage()->chrome().client().graphicsLayerFactory(), client);
 }
 

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -52,8 +52,9 @@ public:
     explicit ServicesOverlayController(Page&);
     ~ServicesOverlayController();
 
-    void ref() const;
-    void deref() const;
+    // DataDetectorHighlightClient.
+    void ref() const final;
+    void deref() const final;
 
     void selectedTelephoneNumberRangesChanged();
     void selectionRectsDidChange(const Vector<LayoutRect>&, const Vector<GapRects>&, bool isTextOnly);

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -32,21 +32,13 @@
 #import <WebCore/GraphicsLayerClient.h>
 #import <WebCore/SimpleRange.h>
 #import <WebCore/Timer.h>
+#import <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakPtr.h>
 
 using DDHighlightRef = struct __DDHighlight*;
-
-namespace WebCore {
-class DataDetectorHighlightClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DataDetectorHighlightClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -57,7 +49,7 @@ class GraphicsLayer;
 
 enum class RenderingUpdateStep : uint32_t;
 
-class DataDetectorHighlightClient : public CanMakeWeakPtr<DataDetectorHighlightClient> {
+class DataDetectorHighlightClient : public AbstractRefCountedAndCanMakeWeakPtr<DataDetectorHighlightClient> {
 public:
     WEBCORE_EXPORT virtual ~DataDetectorHighlightClient() = default;
     WEBCORE_EXPORT virtual DataDetectorHighlight* activeHighlight() const = 0;

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.mm
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.mm
@@ -117,10 +117,8 @@ void DataDetectorHighlight::invalidate()
 
 void DataDetectorHighlight::notifyFlushRequired(const GraphicsLayer*)
 {
-    if (!m_client)
-        return;
-
-    m_client->scheduleRenderingUpdate(RenderingUpdateStep::LayerFlush);
+    if (RefPtr client = m_client.get())
+        client->scheduleRenderingUpdate(RenderingUpdateStep::LayerFlush);
 }
 
 void DataDetectorHighlight::paintContents(const GraphicsLayer&, GraphicsContext& graphicsContext, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>)
@@ -151,10 +149,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 float DataDetectorHighlight::deviceScaleFactor() const
 {
-    if (!m_client)
-        return 1;
-
-    return m_client->deviceScaleFactor();
+    RefPtr client = m_client.get();
+    return client ? client->deviceScaleFactor() : 1;
 }
 
 bool DataDetectorHighlight::isRangeSupportingType() const
@@ -234,10 +230,11 @@ void DataDetectorHighlight::startFadeAnimation()
 
 void DataDetectorHighlight::didFinishFadeOutAnimation()
 {
-    if (!m_client)
+    RefPtr client = m_client.get();
+    if (!client)
         return;
 
-    if (m_client->activeHighlight() == this)
+    if (client->activeHighlight() == this)
         return;
 
     layer().removeFromParent();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -34,6 +34,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
@@ -54,13 +55,17 @@ class PDFDataDetectorItem;
 class UnifiedPDFPlugin;
 class WebMouseEvent;
 
-class PDFDataDetectorOverlayController final : private WebCore::PageOverlayClient, WebCore::DataDetectorHighlightClient {
+class PDFDataDetectorOverlayController final : public RefCounted<PDFDataDetectorOverlayController>, private WebCore::PageOverlayClient, WebCore::DataDetectorHighlightClient {
     WTF_MAKE_TZONE_ALLOCATED(PDFDataDetectorOverlayController);
     WTF_MAKE_NONCOPYABLE(PDFDataDetectorOverlayController);
 public:
-    explicit PDFDataDetectorOverlayController(UnifiedPDFPlugin&);
+    static Ref<PDFDataDetectorOverlayController> create(UnifiedPDFPlugin&);
     virtual ~PDFDataDetectorOverlayController();
     void teardown();
+
+    // WebCore::DataDetectorHighlightClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool handleMouseEvent(const WebMouseEvent&, PDFDocumentLayout::PageIndex);
     RefPtr<WebCore::PageOverlay> protectedOverlay() const { return m_overlay; }
@@ -71,6 +76,8 @@ public:
     void hideActiveHighlightOverlay();
 
 private:
+    explicit PDFDataDetectorOverlayController(UnifiedPDFPlugin&);
+
     // PageOverlayClient
     void willMoveToPage(WebCore::PageOverlay&, WebCore::Page*) final;
     void didMoveToPage(WebCore::PageOverlay&, WebCore::Page*) final { }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -59,6 +59,11 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFDataDetectorOverlayController);
 
+Ref<PDFDataDetectorOverlayController> PDFDataDetectorOverlayController::create(UnifiedPDFPlugin& plugin)
+{
+    return adoptRef(*new PDFDataDetectorOverlayController(plugin));
+}
+
 PDFDataDetectorOverlayController::PDFDataDetectorOverlayController(UnifiedPDFPlugin& plugin)
     : m_plugin(plugin)
 {
@@ -259,7 +264,7 @@ void PDFDataDetectorOverlayController::hideActiveHighlightOverlay()
 void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(std::optional<PDFDocumentLayout::PageIndex> pageIndex, ShouldUpdatePlatformHighlightData shouldUpdatePlatformHighlightData, ActiveHighlightChanged activeHighlightChanged)
 {
     // Regardless of what we repaint, we don't need the stale data after this.
-    auto resetStaleDataDetectorWithHighlight = makeScopeExit([&] {
+    auto resetStaleDataDetectorWithHighlight = makeScopeExit([this, protectedThis = Ref { *this }] {
         m_staleDataDetectorItemWithHighlight = { { }, { } };
     });
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -258,6 +258,7 @@ private:
     void didInvalidateDataDetectorHighlightOverlayRects();
 
     PDFDataDetectorOverlayController& dataDetectorOverlayController() { return *m_dataDetectorOverlayController; }
+    Ref<PDFDataDetectorOverlayController> protectedDataDetectorOverlayController();
 #endif
 
     const PDFDocumentLayout& documentLayout() const { return m_documentLayout; }
@@ -714,7 +715,7 @@ private:
     PDFPageCoverage m_findMatchRects;
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-    std::unique_ptr<PDFDataDetectorOverlayController> m_dataDetectorOverlayController;
+    RefPtr<PDFDataDetectorOverlayController> m_dataDetectorOverlayController;
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -181,7 +181,7 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
     : PDFPluginBase(element)
     , m_pdfMutationObserver(adoptNS([[WKPDFFormMutationObserver alloc] initWithPlugin:this]))
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-    , m_dataDetectorOverlayController { WTF::makeUnique<PDFDataDetectorOverlayController>(*this) }
+    , m_dataDetectorOverlayController(PDFDataDetectorOverlayController::create(*this))
 #endif
 {
     this->setVerticalScrollElasticity(ScrollElasticity::Automatic);
@@ -422,6 +422,11 @@ void UnifiedPDFPlugin::enableDataDetection()
 #endif
 }
 
+Ref<PDFDataDetectorOverlayController> UnifiedPDFPlugin::protectedDataDetectorOverlayController()
+{
+    return dataDetectorOverlayController();
+}
+
 void UnifiedPDFPlugin::handleClickForDataDetectionResult(const DataDetectorElementInfo& dataDetectorElementInfo, const IntPoint& clickPointInPluginSpace)
 {
     RefPtr page = this->page();
@@ -440,7 +445,7 @@ void UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects()
 {
     auto lastKnownMousePositionInDocumentSpace = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, lastKnownMousePositionInView());
     auto pageIndex = protectedPresentationController()->pageIndexForDocumentPoint(lastKnownMousePositionInDocumentSpace);
-    dataDetectorOverlayController().didInvalidateHighlightOverlayRects(pageIndex);
+    protectedDataDetectorOverlayController()->didInvalidateHighlightOverlayRects(pageIndex);
 }
 
 #endif
@@ -1162,7 +1167,7 @@ void UnifiedPDFPlugin::didBeginMagnificationGesture()
     m_inMagnificationGesture = true;
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-    dataDetectorOverlayController().hideActiveHighlightOverlay();
+    protectedDataDetectorOverlayController()->hideActiveHighlightOverlay();
 #endif
 }
 
@@ -2012,7 +2017,7 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
     }
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-    if (dataDetectorOverlayController().handleMouseEvent(event, pageIndex))
+    if (protectedDataDetectorOverlayController()->handleMouseEvent(event, pageIndex))
         return true;
 #endif
 


### PR DESCRIPTION
#### e8c15675870642c43778e720bcb4a1b072919d8e
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for DataDetectorHighlightClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303080">https://bugs.webkit.org/show_bug.cgi?id=303080</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateWithTextRecognitionResult):
* Source/WebCore/editing/SelectionGeometryGatherer.cpp:
(WebCore::SelectionGeometryGatherer::Notifier::~Notifier):
* Source/WebCore/page/ImageOverlayController.cpp:
(WebCore::ImageOverlayController::selectionQuadsDidChange):
(WebCore::ImageOverlayController::uninstallPageOverlay):
(WebCore::ImageOverlayController::protectedPage const):
(WebCore::ImageOverlayController::ref const):
(WebCore::ImageOverlayController::deref const):
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::imageOverlayController):
(WebCore::Page::protectedImageOverlayController):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::handleDataDetectorAction):
(WebCore::ImageOverlayController::scheduleRenderingUpdate):
(WebCore::ImageOverlayController::deviceScaleFactor const):
(WebCore::ImageOverlayController::createGraphicsLayer):
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
(WebCore::DataDetectorHighlight::notifyFlushRequired):
(WebCore::DataDetectorHighlight::deviceScaleFactor const):
(WebCore::DataDetectorHighlight::didFinishFadeOutAnimation):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::create):
(WebKit::PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::UnifiedPDFPlugin::protectedDataDetectorOverlayController):
(WebKit::UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects):
(WebKit::UnifiedPDFPlugin::didBeginMagnificationGesture):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):

Canonical link: <a href="https://commits.webkit.org/303556@main">https://commits.webkit.org/303556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57f19443a2613efe5ac49e3321ff30f1fb2610ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140254 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84752 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e44f08fd-438e-4c75-9ca6-f39e74146898) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68768 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6e84d219-51da-48d5-8c1e-67c9919f4424) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82262 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61ff8075-51d1-4b69-ba18-e8bee9c09d2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3740 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1474 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83488 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142910 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4890 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109847 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110024 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3729 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58372 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4944 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33516 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4782 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5035 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4901 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->