### PR TITLE
[WebXR Hit Test][OpenXR] Integrate with the XR_ANDROID_raycast extension

### DIFF
--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -300,11 +300,13 @@ struct Ray {
 };
 
 struct HitTestOptions {
+    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(HitTestOptions);
     WebCore::TransformationMatrix nativeOrigin;
     Vector<WebCore::XRHitTestTrackableType> entityTypes;
     Ray offsetRay;
 };
 struct TransientInputHitTestOptions {
+    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(TransientInputHitTestOptions);
     String profile;
     Vector<WebCore::XRHitTestTrackableType> entityTypes;
     Ray offsetRay;

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -313,6 +313,7 @@ UIProcess/gtk/WebTextCheckerClient.cpp
 UIProcess/soup/WebProcessPoolSoup.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRHitTestManager.cpp
 UIProcess/XR/openxr/OpenXRInput.cpp
 UIProcess/XR/openxr/OpenXRInputSource.cpp
 UIProcess/XR/openxr/OpenXRLayer.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -288,6 +288,7 @@ UIProcess/wpe/WebPreferencesWPE.cpp
 UIProcess/wpe/WebContextMenuProxyWPE.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRHitTestManager.cpp
 UIProcess/XR/openxr/OpenXRInput.cpp
 UIProcess/XR/openxr/OpenXRInputSource.cpp
 UIProcess/XR/openxr/OpenXRLayer.cpp

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
@@ -94,6 +94,14 @@ bool OpenXRExtensions::loadMethods(XrInstance instance)
         RELEASE_ASSERT(m_methods->xrLocateHandJointsEXT);
     }
 #endif
+#if defined(XR_ANDROID_raycast)
+    if (isExtensionSupported(XR_ANDROID_RAYCAST_EXTENSION_NAME ""_span)) {
+        xrGetInstanceProcAddr(instance, "xrRaycastANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrRaycastANDROID));
+        xrGetInstanceProcAddr(instance, "xrCreateTrackableTrackerANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrCreateTrackableTrackerANDROID));
+        RELEASE_ASSERT(m_methods->xrRaycastANDROID);
+        RELEASE_ASSERT(m_methods->xrCreateTrackableTrackerANDROID);
+    }
+#endif
     return true;
 }
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
@@ -57,6 +57,10 @@ public:
     PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT { nullptr };
     PFN_xrLocateHandJointsEXT xrLocateHandJointsEXT { nullptr };
 #endif
+#if defined(XR_ANDROID_raycast)
+    PFN_xrRaycastANDROID xrRaycastANDROID { nullptr };
+    PFN_xrCreateTrackableTrackerANDROID xrCreateTrackableTrackerANDROID { nullptr };
+#endif
 };
 
 class OpenXRExtensions final {

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "OpenXRHitTestManager.h"
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include "OpenXRExtensions.h"
+#include "OpenXRUtils.h"
+
+namespace WebKit {
+
+OpenXRHitTestManager::OpenXRHitTestManager(XrSession session)
+    : m_session(session)
+{
+#if defined(XR_ANDROID_raycast)
+    auto createInfo = createOpenXRStruct<XrTrackableTrackerCreateInfoANDROID, XR_TYPE_TRACKABLE_TRACKER_CREATE_INFO_ANDROID>();
+    createInfo.trackableType = XR_TRACKABLE_TYPE_PLANE_ANDROID;
+    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrCreateTrackableTrackerANDROID(session, &createInfo, &m_trackableTracker));
+#endif
+}
+
+Vector<PlatformXR::FrameData::HitTestResult> OpenXRHitTestManager::requestHitTest(const PlatformXR::Ray& ray, XrSpace space, XrTime time)
+{
+#if defined(XR_ANDROID_raycast)
+    if (m_trackableTracker == XR_NULL_HANDLE)
+        return { };
+
+    constexpr int maxHitTestResults = 2;
+    auto raycastInfo = createOpenXRStruct<XrRaycastInfoANDROID, XR_TYPE_RAYCAST_INFO_ANDROID>();
+    raycastInfo.maxResults = maxHitTestResults;
+    raycastInfo.trackerCount = 1;
+    raycastInfo.trackers = &m_trackableTracker;
+    raycastInfo.origin = XrVector3f { ray.origin.x(), ray.origin.y(), ray.origin.z() };
+    raycastInfo.trajectory = XrVector3f { ray.direction.x(), ray.direction.y(), ray.direction.z() };
+    raycastInfo.space = space;
+    raycastInfo.time = time;
+
+    XrRaycastHitResultANDROID xrResults[maxHitTestResults];
+    auto xrHitResults = createOpenXRStruct<XrRaycastHitResultsANDROID, XR_TYPE_RAYCAST_HIT_RESULTS_ANDROID>();
+    xrHitResults.resultsCapacityInput = maxHitTestResults;
+    xrHitResults.results = xrResults;
+
+    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrRaycastANDROID(m_session, &raycastInfo, &xrHitResults));
+
+    Vector<PlatformXR::FrameData::HitTestResult> results;
+    for (const auto xrResult : xrResults)
+        results.append(XrPosefToPose(xrResult.pose));
+    return results;
+#else
+    return { };
+#endif
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include <WebCore/PlatformXR.h>
+#include <openxr/openxr.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebKit {
+
+class OpenXRHitTestManager {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRHitTestManager);
+    WTF_MAKE_NONCOPYABLE(OpenXRHitTestManager);
+public:
+    OpenXRHitTestManager(XrSession);
+    Vector<PlatformXR::FrameData::HitTestResult> requestHitTest(const PlatformXR::Ray&, XrSpace, XrTime);
+
+private:
+    XrSession m_session { XR_NULL_HANDLE };
+#if defined(XR_ANDROID_raycast)
+    XrTrackableTrackerANDROID m_trackableTracker { XR_NULL_HANDLE };
+#endif
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)


### PR DESCRIPTION
#### e4fdd06314551926b4600d2e1c696a853804c676
<pre>
[WebXR Hit Test][OpenXR] Integrate with the XR_ANDROID_raycast extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=303081">https://bugs.webkit.org/show_bug.cgi?id=303081</a>

Reviewed by Sergio Villar Senin.

This is an initial implementation, not tested yet.

* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp:
(WebKit::OpenXRExtensions::loadMethods):
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp: Added.
(WebKit::OpenXRHitTestManager::OpenXRHitTestManager):
(WebKit::OpenXRHitTestManager::requestHitTest):
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h: Added.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::requestHitTestSource):
(WebKit::OpenXRCoordinator::requestTransientInputHitTestSource):
(WebKit::OpenXRCoordinator::populateFrameData):

Canonical link: <a href="https://commits.webkit.org/303655@main">https://commits.webkit.org/303655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a1b2b313764210b75d616df686927081020ebf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101501 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68791 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142946 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131268 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109874 "Passed tests") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110051 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3763 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115221 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58418 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20617 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4979 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33569 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68430 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->