### PR TITLE
[WebRTC] traffic class should be set to VI if service class is set to VI

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
@@ -59,6 +59,7 @@ private:
     const Ref<IPC::Connection> m_connection;
     RetainPtr<nw_connection_t> m_nwConnection;
     bool m_isSTUN { false };
+    bool m_enableServiceClass { false };
 #if ASSERT_ENABLED
     bool m_isClosed { false };
 #endif

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -110,6 +110,7 @@ NetworkRTCTCPSocketCocoa::NetworkRTCTCPSocketCocoa(LibWebRTCSocketIdentifier ide
     , m_rtcProvider(rtcProvider)
     , m_connection(WTFMove(connection))
     , m_isSTUN(options & webrtc::PacketSocketFactory::OPT_STUN)
+    , m_enableServiceClass(flags.enableServiceClass)
 {
     auto hostName = remoteAddress.hostname();
     if (hostName.empty())
@@ -176,7 +177,7 @@ void NetworkRTCTCPSocketCocoa::setOption(int option, int value)
     if (option != webrtc::Socket::OPT_DSCP)
         return;
 
-    auto trafficClass = trafficClassFromDSCP(static_cast<webrtc::DiffServCodePoint>(value));
+    auto trafficClass = trafficClassFromDSCP(static_cast<webrtc::DiffServCodePoint>(value), m_enableServiceClass);
     if (!trafficClass) {
         RELEASE_LOG_ERROR(WebRTC, "NetworkRTCTCPSocketCocoa has an unexpected DSCP value %d", value);
         return;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -330,7 +330,7 @@ void NetworkRTCUDPSocketCocoaConnections::setOption(int option, int value)
     if (option != webrtc::Socket::OPT_DSCP)
         return;
 
-    auto trafficClass = trafficClassFromDSCP(static_cast<webrtc::DiffServCodePoint>(value));
+    auto trafficClass = trafficClassFromDSCP(static_cast<webrtc::DiffServCodePoint>(value), m_enableServiceClass);
     if (!trafficClass) {
         RELEASE_LOG_ERROR(WebRTC, "NetworkRTCUDPSocketCocoaConnections has an unexpected DSCP value %d", value);
         return;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h
@@ -41,7 +41,7 @@ namespace WebKit {
 void setNWParametersApplicationIdentifiers(nw_parameters_t, const char* sourceApplicationBundleIdentifier, std::optional<audit_token_t>, const String& attributedBundleIdentifier);
 void setNWParametersTrackerOptions(nw_parameters_t, bool shouldBypassRelay, bool isFirstParty, bool isKnownTracker);
 bool isKnownTracker(const WebCore::RegistrableDomain&);
-std::optional<uint32_t> trafficClassFromDSCP(webrtc::DiffServCodePoint);
+std::optional<uint32_t> trafficClassFromDSCP(webrtc::DiffServCodePoint, bool enableServiceClass);
 
 } // namespace WebKit
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
@@ -71,8 +71,11 @@ bool isKnownTracker(const WebCore::RegistrableDomain& domain)
     return !!NEHelperTrackerGetDisposition(nullptr, bridge_cast(domains.get()), context, &index);
 }
 
-std::optional<uint32_t> trafficClassFromDSCP(webrtc::DiffServCodePoint dscpValue)
+std::optional<uint32_t> trafficClassFromDSCP(webrtc::DiffServCodePoint dscpValue, bool enableServiceClass)
 {
+    if (enableServiceClass)
+        return SO_TC_VI;
+
     switch (dscpValue) {
     case webrtc::DiffServCodePoint::DSCP_NO_CHANGE:
         return { };


### PR DESCRIPTION
#### b7e0ce8cafc16a2dfd4c4245f870b3c68d32594b
<pre>
[WebRTC] traffic class should be set to VI if service class is set to VI
<a href="https://rdar.apple.com/165386600">rdar://165386600</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303083">https://bugs.webkit.org/show_bug.cgi?id=303083</a>

Reviewed by Jean-Yves Avenard.

When we set service class to video interactive, we also need to set traffic to video interactive,
so as to benefit from network slicing.
For now, we force traffic class to video interactive when service class is enabled.
In the future, we might finetune this heuristic based on <a href="https://github.com/w3c/webrtc-extensions/pull/247.">https://github.com/w3c/webrtc-extensions/pull/247.</a>

Canonical link: <a href="https://commits.webkit.org/303528@main">https://commits.webkit.org/303528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4700a0fb2f086a438fb48e0711f4e73c7e5bacd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140253 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/13214bed-e133-44c1-a6a0-7bf5804d1701) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f3720e44-967f-4244-b2a4-6a0c4e28ec7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135670 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82261 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ca9be79-9955-4c4f-a281-1ab607ca3b79) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83487 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142909 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109845 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110022 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27889 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3728 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58371 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4943 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33513 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4781 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->