### PR TITLE
espn.com: Unable to play Monday Night Football (MNF) videos from "Watch" page in Safari (Live content on Mondays only)

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-twice-unbuffered-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-twice-unbuffered-expected.txt
@@ -1,0 +1,21 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = 5)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
+EVENT(update)
+RUN(video.currentTime = 5.5)
+EVENT(seeked)
+RUN(sourceBuffer.remove(0, 5.6))
+RUN(video.currentTime = 0)
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+RUN(video.currentTime = 5.5)
+EVENT(seeked)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-twice-unbuffered.html
+++ b/LayoutTests/media/media-source/media-source-seek-twice-unbuffered.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-seek-twice-unbuffered</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    window.addEventListener('load', event => {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        loader.onload = async () => {
+            source = new MediaSource();
+            run('video.src = URL.createObjectURL(source)');
+            await waitFor(source, 'sourceopen');
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            run('sourceBuffer.timestampOffset = 5');
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            await waitFor(sourceBuffer, 'update');
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
+            await waitFor(sourceBuffer, 'update');
+
+            run('video.currentTime = 5.5');
+            await waitFor(video, 'seeked');
+            run('sourceBuffer.remove(0, 5.6)');
+            run('video.currentTime = 0');
+            await Promise.all([ sleepFor(2), waitFor(sourceBuffer, 'update') ]);
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            run('video.currentTime = 5.5');
+            await waitFor(video, 'seeked');
+
+            endTest();
+        };
+        loader.onerror = () => {
+            failTest('Media data loading failed');
+        };
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -585,7 +585,7 @@ void AudioVideoRendererAVFObjC::prepareToSeek()
 
 Ref<MediaTimePromise> AudioVideoRendererAVFObjC::seekTo(const MediaTime& seekTime)
 {
-    ALWAYS_LOG(LOGIDENTIFIER, seekTime, "state: ", toString(m_seekState), " m_isSynchronizerSeeking: ", m_isSynchronizerSeeking, " hasAvailableVideoFrame: ", m_hasAvailableVideoFrame);
+    ALWAYS_LOG(LOGIDENTIFIER, seekTime, "state: ", toString(m_seekState), " m_isSynchronizerSeeking: ", m_isSynchronizerSeeking, " hasAvailableVideoFrame: ", m_videoRenderer && allRenderersHaveAvailableSamples());
 
     cancelSeekingPromiseIfNeeded();
     if (m_seekState == RequiresFlush)
@@ -597,7 +597,7 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::seekTo(const MediaTime& seekTim
 
     bool isSynchronizerSeeking = m_isSynchronizerSeeking || std::abs((synchronizerTime - seekTime).toMicroseconds()) > 1000;
 
-    if (!isSynchronizerSeeking) {
+    if (!isSynchronizerSeeking && allRenderersHaveAvailableSamples()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Synchroniser doesn't require seeking current: ", synchronizerTime, " seeking: ", seekTime);
         // In cases where the destination seek time matches too closely the synchronizer's existing time
         // no time jumped notification will be issued. In this case, just notify the MediaPlayer that


### PR DESCRIPTION
#### 7cb3a439c8326c8d01124a77b705c2c2f224d008
<pre>
espn.com: Unable to play Monday Night Football (MNF) videos from &quot;Watch&quot; page in Safari (Live content on Mondays only)
<a href="https://rdar.apple.com/159133059">rdar://159133059</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303085">https://bugs.webkit.org/show_bug.cgi?id=303085</a>

Reviewed by Youenn Fablet.

The issue has been a long standing one.
If content was removed from the sourceBuffer while we&apos;re in the middle of a seek,
the renderer would have been flushed and the flag to indicate that a frame was available was set to false.
When content was then re-added, we attempted to seek again, however as the time hadn&apos;t changed
we simply assumed the seek was complete.
As MediaPlayerPrivateMediaSourceAVFObjC would wait for allRenderersHaveAvailableSamples
to become true to change the readyState from HaveMetadata to HaveCurrentData, and this condition
never occurred as no frame was ever re-enqueued: the seek never completed.

As a workaround, we only shorcut the seek when the currentTime will not change
if we do have received samples for all tracks; otherwise we will request a flush
which will automatically re-enqueue new frames. It may cause an unnecessary
flush and re-enqueue, but as this condition only occurs if we attempt to seek
twice to the same location, the performance impact is small.

Added test.
Test: media/media-source/media-source-seek-twice-unbuffered.html
* LayoutTests/media/media-source/media-source-seek-twice-unbuffered-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-twice-unbuffered.html: Added.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::seekTo):

Canonical link: <a href="https://commits.webkit.org/303550@main">https://commits.webkit.org/303550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a52a4c214af6e4eaef2169ea900cd40dd5d29cdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84757 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/688ea526-0de5-4af8-b65b-39e960005630) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101472 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68771 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e40ee326-bd3e-4f09-aab9-68b9c9ed7675) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135676 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82265 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1481 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83493 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142915 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109851 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110028 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27904 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3735 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58377 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4949 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33536 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68400 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5040 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->