### PR TITLE
[GTK][WPE] Do not block while waiting for tiles in the threaded compositor

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -36,6 +36,7 @@ class BitmapTexturePool;
 class CoordinatedTileBuffer;
 class GraphicsContext;
 class GraphicsLayer;
+class GraphicsLayerCoordinated;
 class IntRect;
 class IntSize;
 class SkiaRecordingResult;
@@ -56,9 +57,9 @@ public:
 
     bool useThreadedRendering() const { return m_workerPool; }
 
-    Ref<CoordinatedTileBuffer> paint(const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
-    Ref<SkiaRecordingResult> record(const GraphicsLayer&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);
-    Ref<CoordinatedTileBuffer> replay(const RefPtr<SkiaRecordingResult>&, const IntRect& dirtyRect);
+    Ref<CoordinatedTileBuffer> paint(const GraphicsLayerCoordinated&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
+    Ref<SkiaRecordingResult> record(const GraphicsLayerCoordinated&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);
+    Ref<CoordinatedTileBuffer> replay(const GraphicsLayerCoordinated&, const RefPtr<SkiaRecordingResult>&, const IntRect& dirtyRect);
 
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -78,6 +78,8 @@ public:
         virtual void requestComposition(CompositionReason) = 0;
         virtual RunLoop* compositingRunLoop() const = 0;
         virtual int maxTextureSize() const = 0;
+        virtual void willPaintTile() = 0;
+        virtual void didPaintTile() = 0;
     };
 
     static Ref<CoordinatedPlatformLayer> create();
@@ -191,6 +193,8 @@ public:
     Ref<SkiaRecordingResult> record(const IntRect&);
     Ref<CoordinatedTileBuffer> replay(const RefPtr<SkiaRecordingResult>&, const IntRect&);
 #endif
+    void willPaintTile();
+    void didPaintTile();
     void waitUntilPaintingComplete();
 
 private:

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
@@ -131,6 +131,17 @@ void CoordinatedSceneState::waitUntilPaintingComplete()
         layer->waitUntilPaintingComplete();
 }
 
+void CoordinatedSceneState::willPaintTile()
+{
+    m_pendingTiles++;
+}
+
+void CoordinatedSceneState::didPaintTile()
+{
+    ASSERT(m_pendingTiles.load() > 0);
+    m_pendingTiles--;
+}
+
 } // namespace WebKit
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -62,6 +62,10 @@ public:
 
     void waitUntilPaintingComplete();
 
+    void willPaintTile();
+    void didPaintTile();
+    unsigned pendingTiles() const { return m_pendingTiles.load(); }
+
 private:
     CoordinatedSceneState();
 
@@ -71,6 +75,7 @@ private:
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_pendingLayers WTF_GUARDED_BY_LOCK(m_pendingLayersLock);
     std::atomic<bool> m_didChangeLayers { false };
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_committedLayers;
+    std::atomic<unsigned> m_pendingTiles { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -430,6 +430,17 @@ int LayerTreeHost::maxTextureSize() const
     return m_compositor->maxTextureSize();
 }
 
+void LayerTreeHost::willPaintTile()
+{
+    m_sceneState->willPaintTile();
+}
+
+void LayerTreeHost::didPaintTile()
+{
+    m_sceneState->didPaintTile();
+    m_compositor->pendingTilesDidChange();
+}
+
 #if USE(CAIRO)
 Cairo::PaintingEngine& LayerTreeHost::paintingEngine()
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -143,6 +143,8 @@ private:
     void requestComposition(WebCore::CompositionReason) override;
     RunLoop* compositingRunLoop() const override;
     int maxTextureSize() const override;
+    void willPaintTile() override;
+    void didPaintTile() override;
 
     // GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
@@ -153,6 +153,8 @@ private:
     void requestComposition(WebCore::CompositionReason) override;
     RunLoop* compositingRunLoop() const override;
     int maxTextureSize() const override;
+    void willPaintTile() override { };
+    void didPaintTile() override { };
 
     // GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -69,6 +69,7 @@ public:
 #if PLATFORM(WPE) && USE(GBM) && ENABLE(WPE_PLATFORM)
     void preferredBufferFormatsDidChange();
 #endif
+    void pendingTilesDidChange();
 
     void setSize(const WebCore::IntSize&, float);
     void requestCompositionForRenderingUpdate(Function<void()>&&);
@@ -124,7 +125,8 @@ private:
         Idle,
         Scheduled,
         InProgress,
-        ScheduledWhileInProgress
+        ScheduledWhileInProgress,
+        WaitingForTiles
     };
 
     struct {


### PR DESCRIPTION
#### aa1cd6738768d9d77157ff02722cedf683a8330b
<pre>
[GTK][WPE] Do not block while waiting for tiles in the threaded compositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=303087">https://bugs.webkit.org/show_bug.cgi?id=303087</a>

Reviewed by Nikolas Zimmermann and Miguel Gomez.

Ensure we don&apos;t schedule a composition until all pending tiles are done
instead of synchronously waiting for tiles during the composition.
CoordinatedSceneState now keeps track of the ongoing tile painting
operations. A new state WaitingForTiles is added to the compositor so
that if there are pending tiles when a rendering update composition is
requested we switch to the WaitingForTiles state. The compositor is
notified by LayerTreeHost every time the pending tiles change, so if we
were waiting for tiles and there are no more pending tiles we switch to
Schedule state and continue normally. This is the previous behavior, but
asynchronously waiting for the tiles instead. This will allow to process
other composition requests while waiting for tiles of a rendering
update request.

Canonical link: <a href="https://commits.webkit.org/303564@main">https://commits.webkit.org/303564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b4bab5c1ce9870926199bf81d4971cfc764189

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140384 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5704 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/5215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119023 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/82374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83616 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5021 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37726 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5103 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/5215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110134 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3839 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58541 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20592 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5075 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4913 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68527 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5165 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->