### PR TITLE
[blocks-in-inline] Support hit test phases other than foreground

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-hit-test-float-expected.txt
+++ b/LayoutTests/fast/inline/blocks-in-inline-hit-test-float-expected.txt
@@ -1,0 +1,7 @@
+
+PASS blocks-in-inline-hit-test-float
+PASS with background
+PASS with padding
+PASS floats before block-in-inline
+PASS floats before block-in-inline with background
+

--- a/LayoutTests/fast/inline/blocks-in-inline-hit-test-float.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-hit-test-float.html
@@ -1,0 +1,76 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+section {
+  display: flow-root;
+}
+.float {
+  float: left;
+  width: 200px;
+  height: 20px;
+  background: orange;
+}
+.normal {
+  height: 10px;
+  background: blue;
+}
+</style>
+<body>
+  <section>
+    <a href="#">
+      <div>
+        <div class="float"></div>
+        <div class="normal"></div>
+      </div>
+    </a>
+  </section>
+  <section title="with background">
+    <a href="#" style="background: purple">
+      <div>
+        <div class="float"></div>
+        <div class="normal"></div>
+      </div>
+    </a>
+  </section>
+  <section title="with padding">
+    <a href="#" style="padding: 1px">
+      <div>
+        <div class="float"></div>
+        <div class="normal"></div>
+      </div>
+    </a>
+  </section>
+  <section title="floats before block-in-inline">
+    <div class="float"></div>
+    <div>
+      <a href="#">
+        <div class="normal"></div>
+      </a>
+    </div>
+  </section>
+  <section title="floats before block-in-inline with background">
+    <div class="float"></div>
+    <div>
+      <a href="#" style="background: purple">
+        <div class="normal"></div>
+      </a>
+    </div>
+  </section>
+<script>
+document.body.offsetTop;
+for (const section of document.getElementsByTagName('section')) {
+  test(() => {
+    const float_element = section.querySelector('.float');
+    const float_bounds = float_element.getBoundingClientRect();
+    const normal_element = section.querySelector('.normal');
+    const normal_bounds = normal_element.getBoundingClientRect();
+    const x = float_bounds.x + (float_bounds.width / 2);
+    const y = normal_bounds.y + (normal_bounds.height / 2);
+    const result = document.elementFromPoint(x, y);
+    assert_equals(result, float_element);
+  }, section.title);
+}
+</script>
+</body>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -115,7 +115,6 @@ struct Box {
     bool hasContent() const { return m_hasContent; }
     inline bool isVisible() const;
     // Inline boxes around blocks are visible to hit testing but don't paint.
-    bool suppressesPaintingForBlockInInline() const { return m_suppressesPaintingForBlockInInline; }
     bool isVisibleIgnoringUsedVisibility() const { return !isFullyTruncated() && style().visibility() == Visibility::Visible; }
     bool isFullyTruncated() const { return m_isFullyTruncated; } 
 
@@ -144,7 +143,6 @@ struct Box {
     void setRect(const FloatRect&, const FloatRect& inkOverflow);
     void setHasContent() { m_hasContent = true; }
     void setIsFullyTruncated() { m_isFullyTruncated = true; }
-    void setSuppressesPaintingForBlockInInline() { m_suppressesPaintingForBlockInInline = true; }
 
     Text& text() { ASSERT(isTextOrSoftLineBreak()); return m_text; }
     const Text& text() const { ASSERT(isTextOrSoftLineBreak()); return m_text; }
@@ -194,7 +192,6 @@ private:
     bool m_isFullyTruncated : 1 { false };
     bool m_isInGlyphDisplayListCache : 1 { false };
     bool m_isFirstFormattedLine : 1 { false };
-    bool m_suppressesPaintingForBlockInInline : 1 { false };
 
     Text m_text;
 };

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -372,7 +372,7 @@ static inline bool isNestedInlineBoxWithDifferentFontCascadeFromParent(const Box
     return style.fontCascade() != parentStyle.fontCascade();
 }
 
-void InlineDisplayContentBuilder::appendInlineBoxDisplayBox(const Line::Run& lineRun, const InlineLevelBox& inlineBox, const InlineRect& inlineBoxBorderBox, bool lineHasBlockContent, InlineDisplay::Boxes& boxes)
+void InlineDisplayContentBuilder::appendInlineBoxDisplayBox(const Line::Run& lineRun, const InlineLevelBox& inlineBox, const InlineRect& inlineBoxBorderBox, InlineDisplay::Boxes& boxes)
 {
     ASSERT(lineRun.layoutBox().isInlineBox());
     ASSERT(inlineBox.isInlineBox());
@@ -402,9 +402,6 @@ void InlineDisplayContentBuilder::appendInlineBoxDisplayBox(const Line::Run& lin
         , isLineFullyTruncatedInBlockDirection()
         , isFirstLastBox(inlineBox)
     });
-
-    if (lineHasBlockContent)
-        boxes.last().setSuppressesPaintingForBlockInInline();
 }
 
 void InlineDisplayContentBuilder::appendInlineDisplayBoxAtBidiBoundary(const Box& layoutBox, InlineDisplay::Boxes& boxes)
@@ -540,7 +537,7 @@ void InlineDisplayContentBuilder::processNonBidiContent(const LineLayoutResult& 
             else if (lineRun.isAtomicInlineBox() || lineRun.isListMarker())
                 appendAtomicInlineLevelDisplayBox(lineRun, visualRectRelativeToRoot, boxes);
             else if (lineRun.isInlineBoxStart() || lineRun.isLineSpanningInlineBoxStart())
-                appendInlineBoxDisplayBox(lineRun, lineBox.inlineLevelBoxFor(lineRun), visualRectRelativeToRoot, lineHasBlockContent, boxes);
+                appendInlineBoxDisplayBox(lineRun, lineBox.inlineLevelBoxFor(lineRun), visualRectRelativeToRoot, boxes);
             else if (lineRun.isBlock()) {
                 // Block content should always be placed at the start of the content box even when floats shrink the line.
                 auto adjustedVisualRect = [&] {
@@ -984,7 +981,7 @@ void InlineDisplayContentBuilder::processBidiContent(const LineLayoutResult& lin
             // Non-empty inline boxes are normally get their display boxes generated when we process their content runs, but
             // these trailing runs have their content on the subsequent line(s).
             auto& inlineBox = lineBox.inlineLevelBoxFor(lineRun);
-            appendInlineBoxDisplayBox(lineRun, inlineBox, { { }, m_displayLine.right(), { }, { } }, { }, boxes);
+            appendInlineBoxDisplayBox(lineRun, inlineBox, { { }, m_displayLine.right(), { }, { } }, boxes);
             setInlineBoxGeometry(lineRun.layoutBox(), formattingContext().geometryForBox(lineRun.layoutBox()), { { }, lineBox.logicalRect().right(), { }, { } }, inlineBox.isFirstBox());
         }
     };

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -58,7 +58,7 @@ private:
     void appendAtomicInlineLevelDisplayBox(const Line::Run&, const InlineRect&, InlineDisplay::Boxes&);
     void appendBlockLevelDisplayBox(const Line::Run&, const InlineRect&, InlineDisplay::Boxes&);
     void appendRootInlineBoxDisplayBox(const InlineRect&, bool lineHasContent, InlineDisplay::Boxes&);
-    void appendInlineBoxDisplayBox(const Line::Run&, const InlineLevelBox&, const InlineRect&, bool lineHasBlockContent, InlineDisplay::Boxes&);
+    void appendInlineBoxDisplayBox(const Line::Run&, const InlineLevelBox&, const InlineRect&, InlineDisplay::Boxes&);
     void appendInlineDisplayBoxAtBidiBoundary(const Box&, InlineDisplay::Boxes&);
     void insertRubyAnnotationBox(const Box& annotationBox, size_t insertionPosition, const InlineRect&, InlineDisplay::Boxes&);
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
@@ -42,7 +42,7 @@ public:
         float top { 0 };
         float bottom { 0 };
     };
-    Line(bool hasInflowContent, const FloatRect& lineBoxLogicalRect, const FloatRect& lineBoxRect, const FloatRect& contentOverflow, EnclosingTopAndBottom, float alignmentBaseline, FontBaseline baselineType, float contentLogicalLeft, float contentLogicalLeftIgnoringInlineDirection, float contentLogicalWidth, bool isLeftToRightDirection, bool isHorizontal, bool isTruncatedInBlockDirection);
+    Line(bool hasInflowContent, const FloatRect& lineBoxLogicalRect, const FloatRect& lineBoxRect, const FloatRect& contentOverflow, EnclosingTopAndBottom, float alignmentBaseline, FontBaseline baselineType, float contentLogicalLeft, float contentLogicalLeftIgnoringInlineDirection, float contentLogicalWidth, bool isLeftToRightDirection, bool isHorizontal, bool isTruncatedInBlockDirection, bool hasBlockLevelContent);
 
     // FIXME: We should consider having 2 APIs here where (webkit.org/b/302804)
     // "hasInflowContent" returns true for all inflow content including non-contentful inflow content e.g. <span></span>
@@ -108,6 +108,8 @@ public:
     bool hasContentAfterEllipsisBox() const { return m_hasContentAfterEllipsisBox; }
     void setHasContentAfterEllipsisBox() { m_hasContentAfterEllipsisBox = true; }
 
+    bool hasBlockLevelContent() const { return m_hasBlockLevelContent; }
+
     void setFirstBoxIndex(size_t firstBoxIndex) { m_firstBoxIndex = firstBoxIndex; }
     void setBoxCount(size_t boxCount) { m_boxCount = boxCount; }
     void setIsFirstAfterPageBreak() { m_isFirstAfterPageBreak = true; }
@@ -144,10 +146,11 @@ private:
     bool m_isFullyTruncatedInBlockDirection : 1 { false };
     bool m_hasContentAfterEllipsisBox : 1 { false };
     bool m_hasInflowContent : 1 { false };
+    bool m_hasBlockLevelContent : 1 { false };
     std::optional<Ellipsis> m_ellipsis { };
 };
 
-inline Line::Line(bool hasInflowContent, const FloatRect& lineBoxLogicalRect, const FloatRect& lineBoxRect, const FloatRect& contentOverflow, EnclosingTopAndBottom enclosingLogicalTopAndBottom, float alignmentBaseline, FontBaseline baselineType, float contentLogicalLeft, float contentLogicalLeftIgnoringInlineDirection, float contentLogicalWidth, bool isLeftToRightDirection, bool isHorizontal, bool isTruncatedInBlockDirection)
+inline Line::Line(bool hasInflowContent, const FloatRect& lineBoxLogicalRect, const FloatRect& lineBoxRect, const FloatRect& contentOverflow, EnclosingTopAndBottom enclosingLogicalTopAndBottom, float alignmentBaseline, FontBaseline baselineType, float contentLogicalLeft, float contentLogicalLeftIgnoringInlineDirection, float contentLogicalWidth, bool isLeftToRightDirection, bool isHorizontal, bool isTruncatedInBlockDirection, bool hasBlockLevelContent)
     : m_lineBoxRect(lineBoxRect)
     , m_lineBoxLogicalRect(lineBoxLogicalRect)
     , m_contentOverflow(contentOverflow)
@@ -161,6 +164,7 @@ inline Line::Line(bool hasInflowContent, const FloatRect& lineBoxLogicalRect, co
     , m_isHorizontal(isHorizontal)
     , m_isFullyTruncatedInBlockDirection(isTruncatedInBlockDirection)
     , m_hasInflowContent(hasInflowContent)
+    , m_hasBlockLevelContent(hasBlockLevelContent)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -151,6 +151,7 @@ InlineDisplay::Line InlineDisplayLineBuilder::build(const LineLayoutResult& line
         , isLeftToRightDirection
         , rootInlineBox.layoutBox().writingMode().isHorizontal()
         , lineIsFullyTruncatedInBlockDirection
+        , lineLayoutResult.hasBlockContent()
     };
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -148,8 +148,18 @@ std::optional<size_t> InlineContent::firstBoxIndexForLayoutBox(const Layout::Box
 // Returns a block level box if the line is for block-in-inline.
 const InlineDisplay::Box* InlineContent::blockLevelBoxForLine(const InlineDisplay::Line& line) const
 {
+    if (!line.hasBlockLevelContent())
+        return nullptr;
     auto& lastBox = displayContent().boxes[line.lastBoxIndex()];
+    ASSERT(lastBox.isBlockLevelBox());
     return lastBox.isBlockLevelBox() ? &lastBox : nullptr;
+}
+
+bool InlineContent::isInlineBoxWrapperForBlockLevelBox(const InlineDisplay::Box& box) const
+{
+    if (!box.isInlineBox() || !m_hasBlockLevelBoxes)
+        return false;
+    return lineForBox(box).hasBlockLevelContent();
 }
 
 const Vector<size_t>& InlineContent::nonRootInlineBoxIndexesForLayoutBox(const Layout::Box& layoutBox) const

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -90,6 +90,7 @@ public:
 
     // Returns a block level box if the line is for block-in-inline.
     const InlineDisplay::Box* blockLevelBoxForLine(const InlineDisplay::Line&) const;
+    bool isInlineBoxWrapperForBlockLevelBox(const InlineDisplay::Box&) const;
 
     template<typename Function> void traverseNonRootInlineBoxes(const Layout::Box&, Function&&);
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -85,7 +85,10 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
     }
 
     if (box.isInlineBox()) {
-        if (!box.isVisible() || box.suppressesPaintingForBlockInInline() || !hasDamage(box))
+        if (!box.isVisible() || !hasDamage(box))
+            return;
+        // Don't paint inline boxes wrapping block-in-inline.
+        if (m_inlineContent.isInlineBoxWrapperForBlockLevelBox(box))
             return;
 
         auto canSkipInlineBoxPainting = [&]() {


### PR DESCRIPTION
#### c46b1a7120994b878423201647618e0e4559bc49
<pre>
[blocks-in-inline] Support hit test phases other than foreground
<a href="https://bugs.webkit.org/show_bug.cgi?id=303089">https://bugs.webkit.org/show_bug.cgi?id=303089</a>
<a href="https://rdar.apple.com/165394620">rdar://165394620</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-hit-test-float.html
* LayoutTests/fast/inline/blocks-in-inline-hit-test-float-expected.txt: Added.
* LayoutTests/fast/inline/blocks-in-inline-hit-test-float.html: Added.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::setIsFullyTruncated):
(WebCore::InlineDisplay::Box::suppressesPaintingForBlockInInline const): Deleted.
(WebCore::InlineDisplay::Box::setSuppressesPaintingForBlockInInline): Deleted.

Remove in favor of a bit in Line as we want the same behavior for all inline boxes
on a line including root boxes.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::appendInlineBoxDisplayBox):
(WebCore::Layout::InlineDisplayContentBuilder::processNonBidiContent):
(WebCore::Layout::InlineDisplayContentBuilder::processBidiContent):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h:
(WebCore::InlineDisplay::Line::hasBlockLevelContent const):

Add a bit.

(WebCore::InlineDisplay::Line::Line):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::InlineDisplayLineBuilder::build const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
(WebCore::LayoutIntegration::InlineContent::blockLevelBoxForLine const):
(WebCore::LayoutIntegration::InlineContent::isInlineBoxWrapperForBlockLevelBox const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::hitTest):

Handle additional phases for blocks.

Canonical link: <a href="https://commits.webkit.org/303543@main">https://commits.webkit.org/303543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a135ba9610b336a79ebd8024608f542a491b7c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84786 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/079d161a-8cea-4419-8dcd-56a1c2b710b4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101499 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a818ed49-78a0-4a46-8061-533fa1fd6b78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135705 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82291 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d3a1846-fa62-430d-ba6a-9d008c8933ea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83523 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112758 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142945 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4924 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109873 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3762 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58417 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4978 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33553 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68429 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4935 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->