### PR TITLE
Rename MallocSpan<..., Mmap> to MmapSpan

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -118,7 +118,7 @@
 		46CEA3FA2CC2D39B00FE325C /* SpanCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */; };
 		46E915222CD2E26C00C437B7 /* UnicodeExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46E915212CD2E26C00C437B7 /* UnicodeExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46E93049271F1205005BA6E5 /* SafeStrerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E43647271F10AA00C88C90 /* SafeStrerror.cpp */; };
-		46F071BB2CDEA45300074E61 /* Mmap.h in Headers */ = {isa = PBXBuildFile; fileRef = 46F071BA2CDEA45300074E61 /* Mmap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46F071BB2CDEA45300074E61 /* MmapSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 46F071BA2CDEA45300074E61 /* MmapSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4BF93AD32C8B53C100F0E06C /* RefTrackerMixin.h in Headers */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD50026DEAD /* RefTrackerMixin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		50DE35F5215BB01500B979C7 /* ExternalStringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */; };
 		515F794E1CFC9F4A00CCED93 /* CrossThreadCopier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 515F794B1CFC9F4A00CCED93 /* CrossThreadCopier.cpp */; };
@@ -162,6 +162,7 @@
 		7AC314232C6FCF18002CBAFD /* SchedulePairCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AC314222C6FCF18002CBAFD /* SchedulePairCocoa.mm */; };
 		7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */; };
 		7AFEC6B11EB22B5900DADE36 /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AFEC6B01EB22B5900DADE36 /* UUID.cpp */; };
+		7B8486622ED5E5A400E34DC1 /* AllocSpanMixin.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8486612ED5E5A400E34DC1 /* AllocSpanMixin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7B8A1DC82A336B9000A4CE4E /* SequenceLocked.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
@@ -1331,7 +1332,7 @@
 		46E43646271F10AA00C88C90 /* SafeStrerror.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SafeStrerror.h; sourceTree = "<group>"; };
 		46E43647271F10AA00C88C90 /* SafeStrerror.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SafeStrerror.cpp; sourceTree = "<group>"; };
 		46E915212CD2E26C00C437B7 /* UnicodeExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnicodeExtras.h; sourceTree = "<group>"; };
-		46F071BA2CDEA45300074E61 /* Mmap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Mmap.h; sourceTree = "<group>"; };
+		46F071BA2CDEA45300074E61 /* MmapSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MmapSpan.h; sourceTree = "<group>"; };
 		50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExternalStringImpl.cpp; sourceTree = "<group>"; };
 		50DE35F4215BB01500B979C7 /* ExternalStringImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExternalStringImpl.h; sourceTree = "<group>"; };
 		513E170A1CD7D5BF00E3650B /* LoggingAccumulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoggingAccumulator.h; sourceTree = "<group>"; };
@@ -1424,6 +1425,7 @@
 		7AFEC6B01EB22B5900DADE36 /* UUID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UUID.cpp; sourceTree = "<group>"; };
 		7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafetyAnalysis.h; sourceTree = "<group>"; };
 		7B2739F12632A8940040F182 /* ThreadAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadAssertions.h; sourceTree = "<group>"; };
+		7B8486612ED5E5A400E34DC1 /* AllocSpanMixin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AllocSpanMixin.h; sourceTree = "<group>"; };
 		7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SequenceLocked.h; sourceTree = "<group>"; };
 		7C137941222326C700D7A824 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
 		7C137942222326D500D7A824 /* ieee.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ieee.h; sourceTree = "<group>"; };
@@ -2289,6 +2291,7 @@
 				E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */,
 				CDCC9BC422382FCE00FFB51C /* AggregateLogger.h */,
 				466E7A792D66E57E0096FDA4 /* AlignedStorage.h */,
+				7B8486612ED5E5A400E34DC1 /* AllocSpanMixin.h */,
 				CE1132832370634900A8C83B /* AnsiColors.h */,
 				E37E96522702AD0700E1C36A /* ApproximateTime.cpp */,
 				E37E96532702AD0700E1C36A /* ApproximateTime.h */,
@@ -2523,7 +2526,7 @@
 				A8A472CD151A825B004123FF /* MetaAllocator.cpp */,
 				A8A472CE151A825B004123FF /* MetaAllocator.h */,
 				A8A472CF151A825B004123FF /* MetaAllocatorHandle.h */,
-				46F071BA2CDEA45300074E61 /* Mmap.h */,
+				46F071BA2CDEA45300074E61 /* MmapSpan.h */,
 				0F66B2821DC97BAB004A1D3F /* MonotonicTime.cpp */,
 				0F66B2831DC97BAB004A1D3F /* MonotonicTime.h */,
 				FE8225301B2A1E5B00BA68FD /* NakedPtr.h */,
@@ -3409,6 +3412,7 @@
 				E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */,
 				DD3DC8FA27A4BF8E007E5B61 /* AggregateLogger.h in Headers */,
 				466E7A7A2D66E57E0096FDA4 /* AlignedStorage.h in Headers */,
+				7B8486622ED5E5A400E34DC1 /* AllocSpanMixin.h in Headers */,
 				DD3DC99627A4BF8E007E5B61 /* AnsiColors.h in Headers */,
 				DD3DC92527A4BF8E007E5B61 /* ApproximateTime.h in Headers */,
 				5CB8CB6D28C16CB700539906 /* ArgumentCoder.h in Headers */,
@@ -3664,7 +3668,7 @@
 				DD3DC88127A4BF8E007E5B61 /* MetaAllocator.h in Headers */,
 				DD3DC87027A4BF8E007E5B61 /* MetaAllocatorHandle.h in Headers */,
 				DDF306DB27C08654006A526F /* MetadataSPI.h in Headers */,
-				46F071BB2CDEA45300074E61 /* Mmap.h in Headers */,
+				46F071BB2CDEA45300074E61 /* MmapSpan.h in Headers */,
 				DD3DC96827A4BF8E007E5B61 /* MonotonicTime.h in Headers */,
 				DD3DC96227A4BF8E007E5B61 /* NakedPtr.h in Headers */,
 				5164042D2AB1D46B0042B1C3 /* NativePromise.h in Headers */,

--- a/Source/WTF/wtf/AllocSpanMixin.h
+++ b/Source/WTF/wtf/AllocSpanMixin.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <span>
+#include <wtf/Noncopyable.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+// Mixin for implementing RAII holders for memory that has custom alloc and free functionality.
+template<typename T> class AllocSpanMixin {
+    WTF_MAKE_NONCOPYABLE(AllocSpanMixin);
+public:
+    AllocSpanMixin(AllocSpanMixin&& other)
+        : m_span(other.leakSpan())
+    {
+    }
+
+    void swap(AllocSpanMixin& other)
+    {
+        std::swap(m_span, other.m_span);
+    }
+
+    size_t sizeInBytes() const { return m_span.size_bytes(); }
+
+    std::span<const T> span() const LIFETIME_BOUND { return m_span; }
+    std::span<T> mutableSpan() LIFETIME_BOUND { return m_span; }
+    std::span<T> leakSpan() WARN_UNUSED_RETURN { return std::exchange(m_span, std::span<T> { }); }
+
+    T& operator[](size_t i) LIFETIME_BOUND { return m_span[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return m_span[i]; }
+
+    explicit operator bool() const
+    {
+        return !!m_span.data();
+    }
+
+    bool operator!() const
+    {
+        return !m_span.data();
+    }
+
+protected:
+    AllocSpanMixin() = default;
+    explicit AllocSpanMixin(std::span<T> span)
+        : m_span(span)
+    {
+    }
+    explicit AllocSpanMixin(void* ptr, size_t sizeInBytes)
+        : m_span(unsafeMakeSpan(static_cast<T*>(ptr), sizeInBytes / sizeof(T)))
+    {
+        RELEASE_ASSERT(!(sizeInBytes % sizeof(T)));
+    }
+
+private:
+    std::span<T> m_span;
+};
+
+}

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -7,6 +7,7 @@ set(WTF_PUBLIC_HEADERS
     AbstractRefCounted.h
     AbstractRefCountedAndCanMakeWeakPtr.h
     AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h
+    AllocSpanMixin.h
     ASCIICType.h
     AccessibleAddress.h
     AggregateLogger.h
@@ -188,7 +189,7 @@ set(WTF_PUBLIC_HEADERS
     MessageQueue.h
     MetaAllocator.h
     MetaAllocatorHandle.h
-    Mmap.h
+    MmapSpan.h
     MonotonicTime.h
     NakedPtr.h
     NativePromise.h

--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -30,7 +30,7 @@
 
 #if HAVE(MMAP)
 #include <wtf/MallocSpan.h>
-#include <wtf/Mmap.h>
+#include <wtf/MmapSpan.h>
 #endif
 
 #if OS(WINDOWS)
@@ -56,7 +56,7 @@ public:
     MappedFileData& operator=(MappedFileData&&) = default;
 
 #if HAVE(MMAP)
-    explicit MappedFileData(MallocSpan<uint8_t, Mmap>&&);
+    explicit MappedFileData(MmapSpan<uint8_t>&&);
 
     std::span<uint8_t> leakHandle() WARN_UNUSED_RETURN { return m_fileData.leakSpan(); }
     explicit operator bool() const { return !!m_fileData; }
@@ -75,7 +75,7 @@ public:
 
 private:
 #if HAVE(MMAP)
-    MallocSpan<uint8_t, Mmap> m_fileData;
+    MmapSpan<uint8_t> m_fileData;
 #elif OS(WINDOWS)
     std::span<uint8_t> m_fileData;
     Win32Handle m_fileMapping;

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -182,7 +182,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode mapMode, FileOpenMo
 #endif
     }
 
-    auto fileData = MallocSpan<uint8_t, Mmap>::mmap(nullptr, size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), platformHandle());
+    auto fileData = MmapSpan<uint8_t>::mmap(nullptr, size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), platformHandle());
     if (!fileData)
         return { };
 

--- a/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
+++ b/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
@@ -29,7 +29,7 @@
 namespace WTF::FileSystemImpl {
 
 #if HAVE(MMAP)
-MappedFileData::MappedFileData(MallocSpan<uint8_t, Mmap>&& fileData)
+MappedFileData::MappedFileData(MmapSpan<uint8_t>&& fileData)
     : m_fileData(WTFMove(fileData))
 { }
 

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -32,7 +32,7 @@
 #include <wtf/DataLog.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/MathExtras.h>
-#include <wtf/Mmap.h>
+#include <wtf/MmapSpan.h>
 #include <wtf/PageBlock.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/text/CString.h>
@@ -96,7 +96,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         bytes = bytes + 2 * guardSize;
     }
-    auto result = MallocSpan<uint8_t, Mmap>::mmap(address, bytes, protection, flags, fd);
+    auto result = MmapSpan<uint8_t>::mmap(address, bytes, protection, flags, fd);
     if (!result)
         return result.leakSpan().data();
 

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -30,16 +30,15 @@
 #include <WebCore/PlatformExportMacros.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Forward.h>
-#include <wtf/MallocSpan.h>
 #include <wtf/OptionSet.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 #if OS(DARWIN)
-namespace WTF {
-struct Mmap;
-}
+#include <wtf/MmapSpan.h>
+#else
+#include <wtf/MallocSpan.h>
 #endif
 
 namespace IPC {
@@ -119,10 +118,11 @@ private:
     uint64_t m_destinationID;
 
 #if OS(DARWIN)
-    MallocSpan<uint8_t, WTF::Mmap> m_outOfLineBuffer;
+    using OutOfLineBufferSpan = MmapSpan<uint8_t>;
 #else
-    MallocSpan<uint8_t> m_outOfLineBuffer;
+    using OutOfLineBufferSpan = MallocSpan<uint8_t>;
 #endif
+    OutOfLineBufferSpan m_outOfLineBuffer;
     std::array<uint8_t, 512> m_inlineBuffer;
 
     size_t m_bufferSize { 0 };


### PR DESCRIPTION
#### eb34217e404e09d292f0932dcc884e37fa2a28fd
<pre>
Rename MallocSpan&lt;..., Mmap&gt; to MmapSpan
<a href="https://bugs.webkit.org/show_bug.cgi?id=303091">https://bugs.webkit.org/show_bug.cgi?id=303091</a>
<a href="https://rdar.apple.com/165397945">rdar://165397945</a>

Reviewed by Ben Nham.

MallocSpan&lt;..., Mmap&gt; doesn&apos;t support the interface exposed by
MallocSpan. To fix this, extract the common functionality between
MallocSpan&lt;..., XXX&gt; for any XXX to AllocSpanMixin&lt;T&gt;.

Add explicit MmapSpan to that has unambiguous mmap-related constructors.

The common AllocSpanMixin&lt;T&gt; will be used to implement Cocoa-specific
VMAllocSpan in the future. The upcoming VMAllocSpan will be used in
SharedMemory. This feature is needed to hold memory-owning spans that
originate from IPC or files but do not reserve handles.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/MallocSpan.h:
(WTF::MallocSpan::MallocSpan):
(WTF::MallocSpan::requires):
(WTF::MallocSpan::~MallocSpan):
(WTF::MallocSpan::operator=):
(WTF::MallocSpan::malloc):
(WTF::MallocSpan::zeroedMalloc):
(WTF::MallocSpan::alignedMalloc):
(WTF::MallocSpan::tryMalloc):
(WTF::MallocSpan::tryZeroedMalloc):
(WTF::MallocSpan::tryAlignedMalloc):
(WTF::MallocSpan::realloc):
(WTF::MallocSpan::swap): Deleted.
(WTF::MallocSpan::sizeInBytes const): Deleted.
(WTF::MallocSpan::operator bool const): Deleted.
(WTF::MallocSpan::operator! const): Deleted.
(WTF::MallocSpan::mmap): Deleted.
* Source/WTF/wtf/MappedFileData.h:
* Source/WTF/wtf/Mmap.h: Removed.
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp:
(WTF::FileSystemImpl::MappedFileData::MappedFileData):
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveAndCommit):
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::reserve):
(IPC::allocateBuffer): Deleted.
* Source/WebKit/Platform/IPC/Encoder.h:

Canonical link: <a href="https://commits.webkit.org/303602@main">https://commits.webkit.org/303602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49818591b404defe7d7a816de6915a465c0cea09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84977 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87927434-0fc1-43ba-8366-91acb951e098) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101661 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/df2f5205-36ed-43bc-b63d-7da5365868cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135892 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82461 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/426cb83a-1deb-43cf-a267-1410ff80b23f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1625 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83714 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125016 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143134 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131454 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27947 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3927 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5170 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33736 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164421 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68622 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5260 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->