### PR TITLE
[blocks-in-inline] Inherit anonymous block from containing block

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-anon-block-inheritance-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-anon-block-inheritance-expected.html
@@ -1,0 +1,1 @@
+<div style="direction: ltr; width: 100px; height: 50px; border: 1px solid green;"><span style="direction: rtl"><div style="height: 20px; width: 30px; border: 5px solid black">

--- a/LayoutTests/fast/inline/blocks-in-inline-anon-block-inheritance.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-anon-block-inheritance.html
@@ -1,0 +1,2 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<div style="direction: ltr; width: 100px; height: 50px; border: 1px solid green;"><span style="direction: rtl"><div style="height: 20px; width: 30px; border: 5px solid black">

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -468,7 +468,7 @@ void RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock(RenderInline& p
         if (!firstInRun)
             return;
 
-        auto newBlock = Block::createAnonymousBlockWithStyle(parent.protectedDocument(), parent.style());
+        auto newBlock = Block::createAnonymousBlockWithStyle(parent.protectedDocument(), parent.containingBlock()->style());
         newBlock->setChildrenInline(false);
         CheckedRef block = *newBlock;
         m_builder.attachToRenderElementInternal(parent, WTFMove(newBlock), firstInRun.get());


### PR DESCRIPTION
#### b43707b807acb38cbd30ca6d2936f9434a6db390
<pre>
[blocks-in-inline] Inherit anonymous block from containing block
<a href="https://bugs.webkit.org/show_bug.cgi?id=303106">https://bugs.webkit.org/show_bug.cgi?id=303106</a>
<a href="https://rdar.apple.com/165406191">rdar://165406191</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-anon-block-inheritance.html
* LayoutTests/fast/inline/blocks-in-inline-anon-block-inheritance-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-anon-block-inheritance.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::wrapRunsOfBlocksInAnonymousBlock):

This anonymous block represents the containing block rather than the parent inline box.
Inherit from the block instead.

Canonical link: <a href="https://commits.webkit.org/303549@main">https://commits.webkit.org/303549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0e80cabdae2256a5bb6549d68041a51d349ccfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84806 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f76f37b8-1cb1-42a2-a4e8-fb98b3ffced2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101520 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d3c5c30-0f82-48bc-8c7a-ca10db7018e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9f896dd6-71f7-4456-bf8f-fc0a0e5f955b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83543 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142965 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109892 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110070 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27903 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3781 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58448 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4997 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33573 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5088 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4954 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->