### PR TITLE
Reuse pointer space in StringImplShape (draft)

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2283,7 +2283,22 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             jit.moveTrustedValue(jsBoolean(true), valueRegs);
         else {
             jit.load32(CCallHelpers::Address(scratch2GPR, StringImpl::flagsOffset()), scratchGPR);
+
+
+
+            // NEW: scratch2GPR , scratch2GPR
+            auto oldPath = jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch2GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+            jit.move(scratch2GPR, scratch2GPR);
+            jit.addPtr(CCallHelpers::TrustedImmPtr(StringImpl::dataOffset()), scratch2GPR);
+            auto newPathEnd = jit.jump();
+            oldPath.link(&jit);
+            // OLD:
             jit.loadPtr(CCallHelpers::Address(scratch2GPR, StringImpl::dataOffset()), scratch2GPR);
+            // END OLD:
+            newPathEnd.link(&jit);
+
+
+
             auto is16Bit = jit.branchTest32(CCallHelpers::Zero, scratchGPR, CCallHelpers::TrustedImm32(StringImpl::flagIs8Bit()));
             jit.zeroExtend32ToWord(propertyGPR, scratchGPR);
             jit.load8(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesOne, 0), scratch2GPR);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1872,9 +1872,6 @@ void SpeculativeJIT::compileToLowerCase(Node* node)
     // END OLD:
     newPathEnd.link(this);
 
-
-    
-    
     auto loopStart = label();
     auto loopDone = branch32(AboveOrEqual, indexGPR, lengthGPR);
     load8(BaseIndex(tempGPR, indexGPR, TimesOne), charGPR);
@@ -12765,15 +12762,14 @@ void SpeculativeJIT::emitSwitchCharStringJump(Node* node, SwitchData* data, GPRR
     loadPtr(Address(scratch, StringImpl::dataOffset()), value);
     // END OLD:
     newPathEnd1.link(this);
-    
-    
+
     Jump is8Bit = branchTest32(
         NonZero,
         Address(scratch, StringImpl::flagsOffset()),
         TrustedImm32(StringImpl::flagIs8Bit()));
     
     load16(Address(value), scratch);
-    
+
     Jump ready = jump();
     
     is8Bit.link(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1746,7 +1746,21 @@ void SpeculativeJIT::compileStringSlice(Node* node)
 
     // Refill StringImpl* here.
     loadPtr(Address(stringGPR, JSString::offsetOfValue()), temp2GPR);
+
+
+
+    // NEW: temp2GPR, tempGPR
+    auto oldPath = branchTest32(Zero, Address(temp2GPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(temp2GPR, tempGPR);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), tempGPR);
+    auto newPathEnd = jump();
+    oldPath.link(this);
+    // OLD:
     loadPtr(Address(temp2GPR, StringImpl::dataOffset()), tempGPR);
+    // END OLD:
+    newPathEnd.link(this);
+
+
 
     // Load the character into scratchReg
     zeroExtend32ToWord(startIndexGPR, startIndexGPR);
@@ -1844,8 +1858,23 @@ void SpeculativeJIT::compileToLowerCase(Node* node)
         Zero, Address(tempGPR, StringImpl::flagsOffset()),
         TrustedImm32(StringImpl::flagIs8Bit())));
     load32(Address(tempGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
-    loadPtr(Address(tempGPR, StringImpl::dataOffset()), tempGPR);
 
+
+
+    // NEW: tempGPR, tempGPR
+    auto oldPath = branchTest32(Zero, Address(tempGPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(tempGPR, tempGPR);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), tempGPR);
+    auto newPathEnd = jump();
+    oldPath.link(this);
+    // OLD:
+    loadPtr(Address(tempGPR, StringImpl::dataOffset()), tempGPR);
+    // END OLD:
+    newPathEnd.link(this);
+
+
+    
+    
     auto loopStart = label();
     auto loopDone = branch32(AboveOrEqual, indexGPR, lengthGPR);
     load8(BaseIndex(tempGPR, indexGPR, TimesOne), charGPR);
@@ -1891,7 +1920,22 @@ void SpeculativeJIT::compileStringCodePointAt(Node* node)
     speculationCheck(Uncountable, JSValueRegs(), nullptr, branch32(AboveOrEqual, indexGPR, scratch2GPR));
 
     // Load the character into scratch1GPR
+
+
+
+    // NEW: scratch1GPR, scratch4GPR
+    auto oldPath = branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(scratch1GPR, scratch4GPR);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), scratch4GPR);
+    auto newPathEnd = jump();
+    oldPath.link(this);
+    // OLD:
     loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch4GPR);
+    // END OLD:
+    newPathEnd.link(this);
+
+
+
     auto is16Bit = branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
 
     JumpList done;
@@ -2583,13 +2627,43 @@ void SpeculativeJIT::compileGetCharCodeAt(Node* node)
     // Load the character into scratchReg
     Jump is16Bit = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
 
+
+
+    // NEW: scratchReg, scratchReg
+    auto oldPath1 = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(scratchReg, scratchReg);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), scratchReg);
+    auto newPathEnd1 = jump();
+    oldPath1.link(this);
+    // OLD:
     loadPtr(Address(scratchReg, StringImpl::dataOffset()), scratchReg);
+    // END OLD:
+    newPathEnd1.link(this);
+
+
+
     load8(BaseIndex(scratchReg, indexReg, TimesOne, 0), scratchReg);
     Jump cont8Bit = jump();
 
     is16Bit.link(this);
 
+
+
+
+
+    // NEW: scratchReg, scratchReg
+    auto oldPath2 = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(scratchReg, scratchReg);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), scratchReg);
+    auto newPathEnd2 = jump();
+    oldPath2.link(this);
+    // OLD:
     loadPtr(Address(scratchReg, StringImpl::dataOffset()), scratchReg);
+    // END OLD:
+    newPathEnd2.link(this);
+
+
+
     load16(BaseIndex(scratchReg, indexReg, TimesTwo, 0), scratchReg);
 
     cont8Bit.link(this);
@@ -2640,7 +2714,21 @@ void SpeculativeJIT::compileGetByValOnString(Node* node, const ScopedLambda<std:
     // Load the character into scratchReg
     Jump is16Bit = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
 
+
+
+    // NEW: scratchReg, scratchReg
+    auto oldPath = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(scratchReg, scratchReg);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), scratchReg);
+    auto newPathEnd = jump();
+    oldPath.link(this);
+    // OLD:
     loadPtr(Address(scratchReg, StringImpl::dataOffset()), scratchReg);
+    // END OLD:
+    newPathEnd.link(this);
+
+
+
     load8(BaseIndex(scratchReg, propertyTempReg, TimesOne, 0), scratchReg);
 #if USE(JSVALUE32_64)
     if (node->op() == StringAt && node->arrayMode().isOutOfBounds())
@@ -2668,7 +2756,21 @@ void SpeculativeJIT::compileGetByValOnString(Node* node, const ScopedLambda<std:
 
     is16Bit.link(this);
 
+
+
+    // NEW: scratchReg, scratchReg
+    auto oldPath2 = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(scratchReg, scratchReg);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), scratchReg);
+    auto newPathEnd2 = jump();
+    oldPath2.link(this);
+    // OLD:
     loadPtr(Address(scratchReg, StringImpl::dataOffset()), scratchReg);
+    // END OLD:
+    newPathEnd2.link(this);
+
+
+
     load16(BaseIndex(scratchReg, propertyTempReg, TimesTwo, 0), scratchReg);
 #if USE(JSVALUE32_64)
     if (node->op() == StringAt && node->arrayMode().isOutOfBounds())
@@ -7477,8 +7579,31 @@ void SpeculativeJIT::compileStringEquality(
         Address(rightTempGPR, StringImpl::flagsOffset()),
         TrustedImm32(StringImpl::flagIs8Bit())));
     
+
+
+    // NEW: leftTempGPR, leftTempGPR
+    auto oldPath1 = branchTest32(Zero, Address(leftTempGPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(leftTempGPR, leftTempGPR);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), leftTempGPR);
+    auto newPathEnd1 = jump();
+    oldPath1.link(this);
+    // OLD:
     loadPtr(Address(leftTempGPR, StringImpl::dataOffset()), leftTempGPR);
+    // END OLD:
+    newPathEnd1.link(this);
+
+    // NEW: rightTempGPR, rightTempGPR
+    auto oldPath2 = branchTest32(Zero, Address(rightTempGPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(rightTempGPR, rightTempGPR);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), rightTempGPR);
+    auto newPathEnd2 = jump();
+    oldPath2.link(this);
+    // OLD:
     loadPtr(Address(rightTempGPR, StringImpl::dataOffset()), rightTempGPR);
+    // END OLD:
+    newPathEnd2.link(this);
+
+
     
     Label loop = label();
     
@@ -9899,8 +10024,31 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
                 TrustedImm32(StringImpl::flagIs8Bit())
             ));
 
+
+
+            // NEW: leftStringGPR, leftStringGPR
+            auto oldPath1 = branchTest32(Zero, Address(leftStringGPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+            move(leftStringGPR, leftStringGPR);
+            addPtr(TrustedImmPtr(StringImpl::dataOffset()), leftStringGPR);
+            auto newPathEnd1 = jump();
+            oldPath1.link(this);
+            // OLD:
             loadPtr(Address(leftStringGPR, StringImpl::dataOffset()), leftStringGPR);
+            // END OLD:
+            newPathEnd1.link(this);
+
+            // NEW: rightStringGPR, rightStringGPR
+            auto oldPath2 = branchTest32(Zero, Address(rightStringGPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+            move(rightStringGPR, rightStringGPR);
+            addPtr(TrustedImmPtr(StringImpl::dataOffset()), rightStringGPR);
+            auto newPathEnd2 = jump();
+            oldPath2.link(this);
+            // OLD:
             loadPtr(Address(rightStringGPR, StringImpl::dataOffset()), rightStringGPR);
+            // END OLD:
+            newPathEnd2.link(this);
+
+
 
             sub32(TrustedImm32(1), compareLengthGPR);
 
@@ -12606,7 +12754,18 @@ void SpeculativeJIT::emitSwitchCharStringJump(Node* node, SwitchData* data, GPRR
             TrustedImm32(1)),
         data->fallThrough.block);
     
+
+    // NEW: scratch, value
+    auto oldPath1 = branchTest32(Zero, Address(scratch, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(scratch, value);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), value);
+    auto newPathEnd1 = jump();
+    oldPath1.link(this);
+    // OLD:
     loadPtr(Address(scratch, StringImpl::dataOffset()), value);
+    // END OLD:
+    newPathEnd1.link(this);
+    
     
     Jump is8Bit = branchTest32(
         NonZero,
@@ -12859,7 +13018,18 @@ void SpeculativeJIT::emitSwitchStringOnString(Node* node, SwitchData* data, GPRR
         Address(tempGPR, StringImpl::flagsOffset()),
         TrustedImm32(StringImpl::flagIs8Bit())));
     
+
+
+    // NEW: tempGPR, string
+    auto oldPath1 = branchTest32(Zero, Address(tempGPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(tempGPR, string);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), string);
+    auto newPathEnd1 = jump();
+    oldPath1.link(this);
+    // OLD:
     loadPtr(Address(tempGPR, StringImpl::dataOffset()), string);
+    // END OLD:
+    newPathEnd1.link(this);
     
     Vector<StringSwitchCase> cases;
     for (unsigned i = 0; i < data->cases.size(); ++i) {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3045,7 +3045,21 @@ void SpeculativeJIT::compileRegExpTestInline(Node* node)
             Address(stringImplGPR, StringImpl::flagsOffset()),
             TrustedImm32(StringImpl::flagIs8Bit())));
 
+
+
+        // NEW: stringImplGPR, stringDataGPR
+        auto oldPath = branchTest32(Zero, Address(stringImplGPR, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+        move(stringImplGPR, stringDataGPR);
+        addPtr(TrustedImmPtr(StringImpl::dataOffset()), stringDataGPR);
+        auto newPathEnd = jump();
+        oldPath.link(this);
+        // OLD:
         loadPtr(Address(stringImplGPR, StringImpl::dataOffset()), stringDataGPR);
+        // END OLD:
+        newPathEnd.link(this);
+
+
+
         load32(Address(stringImplGPR, StringImpl::lengthMemoryOffset()), strLengthGPR);
 
         // Clobbering input registers is OK since we already called flushRegisters.

--- a/Source/JavaScriptCore/jit/JITInlines.h
+++ b/Source/JavaScriptCore/jit/JITInlines.h
@@ -77,7 +77,21 @@ ALWAYS_INLINE void JIT::emitLoadCharacterString(RegisterID src, RegisterID dst, 
     loadPtr(MacroAssembler::Address(src, JSString::offsetOfValue()), dst);
     failures.append(branchIfRopeStringImpl(dst));
     failures.append(branch32(NotEqual, MacroAssembler::Address(dst, StringImpl::lengthMemoryOffset()), TrustedImm32(1)));
+
+
+
+    // NEW: dst, regT1
+    auto oldPath = branchTest32(Zero, Address(dst, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(dst, regT1);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), regT1);
+    auto newPathEnd = jump();
+    oldPath.link(this);
+    // OLD:
     loadPtr(MacroAssembler::Address(dst, StringImpl::dataOffset()), regT1);
+    // END OLD:
+    newPathEnd.link(this);
+
+
 
     auto is16Bit = branchTest32(Zero, Address(dst, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
     load8(MacroAssembler::Address(regT1, 0), dst);

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1327,7 +1327,22 @@ void JIT::emit_op_switch_char(const JSInstruction* currentInstruction)
     loadPtr(Address(jsRegT10.payloadGPR(), JSString::offsetOfValue()), regT4);
     auto isRope = branchIfRopeStringImpl(regT4);
     addJump(branch32(NotEqual, Address(regT4, StringImpl::lengthMemoryOffset()), TrustedImm32(1)), defaultOffset);
+
+
+
+    // NEW: regT4, regT5
+    auto oldPath = branchTest32(Zero, Address(regT4, StringImpl::flagsOffset()), TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    move(regT4, regT5);
+    addPtr(TrustedImmPtr(StringImpl::dataOffset()), regT5);
+    auto newPathEnd = jump();
+    oldPath.link(this);
+    // OLD:
     loadPtr(Address(regT4, StringImpl::dataOffset()), regT5);
+    // END OLD:
+    newPathEnd.link(this);
+
+
+
     auto is8Bit = branchTest32(NonZero, Address(regT4, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
     load16(Address(regT5), regT5);
     auto loaded = jump();

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -621,7 +621,23 @@ MacroAssemblerCodeRef<JITThunkPtrTag> stringGetByValGenerator(VM& vm)
     JSInterfaceJIT::JumpList cont8Bit;
     // Load the string flags
     jit.load32(JSInterfaceJIT::Address(stringGPR, StringImpl::flagsOffset()), scratchGPR);
+
+
+    // NEW: stringGPR, stringGPR
+    auto oldPath = jit.branchTest32(
+        JSInterfaceJIT::Zero,
+        JSInterfaceJIT::Address(stringGPR, StringImpl::flagsOffset()),
+        JSInterfaceJIT::TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    jit.move(stringGPR, stringGPR);
+    jit.addPtr(JSInterfaceJIT::TrustedImmPtr(StringImpl::dataOffset()), stringGPR);
+    auto newPathEnd = jit.jump();
+    oldPath.link(&jit);
+    // OLD:
     jit.loadPtr(JSInterfaceJIT::Address(stringGPR, StringImpl::dataOffset()), stringGPR);
+    // END OLD:
+    newPathEnd.link(&jit);
+
+
     auto is16Bit = jit.branchTest32(JSInterfaceJIT::Zero, scratchGPR, JSInterfaceJIT::TrustedImm32(StringImpl::flagIs8Bit()));
     jit.load8(JSInterfaceJIT::BaseIndex(stringGPR, indexGPR, JSInterfaceJIT::TimesOne, 0), stringGPR);
     cont8Bit.append(jit.jump());
@@ -672,7 +688,23 @@ static void stringCharLoad(SpecializedThunkJIT& jit)
     SpecializedThunkJIT::JumpList cont8Bit;
     // Load the string flags
     jit.load32(MacroAssembler::Address(SpecializedThunkJIT::regT0, StringImpl::flagsOffset()), SpecializedThunkJIT::regT2);
+
+
+    // NEW:
+    auto oldPath = jit.branchTest32(
+        JSInterfaceJIT::Zero,
+        JSInterfaceJIT::Address(SpecializedThunkJIT::regT0, StringImpl::flagsOffset()),
+        JSInterfaceJIT::TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    jit.move(SpecializedThunkJIT::regT0, SpecializedThunkJIT::regT0);
+    jit.addPtr(JSInterfaceJIT::TrustedImmPtr(StringImpl::dataOffset()), SpecializedThunkJIT::regT0);
+    auto newPathEnd = jit.jump();
+    oldPath.link(&jit);
+    // OLD:
     jit.loadPtr(MacroAssembler::Address(SpecializedThunkJIT::regT0, StringImpl::dataOffset()), SpecializedThunkJIT::regT0);
+    // END OLD:
+    newPathEnd.link(&jit);
+    
+
     is16Bit.append(jit.branchTest32(MacroAssembler::Zero, SpecializedThunkJIT::regT2, MacroAssembler::TrustedImm32(StringImpl::flagIs8Bit())));
     jit.load8(MacroAssembler::BaseIndex(SpecializedThunkJIT::regT0, SpecializedThunkJIT::regT1, MacroAssembler::TimesOne, 0), SpecializedThunkJIT::regT0);
     cont8Bit.append(jit.jump());
@@ -796,7 +828,23 @@ MacroAssemblerCodeRef<JITThunkPtrTag> stringPrototypeCodePointAtThunkGenerator(V
     // Load the character
     CCallHelpers::JumpList done;
     // Load the string flags
+
+
+    // NEW:
+    auto oldPath = jit.branchTest32(
+        JSInterfaceJIT::Zero,
+        JSInterfaceJIT::Address(SpecializedThunkJIT::regT0, StringImpl::flagsOffset()),
+        JSInterfaceJIT::TrustedImm32(64)); // 64 is the "is immediate flag", if unset take the old path
+    jit.move(GPRInfo::regT0, GPRInfo::regT2);
+    jit.addPtr(JSInterfaceJIT::TrustedImmPtr(StringImpl::dataOffset()), GPRInfo::regT2);
+    auto newPathEnd = jit.jump();
+    oldPath.link(&jit);
+    // OLD:
     jit.loadPtr(CCallHelpers::Address(GPRInfo::regT0, StringImpl::dataOffset()), GPRInfo::regT2);
+    // END OLD:
+    newPathEnd.link(&jit);
+
+
     auto is16Bit = jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(GPRInfo::regT0, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIs8Bit()));
     jit.load8(CCallHelpers::BaseIndex(GPRInfo::regT2, GPRInfo::regT1, CCallHelpers::TimesOne, 0), GPRInfo::regT0);
     done.append(jit.jump());

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -703,7 +703,6 @@ static void stringCharLoad(SpecializedThunkJIT& jit)
     jit.loadPtr(MacroAssembler::Address(SpecializedThunkJIT::regT0, StringImpl::dataOffset()), SpecializedThunkJIT::regT0);
     // END OLD:
     newPathEnd.link(&jit);
-    
 
     is16Bit.append(jit.branchTest32(MacroAssembler::Zero, SpecializedThunkJIT::regT2, MacroAssembler::TrustedImm32(StringImpl::flagIs8Bit())));
     jit.load8(MacroAssembler::BaseIndex(SpecializedThunkJIT::regT0, SpecializedThunkJIT::regT1, MacroAssembler::TimesOne, 0), SpecializedThunkJIT::regT0);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -2283,7 +2283,7 @@ llintOpWithJump(op_switch_char, OpSwitchChar, macro (size, get, jump, dispatch)
     loadi UnlinkedSimpleJumpTable::m_min[t2], t3
     bieq t3, (constexpr INT32_MAX), .opSwitchSlow
 
-    loadp StringImpl::m_data8[t1], t0
+    loadp StringImpl::m_data.latin1[t1], t0
     btinz StringImpl::m_hashAndFlags[t1], HashFlags8BitBuffer, .opSwitchChar8Bit
     loadh [t0], t0
     jmp .opSwitchCharReady

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -2451,7 +2451,14 @@ llintOpWithJump(op_switch_char, OpSwitchChar, macro (size, get, jump, dispatch)
     loadi UnlinkedSimpleJumpTable::m_min[t2], t3
     bieq t3, (constexpr INT32_MAX), .opSwitchSlow
 
-    loadp StringImpl::m_data8[t0], t1
+    btiz StringImpl::m_hashAndFlags[t0], 64, .opOriginalLogic
+    move t0, t1
+    addp (constexpr (StringImpl::dataOffset())), t1
+    jmp .opImmediateLoadDone
+
+.opOriginalLogic:
+    loadp StringImpl::m_data.latin1[t0], t1
+.opImmediateLoadDone:
     btinz StringImpl::m_hashAndFlags[t0], HashFlags8BitBuffer, .opSwitchChar8Bit
     loadh [t1], t0
     jmp .opSwitchCharReady

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -136,13 +136,13 @@ StringImpl::~StringImpl()
     case BufferInternal:
         break;
     case BufferOwned:
-        // We use m_data8, but since it is a union with m_data16 this works either way.
-        ASSERT(m_data8);
-        StringImplMalloc::free(const_cast<Latin1Character*>(m_data8));
+        // We use m_data.latin1, but since it is a union with m_data.char16 this works either way.
+        ASSERT(m_data.latin1);
+        StringImplMalloc::free(const_cast<Latin1Character*>(m_data.latin1));
         break;
     case BufferExternal: {
         auto* external = static_cast<ExternalStringImpl*>(this);
-        external->freeExternalBuffer(const_cast<Latin1Character*>(m_data8), sizeInBytes());
+        external->freeExternalBuffer(const_cast<Latin1Character*>(m_data.latin1), sizeInBytes());
         external->m_free.~ExternalStringImplFreeFunction();
         break;
     }
@@ -192,7 +192,7 @@ template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninit
         CRASH();
 
     SUPPRESS_UNCOUNTED_LOCAL StringImpl* string = static_cast<StringImpl*>(StringImplMalloc::malloc(allocationSize<CharacterType>(length)));
-    data = unsafeMakeSpan(string->tailPointer<CharacterType>(), length);
+    data = unsafeMakeSpan(string->bufferPointer<CharacterType>(), length);
     return constructInternal<CharacterType>(*string, length);
 }
 
@@ -228,7 +228,7 @@ template<typename CharacterType> inline Expected<Ref<StringImpl>, UTF8Conversion
     if (!string)
         return makeUnexpected(UTF8ConversionError::OutOfMemory);
 
-    data = string->tailPointer<CharacterType>();
+    data = string->bufferPointer<CharacterType>();
     return constructInternal<CharacterType>(*string, length);
 }
 
@@ -424,13 +424,13 @@ Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocale()
     auto newImpl = createUninitializedInternalNonEmpty(m_length, data16);
 
     UErrorCode status = U_ZERO_ERROR;
-    int32_t realLength = u_strToLower(data16.data(), length, m_data16, m_length, "", &status);
+    int32_t realLength = u_strToLower(data16.data(), length, m_data.char16, m_length, "", &status);
     if (U_SUCCESS(status) && realLength == length)
         return newImpl;
 
     newImpl = createUninitialized(realLength, data16);
     status = U_ZERO_ERROR;
-    u_strToLower(data16.data(), realLength, m_data16, m_length, "", &status);
+    u_strToLower(data16.data(), realLength, m_data.char16, m_length, "", &status);
     if (U_FAILURE(status))
         return *this;
     return newImpl;

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -424,13 +424,13 @@ Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocale()
     auto newImpl = createUninitializedInternalNonEmpty(m_length, data16);
 
     UErrorCode status = U_ZERO_ERROR;
-    int32_t realLength = u_strToLower(data16.data(), length, m_data.char16, m_length, "", &status);
+    int32_t realLength = u_strToLower(data16.data(), length, dataC16(), m_length, "", &status);
     if (U_SUCCESS(status) && realLength == length)
         return newImpl;
 
     newImpl = createUninitialized(realLength, data16);
     status = U_ZERO_ERROR;
-    u_strToLower(data16.data(), realLength, m_data.char16, m_length, "", &status);
+    u_strToLower(data16.data(), realLength, dataC16(), m_length, "", &status);
     if (U_FAILURE(status))
         return *this;
     return newImpl;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -152,8 +152,10 @@ public:
     static constexpr unsigned MaxLength = std::numeric_limits<int32_t>::max();
     static constexpr unsigned dataOffset() { return OBJECT_OFFSETOF(StringImplShape, m_data); }
 
+    enum InlineBufferTag { InlineBuffer };
     StringImplShape(unsigned refCount, std::span<const Latin1Character>, unsigned hashAndFlags);
     StringImplShape(unsigned refCount, std::span<const char16_t>, unsigned hashAndFlags);
+    StringImplShape(unsigned refCount, unsigned length, unsigned hashAndFlags, InlineBufferTag);
 
     enum ConstructWithConstExprTag { ConstructWithConstExpr };
     template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
@@ -215,7 +217,7 @@ public:
         PointerUnion m_data;
         char m_space8[1];
         Latin1Character m_spaceLatin1[1];
-        char16_t m_space16[1];        
+        char16_t m_space16[1];
     };
 };
 
@@ -267,7 +269,8 @@ private:
 
     // Create a normal 8-bit string with internal storage (BufferInternal).
     enum Force8Bit { Force8BitConstructor };
-    enum InlineBufferTag { InlineBuffer };
+    using StringImplShape::InlineBufferTag;
+    using StringImplShape::InlineBuffer;
     StringImpl(unsigned length, Force8Bit, InlineBufferTag);
 
     // Create a normal 16-bit string with internal storage (BufferInternal).
@@ -917,7 +920,7 @@ inline StringImplShape::StringImplShape(unsigned refCount, std::span<const Latin
     : m_refCount(refCount)
     , m_length(data.size())
     , m_hashAndFlags(hashAndFlags)
-    , m_data{.latin1 = data.data()}
+    , m_data { .latin1 = data.data() }
 {
     RELEASE_ASSERT(data.size() <= MaxLength);
 }
@@ -926,16 +929,24 @@ inline StringImplShape::StringImplShape(unsigned refCount, std::span<const char1
     : m_refCount(refCount)
     , m_length(data.size())
     , m_hashAndFlags(hashAndFlags)
-    , m_data{.char16 = data.data()}
+    , m_data { .char16 = data.data() }
 {
     RELEASE_ASSERT(data.size() <= MaxLength);
+}
+
+inline StringImplShape::StringImplShape(unsigned refCount, unsigned length, unsigned hashAndFlags, InlineBufferTag)
+    : m_refCount(refCount)
+    , m_length(length)
+    , m_hashAndFlags(hashAndFlags)
+{
+    RELEASE_ASSERT(length <= MaxLength);
 }
 
 template<unsigned characterCount> constexpr StringImplShape::StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag)
     : m_refCount(refCount)
     , m_length(length)
     , m_hashAndFlags(hashAndFlags)
-    , m_data{.char8 = characters}
+    , m_data { .char8 = characters }
 {
     RELEASE_ASSERT(length <= MaxLength);
 }
@@ -944,7 +955,7 @@ template<unsigned characterCount> constexpr StringImplShape::StringImplShape(uns
     : m_refCount(refCount)
     , m_length(length)
     , m_hashAndFlags(hashAndFlags)
-    , m_data{.char16 = characters}
+    , m_data { .char16 = characters }
 {
     RELEASE_ASSERT(length <= MaxLength);
 }
@@ -997,7 +1008,7 @@ template<bool isSpecialCharacter(char16_t)> inline bool StringImpl::containsOnly
 }
 
 inline StringImpl::StringImpl(unsigned length, Force8Bit, InlineBufferTag)
-    : StringImplShape(s_refCountIncrement, unsafeMakeSpan(bufferPointer<Latin1Character>(), length), s_hashFlag8BitBuffer | StringWithInlineBuffer | BufferInternal)
+    : StringImplShape(s_refCountIncrement, length, s_hashFlag8BitBuffer | StringWithInlineBuffer | BufferInternal, InlineBuffer)
 {
     ASSERT(dataLatin1());
     ASSERT(m_length);
@@ -1006,7 +1017,7 @@ inline StringImpl::StringImpl(unsigned length, Force8Bit, InlineBufferTag)
 }
 
 inline StringImpl::StringImpl(unsigned length, InlineBufferTag)
-    : StringImplShape(s_refCountIncrement, unsafeMakeSpan(bufferPointer<char16_t>(), length), s_hashZeroValue | StringWithInlineBuffer | BufferInternal)
+    : StringImplShape(s_refCountIncrement, length, s_hashZeroValue | StringWithInlineBuffer | BufferInternal, InlineBuffer)
 {
     ASSERT(dataC16());
     ASSERT(m_length);
@@ -1274,7 +1285,7 @@ inline StringImpl::StringImpl(CreateSymbolTag)
 
 template<typename T> inline size_t StringImpl::allocationSize(Checked<size_t> nCharacters)
 {
-    size_t sizeWithInlineString = tailOffset<T>() + nCharacters * sizeof(T);
+    size_t sizeWithInlineString = bufferOffset<T>() + nCharacters * sizeof(T);
     return sizeWithInlineString > sizeof(StringImpl) ? sizeWithInlineString : sizeof(StringImpl);
 }
 

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -150,8 +150,8 @@ class STRING_IMPL_ALIGNMENT StringImplShape  {
     WTF_MAKE_NONCOPYABLE(StringImplShape);
 public:
     static constexpr unsigned MaxLength = std::numeric_limits<int32_t>::max();
+    static constexpr unsigned dataOffset() { return OBJECT_OFFSETOF(StringImplShape, m_data); }
 
-protected:
     StringImplShape(unsigned refCount, std::span<const Latin1Character>, unsigned hashAndFlags);
     StringImplShape(unsigned refCount, std::span<const char16_t>, unsigned hashAndFlags);
 
@@ -159,17 +159,64 @@ protected:
     template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
     template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char16_t (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
 
+    // The bottom 6 bits in the hash are flags, but reserve 8 bits since StringHash only has 24 bits anyway.
+    static constexpr const unsigned s_flagCount = 8;
+
+    static constexpr const unsigned s_flagMask = (1u << s_flagCount) - 1;
+    static_assert(s_flagCount <= StringHasher::flagCount, "StringHasher reserves enough bits for StringImpl flags");
+    static constexpr const unsigned s_flagStringKindCount = 4;
+
+    static constexpr const unsigned s_hashZeroValue = 0;
+    static constexpr const unsigned s_hashFlagStringKindIsAtom = 1u << (s_flagStringKindCount);
+    static constexpr const unsigned s_hashFlagStringKindIsSymbol = 1u << (s_flagStringKindCount + 1);
+    static constexpr const unsigned s_hashFlagStringHasInlineBuffer = 1u << (s_flagStringKindCount + 2);
+    static constexpr const unsigned s_hashMaskStringKind = s_hashFlagStringKindIsAtom | s_hashFlagStringKindIsSymbol;
+    static constexpr const unsigned s_hashFlagDidReportCost = 1u << 3;
+    static constexpr const unsigned s_hashFlag8BitBuffer = 1u << 2;
+    static constexpr const unsigned s_hashMaskBufferOwnership = (1u << 0) | (1u << 1);
+
+    enum StringKind {
+        StringNormal = 0u, // non-symbol, non-atomic
+        StringAtom = s_hashFlagStringKindIsAtom, // non-symbol, atomic
+        StringSymbol = s_hashFlagStringKindIsSymbol, // symbol, non-atomic
+        StringWithInlineBuffer = s_hashFlagStringHasInlineBuffer, // non-symbol, non-atomic, contiguous
+    };
+
+    enum BufferOwnership {
+        BufferInternal,
+        BufferOwned,
+        BufferSubstring,
+        BufferExternal
+    };
+    constexpr BufferOwnership bufferOwnership() const { return static_cast<BufferOwnership>(m_hashAndFlags & s_hashMaskBufferOwnership); }
+    constexpr bool isExternal() const { return bufferOwnership() == BufferExternal; }
+    constexpr bool isSubString() const { return bufferOwnership() == BufferSubstring; }
+    constexpr bool isInternal() const { return bufferOwnership() == BufferInternal; }
+    constexpr bool isBufferInline() const { return m_hashAndFlags & s_hashFlagStringHasInlineBuffer; }
+
+    constexpr auto dataLatin1() const { return isBufferInline() ? m_spaceLatin1 : m_data.latin1; }
+    constexpr auto dataC8() const { return isBufferInline() ? m_space8 : m_data.char8; }
+    constexpr auto dataC16() const { return isBufferInline() ? m_space16 : m_data.char16; }
+
     std::atomic<unsigned> m_refCount;
     unsigned m_length;
-    union {
-        const Latin1Character* m_data8;
-        const char16_t* m_data16;
-        // It seems that reinterpret_cast prevents constexpr's compile time initialization in VC++.
-        // These are needed to avoid reinterpret_cast.
-        const char* m_data8Char;
-        const char16_t* m_data16Char;
-    };
     mutable unsigned m_hashAndFlags;
+
+    // A pointer union is required for constexpr usage - reinterpret_cast<> is illegal
+    // in constexpr contexts due UB concerns; plain unions don't have this limitation
+    // because the compiler tracks the type they were initialized with.
+    typedef union {
+        const Latin1Character* const latin1;
+        const char* const char8;
+        const char16_t* const char16;
+    } PointerUnion;
+
+    union {
+        PointerUnion m_data;
+        char m_space8[1];
+        Latin1Character m_spaceLatin1[1];
+        char16_t m_space16[1];        
+    };
 };
 
 // FIXME: Use of StringImpl and const is rather confused.
@@ -205,41 +252,26 @@ class StringImpl : private StringImplShape, public NoVirtualDestructorBase {
     friend WTF_EXPORT_PRIVATE bool equal(const StringImpl&, const StringImpl&);
 
 public:
-    enum BufferOwnership { BufferInternal, BufferOwned, BufferSubstring, BufferExternal };
-
     // Prefer using isValidLength over MaxLength when the character type is known.
     template<typename> static constexpr bool isValidLength(size_t);
 
-    static constexpr unsigned MaxLength = StringImplShape::MaxLength;
-
-    // The bottom 6 bits in the hash are flags, but reserve 8 bits since StringHash only has 24 bits anyway.
-    static constexpr const unsigned s_flagCount = 8;
+    using StringImplShape::BufferOwnership;
+    using StringImplShape::BufferInternal;
+    using StringImplShape::BufferOwned;
+    using StringImplShape::BufferSubstring;
+    using StringImplShape::BufferExternal;
+    using StringImplShape::MaxLength;
+    using StringImplShape::s_flagCount;
 
 private:
-    static constexpr const unsigned s_flagMask = (1u << s_flagCount) - 1;
-    static_assert(s_flagCount <= StringHasher::flagCount, "StringHasher reserves enough bits for StringImpl flags");
-    static constexpr const unsigned s_flagStringKindCount = 4;
-
-    static constexpr const unsigned s_hashZeroValue = 0;
-    static constexpr const unsigned s_hashFlagStringKindIsAtom = 1u << (s_flagStringKindCount);
-    static constexpr const unsigned s_hashFlagStringKindIsSymbol = 1u << (s_flagStringKindCount + 1);
-    static constexpr const unsigned s_hashMaskStringKind = s_hashFlagStringKindIsAtom | s_hashFlagStringKindIsSymbol;
-    static constexpr const unsigned s_hashFlagDidReportCost = 1u << 3;
-    static constexpr const unsigned s_hashFlag8BitBuffer = 1u << 2;
-    static constexpr const unsigned s_hashMaskBufferOwnership = (1u << 0) | (1u << 1);
-
-    enum StringKind {
-        StringNormal = 0u, // non-symbol, non-atomic
-        StringAtom = s_hashFlagStringKindIsAtom, // non-symbol, atomic
-        StringSymbol = s_hashFlagStringKindIsSymbol, // symbol, non-atomic
-    };
 
     // Create a normal 8-bit string with internal storage (BufferInternal).
     enum Force8Bit { Force8BitConstructor };
-    StringImpl(unsigned length, Force8Bit);
+    enum InlineBufferTag { InlineBuffer };
+    StringImpl(unsigned length, Force8Bit, InlineBufferTag);
 
     // Create a normal 16-bit string with internal storage (BufferInternal).
-    explicit StringImpl(unsigned length);
+    explicit StringImpl(unsigned length, InlineBufferTag);
 
     // Create a StringImpl adopting ownership of the provided buffer (BufferOwned).
     template<typename Malloc> explicit StringImpl(MallocSpan<Latin1Character, Malloc>);
@@ -304,7 +336,8 @@ public:
     static constexpr unsigned flagIsAtom() { return s_hashFlagStringKindIsAtom; }
     static constexpr unsigned flagIsSymbol() { return s_hashFlagStringKindIsSymbol; }
     static constexpr unsigned maskStringKind() { return s_hashMaskStringKind; }
-    static constexpr unsigned dataOffset() { return OBJECT_OFFSETOF(StringImpl, m_data8); }
+    using StringImplShape::dataOffset;
+
 
     template<typename CharacterType, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
     static Ref<StringImpl> adopt(Vector<CharacterType, inlineCapacity, OverflowHandler, minCapacity, Malloc>&&);
@@ -317,8 +350,8 @@ public:
     bool isEmpty() const { return !m_length; }
 
     bool is8Bit() const { return m_hashAndFlags & s_hashFlag8BitBuffer; }
-    ALWAYS_INLINE std::span<const Latin1Character> span8() const LIFETIME_BOUND { ASSERT(is8Bit()); return unsafeMakeSpan(m_data8, length()); }
-    ALWAYS_INLINE std::span<const char16_t> span16() const LIFETIME_BOUND { ASSERT(!is8Bit() || isEmpty()); return unsafeMakeSpan(m_data16, length()); }
+    ALWAYS_INLINE std::span<const Latin1Character> span8() const LIFETIME_BOUND { ASSERT(is8Bit()); return unsafeMakeSpan(dataLatin1(), length()); }
+    ALWAYS_INLINE std::span<const char16_t> span16() const LIFETIME_BOUND { ASSERT(!is8Bit() || isEmpty()); return unsafeMakeSpan(dataC16(), length()); }
 
     template<typename CharacterType> std::span<const CharacterType> span() const LIFETIME_BOUND;
 
@@ -331,9 +364,10 @@ public:
     bool isAtom() const { return m_hashAndFlags & s_hashFlagStringKindIsAtom; }
     void setIsAtom(bool);
     
-    bool isExternal() const { return bufferOwnership() == BufferExternal; }
-
-    bool isSubString() const { return bufferOwnership() == BufferSubstring; }
+    using StringImplShape::bufferOwnership;
+    using StringImplShape::isExternal;
+    using StringImplShape::isSubString;
+    using StringImplShape::isInternal;
 
     static WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> utf8ForCharacters(std::span<const Latin1Character> characters);
     static WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> utf8ForCharacters(std::span<const char16_t> characters, ConversionMode = LenientConversion);
@@ -389,7 +423,7 @@ public:
         //
         // 1. m_length is only set on construction and never mutated thereafter.
         //
-        // 2. m_data8 and m_data16 are only set on construction and never mutated thereafter.
+        // 2. m_data.latin1 and m_data.char16 are only set on construction and never mutated thereafter.
         //    We also know that a StringImpl never changes from 8 bit to 16 bit because there
         //    is no way to set/clear the s_hashFlag8BitBuffer flag other than at construction.
         //
@@ -528,8 +562,6 @@ public:
     ALWAYS_INLINE static StringStats& stringStats() { return m_stringStats; }
 #endif
 
-    BufferOwnership bufferOwnership() const { return static_cast<BufferOwnership>(m_hashAndFlags & s_hashMaskBufferOwnership); }
-
     template<typename T> static constexpr size_t headerSize() { return tailOffset<T>(); }
     
 protected:
@@ -546,6 +578,7 @@ protected:
 private:
     template<typename> static size_t allocationSize(Checked<size_t> tailElementCount);
     template<typename> static constexpr size_t tailOffset();
+    template<typename> static constexpr size_t bufferOffset();
 
     WTF_EXPORT_PRIVATE size_t find(std::span<const Latin1Character>, size_t start);
     WTF_EXPORT_PRIVATE size_t reverseFind(std::span<const Latin1Character>, size_t start);
@@ -553,6 +586,9 @@ private:
     bool requiresCopy() const;
     template<typename T> const T* tailPointer() const;
     template<typename T> T* tailPointer();
+    template<typename T> const T* bufferPointer() const;
+    template<typename T> T* bufferPointer();
+
     StringImpl* const& substringBuffer() const;
     StringImpl*& substringBuffer();
 
@@ -680,12 +716,12 @@ template<> struct DefaultHash<CompactPtr<StringImpl>>;
 
 template<> ALWAYS_INLINE Ref<StringImpl> StringImpl::constructInternal<Latin1Character>(StringImpl& string, unsigned length)
 {
-    return adoptRef(*new (NotNull, &string) StringImpl { length, Force8BitConstructor });
+    return adoptRef(*new (NotNull, &string) StringImpl { length, Force8BitConstructor, InlineBuffer });
 }
 
 template<> ALWAYS_INLINE Ref<StringImpl> StringImpl::constructInternal<char16_t>(StringImpl& string, unsigned length)
 {
-    return adoptRef(*new (NotNull, &string) StringImpl { length });
+    return adoptRef(*new (NotNull, &string) StringImpl { length, InlineBuffer });
 }
 
 template<> ALWAYS_INLINE std::span<const Latin1Character> StringImpl::span<Latin1Character>() const
@@ -880,8 +916,8 @@ inline bool deprecatedIsNotSpaceOrNewline(char16_t character)
 inline StringImplShape::StringImplShape(unsigned refCount, std::span<const Latin1Character> data, unsigned hashAndFlags)
     : m_refCount(refCount)
     , m_length(data.size())
-    , m_data8(data.data())
     , m_hashAndFlags(hashAndFlags)
+    , m_data{.latin1 = data.data()}
 {
     RELEASE_ASSERT(data.size() <= MaxLength);
 }
@@ -889,8 +925,8 @@ inline StringImplShape::StringImplShape(unsigned refCount, std::span<const Latin
 inline StringImplShape::StringImplShape(unsigned refCount, std::span<const char16_t> data, unsigned hashAndFlags)
     : m_refCount(refCount)
     , m_length(data.size())
-    , m_data16(data.data())
     , m_hashAndFlags(hashAndFlags)
+    , m_data{.char16 = data.data()}
 {
     RELEASE_ASSERT(data.size() <= MaxLength);
 }
@@ -898,8 +934,8 @@ inline StringImplShape::StringImplShape(unsigned refCount, std::span<const char1
 template<unsigned characterCount> constexpr StringImplShape::StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag)
     : m_refCount(refCount)
     , m_length(length)
-    , m_data8Char(characters)
     , m_hashAndFlags(hashAndFlags)
+    , m_data{.char8 = characters}
 {
     RELEASE_ASSERT(length <= MaxLength);
 }
@@ -907,8 +943,8 @@ template<unsigned characterCount> constexpr StringImplShape::StringImplShape(uns
 template<unsigned characterCount> constexpr StringImplShape::StringImplShape(unsigned refCount, unsigned length, const char16_t (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag)
     : m_refCount(refCount)
     , m_length(length)
-    , m_data16Char(characters)
     , m_hashAndFlags(hashAndFlags)
+    , m_data{.char16 = characters}
 {
     RELEASE_ASSERT(length <= MaxLength);
 }
@@ -960,19 +996,19 @@ template<bool isSpecialCharacter(char16_t)> inline bool StringImpl::containsOnly
     return WTF::containsOnly<isSpecialCharacter>(span16());
 }
 
-inline StringImpl::StringImpl(unsigned length, Force8Bit)
-    : StringImplShape(s_refCountIncrement, unsafeMakeSpan(tailPointer<Latin1Character>(), length), s_hashFlag8BitBuffer | StringNormal | BufferInternal)
+inline StringImpl::StringImpl(unsigned length, Force8Bit, InlineBufferTag)
+    : StringImplShape(s_refCountIncrement, unsafeMakeSpan(bufferPointer<Latin1Character>(), length), s_hashFlag8BitBuffer | StringWithInlineBuffer | BufferInternal)
 {
-    ASSERT(m_data8);
+    ASSERT(dataLatin1());
     ASSERT(m_length);
 
     STRING_STATS_ADD_8BIT_STRING(m_length);
 }
 
-inline StringImpl::StringImpl(unsigned length)
-    : StringImplShape(s_refCountIncrement, unsafeMakeSpan(tailPointer<char16_t>(), length), s_hashZeroValue | StringNormal | BufferInternal)
+inline StringImpl::StringImpl(unsigned length, InlineBufferTag)
+    : StringImplShape(s_refCountIncrement, unsafeMakeSpan(bufferPointer<char16_t>(), length), s_hashZeroValue | StringWithInlineBuffer | BufferInternal)
 {
-    ASSERT(m_data16);
+    ASSERT(dataC16());
     ASSERT(m_length);
 
     STRING_STATS_ADD_16BIT_STRING(m_length);
@@ -994,7 +1030,7 @@ template<typename Malloc>
 inline StringImpl::StringImpl(MallocSpan<Latin1Character, Malloc> characters)
     : StringImplShape(s_refCountIncrement, toStringImplMallocSpan(WTFMove(characters)).leakSpan(), s_hashFlag8BitBuffer | StringNormal | BufferOwned)
 {
-    ASSERT(m_data8);
+    ASSERT(dataLatin1());
     ASSERT(m_length);
 
     STRING_STATS_ADD_8BIT_STRING(m_length);
@@ -1003,7 +1039,7 @@ inline StringImpl::StringImpl(MallocSpan<Latin1Character, Malloc> characters)
 inline StringImpl::StringImpl(std::span<const char16_t> characters, ConstructWithoutCopyingTag)
     : StringImplShape(s_refCountIncrement, characters, s_hashZeroValue | StringNormal | BufferInternal)
 {
-    ASSERT(m_data16);
+    ASSERT(dataC16());
     ASSERT(m_length);
 
     STRING_STATS_ADD_16BIT_STRING(m_length);
@@ -1012,7 +1048,7 @@ inline StringImpl::StringImpl(std::span<const char16_t> characters, ConstructWit
 inline StringImpl::StringImpl(std::span<const Latin1Character> characters, ConstructWithoutCopyingTag)
     : StringImplShape(s_refCountIncrement, characters, s_hashFlag8BitBuffer | StringNormal | BufferInternal)
 {
-    ASSERT(m_data8);
+    ASSERT(dataLatin1());
     ASSERT(m_length);
 
     STRING_STATS_ADD_8BIT_STRING(m_length);
@@ -1022,7 +1058,7 @@ template<typename Malloc>
 inline StringImpl::StringImpl(MallocSpan<char16_t, Malloc> characters)
     : StringImplShape(s_refCountIncrement, toStringImplMallocSpan(WTFMove(characters)).leakSpan(), s_hashZeroValue | StringNormal | BufferOwned)
 {
-    ASSERT(m_data16);
+    ASSERT(dataC16());
     ASSERT(m_length);
 
     STRING_STATS_ADD_16BIT_STRING(m_length);
@@ -1032,7 +1068,7 @@ inline StringImpl::StringImpl(std::span<const Latin1Character> characters, Ref<S
     : StringImplShape(s_refCountIncrement, characters, s_hashFlag8BitBuffer | StringNormal | BufferSubstring)
 {
     ASSERT(is8Bit());
-    ASSERT(m_data8);
+    ASSERT(dataLatin1());
     ASSERT(m_length);
     ASSERT(base->bufferOwnership() != BufferSubstring);
 
@@ -1045,7 +1081,7 @@ inline StringImpl::StringImpl(std::span<const char16_t> characters, Ref<StringIm
     : StringImplShape(s_refCountIncrement, characters, s_hashZeroValue | StringNormal | BufferSubstring)
 {
     ASSERT(!is8Bit());
-    ASSERT(m_data16);
+    ASSERT(dataC16());
     ASSERT(m_length);
     ASSERT(base->bufferOwnership() != BufferSubstring);
 
@@ -1062,7 +1098,7 @@ ALWAYS_INLINE Ref<StringImpl> StringImpl::createSubstringSharingImpl(StringImpl&
         return *empty();
 
     // Copying the thing would save more memory sometimes, largely due to the size of pointer.
-    size_t substringSize = allocationSize<StringImpl*>(1);
+    size_t substringSize = sizeof(StringImpl) + sizeof(StringImpl*);
     if (rep.is8Bit()) {
         if (substringSize >= allocationSize<Latin1Character>(length))
             return create(rep.span8().subspan(offset, length));
@@ -1100,7 +1136,7 @@ template<typename CharacterType> ALWAYS_INLINE RefPtr<StringImpl> StringImpl::tr
         output = { };
         return nullptr;
     }
-    output = unsafeMakeSpan(result->tailPointer<CharacterType>(), length);
+    output = unsafeMakeSpan(result->bufferPointer<CharacterType>(), length);
 
     return constructInternal<CharacterType>(*result, length);
 }
@@ -1216,7 +1252,7 @@ inline StringImpl::StringImpl(CreateSymbolTag, std::span<const Latin1Character> 
     : StringImplShape(s_refCountIncrement, characters, s_hashFlag8BitBuffer | StringSymbol | BufferSubstring)
 {
     ASSERT(is8Bit());
-    ASSERT(m_data8);
+    ASSERT(dataLatin1());
     STRING_STATS_ADD_8BIT_STRING2(m_length, true);
 }
 
@@ -1224,7 +1260,7 @@ inline StringImpl::StringImpl(CreateSymbolTag, std::span<const char16_t> charact
     : StringImplShape(s_refCountIncrement, characters, s_hashZeroValue | StringSymbol | BufferSubstring)
 {
     ASSERT(!is8Bit());
-    ASSERT(m_data16);
+    ASSERT(dataC16());
     STRING_STATS_ADD_16BIT_STRING2(m_length, true);
 }
 
@@ -1232,13 +1268,14 @@ inline StringImpl::StringImpl(CreateSymbolTag)
     : StringImplShape(s_refCountIncrement, empty()->span8(), s_hashFlag8BitBuffer | StringSymbol | BufferSubstring)
 {
     ASSERT(is8Bit());
-    ASSERT(m_data8);
+    ASSERT(dataLatin1());
     STRING_STATS_ADD_8BIT_STRING2(m_length, true);
 }
 
-template<typename T> inline size_t StringImpl::allocationSize(Checked<size_t> tailElementCount)
+template<typename T> inline size_t StringImpl::allocationSize(Checked<size_t> nCharacters)
 {
-    return tailOffset<T>() + tailElementCount * sizeof(T);
+    size_t sizeWithInlineString = tailOffset<T>() + nCharacters * sizeof(T);
+    return sizeWithInlineString > sizeof(StringImpl) ? sizeWithInlineString : sizeof(StringImpl);
 }
 
 template<typename CharacterType>
@@ -1251,17 +1288,17 @@ inline constexpr bool StringImpl::isValidLength(size_t length)
 
 template<typename T> constexpr size_t StringImpl::tailOffset()
 {
-    return roundUpToMultipleOf<alignof(T)>(offsetof(StringImpl, m_hashAndFlags) + sizeof(StringImpl::m_hashAndFlags));
+    return roundUpToMultipleOf<alignof(T)>(offsetof(StringImpl, m_data) + sizeof(StringImpl::m_data));
+}
+
+template<typename T> constexpr size_t StringImpl::bufferOffset()
+{
+    return roundUpToMultipleOf<alignof(T)>(offsetof(StringImpl, m_data));
 }
 
 inline bool StringImpl::requiresCopy() const
 {
-    if (bufferOwnership() != BufferInternal)
-        return true;
-
-    if (is8Bit())
-        return m_data8 == tailPointer<Latin1Character>();
-    return m_data16 == tailPointer<char16_t>();
+    return (bufferOwnership() != BufferInternal) || isBufferInline();
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -1273,6 +1310,16 @@ template<typename T> inline const T* StringImpl::tailPointer() const
 template<typename T> inline T* StringImpl::tailPointer()
 {
     return reinterpret_cast_ptr<T*>(reinterpret_cast<uint8_t*>(this) + tailOffset<T>());
+}
+
+template<typename T> inline const T* StringImpl::bufferPointer() const
+{
+    return reinterpret_cast_ptr<const T*>(reinterpret_cast<const uint8_t*>(this) + bufferOffset<T>());
+}
+
+template<typename T> inline T* StringImpl::bufferPointer()
+{
+    return reinterpret_cast_ptr<T*>(reinterpret_cast<uint8_t*>(this) + bufferOffset<T>());
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -355,7 +355,7 @@ bool codePointCompareLessThan(const String&, const String&);
 
 // Shared global empty and null string.
 struct StaticString {
-    constexpr StaticString(StringImpl::StaticStringImpl* pointer)
+    consteval StaticString(StringImpl::StaticStringImpl* pointer)
         : m_pointer(pointer)
     {
     }

--- a/Tools/VisualStudio/WebKit.natvis
+++ b/Tools/VisualStudio/WebKit.natvis
@@ -16,7 +16,7 @@
   <Type Name="WTF::StringImplShape">
     <!-- AtomString -->
     <DisplayString Condition="(m_hashAndFlags &amp; 0x10) &amp;&amp; (m_hashAndFlags &amp; 4)">
-      Atom:{m_data8,[m_length]s}
+      Atom:{m_data.latin1,[m_length]s}
     </DisplayString>
     <DisplayString Condition="(m_hashAndFlags &amp; 0x10)">
       Atom:{m_data16,[m_length]su}
@@ -24,14 +24,14 @@
 
     <!-- Symbol -->
     <DisplayString Condition="(m_hashAndFlags &amp; 0x20) &amp;&amp; (m_hashAndFlags &amp; 4)">
-      &lt;{m_data8,[m_length]s}&gt;
+      &lt;{m_data.latin1,[m_length]s}&gt;
     </DisplayString>
     <DisplayString Condition="(m_hashAndFlags &amp; 0x20)">
       &lt;{m_data16,[m_length]su}&gt;
     </DisplayString>
 
     <DisplayString Condition="(m_hashAndFlags &amp; 4)">
-      {m_data8,[m_length]s}
+      {m_data.latin1,[m_length]s}
     </DisplayString>
     <DisplayString Condition="!(m_hashAndFlags &amp; 4)">
       {m_data16,[m_length]su}

--- a/Tools/gdb/webkit.py
+++ b/Tools/gdb/webkit.py
@@ -127,7 +127,7 @@ class WTFStringImplPrinter(StringPrinter):
 
     def to_string(self):
         if self.is_8bit():
-            return lstring_to_string(self.val['m_data8'], self.get_length())
+            return lstring_to_string(self.val['m_data.latin1'], self.get_length())
         return ustring_to_string(self.val['m_data16'], self.get_length())
 
     def is_8bit(self):

--- a/Tools/lldb/lldb_webkit.py
+++ b/Tools/lldb/lldb_webkit.py
@@ -613,10 +613,10 @@ class WTFStringImplProvider:
         return self.valobj.GetChildMemberWithName('m_length').GetValueAsUnsigned(0)
 
     def get_data8(self):
-        return self.valobj.GetChildAtIndex(2).GetChildMemberWithName('m_data8')
+        return self.valobj.GetChildAtIndex(2).GetChildMemberWithName('m_data.latin1')
 
     def get_data16(self):
-        return self.valobj.GetChildAtIndex(2).GetChildMemberWithName('m_data16')
+        return self.valobj.GetChildAtIndex(2).GetChildMemberWithName('m_data.char16')
 
     def to_string(self):
         error = lldb.SBError()


### PR DESCRIPTION
Not for review yet.

Reuses the pointer `StringImplShape:: m_data8` - which points to the character buffer - to store string data whenever the character buffer is allocated right next to the string. In order to know if that's the case, store an extra flag in `StringImplShape::m_hashAndFlags` that indicates if the buffer is "inline" (`s_hashFlagStringHasInlineBuffer`).

#### 335a146aec792240bae055ef6369a93f2fe9d35e
<pre>
WIP2
</pre>
----------------------------------------------------------------------
#### 8d131be70799640ba03e86dc37b70c8838183797
<pre>
WIP
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e76c6cdc68489c13a96c1102ea63d92400d15029

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5395 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101733 "Failure limit exceed. At least found 401 new test failures: editing/selection/move-by-word-visually-crash-test-5.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker.html imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69065 "Found 33 new test failures: editing/selection/move-by-word-visually-crash-test-5.html imported/w3c/web-platform-tests/badging/idlharness.https.any.html imported/w3c/web-platform-tests/badging/idlharness.https.any.worker.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html imported/w3c/web-platform-tests/event-timing/idlharness.any.html imported/w3c/web-platform-tests/event-timing/idlharness.any.worker.html imported/w3c/web-platform-tests/event-timing/idlharness.window.html imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative.html imported/w3c/web-platform-tests/keyboard-lock/idlharness.https.window.html imported/w3c/web-platform-tests/largest-contentful-paint/idlharness.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135977 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4207 "Found 3 new test failures: editing/selection/move-by-word-visually-crash-test-5.html http/wpt/identity/idl.https.html jquery/traversing.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119208 "Found 1 new API test failure: TestWebKitAPI.WebKitLegacy.WebScriptObjectDescription (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82532 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4090 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker.html imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.worker.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1696 "Found 1 new API test failure: TestWebKitAPI.WebKitLegacy.WebScriptObjectDescription (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83802 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125101 "Found 3640 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/JSON/jx2.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/WOOB1138949.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/mru.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords_sm.js.default, airjs-tests.yaml/stress-test.js.bytecode-cache, airjs-tests.yaml/stress-test.js.default, airjs-tests.yaml/stress-test.js.ftl-eager, airjs-tests.yaml/stress-test.js.ftl-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113151 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37324 "Found 60 new test failures: editing/selection/move-by-word-visually-crash-test-5.html fast/block/basic/015.html fast/css/accent-color/datalist.html fast/css/aspect-ratio-min-height-replaced.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143220 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131539 "Found 3598 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/JSON/jx2.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/WOOB1138949.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/mru.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords_sm.js.default, airjs-tests.yaml/stress-test.js.bytecode-cache, airjs-tests.yaml/stress-test.js.default, airjs-tests.yaml/stress-test.js.ftl-eager, airjs-tests.yaml/stress-test.js.ftl-eager-no-cjit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5201 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37906 "Found 60 new test failures: editing/selection/move-by-word-visually-crash-test-5.html fast/css/aspect-ratio-min-height-replaced.html fast/mediastream/granted-denied-request-management1.html http/tests/canvas/ctx.2d-canvas-style-gradient-no-document-leak.html http/tests/site-isolation/history/add-iframes-and-go-back.html http/tests/site-isolation/remote-frame-loaded-while-hidden.html http/tests/webgpu/webgpu/api/operation/vertex_state/correctness.html http/tests/webgpu/webgpu/api/validation/capability_checks/features/texture_formats.html http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size.html http/wpt/identity/idl.https.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110113 "Failure limit exceed. At least found 322 new test failures: editing/selection/move-by-word-visually-crash-test-5.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.any.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5283 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4458 "Found 60 new test failures: editing/selection/move-by-word-visually-crash-test-5.html fast/dom/document-contentType-data-uri.html fast/forms/color/color-input-swatch-wrapper-appearance-none-inherited.html fast/forms/color/input-color-parts-appearance.html fast/forms/fieldset/abs-pos-child-sizing.html fast/images/individual-animation-toggle.html fast/workers/worker-cloneport.html http/tests/ipc/ipc-fetch-task-message-crash.html http/tests/site-isolation/remote-frame-loaded-while-hidden.html http/tests/webgpu/webgpu/api/operation/rendering/color_target_state.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110295 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3999 "Found 1 new test failure: imported/w3c/web-platform-tests/webxr/idlharness.https.window.html (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115469 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58789 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5255 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33819 "Found 60 new test failures: compositing/scrolling/async-overflow-scrolling/negative-z-in-scroller-hidden-scrollbar.html css3/filters/backdrop/backdrop-filter-with-reflection-value-change.html editing/selection/move-by-word-visually-crash-test-5.html fast/images/individual-animation-toggle.html fast/media/mq-prefers-contrast-live-update.html fast/media/mq-transform-02.html fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html fast/shadow-dom/css-scoping-slotted-invalidation.html http/tests/site-isolation/remote-frame-loaded-while-hidden.html http/wpt/identity/idl.https.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164507 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68707 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42849 "Found 121 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/switchStatement/BugFixRegression_MaxInterpret.js.default, ChakraCore.yaml/ChakraCore/test/switchStatement/duplicateStringCaseArmBug.js.default, ChakraCore.yaml/ChakraCore/test/switchStatement/repeatStringCases.js.default, ChakraCore.yaml/ChakraCore/test/switchStatement/singleCharStringCase.js.default, cdjs-tests.yaml/red_black_tree_test.js.bytecode-cache, cdjs-tests.yaml/red_black_tree_test.js.default, cdjs-tests.yaml/red_black_tree_test.js.dfg-eager, cdjs-tests.yaml/red_black_tree_test.js.eager-jettison-no-cjit, cdjs-tests.yaml/red_black_tree_test.js.mini-mode, cdjs-tests.yaml/red_black_tree_test.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->