### PR TITLE
Introduce CoreIPC Thin type Aliasing For Additional Validation of Common CoreIPC Types

### DIFF
--- a/Source/WebCore/Modules/Model/InternalAPI/DDModel.serialization.in
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDModel.serialization.in
@@ -262,7 +262,7 @@ header: <WebCore/DDImageAsset.h>
     uint32_t height;
     uint32_t bytesPerPixel;
     WebCore::DDModel::DDSemantic semantic;
-    String path;
+    FilePath path;
     String identifier;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -32,7 +32,7 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
 #endif
     bool shouldSuppressMemoryPressureHandler
 
-    Vector<String> urlSchemesRegisteredForCustomProtocols
+    Vector<URLScheme> urlSchemesRegisteredForCustomProtocols
 
 #if PLATFORM(COCOA)
     String uiProcessBundleIdentifier
@@ -46,10 +46,10 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
     std::optional<MemoryPressureHandler::Configuration> memoryPressureHandlerConfiguration
 #endif
 
-    Vector<String> urlSchemesRegisteredAsSecure
-    Vector<String> urlSchemesRegisteredAsBypassingContentSecurityPolicy
-    Vector<String> urlSchemesRegisteredAsLocal
-    Vector<String> urlSchemesRegisteredAsNoAccess
+    Vector<URLScheme> urlSchemesRegisteredAsSecure
+    Vector<URLScheme> urlSchemesRegisteredAsBypassingContentSecurityPolicy
+    Vector<URLScheme> urlSchemesRegisteredAsLocal
+    Vector<URLScheme> urlSchemesRegisteredAsNoAccess
 
     bool enablePrivateClickMeasurement
     bool ftpEnabled

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -42,7 +42,7 @@ enum class WebKit::AllowsCellularAccess : bool;
     String hstsStorageDirectory;
     WebKit::SandboxExtensionHandle hstsStorageDirectoryExtensionHandle;
 #if USE(SOUP)
-    String cookiePersistentStoragePath;
+    FilePath cookiePersistentStoragePath;
     WebKit::SoupCookiePersistentStorageType cookiePersistentStorageType;
     bool persistentCredentialStorageEnabled;
     bool ignoreTLSErrors;

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -148,10 +148,10 @@ public:
         return *this;
     }
 
-    template<typename T>
-    std::optional<T> decode()
+    template<typename T, typename R = T>
+    std::optional<R> decode()
     {
-        std::optional<T> t { ArgumentCoder<std::remove_cvref_t<T>>::decode(*this) };
+        std::optional<R> t { ArgumentCoder<std::remove_cvref_t<T>>::decode(*this) };
         if (!t) [[unlikely]]
             markInvalid();
         return t;

--- a/Source/WebKit/Platform/IPC/IPCValidation.h
+++ b/Source/WebKit/Platform/IPC/IPCValidation.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace IPC {
+
+class Validation {
+public:
+    static bool isValidFilePath(const String& path)
+    {
+        constexpr unsigned maxPathLength = 4096;
+        if (path.length() >= maxPathLength)
+            return false;
+
+        for (unsigned i = 0; i < path.length(); ++i) {
+            auto c = path[i];
+            if (c < 0x20 || c == 0x7F)
+                return false;
+        }
+
+        return true;
+    }
+
+    static bool isValidURLPath(const String& path)
+    {
+        if (path.isEmpty())
+            return true;
+
+        constexpr unsigned maxURLPathLength = 8192;
+        if (path.length() >= maxURLPathLength)
+            return false;
+
+        for (unsigned i = 0; i < path.length(); ++i) {
+            auto c = path[i];
+            if (c < 0x20 || c == 0x7F)
+                return false;
+        }
+
+        return true;
+    }
+
+    static bool isValidHostname(const String& hostname)
+    {
+        if (hostname.isEmpty())
+            return true;
+
+        constexpr unsigned maxHostnameLength = 253;
+        if (hostname.length() > maxHostnameLength)
+            return false;
+
+        for (unsigned i = 0; i < hostname.length(); ++i) {
+            auto c = hostname[i];
+            if (c < 0x20 || c == 0x7F)
+                return false;
+        }
+
+        if (hostname.find(".."_s) != notFound)
+            return false;
+
+        if (hostname.length() > 1) {
+            if (hostname.startsWith('.') || hostname.endsWith('.'))
+                return false;
+        }
+
+        auto labels = hostname.split('.');
+
+        for (const auto& label : labels) {
+            if (label.isEmpty())
+                return false;
+
+            constexpr unsigned maxLabelLength = 63;
+            if (label.length() > maxLabelLength)
+                return false;
+
+            auto first = label[0];
+            auto last = label[label.length() - 1];
+
+            bool firstIsAlphaNum = (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || (first >= '0' && first <= '9');
+            bool lastIsAlphaNum = (last >= 'a' && last <= 'z') || (last >= 'A' && last <= 'Z') || (last >= '0' && last <= '9');
+
+            if (!firstIsAlphaNum || !lastIsAlphaNum)
+                return false;
+
+            for (unsigned i = 0; i < label.length(); ++i) {
+                auto c = label[i];
+                bool isValid = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-';
+                if (!isValid)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    static bool isValidMimeType(const String& mimeType)
+    {
+        if (mimeType.isEmpty())
+            return true;
+
+        constexpr unsigned maxMimeTypeLength = 256;
+        if (mimeType.length() >= maxMimeTypeLength)
+            return false;
+
+        for (unsigned i = 0; i < mimeType.length(); ++i) {
+            auto c = mimeType[i];
+            if (c < 0x20 || c == 0x7F)
+                return false;
+        }
+
+        auto slashPos = mimeType.find('/');
+        if (slashPos == notFound)
+            return false;
+
+        if (slashPos == 0)
+            return false;
+
+        auto semicolonPos = mimeType.find(';');
+        auto endOfSubtype = semicolonPos == notFound ? mimeType.length() : semicolonPos;
+
+        if (slashPos + 1 >= endOfSubtype)
+            return false;
+
+        auto typeSubtype = mimeType.substring(0, endOfSubtype);
+        if (typeSubtype[0] == ' ' || typeSubtype[typeSubtype.length() - 1] == ' ')
+            return false;
+
+        return true;
+    }
+
+    static bool isValidURLScheme(const String& scheme)
+    {
+        if (scheme.isEmpty())
+            return false;
+
+        constexpr unsigned maxSchemeLength = 32;
+        if (scheme.length() >= maxSchemeLength)
+            return false;
+
+        auto first = scheme[0];
+        bool firstIsLetter = (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z');
+        if (!firstIsLetter)
+            return false;
+
+        for (unsigned i = 0; i < scheme.length(); ++i) {
+            auto c = scheme[i];
+            bool isValid = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.';
+            if (!isValid)
+                return false;
+        }
+
+        return true;
+    }
+
+    static bool isValidEmailAddress(const String& email)
+    {
+        if (email.isEmpty())
+            return true;
+
+        constexpr unsigned maxEmailLength = 320;
+        constexpr unsigned maxLocalPartLength = 64;
+        constexpr unsigned maxDomainLength = 255;
+
+        if (email.find('\0') != notFound || email.length() > maxEmailLength)
+            return false;
+
+        auto atPosition = email.find('@');
+        if (atPosition == notFound)
+            return false;
+
+        if (email.reverseFind('@') != atPosition)
+            return false;
+
+        if (atPosition == 0 || atPosition == email.length() - 1)
+            return false;
+
+        auto localPart = email.left(atPosition);
+        auto domainPart = email.substring(atPosition + 1);
+
+        if (localPart.length() > maxLocalPartLength || domainPart.length() > maxDomainLength)
+            return false;
+
+        if (email.find(".."_s) != notFound)
+            return false;
+
+        if (localPart.startsWith('.') || localPart.endsWith('.'))
+            return false;
+
+        if (domainPart.startsWith('.') || domainPart.endsWith('.'))
+            return false;
+
+        for (unsigned i = 0; i < email.length(); ++i) {
+            auto c = email[i];
+            if (c <= 0x20 || c == 0x7F)
+                return false;
+        }
+
+        return true;
+    }
+};
+
+} // namespace IPC

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -24,6 +24,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import copy
+import itertools
 import os
 import re
 import sys
@@ -45,6 +46,7 @@ from webkit.opaque_ipc_types import is_opaque_type, opaque_ipc_types
 # RValue - serializer takes an rvalue reference, instead of an lvalue.
 # WebKitPlatform - put serializer into a file built as part of WebKitPlatform
 # CustomEncoder - Only generate the decoder, not the encoder.
+# Validator - additional C++ to validate the value when decoding
 # WebKitSecureCodingClass - For webkit_secure_coding declarations that need a custom way of establishing the Obj-C class to instantiate (e.g. softlinked frameworks)
 # Wrapper - use a wrapper class to get members and to construct for an external type
 #
@@ -106,6 +108,7 @@ class SerializedType(object):
         self.disableMissingMemberCheck = False
         self.debug_decoding_failure = False
         self.generic_wrapper = None
+        self.type_validator = None
         if attributes is not None:
             for attribute in attributes.split(', '):
                 if '=' in attribute:
@@ -128,6 +131,11 @@ class SerializedType(object):
                         self.custom_secure_coding_class = value
                     elif key == 'Wrapper':
                         self.generic_wrapper = value
+                    elif key == 'Validator':
+                        match = re.search(r'\'(.*)\'', value)
+                        assert match
+                        if match:
+                            self.type_validator = match.groups()[0]
                     else:
                         raise Exception(f'Invalid attribute ({key}={value}) found on struct: {self.namespace}::{self.name}')
                 else:
@@ -211,6 +219,8 @@ class SerializedType(object):
         return 'isValidEnum'
 
     def can_assert_member_order_is_correct(self):
+        if isinstance(self, AliasType):
+            return False
         if self.disableMissingMemberCheck:
             return False
         for member in self.members:
@@ -490,6 +500,20 @@ class UsingStatement(object):
                     raise Exception(f"Justification needed in opaque_ipc_types.tracking.in: [] AliasParam {self.name} {cleaned_line}")
 
 
+class AliasType(SerializedType):
+    def __init__(self, struct_or_class, namespace, name, condition, attributes, metadata):
+        SerializedType.__init__(self, struct_or_class, None, namespace, name, None, [], [], condition, attributes, [], metadata)
+        assert self.alias
+        assert self.type_validator
+
+
+class AliasType(SerializedType):
+    def __init__(self, struct_or_class, namespace, name, condition, attributes, metadata):
+        SerializedType.__init__(self, struct_or_class, None, namespace, name, None, [], [], condition, attributes, [], metadata)
+        assert self.alias
+        assert self.type_validator
+
+
 class ObjCWrappedType(object):
     def __init__(self, ns_type, wrapper, condition):
         self.ns_type = ns_type
@@ -560,11 +584,14 @@ def one_argument_coder_declaration(type, template_argument):
     if template_argument is not None:
         name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
     result.append(f'template<> struct ArgumentCoder<{name_with_template}> {{')
-    for encoder in type.encoders:
-        if type.rvalue:
-            result.append(f'    static void encode({encoder}&, {name_with_template}&&);')
-        else:
-            result.append(f'    static void encode({encoder}&, const {name_with_template}&);')
+    if not isinstance(type, AliasType):
+        for encoder in type.encoders:
+            if type.rvalue:
+                result.append(f'    static void encode({encoder}&, {name_with_template}&&);')
+            else:
+                result.append(f'    static void encode({encoder}&, const {name_with_template}&);')
+    else:
+        name_with_template = remove_alias_struct_or_class(type.alias)
     if type.return_ref:
         result.append(f'    static std::optional<Ref<{name_with_template}>> decode(Decoder&);')
     else:
@@ -595,7 +622,7 @@ def typenames(alias):
 
 
 def remove_template_parameters(alias):
-    match = re.search(r'(struct|class) ([^<]*)<', alias)
+    match = re.search(r'(struct|class) ([^<]*)', alias)
     assert match
     return match.groups()[1]
 
@@ -620,7 +647,7 @@ def get_alias_namespace(alias):
         return None
 
 
-def generate_forward_declarations(serialized_types, serialized_enums, additional_forward_declarations):
+def generate_forward_declarations(serialized_types, serialized_enums, additional_forward_declarations, alias_types):
     result = []
     result.append('')
     serialized_enums_by_namespace = dict()
@@ -633,7 +660,7 @@ def generate_forward_declarations(serialized_types, serialized_enums, additional
             serialized_enums_by_namespace[enum.namespace] += [enum, ]
         else:
             serialized_enums_by_namespace[enum.namespace] = [enum, ]
-    for type in serialized_types:
+    for type in itertools.chain(serialized_types, alias_types):
         for template in type.templates:
             if template.namespace in template_types_by_namespace:
                 template_types_by_namespace[template.namespace] += [template, ]
@@ -690,9 +717,12 @@ def generate_forward_declarations(serialized_types, serialized_enums, additional
                 if namespace is not None:
                     result.append(f'namespace {namespace} {{')
 
-                if namespace is None or get_alias_namespace(type.alias) is None or get_alias_namespace(type.alias) == type.namespace:
-                    result.append(f'template<{typenames(type.alias)}> {alias_struct_or_class(type.alias)} {remove_template_parameters(type.alias)};')
-                result.append(f'using {type.name} = {remove_alias_struct_or_class(type.alias)};')
+                if not len(type.serialized_members()):
+                    result.append(f'{alias_struct_or_class(type.alias)} {type.name} {{ }};')
+                else:
+                    if namespace is None or get_alias_namespace(type.alias) is None or get_alias_namespace(type.alias) == type.namespace:
+                        result.append(f'template<{typenames(type.alias)}> {alias_struct_or_class(type.alias)} {remove_template_parameters(type.alias)};')
+                    result.append(f'using {type.name} = {remove_alias_struct_or_class(type.alias)};')
 
                 if namespace is not None:
                     result.append('}')
@@ -701,7 +731,7 @@ def generate_forward_declarations(serialized_types, serialized_enums, additional
     return result
 
 
-def generate_header(serialized_types, serialized_enums, additional_forward_declarations):
+def generate_header(serialized_types, serialized_enums, additional_forward_declarations, alias_types):
     result = []
     result.append(_license_header)
     result.append('#pragma once')
@@ -717,7 +747,7 @@ def generate_header(serialized_types, serialized_enums, additional_forward_decla
     result.append('#endif')
     result.append('#endif')
 
-    result += generate_forward_declarations(serialized_types, serialized_enums, additional_forward_declarations)
+    result += generate_forward_declarations(serialized_types, serialized_enums, additional_forward_declarations, alias_types)
     result.append('')
     result.append('namespace IPC {')
     result.append('')
@@ -725,6 +755,7 @@ def generate_header(serialized_types, serialized_enums, additional_forward_decla
     result.append('class Encoder;')
     result.append('class StreamConnectionEncoder;')
     result = result + argument_coder_declarations(serialized_types, True, None)
+    result = result + argument_coder_declarations(alias_types, True, None)
     result.append('')
     result.append('} // namespace IPC\n')
     result.append('')
@@ -758,14 +789,84 @@ def resolve_inheritance(serialized_types):
     return result
 
 
-def check_type_members(type, checking_parent_class):
+def strip_container(potential_container):
+    match = re.search(r'Vector<(.*)>', potential_container)
+    if match:
+        return match.groups()[0]
+    match = re.search(r'std::optional<(.*)>', potential_container)
+    if match:
+        return match.groups()[0]
+    match = re.search(r'HashMap<(.*),', potential_container)
+    if match:
+        return match.groups()[0]
+    match = re.search(r'HashSet<(.*)>', potential_container)
+    if match:
+        return match.groups()[0]
+    return potential_container
+
+
+def find_alias(type_to_compare, alias_types, search_containers=False):
+    if search_containers:
+        type_to_compare = strip_container(type_to_compare)
+    return next((t for t in alias_types if t.name == type_to_compare), None)
+
+
+def replace_type(potential_container, target_type):
+    match = re.search(r'Vector<(.*)>', potential_container)
+    if match:
+        return f'Vector<{target_type}>'
+    match = re.search(r'std::optional<(.*)>', potential_container)
+    if match:
+        return f'std::optional<{target_type}>'
+    match = re.search(r'HashMap<(.*),', potential_container)
+    if match:
+        return f'HashMap<{target_type},' + potential_container.split(',')[1]
+    match = re.search(r'HashSet<(.*)>', potential_container)
+    if match:
+        return f'HashSet<{target_type}>'
+    return target_type
+
+
+def validate_container(container_name, potential_container, alias_types):
+    result = []
+    replacement = find_alias(potential_container, alias_types, True)
+    match = re.search(r'Vector<(.*)>', potential_container)
+    if match:
+        result.append(f'    for (auto& item : *{container_name}) {{')
+        result += generate_type_validation('item', replacement);
+        result.append(f'    }}')
+        return result
+    match = re.search(r'std::optional<(.*)>', potential_container)
+    if match:
+        result += generate_type_validation(f'**{container_name}', replacement);
+        return result
+    match = re.search(r'HashMap<(.*),', potential_container)
+    if match:
+        result.append(f'    for (const auto& [key, value] : *{container_name}) {{')
+        result += generate_type_validation('key', replacement);
+        result.append(f'    }}')
+        return result
+    match = re.search(r'HashSet<(.*)>', potential_container)
+    if match:
+        result.append(f'    for (const auto& key : *{container_name}) {{')
+        result += generate_type_validation('key', replacement);
+        result.append(f'    }}')
+        return result
+    print(potential_container)
+    assert False
+
+def check_type_members(type, checking_parent_class, alias_types):
     result = []
     if type.parent_class is not None:
-        result = check_type_members(type.parent_class, True)
+        result = check_type_members(type.parent_class, True, alias_types)
     for member in type.members:
         if member.condition is not None:
             result.append(f'#if {member.condition}')
-        result.append(f'    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.{member.name})>, {member.type}>);')
+        type_to_compare = member.type
+        found_alias_type = find_alias(type_to_compare, alias_types, True)
+        if found_alias_type:
+            type_to_compare = replace_type(type_to_compare, remove_alias_struct_or_class(found_alias_type.alias))
+        result.append(f'    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.{member.name})>, {type_to_compare}>);')
         if member.condition is not None:
             result.append('#endif')
     for member in type.dictionary_members:
@@ -777,7 +878,11 @@ def check_type_members(type, checking_parent_class):
             for member in type.members:
                 if member.condition is not None:
                     result.append(f'#if {member.condition}')
-                result.append(f'        {member.type} {member.name}{" : 1" if "BitField" in member.attributes else ""};')
+                type_to_compare = member.type
+                found_alias_type = find_alias(type_to_compare, alias_types, True)
+                if found_alias_type:
+                    type_to_compare = replace_type(type_to_compare, remove_alias_struct_or_class(found_alias_type.alias))
+                result.append(f'        {type_to_compare} {member.name}{" : 1" if "BitField" in member.attributes else ""};')
                 if member.condition is not None:
                     result.append('#endif')
             for member in type.dictionary_members:
@@ -832,6 +937,8 @@ def encode_cf_type(type):
 
 
 def encode_type(type):
+    if isinstance(type, AliasType):
+        assert False
     if type.cf_type is not None:
         return encode_cf_type(type)
     result = []
@@ -895,13 +1002,13 @@ def should_decode_ref(member, serialized_types):
     return False
 
 
-def decode_type(type, serialized_types):
+def decode_type(type, serialized_types, alias_types):
     if type.cf_type is not None:
         return decode_cf_type(type)
 
     result = []
     if type.parent_class is not None:
-        result = result + decode_type(type.parent_class, serialized_types)
+        result = result + decode_type(type.parent_class, serialized_types, alias_types)
 
     if type.members_are_subclasses:
         result.append(f'    auto type = decoder.decode<{type.subclass_enum_name()}>();')
@@ -915,6 +1022,9 @@ def decode_type(type, serialized_types):
 
     if type.debug_decoding_failure:
         result.append('    bool addedDecodingFailureIndex = false;')
+
+    if isinstance(type, AliasType):
+        result.append(f'    auto result = decoder.decode<{remove_alias_struct_or_class(type.alias)}>();')
 
     for i in range(len(type.serialized_members())):
         member = type.serialized_members()[i]
@@ -973,6 +1083,13 @@ def decode_type(type, serialized_types):
             assert len(decodable_classes) == 0
             if should_decode_ref(member, serialized_types):
                 result.append(f'    auto {sanitized_variable_name} = decoder.decode<Ref<{member.type}>>();')
+            elif find_alias(member.type, alias_types, False):
+                replacement_type = replace_type(member.type, remove_alias_struct_or_class(find_alias(member.type, alias_types, False).alias))
+                result.append(f'    auto {sanitized_variable_name} = decoder.decode<{member.type}, {replacement_type}>();')
+            elif find_alias(member.type, alias_types, True):
+                replacement_type = replace_type(member.type, remove_alias_struct_or_class(find_alias(member.type, alias_types, True).alias))
+                result.append(f'    auto {sanitized_variable_name} = decoder.decode<{replacement_type}>();')
+                result = result + validate_container(sanitized_variable_name, member.type, alias_types);
             else:
                 result.append(f'    auto {sanitized_variable_name} = decoder.decode<{member.type}>();')
             if 'EncodeRequestBody' in member.attributes:
@@ -1053,7 +1170,15 @@ def construct_type(type, specialization, indentation):
     return result
 
 
-def generate_one_impl(type, template_argument, serialized_types):
+def generate_type_validation(variable, type):
+    result = []
+    if type.type_validator:
+        result.append(f'    if (!({type.type_validator}))'.replace('$', variable))
+        result.append(f'        return std::nullopt;')
+    return result
+
+
+def generate_one_impl(type, template_argument, serialized_types, alias_types):
     result = []
     name_with_template = type.namespace_and_name()
     if template_argument is not None:
@@ -1083,6 +1208,8 @@ def generate_one_impl(type, template_argument, serialized_types):
         instanceArgName = 'instance' if type.generic_wrapper is None else 'passedInstance'
         if type.cf_type is not None:
             result.append(f'void ArgumentCoder<{name_with_template}>::encode({encoder}& encoder, {name_with_template} {instanceArgName})')
+        elif isinstance(type, AliasType):
+            continue
         elif type.rvalue:
             result.append(f'void ArgumentCoder<{name_with_template}>::encode({encoder}& encoder, {name_with_template}&& {instanceArgName})')
         else:
@@ -1094,7 +1221,7 @@ def generate_one_impl(type, template_argument, serialized_types):
             else:
                 result.append(f'    auto instance = {type.generic_wrapper}({instanceArgName});')
         if not type.members_are_subclasses and type.cf_type is None:
-            result = result + check_type_members(type, False)
+            result = result + check_type_members(type, False, alias_types)
         result = result + encode_type(type)
         if type.members_are_subclasses:
             result.append('    ASSERT_NOT_REACHED();')
@@ -1104,17 +1231,22 @@ def generate_one_impl(type, template_argument, serialized_types):
         result.append('')
     if type.cf_type is not None:
         result.append(f'std::optional<RetainPtr<{name_with_template}>> ArgumentCoder<RetainPtr<{name_with_template}>>::decode(Decoder& decoder)')
+    elif isinstance(type, AliasType):
+        result.append(f'std::optional<{remove_template_parameters(type.alias)}> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     elif type.return_ref:
         result.append(f'std::optional<Ref<{name_with_template}>> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     else:
         result.append(f'std::optional<{name_with_template}> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     result.append('{')
-    result = result + decode_type(type, serialized_types)
+    result = result + decode_type(type, serialized_types, alias_types)
     if type.cf_type is None:
         if not type.members_are_subclasses:
             result.append('    if (!decoder.isValid()) [[unlikely]]')
             result.append('        return std::nullopt;')
-            if type.populate_from_empty_constructor and not type.has_optional_tuple_bits():
+            if isinstance(type, AliasType):
+                result += generate_type_validation('*result', type)
+                result.append('    return result;')
+            elif type.populate_from_empty_constructor and not type.has_optional_tuple_bits():
                 result.append(f'    {name_with_template} result;')
                 for member in type.serialized_members():
                     if member.condition is not None:
@@ -1122,10 +1254,13 @@ def generate_one_impl(type, template_argument, serialized_types):
                     result.append(f'    result.{member.name} = WTFMove(*{member.name});')
                     if member.condition is not None:
                         result.append('#endif')
+                result += generate_type_validation('*result', type)
                 result.append('    return { WTFMove(result) };')
             elif type.has_optional_tuple_bits() and type.populate_from_empty_constructor:
+                result += generate_type_validation('*result', type)
                 result.append('    return { WTFMove(result) };')
             else:
+                result += generate_type_validation('*result', type)
                 result.append('    return {')
                 if template_argument:
                     result = result + construct_type(type, template_argument.specialization(), 2)
@@ -1143,7 +1278,7 @@ def generate_one_impl(type, template_argument, serialized_types):
     return result
 
 
-def generate_impl(serialized_types, serialized_enums, headers, generating_webkit_platform_impl, objc_wrapped_types):
+def generate_impl(serialized_types, serialized_enums, headers, generating_webkit_platform_impl, objc_wrapped_types, alias_types):
     result = []
     result.append(_license_header)
     result.append('#include "config.h"')
@@ -1214,14 +1349,14 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
     result = result + argument_coder_declarations(serialized_types, False, generating_webkit_platform_impl)
     result.append('')
 
-    for type in serialized_types:
+    for type in itertools.chain(serialized_types, alias_types):
         if type.webkit_platform != generating_webkit_platform_impl:
             continue
         if type.templates:
             for template in type.templates:
-                result.extend(generate_one_impl(type, template, serialized_types))
+                result.extend(generate_one_impl(type, template, serialized_types, alias_types))
         else:
-            result.extend(generate_one_impl(type, None, serialized_types))
+            result.extend(generate_one_impl(type, None, serialized_types, alias_types))
     result.append('} // namespace IPC')
     result.append('')
     result.append('namespace WTF {')
@@ -1413,7 +1548,7 @@ def output_sorted_headers(sorted_headers):
     return result
 
 
-def generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements, objc_wrapped_types):
+def generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements, objc_wrapped_types, alias_types):
     result = []
     result.append(_license_header)
     result.append('#include "config.h"')
@@ -1480,6 +1615,16 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
         result.append('        } },')
         if using_statement.condition is not None:
             result.append('#endif')
+    for alias_type in alias_types:
+        if alias_type.condition is not None:
+            result.append(f'#if {alias_type.condition}')
+        result.append(f'        {{ "{alias_type.name}"_s, {{')
+        result.append(f'        {{')
+        result.append(f'            "{remove_template_parameters(alias_type.alias)}"_s')
+        result.append(f'            , "alias"_s }}')
+        result.append('        } },')
+        if alias_type.condition is not None:
+            result.append('#endif')
     result.append('    };')
     result.append('}')
     result.append('')
@@ -1542,6 +1687,7 @@ def parse_serialized_types(file):
     serialized_enums = []
     using_statements = []
     objc_wrapped_types = []
+    alias_types = []
     additional_forward_declarations = []
     headers = []
 
@@ -1646,6 +1792,10 @@ def parse_serialized_types(file):
                 headers.append(ConditionalHeader(header, type_condition, False, True))
             continue
 
+        match = re.search(r'\[(.*)\] (alias) (.*);', line)
+        if match:
+            alias_types.append(AliasType(match.groups()[1], namespace, match.groups()[2], type_condition, match.groups()[0], metadata))
+            continue
 
         match = re.search(r'(.*)enum class (.*)::(.*) : (.*) {', line)
         if match:
@@ -1770,7 +1920,7 @@ def parse_serialized_types(file):
                     dictionary_members.append(MemberVariable(member_type, member_name, member_condition, []))
                 else:
                     members.append(MemberVariable(member_type, member_name, member_condition, []))
-    return [serialized_types, serialized_enums, headers, using_statements, additional_forward_declarations, objc_wrapped_types]
+    return [serialized_types, serialized_enums, headers, using_statements, additional_forward_declarations, objc_wrapped_types, alias_types]
 
 
 def generate_webkit_secure_coding_impl(serialized_types, headers):
@@ -2021,6 +2171,7 @@ def main(argv):
     serialized_enums = []
     using_statements = []
     objc_wrapped_types = []
+    alias_types = []
     headers = []
     header_set = set()
     header_set.add(ConditionalHeader('"FormDataReference.h"', None))
@@ -2028,7 +2179,7 @@ def main(argv):
     file_extension = argv[1]
     for i in range(2, len(argv)):
         with open(argv[i]) as file:
-            new_types, new_enums, new_headers, new_using_statements, new_additional_forward_declarations, new_objc_wrapped_types = parse_serialized_types(file)
+            new_types, new_enums, new_headers, new_using_statements, new_additional_forward_declarations, new_objc_wrapped_types, new_alias_types = parse_serialized_types(file)
             for type in new_types:
                 type.enforce_opaque_ipc_types_usage()
                 serialized_types.append(type)
@@ -2043,18 +2194,20 @@ def main(argv):
                 additional_forward_declarations_list.append(declaration)
             for objc_wrapped_type in new_objc_wrapped_types:
                 objc_wrapped_types.append(objc_wrapped_type)
+            for alias_type in new_alias_types:
+                alias_types.append(alias_type)
     headers = sorted(header_set)
 
     serialized_types = resolve_inheritance(serialized_types)
 
     with open('GeneratedSerializers.h', "w+") as output:
-        output.write(generate_header(serialized_types, serialized_enums, additional_forward_declarations_list))
+        output.write(generate_header(serialized_types, serialized_enums, additional_forward_declarations_list, alias_types))
     with open('GeneratedSerializers.%s' % file_extension, "w+") as output:
-        output.write(generate_impl(serialized_types, serialized_enums, headers, False, []))
+        output.write(generate_impl(serialized_types, serialized_enums, headers, False, [], alias_types))
     with open('WebKitPlatformGeneratedSerializers.%s' % file_extension, "w+") as output:
-        output.write(generate_impl(serialized_types, serialized_enums, headers, True, objc_wrapped_types))
+        output.write(generate_impl(serialized_types, serialized_enums, headers, True, objc_wrapped_types, alias_types))
     with open('SerializedTypeInfo.%s' % file_extension, "w+") as output:
-        output.write(generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements, objc_wrapped_types))
+        output.write(generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements, objc_wrapped_types, alias_types))
     with open('GeneratedWebKitSecureCoding.h', "w+") as output:
         output.write(generate_webkit_secure_coding_header(serialized_types))
     with open('GeneratedWebKitSecureCoding.%s' % file_extension, "w+") as output:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1566,6 +1566,106 @@ std::optional<WebCore::OpaqueTypeObject> ArgumentCoder<WebCore::OpaqueTypeObject
     };
 }
 
+void ArgumentCoder<ValdidatedStringUserStruct1>::encode(Encoder& encoder, const ValdidatedStringUserStruct1& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.myString)>, WTF::String>);
+    struct ShouldBeSameSizeAsValdidatedStringUserStruct1 : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<ValdidatedStringUserStruct1>, false> {
+        WTF::String myString;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsValdidatedStringUserStruct1) == sizeof(ValdidatedStringUserStruct1));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(ValdidatedStringUserStruct1, myString)
+    >::value);
+
+    encoder << instance.myString;
+}
+
+std::optional<ValdidatedStringUserStruct1> ArgumentCoder<ValdidatedStringUserStruct1>::decode(Decoder& decoder)
+{
+    auto myString = decoder.decode<ValidatedString, WTF::String>();
+    if (!decoder.isValid()) [[unlikely]]
+        return std::nullopt;
+    return {
+        ValdidatedStringUserStruct1 {
+            WTFMove(*myString)
+        }
+    };
+}
+
+void ArgumentCoder<ValdidatedStringUserStruct2>::encode(Encoder& encoder, const ValdidatedStringUserStruct2& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.myString)>, WTF::String>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.myStringVector)>, Vector<WTF::String>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.myStringMap)>, HashMap<WTF::String, SomeObject>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.myStringSet)>, HashSet<WTF::String>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.myOptionalString)>, std::optional<WTF::String>>);
+    struct ShouldBeSameSizeAsValdidatedStringUserStruct2 : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<ValdidatedStringUserStruct2>, false> {
+        WTF::String myString;
+        Vector<WTF::String> myStringVector;
+        HashMap<WTF::String, SomeObject> myStringMap;
+        HashSet<WTF::String> myStringSet;
+        std::optional<WTF::String> myOptionalString;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsValdidatedStringUserStruct2) == sizeof(ValdidatedStringUserStruct2));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(ValdidatedStringUserStruct2, myString)
+        , offsetof(ValdidatedStringUserStruct2, myStringVector)
+        , offsetof(ValdidatedStringUserStruct2, myStringMap)
+        , offsetof(ValdidatedStringUserStruct2, myStringSet)
+        , offsetof(ValdidatedStringUserStruct2, myOptionalString)
+    >::value);
+
+    encoder << instance.myString;
+    encoder << instance.myStringVector;
+    encoder << instance.myStringMap;
+    encoder << instance.myStringSet;
+    encoder << instance.myOptionalString;
+}
+
+std::optional<ValdidatedStringUserStruct2> ArgumentCoder<ValdidatedStringUserStruct2>::decode(Decoder& decoder)
+{
+    auto myString = decoder.decode<ValidatedString, WTF::String>();
+    auto myStringVector = decoder.decode<Vector<WTF::String>>();
+    for (auto& item : *myStringVector) {
+    if (!(item->validate()))
+        return std::nullopt;
+    }
+    auto myStringMap = decoder.decode<HashMap<WTF::String, SomeObject>>();
+    for (const auto& [key, value] : *myStringMap) {
+    if (!(key->validate()))
+        return std::nullopt;
+    }
+    auto myStringSet = decoder.decode<HashSet<WTF::String>>();
+    for (const auto& key : *myStringSet) {
+    if (!(key->validate()))
+        return std::nullopt;
+    }
+    auto myOptionalString = decoder.decode<std::optional<WTF::String>>();
+    if (!(**myOptionalString->validate()))
+        return std::nullopt;
+    if (!decoder.isValid()) [[unlikely]]
+        return std::nullopt;
+    return {
+        ValdidatedStringUserStruct2 {
+            WTFMove(*myString),
+            WTFMove(*myStringVector),
+            WTFMove(*myStringMap),
+            WTFMove(*myStringSet),
+            WTFMove(*myOptionalString)
+        }
+    };
+}
+
+std::optional<WTF::String> ArgumentCoder<ValidatedString>::decode(Decoder& decoder)
+{
+    auto result = decoder.decode<WTF::String>();
+    if (!decoder.isValid()) [[unlikely]]
+        return std::nullopt;
+    if (!(*result->validate()))
+        return std::nullopt;
+    return result;
+}
+
 } // namespace IPC
 
 namespace WTF {

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -131,6 +131,8 @@ struct RequestEncodedWithBodyRValue;
 #if USE(SKIA)
 class SkFooBar;
 #endif
+struct ValdidatedStringUserStruct1;
+struct ValdidatedStringUserStruct2;
 
 #if USE(CFBAR)
 typedef struct __CFBar * CFBarRef;
@@ -148,6 +150,7 @@ using RemoteVideoFrameReference = IPC::ObjectIdentifierReference<RemoteVideoFram
 namespace WebKit {
 using RemoteVideoFrameWriteReference = IPC::ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>;
 }
+class ValidatedString { };
 
 namespace IPC {
 
@@ -432,6 +435,20 @@ template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
 template<> struct ArgumentCoder<WebCore::OpaqueTypeObject> {
     static void encode(Encoder&, const WebCore::OpaqueTypeObject&);
     static std::optional<WebCore::OpaqueTypeObject> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<ValdidatedStringUserStruct1> {
+    static void encode(Encoder&, const ValdidatedStringUserStruct1&);
+    static std::optional<ValdidatedStringUserStruct1> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<ValdidatedStringUserStruct2> {
+    static void encode(Encoder&, const ValdidatedStringUserStruct2&);
+    static std::optional<ValdidatedStringUserStruct2> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<ValidatedString> {
+    static std::optional<WTF::String> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -570,6 +570,34 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "member"_s
             },
         } },
+        { "ValdidatedStringUserStruct1"_s, {
+            {
+                "ValidatedString"_s,
+                "myString"_s
+            },
+        } },
+        { "ValdidatedStringUserStruct2"_s, {
+            {
+                "ValidatedString"_s,
+                "myString"_s
+            },
+            {
+                "Vector<ValidatedString>"_s,
+                "myStringVector"_s
+            },
+            {
+                "HashMap<ValidatedString, SomeObject>"_s,
+                "myStringMap"_s
+            },
+            {
+                "HashSet<ValidatedString>"_s,
+                "myStringSet"_s
+            },
+            {
+                "std::optional<ValidatedString>"_s,
+                "myOptionalString"_s
+            },
+        } },
 #if USE(PASSKIT)
         { "PKPaymentMethod"_s, {
             { "WebKit::CoreIPCPKPaymentMethod"_s, "wrapper"_s }
@@ -621,6 +649,11 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         { "WebCore::NonConditionalVariant"_s, {
         {
             "Variant<int, double>"_s
+            , "alias"_s }
+        } },
+        { "ValidatedString"_s, {
+        {
+            "WTF::String"_s
             , "alias"_s }
         } },
     };

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -370,3 +370,17 @@ using WebCore::ConditionalVariant = Variant<
 >;
 
 using WebCore::NonConditionalVariant = Variant<int, double>
+
+[Alias=class WTF::String, Validator='$->validate()'] alias ValidatedString;
+
+struct ValdidatedStringUserStruct1 {
+    ValidatedString myString;
+}
+
+struct ValdidatedStringUserStruct2 {
+    ValidatedString myString;
+    Vector<ValidatedString> myStringVector;
+    HashMap<ValidatedString, SomeObject> myStringMap;
+    HashSet<ValidatedString> myStringSet;
+    std::optional<ValidatedString> myOptionalString;
+}

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
@@ -50,7 +50,7 @@ webkit_platform_headers: "CoreIPCError.h"
     String m_failingURLStringError;
 #endif
 
-    String m_filePathError;
+    FilePath m_filePathError;
     
     String m_networkTaskDescription;
     String m_networkTaskMetricsPrivacyStance;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -27,7 +27,7 @@ secure_coding_header: <pal/cocoa/PassKitSoftLink.h>
 
 [CustomHeader, WebKitPlatform] class WebKit::CoreIPCPKContact {
     std::optional<WebKit::CoreIPCPersonNameComponents> m_name;
-    String m_emailAddress;
+    EmailAddress m_emailAddress;
     std::optional<WebKit::CoreIPCCNPhoneNumber> m_phoneNumber;
     std::optional<WebKit::CoreIPCCNPostalAddress> m_postalAddress;
     String m_supplementarySublocality;

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -35,7 +35,7 @@ WebFilterEvaluator wrapped by CoreIPCWebFilterEvaluator
 
 #if ENABLE(CONTENT_FILTERING)
 class WebCore::ContentFilterUnblockHandler {
-    String unblockURLHost()
+    Hostname unblockURLHost()
     URL unreachableURL()
 #if HAVE(WEBCONTENTRESTRICTIONS)
     std::optional<URL> evaluatedURL();

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -36,7 +36,7 @@ class WebKit::ContextMenuContextData {
     WebCore::IntRect controlledImageBounds();
     String controlledImageAttachmentID();
     std::optional<WebCore::ElementContext> controlledImageElementContext();
-    String controlledImageMIMEType();
+    MimeType controlledImageMIMEType();
 #endif // ENABLE(SERVICE_CONTROLS)
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     std::optional<WebCore::ShareableBitmapHandle> createPotentialQRCodeNodeSnapshotImageReadOnlyHandle();

--- a/Source/WebKit/Shared/Extensions/WebExtensionCookieParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionCookieParameters.serialization.in
@@ -30,7 +30,7 @@ struct WebKit::WebExtensionCookieParameters {
 [CustomHeader] struct WebKit::WebExtensionCookieFilterParameters {
     std::optional<String> name;
     std::optional<String> domain;
-    std::optional<String> path;
+    std::optional<URLPath> path;
     std::optional<bool> secure;
     std::optional<bool> session;
 };

--- a/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in
@@ -26,7 +26,7 @@
 
 struct WebKit::WebExtensionSidebarParameters {
     bool enabled;
-    String panelPath;
+    FilePath panelPath;
     std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier;
 };
 

--- a/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
@@ -31,6 +31,6 @@
 [RValue] struct WebKit::FullScreenMediaDetails {
     WebKit::FullScreenMediaDetails::Type type;
     WebCore::FloatSize mediaDimensions;
-    String mimeType;
+    MimeType mimeType;
     std::optional<WebCore::SharedMemory::Handle> imageHandle;
 };

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -31,7 +31,7 @@ enum class WebCore::LockBackForwardList : bool;
     WebKit::SandboxExtensionHandle sandboxExtensionHandle;
     RefPtr<WebCore::SharedBuffer> data;
 
-    String MIMEType;
+    MimeType MIMEType;
     String encodingName;
     String baseURLString;
     String unreachableURLString;

--- a/Source/WebKit/Shared/Pasteboard.serialization.in
+++ b/Source/WebKit/Shared/Pasteboard.serialization.in
@@ -34,7 +34,7 @@ header: <WebCore/Pasteboard.h>
 #endif
 #if !(PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN))
     RefPtr<WebCore::SharedBuffer> resourceData;
-    String resourceMIMEType;
+    MimeType resourceMIMEType;
     Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
 #endif
     String suggestedName;

--- a/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.serialization.in
+++ b/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.serialization.in
@@ -22,7 +22,7 @@
 
 header: "ScriptTrackingPrivacyFilter.h"
 [CustomHeader] struct WebKit::ScriptTrackingPrivacyHost {
-    String hostName;
+    Hostname hostName;
     OptionSet<WebCore::ScriptTrackingPrivacyFlag> allowedCategories;
 }
 

--- a/Source/WebKit/Shared/SerializedNode.serialization.in
+++ b/Source/WebKit/Shared/SerializedNode.serialization.in
@@ -41,7 +41,7 @@
     URL baseURL;
     URL baseURLOverride;
     Variant<String, URL> documentURI;
-    String contentType;
+    MimeType contentType;
 };
 [Nested] enum class WebCore::ClonedDocumentType : uint8_t {
     XMLDocument,

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -22,7 +22,7 @@
 
 header: "SessionState.h"
 [CustomHeader] struct WebKit::HTTPBody {
-    String contentType;
+    MimeType contentType;
     Vector<WebKit::HTTPBody::Element> elements;
 };
 
@@ -31,7 +31,7 @@ header: "SessionState.h"
 };
 
 [Nested] struct WebKit::HTTPBody::Element::FileData {
-    String filePath;
+    FilePath filePath;
     int64_t fileStart;
     std::optional<int64_t> fileLength;
     std::optional<WallTime> expectedFileModificationTime;

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -20,7 +20,14 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-webkit_platform_headers: "StreamConnectionEncoder.h"
+webkit_platform_headers: "StreamConnectionEncoder.h" "IPCValidation.h"
+headers: "IPCValidation.h"
+[WebKitPlatform, Alias=class WTF::String, Validator='IPC::Validation::isValidHostname($)'] alias Hostname;
+[WebKitPlatform, Alias=class WTF::String, Validator='IPC::Validation::isValidMimeType($)'] alias MimeType;
+[WebKitPlatform, Alias=class WTF::String, Validator='IPC::Validation::isValidURLScheme($)'] alias URLScheme;
+[WebKitPlatform, Alias=class WTF::String, Validator='IPC::Validation::isValidFilePath($)'] alias FilePath;
+[WebKitPlatform, Alias=class WTF::String, Validator='IPC::Validation::isValidURLPath($)'] alias URLPath;
+[WebKitPlatform, Alias=class WTF::String, Validator='IPC::Validation::isValidEmailAddress($)'] alias EmailAddress;
 
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::URL {
     String string()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -547,7 +547,7 @@ class WebCore::IDBResourceIdentifier {
 class WebCore::IDBValue {
     WebCore::ThreadSafeDataBuffer data()
     Vector<String> blobURLs()
-    Vector<String> blobFilePaths()
+    Vector<FilePath> blobFilePaths()
 };
 
 class WebCore::IDBOpenRequestData {
@@ -1318,7 +1318,7 @@ struct WebCore::RetrieveRecordsOptions {
 
 struct WebCore::ContactInfo {
     Vector<String> name;
-    Vector<String> email;
+    Vector<EmailAddress> email;
     Vector<String> tel;
 };
 
@@ -1645,12 +1645,12 @@ struct WebCore::PublicKeyCredentialRequestOptions {
 }
 
 class WebCore::Site {
-    String protocol()
+    URLScheme protocol()
     WebCore::RegistrableDomain domain()
 }
 
 struct WebCore::AudioConfiguration {
-    String contentType;
+    MimeType contentType;
     String channels;
     std::optional<uint64_t> bitrate;
     std::optional<uint32_t> samplerate;
@@ -1667,7 +1667,7 @@ struct WebCore::Cookie {
     String name;
     String value;
     String domain;
-    String path;
+    URLPath path;
     String partitionKey;
     double created;
     std::optional<double> expires;
@@ -2113,7 +2113,7 @@ enum class WebCore::MediaCaptureType : uint8_t {
 #if ENABLE(ATTACHMENT_ELEMENT)
 struct WebCore::SerializedAttachmentData {
     String identifier;
-    String mimeType;
+    MimeType mimeType;
     Ref<WebCore::SharedBuffer> data;
 };
 
@@ -2130,7 +2130,7 @@ header: <WebCore/FileChooser.h>
 [CustomHeader] struct WebCore::FileChooserSettings {
     bool allowsDirectories;
     bool allowsMultipleFiles;
-    Vector<String> acceptMIMETypes;
+    Vector<MimeType> acceptMIMETypes;
     Vector<String> acceptFileExtensions;
     Vector<String> selectedFiles;
 #if ENABLE(MEDIA_CAPTURE)
@@ -2689,7 +2689,7 @@ class WebCore::DragData {
     WebCore::IntPoint globalPosition();
 #if PLATFORM(COCOA)
     Vector<String> fileNames();
-    Vector<String> promisedFileMIMETypes();
+    Vector<MimeType> promisedFileMIMETypes();
 #endif
     OptionSet<WebCore::DragOperation> draggingSourceOperationMask();
     OptionSet<WebCore::DragApplicationFlags> flags();
@@ -3463,7 +3463,7 @@ enum class WebCore::WasPrivateRelayed : bool;
 
 [CustomHeader] struct WebCore::ResourceResponseData {
     URL url;
-    String mimeType;
+    MimeType mimeType;
     long long expectedContentLength;
     String textEncodingName;
     short httpStatusCode;
@@ -3487,11 +3487,11 @@ enum class WebCore::WasPrivateRelayed : bool;
 [RefCounted, CreateUsing=createWithData] class WebCore::ArchiveResource {
     Ref<WebCore::FragmentedSharedBuffer> protectedData();
     URL url();
-    String mimeType();
+    MimeType mimeType();
     String textEncoding();
     String frameName();
     WebCore::ResourceResponse response();
-    String relativeFilePath();
+    FilePath relativeFilePath();
 };
 
 [RefCounted, CreateUsing=create] class WebCore::LegacyWebArchive {
@@ -4192,7 +4192,7 @@ struct WebCore::SameSiteInfo {
 [RefCounted] class WebCore::SecurityOrigin {
     WebCore::SecurityOriginData m_data;
     String m_domain;
-    String m_filePath;
+    FilePath m_filePath;
     bool m_universalAccess;
     bool m_domainWasSetInDOM;
     bool m_canLoadLocalResources;
@@ -4314,7 +4314,7 @@ enum class WebCore::CDMEncryptionScheme : bool;
 enum class WebCore::CDMKeyGroupingStrategy : bool;
 
 struct WebCore::CDMMediaCapability {
-    String contentType;
+    MimeType contentType;
     String robustness;
     std::optional<WebCore::CDMEncryptionScheme> encryptionScheme;
 };
@@ -5292,12 +5292,12 @@ enum class WebCore::RunningStatus : bool
 
 header: <WebCore/ServiceWorkerRoute.h>
 [CustomHeader] struct WebCore::ServiceWorkerRoutePattern {
-    String protocol;
+    URLScheme protocol;
     String username;
     String password;
-    String hostname;
+    Hostname hostname;
     String port;
-    String pathname;
+    URLPath pathname;
     String search;
     String hash;
 }
@@ -5402,8 +5402,8 @@ class WebCore::SecurityOriginData {
 };
 
 [Nested] class WebCore::SecurityOriginData::Tuple {
-    [Validator='!protocol->isHashTableDeletedValue()'] String protocol;
-    String host;
+    [Validator='!protocol->isHashTableDeletedValue()'] URLScheme protocol;
+    Hostname host;
     std::optional<uint16_t> port;
 };
 
@@ -5745,7 +5745,7 @@ header: <WebCore/RTCDataChannelHandler.h>
     std::optional<bool> ordered;
     std::optional<unsigned short> maxPacketLifeTime;
     std::optional<unsigned short> maxRetransmits;
-    String protocol;
+    URLScheme protocol;
     std::optional<bool> negotiated;
     std::optional<unsigned short> id;
     WebCore::RTCPriorityType priority;
@@ -5940,7 +5940,7 @@ enum class WebCore::LinkIconType : uint8_t {
 struct WebCore::LinkIcon {
     URL url;
     WebCore::LinkIconType type;
-    String mimeType;
+    MimeType mimeType;
     std::optional<unsigned> size;
     Vector<std::pair<String, String>> attributes;
 };
@@ -5990,7 +5990,7 @@ enum class WebCore::PasteboardItemPresentationStyle : uint8_t {
 };
 
 struct WebCore::PasteboardItemInfo {
-    Vector<String> pathsForFileUpload;
+    Vector<FilePath> pathsForFileUpload;
     Vector<String> platformTypesForFileUpload;
     Vector<String> platformTypesByFidelity;
     String suggestedFileName;
@@ -6070,7 +6070,7 @@ struct WebCore::ServiceWorkerJobDataIdentifier {
 struct WebCore::ServiceWorkerImportedScript {
     WebCore::ScriptBuffer script;
     URL responseURL;
-    String mimeType;
+    MimeType mimeType;
 };
 
 #if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)
@@ -6566,7 +6566,7 @@ header: <WebCore/CaretAnimator.h>
 #endif
 
 class WebCore::ProtectionSpace {
-    String host();
+    Hostname host();
     int port();
     WebCore::ProtectionSpace::ServerType serverType();
     String realm();
@@ -7113,7 +7113,7 @@ struct WebCore::CookieChangeSubscription {
 
 [RefCounted] class WebCore::Model {
     Ref<WebCore::SharedBuffer> data()
-    String mimeType()
+    MimeType mimeType()
     URL url()
 }
 
@@ -7283,7 +7283,7 @@ struct WebCore::RemoteUserInputEventData {
 
 struct WebCore::LinkDecorationFilteringData {
     WebCore::RegistrableDomain domain;
-    String path;
+    URLPath path;
     String linkDecoration;
 };
 
@@ -7376,7 +7376,7 @@ class WebCore::NetworkLoadMetrics {
     MonotonicTime responseEnd;
     MonotonicTime workerStart;
 
-    String protocol;
+    URLScheme protocol;
 
     uint16_t redirectCount;
 
@@ -7458,7 +7458,7 @@ struct WebCore::MediaUsageInfo {
 header: <WebCore/NowPlayingInfo.h>
 [CustomHeader] struct WebCore::NowPlayingInfoArtwork {
     String src;
-    String mimeType;
+    MimeType mimeType;
     RefPtr<WebCore::Image> image;
 }
 
@@ -7484,7 +7484,7 @@ struct WebCore::NowPlayingInfo {
 }
 
 struct WebCore::VideoConfiguration {
-    String contentType;
+    MimeType contentType;
     uint32_t width;
     uint32_t height;
     uint64_t bitrate;
@@ -9014,7 +9014,7 @@ header: <WebCore/ScriptTrackingPrivacyCategory.h>
 struct WebCore::ParentalControlsURLFilterParameters {
     URL urlToAllow;
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
-    String configurationPath;
+    FilePath configurationPath;
 #endif
 };
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -61,7 +61,7 @@ struct WebKit::WebHitTestResultData {
     String imageText;
     std::optional<WebCore::SharedMemoryHandle> getImageSharedMemoryHandle();
     RefPtr<WebCore::ShareableBitmap> imageBitmap;
-    String sourceImageMIMEType;
+    MimeType sourceImageMIMEType;
     bool hasEntireImage;
     bool allowsFollowingLink;
     bool allowsFollowingImageURL;

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -99,7 +99,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     bool hasResourceLoadClient;
 
-    Vector<String> mimeTypesWithCustomContentProviders;
+    Vector<MimeType> mimeTypesWithCustomContentProviders;
 
     bool controlledByAutomation;
     bool isProcessSwap;
@@ -170,8 +170,8 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     String overrideContentSecurityPolicy;
     std::optional<double> cpuLimit;
 
-    HashMap<String, WebKit::WebURLSchemeHandlerIdentifier> urlSchemeHandlers;
-    Vector<String> urlSchemesWithLegacyCustomProtocolHandlers;
+    HashMap<URLScheme, WebKit::WebURLSchemeHandlerIdentifier> urlSchemeHandlers;
+    Vector<URLScheme> urlSchemesWithLegacyCustomProtocolHandlers;
 
 #if ENABLE(APPLICATION_MANIFEST)
     std::optional<WebCore::ApplicationManifest> applicationManifest;
@@ -196,7 +196,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     String overriddenMediaType;
     Vector<String> corsDisablingPatterns;
-    HashSet<String> maskedURLSchemes;
+    HashSet<URLScheme> maskedURLSchemes;
     bool loadsSubresources;
     std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<String>> allowedNetworkHosts;
     std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -22,7 +22,7 @@
 
 [RValue, DebugDecodingFailure] struct WebKit::WebProcessCreationParameters {
     WebKit::AuxiliaryProcessCreationParameters auxiliaryProcessParameters;
-    String injectedBundlePath;
+    FilePath injectedBundlePath;
     WebKit::SandboxExtensionHandle injectedBundlePathExtensionHandle;
     Vector<WebKit::SandboxExtensionHandle> additionalSandboxExtensionHandles;
 
@@ -32,22 +32,22 @@
     Vector<WebKit::SandboxExtensionHandle> enableRemoteWebInspectorExtensionHandles;
 #endif
 
-    Vector<String> urlSchemesRegisteredAsEmptyDocument;
-    Vector<String> urlSchemesRegisteredAsSecure;
-    Vector<String> urlSchemesRegisteredAsBypassingContentSecurityPolicy;
-    Vector<String> urlSchemesForWhichDomainRelaxationIsForbidden;
-    Vector<String> urlSchemesRegisteredAsLocal;
+    Vector<URLScheme> urlSchemesRegisteredAsEmptyDocument;
+    Vector<URLScheme> urlSchemesRegisteredAsSecure;
+    Vector<URLScheme> urlSchemesRegisteredAsBypassingContentSecurityPolicy;
+    Vector<URLScheme> urlSchemesForWhichDomainRelaxationIsForbidden;
+    Vector<URLScheme> urlSchemesRegisteredAsLocal;
 #if ENABLE(ALL_LEGACY_REGISTERED_SPECIAL_URL_SCHEMES)
-    Vector<String> urlSchemesRegisteredAsNoAccess;
+    Vector<URLScheme> urlSchemesRegisteredAsNoAccess;
 #endif
-    Vector<String> urlSchemesRegisteredAsDisplayIsolated;
-    Vector<String> urlSchemesRegisteredAsCORSEnabled;
-    Vector<String> urlSchemesRegisteredAsAlwaysRevalidated;
-    Vector<String> urlSchemesRegisteredAsCachePartitioned;
-    Vector<String> urlSchemesRegisteredAsCanDisplayOnlyIfCanRequest;
+    Vector<URLScheme> urlSchemesRegisteredAsDisplayIsolated;
+    Vector<URLScheme> urlSchemesRegisteredAsCORSEnabled;
+    Vector<URLScheme> urlSchemesRegisteredAsAlwaysRevalidated;
+    Vector<URLScheme> urlSchemesRegisteredAsCachePartitioned;
+    Vector<URLScheme> urlSchemesRegisteredAsCanDisplayOnlyIfCanRequest;
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    Vector<String> urlSchemesRegisteredAsWebExtensions;
+    Vector<URLScheme> urlSchemesRegisteredAsWebExtensions;
 #endif
 
     Vector<String> fontAllowList;
@@ -94,7 +94,7 @@
     ProcessID presentingApplicationPID;
 
 #if PLATFORM(COCOA)
-    String uiProcessBundleResourcePath;
+    FilePath uiProcessBundleResourcePath;
     WebKit::SandboxExtensionHandle uiProcessBundleResourcePathExtensionHandle;
 
     bool shouldEnableJIT;
@@ -117,7 +117,7 @@
 #endif
 
 #if PLATFORM(COCOA)
-    Vector<String> mediaMIMETypes;
+    Vector<MimeType> mediaMIMETypes;
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -68,7 +68,7 @@ struct WebKit::InteractionInformationAtPosition {
     WebCore::FloatPoint adjustedPointForNodeRespondingToClickEvents;
     URL url;
     URL imageURL;
-    String imageMIMEType;
+    MimeType imageMIMEType;
     String title;
     String idAttribute;
     WebCore::IntRect bounds;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1708,6 +1708,7 @@
 		84AF2C7C2952374800563FA5 /* module.private.modulemap in Copy Private Module Map */ = {isa = PBXBuildFile; fileRef = 843FD167295234DC00476A01 /* module.private.modulemap */; };
 		8644890B27B47020007A1C66 /* _WKSystemPreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = 8644890A27B47020007A1C66 /* _WKSystemPreferences.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8644890F27B5CB43007A1C66 /* _WKSystemPreferencesInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8644890E27B5CB43007A1C66 /* _WKSystemPreferencesInternal.h */; };
+		864F7B442ED5F0CC001AC17F /* IPCValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 864F7B432ED5F0CC001AC17F /* IPCValidation.h */; };
 		866623F929C2248E0029405A /* WebAutocorrectionData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 866623F829C2248D0029405A /* WebAutocorrectionData.mm */; };
 		86760A6B28DB30DE00D07D06 /* GeneratedSerializers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86760A6928DB305F00D07D06 /* GeneratedSerializers.mm */; };
 		86D1970929AE4E930083B077 /* NetworkProcessConnectionParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D1970829AE4E930083B077 /* NetworkProcessConnectionParameters.h */; };
@@ -7083,6 +7084,7 @@
 		8644890A27B47020007A1C66 /* _WKSystemPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSystemPreferences.h; sourceTree = "<group>"; };
 		8644890C27B47045007A1C66 /* _WKSystemPreferences.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKSystemPreferences.mm; sourceTree = "<group>"; };
 		8644890E27B5CB43007A1C66 /* _WKSystemPreferencesInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSystemPreferencesInternal.h; sourceTree = "<group>"; };
+		864F7B432ED5F0CC001AC17F /* IPCValidation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCValidation.h; sourceTree = "<group>"; };
 		8657EE3928EDB8C500FF9B40 /* Pasteboard.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = Pasteboard.serialization.in; sourceTree = "<group>"; };
 		866623F829C2248D0029405A /* WebAutocorrectionData.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebAutocorrectionData.mm; path = ios/WebAutocorrectionData.mm; sourceTree = "<group>"; };
 		86760A6928DB305F00D07D06 /* GeneratedSerializers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializers.mm; sourceTree = "<group>"; };
@@ -10603,6 +10605,7 @@
 				46CD8C442B059FF500360248 /* IPCSemaphore.serialization.in */,
 				7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */,
 				7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */,
+				864F7B432ED5F0CC001AC17F /* IPCValidation.h */,
 				9BF5EC6325410E9900984E77 /* JSIPCBinding.cpp */,
 				9B47908E253151CC00EC11AB /* JSIPCBinding.h */,
 				9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */,
@@ -17856,6 +17859,7 @@
 				A73E66BD2AB107C3005FC327 /* IPCEvent.h in Headers */,
 				A31F60A425CC7DB900AF14F4 /* IPCSemaphore.h in Headers */,
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
+				864F7B442ED5F0CC001AC17F /* IPCValidation.h in Headers */,
 				46DBC28C2AF96B9F00E6B63A /* ITPThirdPartyData.h in Headers */,
 				46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,


### PR DESCRIPTION
#### eaedd76f35a76ad67058631b8c72508bfdfbe716
<pre>
Introduce CoreIPC Thin type Aliasing For Additional Validation of Common CoreIPC Types
<a href="https://bugs.webkit.org/show_bug.cgi?id=303105">https://bugs.webkit.org/show_bug.cgi?id=303105</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Introduces thin type aliasing for CoreIPC. Allows you got construct
a thin alias around an existing IPC type (including primitives) and
apply additional validation to the type.

* Source/WebCore/Modules/Model/InternalAPI/DDModel.serialization.in:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decode):
* Source/WebKit/Platform/IPC/IPCValidation.h: Added.
(IPC::Validation::isValidFilePath):
(IPC::Validation::isValidURLPath):
(IPC::Validation::isValidHostname):
(IPC::Validation::isValidMimeType):
(IPC::Validation::isValidURLScheme):
(IPC::Validation::isValidEmailAddress):
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.can_assert_member_order_is_correct):
(AliasType):
(AliasType.__init__):
(one_argument_coder_declaration):
(remove_template_parameters):
(generate_forward_declarations):
(generate_header):
(strip_container):
(find_alias):
(replace_type):
(validate_container):
(check_type_members):
(check_type_members.is):
(encode_type):
(decode_type):
(decode_type.is):
(generate_type_validation):
(generate_one_impl):
(generate_impl):
(generate_serialized_type_info):
(parse_serialized_types):
(main):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;ValdidatedStringUserStruct1&gt;::encode):
(IPC::ArgumentCoder&lt;ValdidatedStringUserStruct1&gt;::decode):
(IPC::ArgumentCoder&lt;ValdidatedStringUserStruct2&gt;::encode):
(IPC::ArgumentCoder&lt;ValdidatedStringUserStruct2&gt;::decode):
(IPC::ArgumentCoder&lt;ValidatedString&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/ContextMenuContextData.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionCookieParameters.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in:
* Source/WebKit/Shared/FullScreenMediaDetails.serialization.in:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/Pasteboard.serialization.in:
* Source/WebKit/Shared/ScriptTrackingPrivacyFilter.serialization.in:
* Source/WebKit/Shared/SerializedNode.serialization.in:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaedd76f35a76ad67058631b8c72508bfdfbe716

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132781 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84809 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c90019b8-78d4-473c-af14-530a7cd14818) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101523 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68815 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/daf546f4-7b76-4cba-9d1e-71983e4dd0d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135727 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3922 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118956 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82314 "Found 124 new API test failures: WPE/TestLoaderClient:/webkit/WebKitWebView/user-agent, WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/content-filter, WPE/TestDownloads:/webkit/Downloads/async-decide-destination-cancel, WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-disallowed, WPE/TestDownloads:/webkit/Downloads/local-file, TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidEndShouldBeDispatchedForRemovedFocusField, WPE/TestLoaderClient:/webkit/WebKitWebView/progress, WPE/TestCookieManager:/webkit/WebKitCookieManager/sync-with-webview ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3db06cdb-f4fb-4623-a33e-1d1474ec9bf6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132130 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3809 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1527 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83546 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112784 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142968 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4946 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37659 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/aria-combobox.html accessibility/combobox/combobox-active-element-selected-children.html ... (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/109894 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5028 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4279 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/aria-combobox.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110072 "Found 122 new API test failures: WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/content-filter, WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, WebKitGTK/TestSSL:/webkit/WebKitWebView/client-side-certificate, WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/delete-cookie, WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/clear, TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/navigation-policy, TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidEndShouldBeDispatchedForRemovedFocusField, WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data, TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents ... (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3785 "Found 60 new test failures: cookies/cookie-store-register-eventlistener-from-file-protocol.html cookies/cookie-store-start-listening-for-change-with-null-url-crash.html fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-dark-mode.html fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-light-mode.html fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear.html fast/forms/form-control-refresh/button-like-controls-text-color-matches.html fast/forms/form-control-refresh/button-without-explicit-type-does-not-display-as-submit-button.html fast/forms/form-control-refresh/submit-button-text-color-disabled-state.html fast/images/spatial-image-controls-rtl.html http/tests/iframe-monitor/blob-resource.html ... (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115227 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58451 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5000 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33575 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html ... (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->