### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for ContentKeyGroupDataSource

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
@@ -31,6 +31,7 @@
 
 #if HAVE(AVCONTENTKEYSESSION)
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Assertions.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
@@ -38,17 +39,8 @@
 OBJC_CLASS AVContentKey;
 
 namespace WebCore {
-class ContentKeyGroupDataSource;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ContentKeyGroupDataSource> : std::true_type { };
-}
-
-namespace WebCore {
-
-class ContentKeyGroupDataSource : public CanMakeWeakPtr<ContentKeyGroupDataSource> {
+class ContentKeyGroupDataSource : public AbstractRefCountedAndCanMakeWeakPtr<ContentKeyGroupDataSource> {
 public:
     virtual ~ContentKeyGroupDataSource() = default;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -187,8 +187,12 @@ class CDMInstanceSessionFairPlayStreamingAVFObjC final
 public:
     USING_CAN_MAKE_WEAKPTR(AVContentKeySessionDelegateClient);
 
-    CDMInstanceSessionFairPlayStreamingAVFObjC(Ref<CDMInstanceFairPlayStreamingAVFObjC>&&);
+    static Ref<CDMInstanceSessionFairPlayStreamingAVFObjC> create(Ref<CDMInstanceFairPlayStreamingAVFObjC>&&);
     virtual ~CDMInstanceSessionFairPlayStreamingAVFObjC();
+
+    // ContentKeyGroupDataSource.
+    void ref() const final { CDMInstanceSession::ref(); }
+    void deref() const final { CDMInstanceSession::deref(); }
 
     // CDMInstanceSession
     void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;
@@ -238,6 +242,8 @@ public:
     static RetainPtr<NSDictionary> optionsForKeyRequestWithHashSalt(const String&);
 
 private:
+    explicit CDMInstanceSessionFairPlayStreamingAVFObjC(Ref<CDMInstanceFairPlayStreamingAVFObjC>&&);
+
     bool ensureSessionOrGroup(KeyGroupingStrategy);
     bool isLicenseTypeSupported(LicenseType) const;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -431,7 +431,7 @@ void CDMInstanceFairPlayStreamingAVFObjC::setStorageDirectory(const String& stor
 
 RefPtr<CDMInstanceSession> CDMInstanceFairPlayStreamingAVFObjC::createSession()
 {
-    auto session = adoptRef(*new CDMInstanceSessionFairPlayStreamingAVFObjC(*this));
+    Ref session = CDMInstanceSessionFairPlayStreamingAVFObjC::create(*this);
     m_sessions.append(session);
     return session;
 }
@@ -716,6 +716,11 @@ void CDMInstanceFairPlayStreamingAVFObjC::sessionKeyStatusesChanged(const CDMIns
     m_keyStatusChangedObservers.forEach([] (auto& observer) {
         observer();
     });
+}
+
+Ref<CDMInstanceSessionFairPlayStreamingAVFObjC> CDMInstanceSessionFairPlayStreamingAVFObjC::create(Ref<CDMInstanceFairPlayStreamingAVFObjC>&& instance)
+{
+    return adoptRef(*new CDMInstanceSessionFairPlayStreamingAVFObjC(WTFMove(instance)));
 }
 
 CDMInstanceSessionFairPlayStreamingAVFObjC::CDMInstanceSessionFairPlayStreamingAVFObjC(Ref<CDMInstanceFairPlayStreamingAVFObjC>&& instance)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
@@ -101,11 +101,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)expire
 {
-    if (!_dataSource)
+    RefPtr dataSource = _dataSource.get();
+    if (!dataSource)
         return;
 
 #if HAVE(AVCONTENTKEY_REVOKE)
-    Vector keys = _dataSource->contentKeyGroupDataSourceKeys();
+    Vector keys = dataSource->contentKeyGroupDataSourceKeys();
     OBJC_INFO_LOG(OBJC_LOGIDENTIFIER, "keys=", keys.size());
 
     // FIXME (117803793): Remove staging code once -[AVContentKey revoke] is available in SDKs used by WebKit builders
@@ -131,17 +132,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (uint64_t)logIdentifier
 {
-    return _dataSource ? _dataSource->contentKeyGroupDataSourceLogIdentifier() : 0;
+    RefPtr dataSource = _dataSource.get();
+    return dataSource ? dataSource->contentKeyGroupDataSourceLogIdentifier() : 0;
 }
 
 - (const Logger*)loggerPtr
 {
-    return _dataSource ? &_dataSource->contentKeyGroupDataSourceLogger() : nullptr;
+    RefPtr dataSource = _dataSource.get();
+    return dataSource ? &dataSource->contentKeyGroupDataSourceLogger() : nullptr;
 }
 
 - (WTFLogChannel*)logChannel
 {
-    return _dataSource ? &_dataSource->contentKeyGroupDataSourceLogChannel() : nullptr;
+    RefPtr dataSource = _dataSource.get();
+    return dataSource ? &dataSource->contentKeyGroupDataSourceLogChannel() : nullptr;
 }
 
 @end


### PR DESCRIPTION
#### e858c0eba5802405a466dc0b5fc717afe61abd75
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for ContentKeyGroupDataSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=303111">https://bugs.webkit.org/show_bug.cgi?id=303111</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::createSession):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::create):
* Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm:
(-[WebAVContentKeyGroup expire]):
(-[WebAVContentKeyGroup logIdentifier]):
(-[WebAVContentKeyGroup loggerPtr]):
(-[WebAVContentKeyGroup logChannel]):

Canonical link: <a href="https://commits.webkit.org/303701@main">https://commits.webkit.org/303701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bce46dc4540ee42ce0753ac962fbc40d2b700db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84823 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1704f892-81c3-4b36-9b5c-308d0bc398f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101534 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68831 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b3b1b7a-1787-4122-b71a-502eaf9aa63a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135741 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4138 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 2 new passes 36 flakes; Uploaded test results; layout-tests (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82326 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cbe857f2-9ca2-492b-bdd8-a52f24c7c5c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4032 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1537 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83560 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142982 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4960 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109906 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28018 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3797 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58471 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5014 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33604 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->