### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for AVOutputDeviceMenuControllerTargetPicker

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.h
@@ -28,25 +28,18 @@
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
 
 #include "AVPlaybackTargetPicker.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVOutputDeviceMenuController;
 OBJC_CLASS WebAVOutputDeviceMenuControllerHelper;
 
 namespace WebCore {
-class AVOutputDeviceMenuControllerTargetPicker;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AVOutputDeviceMenuControllerTargetPicker> : std::true_type { };
-}
-
-namespace WebCore {
-
-class AVOutputDeviceMenuControllerTargetPicker final : public AVPlaybackTargetPicker {
+class AVOutputDeviceMenuControllerTargetPicker final : public AVPlaybackTargetPicker, public CanMakeCheckedPtr<AVOutputDeviceMenuControllerTargetPicker> {
     WTF_MAKE_TZONE_ALLOCATED(AVOutputDeviceMenuControllerTargetPicker);
     WTF_MAKE_NONCOPYABLE(AVOutputDeviceMenuControllerTargetPicker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AVOutputDeviceMenuControllerTargetPicker);
 public:
     explicit AVOutputDeviceMenuControllerTargetPicker(AVPlaybackTargetPickerClient&);
     virtual ~AVOutputDeviceMenuControllerTargetPicker();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
@@ -189,13 +189,14 @@ AVOutputContext * AVOutputDeviceMenuControllerTargetPicker::outputContext()
         return;
 
     callOnMainThread([self, protectedSelf = retainPtr(self), keyPath = retainPtr(keyPath)] {
-        if (!m_callback)
+        CheckedPtr callback = m_callback.get();
+        if (!callback)
             return;
 
         if ([keyPath isEqualToString:externalOutputDeviceAvailableKeyName])
-            m_callback->availableDevicesDidChange();
+            callback->availableDevicesDidChange();
         else if ([keyPath isEqualToString:externalOutputDevicePickedKeyName])
-            m_callback->currentDeviceDidChange();
+            callback->currentDeviceDidChange();
     });
 }
 @end


### PR DESCRIPTION
#### af43df4e79e12ddb0b78858affdcdc2418cdbb0b
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for AVOutputDeviceMenuControllerTargetPicker
<a href="https://bugs.webkit.org/show_bug.cgi?id=303112">https://bugs.webkit.org/show_bug.cgi?id=303112</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm:
(-[WebAVOutputDeviceMenuControllerHelper observeValueForKeyPath:ofObject:change:context:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af43df4e79e12ddb0b78858affdcdc2418cdbb0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84825 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7620ab59-fc21-4d8b-a635-46558bc230d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5602 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/5053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c352724f-6eb9-4cea-9605-734808da93aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135743 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/118973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82328 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3a3c6c0e-dfff-453a-b03f-c4c2e8ff41c7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83562 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112810 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142984 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4962 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/37676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109908 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5044 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/5053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110086 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58475 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5016 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5107 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/4973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->