### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for several picker-related media types

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.h
@@ -34,19 +34,11 @@ OBJC_CLASS AVOutputDeviceMenuController;
 OBJC_CLASS WebAVOutputDeviceMenuControllerHelper;
 
 namespace WebCore {
-class AVOutputDeviceMenuControllerTargetPicker;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AVOutputDeviceMenuControllerTargetPicker> : std::true_type { };
-}
-
-namespace WebCore {
 
 class AVOutputDeviceMenuControllerTargetPicker final : public AVPlaybackTargetPicker {
     WTF_MAKE_TZONE_ALLOCATED(AVOutputDeviceMenuControllerTargetPicker);
     WTF_MAKE_NONCOPYABLE(AVOutputDeviceMenuControllerTargetPicker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AVOutputDeviceMenuControllerTargetPicker);
 public:
     explicit AVOutputDeviceMenuControllerTargetPicker(AVPlaybackTargetPickerClient&);
     virtual ~AVOutputDeviceMenuControllerTargetPicker();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVPlaybackTargetPicker.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVPlaybackTargetPicker.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
 
+#include <wtf/AbstractCanMakeCheckedPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
@@ -34,21 +36,10 @@ OBJC_CLASS AVOutputContext;
 OBJC_CLASS NSView;
 
 namespace WebCore {
-class AVPlaybackTargetPicker;
-class AVPlaybackTargetPickerClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AVPlaybackTargetPicker> : std::true_type { };
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AVPlaybackTargetPickerClient> : std::true_type { };
-}
-
-namespace WebCore {
 
 class FloatRect;
 
-class AVPlaybackTargetPickerClient : public CanMakeWeakPtr<AVPlaybackTargetPickerClient> {
+class AVPlaybackTargetPickerClient : public CanMakeWeakPtr<AVPlaybackTargetPickerClient>, public AbstractCanMakeCheckedPtr {
 protected:
     virtual ~AVPlaybackTargetPickerClient() = default;
 
@@ -58,9 +49,10 @@ public:
     virtual void currentDeviceChanged() = 0;
 };
 
-class AVPlaybackTargetPicker : public CanMakeWeakPtr<AVPlaybackTargetPicker> {
+class AVPlaybackTargetPicker : public CanMakeWeakPtr<AVPlaybackTargetPicker>, public CanMakeCheckedPtr<AVPlaybackTargetPicker> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AVPlaybackTargetPicker);
     WTF_MAKE_NONCOPYABLE(AVPlaybackTargetPicker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AVPlaybackTargetPicker);
 public:
     explicit AVPlaybackTargetPicker(AVPlaybackTargetPickerClient& client)
         : m_client(client)
@@ -76,7 +68,7 @@ public:
 
     virtual AVOutputContext* outputContext() = 0;
 
-    WeakPtr<AVPlaybackTargetPickerClient> client() const { return m_client; }
+    AVPlaybackTargetPickerClient* client() const { return m_client.get(); }
 
 private:
     WeakPtr<AVPlaybackTargetPickerClient> m_client;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.h
@@ -35,19 +35,11 @@ OBJC_CLASS AVRoutePickerView;
 OBJC_CLASS WebAVRoutePickerViewHelper;
 
 namespace WebCore {
-class AVRoutePickerViewTargetPicker;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AVRoutePickerViewTargetPicker> : std::true_type { };
-}
-
-namespace WebCore {
 
 class AVRoutePickerViewTargetPicker final : public AVPlaybackTargetPicker {
     WTF_MAKE_TZONE_ALLOCATED(AVRoutePickerViewTargetPicker);
     WTF_MAKE_NONCOPYABLE(AVRoutePickerViewTargetPicker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AVRoutePickerViewTargetPicker);
 public:
     explicit AVRoutePickerViewTargetPicker(AVPlaybackTargetPickerClient&);
     virtual ~AVRoutePickerViewTargetPicker();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.h
@@ -49,6 +49,13 @@ public:
     void stopMonitoringPlaybackTargets() final;
     void invalidatePlaybackTargets() final;
 
+    // AVPlaybackTargetPickerClient.
+    uint32_t checkedPtrCount() const final { return MediaPlaybackTargetPicker::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return MediaPlaybackTargetPicker::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { MediaPlaybackTargetPicker::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { MediaPlaybackTargetPicker::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { MediaPlaybackTargetPicker::setDidBeginCheckedPtrDeletion(); }
+
 private:
     bool externalOutputDeviceAvailable() final;
     Ref<MediaPlaybackTarget> playbackTarget() final;
@@ -58,7 +65,7 @@ private:
     void availableDevicesChanged() final;
     void currentDeviceChanged() final;
 
-    AVPlaybackTargetPicker& routePicker();
+    CheckedRef<AVPlaybackTargetPicker> routePicker();
 
     std::unique_ptr<AVPlaybackTargetPicker> m_routePicker;
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm
@@ -64,15 +64,15 @@ MediaPlaybackTargetPickerMac::~MediaPlaybackTargetPickerMac()
 
 bool MediaPlaybackTargetPickerMac::externalOutputDeviceAvailable()
 {
-    return routePicker().externalOutputDeviceAvailable();
+    return routePicker()->externalOutputDeviceAvailable();
 }
 
 Ref<MediaPlaybackTarget> MediaPlaybackTargetPickerMac::playbackTarget()
 {
-    return MediaPlaybackTargetCocoa::create(routePicker().outputContext());
+    return MediaPlaybackTargetCocoa::create(routePicker()->outputContext());
 }
 
-AVPlaybackTargetPicker& MediaPlaybackTargetPickerMac::routePicker()
+CheckedRef<AVPlaybackTargetPicker> MediaPlaybackTargetPickerMac::routePicker()
 {
     if (m_routePicker)
         return *m_routePicker;
@@ -89,20 +89,20 @@ AVPlaybackTargetPicker& MediaPlaybackTargetPickerMac::routePicker()
 
 void MediaPlaybackTargetPickerMac::showPlaybackTargetPicker(CocoaView* view, const FloatRect& location, bool hasActiveRoute, bool useDarkAppearance)
 {
-    routePicker().showPlaybackTargetPicker(view, location, hasActiveRoute, useDarkAppearance);
+    routePicker()->showPlaybackTargetPicker(view, location, hasActiveRoute, useDarkAppearance);
 }
 
 void MediaPlaybackTargetPickerMac::startingMonitoringPlaybackTargets()
 {
     LOG(Media, "MediaPlaybackTargetPickerMac::startingMonitoringPlaybackTargets");
 
-    routePicker().startingMonitoringPlaybackTargets();
+    routePicker()->startingMonitoringPlaybackTargets();
 }
 
 void MediaPlaybackTargetPickerMac::stopMonitoringPlaybackTargets()
 {
     LOG(Media, "MediaPlaybackTargetPickerMac::stopMonitoringPlaybackTargets");
-    routePicker().stopMonitoringPlaybackTargets();
+    routePicker()->stopMonitoringPlaybackTargets();
 }
 
 void MediaPlaybackTargetPickerMac::invalidatePlaybackTargets()


### PR DESCRIPTION
#### f5e20509529cfc53db42ae829eab81123eeb0cf3
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for several picker-related media types
<a href="https://bugs.webkit.org/show_bug.cgi?id=303112">https://bugs.webkit.org/show_bug.cgi?id=303112</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm:
(WebCore::AVOutputDeviceMenuControllerTargetPicker::availableDevicesDidChange):
(WebCore::AVOutputDeviceMenuControllerTargetPicker::currentDeviceDidChange):
(WebCore::AVOutputDeviceMenuControllerTargetPicker::showPlaybackTargetPicker):
(-[WebAVOutputDeviceMenuControllerHelper initWithCallback:]):
(-[WebAVOutputDeviceMenuControllerHelper observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/graphics/avfoundation/objc/AVPlaybackTargetPicker.h:
(WebCore::AVPlaybackTargetPicker::client const):
* Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm:
(WebCore::AVRoutePickerViewTargetPicker::availableDevicesDidChange):
(WebCore::AVRoutePickerViewTargetPicker::currentDeviceDidChange):
(WebCore::AVRoutePickerViewTargetPicker::devicePickerWasDismissed):
(-[WebAVRoutePickerViewHelper routePickerViewDidEndPresentingRoutes:]):
(-[WebAVRoutePickerViewHelper notificationHandler:]):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm:
(WebCore::MediaPlaybackTargetPickerMac::externalOutputDeviceAvailable):
(WebCore::MediaPlaybackTargetPickerMac::playbackTarget):
(WebCore::MediaPlaybackTargetPickerMac::routePicker):
(WebCore::MediaPlaybackTargetPickerMac::showPlaybackTargetPicker):
(WebCore::MediaPlaybackTargetPickerMac::startingMonitoringPlaybackTargets):
(WebCore::MediaPlaybackTargetPickerMac::stopMonitoringPlaybackTargets):

Canonical link: <a href="https://commits.webkit.org/303700@main">https://commits.webkit.org/303700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35479cc449855ba4fbe492ee9ffbf746f684db04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84852 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e5112b35-a861-4751-92f7-901f6cb3ca35) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101558 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68858 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b8fc3b6-802d-4b61-b429-cc2f94b6ab81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135770 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4129 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 2 new passes 36 flakes; Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82351 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d53abea9-a2ca-44b1-b26f-37f647d8161d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4024 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1546 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143011 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109932 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28019 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3818 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5048 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33628 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4886 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->