### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for CDMPrivate

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/CDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.cpp
@@ -77,7 +77,7 @@ CDM::CDM(Document& document, const String& keySystem, const String& mediaKeysHas
     for (auto& weakFactory : CDMFactory::registeredFactories()) {
         Ref factory = weakFactory.get();
         if (factory->supportsKeySystem(keySystem)) {
-            m_private = factory->createCDM(keySystem, m_mediaKeysHashSalt, *this);
+            lazyInitialize(m_private, factory->createCDM(keySystem, m_mediaKeysHashSalt, *this));
 #if !RELEASE_LOG_DISABLED
             m_private->setLogIdentifier(m_logIdentifier);
 #endif

--- a/Source/WebCore/Modules/encryptedmedia/CDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.h
@@ -102,7 +102,7 @@ private:
 #endif
     String m_keySystem;
     String m_mediaKeysHashSalt;
-    std::unique_ptr<CDMPrivate> m_private;
+    const std::unique_ptr<CDMPrivate> m_private;
 };
 
 }

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -36,9 +36,12 @@
 #include "NotImplemented.h"
 #include "ParsedContentType.h"
 #include "SharedBuffer.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMPrivate);
 
 CDMPrivate::CDMPrivate() = default;
 CDMPrivate::~CDMPrivate() = default;
@@ -86,7 +89,7 @@ void CDMPrivate::doSupportedConfigurationStep(CDMKeySystemConfiguration&& candid
         case ConsentStatus::ConsentDenied:
             // ↳ ConsentDenied:
             //    Return ConsentDenied and updated restrictions.
-            weakThis->doSupportedConfigurationStep(WTFMove(configuration), WTFMove(restrictions), access, WTFMove(callback));
+            CheckedRef { *weakThis }->doSupportedConfigurationStep(WTFMove(configuration), WTFMove(restrictions), access, WTFMove(callback));
             return;
 
         case ConsentStatus::InformUser:

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
@@ -30,17 +30,10 @@
 #include <WebCore/CDMInstance.h>
 #include <WebCore/CDMRequirement.h>
 #include <WebCore/CDMSessionType.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class CDMPrivate;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CDMPrivate> : std::true_type { };
-}
 
 #if !RELEASE_LOG_DISABLED
 namespace WTF {
@@ -69,7 +62,9 @@ public:
 #endif
 };
 
-class CDMPrivate : public CanMakeWeakPtr<CDMPrivate> {
+class CDMPrivate : public CanMakeWeakPtr<CDMPrivate>, public CanMakeCheckedPtr<CDMPrivate> {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(CDMPrivate, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMPrivate);
 public:
     WEBCORE_EXPORT virtual ~CDMPrivate();
 

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
@@ -74,6 +74,7 @@ private:
 
 class CDMPrivateClearKey final : public CDMPrivate {
     WTF_MAKE_TZONE_ALLOCATED(CDMPrivateClearKey);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMPrivateClearKey);
 public:
     CDMPrivateClearKey();
     virtual ~CDMPrivateClearKey();

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
@@ -58,6 +58,7 @@ private:
 
 class CDMPrivateFairPlayStreaming final : public CDMPrivate {
     WTF_MAKE_TZONE_ALLOCATED(CDMPrivateFairPlayStreaming);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMPrivateFairPlayStreaming);
 public:
     CDMPrivateFairPlayStreaming(const String& mediaKeysHashSalt, const CDMPrivateClient&);
     virtual ~CDMPrivateFairPlayStreaming();

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -77,6 +77,7 @@ private:
 
 class CDMPrivateThunder final : public CDMPrivate {
     WTF_MAKE_TZONE_ALLOCATED(CDMPrivateThunder);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMPrivateThunder);
 public:
     CDMPrivateThunder(const String& keySystem);
     virtual ~CDMPrivateThunder() = default;

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -41,15 +41,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class MockCDM;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MockCDM> : std::true_type { };
-}
-
-namespace WebCore {
 
 class MockCDMFactory : public RefCounted<MockCDMFactory>, public CDMFactory {
 public:
@@ -114,6 +105,7 @@ private:
 
 class MockCDM : public CDMPrivate {
     WTF_MAKE_TZONE_ALLOCATED(MockCDM);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MockCDM);
 public:
     MockCDM(WeakPtr<MockCDMFactory>, const String&);
 
@@ -145,13 +137,15 @@ private:
 
 class MockCDMInstance : public CDMInstance, public CanMakeWeakPtr<MockCDMInstance> {
 public:
-    MockCDMInstance(WeakPtr<MockCDM>);
+    static Ref<MockCDMInstance> create(MockCDM&);
 
     MockCDMFactory* factory() const { return m_cdm ? m_cdm->factory() : nullptr; }
     bool distinctiveIdentifiersAllowed() const { return m_distinctiveIdentifiersAllowed; }
     bool persistentStateAllowed() const { return m_persistentStateAllowed; }
 
 private:
+    explicit MockCDMInstance(MockCDM&);
+
     ImplementationType implementationType() const final { return ImplementationType::Mock; }
     void initializeWithConfiguration(const MediaKeySystemConfiguration&, AllowDistinctiveIdentifiers, AllowPersistentState, SuccessCallback&&) final;
     void setServerCertificate(Ref<SharedBuffer>&&, SuccessCallback&&) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
@@ -37,8 +37,11 @@
 #include <WebCore/CDMKeySystemConfiguration.h>
 #include <WebCore/CDMRestrictions.h>
 #include <WebCore/SharedBuffer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCDM);
 
 using namespace WebCore;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
@@ -36,6 +36,8 @@
 namespace WebKit {
 
 class RemoteCDM final : public WebCore::CDMPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteCDM);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteCDM);
 public:
     static std::unique_ptr<RemoteCDM> create(WeakPtr<RemoteCDMFactory>&&, RemoteCDMIdentifier&&, RemoteCDMConfiguration&&, const String& mediaKeysHashSalt);
     virtual ~RemoteCDM() = default;


### PR DESCRIPTION
#### df7f31d56e43d9289258b4faa56b707130679917
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for CDMPrivate
<a href="https://bugs.webkit.org/show_bug.cgi?id=303113">https://bugs.webkit.org/show_bug.cgi?id=303113</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/encryptedmedia/CDM.cpp:
* Source/WebCore/Modules/encryptedmedia/CDM.h:
* Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp:
(WebCore::CDMPrivate::doSupportedConfigurationStep):
* Source/WebCore/platform/encryptedmedia/CDMPrivate.h:
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h:
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h:
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h:
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDM::supportsConfiguration const):
(WebCore::MockCDM::createInstance):
(WebCore::MockCDMInstance::create):
(WebCore::MockCDMInstance::MockCDMInstance):
(WebCore::MockCDMInstance::initializeWithConfiguration):
* Source/WebCore/testing/MockCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.h:

Canonical link: <a href="https://commits.webkit.org/303702@main">https://commits.webkit.org/303702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc75b863103c94ac63eaf37b38303d5f3699c30c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84860 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/71f295da-da7d-442e-95b8-af786fa3cc1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101565 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68865 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4bd88729-b539-4e08-b737-642dfb9f6222) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d238340f-0865-4248-b743-ffc0c318733b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3873 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1548 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83597 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143019 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109939 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110117 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28021 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3826 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115275 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58519 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5056 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33629 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->