### PR TITLE
[JSC] Implement `Promise.race` in C++

### DIFF
--- a/JSTests/microbenchmarks/promise-race.js
+++ b/JSTests/microbenchmarks/promise-race.js
@@ -1,0 +1,8 @@
+const promises = [];
+for (let i = 0; i < 12; i++)
+  promises.push(Promise.resolve(i));
+
+for (var i = 0; i < 1e4; ++i)
+    Promise.race(promises);
+
+drainMicrotasks();

--- a/JSTests/stress/new-promise-capabilities-requires-constructor.js
+++ b/JSTests/stress/new-promise-capabilities-requires-constructor.js
@@ -15,4 +15,4 @@ function shouldThrow(func, errorMessage) {
 
 shouldThrow(() => {
     Promise.race.call(() => { }, []);
-}, `TypeError: function is not a constructor`);
+}, `TypeError: argument is not a constructor`);

--- a/JSTests/stress/promise-race-empty-args.js
+++ b/JSTests/stress/promise-race-empty-args.js
@@ -1,0 +1,14 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const result = Promise.race();
+
+shouldBe(result instanceof Promise, true);
+let error;
+result.catch(e => {
+  error = e;
+})
+drainMicrotasks();
+shouldBe(error instanceof TypeError, true);

--- a/JSTests/stress/promise-race-fast-path-not-thenable.js
+++ b/JSTests/stress/promise-race-fast-path-not-thenable.js
@@ -1,0 +1,17 @@
+function shouldThrowAsync(run, errorType) {
+    let actual;
+    var hadError = false;
+    run().then(function(value) { actual = value; },
+               function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+}
+
+shouldThrowAsync(async function () {
+  var thenable = new Promise(function () {});
+  thenable.then = undefined;
+  await Promise.race([thenable]);
+}, TypeError);

--- a/JSTests/stress/promise-race-multiple-resolved.js
+++ b/JSTests/stress/promise-race-multiple-resolved.js
@@ -1,0 +1,4 @@
+const arr = [];
+const result = Promise.race([arr, {}]);
+arr.__proto__ = result;
+drainMicrotasks();

--- a/JSTests/stress/promise-race-slow-path-non-thenable.js
+++ b/JSTests/stress/promise-race-slow-path-non-thenable.js
@@ -1,0 +1,17 @@
+function shouldThrowAsync(run, errorType) {
+    let actual;
+    var hadError = false;
+    run().then(function(value) { actual = value; },
+               function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+}
+
+shouldThrowAsync(async function () {
+  const nonThenable = {};
+  Promise.resolve = function (v) { return v; };
+  await Promise.race([nonThenable]);
+}, TypeError);

--- a/JSTests/stress/promsie-race-resolve-getter-throws.js
+++ b/JSTests/stress/promsie-race-resolve-getter-throws.js
@@ -1,0 +1,24 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+let count = 0;
+Object.defineProperty(Promise, "resolve", {
+  get() {
+    count++;
+    throw new Error("Error from get resolve");
+  }
+});
+
+let result;
+let caught = false;
+try {
+  result = Promise.race([]);
+} catch {
+  caught = true;
+}
+
+shouldBe(caught, false);
+shouldBe(count, 1);
+shouldBe(result instanceof Promise, true);

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -294,38 +294,6 @@ function any(iterable)
     return promise;
 }
 
-function race(iterable)
-{
-    "use strict";
-
-    if (!@isObject(this))
-        @throwTypeError("|this| is not an object");
-
-    var promiseCapability = @newPromiseCapability(this);
-    var resolve = promiseCapability.resolve;
-    var reject = promiseCapability.reject;
-    var promise = promiseCapability.promise;
-
-    try {
-        var promiseResolve = this.resolve;
-        if (!@isCallable(promiseResolve))
-            @throwTypeError("Promise resolve is not a function");
-
-        for (var value of iterable) {
-            var nextPromise = promiseResolve.@call(this, value);
-            var then = nextPromise.then;
-            if (@isPromise(nextPromise) && then === @defaultPromiseThen)
-                @performPromiseThen(nextPromise, resolve, reject, @undefined, /* context */ promise);
-            else
-                nextPromise.then(resolve, reject);
-        }
-    } catch (error) {
-        reject.@call(@undefined, error);
-    }
-
-    return promise;
-}
-
 function try(callback /*, ...args */)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2230,6 +2230,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->keys), m_setPrimordialPropertiesWatchpointSet);
 
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, promisePrototype(), vm.propertyNames->then), m_promiseThenWatchpointSet);
+    installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_promiseConstructor.get(), vm.propertyNames->resolve), m_promiseResolveWatchpointSet);
 
     // Detect property absence.
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->replaceSymbol, objectPrototype()), m_stringSymbolReplaceWatchpointSet);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -496,6 +496,7 @@ public:
     InlineWatchpointSet m_mapSetWatchpointSet { IsWatched };
     InlineWatchpointSet m_setAddWatchpointSet { IsWatched };
     InlineWatchpointSet m_promiseThenWatchpointSet { IsWatched };
+    InlineWatchpointSet m_promiseResolveWatchpointSet { IsWatched };
     InlineWatchpointSet m_promiseSpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_setPrimordialPropertiesWatchpointSet { IsWatched };
     InlineWatchpointSet m_arraySpeciesWatchpointSet { ClearWatchpoint };
@@ -569,6 +570,7 @@ public:
     InlineWatchpointSet& setAddWatchpointSet() { return m_setAddWatchpointSet; }
     InlineWatchpointSet& setPrimordialPropertiesWatchpointSet() { return m_setPrimordialPropertiesWatchpointSet; }
     InlineWatchpointSet& promiseThenWatchpointSet() { return m_promiseThenWatchpointSet; }
+    InlineWatchpointSet& promiseResolveWatchpointSet() { return m_promiseResolveWatchpointSet; }
     InlineWatchpointSet& arraySpeciesWatchpointSet() { return m_arraySpeciesWatchpointSet; }
     InlineWatchpointSet& promiseSpeciesWatchpointSet() { return m_promiseSpeciesWatchpointSet; }
     InlineWatchpointSet& arrayPrototypeChainIsSaneWatchpointSet() { return m_arrayPrototypeChainIsSaneWatchpointSet; }


### PR DESCRIPTION
#### 72b5e3201731dca82dadaf20938a9c83295fa07d
<pre>
[JSC] Implement `Promise.race` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=300569">https://bugs.webkit.org/show_bug.cgi?id=300569</a>

Reviewed by Yusuke Suzuki.

This reverts commit 303121@main to reland 303034@main.

PromiseFirstResolveWithoutHandlerJob was calling resolvePromise directly,
which could trigger createResolvingFunctions for thenable values and bypass
the first-resolve guard, leading to assertion failure when the same promise
was resolved/rejected multiple times.

So this new patch changes to make PromiseFirstResolveWithoutHandlerJob use
`JSPromise::resolve` and `JSPromise::reject` instead of `JSPromise::resolvePromise`
and `JSPromise::rejectPromise`.

------

This patch changes to implement `Promise.race` in C++.

* JSTests/microbenchmarks/promise-race.js: Added.
* JSTests/stress/new-promise-capabilities-requires-constructor.js:
(shouldThrow):
* JSTests/stress/promise-race-empty-args.js: Added.
(shouldBe):
* JSTests/stress/promise-race-fast-path-not-thenable.js: Added.
(shouldThrowAsync):
(shouldThrowAsync.async var):
* JSTests/stress/promise-race-multiple-resolved.js: Added.
* JSTests/stress/promise-race-slow-path-non-thenable.js: Added.
(shouldThrowAsync):
(shouldThrowAsync.async const):
(shouldThrowAsync.Promise.resolve):
* JSTests/stress/promsie-race-resolve-getter-throws.js: Added.
(shouldBe):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(any):
(race): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::promiseResolveWatchpointSet):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::isFastPromiseConstructor):
(JSC::promiseRaceSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/303893@main">https://commits.webkit.org/303893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12954d258b7bfaea73a0dc6760ac9c884f5cba97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84835 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101544 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68842 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3891 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83572 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124877 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142994 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131315 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110094 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3807 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58487 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20695 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5031 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33606 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164282 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68489 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42652 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->