### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for FrameDestructionObserver

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -470,6 +470,10 @@ public:
 
     virtual ~Document();
 
+    // FrameDestructionObserver.
+    void ref() const final { ContainerNode::ref(); }
+    void deref() const final { ContainerNode::deref(); }
+
     // Nodes belonging to this document increase referencingNodeCount -
     // these are enough to keep the document from being destroyed, but
     // not enough to keep it from removing its children. This allows a

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -198,7 +198,7 @@ public:
 
     WEBCORE_EXPORT virtual ~DocumentLoader();
 
-    // CachedResourceClient, ContentFilterClient.
+    // CachedResourceClient, FrameDestructionObserver, ContentFilterClient.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebCore/loader/FormState.h
+++ b/Source/WebCore/loader/FormState.h
@@ -48,6 +48,10 @@ public:
     static Ref<FormState> create(HTMLFormElement&, StringPairVector&& textFieldValues, Document&, FormSubmissionTrigger, HTMLFormControlElement* submitter = nullptr);
     ~FormState();
 
+    // FrameDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     HTMLFormElement& form() const { return m_form; }
     const StringPairVector& textFieldValues() const { return m_textFieldValues; }
     Document& sourceDocument() const { return m_sourceDocument; }

--- a/Source/WebCore/page/FrameDestructionObserver.h
+++ b/Source/WebCore/page/FrameDestructionObserver.h
@@ -25,23 +25,14 @@
 
 #pragma once
 
-#include <wtf/CheckedRef.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class FrameDestructionObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::FrameDestructionObserver> : std::true_type { };
-}
 
 namespace WebCore {
 
 class LocalFrame;
 
-class FrameDestructionObserver : public CanMakeWeakPtr<FrameDestructionObserver> {
+class FrameDestructionObserver : public AbstractRefCountedAndCanMakeWeakPtr<FrameDestructionObserver> {
 public:
     WEBCORE_EXPORT explicit FrameDestructionObserver(LocalFrame*);
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -255,7 +255,7 @@ LocalFrame::~LocalFrame()
 
     disconnectOwnerElement();
 
-    while (auto destructionObserver = m_destructionObservers.takeAny())
+    while (RefPtr destructionObserver = m_destructionObservers.takeAny())
         destructionObserver->frameDestroyed();
 
     RefPtr localMainFrame = this->localMainFrame();
@@ -893,8 +893,8 @@ void LocalFrame::willDetachPage()
     if (RefPtr parent = dynamicDowncast<LocalFrame>(tree().parent()))
         parent->loader().checkLoadComplete();
 
-    for (auto& observer : m_destructionObservers)
-        observer.willDetachPage();
+    for (Ref observer : m_destructionObservers)
+        observer->willDetachPage();
 
     // FIXME: It's unclear as to why this is called more than once, but it is,
     // so page() could be NULL.

--- a/Source/WebCore/page/UserMessageHandler.h
+++ b/Source/WebCore/page/UserMessageHandler.h
@@ -48,6 +48,10 @@ public:
     }
     virtual ~UserMessageHandler();
 
+    // FrameDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
     JSC::JSValue postLegacySynchronousMessage(JSC::JSGlobalObject&, JSC::JSValue);
 

--- a/Source/WebCore/page/UserMessageHandlersNamespace.h
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.h
@@ -55,7 +55,7 @@ public:
     UserMessageHandler* namedItem(DOMWrapperWorld&, const AtomString&);
     bool isSupportedPropertyName(const AtomString&);
 
-    // UserContentProviderInvalidationClient.
+    // UserContentProviderInvalidationClient, FrameDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebCore/page/win/FrameWin.cpp
+++ b/Source/WebCore/page/win/FrameWin.cpp
@@ -45,11 +45,11 @@ GDIObject<HBITMAP> imageFromRect(const LocalFrame*, IntRect&)
 
 void computePageRectsForFrame(LocalFrame* frame, const IntRect& printRect, float headerHeight, float footerHeight, float userScaleFactor, Vector<IntRect>& outPages, int& outPageHeight)
 {
-    PrintContext printContext(frame);
+    Ref printContext = PrintContext::create(frame);
     float pageHeight = 0;
-    printContext.computePageRects(printRect, headerHeight, footerHeight, userScaleFactor, pageHeight);
+    printContext->computePageRects(printRect, headerHeight, footerHeight, userScaleFactor, pageHeight);
     outPageHeight = static_cast<int>(pageHeight);
-    outPages = printContext.pageRects();
+    outPages = printContext->pageRects();
 }
 
 GDIObject<HBITMAP> imageFromSelection(LocalFrame* frame, bool forceBlackText)

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -840,9 +840,9 @@ String externalRepresentation(LocalFrame* frame, OptionSet<RenderAsTextFlag> beh
     if (!renderer)
         return String();
 
-    PrintContext printContext(frame);
+    Ref printContext = PrintContext::create(frame);
     if (behavior.contains(RenderAsTextFlag::PrintingMode))
-        printContext.begin(renderer->width());
+        printContext->begin(renderer->width());
 
     return externalRepresentation(*renderer, behavior);
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -569,9 +569,9 @@ static bool markerTypesFrom(const String& markerType, OptionSet<DocumentMarkerTy
     return true;
 }
 
-static std::unique_ptr<PrintContext>& printContextForTesting()
+static RefPtr<PrintContext>& printContextForTesting()
 {
-    static NeverDestroyed<std::unique_ptr<PrintContext>> context;
+    static NeverDestroyed<RefPtr<PrintContext>> context;
     return context;
 }
 
@@ -4022,7 +4022,7 @@ ExceptionOr<void> Internals::setViewExposedRect(float x, float y, float width, f
 
 void Internals::setPrinting(int width, int height)
 {
-    printContextForTesting() = makeUnique<PrintContext>(frame());
+    printContextForTesting() = PrintContext::create(frame());
     printContextForTesting()->begin(width, height);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1552,7 +1552,7 @@ void WebPage::drawRectToImage(FrameIdentifier frameID, const PrintInfo& printInf
             graphicsContext.translate(0, -rect.height());
             drawPDFDocument(graphicsContext.protectedPlatformContext().get(), pdfDocument.get(), printInfo, rect);
         } else
-            m_printContext->spoolRect(graphicsContext, rect);
+            Ref { *m_printContext }->spoolRect(graphicsContext, rect);
     }
 #endif
 
@@ -1603,15 +1603,16 @@ void WebPage::drawPagesToPDFImpl(FrameIdentifier frameID, const PrintInfo& print
 
 void WebPage::drawPrintContextPagesToGraphicsContext(GraphicsContext& context, const FloatRect& pageRect, uint32_t first, uint32_t count)
 {
+    RefPtr printContext = m_printContext;
     for (uint32_t page = first; page < first + count; ++page) {
-        if (page >= m_printContext->pageCount())
+        if (page >= printContext->pageCount())
             break;
 
         context.beginPage(pageRect);
 
         context.scale(FloatSize(1, -1));
-        context.translate(0, -m_printContext->pageRect(page).height());
-        m_printContext->spoolPage(context, page, m_printContext->pageRect(page).width());
+        context.translate(0, -printContext->pageRect(page).height());
+        printContext->spoolPage(context, page, printContext->pageRect(page).width());
 
         context.endPage();
     }
@@ -1652,7 +1653,7 @@ void WebPage::drawPrintingRectToSnapshot(RemoteSnapshotIdentifier snapshotIdenti
     float printingScale = static_cast<float>(imageSize.width()) / rect.width();
     context.scale(printingScale);
 
-    m_printContext->spoolRect(context, rect);
+    Ref { *m_printContext }->spoolRect(context, rect);
 
     remoteRenderingBackend->sinkSnapshotRecorderIntoSnapshotFrame(WTFMove(m_remoteSnapshotState->recorder), frameID, Ref { m_remoteSnapshotState->callback }->chain());
     m_remoteSnapshotState = std::nullopt;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2866,7 +2866,7 @@ private:
     const UniqueRef<MediaKeySystemPermissionRequestManager> m_mediaKeySystemPermissionRequestManager;
 #endif
 
-    std::unique_ptr<WebCore::PrintContext> m_printContext;
+    RefPtr<WebCore::PrintContext> m_printContext;
     bool m_inActivePrintContextAccessScope { false };
     bool m_shouldEndPrintingImmediately { false };
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2264,9 +2264,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     float printWidth = root->writingMode().isHorizontal() ? static_cast<float>(documentRect.width()) / printScaleFactor : pageSize.width;
     float printHeight = root->writingMode().isHorizontal() ? pageSize.height : static_cast<float>(documentRect.height()) / printScaleFactor;
 
-    WebCore::PrintContext printContext(_private->coreFrame);
-    printContext.computePageRectsWithPageSize(WebCore::FloatSize(printWidth, printHeight), true);
-    return createNSArray(printContext.pageRects()).autorelease();
+    Ref printContext = WebCore::PrintContext::create(_private->coreFrame);
+    printContext->computePageRectsWithPageSize(WebCore::FloatSize(printWidth, printHeight), true);
+    return createNSArray(printContext->pageRects()).autorelease();
 }
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### b8edece2ff74ee421948bca96943329f6ad71424
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for FrameDestructionObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=303114">https://bugs.webkit.org/show_bug.cgi?id=303114</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/FormState.h:
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::willDetachPage):
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::create):
(WebCore::PrintContext::pageNumberForElement):
(WebCore::PrintContext::pageProperty):
(WebCore::PrintContext::numberOfPages):
(WebCore::PrintContext::spoolAllPagesWithBoundaries):
* Source/WebCore/page/PrintContext.h:
* Source/WebCore/page/UserMessageHandler.h:
* Source/WebCore/page/UserMessageHandlersNamespace.h:
* Source/WebCore/page/win/FrameWin.cpp:
(WebCore::computePageRectsForFrame):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::externalRepresentation):
* Source/WebCore/testing/Internals.cpp:
(WebCore::printContextForTesting):
(WebCore::Internals::setPrinting):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
(webkitFrameGetOrCreate):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::drawRectToImage):
(WebKit::WebPage::drawPrintContextPagesToGraphicsContext):
(WebKit::WebPage::drawPrintingRectToSnapshot):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::beginPrinting):
(WebKit::WebPage::computePagesForPrintingImpl):
(WebKit::WebPage::drawPagesForPrinting):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _computePageRectsWithPrintScaleFactor:pageSize:]):

Canonical link: <a href="https://commits.webkit.org/303726@main">https://commits.webkit.org/303726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6046ac7dd112a9c4780ad6fd701c1daccbaac9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140998 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/121fea06-36fe-4220-938c-f25b2c79541c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102075 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6102b69e-ba46-4a8d-a7ae-f749590a98e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136389 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82871 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/82289559-37bc-4855-82d8-fcf86f5e6359) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2048 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143644 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5613 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110459 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110635 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28038 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4316 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115872 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5668 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34195 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5757 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->