### PR TITLE
[JSC] Rename `JSPromiseReaction` handler fields to reflect they may contain `InternalMicrotask`

### DIFF
--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -576,22 +576,22 @@ void JSPromise::triggerPromiseReactions(VM& vm, JSGlobalObject* globalObject, St
     auto* current = head;
     while (current) {
         JSValue promise = current->promise();
-        JSValue handler = isResolved ? current->onFulfilled() : current->onRejected();
+        JSValue handlerOrEncodedTask = isResolved ? current->onFulfilledOrEncodedTask() : current->onRejectedOrEncodedTask();
         JSValue context = current->context();
         current = current->next();
 
-        if (handler.isInt32()) {
-            auto task = static_cast<InternalMicrotask>(handler.asInt32());
+        if (handlerOrEncodedTask.isInt32()) {
+            auto task = static_cast<InternalMicrotask>(handlerOrEncodedTask.asInt32());
             globalObject->queueMicrotask(task, promise, argument, jsNumber(static_cast<int32_t>(status)), context);
             continue;
         }
 
         if (promise.isUndefinedOrNull()) {
-            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, handler, argument, context, jsUndefined());
+            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, handlerOrEncodedTask, argument, context, jsUndefined());
             continue;
         }
 
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promise, handler, argument, context);
+        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promise, handlerOrEncodedTask, argument, context);
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
@@ -27,7 +27,6 @@
 #include "JSPromiseReaction.h"
 
 #include "JSCInlines.h"
-#include "JSInternalFieldObjectImplInlines.h"
 
 namespace JSC {
 
@@ -47,8 +46,8 @@ void JSPromiseReaction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_promise);
-    visitor.append(thisObject->m_onFulfilled);
-    visitor.append(thisObject->m_onRejected);
+    visitor.append(thisObject->m_onFulfilledOrEncodedTask);
+    visitor.append(thisObject->m_onRejectedOrEncodedTask);
     visitor.append(thisObject->m_context);
     visitor.append(thisObject->m_next);
 }

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSInternalFieldObjectImpl.h"
+#include "JSCell.h"
 
 namespace JSC {
 
@@ -47,14 +47,14 @@ public:
     static JSPromiseReaction* create(VM&, JSValue promise, JSValue onFulfilled, JSValue onRejected, JSValue context, JSPromiseReaction* next);
 
     JSValue promise() const { return m_promise.get(); }
-    JSValue onFulfilled() const { return m_onFulfilled.get(); }
-    JSValue onRejected() const { return m_onRejected.get(); }
+    JSValue onFulfilledOrEncodedTask() const { return m_onFulfilledOrEncodedTask.get(); }
+    JSValue onRejectedOrEncodedTask() const { return m_onRejectedOrEncodedTask.get(); }
     JSValue context() const { return m_context.get(); }
     JSPromiseReaction* next() const { return m_next.get(); }
 
     void setPromise(VM& vm, JSValue value) { m_promise.set(vm, this, value); }
-    void setOnFulfilled(VM& vm, JSValue value) { m_onFulfilled.set(vm, this, value); }
-    void setOnRejected(VM& vm, JSValue value) { m_onRejected.set(vm, this, value); }
+    void setOnFulfilledOrEncodedTask(VM& vm, JSValue value) { m_onFulfilledOrEncodedTask.set(vm, this, value); }
+    void setOnRejectedOrEncodedTask(VM& vm, JSValue value) { m_onRejectedOrEncodedTask.set(vm, this, value); }
     void setContext(VM& vm, JSValue value) { m_context.set(vm, this, value); }
     void setNext(VM& vm, JSPromiseReaction* value) { m_next.setMayBeNull(vm, this, value); }
 
@@ -62,16 +62,18 @@ private:
     JSPromiseReaction(VM& vm, Structure* structure, JSValue promise, JSValue onFulfilled, JSValue onRejected, JSValue context, JSPromiseReaction* next)
         : Base(vm, structure)
         , m_promise(promise, WriteBarrierEarlyInit)
-        , m_onFulfilled(onFulfilled, WriteBarrierEarlyInit)
-        , m_onRejected(onRejected, WriteBarrierEarlyInit)
+        , m_onFulfilledOrEncodedTask(onFulfilled, WriteBarrierEarlyInit)
+        , m_onRejectedOrEncodedTask(onRejected, WriteBarrierEarlyInit)
         , m_context(context, WriteBarrierEarlyInit)
         , m_next(next, WriteBarrierEarlyInit)
     {
     }
 
     WriteBarrier<Unknown> m_promise;
-    WriteBarrier<Unknown> m_onFulfilled;
-    WriteBarrier<Unknown> m_onRejected;
+    // If JSPromiseReaction does not have explicit handlers,
+    // these fields may contain InternalMicrotask encoded as an int32.
+    WriteBarrier<Unknown> m_onFulfilledOrEncodedTask;
+    WriteBarrier<Unknown> m_onRejectedOrEncodedTask;
     WriteBarrier<Unknown> m_context;
     WriteBarrier<JSPromiseReaction> m_next;
 };


### PR DESCRIPTION
#### 7dd2b4bc348cf49ee2debaf368be59ee556780df
<pre>
[JSC] Rename `JSPromiseReaction` handler fields to reflect they may contain `InternalMicrotask`
<a href="https://bugs.webkit.org/show_bug.cgi?id=303115">https://bugs.webkit.org/show_bug.cgi?id=303115</a>

Reviewed by NOBODY (OOPS!).

The onFulfilled and onRejected fields of JSPromiseReaction can now contain an InternalMicrotask value
encoded as an int32[1]. However, their names still suggest they are just handlers, which is misleading.

This patch renames them for clarity.

[1]: <a href="https://commits.webkit.org/302896@main">https://commits.webkit.org/302896@main</a>

* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::triggerPromiseReactions):
* Source/JavaScriptCore/runtime/JSPromiseReaction.cpp:
(JSC::JSPromiseReaction::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSPromiseReaction.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dd2b4bc348cf49ee2debaf368be59ee556780df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84832 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68840 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1538 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83569 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124874 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142991 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131312 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110092 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3806 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58484 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5026 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33601 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164279 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68487 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42651 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->