### PR TITLE
Use C++20 std::ranges projections in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -287,9 +287,7 @@ private:
                 Vector<SwitchCase> cases;
                 for (SwitchCase switchCase : switchValue->cases(m_block))
                     cases.append(switchCase);
-                std::ranges::sort(cases, [](const auto& left, const auto& right) {
-                    return left.caseValue() < right.caseValue();
-                });
+                std::ranges::sort(cases, { }, &SwitchCase::caseValue);
                 FrequentedBlock fallThrough = m_block->fallThrough();
                 m_block->values().removeLast();
                 recursivelyBuildSwitch(cases, fallThrough, 0, false, cases.size(), m_block);

--- a/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
+++ b/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
@@ -191,9 +191,7 @@ bool OptimizeAssociativeExpressionTrees::optimizeRootedTree(Value* root, Inserti
         return false;
     }
 
-    std::ranges::sort(leaves, [](auto* x, auto* y) {
-        return x->index() < y->index();
-    });
+    std::ranges::sort(leaves, { }, &Value::index);
     Vector<Value*, 4> optLeaves;
     Value* lastValue = nullptr;
     unsigned numSeen = 0;

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
@@ -300,9 +300,7 @@ private:
             }
         }
 
-        std::ranges::sort(m_clobbers, [](auto& a, auto& b) {
-            return a.index < b.index;
-        });
+        std::ranges::sort(m_clobbers, { }, &Clobber::index);
 
         if (verbose()) {
             dataLog("Intervals:\n");

--- a/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
@@ -246,9 +246,7 @@ public:
         }
 
         // Now try to coalesce some moves.
-        std::ranges::sort(m_coalescableMoves, [&](auto& a, auto& b) {
-            return a.frequency > b.frequency;
-        });
+        std::ranges::sort(m_coalescableMoves, std::ranges::greater { }, &CoalescableMove::frequency);
 
         for (const CoalescableMove& move : m_coalescableMoves) {
             IndexType slotToKill = remap(move.src);

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -182,9 +182,7 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
         
         RELEASE_ASSERT(edges.size());
         
-        std::ranges::sort(edges, [](auto a, auto b) {
-            return a.count() > b.count();
-        });
+        std::ranges::sort(edges, std::ranges::greater { }, &CallEdge::count);
         RELEASE_ASSERT(edges.first().count() >= edges.last().count());
         
         double totalCallsToKnown = 0;

--- a/Source/JavaScriptCore/dfg/DFGCommonData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.cpp
@@ -152,9 +152,7 @@ void CommonData::validateReferences(const TrackedReferences& trackedReferences)
 
 void CommonData::finalizeCatchEntrypoints(Vector<CatchEntrypointData>&& catchEntrypoints)
 {
-    std::ranges::sort(catchEntrypoints, [](const auto& a, const auto& b) {
-        return a.bytecodeIndex < b.bytecodeIndex;
-    });
+    std::ranges::sort(catchEntrypoints, { }, &CatchEntrypointData::bytecodeIndex);
     ASSERT(m_catchEntrypoints.isEmpty());
     m_catchEntrypoints = WTFMove(catchEntrypoints);
 

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -423,10 +423,7 @@ std::optional<CodeOrigin> JITCode::findPC(CodeBlock* codeBlock, void* pc)
 
 void JITCode::finalizeOSREntrypoints(Vector<OSREntryData>&& osrEntry)
 {
-    auto comparator = [] (const auto& a, const auto& b) {
-        return a.m_bytecodeIndex < b.m_bytecodeIndex;
-    };
-    std::ranges::sort(osrEntry, comparator);
+    std::ranges::sort(osrEntry, { }, &OSREntryData::m_bytecodeIndex);
 
 #if ASSERT_ENABLED
     auto verifyIsSorted = [&] (auto& osrVector) {

--- a/Source/JavaScriptCore/heap/HeapSnapshot.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.cpp
@@ -113,9 +113,7 @@ void HeapSnapshot::finalize()
         m_lastObjectIdentifier = m_nodes.last().identifier;
     }
 
-    std::ranges::sort(m_nodes, [](const auto& a, const auto& b) {
-        return a.cell < b.cell;
-    });
+    std::ranges::sort(m_nodes, { }, &HeapSnapshotNode::cell);
 
 #ifndef NDEBUG
     // Assert there are no duplicates or nullptr cells.

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
@@ -85,9 +85,7 @@ void JITStubRoutineSet::prepareForConservativeScan()
         m_range = Range<uintptr_t> { 0, 0 };
         return;
     }
-    std::ranges::sort(m_routines, [&](const auto& a, const auto& b) {
-        return a.startAddress < b.startAddress;
-    });
+    std::ranges::sort(m_routines, { }, &Routine::startAddress);
     m_range = Range<uintptr_t> {
         m_routines.first().startAddress,
         m_routines.last().routine->endAddress()


### PR DESCRIPTION
#### a511cfc8e4f79dae92406e6ed66d5dd780d1f068
<pre>
Use C++20 std::ranges projections in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=303119">https://bugs.webkit.org/show_bug.cgi?id=303119</a>
<a href="https://rdar.apple.com/165421761">rdar://165421761</a>

Reviewed by Darin Adler and Sam Weinig.

* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp:
(JSC::B3::OptimizeAssociativeExpressionTrees::optimizeRootedTree):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp:
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::computeFromCallLinkInfo):
* Source/JavaScriptCore/dfg/DFGCommonData.cpp:
(JSC::DFG::CommonData::finalizeCatchEntrypoints):
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITCode::finalizeOSREntrypoints):
* Source/JavaScriptCore/heap/HeapSnapshot.cpp:
(JSC::HeapSnapshot::finalize):
* Source/JavaScriptCore/heap/JITStubRoutineSet.cpp:
(JSC::JITStubRoutineSet::prepareForConservativeScan):

Canonical link: <a href="https://commits.webkit.org/303587@main">https://commits.webkit.org/303587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26aff04a7063c9360493fea607bb20842d9aa00f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5315 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43897 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84842 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101550 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68850 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135760 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82342 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1541 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83579 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124884 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143001 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131322 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4984 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110100 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27936 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3813 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58494 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5038 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33609 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164289 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68490 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42653 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->