### PR TITLE
Reduce use of `unsafeGet()` in WebKit/

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -317,6 +317,12 @@ template<typename T> struct IsSmartPtr<RetainPtr<T>> {
 };
 
 template<typename P> struct HashTraits<RetainPtr<P>> : SimpleClassHashTraits<RetainPtr<P>> {
+    static RetainPtr<P>::PtrType emptyValue() { return nullptr; }
+    static bool isEmptyValue(const RetainPtr<P>& value) { return !value; }
+
+    using PeekType = RetainPtr<P>::PtrType;
+    static PeekType peek(const RetainPtr<P>& value) { return value.get(); }
+    static PeekType peek(P* value) { return value; }
 };
 
 template<typename P> struct DefaultHash<RetainPtr<P>> : PtrHash<RetainPtr<P>> { };

--- a/Source/WebCore/editing/cocoa/AlternativeTextContextController.mm
+++ b/Source/WebCore/editing/cocoa/AlternativeTextContextController.mm
@@ -51,7 +51,7 @@ void AlternativeTextContextController::replaceAlternatives(PlatformTextAlternati
 
 PlatformTextAlternatives *AlternativeTextContextController::alternativesForContext(DictationContext context) const
 {
-    return m_alternatives.get(context).unsafeGet();
+    return m_alternatives.get(context);
 }
 
 void AlternativeTextContextController::removeAlternativesForContext(DictationContext context)

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -244,14 +244,14 @@ inline static RetainPtr<NSParagraphStyle> reconstructStyle(const ParagraphStyle&
 
     if (!style.textTableBlockIDs.isEmpty()) {
         RetainPtr blocks = createNSArray(style.textTableBlockIDs, [&] (auto& object) -> id {
-            return tableBlocks.get(object).unsafeGet();
+            return tableBlocks.get(object);
         });
         [mutableStyle setTextBlocks:blocks.get()];
     }
 
     if (!style.textListIDs.isEmpty()) {
         RetainPtr textLists = createNSArray(style.textListIDs, [&] (auto& object) -> id {
-            return lists.get(object).unsafeGet();
+            return lists.get(object);
         });
         [mutableStyle setTextLists:textLists.get()];
     }

--- a/Source/WebCore/page/cocoa/DataDetectionResultsStorage.h
+++ b/Source/WebCore/page/cocoa/DataDetectionResultsStorage.h
@@ -47,7 +47,7 @@ public:
     void setDocumentLevelResults(NSArray *results) { m_documentLevelResults = results; }
     NSArray *documentLevelResults() const { return m_documentLevelResults.get(); }
 
-    DDScannerResult *imageOverlayDataDetectionResult(ImageOverlayDataDetectionResultIdentifier identifier) { return m_imageOverlayResults.get(identifier).unsafeGet(); }
+    DDScannerResult *imageOverlayDataDetectionResult(ImageOverlayDataDetectionResultIdentifier identifier) { return m_imageOverlayResults.get(identifier); }
     ImageOverlayDataDetectionResultIdentifier addImageOverlayDataDetectionResult(DDScannerResult *result)
     {
         auto newIdentifier = ImageOverlayDataDetectionResultIdentifier::generate();

--- a/Source/WebCore/platform/graphics/Icon.h
+++ b/Source/WebCore/platform/graphics/Icon.h
@@ -77,7 +77,7 @@ public:
     WEBCORE_EXPORT static RefPtr<Icon> create(CocoaImage *);
     WEBCORE_EXPORT static RefPtr<Icon> create(PlatformImagePtr&&);
 
-    RetainPtr<CocoaImage> image() const { return m_image; };
+    CocoaImage* image() const { return m_image.get(); };
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm
+++ b/Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm
@@ -75,7 +75,7 @@ NSDateFormatter *LocalizedDateCache::formatterForDateType(DateComponentsType typ
 {
     int key = static_cast<int>(type);
     if (m_formatterMap.contains(key))
-        return m_formatterMap.get(key).unsafeGet();
+        return m_formatterMap.get(key);
 
     auto dateFormatter = createFormatterForType(type);
     m_formatterMap.set(key, dateFormatter.get());

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1816,9 +1816,9 @@ RenderThemeCocoa::IconAndSize RenderThemeMac::iconForAttachment(const String& fi
         return IconAndSize { nil, FloatSize() };
 
     if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title)) {
-        auto image = icon->image();
+        RetainPtr image = icon->image();
         auto size = [image size];
-        return IconAndSize { image, FloatSize(size) };
+        return IconAndSize { WTFMove(image), FloatSize(size) };
     }
 
     return IconAndSize { nil, FloatSize() };

--- a/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm
+++ b/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm
@@ -46,11 +46,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(TextExtractionFilter);
 
 TextExtractionFilter& TextExtractionFilter::singleton()
 {
-    if (RefPtr instance = WebKit::singleton())
-        return *instance.unsafeGet();
-
-    WebKit::singleton() = adoptRef(*new TextExtractionFilter);
-    return singleton();
+    if (auto& instance = WebKit::singleton(); !instance)
+        instance = adoptRef(*new TextExtractionFilter);
+    return *WebKit::singleton();
 }
 
 TextExtractionFilter* TextExtractionFilter::singletonIfCreated()

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -114,7 +114,7 @@ inline std::optional<String> toOptional(NSString *maybeNil)
 
 inline CocoaImage *toCocoaImage(RefPtr<WebCore::Icon> icon)
 {
-    return icon ? icon->image().unsafeGet() : nil;
+    return icon ? icon->image() : nil;
 }
 
 enum class JSONOptions {

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -119,20 +119,20 @@ void WebBackForwardListFrameItem::setChild(Ref<FrameState>&& frameState)
     m_children.append(WTFMove(childItem));
 }
 
-WebBackForwardListFrameItem& WebBackForwardListFrameItem::rootFrame()
+Ref<WebBackForwardListFrameItem> WebBackForwardListFrameItem::rootFrame()
 {
     Ref rootFrame = *this;
     while (rootFrame->m_parent && rootFrame->m_parent->identifier().processIdentifier() == identifier().processIdentifier())
         rootFrame = *rootFrame->m_parent;
-    return rootFrame.unsafeGet();
+    return rootFrame;
 }
 
-WebBackForwardListFrameItem& WebBackForwardListFrameItem::mainFrame()
+Ref<WebBackForwardListFrameItem> WebBackForwardListFrameItem::mainFrame()
 {
     Ref mainFrame = *this;
     while (mainFrame->m_parent)
         mainFrame = *mainFrame->m_parent;
-    return mainFrame.unsafeGet();
+    return mainFrame;
 }
 
 Ref<WebBackForwardListFrameItem> WebBackForwardListFrameItem::protectedMainFrame()

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -58,8 +58,8 @@ public:
     void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }
     bool sharesAncestor(WebBackForwardListFrameItem&) const;
 
-    WebBackForwardListFrameItem& rootFrame();
-    WebBackForwardListFrameItem& mainFrame();
+    Ref<WebBackForwardListFrameItem> rootFrame();
+    Ref<WebBackForwardListFrameItem> mainFrame();
     Ref<WebBackForwardListFrameItem> protectedMainFrame();
     WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);
     RefPtr<WebBackForwardListFrameItem> protectedChildItemForFrameID(WebCore::FrameIdentifier);

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -205,8 +205,10 @@ void WebBackForwardListItem::setWasRestoredFromSession()
 
 WebBackForwardListFrameItem& WebBackForwardListItem::navigatedFrameItem() const
 {
-    if (RefPtr childItem = m_navigatedFrameID ? m_mainFrameItem->childItemForFrameID(*m_navigatedFrameID) : nullptr)
-        return childItem.releaseNonNull().unsafeGet();
+    if (m_navigatedFrameID) {
+        if (auto* childItem = m_mainFrameItem->childItemForFrameID(*m_navigatedFrameID))
+            return *childItem;
+    }
     return m_mainFrameItem;
 }
 

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
@@ -70,12 +70,12 @@ WTF::String FrameInfo::title() const
 
 const WebKit::WebPageProxy* FrameInfo::page() const
 {
-    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID).unsafeGet();
+    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID);
 }
 
 WebKit::WebPageProxy* FrameInfo::page()
 {
-    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID).unsafeGet();
+    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID);
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIScriptMessage.h
+++ b/Source/WebKit/UIProcess/API/APIScriptMessage.h
@@ -51,7 +51,7 @@ public:
 
 #if PLATFORM(COCOA)
     const RetainPtr<id>& body() const { return m_body; }
-    const RetainPtr<NSString> cocoaName() const { return m_cocoaName; }
+    NSString *cocoaName() const { return m_cocoaName.get(); }
 #endif
     API::Object* apiBody() const { return m_apiBody.get(); }
     WebKit::WebPageProxy* page() const;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -322,7 +322,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (id <WKDownloadDelegate>)delegate
 {
-    return _delegate.get().unsafeGet();
+    return _delegate.getAutoreleased();
 }
 
 - (void)setDelegate:(id<WKDownloadDelegatePrivate>)delegate

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
@@ -62,7 +62,7 @@
 
 - (NSString *)name
 {
-    return Ref { *_scriptMessage }->cocoaName().unsafeGet();
+    return Ref { *_scriptMessage }->cocoaName();
 }
 
 - (WKContentWorld *)world

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
@@ -139,7 +139,7 @@ private:
     RefPtr page = _dataTask->page();
     if (!page)
         return nil;
-    return page->cocoaView().unsafeGet();
+    return page->cocoaView().autorelease();
 }
 
 - (id <_WKDataTaskDelegate>)delegate

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -97,7 +97,7 @@ Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *inspector)
 
 - (id <_WKInspectorDelegate>)delegate
 {
-    return _delegate.get().unsafeGet();
+    return _delegate.getAutoreleased();
 }
 
 - (void)setDelegate:(id<_WKInspectorDelegate>)delegate

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
@@ -43,7 +43,7 @@
 - (NSData *)data
 {
     if (auto messageData = self._protectedMessage->data())
-        return toNSData(*messageData).unsafeGet();
+        return toNSData(*messageData).autorelease();
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
@@ -46,17 +46,17 @@
 
 - (NSData *)applicationServerKey
 {
-    return toNSData(self._protectedData->applicationServerKey()).unsafeGet();
+    return toNSData(self._protectedData->applicationServerKey()).autorelease();
 }
 
 - (NSData *)authenticationSecret
 {
-    return toNSData(self._protectedData->sharedAuthenticationSecret()).unsafeGet();
+    return toNSData(self._protectedData->sharedAuthenticationSecret()).autorelease();
 }
 
 - (NSData *)ecdhPublicKey
 {
-    return toNSData(self._protectedData->clientECDHPublicKey()).unsafeGet();
+    return toNSData(self._protectedData->clientECDHPublicKey()).autorelease();
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -247,8 +247,8 @@ void ApplicationStateTracker::setWindow(UIWindow *window)
     case ApplicationType::ViewService: {
         UIViewController *serviceViewController = nil;
 
-        for (UIView *view = m_view.get().unsafeGet(); view; view = view.superview) {
-            auto viewController = WebCore::viewController(view);
+        for (RetainPtr view = m_view.get(); view; view = view.get().superview) {
+            auto viewController = WebCore::viewController(view.get());
 
             if (viewController._hostProcessIdentifier) {
                 serviceViewController = viewController;

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -159,7 +159,7 @@ ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdenti
     if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled())
         return nullptr;
 
-    return m_inlinePreviews.get(modelIdentifier.uuid).unsafeGet();
+    return m_inlinePreviews.get(modelIdentifier.uuid);
 }
 
 void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCore::FloatSize size, CompletionHandler<void(Expected<std::pair<String, uint32_t>, WebCore::ResourceError>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -242,7 +242,7 @@ static RetainPtr<LPLinkMetadata> placeholderMetadataWithFileURL(NSURL *url)
 
 - (id<WKShareSheetDelegate>)delegate
 {
-    return _delegate.get().unsafeGet();
+    return _delegate.getAutoreleased();
 }
 
 - (void)setDelegate:(id<WKShareSheetDelegate>)delegate

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -418,7 +418,7 @@ RefPtr<WebCore::Icon> WebExtension::bestIcon(RefPtr<JSON::Object> icons, WebCore
             if (!resultImage)
                 resultImage = imageValue.value().get();
             else
-                [resultImage->image() addRepresentations:imageValue.value()->image().get().representations];
+                [resultImage->image() addRepresentations:imageValue.value()->image().representations];
         } else if (reportError && !imageValue && imageValue.error())
             reportError(imageValue.error().releaseNonNull());
     }
@@ -428,7 +428,7 @@ RefPtr<WebCore::Icon> WebExtension::bestIcon(RefPtr<JSON::Object> icons, WebCore
     auto *images = mapObjects<NSDictionary>(scalePaths, ^id(NSNumber *scale, NSString *path) {
         auto imageValue = iconForPath(path, idealSize, scale.doubleValue);
         if (imageValue)
-            return imageValue.value()->image().get();
+            return imageValue.value()->image();
 
         if (reportError && !imageValue && imageValue.error())
             reportError(imageValue.error().releaseNonNull());
@@ -484,8 +484,8 @@ RefPtr<WebCore::Icon> WebExtension::bestIconVariant(RefPtr<JSON::Array> variants
     if (!lightIcon || !darkIcon)
         return lightIcon ?: darkIcon;
 
-    auto *lightImage = lightIcon->image().get();
-    auto *darkImage = darkIcon->image().get();
+    auto *lightImage = lightIcon->image();
+    auto *darkImage = darkIcon->image();
 #if USE(APPKIT)
     // The images need to be the same size to draw correctly in the block.
     auto imageSize = lightImage.size.width >= darkImage.size.width ? lightImage.size : darkImage.size;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -71,12 +71,8 @@ WebBackForwardListItem* WebBackForwardList::itemForID(BackForwardItemIdentifier 
     if (!m_page)
         return nullptr;
 
-    RefPtr item = WebBackForwardListItem::itemForID(identifier);
-    if (!item)
-        return nullptr;
-
-    ASSERT(item->pageID() == m_page->identifier());
-    return item.unsafeGet();
+    ASSERT(!WebBackForwardListItem::itemForID(identifier) || WebBackForwardListItem::itemForID(identifier)->pageID() == m_page->identifier());
+    return WebBackForwardListItem::itemForID(identifier);
 }
 
 void WebBackForwardList::pageClosed()

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -746,21 +746,21 @@ auto WebFrameProxy::traverseNext(CanWrap canWrap) const -> TraversalResult
 auto WebFrameProxy::traversePrevious(CanWrap canWrap) -> TraversalResult
 {
     if (RefPtr previousSibling = this->previousSibling())
-        return { RefPtr { previousSibling->deepLastChild() }, DidWrap::No };
+        return { previousSibling->deepLastChild(), DidWrap::No };
     if (RefPtr parent = parentFrame())
         return { WTFMove(parent), DidWrap::No };
 
     if (canWrap == CanWrap::Yes)
-        return { RefPtr { deepLastChild() }, DidWrap::Yes };
+        return { deepLastChild(), DidWrap::Yes };
     return { };
 }
 
-WebFrameProxy* WebFrameProxy::deepLastChild()
+RefPtr<WebFrameProxy> WebFrameProxy::deepLastChild()
 {
     RefPtr result = this;
     for (RefPtr last = lastChild(); last; last = last->lastChild())
         result = last;
-    return result.unsafeGet();
+    return result;
 }
 
 WebFrameProxy* WebFrameProxy::firstChild() const

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -286,7 +286,7 @@ private:
 
     std::optional<WebCore::PageIdentifier> pageIdentifier() const;
 
-    WebFrameProxy* deepLastChild();
+    RefPtr<WebFrameProxy> deepLastChild();
     WebFrameProxy* firstChild() const;
     WebFrameProxy* lastChild() const;
     WebFrameProxy* nextSibling() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -798,7 +798,7 @@ static HashMap<WebPageProxyIdentifier, WeakPtr<WebPageProxy>>& webPageProxyMap()
     return map.get();
 }
 
-RefPtr<WebPageProxy> WebPageProxy::fromIdentifier(std::optional<WebPageProxyIdentifier> identifier)
+WebPageProxy* WebPageProxy::fromIdentifier(std::optional<WebPageProxyIdentifier> identifier)
 {
     return identifier ? webPageProxyMap().get(*identifier) : nullptr;
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -701,7 +701,7 @@ public:
     using Identifier = WebPageProxyIdentifier;
 
     Identifier identifier() const { return m_identifier; }
-    static RefPtr<WebPageProxy> fromIdentifier(std::optional<Identifier>);
+    static WebPageProxy* fromIdentifier(std::optional<Identifier>);
     WebCore::PageIdentifier webPageIDInMainFrameProcess() const { return m_webPageID; }
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return webPageIDInMainFrameProcess(); }
     WebCore::PageIdentifier webPageIDInProcess(const WebProcessProxy&) const;

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -200,12 +200,12 @@ void DragDropInteractionState::addDefaultDropPreview(UIDragItem *item, UITargete
 
 UITargetedDragPreview *DragDropInteractionState::defaultDropPreview(UIDragItem *item) const
 {
-    return m_defaultDropPreviews.get(item).unsafeGet();
+    return m_defaultDropPreviews.get(item);
 }
 
 UITargetedDragPreview *DragDropInteractionState::finalDropPreview(UIDragItem *item) const
 {
-    return m_finalDropPreviews.get(item).unsafeGet();
+    return m_finalDropPreviews.get(item);
 }
 
 void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UIView *previewContainer, RefPtr<WebCore::TextIndicator>&& textIndicator)

--- a/Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm
@@ -52,7 +52,7 @@
 
 - (UIScrollView *)lastTouchedScrollView
 {
-    return _lastTouchedScrollView.get().unsafeGet();
+    return _lastTouchedScrollView.getAutoreleased();
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -617,7 +617,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Top]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Top, wrapper);
     }
-    return wrapper.unsafeGet();
+    return wrapper.autorelease();
 }
 
 - (WKUIScrollEdgeEffect *)_wk_leftEdgeEffect
@@ -631,7 +631,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Left]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Left, wrapper);
     }
-    return wrapper.unsafeGet();
+    return wrapper.autorelease();
 }
 
 - (WKUIScrollEdgeEffect *)_wk_rightEdgeEffect
@@ -645,7 +645,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Right]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Right, wrapper);
     }
-    return wrapper.unsafeGet();
+    return wrapper.autorelease();
 }
 
 - (WKUIScrollEdgeEffect *)_wk_bottomEdgeEffect
@@ -659,7 +659,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Bottom]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Bottom, wrapper);
     }
-    return wrapper.unsafeGet();
+    return wrapper.autorelease();
 }
 
 - (void)_setInternalTopPocketColor:(UIColor *)color

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -172,8 +172,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
 #endif
 
     for (id<UIInteraction> interaction in _view.interactions) {
-        if (RetainPtr selectionInteraction = dynamic_objc_cast<UITextSelectionDisplayInteraction>(interaction))
-            return selectionInteraction.unsafeGet();
+        if (auto* selectionInteraction = dynamic_objc_cast<UITextSelectionDisplayInteraction>(interaction))
+            return selectionInteraction;
     }
 
     return nil;
@@ -230,7 +230,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
     if (newContainer == _view)
         return;
 
-    auto findParentViewBelowNewContainer = [&](UIView *view) -> UIView * {
+    auto findParentViewBelowNewContainer = [&](UIView *view) -> RetainPtr<UIView> {
         if (view == newContainer)
             return nil;
 
@@ -239,7 +239,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
                 return nil;
 
             if ([foundView superview] == newContainer)
-                return foundView.unsafeGet();
+                return foundView;
         }
 
         return nil;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -264,7 +264,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id<WKFullScreenViewControllerDelegate>)delegate
 {
-    return _delegate.get().unsafeGet();
+    return _delegate.getAutoreleased();
 }
 
 - (void)setDelegate:(id<WKFullScreenViewControllerDelegate>)delegate

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1703,20 +1703,20 @@ void WebViewImpl::viewDidEndLiveResize()
 void WebViewImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIdentifier frameID, const WebCore::IntRect& rect)
 {
     removePDFHUD(identifier);
-    auto hud = adoptNS([[WKPDFHUDView alloc] initWithFrame:rect pluginIdentifier:identifier frameIdentifier:frameID page:m_page.get()]);
+    RetainPtr hud = adoptNS([[WKPDFHUDView alloc] initWithFrame:rect pluginIdentifier:identifier frameIdentifier:frameID page:m_page.get()]);
     [m_view.get() addSubview:hud.get()];
     _pdfHUDViews.add(identifier, WTFMove(hud));
 }
 
 void WebViewImpl::updatePDFHUDLocation(PDFPluginIdentifier identifier, const WebCore::IntRect& rect)
 {
-    if (auto hud = _pdfHUDViews.get(identifier))
+    if (RetainPtr hud = _pdfHUDViews.get(identifier))
         [hud setFrame:rect];
 }
 
 void WebViewImpl::removePDFHUD(PDFPluginIdentifier identifier)
 {
-    if (auto hud = _pdfHUDViews.take(identifier))
+    if (RetainPtr hud = _pdfHUDViews.take(identifier))
         [hud removeFromSuperview];
 }
 

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -147,7 +147,7 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
 {
     RetainPtr settings = [UNMutableNotificationSettings emptySettings];
     [settings setAuthorizationStatus:m_hasPermission ? UNAuthorizationStatusAuthorized : UNAuthorizationStatusNotDetermined];
-    return settings.unsafeGet();
+    return settings.autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,5 +1,13 @@
 WebCoreSupport/SocketStreamHandleImplCFNet.cpp
 cf/WebCoreSupport/WebInspectorClientCF.cpp
+[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
+[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebInspectorClientIOS.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] ios/WebView/WebPDFViewIOS.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
+[ iOS ] ios/WebView/WebPlainWhiteView.mm
 mac/DOM/DOM.mm
 mac/DOM/DOMAbstractView.mm
 mac/DOM/DOMBlob.mm
@@ -49,6 +57,8 @@ mac/Misc/WebNSURLExtras.mm
 mac/Plugins/WebBasePluginPackage.mm
 [ Mac ] mac/Plugins/WebPluginController.mm
 mac/Plugins/WebPluginDatabase.mm
+[ iOS ] mac/Storage/WebDatabaseManager.mm
+[ iOS ] mac/Storage/WebDatabaseManagerClient.mm
 mac/Storage/WebStorageManager.mm
 [ Mac ] mac/WebCoreSupport/PopupMenuMac.mm
 mac/WebCoreSupport/WebChromeClient.mm
@@ -58,9 +68,10 @@ mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebFrameNetworkingContext.mm
 [ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
-mac/WebCoreSupport/WebNotificationClient.mm
+[ iOS ] mac/WebCoreSupport/WebProgressTrackerClient.mm
 mac/WebCoreSupport/WebVisitedLinkStore.mm
 [ Mac ] mac/WebInspector/WebNodeHighlight.mm
+[ iOS ] mac/WebInspector/WebNodeHighlighter.mm
 mac/WebView/WebArchive.mm
 mac/WebView/WebDataSource.mm
 mac/WebView/WebDelegateImplementationCaching.mm
@@ -81,15 +92,3 @@ mac/WebView/WebScriptWorld.mm
 [ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
 mac/WebView/WebViewRenderingUpdateScheduler.mm
-[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
-[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
-[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
-[ iOS ] ios/WebCoreSupport/WebInspectorClientIOS.mm
-[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
-[ iOS ] ios/WebView/WebPDFViewIOS.mm
-[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
-[ iOS ] ios/WebView/WebPlainWhiteView.mm
-[ iOS ] mac/Storage/WebDatabaseManager.mm
-[ iOS ] mac/Storage/WebDatabaseManagerClient.mm
-[ iOS ] mac/WebCoreSupport/WebProgressTrackerClient.mm
-[ iOS ] mac/WebInspector/WebNodeHighlighter.mm

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -188,7 +188,7 @@ static inline WebHistoryDateKey dateKey(NSTimeInterval date)
     ASSERT_ARG(entry, entry != nil);
     ASSERT(_entriesByDate->contains(dateKey));
 
-    NSMutableArray *entriesForDate = _entriesByDate->get(dateKey).unsafeGet();
+    RetainPtr<NSMutableArray> entriesForDate = _entriesByDate->get(dateKey);
     NSTimeInterval entryDate = [entry lastVisitedTimeInterval];
 
     unsigned count = [entriesForDate count];
@@ -452,7 +452,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WebHistoryDateKey dateKey;
     if (![self findKey:&dateKey forDay:[date timeIntervalSinceReferenceDate]])
         return nil;
-    return _entriesByDate->get(dateKey).unsafeGet();
+    return _entriesByDate->get(dateKey);
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -879,7 +879,7 @@ WebHistoryWriter::WebHistoryWriter(DateToEntriesMap* entriesByDate)
 void WebHistoryWriter::writeHistoryItems(BinaryPropertyListObjectStream& stream)
 {
     for (int dateIndex = m_dateKeys.size() - 1; dateIndex >= 0; dateIndex--) {
-        NSArray *entries = m_entriesByDate->get(m_dateKeys[dateIndex]).unsafeGet();
+        RetainPtr<NSArray> entries = m_entriesByDate->get(m_dateKeys[dateIndex]);
         NSUInteger entryCount = [entries count];
         for (NSUInteger entryIndex = 0; entryIndex < entryCount; ++entryIndex)
             writeHistoryItem(stream, [entries objectAtIndex:entryIndex]);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -404,7 +404,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
     auto suggestedURL = saveDatas[0].url;
     ASSERT(!suggestedURL.isEmpty());
 
-    NSURL *platformURL = m_suggestedToActualURLMap.get(suggestedURL).unsafeGet();
+    RetainPtr<NSURL> platformURL = m_suggestedToActualURLMap.get(suggestedURL);
     if (!platformURL) {
         platformURL = [NSURL URLWithString:suggestedURL.createNSString().get()];
         // The user must confirm new filenames before we can save to them.
@@ -436,17 +436,17 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
     };
 
     if (!forceSaveAs) {
-        saveToURL(platformURL);
+        saveToURL(platformURL.get());
         return;
     }
 
     NSSavePanel *panel = [NSSavePanel savePanel];
-    panel.nameFieldStringValue = platformURL.lastPathComponent;
+    panel.nameFieldStringValue = platformURL.get().lastPathComponent;
 
     // If we have a file URL we've already saved this file to a path and
     // can provide a good directory to show. Otherwise, use the system's
     // default behavior for the initial directory to show in the dialog.
-    if (platformURL.isFileURL)
+    if (platformURL.get().isFileURL)
         panel.directoryURL = [platformURL URLByDeletingLastPathComponent];
 
     auto completionHandler = ^(NSInteger result) {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
@@ -74,11 +74,11 @@ bool WebNotificationClient::show(ScriptExecutionContext&, NotificationData&& not
 
 void WebNotificationClient::cancel(NotificationData&& notification)
 {
-    WebNotification *webNotification = m_notificationMap.get(notification.notificationID).unsafeGet();
+    RetainPtr webNotification = m_notificationMap.get(notification.notificationID);
     if (!webNotification)
         return;
 
-    [[m_webView _notificationProvider] cancelNotification:webNotification];
+    [[m_webView _notificationProvider] cancelNotification:webNotification.get()];
 }
 
 void WebNotificationClient::notificationObjectDestroyed(NotificationData&& notification)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8634,7 +8634,7 @@ FORWARD(toggleUnderline)
 
 - (id)_objectForIdentifier:(unsigned long)identifier
 {
-    return _private->identifierMap.get(identifier).unsafeGet();
+    return _private->identifierMap.get(identifier);
 }
 
 - (void)_removeObjectForIdentifier:(unsigned long)identifier

--- a/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
@@ -219,13 +219,13 @@ static RetainPtr<CFStringRef> toUTI(NSString *type)
 
 - (NSData *)dataForType:(NSString *)dataType
 {
-    if (NSData *data = (__bridge NSData *)_data.get(toUTI(dataType).get()).unsafeGet())
+    if (NSData *data = (__bridge NSData *)_data.get(toUTI(dataType).get()))
         return data;
 
     if (_owner && [_owner respondsToSelector:@selector(pasteboard:provideDataForType:)])
         [_owner pasteboard:self provideDataForType:dataType];
 
-    return (__bridge NSData *)_data.get(toUTI(dataType).get()).unsafeGet();
+    return (__bridge NSData *)_data.get(toUTI(dataType).get());
 }
 
 - (BOOL)setPropertyList:(id)propertyList forType:(NSString *)dataType

--- a/Tools/DumpRenderTree/mac/MockWebNotificationProvider.mm
+++ b/Tools/DumpRenderTree/mac/MockWebNotificationProvider.mm
@@ -97,12 +97,12 @@
 
 - (void)webView:(WebView *)webView didShowNotification:(NSString *)notificationID
 {
-    [_notifications.get(String(notificationID)).get() dispatchShowEvent];
+    [_notifications.get(String(notificationID))dispatchShowEvent];
 }
 
 - (void)webView:(WebView *)webView didClickNotification:(NSString *)notificationID
 {
-    [_notifications.get(String(notificationID)).get() dispatchClickEvent];
+    [_notifications.get(String(notificationID)) dispatchClickEvent];
 }
 
 - (void)webView:(WebView *)webView didCloseNotifications:(NSArray *)notificationIDs

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -381,7 +381,7 @@ static RetainPtr<WKWebView> createdWebView;
     }, 0.1);
 
     doAsynchronouslyIfNecessary([self, finalURL](id <WKURLSchemeTask> task) {
-        if (auto data = _dataMappings.get([finalURL absoluteString]))
+        if (RetainPtr data = _dataMappings.get([finalURL absoluteString]))
             [task didReceiveData:data.get()];
         else if (_bytes)
             [task didReceiveData:toNSData(_bytes.span8()).get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -3049,7 +3049,7 @@ static bool didStartURLSchemeTaskForImportedScript = false;
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:finalURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerDictionary]);
     [task didReceiveResponse:response.get()];
 
-    if (auto data = _dataMappings.get([finalURL absoluteString]))
+    if (RetainPtr data = _dataMappings.get([finalURL absoluteString]))
         [task didReceiveData:data.get()];
     else if (_bytes)
         [task didReceiveData:toNSData(byteCast<uint8_t>(unsafeSpan(_bytes))).get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -1123,7 +1123,7 @@ static unsigned loadCount;
     auto response = adoptNS([[NSURLResponse alloc] initWithURL:finalURL MIMEType:@"text/html" expectedContentLength:1 textEncodingName:nil]);
     [task didReceiveResponse:response.get()];
 
-    if (auto data = _dataMappings.get([finalURL absoluteString]))
+    if (RetainPtr data = _dataMappings.get([finalURL absoluteString]))
         [task didReceiveData:data.get()];
     else
         [task didReceiveData:[@"Hello" dataUsingEncoding:NSUTF8StringEncoding]];


### PR DESCRIPTION
#### b4952badb66f20d73d9b3ac12b36e131f6bc2d65
<pre>
Reduce use of `unsafeGet()` in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=303122">https://bugs.webkit.org/show_bug.cgi?id=303122</a>

Reviewed by Timothy Hatcher and Darin Adler.

Part of it was tweaking the HashTraits for RetainPtr to use
a `P*` as PeekType instead of a `RetainPtr&lt;P&gt;`, similarly to
what we do for `RefPtr&lt;P&gt;`.

* Source/WTF/wtf/RetainPtr.h:
(WTF::HashTraits&lt;RetainPtr&lt;P&gt;&gt;::emptyValue):
(WTF::HashTraits&lt;RetainPtr&lt;P&gt;&gt;::isEmptyValue):
(WTF::HashTraits&lt;RetainPtr&lt;P&gt;&gt;::peek):
* Source/WebCore/editing/cocoa/AlternativeTextContextController.mm:
(WebCore::AlternativeTextContextController::alternativesForContext const):
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::reconstructStyle):
* Source/WebCore/page/cocoa/DataDetectionResultsStorage.h:
(WebCore::DataDetectionResultsStorage::imageOverlayDataDetectionResult):
* Source/WebCore/platform/graphics/Icon.h:
(WebCore::Icon::image const):
* Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm:
(WebCore::LocalizedDateCache::formatterForDateType):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::iconForAttachment):
* Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm:
(WebKit::TextExtractionFilter::singleton):
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::toCocoaImage):
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::rootFrame):
(WebKit::WebBackForwardListFrameItem::mainFrame):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::navigatedFrameItem const):
* Source/WebKit/UIProcess/API/APIFrameInfo.cpp:
(API::FrameInfo::page const):
(API::FrameInfo::page):
* Source/WebKit/UIProcess/API/APIScriptMessage.h:
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload delegate]):
* Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm:
(-[WKScriptMessage name]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm:
(-[_WKDataTask webView]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector delegate]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm:
(-[_WKWebPushMessage data]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm:
(-[_WKWebPushSubscriptionData applicationServerKey]):
(-[_WKWebPushSubscriptionData authenticationSecret]):
(-[_WKWebPushSubscriptionData ecdhPublicKey]):
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::ApplicationStateTracker::setWindow):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::previewForModelIdentifier):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet delegate]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::bestIcon):
(WebKit::WebExtension::bestIconVariant):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::itemForID):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::traversePrevious):
(WebKit::WebFrameProxy::deepLastChild):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::fromIdentifier):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::defaultDropPreview const):
(WebKit::DragDropInteractionState::finalDropPreview const):
* Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm:
(-[WKHighlightLongPressGestureRecognizer lastTouchedScrollView]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _wk_topEdgeEffect]):
(-[WKScrollView _wk_leftEdgeEffect]):
(-[WKScrollView _wk_rightEdgeEffect]):
(-[WKScrollView _wk_bottomEdgeEffect]):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper textSelectionDisplayInteraction]):
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController delegate]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::createPDFHUD):
(WebKit::WebViewImpl::updatePDFHUDLocation):
(WebKit::WebViewImpl::removePDFHUD):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter notificationSettings]):
* Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKitLegacy/mac/History/WebHistory.mm:
(-[WebHistoryPrivate insertItem:forDateKey:]):
(-[WebHistoryPrivate orderedItemsLastVisitedOnDay:]):
(WebHistoryWriter::writeHistoryItems):
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorFrontendClient::save):
* Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm:
(WebNotificationClient::cancel):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _objectForIdentifier:]):
* Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm:
(-[LocalPasteboard dataForType:]):
* Tools/DumpRenderTree/mac/MockWebNotificationProvider.mm:
(-[MockWebNotificationProvider webView:didShowNotification:]):
(-[MockWebNotificationProvider webView:didClickNotification:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[PSONScheme webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[ServiceWorkerSchemeHandler webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(-[DataMappingSchemeHandler webView:startURLSchemeTask:]):

Canonical link: <a href="https://commits.webkit.org/303705@main">https://commits.webkit.org/303705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd9737bfb6882786605e36dc67d5e5bba2793b3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140776 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85267 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4e22c4c-8faf-40d1-9689-c2345e8e20d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101902 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69364 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00d806d0-dc4c-440a-a91b-58f3202a84e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82696 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5b5b995-a853-4606-9556-3d1b5133334b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4305 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1887 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125294 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143424 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131731 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110277 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110460 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4178 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115669 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59141 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5448 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34023 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164698 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5294 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68900 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43002 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5404 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->