### PR TITLE
Attachment text should override any external text alignment

### DIFF
--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<body>
+<div style="text-align:center">
+text-align:center<br>
+<attachment title="c.txt" style="text-align:start"></attachment>
+</div>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+takeExpectedScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-rtl-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-rtl-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<body style="direction:rtl">
+direction:rtl
+<div style="text-align:center">
+text-align:center<br>
+<attachment title="c.txt" style="text-align:start"></attachment>
+</div>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+takeExpectedScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-rtl.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-rtl.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<body style="direction:rtl">
+direction:rtl
+<div style="text-align:center">
+text-align:center<br>
+<attachment title="c.txt"></attachment>
+</div>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html class="reftest-wait">
+<body>
+<div style="text-align:center">
+text-align:center<br>
+<attachment title="c.txt"></attachment>
+</div>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -46,6 +46,8 @@ div#attachment-container {
     background-color: canvas;
     border-radius: 8px;
     font: caption;
+    direction: inherit;
+    text-align: start;
     pointer-events: none;
     user-select: none;
     -webkit-user-select: none;


### PR DESCRIPTION
#### fa3dfaa18b666d7d0407ee145666bde979ec9ee1
<pre>
Attachment text should override any external text alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=303159">https://bugs.webkit.org/show_bug.cgi?id=303159</a>
<a href="https://rdar.apple.com/113227073">rdar://113227073</a>

Reviewed by Tim Horton.

If an attachment is placed inside container element with a set
`text-align` style, it impacts the alignment of all texts inside the
attachments. E.g., if an attachment is inside a centered paragraph, its
title would become centered (inside the information area) as well.

But we want to keep control of the styling inside the attachment brick.
So this patch adds an explicit `text-align: start` to ensure all texts
are left/right aligned according to the general text `direction`.

The added `direction: inherit` ensures the direction inside the shadow
tree comes from the containing document.

* LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-expected.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-rtl-expected.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center-rtl.html: Added.
* LayoutTests/fast/attachment/cocoa/wide-attachment-text-align-center.html: Added.
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):

Canonical link: <a href="https://commits.webkit.org/303616@main">https://commits.webkit.org/303616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b74cdb087d2da7b70eee5cb90f66cf0be2df04d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84947 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f012fbb-d233-4180-9fde-7c3ca4571333) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101634 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68956 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ab4f33e-c63a-4edf-9cdc-7a076ba7c0e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135862 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82434 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/79e2e74d-6ac7-478c-9953-73d0bd68c88c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4039 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1595 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83684 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143103 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5086 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110012 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3898 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58645 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5140 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33703 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5098 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->