### PR TITLE
SVGLength percentage resolution fails for elements inside non-instanced <symbol> or when viewportElement() returns nullptr

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-baseval-in-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-baseval-in-display-none-expected.txt
@@ -1,4 +1,4 @@
 
 PASS With em
-FAIL With em and percentage The operation is not supported.
+FAIL With em and percentage assert_equals: r1.height expected 120 but got 120.00000762939453
 

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -230,14 +230,17 @@ SVGSVGElement* SVGElement::ownerSVGElement() const
     return nullptr;
 }
 
-SVGElement* SVGElement::viewportElement() const
+SVGElement* SVGElement::viewportElement(ViewportElementType type) const
 {
     // This function needs shadow tree support - as RenderSVGContainer uses this function
-    // to determine the "overflow" property. <use> on <symbol> wouldn't work otherwhise.
+    // to determine the "overflow" property. <use> on <symbol> wouldn't work otherwise.
     auto* node = parentNode();
     while (node) {
-        if (is<SVGSVGElement>(*node) || is<SVGImageElement>(*node) || node->hasTagName(SVGNames::symbolTag))
-            return downcast<SVGElement>(node);
+        if (is<SVGSVGElement>(*node) || is<SVGImageElement>(*node))
+            return dynamicDowncast<SVGElement>(node);
+
+        if (type == ViewportElementType::Any && node->hasTagName(SVGNames::symbolTag))
+            return dynamicDowncast<SVGElement>(node);
 
         node = node->parentOrShadowHostNode();
     }

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -70,7 +70,13 @@ public:
     bool isOutermostSVGSVGElement() const;
 
     SVGSVGElement* ownerSVGElement() const;
-    SVGElement* viewportElement() const;
+
+    enum class ViewportElementType : uint8_t {
+        Any, // Returns first SVGSVGElement, SVGImageElement, or symbol
+        SVGSVGOnly // Returns only SVGSVGElement
+    };
+
+    SVGElement* viewportElement(ViewportElementType = ViewportElementType::Any) const;
 
     String title() const override;
     virtual bool supportsMarkers() const { return false; }

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -33,6 +33,7 @@
 #include "LocalFrame.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
+#include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGSVGElement.h"
 #include "StyleLengthResolution.h"
@@ -421,6 +422,8 @@ std::optional<FloatSize> SVGLengthContext::viewportSize() const
 
 std::optional<FloatSize> SVGLengthContext::computeViewportSize() const
 {
+    using ViewportElementType = SVGElement::ViewportElementType;
+
     ASSERT(m_context);
 
     // Root <svg> element lengths are resolved against the top level viewport,
@@ -432,8 +435,8 @@ std::optional<FloatSize> SVGLengthContext::computeViewportSize() const
     if (m_context->isOutermostSVGSVGElement())
         return downcast<SVGSVGElement>(*protectedContext()).currentViewportSizeExcludingZoom();
 
-    // Take size from nearest viewport element.
-    RefPtr svg = dynamicDowncast<SVGSVGElement>(m_context->viewportElement());
+    // Take size from nearest SVGSVGElement, skipping over <symbol> elements.
+    RefPtr svg = dynamicDowncast<SVGSVGElement>(m_context->viewportElement(ViewportElementType::SVGSVGOnly));
     if (!svg)
         return std::nullopt;
 


### PR DESCRIPTION
#### aa1b9b223e9760f309aa77ff99f36e346421ddeb
<pre>
SVGLength percentage resolution fails for elements inside non-instanced &lt;symbol&gt; or when viewportElement() returns nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=303127">https://bugs.webkit.org/show_bug.cgi?id=303127</a>
<a href="https://rdar.apple.com/165431008">rdar://165431008</a>

Reviewed by Simon Fraser.

SVGLength.value was throwing `NotSupportedError` when resolving percentage
values for elements inside non-instanced &lt;symbol&gt; elements or display:none
containers. According to the SVG specification [1], either an &lt;svg&gt; element
or a &lt;symbol&gt; element that is instanced by a &lt;use&gt; element establishes a
new viewport. For non-instanced &lt;symbol&gt; elements, the nearest ancestor
&lt;svg&gt; should provide the viewport for percentage resolution.

Fix viewport calculation by extending viewportElement() with a
ViewportElementType enum that allows callers to specify whether they want
any viewport element (including &lt;symbol&gt;) or specifically an &lt;svg&gt; element.
This eliminates the need for manual ancestor walks in computeViewportSize()
while preserving the original behavior for normal viewport elements.

When ViewportElementType::SVGSVGOnly is specified, viewportElement() now
walks up the ancestor tree to find the nearest &lt;svg&gt; element, skipping
&lt;symbol&gt; elements. This matches other browser engines (Blink / Chromium
and Gecko / Firefox).

[1] <a href="https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport">https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport</a>

NOTE: We still don&apos;t progress WPT due to floating point issue with height
in WPT test but it progress for width.

* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::viewportElement const):
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::computeViewportSize const):
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-baseval-in-display-none-expected.txt: Partial Progression

Canonical link: <a href="https://commits.webkit.org/304197@main">https://commits.webkit.org/304197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c3b452b248dc5ea8ae3075f82b28c57618f764c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86301 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c53387ee-bac7-4fa3-a065-f01fc87d537f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102660 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69930 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a8a782e5-5170-4f2f-8cb6-8ce775555abc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8af7ab35-0261-4113-9f3e-b1ed295c586f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5001 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2603 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2048 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144476 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111040 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111289 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4832 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60220 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6483 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34821 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6322 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70042 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->