### PR TITLE
[MSE] ended event may never be fired

### DIFF
--- a/LayoutTests/media/media-source/media-source-ended-expected.txt
+++ b/LayoutTests/media/media-source/media-source-ended-expected.txt
@@ -1,0 +1,7 @@
+
+EVENT(update)
+EVENT(update)
+EVENT(ended)
+EXPECTED (video.currentTime == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-ended.html
+++ b/LayoutTests/media/media-source/media-source-ended.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source ended event fired.</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+        function loaderPromise(loader) {
+            return new Promise((resolve, reject) => {
+                loader.onload = resolve;
+                loader.onerror = reject;
+            });
+        }
+
+        async function runTest() {
+            findMediaElement();
+
+            waitForAndFail(video, 'error');
+            const canplayPromise = waitFor(video, 'canplay', true);
+
+            const loader1 = new MediaSourceLoader('content/test-vp8-24fps-manifest.json');
+            const loader1Promise = loaderPromise(loader1);
+
+            const source = new MediaSource();
+            video.src = URL.createObjectURL(source);
+            await waitFor(source, 'sourceopen', true);
+
+            await loader1Promise;
+            const sourceBuffer = source.addSourceBuffer(loader1.type());
+            sourceBuffer.appendWindowEnd = 1.0;
+
+            sourceBuffer.appendBuffer(loader1.initSegment());
+            await waitFor(sourceBuffer, 'update');
+            sourceBuffer.appendBuffer(loader1.mediaSegment(0));
+            await waitFor(sourceBuffer, 'update');
+
+            source.endOfStream();
+
+            await canplayPromise;
+            video.play();
+
+            await waitFor(video, 'ended');
+
+            testExpected("video.currentTime", video.duration);
+
+            endTest()
+        }
+
+    </script>
+</head>
+<body onload="runTest().catch(failTest)">
+    <video muted></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4849,6 +4849,7 @@ webkit.org/b/302326 fast/dom/rtl-scroll-to-leftmost-and-resize.html [ Failure Ti
 webkit.org/b/298463 accessibility/crash-deleting-dynamically-updated-text-input.html [ Skip ]
 
 webkit.org/b/303124 media/media-source/media-source-changetype-vp8-vp9.html [ Failure ]
+webkit.org/b/303130 media/media-source/media-source-ended.html [ Failure ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1302,6 +1302,7 @@ media/video-webm-seek-singlekeyframe.html [ Skip ]
 media/video-webm-canvas-drawing.html [ Skip ]
 media/media-source/media-source-changetype-vp8-vp9.html [ Skip ]
 media/media-source/media-source-webm-seek-singlekeyframe.html [ Skip ]
+media/media-source/media-source-ended.html [ Skip ]
 
 # Managed MediaSource isn't enabled on WK1
 media/media-source/media-managedmse-append.html [ Skip ]

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -712,6 +712,9 @@ ExceptionOr<void> MediaSource::setDurationInternal(const MediaTime& newDuration)
     // 6. Update the media duration to new duration and run the HTMLMediaElement duration change algorithm.
     protectedPrivate()->durationChanged(duration);
 
+    // Changing the duration may affect the buffered range.
+    updateBufferedIfNeeded(true);
+
     // Changing the duration affects the buffered range.
     monitorSourceBuffers();
 


### PR DESCRIPTION
#### cf7ea924ed644fa09867e08eee263362ff798c91
<pre>
[MSE] ended event may never be fired
<a href="https://bugs.webkit.org/show_bug.cgi?id=303126">https://bugs.webkit.org/show_bug.cgi?id=303126</a>
<a href="https://rdar.apple.com/165430052">rdar://165430052</a>

Reviewed by Youenn Fablet.

We had two issues:
1- If the duration was changed which resulted in an updated buffered range (as per spec <a href="https://www.w3.org/TR/media-source-2/#htmlmediaelement-extensions-buffered)">https://www.w3.org/TR/media-source-2/#htmlmediaelement-extensions-buffered)</a>
we wouldn&apos;t have notified the media player that the buffered range got updated.
2- The gap observer used to stop playback at the start of a gap, was only updated once the buffered changed,
if the currentTime wasn&apos;t included in the existing range, we assumed playback was already stalled and didn&apos;t need
to set a time observer. But when we start playback (currentTime == 0), and the video didn&apos;t exactly start at 0
(which is commonly the case with video), we would assume the above, even though
we would skip this start gap.
We now set the time observer to be of the video&apos;s duration should the video
not start precisely at zero.

Test: media/media-source/media-source-ended.html

* LayoutTests/media/media-source/media-source-ended-expected.txt: Added.
* LayoutTests/media/media-source/media-source-ended.html: Added.
* LayoutTests/platform/glib/TestExpectations: New test failing on GStreamer based player webkit.org/b/303130
* LayoutTests/platform/mac-wk1/TestExpectations: WK1 doesn&apos;t have support for MSE webm
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setDurationInternal): Refresh buffered attribute as needed.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::durationChanged):

Canonical link: <a href="https://commits.webkit.org/303596@main">https://commits.webkit.org/303596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d0983636819f5e3dbdfaf582fefd901508f12b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84934 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/16522a63-515b-4a58-8d3e-4ccd7d21fdc3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101624 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68942 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0df8567f-d5b4-46ec-ae61-ceea4e1cb57d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135849 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b95dae20-7a01-483c-849f-d92512d963f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3960 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1583 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83671 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143090 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110000 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27942 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3888 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58624 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5127 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33694 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4967 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5217 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->