### PR TITLE
[MSE] WebCoreDecompressionSession will error when going from a VideoDecoder to a VTDecompressionSession

### DIFF
--- a/LayoutTests/media/media-source/media-source-changetype-vp8-vp9-expected.txt
+++ b/LayoutTests/media/media-source/media-source-changetype-vp8-vp9-expected.txt
@@ -1,0 +1,8 @@
+
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EXPECTED (video.currentTime >= '0.6') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-changetype-vp8-vp9.html
+++ b/LayoutTests/media/media-source/media-source-changetype-vp8-vp9.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source can change from vp8 to vp9</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+        function loaderPromise(loader) {
+            return new Promise((resolve, reject) => {
+                loader.onload = resolve;
+                loader.onerror = reject;
+            });
+        }
+
+        async function runTest() {
+            findMediaElement();
+
+            waitForAndFail(video, 'error');
+            const canplayPromise = waitFor(video, 'canplay', true);
+
+            const loader1 = new MediaSourceLoader('content/test-vp8-24fps-manifest.json');
+            const loader1Promise = loaderPromise(loader1);
+            const loader2 = new MediaSourceLoader('content/test-vp9-24fps-manifest.json');
+            const loader2Promise = loaderPromise(loader2);
+            video.disableRemotePlayback = true;
+
+            const source = new MediaSource();
+            video.src = URL.createObjectURL(source);
+            await waitFor(source, 'sourceopen', true);
+
+            await loader1Promise;
+            const sourceBuffer = source.addSourceBuffer(loader1.type());
+            sourceBuffer.appendWindowEnd = 1.0;
+
+            sourceBuffer.appendBuffer(loader1.initSegment());
+            await waitFor(sourceBuffer, 'update');
+            sourceBuffer.appendBuffer(loader1.mediaSegment(0));
+            await waitFor(sourceBuffer, 'update');
+
+            sourceBuffer.timestampOffset = 0.5;
+
+            await loader2Promise;
+
+            sourceBuffer.changeType(loader2.type());
+            sourceBuffer.appendBuffer(loader2.initSegment());
+            await waitFor(sourceBuffer, 'update');
+            sourceBuffer.appendBuffer(loader2.mediaSegment(0));
+            await waitFor(sourceBuffer, 'update');
+
+            source.endOfStream();
+
+            await canplayPromise;
+            video.play();
+
+            await testExpectedEventually("video.currentTime", .6, ">=")
+
+            endTest()
+        }
+
+    </script>
+</head>
+<body onload="runTest().catch(failTest)">
+    <video muted></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4848,6 +4848,8 @@ webkit.org/b/302326 fast/dom/rtl-scroll-to-leftmost-and-resize.html [ Failure Ti
 
 webkit.org/b/298463 accessibility/crash-deleting-dynamically-updated-text-input.html [ Skip ]
 
+webkit.org/b/303124 media/media-source/media-source-changetype-vp8-vp9.html [ Failure ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1300,6 +1300,7 @@ media/media-rvfc-paused-webm.html [ Skip ]
 media/media-rvfc-playing-webm.html [ Skip ]
 media/video-webm-seek-singlekeyframe.html [ Skip ]
 media/video-webm-canvas-drawing.html [ Skip ]
+media/media-source/media-source-changetype-vp8-vp9.html [ Skip ]
 media/media-source/media-source-webm-seek-singlekeyframe.html [ Skip ]
 
 # Managed MediaSource isn't enabled on WK1


### PR DESCRIPTION
#### 454d2c90e3ecdbcddf21c2457422ae71fb702c3d
<pre>
[MSE] WebCoreDecompressionSession will error when going from a VideoDecoder to a VTDecompressionSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=303124">https://bugs.webkit.org/show_bug.cgi?id=303124</a>
<a href="https://rdar.apple.com/165427008">rdar://165427008</a>

Reviewed by Youenn Fablet.

Detect video FormatDescription change when a WebCodec&apos;s VideoDecoder is in
use and reset decoder if needed.

Test: media/media-source/media-source-changetype-vp8-vp9.html

* LayoutTests/media/media-source/media-source-changetype-vp8-vp9-expected.txt: Added.
* LayoutTests/media/media-source/media-source-changetype-vp8-vp9.html: Added.
* LayoutTests/platform/glib/TestExpectations: webkit.org/b/303124 invalid currentTime at the end.
* LayoutTests/platform/mac-wk1/TestExpectations: wk1 doesn&apos;t support MSE webm
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::ensureDecompressionSessionForSample):

Canonical link: <a href="https://commits.webkit.org/303581@main">https://commits.webkit.org/303581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02e96b7859d05dfd6b12b8984848ce3a15c9cd4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84924 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d2aa0eed-de33-4ebd-a2b9-015876808c71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101615 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/10ecef35-6262-4c32-bee4-25de65346a77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135840 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82413 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d4fa306-498e-4918-8b6f-68d0aafe1db3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83662 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143081 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5064 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109990 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3875 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115330 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58606 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5118 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33684 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5208 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->