### PR TITLE
AirPods capture mute does not work with multi-microphone capture

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h
@@ -186,6 +186,9 @@ private:
     enum class SyncUpdate : bool { No, Yes };
     void updateMutedState(SyncUpdate = SyncUpdate::No);
 
+    static bool isAnyUnitCapturingExceptFor(CoreAudioCaptureUnit*);
+    static bool isAnyUnitCapturing();
+
     CreationCallback m_creationCallback;
     GetSampleRateCallback m_getSampleRateCallback;
     std::unique_ptr<InternalUnit> m_ioUnit;


### PR DESCRIPTION
#### d037c190b104fe39c6f8f4d1c32b932cc8273d6c
<pre>
AirPods capture mute does not work with multi-microphone capture
<a href="https://rdar.apple.com/165432476">rdar://165432476</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303128">https://bugs.webkit.org/show_bug.cgi?id=303128</a>

Reviewed by Jean-Yves Avenard.

When VPIO is no longer running but non-VPIO capture is ongoing, muting/unmuting via AirPods should still work.
This was not the case as we were checking whether the VPIO unit was producing microphone samples or not.
We update the check to include all units.

We also update the test in CoreAudioCaptureUnit::updateMutedState to only check for other units.

Manually tested.

* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.cpp:
(WebCore::CoreAudioCaptureUnit::isAnyUnitCapturingExceptFor):
(WebCore::CoreAudioCaptureUnit::isAnyUnitCapturing):
(WebCore::CoreAudioCaptureUnit::updateMutedState):
(WebCore::CoreAudioCaptureUnit::disableMutedSpeechActivityEventListener):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.h:

Canonical link: <a href="https://commits.webkit.org/303576@main">https://commits.webkit.org/303576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f969773b169db224538f0c5531ab629220c2603

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84898 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/230667b2-0eee-4505-82c1-e61a0b6c8e8e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5738 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/5233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101596 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db9e43e8-7a4a-49f3-8177-faa410f9b97e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135815 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82391 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef9d15cd-ac9e-4611-835a-ac8e50ab962f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83635 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143056 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109972 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5121 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/5233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27923 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3856 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5093 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33664 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68545 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5051 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->