### PR TITLE
[blocks-in-inline] Paint outlines

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-outline-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-outline-expected.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.outline-container {
+  margin: 10px 0px;
+  width: 10px;
+  height: 10px;
+  outline: auto;
+  font: 10px/1 Ahem;
+}
+
+.outline-container > span > div {
+  color: lime;
+}
+
+.inline-block-text > .outline-container > span > div {
+  display: inline-block;
+}
+
+.inline-text > .outline-container > span > div {
+  display: inline;
+}
+</style>
+<p>Test passes if the outline is wrapping all the green boxes.</p>
+<div style="display: grid; grid-template-columns: repeat(6, 100px);">
+  <div>
+    <div class="outline-container" style="padding-left: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div>
+    <div class="outline-container" style="padding-left: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-block-text">
+    <div class="outline-container" style="padding-left: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-block-text">
+    <div class="outline-container" style="padding-left: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-text">
+    <div class="outline-container" style="padding-left: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-text">
+    <div class="outline-container" style="padding-left: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/fast/inline/blocks-in-inline-outline.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-outline.html
@@ -1,0 +1,165 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.outline-container {
+  margin: 10px 0px;
+  width: 10px;
+  height: 10px;
+  outline: auto;
+  font: 10px/1 Ahem;
+}
+
+.outline-container > span > div {
+  color: lime;
+}
+
+.inline-block-text > .outline-container > span > div {
+  display: inline-block;
+}
+
+.inline-text > .outline-container > span > div {
+  display: inline;
+}
+</style>
+<p>Test passes if the outline is wrapping all the green boxes.</p>
+<div style="display: grid; grid-template-columns: repeat(6, 100px);">
+  <div>
+    <div class="outline-container" style="padding-left: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div>
+    <div class="outline-container" style="padding-left: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-block-text">
+    <div class="outline-container" style="padding-left: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-block-text">
+    <div class="outline-container" style="padding-left: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-text">
+    <div class="outline-container" style="padding-left: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 5px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 5px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+  <div class="inline-text">
+    <div class="outline-container" style="padding-left: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-right: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-top: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding-bottom: 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 0px 20px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px 0px;">
+      <span><div>XX</div></span>
+    </div>
+    <div class="outline-container" style="padding: 20px;">
+      <span><div>XX</div></span>
+    </div>
+  </div>
+</div>

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -181,6 +181,18 @@ RenderObject::HighlightState LineBox::ellipsisSelectionState() const
     return selectionStart <= *selectionRange.truncation && selectionEnd >= *selectionRange.truncation ? RenderObject::HighlightState::Inside : RenderObject::HighlightState::None;
 }
 
+LeafBoxIterator LineBox::blockLevelBox() const
+{
+    if (!hasBlockLevelContent())
+        return { };
+    auto blockBox = lineRightmostLeafBox();
+    if (!blockBox || !blockBox->isBlockLevelBox()) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+    return blockBox;
+}
+
 }
 }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -87,6 +87,9 @@ public:
     bool isFirst() const;
     bool isFirstAfterPageBreak() const;
 
+    bool hasBlockLevelContent() const;
+    LeafBoxIterator blockLevelBox() const;
+
     // Text-relative left/right
     LeafBoxIterator lineLeftmostLeafBox() const;
     LeafBoxIterator lineRightmostLeafBox() const;
@@ -317,6 +320,13 @@ inline bool LineBox::isFirstAfterPageBreak() const
 inline bool LineBox::isFirst() const
 {
     return !previous();
+}
+
+inline bool LineBox::hasBlockLevelContent() const
+{
+    return WTF::switchOn(m_pathVariant, [](const auto& path) {
+        return path.hasBlockLevelContent();
+    });
 }
 
 inline size_t LineBox::lineIndex() const

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
@@ -77,12 +77,12 @@ public:
     const RenderBlockFlow& formattingContextRoot() const { return m_rootInlineBox->blockFlow(); }
 
     bool isFirstAfterPageBreak() const { return false; }
+    bool hasBlockLevelContent() const { return false; }
 
     size_t lineIndex() const
     {
         return formattingContextRoot().legacyRootBox() ? 1 : 0;
     }
-
 
     void traverseNext()
     {

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -89,6 +89,7 @@ public:
     const RenderBlockFlow& formattingContextRoot() const { return m_inlineContent->formattingContextRoot(); }
 
     bool isFirstAfterPageBreak() const { return line().isFirstAfterPageBreak(); }
+    bool hasBlockLevelContent() const { return line().hasBlockLevelContent(); }
 
     size_t lineIndex() const { return m_lineIndex; }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2739,23 +2739,27 @@ void RenderBlock::addFocusRingRects(Vector<LayoutRect>& rects, const LayoutPoint
     if (!hasNonVisibleOverflow() && !hasControlClip()) {
         if (childrenInline())
             addFocusRingRectsForInlineChildren(rects, additionalOffset, paintContainer);
-    
-        for (auto& box : childrenOfType<RenderBox>(*this)) {
-            if (is<RenderListMarker>(box) || box.isOutOfFlowPositioned())
-                continue;
 
-            FloatPoint pos;
-            // FIXME: This doesn't work correctly with transforms.
-            if (box.layer())
-                pos = box.localToContainerPoint(FloatPoint(), paintContainer);
-            else
-                pos = FloatPoint(additionalOffset.x() + box.x(), additionalOffset.y() + box.y());
-            box.addFocusRingRects(rects, flooredLayoutPoint(pos), paintContainer);
-        }
+        for (auto& box : childrenOfType<RenderBox>(*this))
+            addFocusRingRectsForBlockChild(box, rects, additionalOffset, paintContainer);
     }
 
     if (inlineContinuation)
         inlineContinuation->addFocusRingRects(rects, flooredLayoutPoint(LayoutPoint(additionalOffset + inlineContinuation->containingBlock()->location() - location())), paintContainer);
+}
+
+void RenderBlock::addFocusRingRectsForBlockChild(const RenderBox& box, Vector<LayoutRect>& rects, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer) const
+{
+    if (is<RenderListMarker>(box) || box.isOutOfFlowPositioned())
+        return;
+
+    FloatPoint pos;
+    // FIXME: This doesn't work correctly with transforms.
+    if (box.layer())
+        pos = box.localToContainerPoint(FloatPoint(), paintContainer);
+    else
+        pos = FloatPoint(additionalOffset.x() + box.x(), additionalOffset.y() + box.y());
+    box.addFocusRingRects(rects, flooredLayoutPoint(pos), paintContainer);
 }
 
 LayoutUnit RenderBlock::offsetFromLogicalTopOfFirstPage() const

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -314,8 +314,9 @@ protected:
     void addOverflowFromOutOfFlowBoxes();
     void addVisualOverflowFromTheme();
 
-    void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = 0) const override;
+    void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = nullptr) const override;
     virtual void addFocusRingRectsForInlineChildren(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer) const;
+    void addFocusRingRectsForBlockChild(const RenderBox&, Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject*) const;
 
     void computeFragmentRangeForBoxChild(const RenderBox&) const;
 


### PR DESCRIPTION
#### 238913f44ed9760a49e436ae759009d29828215b
<pre>
[blocks-in-inline] Paint outlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=303129">https://bugs.webkit.org/show_bug.cgi?id=303129</a>
<a href="https://rdar.apple.com/165433482">rdar://165433482</a>

Reviewed by Alan Baradlay.

Outline painting needs to descend to blocks too.

Test: fast/inline/blocks-in-inline-outline.html
* LayoutTests/fast/inline/blocks-in-inline-outline-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-outline.html: Added.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp:
(WebCore::InlineIterator::LineBox::blockLevelBox const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
(WebCore::InlineIterator::LineBox::hasBlockLevelContent const):

Add helper functions for block-in-inline lines.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::hasBlockLevelContent const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::hasBlockLevelContent const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::addFocusRingRects const):
(WebCore::RenderBlock::addFocusRingRectsForBlockChild const):

Factor into a function.

* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::addFocusRingRectsForInlineChildren const):

Descends into blocks-in-inline.

Canonical link: <a href="https://commits.webkit.org/303567@main">https://commits.webkit.org/303567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9418dfcbf2a7a774fa7085f061f9b0099c57c182

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84882 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e5bcf54f-dd2f-4aae-a5ef-64802bb50548) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5708 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/5217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101582 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f4c371e8-bbd6-4b12-b3e9-e8fb86b8525f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135799 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82377 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f603986-8beb-4665-be91-a9bb010b2e89) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83618 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143040 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5023 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109959 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5105 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/5217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27917 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3844 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58545 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5077 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33649 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->