### PR TITLE
[MSE] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit times out.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit-expected.txt
@@ -1,8 +1,18 @@
 
-FAIL Check if browser supports enough test media types and pairs of audio-only or video-only media with same bytestream format assert_true: Browser doesn't support at least 2 audio-only or 2 video-only test media with same bytestream format expected true got false
+PASS Check if browser supports enough test media types and pairs of audio-only or video-only media with same bytestream format
+PASS Test audio-only implicit changeType for audio/webm; codecs="vorbis" <-> audio/webm; codecs="vorbis"
+PASS Test audio-only implicit changeType for audio/webm; codecs="vorbis" <-> audio/webm; codecs="vorbis" (using types without codecs parameters for addSourceBuffer)
 PASS Test audio-only implicit changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mp4; codecs="mp4a.40.2"
 PASS Test audio-only implicit changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters for addSourceBuffer)
 PASS Test audio-only implicit changeType for audio/mpeg <-> audio/mpeg
+PASS Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8"
+PASS Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8" (using types without codecs parameters for addSourceBuffer)
+PASS Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9"
+PASS Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9" (using types without codecs parameters for addSourceBuffer)
+PASS Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8"
+PASS Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8" (using types without codecs parameters for addSourceBuffer)
+PASS Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9"
+PASS Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9" (using types without codecs parameters for addSourceBuffer)
 PASS Test video-only implicit changeType for video/mp4; codecs="avc1.4D4001" <-> video/mp4; codecs="avc1.4D4001"
 PASS Test video-only implicit changeType for video/mp4; codecs="avc1.4D4001" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters for addSourceBuffer)
 

--- a/LayoutTests/media/media-source/media-source-multiple-initialization-segments-expected.txt
+++ b/LayoutTests/media/media-source/media-source-multiple-initialization-segments-expected.txt
@@ -7,10 +7,7 @@ EVENT(updateend)
 Test that a replacement initialization segment containing a track with the same codec but a different trackID succeeds.
 RUN(sourceBuffer.appendBuffer(initSegment))
 EVENT(updateend)
-Test that a replacement initialization segment containing a track with a different codec but the same trackID fails.
-RUN(sourceBuffer.appendBuffer(initSegment))
-EVENT(error)
-EVENT(updateend)
+RUN(source.endOfStream())
 EVENT(sourceended)
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-source-multiple-initialization-segments.html
+++ b/LayoutTests/media/media-source/media-source-multiple-initialization-segments.html
@@ -32,8 +32,6 @@
     }
 
     function sourceEnded() {
-        if (!expected)
-            logResult(Failed, 'Unexpected "sourceended" event');
         endTest();
     }
     
@@ -47,14 +45,7 @@
     }
 
     function secondUpdate() {
-        consoleWrite('Test that a replacement initialization segment containing a track with a different codec but the same trackID fails.')
-        waitForEventOn(sourceBuffer, 'error');
-        waitForEventOn(sourceBuffer, 'updateend');
-        expected = true;
-        initSegment = makeAInit(100, [
-            makeATrack(2, '!moc', TRACK_KIND.VIDEO),
-        ]);
-        run('sourceBuffer.appendBuffer(initSegment)');
+        run('source.endOfStream()');
     }
 
     </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1073,8 +1073,6 @@ webkit.org/b/214661 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCSctpTran
 
 webkit.org/b/230485 [ Release ] imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-events.html [ Pass Failure ]
 
-webkit.org/b/214683 [ Debug ] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html [ Pass Failure ]
-
 webkit.org/b/214824 [ Debug ] js/throw-large-string-oom.html [ Skip ]
 
 webkit.org/b/215304 fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1595,7 +1595,6 @@ imported/w3c/web-platform-tests/css/css-sizing/percentage-height-in-flexbox.html
 [ Debug ] accessibility/roles-exposed.html [ Pass Timeout ]
 
 # rdar://66910555 ([ Layout Tests ] REGRESSION (r264345): [ macOS ] 2 media-source/mediasource-changetype-play are a flaky failure)
-imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html [ Pass Failure ]
 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html [ Crash Pass Failure ]
 
 # WebP images

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1099,49 +1099,9 @@ bool SourceBuffer::validateInitializationSegment(const SourceBufferPrivateClient
 
     // Note: those are checks from step 3.1
     //   * The number of audio, video, and text tracks match what was in the first initialization segment.
-    if (segment.audioTracks.size() != protectedAudioTracks()->length()
-        || segment.videoTracks.size() != protectedVideoTracks()->length()
-        || segment.textTracks.size() != protectedTextTracks()->length())
-        return false;
-
-    //   * The codecs for each track, match what was specified in the first initialization segment.
-    // (Note: Issue #155 strikes out this check. For broad compatibility when this experimental feature
-    // is not enabled, only perform this check if the "pending initialization segment for changeType flag"
-    // is not set.)
-    for (auto& audioTrackInfo : segment.audioTracks) {
-        auto audioCodec = RefPtr { audioTrackInfo.description }->codec().toAtomString();
-        if (m_audioCodecs.contains(audioCodec))
-            continue;
-
-        if (!m_pendingInitializationSegmentForChangeType)
-            return false;
-
-        m_audioCodecs.append(WTFMove(audioCodec));
-    }
-
-    for (auto& videoTrackInfo : segment.videoTracks) {
-        auto videoCodec = RefPtr { videoTrackInfo.description }->codec().toAtomString();
-        if (m_videoCodecs.contains(videoCodec))
-            continue;
-
-        if (!m_pendingInitializationSegmentForChangeType)
-            return false;
-
-        m_videoCodecs.append(WTFMove(videoCodec));
-    }
-
-    for (auto& textTrackInfo : segment.textTracks) {
-        auto textCodec = RefPtr { textTrackInfo.description }->codec().toAtomString();
-        if (m_textCodecs.contains(textCodec))
-            continue;
-
-        if (!m_pendingInitializationSegmentForChangeType)
-            return false;
-
-        m_textCodecs.append(WTFMove(textCodec));
-    }
-
-    return true;
+    return segment.audioTracks.size() == protectedAudioTracks()->length()
+        && segment.videoTracks.size() == protectedVideoTracks()->length()
+        && segment.textTracks.size() == protectedTextTracks()->length();
 }
 
 void SourceBuffer::appendError(bool decodeError)


### PR DESCRIPTION
#### be44d2f8f97f3e729b8da234f3b174a50c7cd3ac
<pre>
[MSE] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit times out.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302692">https://bugs.webkit.org/show_bug.cgi?id=302692</a>
<a href="https://rdar.apple.com/164942617">rdar://164942617</a>

Reviewed by Youenn Fablet.

webkit.org/b/303124 and webkit.org/b/303126 were responsible for error and timeouts respectively.
Also, our SourceBuffer was based on an old spec version that forbade switching codec
to one different than the one in the original init segment, without calling changeType.
This requirement was removed and it become a &quot;MAY&quot;. As our architecture supports
changing codecs on the fly (but not container), we completely remove this
artificial limitation.

Covered by existing test, expectations updated.
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit-expected.txt:
* LayoutTests/media/media-source/media-source-multiple-initialization-segments-expected.txt:
* LayoutTests/media/media-source/media-source-multiple-initialization-segments.html: Remove test no longer valid per last spec.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::validateInitializationSegment):

Canonical link: <a href="https://commits.webkit.org/303618@main">https://commits.webkit.org/303618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5076f7e5a69b292d5150f1de06d59d12ab2bcb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140484 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84980 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a220ac4-5162-48a1-b8ee-de54b5a712a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101663 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68993 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a092e36c-a5f7-49b0-83a4-211d9bfbfae5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82463 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/166a6e42-c30a-4c17-80dc-ec2c55ac3db4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4015 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83717 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143137 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110040 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110221 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27953 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3929 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58689 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5173 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33738 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68625 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->