### PR TITLE
[GTK][WPE] Unify touch Pointer Event handling and make it capture aware

### DIFF
--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -105,6 +105,10 @@ public:
     static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const DoublePoint& touchDelta = { });
 #endif
 
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(WPE) || PLATFORM(GTK))
+    static unsigned pointerIdForTouchPoint(const PlatformTouchPoint&);
+#endif
+
     virtual ~PointerEvent();
 
     PointerID pointerId() const { return m_pointerId; }

--- a/Source/WebCore/dom/glib/PointerEventGLib.cpp
+++ b/Source/WebCore/dom/glib/PointerEventGLib.cpp
@@ -77,9 +77,14 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTou
 // the ids 0 and 1 are used for the pointer ids of mouse and pen/stylus.
 static constexpr unsigned touchMinimumPointerId = WebCore::mousePointerID + 1;
 
+unsigned PointerEvent::pointerIdForTouchPoint(const PlatformTouchPoint& point)
+{
+    return touchMinimumPointerId + point.id();
+}
+
 PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const DoublePoint& touchDelta)
     : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp(), WTF::move(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, std::nullopt, IsSimulated::No, IsTrusted::Yes)
-    , m_pointerId(touchMinimumPointerId + event.touchPoints().at(index).id())
+    , m_pointerId(pointerIdForTouchPoint(event.touchPoints().at(index)))
     , m_width(2 * event.touchPoints().at(index).radius().width())
     , m_height(2 * event.touchPoints().at(index).radius().height())
     , m_pressure(event.touchPoints().at(index).force())

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -104,6 +104,7 @@
 #include "PlatformWheelEvent.h"
 #include "PluginDocument.h"
 #include "PointerCaptureController.h"
+#include "PointerEvent.h"
 #include "PointerEventTypeNames.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "Range.h"
@@ -5465,11 +5466,7 @@ Expected<bool, RemoteFrameGeometryTransformer> EventHandler::handleTouchEvent(co
 
         // Increment the platform touch id by 1 to avoid storing a key of 0 in the hashmap.
         unsigned touchPointTargetKey = point.id() + 1;
-#if PLATFORM(WPE)
-        bool pointerCancelled = false;
-#endif
         RefPtr<EventTarget> touchTarget;
-        RefPtr<EventTarget> pointerTarget;
         if (pointState == PlatformTouchPoint::TouchPressed) {
             HitTestResult result;
             if (freshTouchEvents) {
@@ -5500,7 +5497,6 @@ Expected<bool, RemoteFrameGeometryTransformer> EventHandler::handleTouchEvent(co
                 continue;
             m_originatingTouchPointTargets.set(touchPointTargetKey, element);
             touchTarget = element;
-            pointerTarget = element;
         } else if (pointState == PlatformTouchPoint::TouchReleased || pointState == PlatformTouchPoint::TouchCancelled) {
             // No need to perform a hit-test since we only need to unset :hover and :active states.
             if (!shouldGesturesTriggerActive() && allTouchReleased)
@@ -5511,20 +5507,9 @@ Expected<bool, RemoteFrameGeometryTransformer> EventHandler::handleTouchEvent(co
             // The target should be the original target for this touch, so get it from the hashmap. As it's a release or cancel
             // we also remove it from the map.
             touchTarget = m_originatingTouchPointTargets.take(touchPointTargetKey);
-
-#if PLATFORM(WPE)
-            HitTestResult result = hitTestResultAtPoint(pagePoint, hitType | HitTestRequest::Type::AllowChildFrameContent);
-            pointerTarget = result.targetElement();
-            pointerCancelled = (pointerTarget != touchTarget);
-#endif
         } else {
             // No hittest is performed on move or stationary, since the target is not allowed to change anyway.
             touchTarget = m_originatingTouchPointTargets.get(touchPointTargetKey);
-
-#if PLATFORM(WPE)
-            HitTestResult result = hitTestResultAtPoint(pagePoint, hitType | HitTestRequest::Type::AllowChildFrameContent);
-            pointerTarget = result.targetElement();
-#endif
         }
 
         RefPtr touchTargetNode = dynamicDowncast<Node>(touchTarget);
@@ -5537,25 +5522,25 @@ Expected<bool, RemoteFrameGeometryTransformer> EventHandler::handleTouchEvent(co
         if (!targetFrame)
             continue;
 
-#if PLATFORM(WPE)
-        // FIXME: WPE currently does not send touch stationary events, so create a naive TouchReleased PlatformTouchPoint
-        // on release if the hit test result changed since the previous TouchPressed or TouchMoved
-        if (pointState == PlatformTouchPoint::TouchReleased && pointerCancelled) {
-            PlatformTouchEvent cancelEvent = event;
-            Vector<PlatformTouchPoint> cancelEventPoints = event.touchPoints();
-            cancelEventPoints.at(index) = PlatformTouchPoint(
-                point.id(), PlatformTouchPoint::State::TouchCancelled, point.screenPos(), point.pos());
-            cancelEvent.setTouchPoints(cancelEventPoints);
-            protect(document->page())->pointerCaptureController().dispatchEventForTouchAtIndex(
-                *touchTarget, cancelEvent, index, !index, *document->windowProxy(), { 0, 0 });
-        }
-#endif
-
 #if PLATFORM(WPE) || PLATFORM(GTK)
+        RefPtr<EventTarget> pointerTarget = touchTarget;
+
+        if (pointState != PlatformTouchPoint::TouchPressed) {
+            pointerTarget = protect(document->page())->pointerCaptureController().pointerCaptureElement(document.ptr(), PointerEvent::pointerIdForTouchPoint(point));
+
+            if (!pointerTarget) {
+                HitTestResult result = hitTestResultAtPoint(pagePoint, hitType | HitTestRequest::Type::AllowChildFrameContent);
+                pointerTarget = result.targetElement();
+
+                if (!pointerTarget)
+                    continue;
+            }
+        }
+
         // FIXME: Pass the touch delta for pointermove events by remembering the position per pointerID similar to
         // Apple's m_touchLastGlobalPositionAndDeltaMap
         protect(document->page())->pointerCaptureController().dispatchEventForTouchAtIndex(
-            pointerTarget ? *pointerTarget : *touchTarget, event, index, !index, *document->windowProxy(), { 0, 0 });
+            *pointerTarget, event, index, !index, *document->windowProxy(), { 0, 0 });
 #endif
 
         // pagePoint should always be relative to the target elements containing frame.

--- a/Source/WebCore/platform/PlatformTouchPoint.h
+++ b/Source/WebCore/platform/PlatformTouchPoint.h
@@ -47,18 +47,6 @@ public:
     {
     }
 
-#if PLATFORM(WPE)
-    // FIXME: since WPE currently does not send touch stationary events, we need to be able to
-    // create a PlatformTouchPoint of type TouchCancelled artificially
-    PlatformTouchPoint(unsigned id, State state, DoublePoint screenPos, DoublePoint pos)
-        : m_id(id)
-        , m_state(state)
-        , m_screenPos(screenPos)
-        , m_pos(pos)
-    {
-    }
-#endif
-
     unsigned id() const { return m_id; }
     State state() const { return m_state; }
     DoublePoint screenPos() const { return m_screenPos; }


### PR DESCRIPTION
#### e949d0194653321706afb55d69bf3c4eb14c881a
<pre>
[GTK][WPE] Unify touch Pointer Event handling and make it capture aware
<a href="https://bugs.webkit.org/show_bug.cgi?id=303134">https://bugs.webkit.org/show_bug.cgi?id=303134</a>

Reviewed by Carlos Garcia Campos.

As it is right now, touch Pointer Events in WPE ignore the requirement to
implicitly capture the touch pointer given by the spec, while in GTK they force
the capture unconditionally. While GTK gives the right behavior by default, web
content should be able to control pointer capture with Element::setPointerCapture
and Element::releasePointerCapture API.

Unify the behavior between WPE and GTK ports and make it handle pointer captures.
Take advantage of the fact that we don&apos;t have to perform hit testing while
the pointer remains captured.

Also, remove the injection of pointercancel events in WPE port, as this behavior
doesn&apos;t seem to match anything described in the Pointer Events spec.

* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/glib/PointerEventGLib.cpp:
(WebCore::PointerEvent::pointerIdForTouchPoint): Expose pointerId mapping
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/platform/PlatformTouchPoint.h:

Canonical link: <a href="https://commits.webkit.org/309600@main">https://commits.webkit.org/309600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b4b95d6f5ffa3bbc38614044283d4cf6fc918ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17751 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15702 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162165 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5290 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124548 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33879 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135158 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79925 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11923 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87317 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22840 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->