### PR TITLE
ScriptBuffer IPC serialization is doing redundant work

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -422,7 +422,8 @@ void FetchBodyConsumer::append(const SharedBuffer& buffer)
 
 void FetchBodyConsumer::setData(Ref<FragmentedSharedBuffer>&& data)
 {
-    m_buffer = WTFMove(data);
+    m_buffer.reset();
+    m_buffer.append(WTFMove(data));
 }
 
 RefPtr<FragmentedSharedBuffer> FetchBodyConsumer::takeData()

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -98,7 +98,7 @@ private:
             return emptyString();
 
         if (!m_contiguousBuffer && (!m_containsOnlyASCII || *m_containsOnlyASCII))
-            m_contiguousBuffer = m_scriptBuffer.protectedBuffer()->makeContiguous();
+            m_contiguousBuffer = m_scriptBuffer.buffer()->makeContiguous();
         if (!m_containsOnlyASCII) {
             m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->span());
             if (*m_containsOnlyASCII)

--- a/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
@@ -64,7 +64,7 @@ public:
     void lockUnderlyingBufferImpl() final
     {
         ASSERT(!m_buffer);
-        if (RefPtr<const FragmentedSharedBuffer> buffer = m_scriptBuffer.buffer().get())
+        if (RefPtr buffer = m_scriptBuffer.buffer())
             m_buffer = buffer->makeContiguous();
     }
 

--- a/Source/WebCore/loader/SubstituteResource.h
+++ b/Source/WebCore/loader/SubstituteResource.h
@@ -48,7 +48,7 @@ protected:
     SubstituteResource(URL&& url, ResourceResponse&& response, Ref<FragmentedSharedBuffer>&& data)
         : m_url(WTFMove(url))
         , m_response(WTFMove(response))
-        , m_data(WTFMove(data))
+        , m_data(data)
     {
     }
 

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -339,11 +339,7 @@ class SharedBufferBuilder {
 public:
     SharedBufferBuilder() = default;
     SharedBufferBuilder(SharedBufferBuilder&&) = default;
-    WEBCORE_EXPORT explicit SharedBufferBuilder(RefPtr<FragmentedSharedBuffer>&&);
-    explicit SharedBufferBuilder(Ref<FragmentedSharedBuffer>&& buffer) { initialize(WTFMove(buffer)); }
-    explicit SharedBufferBuilder(RefPtr<SharedBuffer>&& buffer)
-        : SharedBufferBuilder(RefPtr<FragmentedSharedBuffer>{ WTFMove(buffer) }) { }
-    explicit SharedBufferBuilder(Ref<SharedBuffer>&& buffer) { initialize(WTFMove(buffer)); }
+    SharedBufferBuilder(const FragmentedSharedBuffer& buffer) { append(buffer); }
 
     template <typename... Args>
     SharedBufferBuilder(std::in_place_t, Args&&... arg)
@@ -353,7 +349,6 @@ public:
     }
 
     SharedBufferBuilder& operator=(SharedBufferBuilder&&) = default;
-    WEBCORE_EXPORT SharedBufferBuilder& operator=(RefPtr<FragmentedSharedBuffer>&&);
 
     WEBCORE_EXPORT void append(const FragmentedSharedBuffer&);
     WEBCORE_EXPORT void append(std::span<const uint8_t>);

--- a/Source/WebCore/workers/ScriptBuffer.h
+++ b/Source/WebCore/workers/ScriptBuffer.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include <WebCore/ShareableResource.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Platform.h>
 
@@ -39,19 +38,13 @@ namespace WebCore {
 class ScriptBuffer {
 public:
     ScriptBuffer() = default;
-
-    ScriptBuffer(RefPtr<FragmentedSharedBuffer>&& buffer)
-        : m_buffer(WTFMove(buffer))
-    {
-    }
+    WEBCORE_EXPORT explicit ScriptBuffer(const String&);
+    WEBCORE_EXPORT explicit ScriptBuffer(RefPtr<const FragmentedSharedBuffer>&&);
 
     static ScriptBuffer empty();
 
-    WEBCORE_EXPORT explicit ScriptBuffer(const String&);
-
     String toString() const;
-    const SharedBufferBuilder& buffer() const { return m_buffer; }
-    RefPtr<const FragmentedSharedBuffer> protectedBuffer() const { return m_buffer.get(); }
+    RefPtr<const FragmentedSharedBuffer> buffer() const { return m_buffer.get(); }
     size_t size() const { return m_buffer.size(); }
 
     ScriptBuffer isolatedCopy() const { return ScriptBuffer(m_buffer ? RefPtr<FragmentedSharedBuffer>(m_buffer.copy()) : nullptr); }
@@ -61,15 +54,6 @@ public:
     WEBCORE_EXPORT bool containsSingleFileMappedSegment() const;
     void append(const String&);
     void append(const FragmentedSharedBuffer&);
-
-#if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)
-    using IPCData = Variant<ShareableResourceHandle, RefPtr<FragmentedSharedBuffer>>;
-#else
-    using IPCData = RefPtr<FragmentedSharedBuffer>;
-#endif
-
-    WEBCORE_EXPORT static std::optional<ScriptBuffer> fromIPCData(IPCData&&);
-    WEBCORE_EXPORT IPCData ipcData() const;
 
     bool operator==(const ScriptBuffer& other) const { return m_buffer == other.m_buffer; }
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -90,7 +90,7 @@ bool WorkerFontLoadRequest::ensureCustomFontData()
         convertWOFFToSfntIfNecessary(contiguousData);
         if (contiguousData) {
             RefPtr fontCustomPlatformData = FontCustomPlatformData::create(*contiguousData, m_url.fragmentIdentifier().toString());
-            m_data = WTFMove(contiguousData);
+            m_data.append(*contiguousData);
             if (!fontCustomPlatformData) {
                 m_errorOccurred = true;
                 return false;

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -91,7 +91,7 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
     size_t size = script.size();
 
     auto iterateOverBufferAndWriteData = [&](NOESCAPE const Function<bool(std::span<const uint8_t>)>& writeData) {
-        script.protectedBuffer()->forEachSegment([&](std::span<const uint8_t> span) {
+        script.buffer()->forEachSegment([&](std::span<const uint8_t> span) {
             writeData(span);
         });
     };
@@ -134,8 +134,10 @@ ScriptBuffer SWScriptStorage::retrieve(const ServiceWorkerRegistrationKey& regis
     }
 
     // FIXME: Do we need to disable file mapping in more cases to avoid having too many file descriptors open?
-    RefPtr<FragmentedSharedBuffer> buffer = SharedBuffer::createWithContentsOfFile(scriptPath, FileSystem::MappedFileMode::Private, shouldUseFileMapping(*fileSize) ? SharedBuffer::MayUseFileMapping::Yes : SharedBuffer::MayUseFileMapping::No);
-    return buffer;
+    RefPtr buffer = SharedBuffer::createWithContentsOfFile(scriptPath, FileSystem::MappedFileMode::Private, shouldUseFileMapping(*fileSize) ? SharedBuffer::MayUseFileMapping::Yes : SharedBuffer::MayUseFileMapping::No);
+    if (!buffer)
+        return { };
+    return ScriptBuffer { *buffer };
 }
 
 void SWScriptStorage::clear(const ServiceWorkerRegistrationKey& registrationKey)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6088,17 +6088,9 @@ struct WebCore::ServiceWorkerImportedScript {
     String mimeType;
 };
 
-#if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)
-[CreateUsing=fromIPCData] class WebCore::ScriptBuffer {
-    Variant<WebCore::ShareableResourceHandle, RefPtr<WebCore::FragmentedSharedBuffer>> ipcData();
+class WebCore::ScriptBuffer {
+    RefPtr<const WebCore::FragmentedSharedBuffer> buffer();
 };
-#endif
-
-#if !ENABLE(SHAREABLE_RESOURCE) || !PLATFORM(COCOA)
-[CreateUsing=fromIPCData] class WebCore::ScriptBuffer {
-    RefPtr<WebCore::FragmentedSharedBuffer> ipcData();
-};
-#endif
 
 header: <wtf/RobinHoodHashTable.h>
 struct WebCore::ServiceWorkerContextData {


### PR DESCRIPTION
#### db14efcc24bcc45321da73cc77b502b0dcab3e66
<pre>
ScriptBuffer IPC serialization is doing redundant work
<a href="https://bugs.webkit.org/show_bug.cgi?id=303135">https://bugs.webkit.org/show_bug.cgi?id=303135</a>
<a href="https://rdar.apple.com/problem/165440987">rdar://problem/165440987</a>

Reviewed by Jean-Yves Avenard.

When serializing ScriptBuffer for IPC, serialization would create:
 - SharedMemory
 - ShareableResource
 - ShareableResourceHandle

ScriptBuffer contains a FragmentedSharedBuffer. We already have
IPC serialization for FragmentedSharedBuffer. We should simply use that.

Add FragmentedSharedBuffer serialization feature where single-segment
mmap-backed data is sent as directly shared memory.

This is work towards removing SharedMemory::wrapMap, which is unsafe
function and should be removed in favor of
SharedMemoryHandle::createVMShared() used here.

Removes
SharedBufferBuilder&amp; SharedBufferBuilder::operator=(RefPtr&lt;FragmentedSharedBuffer&gt;&amp;&amp;)
because it was buggy (did not reset()). It also is overly specific
operation for what it does.

Removes ShareBufferBuilder(RefPtr&lt;..SharedBuffer&gt;&amp;&amp;) constructor
variants, as they did not adopt the ptr, but implied that they did. Their
lack of const qualified ..SharedBuffer and use of rvalue RefPtr vs.
ShareBufferBuilder::append(const FragmentedSharedBuffer&amp;) created
inconsistent API surface.

* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::setData):
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
* Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h:
* Source/WebCore/loader/SubstituteResource.h:
(WebCore::SubstituteResource::SubstituteResource):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::toIPCData const):
(WebCore::SharedBufferBuilder::initialize): Deleted.
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBufferBuilder::SharedBufferBuilder):
* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::ScriptBuffer::ScriptBuffer):
(WebCore::tryConvertToShareableResourceHandle): Deleted.
(WebCore::ScriptBuffer::fromIPCData): Deleted.
(WebCore::ScriptBuffer::ipcData const): Deleted.
* Source/WebCore/workers/ScriptBuffer.h:
(WebCore::ScriptBuffer::buffer const):
(WebCore::ScriptBuffer::ScriptBuffer):
(WebCore::ScriptBuffer::protectedBuffer const): Deleted.
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::ensureCustomFontData):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):
(WebCore::SWScriptStorage::retrieve):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303676@main">https://commits.webkit.org/303676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c2ac58045c9cb4091f6266126e5c75147461bfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140836 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7df92d4-9a42-4b82-ad80-a118e72855da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5648 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ed10a7f5-1a9e-43ef-be80-304b1eb12237) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136229 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82754 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d10319d4-3df9-4b71-b018-9b2cc6dabde9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143484 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38161 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4688 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110516 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27999 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115723 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5508 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68960 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5597 "Failed to checkout and rebase branch from PR 54481") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->