### PR TITLE
[threaded-animations] scroll-driven animations should only be accelerated if their source is composited

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html
+++ b/LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html
@@ -14,7 +14,6 @@ html {
     height: 100%;
 
     background-color: green;
-    opacity: 0;
 }
 
 </style>

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html
@@ -52,7 +52,7 @@ promise_test(async t => {
     const scroller = iframe.contentDocument.documentElement;
 
     const timeline = new ScrollTimeline({ source : scroller });
-    const animation = target().animate({ opacity: 1 }, { timeline });
+    const animation = target().animate({ opacity: 0 }, { timeline });
 
     await animationAcceleration(animation);
 

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Scroll-driven animations can't be threaded if the scroll timeline source has 'overflow: hidden'.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<body>
+<script src="threaded-animations-utils.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
+<script>
+
+promise_test(async t => {
+    const source = createDiv(t);
+    const target = createDiv(t);
+    source.appendChild(target);
+
+    source.attributeStyleMap.set("height", "100px");
+    source.attributeStyleMap.set("overflow", "hidden");
+    target.attributeStyleMap.set("height", "200px");
+
+    const timeline = new ScrollTimeline({ source });
+    const animation = target.animate({ opacity: [0, 1] }, { timeline });
+
+    await animationAcceleration(animation);
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 0, "A scroll-driven animation with an 'overflow: hidden' source can't be accelerated");
+
+    source.attributeStyleMap.set("overflow", "scroll");
+    await threadedAnimationsCommit();
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1, "A scroll-driven animation with an 'overflow: scroll' source can be accelerated");
+}, "Scroll-driven animations can't be threaded if the scroll timeline source has 'overflow: hidden'.");
+
+</script>
+</body>

--- a/LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js
@@ -19,3 +19,8 @@ const legacyAnimationCommit = async () => {
     await new Promise(requestAnimationFrame);
     await new Promise(requestAnimationFrame);
 };
+
+const threadedAnimationsCommit = async () => {
+    await new Promise(requestAnimationFrame);
+    await new Promise(setTimeout);
+};

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -138,6 +138,20 @@ Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation()
     ASSERT_NOT_REACHED();
     return AcceleratedTimeline::create(m_acceleratedTimelineIdentifier, 0_s);
 }
+
+void AnimationTimeline::runPostRenderingUpdateTasks()
+{
+    m_acceleratedRepresentation = nullptr;
+
+    bool previousCanBeAccelerated = std::exchange(m_canBeAccelerated, computeCanBeAccelerated());
+    if (m_canBeAccelerated == previousCanBeAccelerated)
+        return;
+
+    for (const auto& animation : m_animations) {
+        if (RefPtr keyframeEffect = animation->keyframeEffect())
+            keyframeEffect->timelineAccelerationAbilityDidChange();
+    }
+}
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -80,8 +80,10 @@ public:
     static void updateGlobalPosition(WebAnimation&);
 
 #if ENABLE(THREADED_ANIMATIONS)
-    void clearAcceleratedRepresentation() { m_acceleratedRepresentation = nullptr; }
+    bool canBeAccelerated() const { return m_canBeAccelerated; }
+    virtual bool computeCanBeAccelerated() const { return false; }
     AcceleratedTimeline& acceleratedRepresentation();
+    void runPostRenderingUpdateTasks();
 #endif
 
 protected:
@@ -100,6 +102,7 @@ protected:
 private:
 #if ENABLE(THREADED_ANIMATIONS)
     RefPtr<AcceleratedTimeline> m_acceleratedRepresentation;
+    bool m_canBeAccelerated { false };
 #endif
     std::optional<WebAnimationTime> m_currentTime;
     std::optional<WebAnimationTime> m_duration;

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -259,10 +259,11 @@ void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResoluti
 void AnimationTimelinesController::runPostRenderingUpdateTasks()
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    if (m_acceleratedEffectStackUpdater) {
+    if (m_document->settings().threadedScrollDrivenAnimationsEnabled()) {
         for (Ref timeline : m_timelines)
-            timeline->clearAcceleratedRepresentation();
-        m_acceleratedEffectStackUpdater->update();
+            timeline->runPostRenderingUpdateTasks();
+        if (m_acceleratedEffectStackUpdater)
+            m_acceleratedEffectStackUpdater->update();
     }
 #endif
     // https://drafts.csswg.org/scroll-animations-1/#event-loop

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -98,6 +98,7 @@ private:
 
     AnimationTimelinesController* controller() const override;
 #if ENABLE(THREADED_ANIMATIONS)
+    bool computeCanBeAccelerated() const final { return true; }
     Ref<AcceleratedTimeline> createAcceleratedRepresentation() override;
 #endif
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1922,7 +1922,7 @@ const TimingFunction* KeyframeEffect::timingFunctionForKeyframeAtIndex(size_t in
 
 bool KeyframeEffect::canBeAccelerated() const
 {
-    if (!animation())
+    if (!animation() || !animation()->timeline())
         return false;
 
     if (m_acceleratedPropertiesState == AcceleratedProperties::None)
@@ -1947,7 +1947,7 @@ bool KeyframeEffect::canBeAccelerated() const
 
 #if ENABLE(THREADED_ANIMATIONS)
     if (canHaveAcceleratedRepresentation())
-        return !animation()->pending();
+        return !animation()->pending() && animation()->timeline()->canBeAccelerated();
 #endif
 
     if (m_isAssociatedWithProgressBasedTimeline)
@@ -3105,6 +3105,12 @@ void KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate(const std::o
     if (auto currentTarget = targetStyleable())
         timelinesController->scheduleAcceleratedEffectStackUpdateForTarget(*currentTarget);
 }
+
+void KeyframeEffect::timelineAccelerationAbilityDidChange()
+{
+    scheduleAssociatedAcceleratedEffectStackUpdate();
+}
+
 #endif
 
 const KeyframeInterpolation::Keyframe& KeyframeEffect::keyframeAtIndex(size_t index) const

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -197,6 +197,7 @@ public:
     bool canHaveAcceleratedRepresentation() const;
     const AcceleratedEffect* acceleratedRepresentation() const { return m_acceleratedRepresentation.get(); }
     void setAcceleratedRepresentation(const AcceleratedEffect* acceleratedRepresentation) { m_acceleratedRepresentation = acceleratedRepresentation; }
+    void timelineAccelerationAbilityDidChange();
 #endif
 
 private:

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -391,6 +391,18 @@ void ScrollTimeline::animationTimingDidChange(WebAnimation& animation)
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
+bool ScrollTimeline::computeCanBeAccelerated() const
+{
+    RefPtr source = this->source();
+    if (!source)
+        return false;
+
+    ASSERT(source->document().settings().threadedScrollDrivenAnimationsEnabled());
+
+    CheckedPtr sourceScrollableArea = scrollableAreaForSourceRenderer(source->renderer(), source->document());
+    return sourceScrollableArea && !!sourceScrollableArea->scrollingNodeID();
+}
+
 Ref<AcceleratedTimeline> ScrollTimeline::createAcceleratedRepresentation()
 {
     ASSERT(this->source());

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -104,6 +104,7 @@ private:
 
     bool isScrollTimeline() const final { return true; }
 #if ENABLE(THREADED_ANIMATIONS)
+    bool computeCanBeAccelerated() const final;
     Ref<AcceleratedTimeline> createAcceleratedRepresentation() override;
 #endif
 


### PR DESCRIPTION
#### 87befbbe824b580abd8dca0f8efade4da4c02cf4
<pre>
[threaded-animations] scroll-driven animations should only be accelerated if their source is composited
<a href="https://bugs.webkit.org/show_bug.cgi?id=303136">https://bugs.webkit.org/show_bug.cgi?id=303136</a>
<a href="https://rdar.apple.com/165441462">rdar://165441462</a>

Reviewed by Anne van Kesteren.

Scroll-driven animations make the assumption that their timeline&apos;s source is composited,
exemplified in code with `ASSERT(sourceScrollableArea-&gt;scrollingNodeID())` in the
`ScrollTimeline::createAcceleratedRepresentation()` function. This assumption and that
assertion fail in a number of demos where `overflow: hidden` is set and the source is
not composited.

To address this, we add a new `canBeAccelerated()` function for timelines allowing
acceleration to be opt-in. In the case of document timelines, this is always true.
For progress-based timelines, we ensure their source is composited. Then, in the
`KeyframeEffect::canBeAccelerated()` function we add a check that the animation
timeline can indeed be accelerated.

This acceleration ability is controlled by a cached boolean flag for progress-based
timelines that is updated under `Document::runPostRenderingUpdateAnimationTasks()`.
To do so, we introduce a new `AnimationTimeline::runPostRenderingUpdateTasks()` which,
on top of resetting the accelerated representation as was previously done, updates
that boolean flag, and if it changed, notifies all associated animation effects such
that they may update their accelerated representation.

We test this behavior with a new test that checks that we can make an animation become
accelerated by virtue of toggling the `overflow` property on its timeline&apos;s source.

This uncovered a small issue in `webanimations/threaded-animations/scroll-timeline-in-iframe.html`
where if no content was rendered, the iframe&apos;s document scroller wouldn&apos;t be composited
and the test would fail. We work around this for the moment bug filed bug 303137 to address this.

Test: webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change.html

* LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html:
* LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html:
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change.html: Added.
* LayoutTests/webanimations/threaded-animations/threaded-animations-utils.js:
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::runPostRenderingUpdateTasks):
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::canBeAccelerated const):
(WebCore::AnimationTimeline::computeCanBeAccelerated const):
(WebCore::AnimationTimeline::clearAcceleratedRepresentation): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::runPostRenderingUpdateTasks):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::timelineAccelerationAbilityDidChange):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::computeCanBeAccelerated const):
* Source/WebCore/animation/ScrollTimeline.h:

Canonical link: <a href="https://commits.webkit.org/303589@main">https://commits.webkit.org/303589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91b8faa512b8186ffe22864eca67e18907aa271e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140447 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5276 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135858 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/82430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/83680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143099 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5082 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/37784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5164 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/110188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/3894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58638 "Failed to checkout and rebase branch from PR 54482") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20595 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5136 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/4976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/68588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5094 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->