### PR TITLE
Introduce OutlinePainter

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2855,6 +2855,7 @@ rendering/MarkedText.cpp
 rendering/MotionPath.cpp
 rendering/NinePieceImagePainter.cpp
 rendering/OrderIterator.cpp
+rendering/OutlinePainter.cpp
 rendering/PathOperation.cpp
 rendering/PointerEventsHitRules.cpp
 rendering/PositionedLayoutConstraints.cpp

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -125,17 +125,6 @@ static bool decorationHasAllSimpleEdges(const RectEdges<BorderEdge>& edges)
     return true;
 }
 
-struct BorderPainter::Sides {
-    std::optional<BorderData::Radii> radii { }; // FIXME: Do we need this separately from the shape?
-    const BorderEdges& edges;
-    bool haveAllSolidEdges { true };
-    bool outerEdgeIsRectangular { true };
-    bool innerEdgeIsRectangular { true };
-    BleedAvoidance bleedAvoidance { BleedAvoidance::None };
-    RectEdges<bool> closedEdges = { true };
-    bool appliedClipAlready { false };
-};
-
 BorderPainter::BorderPainter(const RenderElement& renderer, const PaintInfo& paintInfo)
     : m_renderer(renderer)
     , m_paintInfo(paintInfo)
@@ -192,7 +181,7 @@ LayoutRect shrinkRectByOneDevicePixel(const GraphicsContext& context, const Layo
     return shrunkRect;
 }
 
-static bool decorationHasAllSolidEdges(const RectEdges<BorderEdge>& edges)
+bool BorderPainter::decorationHasAllSolidEdges(const RectEdges<BorderEdge>& edges)
 {
     for (auto side : allBoxSides) {
         auto& currEdge = edges.at(side);
@@ -286,108 +275,6 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
         closedEdges,
         appliedClipAlready,
     });
-}
-
-void BorderPainter::paintOutline(const LayoutRect& paintRect) const
-{
-    auto& styleToUse = m_renderer->style();
-
-    // Only paint the focus ring by hand if the theme isn't able to draw it.
-    if (styleToUse.outlineStyle() == OutlineStyle::Auto && !m_renderer->theme().supportsFocusRing(m_renderer, styleToUse)) {
-        Vector<LayoutRect> focusRingRects;
-        LayoutRect paintRectToUse { paintRect };
-        if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer.get()))
-            paintRectToUse = m_renderer->theme().adjustedPaintRect(*box, paintRectToUse);
-        m_renderer->addFocusRingRects(focusRingRects, paintRectToUse.location(), m_paintInfo.paintContainer);
-        m_renderer->paintFocusRing(m_paintInfo, styleToUse, focusRingRects);
-    }
-
-    if (m_renderer->hasOutlineAnnotation() && styleToUse.outlineStyle() != OutlineStyle::Auto && !m_renderer->theme().supportsFocusRing(m_renderer, styleToUse))
-        m_renderer->addPDFURLRect(m_paintInfo, paintRect.location());
-
-    auto borderStyle = toBorderStyle(styleToUse.outlineStyle());
-    if (!borderStyle || *borderStyle == BorderStyle::None)
-        return;
-
-    auto outlineWidth = Style::evaluate<LayoutUnit>(styleToUse.outlineWidth(), styleToUse.usedZoomForLength());
-    auto outlineOffset = Style::evaluate<LayoutUnit>(styleToUse.outlineOffset(), Style::ZoomNeeded { });
-
-    auto outerRect = paintRect;
-    outerRect.inflate(outlineOffset + outlineWidth);
-    // FIXME: This prevents outlines from painting inside the object http://webkit.org/b/12042.
-    if (outerRect.isEmpty())
-        return;
-
-    auto hasBorderRadius = styleToUse.hasBorderRadius();
-    auto closedEdges = RectEdges<bool> { true };
-
-    auto outlineEdgeWidths = RectEdges<LayoutUnit> { outlineWidth };
-    auto outlineShape = BorderShape::shapeForOutsetRect(styleToUse, paintRect, outerRect, outlineEdgeWidths, closedEdges);
-
-    auto bleedAvoidance = BleedAvoidance::ShrinkBackground;
-    auto appliedClipAlready = false;
-    auto edges = borderEdgesForOutline(styleToUse, *borderStyle, document().deviceScaleFactor());
-    auto haveAllSolidEdges = decorationHasAllSolidEdges(edges);
-
-    paintSides(outlineShape, {
-        hasBorderRadius ? std::make_optional(styleToUse.borderRadii()) : std::nullopt,
-        edges,
-        haveAllSolidEdges,
-        outlineShape.outerShapeIsRectangular(),
-        outlineShape.innerShapeIsRectangular(),
-        bleedAvoidance,
-        closedEdges,
-        appliedClipAlready,
-    });
-}
-
-void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<LayoutRect>& lineRects) const
-{
-    if (lineRects.size() == 1) {
-        auto adjustedPaintRect = lineRects[0];
-        adjustedPaintRect.moveBy(paintOffset);
-        paintOutline(adjustedPaintRect);
-        return;
-    }
-
-    auto& styleToUse = m_renderer->style();
-    auto outlineOffset = Style::evaluate<float>(styleToUse.outlineOffset(), Style::ZoomNeeded { });
-    auto outlineWidth = Style::evaluate<float>(styleToUse.outlineWidth(), styleToUse.usedZoomForLength());
-    auto deviceScaleFactor = document().deviceScaleFactor();
-
-    Vector<FloatRect> pixelSnappedRects;
-    for (size_t index = 0; index < lineRects.size(); ++index) {
-        auto rect = lineRects[index];
-
-        rect.moveBy(paintOffset);
-        rect.inflate(outlineOffset + outlineWidth / 2);
-        pixelSnappedRects.append(snapRectToDevicePixels(rect, deviceScaleFactor));
-    }
-    auto path = PathUtilities::pathWithShrinkWrappedRectsForOutline(pixelSnappedRects, styleToUse.border().radii(), outlineOffset, styleToUse.writingMode(), deviceScaleFactor);
-    if (path.isEmpty()) {
-        // Disjoint line spanning inline boxes.
-        for (auto rect : lineRects) {
-            rect.moveBy(paintOffset);
-            paintOutline(rect);
-        }
-        return;
-    }
-
-    auto& graphicsContext = m_paintInfo.context();
-    auto outlineColor = styleToUse.visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
-    auto useTransparencyLayer = !outlineColor.isOpaque();
-    if (useTransparencyLayer) {
-        graphicsContext.beginTransparencyLayer(outlineColor.alphaAsFloat());
-        outlineColor = outlineColor.opaqueColor();
-    }
-
-    graphicsContext.setStrokeColor(outlineColor);
-    graphicsContext.setStrokeThickness(outlineWidth);
-    graphicsContext.setStrokeStyle(StrokeStyle::SolidStroke);
-    graphicsContext.strokePath(path);
-
-    if (useTransparencyLayer)
-        graphicsContext.endTransparencyLayer();
 }
 
 void BorderPainter::paintSides(const BorderShape& borderShape, const Sides& sides) const

--- a/Source/WebCore/rendering/BorderPainter.h
+++ b/Source/WebCore/rendering/BorderPainter.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "BorderData.h"
 #include "GraphicsTypes.h"
 #include "RenderBoxModelObject.h"
 #include "RenderElement.h"
@@ -36,8 +37,6 @@ public:
     BorderPainter(const RenderElement&, const PaintInfo&);
 
     void paintBorder(const LayoutRect&, const RenderStyle&, BleedAvoidance = BleedAvoidance::None, RectEdges<bool> closedEdges = { true }) const;
-    void paintOutline(const LayoutRect&) const;
-    void paintOutline(const LayoutPoint& paintOffset, const Vector<LayoutRect>& lineRects) const;
 
     bool paintNinePieceImage(const LayoutRect&, const RenderStyle&, const Style::BorderImage&, CompositeOperator = CompositeOperator::SourceOver) const;
     bool paintNinePieceImage(const LayoutRect&, const RenderStyle&, const Style::MaskBorder&, CompositeOperator = CompositeOperator::SourceOver) const;
@@ -47,9 +46,21 @@ public:
     static std::optional<Path> pathForBorderArea(const LayoutRect&, const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true });
 
     static bool shouldAntialiasLines(GraphicsContext&);
+    static bool decorationHasAllSolidEdges(const RectEdges<BorderEdge>&);
 
 private:
-    struct Sides;
+    friend class OutlinePainter;
+
+    struct Sides {
+        std::optional<BorderData::Radii> radii { }; // FIXME: Do we need this separately from the shape?
+        const BorderEdges& edges;
+        bool haveAllSolidEdges { true };
+        bool outerEdgeIsRectangular { true };
+        bool innerEdgeIsRectangular { true };
+        BleedAvoidance bleedAvoidance { BleedAvoidance::None };
+        RectEdges<bool> closedEdges = { true };
+        bool appliedClipAlready { false };
+    };
     void paintSides(const BorderShape&, const Sides&) const;
 
     template<typename T>

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
+ *           (C) 1999 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
+ *           (C) 2005, 2006 Samuel Weinig (sam.weinig@gmail.com)
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Google Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "OutlinePainter.h"
+
+#include "BorderEdge.h"
+#include "BorderPainter.h"
+#include "BorderShape.h"
+#include "FloatRoundedRect.h"
+#include "GeometryUtilities.h"
+#include "GraphicsContext.h"
+#include "PaintInfo.h"
+#include "PathUtilities.h"
+#include "RenderBox.h"
+#include "RenderObjectDocument.h"
+#include "RenderStyleInlines.h"
+#include "RenderTheme.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
+
+namespace WebCore {
+
+OutlinePainter::OutlinePainter(const RenderElement& renderer, const PaintInfo& paintInfo)
+    : m_renderer(renderer)
+    , m_paintInfo(paintInfo)
+{
+}
+
+void OutlinePainter::paintOutline(const LayoutRect& paintRect) const
+{
+    CheckedRef renderer = m_renderer;
+    CheckedRef styleToUse = renderer->style();
+
+    // Only paint the focus ring by hand if the theme isn't able to draw it.
+    if (styleToUse->outlineStyle() == OutlineStyle::Auto && !renderer->theme().supportsFocusRing(renderer, styleToUse.get())) {
+        Vector<LayoutRect> focusRingRects;
+        LayoutRect paintRectToUse { paintRect };
+        if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer.get()))
+            paintRectToUse = renderer->theme().adjustedPaintRect(*box, paintRectToUse);
+        CheckedPtr paintContainer = m_paintInfo.paintContainer;
+        renderer->addFocusRingRects(focusRingRects, paintRectToUse.location(), paintContainer.get());
+        renderer->paintFocusRing(m_paintInfo, styleToUse.get(), focusRingRects);
+    }
+
+    if (renderer->hasOutlineAnnotation() && styleToUse->outlineStyle() != OutlineStyle::Auto && !renderer->theme().supportsFocusRing(renderer, styleToUse.get()))
+        renderer->addPDFURLRect(m_paintInfo, paintRect.location());
+
+    auto borderStyle = toBorderStyle(styleToUse->outlineStyle());
+    if (!borderStyle || *borderStyle == BorderStyle::None)
+        return;
+
+    auto outlineWidth = Style::evaluate<LayoutUnit>(styleToUse->outlineWidth(), styleToUse->usedZoomForLength());
+    auto outlineOffset = Style::evaluate<LayoutUnit>(styleToUse->outlineOffset(), Style::ZoomNeeded { });
+
+    auto outerRect = paintRect;
+    outerRect.inflate(outlineOffset + outlineWidth);
+    // FIXME: This prevents outlines from painting inside the object http://webkit.org/b/12042.
+    if (outerRect.isEmpty())
+        return;
+
+    auto hasBorderRadius = styleToUse->hasBorderRadius();
+    auto closedEdges = RectEdges<bool> { true };
+
+    auto outlineEdgeWidths = RectEdges<LayoutUnit> { outlineWidth };
+    auto outlineShape = BorderShape::shapeForOutsetRect(styleToUse.get(), paintRect, outerRect, outlineEdgeWidths, closedEdges);
+
+    auto bleedAvoidance = BleedAvoidance::ShrinkBackground;
+    auto appliedClipAlready = false;
+    auto edges = borderEdgesForOutline(styleToUse, *borderStyle, renderer->protectedDocument()->deviceScaleFactor());
+    auto haveAllSolidEdges = BorderPainter::decorationHasAllSolidEdges(edges);
+
+    BorderPainter { renderer, m_paintInfo }.paintSides(outlineShape, {
+        hasBorderRadius ? std::make_optional(styleToUse->borderRadii()) : std::nullopt,
+        edges,
+        haveAllSolidEdges,
+        outlineShape.outerShapeIsRectangular(),
+        outlineShape.innerShapeIsRectangular(),
+        bleedAvoidance,
+        closedEdges,
+        appliedClipAlready,
+    });
+}
+
+void OutlinePainter::paintOutline(const LayoutPoint& paintOffset, const Vector<LayoutRect>& lineRects) const
+{
+    if (lineRects.size() == 1) {
+        auto adjustedPaintRect = lineRects[0];
+        adjustedPaintRect.moveBy(paintOffset);
+        paintOutline(adjustedPaintRect);
+        return;
+    }
+
+    auto renderer = CheckedRef { m_renderer };
+    auto styleToUse = CheckedRef { renderer->style() };
+
+    auto outlineOffset = Style::evaluate<float>(styleToUse->outlineOffset(), Style::ZoomNeeded { });
+    auto outlineWidth = Style::evaluate<float>(styleToUse->outlineWidth(), styleToUse->usedZoomForLength());
+    auto deviceScaleFactor = renderer->protectedDocument()->deviceScaleFactor();
+
+    Vector<FloatRect> pixelSnappedRects;
+    for (size_t index = 0; index < lineRects.size(); ++index) {
+        auto rect = lineRects[index];
+
+        rect.moveBy(paintOffset);
+        rect.inflate(outlineOffset + outlineWidth / 2);
+        pixelSnappedRects.append(snapRectToDevicePixels(rect, deviceScaleFactor));
+    }
+    auto path = PathUtilities::pathWithShrinkWrappedRectsForOutline(pixelSnappedRects, styleToUse->border().radii(), outlineOffset, styleToUse->writingMode(), deviceScaleFactor);
+    if (path.isEmpty()) {
+        // Disjoint line spanning inline boxes.
+        for (auto rect : lineRects) {
+            rect.moveBy(paintOffset);
+            paintOutline(rect);
+        }
+        return;
+    }
+
+    auto& graphicsContext = m_paintInfo.context();
+    auto outlineColor = styleToUse->visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
+    auto useTransparencyLayer = !outlineColor.isOpaque();
+    if (useTransparencyLayer) {
+        graphicsContext.beginTransparencyLayer(outlineColor.alphaAsFloat());
+        outlineColor = outlineColor.opaqueColor();
+    }
+
+    graphicsContext.setStrokeColor(outlineColor);
+    graphicsContext.setStrokeThickness(outlineWidth);
+    graphicsContext.setStrokeStyle(StrokeStyle::SolidStroke);
+    graphicsContext.strokePath(path);
+
+    if (useTransparencyLayer)
+        graphicsContext.endTransparencyLayer();
+}
+
+}

--- a/Source/WebCore/rendering/OutlinePainter.h
+++ b/Source/WebCore/rendering/OutlinePainter.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
+ *           (C) 1999 Antti Koivisto (koivisto@kde.org)
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Google Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include "RenderElement.h"
+
+namespace WebCore {
+
+struct PaintInfo;
+
+class OutlinePainter {
+public:
+    OutlinePainter(const RenderElement&, const PaintInfo&);
+
+    void paintOutline(const LayoutRect&) const;
+    void paintOutline(const LayoutPoint& paintOffset, const Vector<LayoutRect>& lineRects) const;
+
+private:
+    CheckedRef<const RenderElement> m_renderer;
+    const PaintInfo& m_paintInfo;
+};
+
+}

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -27,7 +27,6 @@
 
 #include "AXObjectCache.h"
 #include "AnchorPositionEvaluator.h"
-#include "BorderPainter.h"
 #include "BorderShape.h"
 #include "ContainerNodeInlines.h"
 #include "ContentVisibilityDocumentState.h"
@@ -52,6 +51,7 @@
 #include "LayoutIntegrationLineLayout.h"
 #include "LocalFrame.h"
 #include "Logging.h"
+#include "OutlinePainter.h"
 #include "Page.h"
 #include "PathUtilities.h"
 #include "ReferencedSVGResources.h"
@@ -2170,7 +2170,7 @@ void RenderElement::paintOutline(PaintInfo& paintInfo, const LayoutRect& paintRe
     if (!hasOutline())
         return;
 
-    BorderPainter { *this, paintInfo }.paintOutline(paintRect);
+    OutlinePainter { *this, paintInfo }.paintOutline(paintRect);
 }
 
 void RenderElement::issueRepaintForOutlineAuto(float outlineSize)

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "RenderInline.h"
 
-#include "BorderPainter.h"
 #include "Chrome.h"
 #include "FloatQuad.h"
 #include "FrameSelection.h"
@@ -36,6 +35,7 @@
 #include "InlineIteratorLineBox.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LegacyInlineTextBox.h"
+#include "OutlinePainter.h"
 #include "RenderBlock.h"
 #include "RenderBoxInlines.h"
 #include "RenderChildIterator.h"
@@ -974,7 +974,7 @@ void RenderInline::paintOutline(PaintInfo& paintInfo, const LayoutPoint& paintOf
 
         rects.append(LayoutRect { enclosingVisualRect });
     }
-    BorderPainter { *this, paintInfo }.paintOutline(paintOffset, rects);
+    OutlinePainter { *this, paintInfo }.paintOutline(paintOffset, rects);
 }
 
 bool isEmptyInline(const RenderInline& renderer)

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -30,6 +30,7 @@
 #include "CSSFontSelector.h"
 #include "Chrome.h"
 #include "ColorBlending.h"
+#include "DocumentInlines.h"
 #include "DocumentPage.h"
 #include "ElementInlines.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -48,6 +48,7 @@
 #include "RenderTheme.h"
 #include "RenderView.h"
 #include "RenderedDocumentMarker.h"
+#include "Settings.h"
 #include "StyleTextDecorationLine.h"
 #include "StyleTextDecorationThickness.h"
 #include "StyledMarkedText.h"


### PR DESCRIPTION
#### 842f01785f3b83ea653eb257595bfdb79269e175
<pre>
Introduce OutlinePainter
<a href="https://bugs.webkit.org/show_bug.cgi?id=303138">https://bugs.webkit.org/show_bug.cgi?id=303138</a>
<a href="https://rdar.apple.com/165443157">rdar://165443157</a>

Reviewed by Alan Baradlay.

Move outline painting out of BorderPainter.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::decorationHasAllSolidEdges):
(): Deleted.
(WebCore::decorationHasAllSolidEdges): Deleted.
(WebCore::BorderPainter::paintOutline const): Deleted.
* Source/WebCore/rendering/BorderPainter.h:
(WebCore::BorderPainter::paintBorder):
* Source/WebCore/rendering/OutlinePainter.cpp: Added.
(WebCore::OutlinePainter::OutlinePainter):
(WebCore::OutlinePainter::paintOutline const):
* Source/WebCore/rendering/OutlinePainter.h: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::paintOutline):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::paintOutline const):
* Source/WebCore/rendering/RenderMenuList.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:

Canonical link: <a href="https://commits.webkit.org/303579@main">https://commits.webkit.org/303579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb1a6c816f085b09a365705ece99a832f7361b9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84918 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e16c5547-ec85-4cee-9f73-7f99db1f3387) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101611 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68926 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ebb1c950-169b-45f2-bd01-126db272f4b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135834 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82406 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1ae0abb4-469b-4653-b9af-3414a1da4394) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83658 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143075 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109986 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110166 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27927 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3874 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5112 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33680 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4951 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68564 "Found 1 new failure in rendering/MarkedText.h and found 2 fixed files: rendering/RenderTableCellInlines.h, rendering/BorderPainter.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->