### PR TITLE
Return vertical writing mode aware intrinsic information for SVG

### DIFF
--- a/LayoutTests/svg/in-html/sizing/svg-inline-vertical-expected.txt
+++ b/LayoutTests/svg/in-html/sizing/svg-inline-vertical-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Test size calculation in vertical writing mode (1)
+PASS Test size calculation in vertical writing mode (2)
+PASS Test size calculation in vertical writing mode (3)
+PASS Test size calculation in vertical writing mode (4)
+PASS Test size calculation in vertical writing mode (5)
+

--- a/LayoutTests/svg/in-html/sizing/svg-inline-vertical.html
+++ b/LayoutTests/svg/in-html/sizing/svg-inline-vertical.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Test SVG sizing in vertical writing mode</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+  div {
+      -webkit-writing-mode: vertical-rl;
+      writing-mode: vertical-rl;
+      height: 200px;
+  }
+</style>
+<div>
+  <!-- All SVGs expected size is 100x200 -->
+  <svg width="100" height="200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg style="width: auto !important; height: auto !important" width="100" height="200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg viewBox="0 0 100 200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg width="100" viewBox="0 0 100 200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg height="200" viewBox="0 0 100 200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+</div>
+<script>
+  var svgs = document.querySelectorAll('svg');
+  [].forEach.call(svgs, function (svg, index) {
+      test(function() {
+          var bounds = svg.getBoundingClientRect();
+          assert_equals(bounds.height, 200, "Height");
+          assert_equals(bounds.width, 100, "Width");
+
+      }, "Test size calculation in vertical writing mode (" + (index + 1) + ")");
+  });
+</script>

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -103,7 +103,11 @@ FloatSize RenderSVGRoot::computeIntrinsicSize() const
 {
     ASSERT_IMPLIES(view().frameView().layoutContext().isInRenderTreeLayout(), !shouldApplySizeContainment());
     // https://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
-    return FloatSize { svgSVGElement().intrinsicWidth(), svgSVGElement().intrinsicHeight() };
+    FloatSize intrinsicSize = { svgSVGElement().intrinsicWidth(), svgSVGElement().intrinsicHeight() };
+    // Transpose for vertical writing mode
+    if (!isHorizontalWritingMode())
+        return intrinsicSize.transposedSize();
+    return intrinsicSize;
 }
 
 FloatSize RenderSVGRoot::preferredAspectRatio() const
@@ -121,7 +125,10 @@ FloatSize RenderSVGRoot::preferredAspectRatio() const
         FloatSize viewBoxSize = svgSVGElement().currentViewBoxRect().size();
         if (!viewBoxSize.isEmpty()) {
             // The viewBox can only yield an intrinsic ratio, not an intrinsic size.
-            intrinsicRatioValue = { viewBoxSize.width(), viewBoxSize.height() };
+            if (isHorizontalWritingMode())
+                intrinsicRatioValue = { viewBoxSize.width(), viewBoxSize.height() };
+            else
+                intrinsicRatioValue = { viewBoxSize.height(), viewBoxSize.width() };
         }
     }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -92,7 +92,11 @@ bool LegacyRenderSVGRoot::hasIntrinsicAspectRatio() const
 FloatSize LegacyRenderSVGRoot::computeIntrinsicSize() const
 {
     ASSERT_IMPLIES(view().frameView().layoutContext().isInRenderTreeLayout(), !shouldApplySizeContainment());
-    return { svgSVGElement().intrinsicWidth(), svgSVGElement().intrinsicHeight() };
+    FloatSize intrinsicSize = { svgSVGElement().intrinsicWidth(), svgSVGElement().intrinsicHeight() };
+    // Transpose for vertical writing mode
+    if (!isHorizontalWritingMode())
+        return intrinsicSize.transposedSize();
+    return intrinsicSize;
 }
 
 FloatSize LegacyRenderSVGRoot::preferredAspectRatio() const
@@ -111,7 +115,10 @@ FloatSize LegacyRenderSVGRoot::preferredAspectRatio() const
         FloatSize viewBoxSize = svgSVGElement().currentViewBoxRect().size();
         if (!viewBoxSize.isEmpty()) {
             // The viewBox can only yield an intrinsic ratio, not an intrinsic size.
-            intrinsicRatioValue = { viewBoxSize.width(), viewBoxSize.height() };
+            if (isHorizontalWritingMode())
+                intrinsicRatioValue = { viewBoxSize.width(), viewBoxSize.height() };
+            else
+                intrinsicRatioValue = { viewBoxSize.height(), viewBoxSize.width() };
         }
     }
 


### PR DESCRIPTION
#### 0c439897071503618fcd76a63e587c9ff4360403
<pre>
Return vertical writing mode aware intrinsic information for SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=248769">https://bugs.webkit.org/show_bug.cgi?id=248769</a>
<a href="https://rdar.apple.com/103262534">rdar://103262534</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium. Also,
it fixes it for both Legacy SVG and Layer Based SVG engine.

Merge (Test): <a href="https://chromium.googlesource.com/chromium/blink/+/60af46f13e39be1daacbcdab27c4e7212ae27886">https://chromium.googlesource.com/chromium/blink/+/60af46f13e39be1daacbcdab27c4e7212ae27886</a>

SVG intrinsic dimensions need to be transposed for vertical writing modes
to correctly map physical dimensions to logical layout coordinates.

This patch updates computeIntrinsicSize() to transpose dimensions for
vertical writing modes, and updates preferredAspectRatio() to handle both
intrinsic size and viewBox ratios correctly in vertical contexts.

Test: svg/in-html/sizing/svg-inline-vertical.html
* LayoutTests/svg/in-html/sizing/svg-inline-vertical.html: Added.
* LayoutTests/svg/in-html/sizing/svg-inline-vertical-expected.txt: Added.

* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::computeIntrinsicSize const):
(WebCore::RenderSVGRoot::preferredAspectRatio const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::computeIntrinsicSize const):
(WebCore::LegacyRenderSVGRoot::preferredAspectRatio const):

Canonical link: <a href="https://commits.webkit.org/303578@main">https://commits.webkit.org/303578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33cbdaf679507d38a757414520f2779d5c8961ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5380 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/43981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84909 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2871e4de-606b-4c35-abfa-a20e1052ced1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101605 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68918 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f45ec18c-e3a3-4b72-8cd1-12d6b86fdf63) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135825 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82400 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/622297d7-bd0a-452d-89ec-e6965d2f5fcf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83645 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112934 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143066 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109980 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3864 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115321 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58585 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5103 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33675 "Unable to confirm if test failures are introduced by change, retrying build") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68555 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5193 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->