### PR TITLE
[GStreamer] Add Layout Tests for content type frame rate limits

### DIFF
--- a/LayoutTests/platform/glib/media/media-can-play-video-decoding-limit-expected.txt
+++ b/LayoutTests/platform/glib/media/media-can-play-video-decoding-limit-expected.txt
@@ -1,0 +1,19 @@
+
+Test that limits enforced by the VIDEO_DECODING_LIMIT build flag are enforced.
+
+WebKit must be built with -DVIDEO_DECODING_LIMIT=7680x4320@60.
+
+Tools/Scripts/build-webkit should have set that limit automatically.
+
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=800; height=600; framerate=30') == 'probably') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=800; height=600; framerate=60') == 'probably') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=7680; height=4320; framerate=30') == 'probably') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=7680; height=4320; framerate=60') == 'probably') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=7680; height=4320; framerate=61') == '') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=800; height=600; framerate=61') == '') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=800; height=4321; framerate=60') == '') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=7681; height=600; framerate=60') == '') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=7681; height=4321; framerate=60') == '') OK
+EXPECTED (video.canPlayType('video/mp4; codecs=avc1; width=7681; height=4321; framerate=61') == '') OK
+END OF TEST
+

--- a/LayoutTests/platform/glib/media/media-can-play-video-decoding-limit.html
+++ b/LayoutTests/platform/glib/media/media-can-play-video-decoding-limit.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../../media/video-test.js"></script>
+        <script>
+            async function start() {
+                video = mediaElement = document.getElementsByTagName('video')[0];
+
+                const tests = [
+                    "800x600@30=true",
+                    "800x600@60=true",
+                    "7680x4320@30=true",
+                    "7680x4320@60=true",
+                    "7680x4320@61=false",
+                    "800x600@61=false",
+                    "800x4321@60=false",
+                    "7681x600@60=false",
+                    "7681x4321@60=false",
+                    "7681x4321@61=false"
+                ];
+
+                for (t of tests) {
+                    var [width, height, framerate, expectation] = t.split(/[x@=]/);
+                    expectation = (expectation == "true") ? "probably" : "";
+
+                    testExpected("video.canPlayType('video/mp4; codecs=avc1; width=" + width
+                        + "; height=" + height + "; framerate=" + framerate + "')",
+                        expectation);
+                }
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload="start()">
+        <video controls></video>
+        <p>Test that limits enforced by the VIDEO_DECODING_LIMIT build flag are enforced.</p>
+        <p>WebKit must be built with -DVIDEO_DECODING_LIMIT=7680x4320@60.</p>
+        <p><code>Tools/Scripts/build-webkit</code> should have set that limit automatically.</p>
+    </body>
+</html>

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -278,6 +278,19 @@ if (isCMakeBuild() && !isAnyWindows()) {
     # Allow ccache to hit when building on different directories
     $ENV{"CCACHE_BASEDIR"} //= sourceDir();
 
+    if (isGtk() || isWPE()) {
+        use constant VIDEO_DECODING_LIMIT => "-DVIDEO_DECODING_LIMIT=7680x4320\@60";
+        my $videoDecodingLimitFound = 0;
+        foreach my $cmakeArg (@cmakeArgs) {
+            if (!rindex $cmakeArg, "-DVIDEO_DECODING_LIMIT", 0) {
+                $videoDecodingLimitFound = 1;
+            }
+        }
+        if (!$videoDecodingLimitFound) {
+            push @cmakeArgs, VIDEO_DECODING_LIMIT;
+        }
+    }
+
     buildCMakeProjectOrExit($clean, $prefixPath, $makeArgs, @featureArgs, @cmakeArgs);
 }
 


### PR DESCRIPTION
#### 2f95edbbfe0700759b346c4ebfe1ee29688a1bd6
<pre>
[GStreamer] Add Layout Tests for content type frame rate limits
<a href="https://bugs.webkit.org/show_bug.cgi?id=303148">https://bugs.webkit.org/show_bug.cgi?id=303148</a>

Reviewed by Xabier Rodriguez-Calvar.

The content type frame rate limits should have a Layout Test, as Phil
suggested in [1].

See: <a href="https://bugs.webkit.org/show_bug.cgi?id=296572">https://bugs.webkit.org/show_bug.cgi?id=296572</a>

This LayoutTest checks that the content can&apos;t be played when any of the
width, height and framerate parameters go beyond the maximum limits
specified by the -DVIDEO_DECODING_LIMIT=7680x4320@60 build flag now used
by default by build-webkit. This 8K at 60fps limit shouldn&apos;t affect the
WebKit developers using the script too much, and in any case, it can be
overridden by passing a different value to build-webkit.

[1] <a href="https://github.com/WebKit/WebKit/pull/48614#pullrequestreview-3065922145">https://github.com/WebKit/WebKit/pull/48614#pullrequestreview-3065922145</a>

* LayoutTests/platform/glib/media/media-can-play-video-decoding-limit-expected.txt: Added.
* LayoutTests/platform/glib/media/media-can-play-video-decoding-limit.html: Added.
* Tools/Scripts/build-webkit: Added VIDEO_DECODING_LIMIT build flag, needed to exercise the limits check.

Canonical link: <a href="https://commits.webkit.org/303599@main">https://commits.webkit.org/303599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3052002390261181ea5923cffb71745149e2832e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140488 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101667 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/84984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135899 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119126 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82467 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83721 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125023 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143141 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131461 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5123 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110044 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110225 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3933 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58693 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5177 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33743 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164428 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5017 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->