### PR TITLE
[RenderStyleGen] Extend getter/setter generation to all non-special cased properties

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3190,6 +3190,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/SVGRenderStyle.h
     rendering/style/SVGRenderStyleDefs.h
     rendering/style/StyleAppleColorFilterData.h
+    rendering/style/StyleBackdropFilterData.h
     rendering/style/StyleBackgroundData.h
     rendering/style/StyleBoxData.h
     rendering/style/StyleCachedImage.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2989,6 +2989,7 @@ rendering/style/RenderStyleConstants.cpp
 rendering/style/SVGRenderStyle.cpp
 rendering/style/SVGRenderStyleDefs.cpp
 rendering/style/StyleAppleColorFilterData.cpp
+rendering/style/StyleBackdropFilterData.cpp
 rendering/style/StyleBackgroundData.cpp
 rendering/style/StyleBoxData.cpp
 rendering/style/StyleCachedImage.cpp

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -53,6 +53,7 @@
 #include "StylePositionVisibility.h"
 #include "StyleResize.h"
 #include "StyleScrollBehavior.h"
+#include "StyleScrollbarWidth.h"
 #include "StyleSpeakAs.h"
 #include "StyleTextAlign.h"
 #include "StyleTextAlignLast.h"
@@ -2351,7 +2352,7 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-#define TYPE ScrollbarWidth
+#define TYPE Style::ScrollbarWidth
 #define FOR_EACH(CASE) CASE(Auto) CASE(Thin) CASE(None)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -295,6 +295,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BlockStepAlign",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -314,6 +317,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BlockStepInsert",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -333,6 +339,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BlockStepRound",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -348,6 +357,9 @@
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",
                 "style-converter": "StyleType<BlockStepSize>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::BlockStepSize",
                 "parser-grammar": "none | <length [0,inf]>",
                 "parser-exported": true
             },
@@ -406,9 +418,12 @@
                 "discard"
             ],
             "codegen-properties": {
-                "render-style-name-for-methods": "OverflowContinue",
-                "parser-grammar": "<<values>>",
                 "settings-flag": "cssLineClampEnabled",
+                "render-style-name-for-methods": "OverflowContinue",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "OverflowContinue",
+                "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
             "specification": {
@@ -538,6 +553,9 @@
             ],
             "codegen-properties": {
                 "parser-grammar": "<<values>>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FieldSizing",
                 "settings-flag": "cssFieldSizingEnabled"
             },
             "specification": {
@@ -791,6 +809,9 @@
             "codegen-properties": {
                 "settings-flag": "cssTextBoxTrimEnabled",
                 "style-converter": "StyleType<TextBoxEdge>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::TextBoxEdge",
                 "parser-function": "consumeTextBoxEdge",
                 "parser-grammar-unused": "auto | [ [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]? ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -812,6 +833,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssTextBoxTrimEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextBoxTrim",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -1341,6 +1365,9 @@
                 "style-builder-custom": "Value",
                 "style-converter": "StyleType<TextSizeAdjust>",
                 "render-style-name-for-methods": "TextSizeAdjust",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::TextSizeAdjust",
                 "parser-grammar": "auto | none | <percentage [0,inf]>"
             },
             "status": "experimental",
@@ -1489,6 +1516,9 @@
             "codegen-properties": {
                 "style-builder-custom": "Value",
                 "high-priority": true,
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextZoom",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard",
@@ -1534,6 +1564,9 @@
             "codegen-properties": {
                 "top-priority": true,
                 "top-priority-reason": "This is a top priority property to ensure that its value can be checked when determining a smart default font size', (<https://trac.webkit.org/browser/trunk/Source/WebCore/ChangeLog?rev=172861>).",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "RubyPosition",
                 "parser-grammar": "<<values>>",
                 "parser-grammar-comment": "Current spec grammar is '[ alternate || [ over | under ] ] | inter-character'"
             },
@@ -2064,6 +2097,9 @@
                 "visited-link-color-support": true,
                 "color-property": true,
                 "disables-native-appearance": true,
+                "render-style-storage-path": ["m_nonInheritedData", "backgroundData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "specification": {
@@ -2215,6 +2251,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<SVGBaselineShift>",
+                "render-style-storage-path": ["m_svgStyle", "miscData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGBaselineShift",
                 "parser-grammar": "baseline | sub | super | <length-percentage>"
             },
             "specification": {
@@ -2233,6 +2272,9 @@
             "codegen-properties": {
                 "settings-flag": "cssLineClampEnabled",
                 "style-converter": "StyleType<BlockEllipsis>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::BlockEllipsis",
                 "parser-grammar": "none | auto | <string>",
                 "parser-exported": true
             },
@@ -3602,6 +3644,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<BoxShadows>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::BoxShadows",
                 "parser-function": "consumeBoxShadow",
                 "parser-grammar-unused": "none | <shadow>#",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation."
@@ -3622,6 +3667,9 @@
                 "aliases": [
                     "-webkit-box-sizing"
                 ],
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BoxSizing",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -3657,6 +3705,9 @@
             ],
             "codegen-properties": {
                 "render-style-initial": "initialBreakBetween",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BreakBetween",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -3689,6 +3740,9 @@
             ],
             "codegen-properties": {
                 "render-style-initial": "initialBreakBetween",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BreakBetween",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -3711,6 +3765,9 @@
             ],
             "codegen-properties": {
                 "render-style-initial": "initialBreakInside",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BreakInside",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -3797,6 +3854,9 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "style-converter": "StyleType<Clip>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Clip",
                 "parser-grammar": "<rect()> | auto"
             },
             "specification": {
@@ -3824,6 +3884,9 @@
                     "-webkit-clip-path"
                 ],
                 "style-converter": "StyleType<ClipPath>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ClipPath",
                 "parser-function": "consumeClipPath",
                 "parser-grammar-unused": "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form and default values in '||' groups."
@@ -3891,6 +3954,9 @@
             "codegen-properties": {
                 "style-converter": "StyleType<Content>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Content",
                 "separator": " ",
                 "parser-function": "consumeContent",
                 "parser-grammar-unused": "none | normal | [ <image> | open-quote | close-quote | no-open-quote | no-close-quote | attr(<custom-ident>,<declaration-value>?) | counter(<counter-name>, <counter-style>?) | counters(<counter-name>, <string>, <counter-style>?) ]+",
@@ -4221,6 +4287,9 @@
             "initial": "0",
             "codegen-properties": {
                 "style-converter": "StyleType<SVGCenterCoordinateComponent>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGCenterCoordinateComponent",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -4233,6 +4302,9 @@
             "initial": "0",
             "codegen-properties": {
                 "style-converter": "StyleType<SVGCenterCoordinateComponent>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGCenterCoordinateComponent",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -4248,6 +4320,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<SVGPathData>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGPathData",
                 "parser-grammar": "none | <path()>",
                 "settings-flag": "cssDPropertyEnabled"
             },
@@ -4292,9 +4367,11 @@
                 "no-limit"
             ],
             "codegen-properties": {
-                "animation-wrapper-comment": "FIXME: Use StyleTypeWrapper when dynamic-range-limit-mix() is implemented; see webkit.org/b/293339",
                 "settings-flag": "supportHDRDisplayEnabled",
                 "style-converter": "StyleType<DynamicRangeLimit>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::DynamicRangeLimit",
                 "parser-function": "consumeDynamicRangeLimit",
                 "parser-grammar-unused": "<<values>> | <dynamic-range-limit-mix()>",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation and recursive grammars."
@@ -4340,6 +4417,9 @@
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyFill", "&RenderStyle::fill", "&RenderStyle::setFill", "&RenderStyle::visitedLinkFill", "&RenderStyle::setVisitedLinkFill"],
                 "style-builder-custom": "All",
                 "style-extractor-converter": "StyleType<SVGPaint>",
+                "render-style-storage-path": ["m_svgStyle", "fillData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGPaint",
                 "color-property": true,
                 "parser-grammar": "none | <color> | [ <url> [ none | <color> ]? ]",
                 "parser-grammar-comment": "Current spec grammar is 'none | <color> | [ <url> [ none | <color> ]? ] | context-fill | context-stroke'",
@@ -4356,6 +4436,9 @@
             "initial": "1",
             "codegen-properties": {
                 "style-converter": "StyleType<Opacity>",
+                "render-style-storage-path": ["m_svgStyle", "fillData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Opacity",
                 "parser-grammar": "<opacity-value>"
             },
             "specification": {
@@ -4410,6 +4493,9 @@
             "initial": "black",
             "codegen-properties": {
                 "color-property": true,
+                "render-style-storage-path": ["m_svgStyle", "miscData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "specification": {
@@ -4422,6 +4508,9 @@
             "initial": "1",
             "codegen-properties": {
                 "style-converter": "StyleType<Opacity>",
+                "render-style-storage-path": ["m_svgStyle", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Opacity",
                 "parser-grammar": "<opacity-value>"
             },
             "specification": {
@@ -4528,6 +4617,9 @@
                 },
                 "accepts-quirky-length": true,
                 "render-style-initial": "initialSize",
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::PreferredSize",
                 "style-builder-converter": "StyleType<PreferredSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
@@ -4547,6 +4639,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<ImageOrientation>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::ImageOrientation",
                 "parser-grammar": "<<values>>",
                 "parser-grammar-comment": "Current spec grammar is 'from-image | none | [ <angle> || flip ]'"
             },
@@ -4589,6 +4684,9 @@
                 }
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ImageRendering",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -4663,6 +4761,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssInputSecurityEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "InputSecurity",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -4786,6 +4887,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<ItemTolerance>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ItemTolerance",
                 "parser-grammar": "normal | <length-percentage> | infinite"
             },
             "specification": {
@@ -4843,6 +4947,9 @@
             "initial": "white",
             "codegen-properties": {
                 "color-property": true,
+                "render-style-storage-path": ["m_svgStyle", "miscData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "specification": {
@@ -4866,6 +4973,9 @@
             "codegen-properties": {
                 "settings-flag": "cssLineFitEdgeEnabled",
                 "style-converter": "StyleType<LineFitEdge>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::LineFitEdge",
                 "parser-function": "consumeLineFitEdge",
                 "parser-grammar-unused": "leading | [ [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]? ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -4933,6 +5043,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<ImageOrNone>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ImageOrNone",
                 "parser-grammar": "<image> | none"
             },
             "specification": {
@@ -5059,6 +5172,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<ListStyleType>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ListStyleType",
                 "parser-grammar": "<counter-style> | <string> | none",
                 "parser-exported": true
             },
@@ -5337,6 +5453,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<SVGMarkerResource>",
+                "render-style-storage-path": ["m_svgStyle", "inheritedResourceData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGMarkerResource",
                 "parser-grammar": "none | <marker-ref>"
             },
             "specification": {
@@ -5353,6 +5472,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<SVGMarkerResource>",
+                "render-style-storage-path": ["m_svgStyle", "inheritedResourceData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGMarkerResource",
                 "parser-grammar": "none | <marker-ref>"
             },
             "specification": {
@@ -5369,6 +5491,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<SVGMarkerResource>",
+                "render-style-storage-path": ["m_svgStyle", "inheritedResourceData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGMarkerResource",
                 "parser-grammar": "none | <marker-ref>"
             },
             "specification": {
@@ -5801,6 +5926,9 @@
                 "style-converter": "StyleType<MathDepth>",
                 "top-priority": true,
                 "top-priority-reason": "This is top priority since it affects 'font-size', which is 'high-priority'",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::MathDepth",
                 "parser-grammar": "auto-add | add(<integer>) | <integer>"
             },
             "specification": {
@@ -5817,6 +5945,9 @@
                 "compact"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "MathShift",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -5833,6 +5964,9 @@
                 "compact"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "MathStyle",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -5945,6 +6079,9 @@
                 },
                 "accepts-quirky-length": true,
                 "render-style-initial": "initialMaxSize",
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::MaximumSize",
                 "style-builder-converter": "StyleType<MaximumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<max-width-or-height>"
@@ -6021,6 +6158,9 @@
             "codegen-properties": {
                 "settings-flag": "cssLineClampEnabled",
                 "style-converter": "StyleType<MaximumLines>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::MaximumLines",
                 "parser-grammar": "none | <integer [1,inf]>",
                 "parser-exported": true
             },
@@ -6078,6 +6218,9 @@
                 },
                 "accepts-quirky-length": true,
                 "render-style-initial": "initialMaxSize",
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::MaximumSize",
                 "style-builder-converter": "StyleType<MaximumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<max-width-or-height>"
@@ -6192,6 +6335,9 @@
                 },
                 "accepts-quirky-length": true,
                 "render-style-initial": "initialMinSize",
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::MinimumSize",
                 "style-builder-converter": "StyleType<MinimumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
@@ -6306,6 +6452,9 @@
                 },
                 "accepts-quirky-length": true,
                 "render-style-initial": "initialMinSize",
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::MinimumSize",
                 "style-builder-converter": "StyleType<MinimumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
@@ -6326,6 +6475,9 @@
                 "scale-down"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ObjectFit",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -6338,6 +6490,9 @@
             "initial": "50% 50%",
             "codegen-properties": {
                 "style-converter": "StyleType<ObjectPosition>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ObjectPosition",
                 "parser-grammar": "<position>"
             },
             "specification": {
@@ -6354,6 +6509,9 @@
             "codegen-properties": {
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-converter": "StyleType<OffsetPath>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::OffsetPath",
                 "parser-function": "consumeOffsetPath",
                 "parser-grammar-unused": "none | <ray()> | <path()> | <url> | [ <basic-shape> && <coord-box>? ] | <coord-box>",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form and the strong value representation."
@@ -6369,6 +6527,9 @@
             "codegen-properties": {
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-converter": "StyleType<OffsetDistance>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::OffsetDistance",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -6386,6 +6547,9 @@
             "codegen-properties": {
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-converter": "StyleType<OffsetPosition>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::OffsetPosition",
                 "parser-grammar": "normal | auto | <position>"
             },
             "specification": {
@@ -6402,6 +6566,9 @@
             "codegen-properties": {
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-converter": "StyleType<OffsetAnchor>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::OffsetAnchor",
                 "parser-grammar": "auto | <position>"
             },
             "specification": {
@@ -6419,6 +6586,9 @@
             "codegen-properties": {
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-converter": "StyleType<OffsetRotate>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::OffsetRotate",
                 "parser-grammar": "[ [ auto | reverse ] || <angle> ]@(type=CSSOffsetRotateValue)"
             },
             "specification": {
@@ -6453,6 +6623,9 @@
                 ],
                 "animation-wrapper-acceleration": "always",
                 "style-converter": "StyleType<Opacity>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Opacity",
                 "parser-grammar": "<opacity-value>"
             },
             "status": {
@@ -6470,6 +6643,9 @@
             "codegen-properties": {
                 "style-converter": "StyleType<Orphans>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Orphans",
                 "parser-grammar": "<integer [1,inf]>"
             },
             "specification": {
@@ -6589,6 +6765,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssScrollAnchoringEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "OverflowAnchor",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -6610,6 +6789,9 @@
                 "aliases": [
                     "word-wrap"
                 ],
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "OverflowWrap",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -6754,6 +6936,9 @@
                     "name": "overscroll-behavior",
                     "resolver": "horizontal"
                 },
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "OverscrollBehavior",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -6776,6 +6961,9 @@
                     "name": "overscroll-behavior",
                     "resolver": "vertical"
                 },
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "OverscrollBehavior",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -7176,6 +7364,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<Quotes>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Quotes",
                 "parser-function": "consumeQuotes",
                 "parser-grammar-unused": "auto | none | [ <string> <string> ]+",
                 "parser-grammar-unused-reason": "Needs support for flattening order group into parent list."
@@ -7192,6 +7383,9 @@
             "initial": "0",
             "codegen-properties": {
                 "style-converter": "StyleType<SVGRadius>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGRadius",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {
@@ -7216,6 +7410,9 @@
             ],
             "codegen-properties": {
                 "style-builder-converter": "StyleType<Resize>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::Resize",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7258,6 +7455,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssRubyAlignEnabled",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "RubyAlign",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7277,6 +7477,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssRubyOverhangEnabled",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "RubyOverhang",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7293,6 +7496,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<SVGRadiusComponent>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGRadiusComponent",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -7308,6 +7514,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<SVGRadiusComponent>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGRadiusComponent",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -7338,6 +7547,9 @@
             "initial": "black",
             "codegen-properties": {
                 "color-property": true,
+                "render-style-storage-path": ["m_svgStyle", "stopData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "specification": {
@@ -7350,6 +7562,9 @@
             "initial": "1",
             "codegen-properties": {
                 "style-converter": "StyleType<Opacity>",
+                "render-style-storage-path": ["m_svgStyle", "stopData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Opacity",
                 "parser-grammar": "<opacity-value>"
             },
             "specification": {
@@ -7377,6 +7592,9 @@
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStroke", "&RenderStyle::stroke", "&RenderStyle::setStroke", "&RenderStyle::visitedLinkStroke", "&RenderStyle::setVisitedLinkStroke"],
                 "style-builder-custom": "All",
                 "style-extractor-converter": "StyleType<SVGPaint>",
+                "render-style-storage-path": ["m_svgStyle", "strokeData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGPaint",
                 "color-property": true,
                 "parser-grammar": "none | <color> | [ <url> [ none | <color> ]? ]",
                 "parser-grammar-comment": "Current spec grammar is 'none | <color> | [ <url> [ none | <color> ]? ] | context-fill | context-stroke'",
@@ -7396,8 +7614,11 @@
             ],
             "codegen-properties": {
                 "animation-wrapper-requires-non-additive-or-cumulative-interpolation": true,
-                "render-style-name-for-methods": "StrokeDashArray",
                 "style-converter": "StyleType<SVGStrokeDasharray>",
+                "render-style-name-for-methods": "StrokeDashArray",
+                "render-style-storage-path": ["m_svgStyle", "strokeData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGStrokeDasharray",
                 "parser-function": "consumeStrokeDasharray",
                 "parser-function-allows-number-or-integer-input": true,
                 "parser-grammar-unused": "none | [ [ <length-percentage [0,inf] unitless-zero=forbidden> | <number [0,inf]> ]+ ]#",
@@ -7414,8 +7635,11 @@
             "inherited": true,
             "initial": "0",
             "codegen-properties": {
-                "render-style-name-for-methods": "StrokeDashOffset",
                 "style-converter": "StyleType<SVGStrokeDashoffset>",
+                "render-style-name-for-methods": "StrokeDashOffset",
+                "render-style-storage-path": ["m_svgStyle", "strokeData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGStrokeDashoffset",
                 "parser-grammar": "<length-percentage> | <number>"
             },
             "specification": {
@@ -7434,6 +7658,9 @@
             ],
             "codegen-properties": {
                 "render-style-name-for-methods": "CapStyle",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "LineCap",
                 "parser-grammar": "<<values>>"
             },
             "status": "supported",
@@ -7455,6 +7682,9 @@
             ],
             "codegen-properties": {
                 "render-style-name-for-methods": "JoinStyle",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "LineJoin",
                 "parser-grammar": "<<values>>",
                 "comment": "FIXME: Does not match the specification in either SVG2 or CSS Fill and Stroke Module Level 3"
             },
@@ -7473,6 +7703,9 @@
             "codegen-properties": {
                 "style-converter": "StyleType<StrokeMiterlimit>",
                 "render-style-name-for-methods": "StrokeMiterLimit",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::StrokeMiterlimit",
                 "parser-grammar": "<number [0,inf]>",
                 "parser-grammar-comment": "Current spec grammar is '<number [1,inf]>'."
             },
@@ -7490,6 +7723,9 @@
             "initial": "1",
             "codegen-properties": {
                 "style-converter": "StyleType<Opacity>",
+                "render-style-storage-path": ["m_svgStyle", "strokeData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Opacity",
                 "parser-grammar": "<opacity-value>"
             },
             "specification": {
@@ -7506,6 +7742,9 @@
                 "animation-wrapper-comment": "FIXME: Why doesn't this use VisitedAffectedStyleTypeWrapper?",
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStrokeColor", "&RenderStyle::strokeColor", "&RenderStyle::setStrokeColor"],
                 "style-builder-custom": "Value",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "visited-link-color-support": true,
                 "color-property": true,
                 "parser-grammar": "<color>"
@@ -7523,6 +7762,9 @@
             "codegen-properties": {
                 "style-builder-custom": "Value",
                 "style-converter": "StyleType<StrokeWidth>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::StrokeWidth",
                 "parser-grammar": "<length-percentage [0,inf]> | <number [0,inf]>"
             },
             "status": "supported",
@@ -7566,6 +7808,9 @@
                 "fixed"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TableLayoutType",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7579,6 +7824,9 @@
             "initial": "8",
             "codegen-properties": {
                 "style-converter": "StyleType<TabSize>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::TabSize",
                 "parser-grammar": "<number [0,inf]> | <length [0,inf]>"
             },
             "specification": {
@@ -7652,6 +7900,9 @@
             ],
             "codegen-properties": {
                 "style-builder-converter": "StyleType<TextAlignLast>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::TextAlignLast",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7689,6 +7940,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssTextGroupAlignEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextGroupAlign",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7708,6 +7962,9 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "style-converter": "StyleType<TextIndent>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::TextIndent",
                 "parser-grammar": "<length-percentage> && hanging? && each-line?"
             },
             "specification": {
@@ -7735,6 +7992,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssTextJustifyEnabled",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextJustify",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7750,6 +8010,9 @@
                 "ellipsis"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextOverflow",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7766,6 +8029,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<TextShadows>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::TextShadows",
                 "parser-function": "consumeTextShadow",
                 "parser-grammar-unused": "none | [ <color>? && <length>{2,3} ]#",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation.",
@@ -8088,6 +8354,9 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "style-converter": "StyleType<VerticalAlign>",
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::VerticalAlign",
                 "parser-grammar": "<<values>> | <length-percentage>",
                 "parser-grammar-comment": "Current spec has 'vertical-align' specified as a shorthand with grammar '[ first | last] || <<'alignment-baseline'>> || <<'baseline-shift'>>'"
             },
@@ -8168,6 +8437,9 @@
             "codegen-properties": {
                 "style-converter": "StyleType<Widows>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Widows",
                 "parser-grammar": "<integer [1,inf]>"
             },
             "specification": {
@@ -8225,6 +8497,9 @@
                 },
                 "accepts-quirky-length": true,
                 "render-style-initial": "initialSize",
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::PreferredSize",
                 "style-builder-converter": "StyleType<PreferredSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
@@ -8244,6 +8519,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<WillChange>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::WillChange",
                 "parser-function": "consumeWillChange",
                 "parser-grammar-unused": "auto | [ scroll-position | contents | <custom-ident excluding=will-change,none,all,auto,scroll-position,contents> ]#",
                 "parser-grammar-unused-reason": "Needs support for CSS property names in the value of a property."
@@ -8275,6 +8553,9 @@
                 "aliases": [
                     "-epub-word-break"
                 ],
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "WordBreak",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -8310,6 +8591,9 @@
             "initial": "0",
             "codegen-properties": {
                 "style-converter": "StyleType<SVGCoordinateComponent>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGCoordinateComponent",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -8322,6 +8606,9 @@
             "initial": "0",
             "codegen-properties": {
                 "style-converter": "StyleType<SVGCoordinateComponent>",
+                "render-style-storage-path": ["m_svgStyle", "layoutData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::SVGCoordinateComponent",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -8411,6 +8698,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<AspectRatio>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::AspectRatio",
                 "parser-grammar": "auto || <ratio>"
             },
             "specification": {
@@ -8448,6 +8738,9 @@
                     "resolver": "vertical"
                 },
                 "style-converter": "StyleType<ContainIntrinsicSize>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ContainIntrinsicSize",
                 "parser-grammar": "[ auto? [ none | <length [0,inf]> ] ]@(type=CSSValuePair)",
                 "parser-exported": true
             },
@@ -8469,6 +8762,9 @@
                     "resolver": "horizontal"
                 },
                 "style-converter": "StyleType<ContainIntrinsicSize>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ContainIntrinsicSize",
                 "parser-grammar": "[ auto? [ none | <length [0,inf]> ] ]@(type=CSSValuePair)",
                 "parser-exported": true
              },
@@ -8553,6 +8849,9 @@
             "codegen-properties": {
                 "style-converter": "StyleType<ContainerNames>",
                 "render-style-name-for-methods": "ContainerNames",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ContainerNames",
                 "parser-grammar": "none | <single-container-name>+@(no-single-item-opt)"
             },
             "specification": {
@@ -8569,6 +8868,9 @@
                 "inline-size"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ContainerType",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -8587,6 +8889,9 @@
             "codegen-properties": {
                 "animation-wrapper": "NonNormalizedDiscreteWrapper<ContentVisibility>",
                 "animation-wrapper-requires-non-normalized-discrete-interpolation": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ContentVisibility",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -8658,6 +8963,9 @@
             "initial": "0px",
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitBorderSpacing>",
+                "render-style-storage-path": ["m_inheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitBorderSpacing",
                 "parser-grammar": "<length [0,inf]>"
             },
             "status": "non-standard"
@@ -8701,6 +9009,9 @@
             "initial": "0px",
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitBorderSpacing>",
+                "render-style-storage-path": ["m_inheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitBorderSpacing",
                 "parser-grammar": "<length [0,inf]>"
             },
             "status": "non-standard"
@@ -8716,6 +9027,9 @@
                 "baseline"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "deprecatedFlexibleBox"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BoxAlignment",
                 "parser-grammar": "<<values>>"
             },
             "status": "obsolete",
@@ -8746,6 +9060,9 @@
             "initial": "0",
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitBoxFlex>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "deprecatedFlexibleBox"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitBoxFlex",
                 "parser-grammar": "<number>"
             },
             "status": "obsolete",
@@ -8759,6 +9076,9 @@
             "initial": "1",
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitBoxFlexGroup>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "deprecatedFlexibleBox"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitBoxFlexGroup",
                 "parser-grammar": "<integer [0,inf]>"
             },
             "status": "obsolete",
@@ -8775,6 +9095,9 @@
                 "multiple"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "deprecatedFlexibleBox"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BoxLines",
                 "parser-grammar": "<<values>>"
             },
             "status": "obsolete",
@@ -8788,6 +9111,9 @@
             "initial": "1",
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitBoxOrdinalGroup>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "deprecatedFlexibleBox"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitBoxOrdinalGroup",
                 "parser-grammar": "<integer [1,inf]>"
             },
             "status": "obsolete",
@@ -8806,6 +9132,9 @@
                 "block-axis"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "deprecatedFlexibleBox"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BoxOrient",
                 "parser-grammar": "<<values>>"
             },
             "status": "obsolete",
@@ -8824,6 +9153,9 @@
                 "justify"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "deprecatedFlexibleBox"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BoxPack",
                 "parser-grammar": "<<values>>"
             },
             "status": "obsolete",
@@ -8837,6 +9169,9 @@
             "initial": "none",
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitBoxReflect>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::WebkitBoxReflect",
                 "parser-function": "consumeWebkitBoxReflect",
                 "parser-grammar-unused": "none | [ [ above | below | left | right ] <length-percentage>? <border-image>? ]",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals and property references."
@@ -8868,6 +9203,9 @@
                 "auto"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ColumnAxis",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -8946,6 +9284,9 @@
                     "-webkit-column-count"
                 ],
                 "style-converter": "StyleType<ColumnCount>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::ColumnCount",
                 "parser-grammar": "auto | <integer [1,inf]>",
                 "parser-exported": true
             },
@@ -8965,6 +9306,9 @@
                 "aliases": [
                     "-webkit-column-fill"
                 ],
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ColumnFill",
                 "parser-grammar": "<<values>>"
             },
             "specification":  {
@@ -8981,6 +9325,9 @@
                     "-webkit-column-gap"
                 ],
                 "style-converter": "StyleType<GapGutter>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GapGutter",
                 "parser-grammar": "<gap-gutter>",
                 "parser-exported": true
             },
@@ -8997,6 +9344,9 @@
                     "grid-row-gap"
                 ],
                 "style-converter": "StyleType<GapGutter>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GapGutter",
                 "parser-grammar": "<gap-gutter>",
                 "parser-exported": true
             },
@@ -9032,6 +9382,9 @@
                 "reverse"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ColumnProgression",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -9133,6 +9486,9 @@
                 "aliases": [
                     "-webkit-column-span"
                 ],
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ColumnSpan",
                 "parser-grammar": "<<values>>"
             },
             "specification":  {
@@ -9151,6 +9507,9 @@
                     "-webkit-column-width"
                 ],
                 "style-converter": "StyleType<ColumnWidth>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::ColumnWidth",
                 "parser-grammar": "auto | <length [0,inf]>",
                 "parser-exported": true
             },
@@ -9185,6 +9544,9 @@
                 "slice"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BoxDecorationBreak",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -9235,6 +9597,9 @@
                 "isolate"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Isolation",
                 "parser-grammar": "<<values>>"
             },
             "specification":  {
@@ -9254,6 +9619,9 @@
                 ],
                 "animation-wrapper-acceleration": "always",
                 "style-converter": "StyleType<Filter>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "filter"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Filter",
                 "parser-function": "consumeFilter",
                 "parser-grammar-unused": "none | <filter-value-list>",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation."
@@ -9273,6 +9641,9 @@
             "codegen-properties": {
                 "settings-flag": "colorFilterEnabled",
                 "style-converter": "StyleType<AppleColorFilter>",
+                "render-style-storage-path": ["m_rareInheritedData", "appleColorFilter"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::AppleColorFilter",
                 "parser-function": "consumeAppleColorFilter",
                 "parser-grammar-unused": "none | <-apple-color-filter-value-list>",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation."
@@ -9343,6 +9714,9 @@
                     "-webkit-align-items"
                 ],
                 "style-converter": "StyleType<AlignItems>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::AlignItems",
                 "parser-function": "consumeAlignItems",
                 "parser-grammar-unused": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals.",
@@ -9379,6 +9753,9 @@
                     "-webkit-align-self"
                 ],
                 "style-converter": "StyleType<AlignSelf>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::AlignSelf",
                 "parser-function": "consumeAlignSelf",
                 "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals.",
@@ -9456,6 +9833,9 @@
                     "-webkit-flex-basis"
                 ],
                 "style-converter": "StyleType<FlexBasis>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "flexibleBox"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::FlexBasis",
                 "parser-grammar": "auto | content | <width-or-height-keyword> | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -9476,6 +9856,9 @@
                 "aliases": [
                     "-webkit-flex-direction"
                 ],
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "flexibleBox"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FlexDirection",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -9509,6 +9892,9 @@
                     "-webkit-flex-grow"
                 ],
                 "style-converter": "StyleType<FlexGrow>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "flexibleBox"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FlexGrow",
                 "parser-grammar": "<number [0,inf]>"
             },
             "specification": {
@@ -9524,6 +9910,9 @@
                     "-webkit-flex-shrink"
                 ],
                 "style-converter": "StyleType<FlexShrink>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "flexibleBox"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FlexShrink",
                 "parser-grammar": "<number [0,inf]>"
             },
             "specification": {
@@ -9543,6 +9932,9 @@
                 "aliases": [
                     "-webkit-flex-wrap"
                 ],
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "flexibleBox"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FlexWrap",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -9574,6 +9966,9 @@
                     "-webkit-justify-content"
                 ],
                 "style-converter": "StyleType<JustifyContent>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::JustifyContent",
                 "parser-function": "consumeJustifyContent",
                 "parser-grammar-unused": "normal | <content-distribution> | [ <overflow-position>? [ <content-position> | left | right ] ]",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals.",
@@ -9608,6 +10003,9 @@
             "codegen-properties": {
                 "animation-wrapper-acceleration": "always",
                 "style-converter": "StyleType<Filter>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "backdropFilter"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Filter",
                 "parser-function": "consumeFilter",
                 "parser-grammar-unused": "none | <filter-value-list>",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation.",
@@ -9636,6 +10034,9 @@
             "initial": "auto",
             "codegen-properties": {
                 "style-converter": "StyleType<JustifySelf>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::JustifySelf",
                 "parser-function": "consumeJustifySelf",
                 "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? [ <self-position> | left | right ] ]",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals."
@@ -9653,6 +10054,9 @@
                     "-webkit-justify-items"
                 ],
                 "style-converter": "StyleType<JustifyItems>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::JustifyItems",
                 "parser-function": "consumeJustifyItems",
                 "parser-grammar-unused": "[ normal | stretch | <baseline-position> | [ <overflow-position>? [ <self-position> | left | right ] ] | legacy | legacy ] && [ left | right | center ]",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals."
@@ -9755,6 +10159,9 @@
             "codegen-properties": {
                 "separator": " ",
                 "style-converter": "StyleType<GridTrackSizes>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "grid"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridTrackSizes",
                 "parser-function": "consumeGridTrackList",
                 "parser-grammar-unused": "<track-size>+",
                 "parser-grammar-unused-reason": "Needs investigation."
@@ -9771,6 +10178,9 @@
             "codegen-properties": {
                 "separator": " ",
                 "style-converter": "StyleType<GridTrackSizes>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "grid"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridTrackSizes",
                 "parser-function": "consumeGridTrackList",
                 "parser-grammar-unused": "<track-size>+",
                 "parser-grammar-unused-reason": "Needs investigation."
@@ -9786,6 +10196,9 @@
             "codegen-properties": {
                 "render-style-name-for-methods": "GridItemColumnEnd",
                 "style-converter": "StyleType<GridPosition>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "gridItem"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridPosition",
                 "parser-function": "consumeGridLine",
                 "parser-grammar-unused": "<grid-line>",
                 "parser-grammar-unused-reason": "Needs support for ordered groups with a keyword/literal first term differentiator."
@@ -9801,6 +10214,9 @@
             "codegen-properties": {
                 "render-style-name-for-methods": "GridItemColumnStart",
                 "style-converter": "StyleType<GridPosition>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "gridItem"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridPosition",
                 "parser-function": "consumeGridLine",
                 "parser-grammar-unused": "<grid-line>",
                 "parser-grammar-unused-reason": "Needs support for ordered groups with a keyword/literal first term differentiator."
@@ -9833,6 +10249,9 @@
             "codegen-properties": {
                 "style-builder-converter": "StyleType<GridTemplateList>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "grid"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridTemplateList",
                 "parser-function": "consumeGridTemplatesRowsOrColumns",
                 "parser-grammar-unused": "none | <track-list> | <auto-track-list>",
                 "parser-grammar-unused-reason": "Needs investigation."
@@ -9848,6 +10267,9 @@
             "codegen-properties": {
                 "style-builder-converter": "StyleType<GridTemplateList>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "grid"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridTemplateList",
                 "parser-function": "consumeGridTemplatesRowsOrColumns",
                 "parser-grammar-unused": "none | <track-list> | <auto-track-list>",
                 "parser-grammar-unused-reason": "Needs investigation."
@@ -9863,6 +10285,9 @@
             "codegen-properties": {
                 "render-style-name-for-methods": "GridItemRowEnd",
                 "style-converter": "StyleType<GridPosition>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "gridItem"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridPosition",
                 "parser-function": "consumeGridLine",
                 "parser-grammar-unused": "<grid-line>",
                 "parser-grammar-unused-reason": "Needs support for ordered groups with a keyword/literal first term differentiator."
@@ -9878,6 +10303,9 @@
             "codegen-properties": {
                 "render-style-name-for-methods": "GridItemRowStart",
                 "style-converter": "StyleType<GridPosition>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "gridItem"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridPosition",
                 "parser-function": "consumeGridLine",
                 "parser-grammar-unused": "<grid-line>",
                 "parser-grammar-unused-reason": "Needs support for ordered groups with a keyword/literal first term differentiator."
@@ -9924,6 +10352,9 @@
             "initial": "none",
             "codegen-properties": {
                 "style-converter": "StyleType<GridTemplateAreas>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "grid"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::GridTemplateAreas",
                 "parser-function": "consumeGridTemplateAreas",
                 "parser-grammar-unused": "none | <string>+",
                 "parser-grammar-unused-reason": "Needs support for nested grammars in <string> values."
@@ -9938,6 +10369,9 @@
             "initial": "row",
             "codegen-properties": {
                 "style-converter": "StyleType<GridAutoFlow>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "grid"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::GridAutoFlow",
                 "parser-function": "consumeGridAutoFlow",
                 "parser-grammar-unused": "[ row | column ] || dense",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -9959,6 +10393,9 @@
                     "-webkit-hyphenate-character"
                 ],
                 "style-converter": "StyleType<HyphenateCharacter>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::HyphenateCharacter",
                 "parser-grammar": "auto | <string>"
             },
             "specification": {
@@ -9975,6 +10412,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<HyphenateLimitEdge>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::HyphenateLimitEdge",
                 "parser-grammar": "auto | <number [0,inf]>"
             },
             "status": "non-standard"
@@ -9988,6 +10428,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<HyphenateLimitEdge>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::HyphenateLimitEdge",
                 "parser-grammar": "auto | <number [0,inf]>"
             },
             "status": "non-standard"
@@ -10001,6 +10444,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<HyphenateLimitLines>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::HyphenateLimitLines",
                 "parser-grammar": "no-limit | <number [0,inf]>"
             },
             "status": {
@@ -10025,6 +10471,9 @@
                     "-epub-hyphens",
                     "-webkit-hyphens"
                 ],
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Hyphens",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -10040,6 +10489,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitInitialLetter>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::WebkitInitialLetter",
                 "parser-grammar": "normal | <number [0,inf]>{1,2}@(type=CSSValuePair default=previous)",
                 "parser-grammar-comment": "Spec does not match our implementation. Spec is 'normal | [ <number [1,inf]> <integer [1,inf]> ] | [ <number [1,inf]> && [ drop | raise ]? ]'"
             },
@@ -10083,6 +10535,9 @@
                 "edges"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "LineAlign",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -10114,6 +10569,9 @@
                 "aliases": [
                     "-webkit-line-break"
                 ],
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "LineBreak",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -10146,6 +10604,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitLineClamp>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::WebkitLineClamp",
                 "parser-grammar": "none | <percentage [0,inf]> | <integer [1,inf]>"
             },
             "status": "non-standard"
@@ -10159,6 +10620,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitLineGrid>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::WebkitLineGrid",
                 "parser-grammar": "none | <custom-ident>"
             },
             "status": {
@@ -10179,6 +10643,9 @@
                 "contain"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "LineSnap",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -10205,6 +10672,9 @@
             ],
             "codegen-properties": {
                 "internal-only": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "marquee"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "MarqueeDirection",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -10214,8 +10684,11 @@
             "initial": "6px",
             "codegen-properties": {
                 "accepts-quirky-length": true,
-                "style-converter": "StyleType<WebkitMarqueeIncrement>",
                 "internal-only": true,
+                "style-converter": "StyleType<WebkitMarqueeIncrement>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "marquee"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::WebkitMarqueeIncrement",
                 "parser-grammar": "<length-percentage>"
             },
             "status": "non-standard"
@@ -10224,8 +10697,11 @@
             "animation-type": "not animatable (internal)",
             "initial": "infinite",
             "codegen-properties": {
-                "style-converter": "StyleType<WebkitMarqueeRepetition>",
                 "internal-only": true,
+                "style-converter": "StyleType<WebkitMarqueeRepetition>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "marquee"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitMarqueeRepetition",
                 "parser-grammar": "infinite | <integer [0,inf]>"
             },
             "status": "non-standard"
@@ -10234,8 +10710,11 @@
             "animation-type": "not animatable (internal)",
             "initial": "85ms",
             "codegen-properties": {
-                "style-converter": "StyleType<WebkitMarqueeSpeed>",
                 "internal-only": true,
+                "style-converter": "StyleType<WebkitMarqueeSpeed>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "marquee"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitMarqueeSpeed",
                 "parser-grammar": "<time [0,inf]>"
             },
             "status": "non-standard"
@@ -10250,8 +10729,11 @@
                 "alternate"
             ],
             "codegen-properties": {
-                "render-style-name-for-methods": "MarqueeBehavior",
                 "internal-only": true,
+                "render-style-name-for-methods": "MarqueeBehavior",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData", "marquee"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "MarqueeBehavior",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -10362,6 +10844,9 @@
             "codegen-properties": {
                 "render-style-initial": "initialNBSPMode",
                 "render-style-setter": "setNBSPMode",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "NBSPMode",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -10380,9 +10865,12 @@
                 "aliases": [
                     "supported-color-schemes"
                 ],
+                "enable-if": "ENABLE_DARK_MODE_CSS",
                 "style-converter": "StyleType<ColorScheme>",
                 "style-builder-custom": "Value",
-                "enable-if": "ENABLE_DARK_MODE_CSS",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::ColorScheme",
                 "top-priority": true,
                 "top-priority-reason": "This is a top priority property to ensure that its value can be checked when resolving colors.",
                 "parser-function": "consumeColorScheme",
@@ -10406,6 +10894,9 @@
                     "-webkit-order"
                 ],
                 "style-converter": "StyleType<Order>",
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::Order",
                 "parser-grammar": "<integer>"
             },
             "specification": {
@@ -10421,6 +10912,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<Perspective>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Perspective",
                 "parser-grammar": "none | <length [0,inf]>",
                 "parser-exported": true
             },
@@ -10563,6 +11057,9 @@
             ],
             "codegen-properties": {
                 "render-style-name-for-methods": "TextCombine",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextCombine",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -10636,6 +11133,9 @@
                 "aliases": [
                     "-webkit-text-decoration-style"
                 ],
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextDecorationStyle",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -10652,6 +11152,9 @@
                 ],
                 "visited-link-color-support": true,
                 "color-property": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "specification": {
@@ -10687,6 +11190,9 @@
                 "all"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextDecorationSkipInk",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -10723,6 +11229,9 @@
             "initial": "auto",
             "codegen-properties": {
                 "style-converter": "StyleType<TextUnderlineOffset>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::TextUnderlineOffset",
                 "parser-grammar": "auto | <length-percentage>"
             },
             "specification": {
@@ -10739,6 +11248,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<TextDecorationThickness>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::TextDecorationThickness",
                 "parser-grammar": "auto | from-font | <length-percentage>"
             },
             "specification": {
@@ -10800,6 +11312,9 @@
                 ],
                 "visited-link-color-support": true,
                 "color-property": true,
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "specification": {
@@ -10833,6 +11348,9 @@
                     "-webkit-text-emphasis-style"
                 ],
                 "style-converter": "StyleType<TextEmphasisStyle>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::TextEmphasisStyle",
                 "parser-grammar": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>"
             },
             "specification": {
@@ -10847,6 +11365,9 @@
             "codegen-properties": {
                 "visited-link-color-support": true,
                 "color-property": true,
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "status": {
@@ -10865,6 +11386,9 @@
                 "none"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextSecurity",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -10891,6 +11415,9 @@
             "codegen-properties": {
                 "visited-link-color-support": true,
                 "color-property": true,
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "status": {
@@ -10909,6 +11436,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<WebkitTextStrokeWidth>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitTextStrokeWidth",
                 "parser-grammar": "<line-width>"
             },
             "status": {
@@ -10926,6 +11456,9 @@
                 "animation-wrapper-acceleration": "always",
                 "style-converter": "StyleType<Transform>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "transform"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Transform",
                 "parser-grammar": "none | <transform-list>",
                 "parser-exported": true
             },
@@ -10945,6 +11478,9 @@
                 "view-box"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData", "transform"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TransformBox",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -11037,6 +11573,9 @@
                     "-webkit-transform-style"
                 ],
                 "render-style-name-for-methods": "TransformStyle3D",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TransformStyle3D",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -11054,6 +11593,9 @@
                 "animation-wrapper-acceleration": "always",
                 "style-builder-converter": "StyleType<Translate>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Translate",
                 "parser-function": "consumeTranslate",
                 "parser-grammar-unused": "none | [ <length-percentage> [ <length-percentage> <length>? ]? ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -11073,6 +11615,9 @@
                 "animation-wrapper-acceleration": "always",
                 "style-builder-converter": "StyleType<Scale>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Scale",
                 "parser-function": "consumeScale",
                 "parser-grammar-unused": "none | [ <number-or-percentage-resolved-to-number> ]{1,3}",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -11096,6 +11641,9 @@
                 "animation-wrapper-acceleration": "always",
                 "style-builder-converter": "StyleType<Rotate>",
                 "style-extractor-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Rotate",
                 "parser-function": "consumeRotate",
                 "parser-grammar-unused": "none | <angle> | [ [ x | y | z | <number>{3} ] && <angle> ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -11114,6 +11662,9 @@
                 "element"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "UserDrag",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -11128,6 +11679,9 @@
                 "read-write-plaintext-only"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "UserModify",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -11149,6 +11703,9 @@
                 "all"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "UserSelect",
                 "parser-grammar": "<<values>>"
             },
             "status": {
@@ -11168,6 +11725,9 @@
                 "smooth"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::ScrollBehavior",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -11599,6 +12159,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<ScrollSnapAlign>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ScrollSnapAlign",
                 "parser-grammar": "[ none | start | end | center ]{1,2}@(type=CSSValuePair default=previous)"
             },
             "specification": {
@@ -11621,6 +12184,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<ScrollSnapType>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ScrollSnapType",
                 "parser-function": "consumeScrollSnapType",
                 "parser-grammar-unused": "none | [ [ x | y | block | inline | both ] [ mandatory | proximity ]? ]",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals."
@@ -11638,6 +12204,9 @@
                 "normal"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "ScrollSnapStop",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -11672,8 +12241,11 @@
             ],
             "codegen-properties": {
                 "settings-flag": "scrollDrivenAnimationsEnabled",
-                "render-style-name-for-methods": "ScrollTimelineAxes",
                 "style-converter": "StyleType<ProgressTimelineAxes>",
+                "render-style-name-for-methods": "ScrollTimelineAxes",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ProgressTimelineAxes",
                 "parser-exported": true,
                 "parser-grammar": "<axis>#"
             },
@@ -11690,8 +12262,11 @@
             ],
             "codegen-properties": {
                 "settings-flag": "scrollDrivenAnimationsEnabled",
-                "render-style-name-for-methods": "ScrollTimelineNames",
                 "style-converter": "StyleType<ProgressTimelineNames>",
+                "render-style-name-for-methods": "ScrollTimelineNames",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ProgressTimelineNames",
                 "parser-exported": true,
                 "parser-grammar": "<single-scroll-timeline-name>#"
             },
@@ -11710,6 +12285,9 @@
             "codegen-properties": {
                 "settings-flag": "cssScrollbarColorEnabled",
                 "style-converter": "StyleType<ScrollbarColor>",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ScrollbarColor",
                 "parser-function": "consumeScrollbarColor",
                 "parser-grammar-unused": "auto | <color>{2}",
                 "parser-grammar-unused-reason": "Needs support for non-coalescing CSSValuePair."
@@ -11731,6 +12309,9 @@
             "codegen-properties": {
                 "settings-flag": "cssScrollbarGutterEnabled",
                 "style-converter": "StyleType<ScrollbarGutter>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ScrollbarGutter",
                 "parser-grammar": "auto | [ stable && both-edges? ]@(type=CSSValuePair)"
             },
             "specification": {
@@ -11752,6 +12333,9 @@
             "codegen-properties": {
                 "settings-flag": "cssScrollbarWidthEnabled",
                 "style-converter": "StyleType<ScrollbarWidth>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::ScrollbarWidth",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -11773,6 +12357,9 @@
                     "-webkit-shape-outside"
                 ],
                 "style-converter": "StyleType<ShapeOutside>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ShapeOutside",
                 "parser-function": "consumeShapeOutside",
                 "parser-grammar-unused": "none | [ <basic-shape> || <shape-box> ] | <image>",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form and the strong value representation."
@@ -11790,6 +12377,9 @@
                     "-webkit-shape-margin"
                 ],
                 "style-converter": "StyleType<ShapeMargin>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ShapeMargin",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {
@@ -11805,6 +12395,9 @@
                     "-webkit-shape-image-threshold"
                 ],
                 "style-converter": "StyleType<ShapeImageThreshold>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::ShapeImageThreshold",
                 "parser-grammar": "<number>",
                 "parser-grammar-comment": "Current spec grammar is '<opacity-value>'"
             },
@@ -11822,6 +12415,9 @@
             ],
            "codegen-properties": {
                "style-converter": "StyleType<NameScope>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::NameScope",
                "parser-grammar": "none | all | <dashed-ident>#",
                "settings-flag": "scrollDrivenAnimationsEnabled"
            },
@@ -11858,8 +12454,11 @@
             ],
             "codegen-properties": {
                 "settings-flag": "scrollDrivenAnimationsEnabled",
-                "render-style-name-for-methods": "ViewTimelineAxes",
                 "style-converter": "StyleType<ProgressTimelineAxes>",
+                "render-style-name-for-methods": "ViewTimelineAxes",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ProgressTimelineAxes",
                 "parser-exported": true,
                 "parser-grammar": "<axis>#"
             },
@@ -11877,8 +12476,11 @@
             ],
             "codegen-properties": {
                 "settings-flag": "scrollDrivenAnimationsEnabled",
-                "render-style-name-for-methods": "ViewTimelineInsets",
                 "style-converter": "StyleType<ViewTimelineInsets>",
+                "render-style-name-for-methods": "ViewTimelineInsets",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ViewTimelineInsets",
                 "parser-grammar": "<single-view-timeline-inset-item>#@(no-single-item-opt)"
             },
             "specification": {
@@ -11894,8 +12496,11 @@
             ],
             "codegen-properties": {
                 "settings-flag": "scrollDrivenAnimationsEnabled",
-                "render-style-name-for-methods": "ViewTimelineNames",
                 "style-converter": "StyleType<ProgressTimelineNames>",
+                "render-style-name-for-methods": "ViewTimelineNames",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ProgressTimelineNames",
                 "parser-exported": true,
                 "parser-grammar": "<single-scroll-timeline-name>#"
             },
@@ -11914,6 +12519,9 @@
                 "settings-flag": "viewTransitionClassesEnabled",
                 "style-converter": "StyleType<ViewTransitionClasses>",
                 "render-style-name-for-methods": "ViewTransitionClasses",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ViewTransitionClasses",
                 "parser-grammar": "none | <custom-ident excluding=none>+@(no-single-item-opt)"
             },
             "specification": {
@@ -11932,6 +12540,9 @@
             "codegen-properties": {
                 "settings-flag": "viewTransitionsEnabled",
                 "style-converter": "StyleType<ViewTransitionName>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::ViewTransitionName",
                 "parser-grammar": "none | auto | match-element | <custom-ident>"
             },
             "specification": {
@@ -11948,6 +12559,9 @@
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningEnabled",
                 "render-style-name-for-methods": "AnchorNames",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::AnchorNames",
                 "style-converter": "StyleType<AnchorNames>",
                 "parser-grammar": "none | <dashed-ident>#"
             },
@@ -11961,6 +12575,9 @@
             "initial": "none",
             "codegen-properties": {
                 "style-converter": "StyleType<NameScope>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::NameScope",
                 "parser-grammar": "none | all | <dashed-ident>#",
                 "settings-flag": "cssAnchorPositioningEnabled"
             },
@@ -11978,6 +12595,9 @@
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningEnabled",
                 "style-converter": "StyleType<PositionAnchor>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::PositionAnchor",
                 "parser-grammar": "auto | <dashed-ident>"
             },
             "specification": {
@@ -11995,6 +12615,9 @@
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningEnabled",
                 "style-converter": "StyleType<PositionArea>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::PositionArea",
                 "parser-function": "consumePositionArea",
                 "parser-grammar-unused": "none | <position-area>",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -12032,6 +12655,9 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningEnabled",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::PositionTryOrder",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -12048,6 +12674,9 @@
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningEnabled",
                 "style-converter": "StyleType<PositionTryFallbacks>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::PositionTryFallbacks",
                 "parser-function": "consumePositionTryFallbacks",
                 "parser-grammar-unused": "none | [ [<dashed-ident> || <try-tactic>] | <position-area> ]#",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -12083,6 +12712,9 @@
             "codegen-properties": {
                 "enable-if": "ENABLE_TOUCH_EVENTS",
                 "color-property": true,
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
             },
             "status": "non-standard"
@@ -12098,6 +12730,9 @@
             "codegen-properties": {
                 "enable-if": "ENABLE_WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY",
                 "settings-flag": "legacyOverflowScrollingTouchEnabled",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::WebkitOverflowScrolling",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -12138,6 +12773,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<TouchAction>",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::TouchAction",
                 "parser-grammar": "auto | none | [ pan-x || pan-y || pinch-zoom ]@(no-single-item-opt) | manipulation",
                 "parser-grammar-comment": "Current spec grammar is 'auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] ] | manipulation'"
             },
@@ -12155,6 +12793,9 @@
             ],
             "codegen-properties": {
                 "enable-if": "ENABLE_WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY",
+                "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::WebkitTouchCallout",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -12201,6 +12842,9 @@
             "codegen-properties": {
                 "enable-if": "HAVE_CORE_MATERIAL",
                 "settings-flag": "useSystemAppearance",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "AppleVisualEffect",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -12215,6 +12859,9 @@
             ],
             "codegen-properties": {
                 "enable-if": "ENABLE_APPLE_PAY",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ApplePayButtonStyle",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -12265,6 +12912,9 @@
             ],
             "codegen-properties": {
                 "enable-if": "ENABLE_APPLE_PAY",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ApplePayButtonType",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -5342,6 +5342,7 @@ class GenerateRenderStyleGenerated:
                 system_headers=[
                     "<WebCore/SVGRenderStyle.h>",
                     "<WebCore/StyleAppleColorFilterData.h>",
+                    "<WebCore/StyleBackdropFilterData.h>",
                     "<WebCore/StyleBackgroundData.h>",
                     "<WebCore/StyleBoxData.h>",
                     "<WebCore/StyleDeprecatedFlexibleBoxData.h>",

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -7014,7 +7014,7 @@ ScrollbarWidth LocalFrameView::scrollbarWidthStyle()  const
     auto* document = m_frame->document();
     auto scrollingObject = document && document->documentElement() ? document->documentElement()->renderer() : nullptr;
     if (scrollingObject && renderView())
-        return scrollingObject->style().scrollbarWidth().value;
+        return Style::toPlatform(scrollingObject->style().scrollbarWidth());
     return ScrollbarWidth::Auto;
 }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -369,9 +369,9 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
 
     if (layer() && oldStyle && oldStyle->scrollbarWidth() != newStyle.scrollbarWidth()) {
         if (isDocElementRenderer)
-            view().frameView().scrollbarWidthChanged(newStyle.scrollbarWidth().platform());
+            view().frameView().scrollbarWidthChanged(Style::toPlatform(newStyle.scrollbarWidth()));
         else if (CheckedPtr scrollableArea = layer()->scrollableArea())
-            scrollableArea->scrollbarWidthChanged(newStyle.scrollbarWidth().platform());
+            scrollableArea->scrollbarWidthChanged(Style::toPlatform(newStyle.scrollbarWidth()));
     }
 
     if (layer() && oldStyle && oldStyle->scrollbarColor() != newStyle.scrollbarColor()) {

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -721,7 +721,7 @@ RenderLayer::OverflowControlRects RenderLayerScrollableArea::overflowControlsRec
     bool haveNonOverlayVerticalScrollbar = isNonOverlayScrollbar(vBar.get());
     bool placeVerticalScrollbarOnTheLeft = shouldPlaceVerticalScrollbarOnLeft();
     bool haveResizer = renderBox.style().resize() != Style::Resize::None && !renderBox.style().pseudoElementType();
-    bool scrollbarsAvoidCorner = ((haveNonOverlayHorizontalScrollbar && haveNonOverlayVerticalScrollbar) || (haveResizer && (haveNonOverlayHorizontalScrollbar || haveNonOverlayVerticalScrollbar))) && !renderBox.style().scrollbarWidth().isNone();
+    bool scrollbarsAvoidCorner = ((haveNonOverlayHorizontalScrollbar && haveNonOverlayVerticalScrollbar) || (haveResizer && (haveNonOverlayHorizontalScrollbar || haveNonOverlayVerticalScrollbar))) && renderBox.style().scrollbarWidth() != Style::ScrollbarWidth::None;
 
     IntSize cornerSize;
     if (scrollbarsAvoidCorner) {
@@ -1061,7 +1061,7 @@ Style::ScrollbarGutter RenderLayerScrollableArea::scrollbarGutterStyle()  const
 ScrollbarWidth RenderLayerScrollableArea::scrollbarWidthStyle()  const
 {
     if (m_layer.renderBox())
-        return m_layer.renderer().style().scrollbarWidth().platform();
+        return Style::toPlatform(m_layer.renderer().style().scrollbarWidth());
     return ScrollbarWidth::Auto;
 }
 
@@ -1574,7 +1574,7 @@ void RenderLayerScrollableArea::paintResizer(GraphicsContext& context, const Lay
     renderer.theme().paintPlatformResizer(renderer, context, resizerAbsRect);
 
     // Draw a frame around the resizer if there are any scrollbars present.
-    if (!hasOverlayScrollbars() && (m_vBar || m_hBar) && !renderer.style().scrollbarWidth().isNone())
+    if (!hasOverlayScrollbars() && (m_vBar || m_hBar) && renderer.style().scrollbarWidth() != Style::ScrollbarWidth::None)
         renderer.theme().paintPlatformResizerFrame(renderer, context, resizerAbsRect);
 }
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -475,7 +475,7 @@ void RenderReplaced::computeAspectRatioInformationForRenderBox(RenderBox* conten
             preferredAspectRatio = renderReplaced->preferredAspectRatio();
         }
         if (style().aspectRatio().isRatio() || (style().aspectRatio().isAutoAndRatio() && preferredAspectRatio.isEmpty()))
-            preferredAspectRatio = FloatSize::narrowPrecision(style().aspectRatioWidth().value, style().aspectRatioHeight().value);
+            preferredAspectRatio = FloatSize::narrowPrecision(style().aspectRatio().width().value, style().aspectRatio().height().value);
 
         // Handle zoom & vertical writing modes here, as the embedded document doesn't know about them.
         intrinsicSize.scale(style().usedZoom());

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -95,7 +95,7 @@ void RenderTextControl::styleDidChange(StyleDifference diff, const RenderStyle* 
 int RenderTextControl::scrollbarThickness() const
 {
     // FIXME: We should get the size of the scrollbar from the RenderTheme instead.
-    return ScrollbarTheme::theme().scrollbarThickness(this->style().scrollbarWidth().platform(), OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize);
+    return ScrollbarTheme::theme().scrollbarThickness(Style::toPlatform(this->style().scrollbarWidth()), OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize);
 }
 
 RenderBox::LogicalExtentComputedValues RenderTextControl::computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -897,7 +897,7 @@ static bool rareInheritedDataChangeRequiresLayout(const StyleRareInheritedData& 
         || first.hangingPunctuation != second.hangingPunctuation
         || first.usedContentVisibility != second.usedContentVisibility
 #if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-        || first.webkitOverflowScrolling != second.webkitOverflowScrolling
+        || first.overflowScrolling != second.overflowScrolling
 #endif
         || first.listStyleType != second.listStyleType
         || first.listStyleImage != second.listStyleImage
@@ -911,7 +911,7 @@ static bool rareInheritedDataChangeRequiresLayout(const StyleRareInheritedData& 
     if (first.capStyle != second.capStyle
         || first.joinStyle != second.joinStyle
         || first.strokeWidth != second.strokeWidth
-        || first.miterLimit != second.miterLimit)
+        || first.strokeMiterLimit != second.strokeMiterLimit)
         return true;
 
     if (first.quotes != second.quotes)
@@ -927,21 +927,21 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
 
     if (m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr()) {
         if (m_nonInheritedData->boxData.ptr() != other.m_nonInheritedData->boxData.ptr()) {
-            if (m_nonInheritedData->boxData->width() != other.m_nonInheritedData->boxData->width()
-                || m_nonInheritedData->boxData->minWidth() != other.m_nonInheritedData->boxData->minWidth()
-                || m_nonInheritedData->boxData->maxWidth() != other.m_nonInheritedData->boxData->maxWidth()
-                || m_nonInheritedData->boxData->height() != other.m_nonInheritedData->boxData->height()
-                || m_nonInheritedData->boxData->minHeight() != other.m_nonInheritedData->boxData->minHeight()
-                || m_nonInheritedData->boxData->maxHeight() != other.m_nonInheritedData->boxData->maxHeight())
+            if (m_nonInheritedData->boxData->width != other.m_nonInheritedData->boxData->width
+                || m_nonInheritedData->boxData->minWidth != other.m_nonInheritedData->boxData->minWidth
+                || m_nonInheritedData->boxData->maxWidth != other.m_nonInheritedData->boxData->maxWidth
+                || m_nonInheritedData->boxData->height != other.m_nonInheritedData->boxData->height
+                || m_nonInheritedData->boxData->minHeight != other.m_nonInheritedData->boxData->minHeight
+                || m_nonInheritedData->boxData->maxHeight != other.m_nonInheritedData->boxData->maxHeight)
                 return true;
 
-            if (m_nonInheritedData->boxData->verticalAlign() != other.m_nonInheritedData->boxData->verticalAlign())
+            if (m_nonInheritedData->boxData->verticalAlign != other.m_nonInheritedData->boxData->verticalAlign)
                 return true;
 
-            if (m_nonInheritedData->boxData->boxSizing() != other.m_nonInheritedData->boxData->boxSizing())
+            if (m_nonInheritedData->boxData->boxSizing != other.m_nonInheritedData->boxData->boxSizing)
                 return true;
 
-            if (m_nonInheritedData->boxData->usedZIndex().isAuto() != other.m_nonInheritedData->boxData->usedZIndex().isAuto())
+            if (m_nonInheritedData->boxData->hasAutoUsedZIndex != other.m_nonInheritedData->boxData->hasAutoUsedZIndex)
                 return true;
         }
 
@@ -968,7 +968,7 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
                         return true;
 
                     // Optimize for the case where a positioned layer is moving but not changing size.
-                    if (!positionChangeIsMovementOnly(m_nonInheritedData->surroundData->inset, other.m_nonInheritedData->surroundData->inset, m_nonInheritedData->boxData->width()))
+                    if (!positionChangeIsMovementOnly(m_nonInheritedData->surroundData->inset, other.m_nonInheritedData->surroundData->inset, m_nonInheritedData->boxData->width))
                         return true;
                 }
             }
@@ -1084,7 +1084,7 @@ bool RenderStyle::changeRequiresOutOfFlowMovementLayoutOnly(const RenderStyle& o
         return false;
 
     // Optimize for the case where a out-of-flow box is moving but not changing size.
-    return (m_nonInheritedData->surroundData->inset != other.m_nonInheritedData->surroundData->inset) && positionChangeIsMovementOnly(m_nonInheritedData->surroundData->inset, other.m_nonInheritedData->surroundData->inset, m_nonInheritedData->boxData->width());
+    return (m_nonInheritedData->surroundData->inset != other.m_nonInheritedData->surroundData->inset) && positionChangeIsMovementOnly(m_nonInheritedData->surroundData->inset, other.m_nonInheritedData->surroundData->inset, m_nonInheritedData->boxData->width);
 }
 
 static bool miscDataChangeRequiresLayerRepaint(const StyleMiscNonInheritedData& first, const StyleMiscNonInheritedData& second, OptionSet<StyleDifferenceContextSensitiveProperty>& changedContextSensitiveProperties)
@@ -1368,12 +1368,12 @@ bool RenderStyle::scrollAnchoringSuppressionStyleDidChange(const RenderStyle* ot
         return false;
 
     if (m_nonInheritedData->boxData.ptr() != other->m_nonInheritedData->boxData.ptr()) {
-        if (m_nonInheritedData->boxData->width() != other->m_nonInheritedData->boxData->width()
-            || m_nonInheritedData->boxData->minWidth() != other->m_nonInheritedData->boxData->minWidth()
-            || m_nonInheritedData->boxData->maxWidth() != other->m_nonInheritedData->boxData->maxWidth()
-            || m_nonInheritedData->boxData->height() != other->m_nonInheritedData->boxData->height()
-            || m_nonInheritedData->boxData->minHeight() != other->m_nonInheritedData->boxData->minHeight()
-            || m_nonInheritedData->boxData->maxHeight() != other->m_nonInheritedData->boxData->maxHeight())
+        if (m_nonInheritedData->boxData->width != other->m_nonInheritedData->boxData->width
+            || m_nonInheritedData->boxData->minWidth != other->m_nonInheritedData->boxData->minWidth
+            || m_nonInheritedData->boxData->maxWidth != other->m_nonInheritedData->boxData->maxWidth
+            || m_nonInheritedData->boxData->height != other->m_nonInheritedData->boxData->height
+            || m_nonInheritedData->boxData->minHeight != other->m_nonInheritedData->boxData->minHeight
+            || m_nonInheritedData->boxData->maxHeight != other->m_nonInheritedData->boxData->maxHeight)
             return true;
     }
 
@@ -1555,32 +1555,32 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTransformOriginY);
         if (first.origin.z != second.origin.z)
             changingProperties.m_properties.set(CSSPropertyTransformOriginZ);
-        if (first.transformBox != second.transformBox)
+        if (static_cast<TransformBox>(first.transformBox) != static_cast<TransformBox>(second.transformBox))
             changingProperties.m_properties.set(CSSPropertyTransformBox);
         if (first.transform != second.transform)
             changingProperties.m_properties.set(CSSPropertyTransform);
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaNonInheritedBoxData = [&](auto& first, auto& second) {
-        if (first.width() != second.width())
+        if (first.width != second.width)
             changingProperties.m_properties.set(CSSPropertyWidth);
-        if (first.height() != second.height())
+        if (first.height != second.height)
             changingProperties.m_properties.set(CSSPropertyHeight);
-        if (first.minWidth() != second.minWidth())
+        if (first.minWidth != second.minWidth)
             changingProperties.m_properties.set(CSSPropertyMinWidth);
-        if (first.maxWidth() != second.maxWidth())
+        if (first.maxWidth != second.maxWidth)
             changingProperties.m_properties.set(CSSPropertyMaxWidth);
-        if (first.minHeight() != second.minHeight())
+        if (first.minHeight != second.minHeight)
             changingProperties.m_properties.set(CSSPropertyMinHeight);
-        if (first.maxHeight() != second.maxHeight())
+        if (first.maxHeight != second.maxHeight)
             changingProperties.m_properties.set(CSSPropertyMaxHeight);
-        if (first.verticalAlign() != second.verticalAlign())
+        if (first.verticalAlign != second.verticalAlign)
             changingProperties.m_properties.set(CSSPropertyVerticalAlign);
         if (first.specifiedZIndex() != second.specifiedZIndex())
             changingProperties.m_properties.set(CSSPropertyZIndex);
-        if (first.boxSizing() != second.boxSizing())
+        if (static_cast<BoxSizing>(first.boxSizing) != static_cast<BoxSizing>(second.boxSizing))
             changingProperties.m_properties.set(CSSPropertyBoxSizing);
-        if (first.boxDecorationBreak() != second.boxDecorationBreak())
+        if (static_cast<BoxDecorationBreak>(first.boxDecorationBreak) != static_cast<BoxDecorationBreak>(second.boxDecorationBreak))
             changingProperties.m_properties.set(CSSPropertyWebkitBoxDecorationBreak);
         // Non animated styles are followings.
         // usedZIndex
@@ -1599,7 +1599,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyBackgroundRepeat);
             changingProperties.m_properties.set(CSSPropertyBackgroundBlendMode);
         }
-        if (first.color != second.color)
+        if (first.backgroundColor != second.backgroundColor)
             changingProperties.m_properties.set(CSSPropertyBackgroundColor);
         if (first.outline != second.outline) {
             changingProperties.m_properties.set(CSSPropertyOutlineColor);
@@ -2033,7 +2033,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTextIndent);
         if (first.textUnderlineOffset != second.textUnderlineOffset)
             changingProperties.m_properties.set(CSSPropertyTextUnderlineOffset);
-        if (first.miterLimit != second.miterLimit)
+        if (first.strokeMiterLimit != second.strokeMiterLimit)
             changingProperties.m_properties.set(CSSPropertyStrokeMiterlimit);
         if (first.widows != second.widows)
             changingProperties.m_properties.set(CSSPropertyWidows);
@@ -2175,12 +2175,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
 
     if (m_svgStyle.ptr() != other.m_svgStyle.ptr())
         m_svgStyle->conservativelyCollectChangedAnimatableProperties(*other.m_svgStyle, changingProperties);
-}
-
-void RenderStyle::setQuotes(Style::Quotes&& quotes)
-{
-    if (m_rareInheritedData->quotes != quotes)
-        m_rareInheritedData.access().quotes = WTFMove(quotes);
 }
 
 bool RenderStyle::affectedByTransformOrigin() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -343,7 +343,6 @@ struct ScrollSnapType;
 struct ScrollTimelines;
 struct ScrollbarColor;
 struct ScrollbarGutter;
-struct ScrollbarWidth;
 struct ShapeMargin;
 struct ShapeOutside;
 struct SpeakAs;
@@ -397,6 +396,7 @@ enum class Resize : uint8_t;
 enum class SVGGlyphOrientationHorizontal : uint8_t;
 enum class SVGGlyphOrientationVertical : uint8_t;
 enum class ScrollBehavior : bool;
+enum class ScrollbarWidth : uint8_t;
 enum class TextAlignLast : uint8_t;
 enum class TextAlign : uint8_t;
 enum class WebkitOverflowScrolling : bool;
@@ -904,8 +904,6 @@ public:
     inline StyleAppearance usedAppearance() const;
 
     inline const Style::AspectRatio& aspectRatio() const;
-    inline Style::Number<CSS::Nonnegative> aspectRatioWidth() const;
-    inline Style::Number<CSS::Nonnegative> aspectRatioHeight() const;
     inline Style::Number<CSS::Nonnegative> aspectRatioLogicalWidth() const;
     inline Style::Number<CSS::Nonnegative> aspectRatioLogicalHeight() const;
     inline double logicalAspectRatio() const;
@@ -1196,7 +1194,7 @@ public:
     inline Style::ScrollbarWidth scrollbarWidth() const;
 
 #if ENABLE(TOUCH_EVENTS)
-    inline Style::Color tapHighlightColor() const;
+    inline const Style::Color& tapHighlightColor() const;
 #endif
 
 #if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
@@ -1660,9 +1658,6 @@ public:
 
     void setPointerEvents(PointerEvents p) { m_inheritedFlags.pointerEvents = static_cast<unsigned>(p); }
 
-    inline void clearAnimations();
-    inline void clearTransitions();
-
     void adjustAnimations();
     void adjustTransitions();
     void adjustBackgroundLayers();
@@ -1975,8 +1970,8 @@ public:
     void setDisallowsFastPathInheritance() { m_nonInheritedFlags.disallowsFastPathInheritance = true; }
 
     inline void setMathDepth(Style::MathDepth);
-    inline void setMathShift(const MathShift&);
-    inline void setMathStyle(const MathStyle&);
+    inline void setMathShift(MathShift);
+    inline void setMathStyle(MathStyle);
 
     void setTextSpacingTrim(Style::TextSpacingTrim);
     void setTextAutospace(Style::TextAutospace);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -74,964 +74,79 @@ namespace WebCore {
 
 using namespace CSS::Literals;
 
-inline bool RenderStyle::affectsTransform() const { return hasTransform() || hasOffsetPath() || hasRotate() || hasScale() || hasTranslate(); }
-inline Style::AlignItems RenderStyle::alignItems() const { return m_nonInheritedData->miscData->alignItems; }
-inline Style::AlignSelf RenderStyle::alignSelf() const { return m_nonInheritedData->miscData->alignSelf; }
+// MARK: - Non-property values
+
+inline bool RenderStyle::effectiveInert() const { return m_rareInheritedData->effectiveInert; }
+inline bool RenderStyle::isEffectivelyTransparent() const { return m_rareInheritedData->effectivelyTransparent; }
+inline bool RenderStyle::insideDefaultButton() const { return m_rareInheritedData->insideDefaultButton; }
+inline bool RenderStyle::insideSubmitButton() const { return m_rareInheritedData->insideSubmitButton; }
+inline bool RenderStyle::isInSubtreeWithBlendMode() const { return m_rareInheritedData->isInSubtreeWithBlendMode; }
+inline bool RenderStyle::isForceHidden() const { return m_rareInheritedData->isForceHidden; }
+inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData->rareData->usesAnchorFunctions; }
+inline EnumSet<BoxAxis> RenderStyle::anchorFunctionScrollCompensatedAxes() const { return EnumSet<BoxAxis>::fromRaw(m_nonInheritedData->rareData->anchorFunctionScrollCompensatedAxes); }
+inline bool RenderStyle::isPopoverInvoker() const { return m_nonInheritedData->rareData->isPopoverInvoker; }
+inline bool RenderStyle::autoRevealsWhenFound() const { return m_rareInheritedData->autoRevealsWhenFound; }
+inline bool RenderStyle::nativeAppearanceDisabled() const { return m_nonInheritedData->rareData->nativeAppearanceDisabled; }
+inline OptionSet<EventListenerRegionType> RenderStyle::eventListenerRegionTypes() const { return m_rareInheritedData->eventListenerRegionTypes; }
+inline std::optional<PseudoElementType> RenderStyle::pseudoElementType() const { return m_nonInheritedFlags.pseudoElementType ? std::make_optional(static_cast<PseudoElementType>(m_nonInheritedFlags.pseudoElementType - 1)) : std::nullopt; }
+inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return m_nonInheritedData->rareData->pseudoElementNameArgument; }
+inline bool RenderStyle::hasAnyPublicPseudoStyles() const { return m_nonInheritedFlags.hasAnyPublicPseudoStyles(); }
+
+// MARK: transform constants
+
 constexpr auto RenderStyle::allTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::TransformOrigin, TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
-inline const Style::Animations& RenderStyle::animations() const { return m_nonInheritedData->miscData->animations; }
-inline const Style::AnchorNames& RenderStyle::anchorNames() const { return m_nonInheritedData->rareData->anchorNames; }
-inline const Style::NameScope& RenderStyle::anchorScope() const { return m_nonInheritedData->rareData->anchorScope; }
-inline StyleAppearance RenderStyle::appearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->appearance); }
-inline const Style::AppleColorFilter& RenderStyle::appleColorFilter() const { return m_rareInheritedData->appleColorFilter->appleColorFilter; }
-#if HAVE(CORE_MATERIAL)
-inline AppleVisualEffect RenderStyle::appleVisualEffect() const { return static_cast<AppleVisualEffect>(m_nonInheritedData->rareData->appleVisualEffect); }
-#endif
-inline const Style::AspectRatio& RenderStyle::aspectRatio() const { return m_nonInheritedData->miscData->aspectRatio; }
-inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioHeight() const { return aspectRatio().height(); }
-inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioLogicalHeight() const { return writingMode().isHorizontal() ? aspectRatioHeight() : aspectRatioWidth(); }
-inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioLogicalWidth() const { return writingMode().isHorizontal() ? aspectRatioWidth() : aspectRatioHeight(); }
-inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioWidth() const { return aspectRatio().width(); }
-inline bool RenderStyle::autoWrap() const { return textWrapMode() != TextWrapMode::NoWrap; }
-inline const Style::Color& RenderStyle::backgroundColor() const { return m_nonInheritedData->backgroundData->color; }
-inline const Style::BackgroundLayers& RenderStyle::backgroundLayers() const { return m_nonInheritedData->backgroundData->background; }
-inline const Style::BlockEllipsis& RenderStyle::blockEllipsis() const { return m_rareInheritedData->blockEllipsis; }
-inline BlockStepAlign RenderStyle::blockStepAlign() const { return static_cast<BlockStepAlign>(m_nonInheritedData->rareData->blockStepAlign); }
-inline BlockStepInsert RenderStyle::blockStepInsert() const { return static_cast<BlockStepInsert>(m_nonInheritedData->rareData->blockStepInsert); }
-inline BlockStepRound RenderStyle::blockStepRound() const { return static_cast<BlockStepRound>(m_nonInheritedData->rareData->blockStepRound); }
-inline const Style::BlockStepSize& RenderStyle::blockStepSize() const { return m_nonInheritedData->rareData->blockStepSize; }
-inline const BorderData& RenderStyle::border() const { return m_nonInheritedData->surroundData->border; }
-inline Style::LineWidth RenderStyle::borderAfterWidth() const { return borderAfterWidth(writingMode()); }
-inline Style::LineWidth RenderStyle::borderBeforeWidth() const { return borderBeforeWidth(writingMode()); }
-inline const BorderValue& RenderStyle::borderBottom() const { return border().bottom(); }
-inline const Style::Color& RenderStyle::borderBottomColor() const { return border().bottom().color(); }
-inline bool RenderStyle::borderBottomIsTransparent() const { return border().bottom().isTransparent(); }
-inline const Style::BorderRadiusValue& RenderStyle::borderBottomLeftRadius() const { return border().bottomLeftRadius(); }
-inline const Style::BorderRadiusValue& RenderStyle::borderBottomRightRadius() const { return border().bottomRightRadius(); }
-inline BorderStyle RenderStyle::borderBottomStyle() const { return border().bottom().style(); }
-inline Style::LineWidth RenderStyle::borderBottomWidth() const { return border().borderBottomWidth(); }
-inline Style::LineWidth RenderStyle::borderEndWidth() const { return borderEndWidth(writingMode()); }
-inline const Style::BorderImage& RenderStyle::borderImage() const { return border().image(); }
-inline NinePieceImageRule RenderStyle::borderImageHorizontalRule() const { return borderImageRepeat().horizontalRule(); }
-inline const Style::BorderImageOutset& RenderStyle::borderImageOutset() const { return borderImage().outset(); }
-inline LayoutBoxExtent RenderStyle::borderImageOutsets() const { return imageOutsets(borderImage()); }
-inline const Style::BorderImageRepeat& RenderStyle::borderImageRepeat() const { return borderImage().repeat(); }
-inline const Style::BorderImageSlice& RenderStyle::borderImageSlice() const { return borderImage().slice(); }
-inline const Style::BorderImageSource& RenderStyle::borderImageSource() const { return borderImage().source(); }
-inline NinePieceImageRule RenderStyle::borderImageVerticalRule() const { return borderImageRepeat().verticalRule(); }
-inline const Style::BorderImageWidth& RenderStyle::borderImageWidth() const { return borderImage().width(); }
-inline const BorderValue& RenderStyle::borderLeft() const { return border().left(); }
-inline const Style::Color& RenderStyle::borderLeftColor() const { return border().left().color(); }
-inline bool RenderStyle::borderLeftIsTransparent() const { return border().left().isTransparent(); }
-inline BorderStyle RenderStyle::borderLeftStyle() const { return border().left().style(); }
-inline Style::LineWidth RenderStyle::borderLeftWidth() const { return border().borderLeftWidth(); }
-inline const Style::BorderRadius& RenderStyle::borderRadii() const { return border().radii(); }
-inline const BorderValue& RenderStyle::borderRight() const { return border().right(); }
-inline const Style::Color& RenderStyle::borderRightColor() const { return border().right().color(); }
-inline bool RenderStyle::borderRightIsTransparent() const { return border().right().isTransparent(); }
-inline BorderStyle RenderStyle::borderRightStyle() const { return border().right().style(); }
-inline Style::LineWidth RenderStyle::borderRightWidth() const { return border().borderRightWidth(); }
-inline Style::LineWidth RenderStyle::borderStartWidth() const { return borderStartWidth(writingMode()); }
-inline const BorderValue& RenderStyle::borderTop() const { return border().top(); }
-inline const Style::Color& RenderStyle::borderTopColor() const { return border().top().color(); }
-inline bool RenderStyle::borderTopIsTransparent() const { return border().top().isTransparent(); }
-inline const Style::BorderRadiusValue& RenderStyle::borderTopLeftRadius() const { return border().topLeftRadius(); }
-inline const Style::BorderRadiusValue& RenderStyle::borderTopRightRadius() const { return border().topRightRadius(); }
-inline BorderStyle RenderStyle::borderTopStyle() const { return border().top().style(); }
-inline Style::LineWidth RenderStyle::borderTopWidth() const { return border().borderTopWidth(); }
-inline Style::LineWidthBox RenderStyle::borderWidth() const { return border().borderWidth(); }
-inline Style::WebkitBorderSpacing RenderStyle::borderHorizontalSpacing() const { return m_inheritedData->borderHorizontalSpacing; }
-inline Style::WebkitBorderSpacing RenderStyle::borderVerticalSpacing() const { return m_inheritedData->borderVerticalSpacing; }
-inline const Style::InsetEdge& RenderStyle::bottom() const { return m_nonInheritedData->surroundData->inset.bottom(); }
-inline BoxAlignment RenderStyle::boxAlign() const { return static_cast<BoxAlignment>(m_nonInheritedData->miscData->deprecatedFlexibleBox->align); }
-inline Style::WebkitBoxFlex RenderStyle::boxFlex() const { return m_nonInheritedData->miscData->deprecatedFlexibleBox->flex; }
-inline Style::WebkitBoxFlexGroup RenderStyle::boxFlexGroup() const { return m_nonInheritedData->miscData->deprecatedFlexibleBox->flexGroup; }
-inline BoxLines RenderStyle::boxLines() const { return static_cast<BoxLines>(m_nonInheritedData->miscData->deprecatedFlexibleBox->lines); }
-inline Style::WebkitBoxOrdinalGroup RenderStyle::boxOrdinalGroup() const { return m_nonInheritedData->miscData->deprecatedFlexibleBox->ordinalGroup; }
-inline BoxOrient RenderStyle::boxOrient() const { return static_cast<BoxOrient>(m_nonInheritedData->miscData->deprecatedFlexibleBox->orient); }
-inline BoxPack RenderStyle::boxPack() const { return static_cast<BoxPack>(m_nonInheritedData->miscData->deprecatedFlexibleBox->pack); }
-inline const Style::WebkitBoxReflect& RenderStyle::boxReflect() const { return m_nonInheritedData->rareData->boxReflect; }
-inline bool RenderStyle::hasBoxReflect() const { return !boxReflect().isNone(); }
-inline const Style::BoxShadows& RenderStyle::boxShadow() const { return m_nonInheritedData->miscData->boxShadow; }
-inline bool RenderStyle::hasBoxShadow() const { return !boxShadow().isNone(); }
-inline BoxSizing RenderStyle::boxSizing() const { return m_nonInheritedData->boxData->boxSizing(); }
+constexpr auto RenderStyle::individualTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
+
+// MARK: Custom property support
+
+inline const Style::CustomPropertyData& RenderStyle::inheritedCustomProperties() const { return m_rareInheritedData->customProperties.get(); }
+inline const Style::CustomPropertyData& RenderStyle::nonInheritedCustomProperties() const { return m_nonInheritedData->rareData->customProperties.get(); }
+
+// MARK: Derived values
+
 inline BoxSizing RenderStyle::boxSizingForAspectRatio() const { return aspectRatio().isAutoAndRatio() ? BoxSizing::ContentBox : boxSizing(); }
-inline BreakBetween RenderStyle::breakAfter() const { return static_cast<BreakBetween>(m_nonInheritedData->rareData->breakAfter); }
-inline BreakBetween RenderStyle::breakBefore() const { return static_cast<BreakBetween>(m_nonInheritedData->rareData->breakBefore); }
-inline BreakInside RenderStyle::breakInside() const { return static_cast<BreakInside>(m_nonInheritedData->rareData->breakInside); }
-inline LineCap RenderStyle::capStyle() const { return static_cast<LineCap>(m_rareInheritedData->capStyle); }
-inline const Style::Color& RenderStyle::caretColor() const { return m_rareInheritedData->caretColor; }
-inline const Style::Clip& RenderStyle::clip() const { return m_nonInheritedData->rareData->clip; }
-inline const Style::ClipPath& RenderStyle::clipPath() const { return m_nonInheritedData->rareData->clipPath; }
 inline bool RenderStyle::collapseWhiteSpace() const { return collapseWhiteSpace(whiteSpaceCollapse()); }
-inline ColumnAxis RenderStyle::columnAxis() const { return static_cast<ColumnAxis>(m_nonInheritedData->miscData->multiCol->axis); }
-inline Style::ColumnCount RenderStyle::columnCount() const { return m_nonInheritedData->miscData->multiCol->count; }
-inline ColumnFill RenderStyle::columnFill() const { return static_cast<ColumnFill>(m_nonInheritedData->miscData->multiCol->fill); }
-inline const Style::GapGutter& RenderStyle::columnGap() const { return m_nonInheritedData->rareData->columnGap; }
-inline const Style::ItemTolerance& RenderStyle::itemTolerance() const { return m_nonInheritedData->rareData->itemTolerance; }
-inline ColumnProgression RenderStyle::columnProgression() const { return static_cast<ColumnProgression>(m_nonInheritedData->miscData->multiCol->progression); }
-inline const Style::Color& RenderStyle::columnRuleColor() const { return m_nonInheritedData->miscData->multiCol->rule.color(); }
-inline bool RenderStyle::columnRuleIsTransparent() const { return m_nonInheritedData->miscData->multiCol->rule.isTransparent(); }
-inline BorderStyle RenderStyle::columnRuleStyle() const { return m_nonInheritedData->miscData->multiCol->rule.style(); }
-inline Style::LineWidth RenderStyle::columnRuleWidth() const { return m_nonInheritedData->miscData->multiCol->ruleWidth(); }
-inline ColumnSpan RenderStyle::columnSpan() const { return static_cast<ColumnSpan>(m_nonInheritedData->miscData->multiCol->columnSpan); }
-inline Style::ColumnWidth RenderStyle::columnWidth() const { return m_nonInheritedData->miscData->multiCol->width; }
-inline const Style::LetterSpacing& RenderStyle::computedLetterSpacing() const { return m_inheritedData->fontData->letterSpacing; }
-inline Style::WebkitLocale RenderStyle::computedLocale() const { return fontDescription().computedLocale(); }
-inline const Style::WordSpacing& RenderStyle::computedWordSpacing() const { return m_inheritedData->fontData->wordSpacing; }
-inline Style::Contain RenderStyle::contain() const { return Style::Contain::fromRaw(m_nonInheritedData->rareData->contain); }
-inline const Style::ContainIntrinsicSize& RenderStyle::containIntrinsicLogicalHeight() const { return writingMode().isHorizontal() ? containIntrinsicHeight() : containIntrinsicWidth(); }
-inline const Style::ContainIntrinsicSize& RenderStyle::containIntrinsicLogicalWidth() const { return writingMode().isHorizontal() ? containIntrinsicWidth() : containIntrinsicHeight(); }
-inline const Style::ContainIntrinsicSize& RenderStyle::containIntrinsicHeight() const { return m_nonInheritedData->rareData->containIntrinsicHeight; }
-inline const Style::ContainIntrinsicSize& RenderStyle::containIntrinsicWidth() const { return m_nonInheritedData->rareData->containIntrinsicWidth; }
-inline const Style::ContainerNames& RenderStyle::containerNames() const { return m_nonInheritedData->rareData->containerNames; }
-inline ContainerType RenderStyle::containerType() const { return static_cast<ContainerType>(m_nonInheritedData->rareData->containerType); }
-inline const Style::Content& RenderStyle::content() const { return m_nonInheritedData->miscData->content; }
-inline ContentVisibility RenderStyle::contentVisibility() const { return static_cast<ContentVisibility>(m_nonInheritedData->rareData->contentVisibility); }
-inline Style::Cursor RenderStyle::cursor() const { return { m_rareInheritedData->cursorImages, cursorType() }; }
+inline bool RenderStyle::preserveNewline() const { return preserveNewline(whiteSpaceCollapse()); }
+inline bool RenderStyle::preserves3D() const { return usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
+inline bool RenderStyle::affectsTransform() const { return hasTransform() || hasOffsetPath() || hasRotate() || hasScale() || hasTranslate(); }
+inline CSSPropertyID RenderStyle::usedStrokeColorProperty() const { return hasExplicitlySetStrokeColor() ? CSSPropertyStrokeColor : CSSPropertyWebkitTextStrokeColor; }
+// ignore non-standard ::-webkit-scrollbar when standard properties are in use
+inline bool RenderStyle::usesStandardScrollbarStyle() const { return scrollbarWidth() != Style::ScrollbarWidth::Auto || !scrollbarColor().isAuto(); }
+inline bool RenderStyle::usesLegacyScrollbarStyle() const { return hasPseudoStyle(PseudoElementType::WebKitScrollbar) && !usesStandardScrollbarStyle(); }
+inline bool RenderStyle::specifiesColumns() const { return !columnCount().isAuto() || !columnWidth().isAuto() || !hasInlineColumnAxis(); }
+inline bool RenderStyle::columnRuleIsTransparent() const { return m_nonInheritedData->miscData->multiCol->columnRule.isTransparent(); }
+inline LayoutBoxExtent RenderStyle::borderImageOutsets() const { return imageOutsets(borderImage()); }
+inline LayoutBoxExtent RenderStyle::maskBorderOutsets() const { return imageOutsets(maskBorder()); }
+inline bool RenderStyle::autoWrap() const { return textWrapMode() != TextWrapMode::NoWrap; }
+inline bool RenderStyle::borderBottomIsTransparent() const { return border().bottom().isTransparent(); }
+inline bool RenderStyle::borderLeftIsTransparent() const { return border().left().isTransparent(); }
+inline bool RenderStyle::borderRightIsTransparent() const { return border().right().isTransparent(); }
+inline bool RenderStyle::borderTopIsTransparent() const { return border().top().isTransparent(); }
+
+// MARK: Cached used values
+
 inline StyleAppearance RenderStyle::usedAppearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->usedAppearance); }
+inline Style::ZIndex RenderStyle::usedZIndex() const { return m_nonInheritedData->boxData->usedZIndex(); }
+inline Style::Contain RenderStyle::usedContain() const { return m_nonInheritedData->rareData->usedContain(); }
+inline float RenderStyle::usedZoom() const { return m_rareInheritedData->usedZoom; }
+inline ContentVisibility RenderStyle::usedContentVisibility() const { return static_cast<ContentVisibility>(m_rareInheritedData->usedContentVisibility); }
+inline Style::TouchAction RenderStyle::usedTouchAction() const { return m_rareInheritedData->usedTouchAction; }
 #if HAVE(CORE_MATERIAL)
 inline AppleVisualEffect RenderStyle::usedAppleVisualEffectForSubtree() const { return static_cast<AppleVisualEffect>(m_rareInheritedData->usedAppleVisualEffectForSubtree); }
 #endif
-inline Style::Contain RenderStyle::usedContain() const { return m_nonInheritedData->rareData->usedContain(); }
-inline bool RenderStyle::effectiveInert() const { return m_rareInheritedData->effectiveInert; }
-inline bool RenderStyle::isEffectivelyTransparent() const { return m_rareInheritedData->effectivelyTransparent; }
-inline PointerEvents RenderStyle::usedPointerEvents() const { return effectiveInert() ? PointerEvents::None : pointerEvents(); }
-inline CSSPropertyID RenderStyle::usedStrokeColorProperty() const { return hasExplicitlySetStrokeColor() ? CSSPropertyStrokeColor : CSSPropertyWebkitTextStrokeColor; }
-inline Style::TouchAction RenderStyle::usedTouchAction() const { return m_rareInheritedData->usedTouchAction; }
+
+// MARK: Derived used values
+
 inline UserModify RenderStyle::usedUserModify() const { return effectiveInert() ? UserModify::ReadOnly : userModify(); }
-inline float RenderStyle::usedZoom() const { return m_rareInheritedData->usedZoom; }
-inline OptionSet<EventListenerRegionType> RenderStyle::eventListenerRegionTypes() const { return m_rareInheritedData->eventListenerRegionTypes; }
-inline FieldSizing RenderStyle::fieldSizing() const { return static_cast<FieldSizing>(m_nonInheritedData->rareData->fieldSizing); }
-inline const Style::Filter& RenderStyle::filter() const { return m_nonInheritedData->miscData->filter->filter; }
-inline const Style::FlexBasis& RenderStyle::flexBasis() const { return m_nonInheritedData->miscData->flexibleBox->flexBasis; }
-inline FlexDirection RenderStyle::flexDirection() const { return static_cast<FlexDirection>(m_nonInheritedData->miscData->flexibleBox->flexDirection); }
-inline Style::FlexGrow RenderStyle::flexGrow() const { return m_nonInheritedData->miscData->flexibleBox->flexGrow; }
-inline Style::FlexShrink RenderStyle::flexShrink() const { return m_nonInheritedData->miscData->flexibleBox->flexShrink; }
-inline FlexWrap RenderStyle::flexWrap() const { return static_cast<FlexWrap>(m_nonInheritedData->miscData->flexibleBox->flexWrap); }
-inline Style::FontFamilies RenderStyle::fontFamily() const { return { fontDescription().families(), fontDescription().isSpecifiedFont() }; }
-inline Style::FontPalette RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
-inline Style::FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
-inline Style::FontStyle RenderStyle::fontStyle() const { return { fontDescription().fontStyleSlope(), fontDescription().fontStyleAxis() }; }
-inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
-inline Style::FontFeatureSettings RenderStyle::fontFeatureSettings() const { return fontDescription().featureSettings(); }
-inline Style::FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
-inline Style::FontWeight RenderStyle::fontWeight() const { return fontDescription().weight(); }
-inline Style::FontWidth RenderStyle::fontWidth() const { return fontDescription().width(); }
-inline Kerning RenderStyle::fontKerning() const { return fontDescription().kerning(); }
-inline FontSmoothingMode RenderStyle::fontSmoothing() const { return fontDescription().fontSmoothing(); }
-inline FontSynthesisLonghandValue RenderStyle::fontSynthesisSmallCaps() const { return fontDescription().fontSynthesisSmallCaps(); }
-inline FontSynthesisLonghandValue RenderStyle::fontSynthesisStyle() const { return fontDescription().fontSynthesisStyle(); }
-inline FontSynthesisLonghandValue RenderStyle::fontSynthesisWeight() const { return fontDescription().fontSynthesisWeight(); }
-inline Style::FontVariantAlternates RenderStyle::fontVariantAlternates() const { return fontDescription().variantAlternates(); }
-inline FontVariantCaps RenderStyle::fontVariantCaps() const { return fontDescription().variantCaps(); }
-inline Style::FontVariantEastAsian RenderStyle::fontVariantEastAsian() const { return fontDescription().variantEastAsian(); }
-inline FontVariantEmoji RenderStyle::fontVariantEmoji() const { return fontDescription().variantEmoji(); }
-inline Style::FontVariantLigatures RenderStyle::fontVariantLigatures() const { return fontDescription().variantLigatures(); }
-inline Style::FontVariantNumeric RenderStyle::fontVariantNumeric() const { return fontDescription().variantNumeric(); }
-inline FontVariantPosition RenderStyle::fontVariantPosition() const { return fontDescription().variantPosition(); }
-inline Style::WebkitLocale RenderStyle::locale() const { return fontDescription().specifiedLocale(); }
-inline TextRenderingMode RenderStyle::textRendering() const { return fontDescription().textRenderingMode(); }
-inline const Style::GapGutter& RenderStyle::gap(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? columnGap() : rowGap(); }
-inline const Style::GridTrackSizes& RenderStyle::gridAutoColumns() const { return m_nonInheritedData->rareData->grid->m_gridAutoColumns; }
-inline Style::GridAutoFlow RenderStyle::gridAutoFlow() const { return m_nonInheritedData->rareData->grid->m_gridAutoFlow; }
-inline const Style::GridTrackSizes& RenderStyle::gridAutoRows() const { return m_nonInheritedData->rareData->grid->m_gridAutoRows; }
-inline const Style::GridTrackSizes& RenderStyle::gridAutoList(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridAutoColumns() : gridAutoRows(); }
-inline const Style::GridTemplateList& RenderStyle::gridTemplateColumns() const { return m_nonInheritedData->rareData->grid->m_gridTemplateColumns; }
-inline const Style::GridPosition& RenderStyle::gridItemColumnEnd() const { return m_nonInheritedData->rareData->gridItem->gridColumnEnd; }
-inline const Style::GridPosition& RenderStyle::gridItemColumnStart() const { return m_nonInheritedData->rareData->gridItem->gridColumnStart; }
-inline const Style::GridPosition& RenderStyle::gridItemEnd(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridItemColumnEnd() : gridItemRowEnd(); }
-inline const Style::GridPosition& RenderStyle::gridItemRowEnd() const { return m_nonInheritedData->rareData->gridItem->gridRowEnd; }
-inline const Style::GridPosition& RenderStyle::gridItemRowStart() const { return m_nonInheritedData->rareData->gridItem->gridRowStart; }
-inline const Style::GridPosition& RenderStyle::gridItemStart(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridItemColumnStart() : gridItemRowStart(); }
-inline const Style::GridTemplateList& RenderStyle::gridTemplateRows() const { return m_nonInheritedData->rareData->grid->m_gridTemplateRows; }
-inline const Style::GridTemplateList& RenderStyle::gridTemplateList(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridTemplateColumns() : gridTemplateRows(); }
-inline const Style::GridTemplateAreas& RenderStyle::gridTemplateAreas() const { return m_nonInheritedData->rareData->grid->m_gridTemplateAreas; }
-inline Style::HangingPunctuation RenderStyle::hangingPunctuation() const { return Style::HangingPunctuation::fromRaw(m_rareInheritedData->hangingPunctuation); }
-inline bool RenderStyle::hasAnimations() const { return !animations().isInitial(); }
-inline bool RenderStyle::hasAnimationsOrTransitions() const { return hasAnimations() || hasTransitions(); }
-inline bool RenderStyle::hasAnyPublicPseudoStyles() const { return m_nonInheritedFlags.hasAnyPublicPseudoStyles(); }
-// FIXME: Rename this function.
-inline bool RenderStyle::hasAppearance() const { return appearance() != StyleAppearance::None && appearance() != StyleAppearance::Base; }
-inline bool RenderStyle::hasAppleColorFilter() const { return !appleColorFilter().isNone(); }
-#if HAVE(CORE_MATERIAL)
-inline bool RenderStyle::hasAppleVisualEffect() const { return appleVisualEffect() != AppleVisualEffect::None; }
-inline bool RenderStyle::hasAppleVisualEffectRequiringBackdropFilter() const { return appleVisualEffectNeedsBackdrop(appleVisualEffect()); }
-#endif
-inline bool RenderStyle::hasAspectRatio() const { return aspectRatio().hasRatio(); }
-inline bool RenderStyle::hasAttrContent() const { return m_nonInheritedData->miscData->hasAttrContent; }
-inline bool RenderStyle::hasAutoCaretColor() const { return m_rareInheritedData->hasAutoCaretColor; }
-inline bool RenderStyle::hasAutoLeftAndRight() const { return left().isAuto() && right().isAuto(); }
-inline bool RenderStyle::hasAutoLengthContainIntrinsicSize() const { return containIntrinsicWidth().hasAuto() || containIntrinsicHeight().hasAuto(); }
-inline bool RenderStyle::hasAutoTopAndBottom() const { return top().isAuto() && bottom().isAuto(); }
-inline bool RenderStyle::hasBackground() const { return visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || hasBackgroundImage(); }
-inline bool RenderStyle::hasBackgroundImage() const { return Style::hasImageInAnyLayer(backgroundLayers()); }
-inline bool RenderStyle::hasBlendMode() const { return blendMode() != BlendMode::Normal; }
-inline bool RenderStyle::hasBorder() const { return border().hasBorder(); }
-inline bool RenderStyle::hasBorderImage() const { return border().hasBorderImage(); }
-inline bool RenderStyle::hasBorderImageOutsets() const { return borderImage().hasSource() && !borderImage().outset().isZero(); }
-inline bool RenderStyle::hasBorderRadius() const { return border().hasBorderRadius(); }
-inline bool RenderStyle::hasClip() const { return !clip().isAuto(); }
-inline bool RenderStyle::hasClipPath() const { return !clipPath().isNone(); }
-inline bool RenderStyle::hasContent() const { return content().isData(); }
-inline bool RenderStyle::hasDisplayAffectedByAnimations() const { return m_nonInheritedData->miscData->hasDisplayAffectedByAnimations; }
-// FIXME: Rename this function.
-inline bool RenderStyle::hasUsedAppearance() const { return usedAppearance() != StyleAppearance::None && usedAppearance() != StyleAppearance::Base; }
-inline bool RenderStyle::hasUsedContentNone() const { return content().isNone() || (content().isNormal() && (pseudoElementType() == PseudoElementType::Before || pseudoElementType() == PseudoElementType::After)); }
-inline bool RenderStyle::hasExplicitlySetBorderBottomLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomLeftRadius; }
-inline bool RenderStyle::hasExplicitlySetBorderBottomRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomRightRadius; }
-inline bool RenderStyle::hasExplicitlySetBorderRadius() const { return hasExplicitlySetBorderBottomLeftRadius() || hasExplicitlySetBorderBottomRightRadius() || hasExplicitlySetBorderTopLeftRadius() || hasExplicitlySetBorderTopRightRadius(); }
-inline bool RenderStyle::hasExplicitlySetBorderTopLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopLeftRadius; }
-inline bool RenderStyle::hasExplicitlySetBorderTopRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopRightRadius; }
-inline bool RenderStyle::hasExplicitlySetPadding() const { return hasExplicitlySetPaddingBottom() || hasExplicitlySetPaddingLeft() || hasExplicitlySetPaddingRight() || hasExplicitlySetPaddingTop(); }
-inline bool RenderStyle::hasExplicitlySetPaddingBottom() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingBottom; }
-inline bool RenderStyle::hasExplicitlySetPaddingLeft() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingLeft; }
-inline bool RenderStyle::hasExplicitlySetPaddingRight() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingRight; }
-inline bool RenderStyle::hasExplicitlySetPaddingTop() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingTop; }
-inline bool RenderStyle::hasExplicitlySetStrokeColor() const { return m_rareInheritedData->hasSetStrokeColor; }
-inline bool RenderStyle::hasFilter() const { return !filter().isNone(); }
-inline bool RenderStyle::hasInFlowPosition() const { return position() == PositionType::Relative || position() == PositionType::Sticky; }
-inline bool RenderStyle::hasIsolation() const { return isolation() != Isolation::Auto; }
-inline bool RenderStyle::hasMask() const { return Style::hasImageInAnyLayer(maskLayers()) || maskBorder().hasSource(); }
-inline bool RenderStyle::hasOffsetPath() const { return !WTF::holdsAlternative<CSS::Keyword::None>(m_nonInheritedData->rareData->offsetPath); }
-inline bool RenderStyle::hasOpacity() const { return !opacity().isOpaque(); }
-inline bool RenderStyle::hasOutOfFlowPosition() const { return position() == PositionType::Absolute || position() == PositionType::Fixed; }
-inline bool RenderStyle::hasOutline() const { return outlineStyle() != OutlineStyle::None && outlineWidth().isPositive(); }
-inline bool RenderStyle::hasOutlineInVisualOverflow() const { return hasOutline() && outlineSize() > 0; }
-inline bool RenderStyle::hasPerspective() const { return !perspective().isNone(); }
-inline bool RenderStyle::hasPositionedMask() const { return Style::hasImageInAnyLayer(maskLayers()); }
-inline bool RenderStyle::hasPseudoStyle(PseudoElementType pseudo) const { return m_nonInheritedFlags.hasPseudoStyle(pseudo); }
-inline bool RenderStyle::hasRotate() const { return !rotate().isNone(); }
-inline bool RenderStyle::hasScale() const { return !scale().isNone(); }
-inline bool RenderStyle::hasStaticBlockPosition(bool horizontal) const { return horizontal ? hasAutoTopAndBottom() : hasAutoLeftAndRight(); }
-inline bool RenderStyle::hasStaticInlinePosition(bool horizontal) const { return horizontal ? hasAutoLeftAndRight() : hasAutoTopAndBottom(); }
-inline bool RenderStyle::hasTextCombine() const { return textCombine() != TextCombine::None; }
-inline bool RenderStyle::hasTransform() const { return !transform().isNone() || hasOffsetPath(); }
-inline bool RenderStyle::hasTransformRelatedProperty() const { return hasTransform() || hasRotate() || hasScale() || hasTranslate() || transformStyle3D() == TransformStyle3D::Preserve3D || hasPerspective(); }
-inline bool RenderStyle::hasTranslate() const { return !translate().isNone(); }
-inline bool RenderStyle::hasTransitions() const { return !transitions().isInitial(); }
-inline bool RenderStyle::hasViewportConstrainedPosition() const { return position() == PositionType::Fixed || position() == PositionType::Sticky; }
-inline bool RenderStyle::hasVisibleBorder() const { return border().hasVisibleBorder(); }
-inline bool RenderStyle::hasVisibleBorderDecoration() const { return hasVisibleBorder() || hasBorderImage(); }
-inline bool RenderStyle::hasVisitedLinkAutoCaretColor() const { return m_rareInheritedData->hasVisitedLinkAutoCaretColor; }
-inline const Style::PreferredSize& RenderStyle::height() const { return m_nonInheritedData->boxData->height(); }
-inline Style::HyphenateLimitEdge RenderStyle::hyphenateLimitAfter() const { return m_rareInheritedData->hyphenateLimitAfter; }
-inline Style::HyphenateLimitEdge RenderStyle::hyphenateLimitBefore() const { return m_rareInheritedData->hyphenateLimitBefore; }
-inline Style::HyphenateLimitLines RenderStyle::hyphenateLimitLines() const { return m_rareInheritedData->hyphenateLimitLines; }
-inline const Style::HyphenateCharacter& RenderStyle::hyphenateCharacter() const { return m_rareInheritedData->hyphenateCharacter; }
-inline Hyphens RenderStyle::hyphens() const { return static_cast<Hyphens>(m_rareInheritedData->hyphens); }
-inline Style::ImageOrientation RenderStyle::imageOrientation() const { return static_cast<Style::ImageOrientation>(m_rareInheritedData->imageOrientation); }
-inline ImageRendering RenderStyle::imageRendering() const { return static_cast<ImageRendering>(m_rareInheritedData->imageRendering); }
-constexpr auto RenderStyle::individualTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
-inline const Style::CustomPropertyData& RenderStyle::inheritedCustomProperties() const { return m_rareInheritedData->customProperties.get(); }
-constexpr Style::AlignContent RenderStyle::initialAlignContent() { return CSS::Keyword::Normal { }; }
-constexpr Style::AlignItems RenderStyle::initialAlignItems() { return CSS::Keyword::Normal { }; }
-constexpr Style::AlignSelf RenderStyle::initialAlignSelf() { return CSS::Keyword::Auto { }; }
-inline Style::AnchorNames RenderStyle::initialAnchorNames() { return CSS::Keyword::None { }; }
-inline Style::NameScope RenderStyle::initialAnchorScope() { return CSS::Keyword::None { }; }
-inline Style::Animations RenderStyle::initialAnimations() { return CSS::Keyword::None { }; }
-constexpr StyleAppearance RenderStyle::initialAppearance() { return StyleAppearance::None; }
-#if HAVE(CORE_MATERIAL)
-constexpr AppleVisualEffect RenderStyle::initialAppleVisualEffect() { return AppleVisualEffect::None; }
-#endif
-inline Style::AppleColorFilter RenderStyle::initialAppleColorFilter() { return CSS::Keyword::None { }; }
-inline Style::AspectRatio RenderStyle::initialAspectRatio() { return CSS::Keyword::Auto { }; }
-constexpr BackfaceVisibility RenderStyle::initialBackfaceVisibility() { return BackfaceVisibility::Visible; }
-inline Style::Color RenderStyle::initialBackgroundColor() { return Color::transparentBlack; }
-inline Style::BackgroundLayers RenderStyle::initialBackgroundLayers() { return CSS::Keyword::None { }; }
-inline Style::BlockEllipsis RenderStyle::initialBlockEllipsis() { return CSS::Keyword::None { }; }
-constexpr BlockStepAlign RenderStyle::initialBlockStepAlign() { return BlockStepAlign::Auto; }
-constexpr BlockStepInsert RenderStyle::initialBlockStepInsert() { return BlockStepInsert::MarginBox; }
-constexpr BlockStepRound RenderStyle::initialBlockStepRound() { return BlockStepRound::Up; }
-inline Style::BlockStepSize RenderStyle::initialBlockStepSize() { return CSS::Keyword::None { }; }
-constexpr BorderCollapse RenderStyle::initialBorderCollapse() { return BorderCollapse::Separate; }
-constexpr Style::WebkitBorderSpacing RenderStyle::initialBorderHorizontalSpacing() { return 0_css_px; }
-inline Style::BorderImage RenderStyle::initialBorderImage() { return Style::BorderImage { }; }
-inline Style::BorderImageSource RenderStyle::initialBorderImageSource() { return CSS::Keyword::None { }; }
-inline Style::BorderRadiusValue RenderStyle::initialBorderRadius() { return { 0_css_px, 0_css_px }; }
-constexpr BorderStyle RenderStyle::initialBorderStyle() { return BorderStyle::None; }
-constexpr Style::WebkitBorderSpacing RenderStyle::initialBorderVerticalSpacing() { return 0_css_px; }
-constexpr Style::LineWidth RenderStyle::initialBorderWidth() { return Style::LineWidth { 3.0f }; }
-constexpr BoxAlignment RenderStyle::initialBoxAlign() { return BoxAlignment::Stretch; }
-constexpr BoxDecorationBreak RenderStyle::initialBoxDecorationBreak() { return BoxDecorationBreak::Slice; }
-constexpr BoxDirection RenderStyle::initialBoxDirection() { return BoxDirection::Normal; }
-constexpr Style::WebkitBoxFlex RenderStyle::initialBoxFlex() { return 0; }
-constexpr Style::WebkitBoxFlexGroup RenderStyle::initialBoxFlexGroup() { return 1; }
-constexpr BoxLines RenderStyle::initialBoxLines() { return BoxLines::Single; }
-constexpr Style::WebkitBoxOrdinalGroup RenderStyle::initialBoxOrdinalGroup() { return 1; }
-constexpr BoxOrient RenderStyle::initialBoxOrient() { return BoxOrient::Horizontal; }
-constexpr BoxPack RenderStyle::initialBoxPack() { return BoxPack::Start; }
-inline Style::BoxShadows RenderStyle::initialBoxShadow() { return CSS::Keyword::None { }; }
-constexpr BoxSizing RenderStyle::initialBoxSizing() { return BoxSizing::ContentBox; }
-inline Style::WebkitBoxReflect RenderStyle::initialBoxReflect() { return CSS::Keyword::None { }; }
-constexpr BreakBetween RenderStyle::initialBreakBetween() { return BreakBetween::Auto; }
-constexpr BreakInside RenderStyle::initialBreakInside() { return BreakInside::Auto; }
-constexpr LineCap RenderStyle::initialCapStyle() { return LineCap::Butt; }
-constexpr CaptionSide RenderStyle::initialCaptionSide() { return CaptionSide::Top; }
-constexpr Clear RenderStyle::initialClear() { return Clear::None; }
-inline Style::Clip RenderStyle::initialClip() { return CSS::Keyword::Auto { }; }
-inline Style::ClipPath RenderStyle::initialClipPath() { return CSS::Keyword::None { }; }
-inline Color RenderStyle::initialColor() { return Color::black; }
-constexpr ColumnAxis RenderStyle::initialColumnAxis() { return ColumnAxis::Auto; }
-constexpr Style::ColumnCount RenderStyle::initialColumnCount() { return CSS::Keyword::Auto { }; }
-constexpr ColumnFill RenderStyle::initialColumnFill() { return ColumnFill::Balance; }
-inline Style::GapGutter RenderStyle::initialColumnGap() { return CSS::Keyword::Normal { }; }
-inline Style::ItemTolerance RenderStyle::initialItemTolerance() { return CSS::Keyword::Normal { }; }
-constexpr ColumnProgression RenderStyle::initialColumnProgression() { return ColumnProgression::Normal; }
-constexpr Style::LineWidth RenderStyle::initialColumnRuleWidth() { return Style::LineWidth { 3.0f }; }
-constexpr ColumnSpan RenderStyle::initialColumnSpan() { return ColumnSpan::None; }
-constexpr Style::ColumnWidth RenderStyle::initialColumnWidth() { return CSS::Keyword::Auto { }; }
-inline Style::ContainIntrinsicSize RenderStyle::initialContainIntrinsicHeight() { return CSS::Keyword::None { }; }
-inline Style::ContainIntrinsicSize RenderStyle::initialContainIntrinsicWidth() { return CSS::Keyword::None { }; }
-inline Style::ContainerNames RenderStyle::initialContainerNames() { return CSS::Keyword::None { }; }
-constexpr ContainerType RenderStyle::initialContainerType() { return ContainerType::Normal; }
-constexpr Style::Contain RenderStyle::initialContain() { return CSS::Keyword::None { }; }
-inline Style::Content RenderStyle::initialContent() { return CSS::Keyword::Normal { }; }
-constexpr ContentVisibility RenderStyle::initialContentVisibility() { return ContentVisibility::Visible; }
-constexpr Style::CornerShapeValue RenderStyle::initialCornerShapeValue() { return Style::CornerShapeValue::round(); }
-inline Style::Cursor RenderStyle::initialCursor() { return CSS::Keyword::Auto { }; }
-constexpr TextDirection RenderStyle::initialDirection() { return TextDirection::LTR; }
-constexpr DisplayType RenderStyle::initialDisplay() { return DisplayType::Inline; }
-constexpr EmptyCell RenderStyle::initialEmptyCells() { return EmptyCell::Show; }
-constexpr FieldSizing RenderStyle::initialFieldSizing() { return FieldSizing::Fixed; }
-inline Style::Filter RenderStyle::initialFilter() { return CSS::Keyword::None { }; }
-inline Style::FlexBasis RenderStyle::initialFlexBasis() { return CSS::Keyword::Auto { }; }
-constexpr FlexDirection RenderStyle::initialFlexDirection() { return FlexDirection::Row; }
-constexpr Style::FlexGrow RenderStyle::initialFlexGrow() { return 0_css_number; }
-constexpr Style::FlexShrink RenderStyle::initialFlexShrink() { return 1_css_number; }
-constexpr FlexWrap RenderStyle::initialFlexWrap() { return FlexWrap::NoWrap; }
-constexpr Float RenderStyle::initialFloating() { return Float::None; }
-constexpr FontOpticalSizing RenderStyle::initialFontOpticalSizing() { return FontOpticalSizing::Enabled; }
-inline Style::FontFeatureSettings RenderStyle::initialFontFeatureSettings() { return CSS::Keyword::Normal { }; }
-inline Style::FontVariationSettings RenderStyle::initialFontVariationSettings() { return CSS::Keyword::Normal { }; }
-inline Style::FontPalette RenderStyle::initialFontPalette() { return CSS::Keyword::Normal { }; }
-inline Style::FontSizeAdjust RenderStyle::initialFontSizeAdjust() { return CSS::Keyword::None { }; }
-inline Style::FontStyle RenderStyle::initialFontStyle() { return CSS::Keyword::Normal { }; }
-inline Style::FontWeight RenderStyle::initialFontWeight() { return CSS::Keyword::Normal { }; }
-inline Style::FontWidth RenderStyle::initialFontWidth() { return CSS::Keyword::Normal { }; }
-constexpr Kerning RenderStyle::initialFontKerning() { return Kerning::Auto; }
-constexpr FontSmoothingMode RenderStyle::initialFontSmoothing() { return FontSmoothingMode::AutoSmoothing; }
-constexpr FontSynthesisLonghandValue RenderStyle::initialFontSynthesisSmallCaps() { return FontSynthesisLonghandValue::Auto; }
-constexpr FontSynthesisLonghandValue RenderStyle::initialFontSynthesisStyle() { return FontSynthesisLonghandValue::Auto; }
-constexpr FontSynthesisLonghandValue RenderStyle::initialFontSynthesisWeight() { return FontSynthesisLonghandValue::Auto; }
-inline Style::FontVariantAlternates RenderStyle::initialFontVariantAlternates() { return CSS::Keyword::Normal { }; }
-constexpr FontVariantCaps RenderStyle::initialFontVariantCaps() { return FontVariantCaps::Normal; }
-constexpr Style::FontVariantEastAsian RenderStyle::initialFontVariantEastAsian() { return CSS::Keyword::Normal { }; }
-constexpr FontVariantEmoji RenderStyle::initialFontVariantEmoji() { return FontVariantEmoji::Normal; }
-constexpr Style::FontVariantLigatures RenderStyle::initialFontVariantLigatures() { return CSS::Keyword::Normal { }; }
-constexpr Style::FontVariantNumeric RenderStyle::initialFontVariantNumeric() { return CSS::Keyword::Normal { }; }
-constexpr FontVariantPosition RenderStyle::initialFontVariantPosition() { return FontVariantPosition::Normal; }
-inline Style::WebkitLocale RenderStyle::initialLocale() { return CSS::Keyword::Auto { }; }
-constexpr Style::TextAutospace RenderStyle::initialTextAutospace() { return CSS::Keyword::NoAutospace { }; }
-constexpr TextRenderingMode RenderStyle::initialTextRendering() { return TextRenderingMode::AutoTextRendering; }
-constexpr Style::TextSpacingTrim RenderStyle::initialTextSpacingTrim() { return CSS::Keyword::SpaceAll { }; }
-inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }
-constexpr Style::GridAutoFlow RenderStyle::initialGridAutoFlow() { return CSS::Keyword::Row { }; }
-inline Style::GridTrackSizes RenderStyle::initialGridAutoRows() { return CSS::Keyword::Auto { }; }
-inline Style::GridPosition RenderStyle::initialGridItemColumnEnd() { return CSS::Keyword::Auto { }; }
-inline Style::GridPosition RenderStyle::initialGridItemColumnStart() { return CSS::Keyword::Auto { }; }
-inline Style::GridPosition RenderStyle::initialGridItemRowEnd() { return CSS::Keyword::Auto { }; }
-inline Style::GridPosition RenderStyle::initialGridItemRowStart() { return CSS::Keyword::Auto { }; }
-inline Style::GridTemplateList RenderStyle::initialGridTemplateColumns() { return CSS::Keyword::None { }; }
-inline Style::GridTemplateList RenderStyle::initialGridTemplateRows() { return CSS::Keyword::None { }; }
-inline Style::GridTemplateAreas RenderStyle::initialGridTemplateAreas() { return CSS::Keyword::None { }; }
-constexpr Style::HangingPunctuation RenderStyle::initialHangingPunctuation() { return CSS::Keyword::None { }; }
-constexpr Style::HyphenateLimitEdge RenderStyle::initialHyphenateLimitAfter() { return CSS::Keyword::Auto { }; }
-constexpr Style::HyphenateLimitEdge RenderStyle::initialHyphenateLimitBefore() { return CSS::Keyword::Auto { }; }
-constexpr Style::HyphenateLimitLines RenderStyle::initialHyphenateLimitLines() { return CSS::Keyword::NoLimit { }; }
-inline Style::HyphenateCharacter RenderStyle::initialHyphenateCharacter() { return CSS::Keyword::Auto { }; }
-constexpr Hyphens RenderStyle::initialHyphens() { return Hyphens::Manual; }
-constexpr Style::ImageOrientation RenderStyle::initialImageOrientation() { return Style::ImageOrientation::FromImage; }
-constexpr ImageRendering RenderStyle::initialImageRendering() { return ImageRendering::Auto; }
-inline Style::InsetEdge RenderStyle::initialInset() { return CSS::Keyword::Auto { }; }
-constexpr Style::WebkitInitialLetter RenderStyle::initialInitialLetter() { return CSS::Keyword::Normal { }; }
-constexpr InputSecurity RenderStyle::initialInputSecurity() { return InputSecurity::Auto; }
-constexpr LineJoin RenderStyle::initialJoinStyle() { return LineJoin::Miter; }
-constexpr Style::JustifyContent RenderStyle::initialJustifyContent() { return CSS::Keyword::Normal { }; }
-constexpr Style::JustifyItems RenderStyle::initialJustifyItems() { return CSS::Keyword::Legacy { }; }
-constexpr Style::JustifySelf RenderStyle::initialJustifySelf() { return CSS::Keyword::Auto { }; }
-inline const Style::InsetBox& RenderStyle::insetBox() const { return m_nonInheritedData->surroundData->inset; }
-inline const Style::WebkitInitialLetter& RenderStyle::initialLetter() const { return m_nonInheritedData->rareData->initialLetter; }
-inline Style::LetterSpacing RenderStyle::initialLetterSpacing() { return CSS::Keyword::Normal { }; }
-constexpr LineAlign RenderStyle::initialLineAlign() { return LineAlign::None; }
-constexpr Style::WebkitLineBoxContain RenderStyle::initialLineBoxContain() { return { Style::WebkitLineBoxContainValue::Block, Style::WebkitLineBoxContainValue::Inline, Style::WebkitLineBoxContainValue::Replaced }; }
-constexpr LineBreak RenderStyle::initialLineBreak() { return LineBreak::Auto; }
-constexpr Style::WebkitLineClamp RenderStyle::initialLineClamp() { return CSS::Keyword::None { }; }
-inline Style::WebkitLineGrid RenderStyle::initialLineGrid() { return CSS::Keyword::None { }; }
-inline Style::LineHeight RenderStyle::initialLineHeight() { return CSS::Keyword::Normal { }; }
-constexpr LineSnap RenderStyle::initialLineSnap() { return LineSnap::None; }
-inline Style::ImageOrNone RenderStyle::initialListStyleImage() { return CSS::Keyword::None { }; }
-constexpr ListStylePosition RenderStyle::initialListStylePosition() { return ListStylePosition::Outside; }
-inline Style::ListStyleType RenderStyle::initialListStyleType() { return CSS::Keyword::Disc { }; }
-inline Style::MarginEdge RenderStyle::initialMargin() { return 0_css_px; }
-constexpr Style::MarginTrim RenderStyle::initialMarginTrim() { return CSS::Keyword::None { }; }
-constexpr MarqueeBehavior RenderStyle::initialMarqueeBehavior() { return MarqueeBehavior::Scroll; }
-constexpr MarqueeDirection RenderStyle::initialMarqueeDirection() { return MarqueeDirection::Auto; }
-inline Style::WebkitMarqueeIncrement RenderStyle::initialMarqueeIncrement() { return 6_css_px; }
-constexpr Style::WebkitMarqueeRepetition RenderStyle::initialMarqueeRepetition() { return CSS::Keyword::Infinite { }; }
-constexpr Style::WebkitMarqueeSpeed RenderStyle::initialMarqueeSpeed() { return 85_css_ms; }
-inline Style::MaskBorder RenderStyle::initialMaskBorder() { return Style::MaskBorder { }; }
-inline Style::MaskBorderSource RenderStyle::initialMaskBorderSource() { return CSS::Keyword::None { }; }
-inline Style::MaskLayers RenderStyle::initialMaskLayers() { return CSS::Keyword::None { }; }
-constexpr Style::MathDepth RenderStyle::initialMathDepth() { return 0_css_integer; }
-constexpr MathShift RenderStyle::initialMathShift() { return MathShift::Normal; }
-constexpr MathStyle RenderStyle::initialMathStyle() { return MathStyle::Normal; }
-constexpr Style::MaximumLines RenderStyle::initialMaxLines() { return CSS::Keyword::None { }; }
-inline Style::MaximumSize RenderStyle::initialMaxSize() { return CSS::Keyword::None { }; }
-inline Style::MinimumSize RenderStyle::initialMinSize() { return CSS::Keyword::Auto { }; }
-constexpr NBSPMode RenderStyle::initialNBSPMode() { return NBSPMode::Normal; }
-constexpr ObjectFit RenderStyle::initialObjectFit() { return ObjectFit::Fill; }
-inline Style::ObjectPosition RenderStyle::initialObjectPosition() { return { 50_css_percentage, 50_css_percentage }; }
-inline Style::OffsetAnchor RenderStyle::initialOffsetAnchor() { return CSS::Keyword::Auto { }; }
-inline Style::OffsetDistance RenderStyle::initialOffsetDistance() { return 0_css_px; }
-inline Style::OffsetPath RenderStyle::initialOffsetPath() { return CSS::Keyword::None { }; }
-inline Style::OffsetPosition RenderStyle::initialOffsetPosition() { return CSS::Keyword::Normal { }; }
-constexpr Style::OffsetRotate RenderStyle::initialOffsetRotate() { return CSS::Keyword::Auto { }; }
-constexpr Style::Opacity RenderStyle::initialOpacity() { return 1_css_number; }
-constexpr Style::Order RenderStyle::initialOrder() { return 0_css_integer; }
-constexpr Style::Orphans RenderStyle::initialOrphans() { return CSS::Keyword::Auto { }; }
-constexpr OverflowAnchor RenderStyle::initialOverflowAnchor() { return OverflowAnchor::Auto; }
-inline OverflowContinue RenderStyle::initialOverflowContinue() { return OverflowContinue::Auto; }
-constexpr Style::Length<> RenderStyle::initialOutlineOffset() { return 0_css_px; }
-constexpr OutlineStyle RenderStyle::initialOutlineStyle() { return OutlineStyle::None; }
-constexpr Style::LineWidth RenderStyle::initialOutlineWidth() { return Style::LineWidth { 3.0f }; }
-constexpr OverflowWrap RenderStyle::initialOverflowWrap() { return OverflowWrap::Normal; }
-constexpr Overflow RenderStyle::initialOverflowX() { return Overflow::Visible; }
-constexpr Overflow RenderStyle::initialOverflowY() { return Overflow::Visible; }
-constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorX() { return OverscrollBehavior::Auto; }
-constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorY() { return OverscrollBehavior::Auto; }
-inline Style::PaddingEdge RenderStyle::initialPadding() { return 0_css_px; }
-inline Style::PageSize RenderStyle::initialPageSize() { return CSS::Keyword::Auto { }; }
-constexpr Style::SVGPaintOrder RenderStyle::initialPaintOrder() { return CSS::Keyword::Normal { }; }
-inline Style::Perspective RenderStyle::initialPerspective() { return CSS::Keyword::None { }; }
-inline Style::PerspectiveOrigin RenderStyle::initialPerspectiveOrigin() { return { initialPerspectiveOriginX(), initialPerspectiveOriginY() }; }
-inline Style::PerspectiveOriginX RenderStyle::initialPerspectiveOriginX() { return 50_css_percentage; }
-inline Style::PerspectiveOriginY RenderStyle::initialPerspectiveOriginY() { return 50_css_percentage; }
-constexpr PointerEvents RenderStyle::initialPointerEvents() { return PointerEvents::Auto; }
-constexpr PositionType RenderStyle::initialPosition() { return PositionType::Static; }
-inline Style::PositionAnchor RenderStyle::initialPositionAnchor() { return CSS::Keyword::Auto { }; }
-inline Style::PositionArea RenderStyle::initialPositionArea() { return CSS::Keyword::None { }; }
-inline Style::PositionTryFallbacks RenderStyle::initialPositionTryFallbacks() { return CSS::Keyword::None { }; }
-constexpr Style::PositionTryOrder RenderStyle::initialPositionTryOrder() { return Style::PositionTryOrder::Normal; }
-constexpr Style::PositionVisibility RenderStyle::initialPositionVisibility() { return Style::PositionVisibilityValue::AnchorsVisible; }
-constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
-inline Style::Quotes RenderStyle::initialQuotes() { return CSS::Keyword::Auto { }; }
-constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
-constexpr Style::Resize RenderStyle::initialResize() { return Style::Resize::None; }
-inline Style::GapGutter RenderStyle::initialRowGap() { return CSS::Keyword::Normal { }; }
-constexpr RubyPosition RenderStyle::initialRubyPosition() { return RubyPosition::Over; }
-constexpr RubyAlign RenderStyle::initialRubyAlign() { return RubyAlign::SpaceAround; }
-constexpr RubyOverhang RenderStyle::initialRubyOverhang() { return RubyOverhang::Auto; }
-constexpr Style::ScrollBehavior RenderStyle::initialScrollBehavior() { return Style::ScrollBehavior::Auto; }
-inline Style::ScrollMarginEdge RenderStyle::initialScrollMargin() { return 0_css_px; }
-inline Style::ScrollPaddingEdge RenderStyle::initialScrollPadding() { return CSS::Keyword::Auto { }; }
-constexpr Style::ScrollSnapAlign RenderStyle::initialScrollSnapAlign() { return CSS::Keyword::None { }; }
-constexpr ScrollSnapStop RenderStyle::initialScrollSnapStop() { return ScrollSnapStop::Normal; }
-constexpr Style::ScrollSnapType RenderStyle::initialScrollSnapType() { return CSS::Keyword::None { }; }
-inline Style::ProgressTimelineAxes RenderStyle::initialScrollTimelineAxes() { return CSS::Keyword::Block { }; }
-inline Style::ProgressTimelineNames RenderStyle::initialScrollTimelineNames() { return CSS::Keyword::None { }; }
-inline Style::ScrollbarColor RenderStyle::initialScrollbarColor() { return CSS::Keyword::Auto { }; }
-constexpr Style::ScrollbarGutter RenderStyle::initialScrollbarGutter() { return CSS::Keyword::Auto { }; }
-constexpr Style::ScrollbarWidth RenderStyle::initialScrollbarWidth() { return CSS::Keyword::Auto { }; }
-constexpr Style::ShapeImageThreshold RenderStyle::initialShapeImageThreshold() { return 0_css_number; }
-inline Style::ShapeMargin RenderStyle::initialShapeMargin() { return 0_css_px; }
-inline Style::ShapeOutside RenderStyle::initialShapeOutside() { return CSS::Keyword::None { }; }
-inline Style::PreferredSize RenderStyle::initialSize() { return CSS::Keyword::Auto { }; }
-constexpr Style::SpeakAs RenderStyle::initialSpeakAs() { return CSS::Keyword::Normal { }; }
-constexpr Style::ZIndex RenderStyle::initialSpecifiedZIndex() { return CSS::Keyword::Auto { }; }
-inline Style::Color RenderStyle::initialStrokeColor() { return { Color::transparentBlack }; }
-constexpr Style::StrokeMiterlimit RenderStyle::initialStrokeMiterLimit() { return 4_css_number; }
-inline Style::StrokeWidth RenderStyle::initialStrokeWidth() { return 1_css_px; }
-constexpr Style::TabSize RenderStyle::initialTabSize() { return 8_css_number; }
-constexpr TableLayoutType RenderStyle::initialTableLayout() { return TableLayoutType::Auto; }
-constexpr Style::TextAlign RenderStyle::initialTextAlign() { return Style::TextAlign::Start; }
-constexpr Style::TextAlignLast RenderStyle::initialTextAlignLast() { return Style::TextAlignLast::Auto; }
-constexpr TextBoxTrim RenderStyle::initialTextBoxTrim() { return TextBoxTrim::None; }
-constexpr Style::TextBoxEdge RenderStyle::initialTextBoxEdge() { return CSS::Keyword::Auto { }; }
-constexpr Style::LineFitEdge RenderStyle::initialLineFitEdge() { return CSS::Keyword::Leading { }; }
-constexpr TextCombine RenderStyle::initialTextCombine() { return TextCombine::None; }
-inline Style::Color RenderStyle::initialTextDecorationColor() { return CSS::Keyword::Currentcolor { }; }
-constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLine() { return CSS::Keyword::None { }; }
-constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLineInEffect() { return initialTextDecorationLine(); }
-constexpr TextDecorationSkipInk RenderStyle::initialTextDecorationSkipInk() { return TextDecorationSkipInk::Auto; }
-constexpr TextDecorationStyle RenderStyle::initialTextDecorationStyle() { return TextDecorationStyle::Solid; }
-inline Style::TextDecorationThickness RenderStyle::initialTextDecorationThickness() { return CSS::Keyword::Auto { }; }
-inline Style::Color RenderStyle::initialTextEmphasisColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::TextEmphasisStyle RenderStyle::initialTextEmphasisStyle() { return CSS::Keyword::None { }; }
-constexpr Style::TextEmphasisPosition RenderStyle::initialTextEmphasisPosition() { return { Style::TextEmphasisPositionValue::Over, Style::TextEmphasisPositionValue::Right }; }
-inline Style::Color RenderStyle::initialTextFillColor() { return CSS::Keyword::Currentcolor { }; }
-inline bool RenderStyle::hasExplicitlySetColor() const { return m_inheritedFlags.hasExplicitlySetColor; }
-constexpr TextGroupAlign RenderStyle::initialTextGroupAlign() { return TextGroupAlign::None; }
-inline Style::TextIndent RenderStyle::initialTextIndent() { return 0_css_px; }
-constexpr TextJustify RenderStyle::initialTextJustify() { return TextJustify::Auto; }
-constexpr TextOrientation RenderStyle::initialTextOrientation() { return TextOrientation::Mixed; }
-constexpr TextOverflow RenderStyle::initialTextOverflow() { return TextOverflow::Clip; }
-constexpr TextSecurity RenderStyle::initialTextSecurity() { return TextSecurity::None; }
-inline Style::TextShadows RenderStyle::initialTextShadow() { return CSS::Keyword::None { }; }
-inline Style::Color RenderStyle::initialTextStrokeColor() { return CSS::Keyword::Currentcolor { }; }
-constexpr Style::WebkitTextStrokeWidth RenderStyle::initialTextStrokeWidth() { return 0_css_px; }
-constexpr Style::TextTransform RenderStyle::initialTextTransform() { return CSS::Keyword::None { }; }
-inline Style::TextUnderlineOffset RenderStyle::initialTextUnderlineOffset() { return CSS::Keyword::Auto { }; }
-constexpr Style::TextUnderlinePosition RenderStyle::initialTextUnderlinePosition() { return CSS::Keyword::Auto { }; }
-constexpr TextWrapMode RenderStyle::initialTextWrapMode() { return TextWrapMode::Wrap; }
-constexpr TextWrapStyle RenderStyle::initialTextWrapStyle() { return TextWrapStyle::Auto; }
-constexpr TextZoom RenderStyle::initialTextZoom() { return TextZoom::Normal; }
-constexpr Style::TouchAction RenderStyle::initialTouchAction() { return CSS::Keyword::Auto { }; }
-inline Style::Transform RenderStyle::initialTransform() { return CSS::Keyword::None { }; }
-constexpr TransformBox RenderStyle::initialTransformBox() { return TransformBox::ViewBox; }
-inline Style::Transitions RenderStyle::initialTransitions() { return CSS::Keyword::All { }; }
-inline Style::Rotate RenderStyle::initialRotate() { return CSS::Keyword::None { }; }
-inline Style::Scale RenderStyle::initialScale() { return CSS::Keyword::None { }; }
-inline Style::Translate RenderStyle::initialTranslate() { return CSS::Keyword::None { }; }
-inline Style::TransformOrigin RenderStyle::initialTransformOrigin() { return { initialTransformOriginX(), initialTransformOriginY(), initialTransformOriginZ() }; }
-inline Style::TransformOriginX RenderStyle::initialTransformOriginX() { return 50_css_percentage; }
-inline Style::TransformOriginY RenderStyle::initialTransformOriginY() { return 50_css_percentage; }
-inline Style::TransformOriginZ RenderStyle::initialTransformOriginZ() { return 0_css_px; }
-constexpr TransformStyle3D RenderStyle::initialTransformStyle3D() { return TransformStyle3D::Flat; }
-constexpr UnicodeBidi RenderStyle::initialUnicodeBidi() { return UnicodeBidi::Normal; }
-constexpr Style::ZIndex RenderStyle::initialUsedZIndex() { return CSS::Keyword::Auto { }; }
-constexpr UserDrag RenderStyle::initialUserDrag() { return UserDrag::Auto; }
-constexpr UserModify RenderStyle::initialUserModify() { return UserModify::ReadOnly; }
-constexpr UserSelect RenderStyle::initialUserSelect() { return UserSelect::Text; }
-inline Style::VerticalAlign RenderStyle::initialVerticalAlign() { return CSS::Keyword::Baseline { }; }
-inline Style::ProgressTimelineAxes RenderStyle::initialViewTimelineAxes() { return CSS::Keyword::Block { };}
-inline Style::ViewTimelineInsets RenderStyle::initialViewTimelineInsets() { return CSS::Keyword::Auto { };}
-inline Style::ProgressTimelineNames RenderStyle::initialViewTimelineNames() { return CSS::Keyword::None { }; }
-inline Style::ViewTransitionClasses RenderStyle::initialViewTransitionClasses() { return CSS::Keyword::None { }; }
-inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { return CSS::Keyword::None { }; }
-constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
-inline Style::NameScope RenderStyle::initialTimelineScope() { return CSS::Keyword::None { }; }
-constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
-constexpr Style::Widows RenderStyle::initialWidows() { return CSS::Keyword::Auto { }; }
-inline Style::WillChange RenderStyle::initialWillChange() { return CSS::Keyword::Auto { }; }
-constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
-inline Style::WordSpacing RenderStyle::initialWordSpacing() { return CSS::Keyword::Normal { }; }
-constexpr StyleWritingMode RenderStyle::initialWritingMode() { return StyleWritingMode::HorizontalTb; }
-inline InputSecurity RenderStyle::inputSecurity() const { return static_cast<InputSecurity>(m_nonInheritedData->rareData->inputSecurity); }
-inline bool RenderStyle::isColumnFlexDirection() const { return flexDirection() == FlexDirection::Column || flexDirection() == FlexDirection::ColumnReverse; }
-inline bool RenderStyle::isRowFlexDirection() const { return flexDirection() == FlexDirection::Row || flexDirection() == FlexDirection::RowReverse; }
-constexpr bool RenderStyle::isDisplayBlockLevel() const { return isDisplayBlockType(display()); }
-constexpr bool RenderStyle::isDisplayDeprecatedFlexibleBox(DisplayType display) { return display == DisplayType::Box || display == DisplayType::InlineBox; }
-constexpr bool RenderStyle::isDisplayFlexibleBox(DisplayType display) { return display == DisplayType::Flex || display == DisplayType::InlineFlex; }
-constexpr bool RenderStyle::isDisplayDeprecatedFlexibleBox() const { return isDisplayDeprecatedFlexibleBox(display()); }
-constexpr bool RenderStyle::isDisplayFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox() const { return isDisplayFlexibleOrGridFormattingContextBox() || isDisplayDeprecatedFlexibleBox(); }
-constexpr bool RenderStyle::isDisplayFlexibleOrGridFormattingContextBox() const { return isDisplayFlexibleOrGridFormattingContextBox(display()); }
-constexpr bool RenderStyle::isDisplayFlexibleOrGridFormattingContextBox(DisplayType display) { return isDisplayFlexibleBox(display) || isDisplayGridFormattingContextBox(display); }
-constexpr bool RenderStyle::isDisplayGridFormattingContextBox(DisplayType display) { return isDisplayGridBox(display) || isDisplayGridLanesBox(display); }
-constexpr bool RenderStyle::isDisplayGridBox(DisplayType display) { return display == DisplayType::Grid || display == DisplayType::InlineGrid; }
-constexpr bool RenderStyle::isDisplayGridLanesBox(DisplayType display) { return display == DisplayType::GridLanes || display == DisplayType::InlineGridLanes; }
-constexpr bool RenderStyle::isDisplayInlineType() const { return isDisplayInlineType(display()); }
-constexpr bool RenderStyle::isDisplayListItemType(DisplayType display) { return display == DisplayType::ListItem; }
-constexpr bool RenderStyle::isDisplayTableOrTablePart() const { return isDisplayTableOrTablePart(display()); }
-constexpr bool RenderStyle::isInternalTableBox() const { return isInternalTableBox(display()); }
-constexpr bool RenderStyle::isRubyContainerOrInternalRubyBox() const { return isRubyContainerOrInternalRubyBox(display()); }
-inline bool RenderStyle::isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && (logicalWidth().isSpecified() || logicalWidth().isFitContent() || logicalWidth().isFillAvailable() || logicalWidth().isMinContent()); }
-inline bool RenderStyle::isFloating() const { return floating() != Float::None; }
-constexpr bool RenderStyle::isOriginalDisplayBlockType() const { return isDisplayBlockType(originalDisplay()); }
-constexpr bool RenderStyle::isOriginalDisplayInlineType() const { return isDisplayInlineType(originalDisplay()); }
-constexpr bool RenderStyle::isOriginalDisplayListItemType() const { return isDisplayListItemType(originalDisplay()); }
-inline bool RenderStyle::isOverflowVisible() const { return overflowX() == Overflow::Visible || overflowY() == Overflow::Visible; }
-inline bool RenderStyle::isReverseFlexDirection() const { return flexDirection() == FlexDirection::RowReverse || flexDirection() == FlexDirection::ColumnReverse; }
-inline LineJoin RenderStyle::joinStyle() const { return static_cast<LineJoin>(m_rareInheritedData->joinStyle); }
-inline Style::JustifyContent RenderStyle::justifyContent() const { return m_nonInheritedData->miscData->justifyContent; }
-inline Style::JustifyItems RenderStyle::justifyItems() const { return m_nonInheritedData->miscData->justifyItems; }
-inline Style::JustifySelf RenderStyle::justifySelf() const { return m_nonInheritedData->miscData->justifySelf; }
-inline const Style::InsetEdge& RenderStyle::left() const { return m_nonInheritedData->surroundData->inset.left(); }
-inline float RenderStyle::usedLetterSpacing() const { return m_inheritedData->fontData->fontCascade.letterSpacing(); }
-inline const FontCascade& RenderStyle::fontCascade() const { return m_inheritedData->fontData->fontCascade; }
-inline LineAlign RenderStyle::lineAlign() const { return static_cast<LineAlign>(m_rareInheritedData->lineAlign); }
-inline Style::WebkitLineBoxContain RenderStyle::lineBoxContain() const { return Style::WebkitLineBoxContain::fromRaw(m_rareInheritedData->lineBoxContain); }
-inline LineBreak RenderStyle::lineBreak() const { return static_cast<LineBreak>(m_rareInheritedData->lineBreak); }
-inline const Style::WebkitLineClamp& RenderStyle::lineClamp() const { return m_nonInheritedData->rareData->lineClamp; }
-inline const Style::WebkitLineGrid& RenderStyle::lineGrid() const { return m_rareInheritedData->lineGrid; }
-inline LineSnap RenderStyle::lineSnap() const { return static_cast<LineSnap>(m_rareInheritedData->lineSnap); }
-inline const Style::ImageOrNone& RenderStyle::listStyleImage() const { return m_rareInheritedData->listStyleImage; }
-inline const Style::ListStyleType& RenderStyle::listStyleType() const { return m_rareInheritedData->listStyleType; }
-inline const Style::InsetEdge& RenderStyle::logicalBottom() const { return m_nonInheritedData->surroundData->inset.after(writingMode()); }
-inline const Style::PreferredSize& RenderStyle::logicalHeight() const { return logicalHeight(writingMode()); }
-inline const Style::PreferredSize& RenderStyle::logicalHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? height() : width(); }
-inline const Style::InsetEdge& RenderStyle::logicalLeft() const { return m_nonInheritedData->surroundData->inset.logicalLeft(writingMode()); }
-inline const Style::MaximumSize& RenderStyle::logicalMaxHeight() const { return logicalMaxHeight(writingMode()); }
-inline const Style::MaximumSize& RenderStyle::logicalMaxHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? maxHeight() : maxWidth(); }
-inline const Style::MaximumSize& RenderStyle::logicalMaxWidth() const { return logicalMaxWidth(writingMode()); }
-inline const Style::MaximumSize& RenderStyle::logicalMaxWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? maxWidth() : maxHeight(); }
-inline const Style::MinimumSize& RenderStyle::logicalMinHeight() const { return logicalMinHeight(writingMode()); }
-inline const Style::MinimumSize& RenderStyle::logicalMinHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? minHeight() : minWidth(); }
-inline const Style::MinimumSize& RenderStyle::logicalMinWidth() const { return logicalMinWidth(writingMode()); }
-inline const Style::MinimumSize& RenderStyle::logicalMinWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? minWidth() : minHeight(); }
-inline const Style::InsetEdge& RenderStyle::logicalRight() const { return m_nonInheritedData->surroundData->inset.logicalRight(writingMode()); }
-inline const Style::InsetEdge& RenderStyle::logicalTop() const { return m_nonInheritedData->surroundData->inset.before(writingMode()); }
-inline const Style::PreferredSize& RenderStyle::logicalWidth() const { return logicalWidth(writingMode()); }
-inline const Style::PreferredSize& RenderStyle::logicalWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? width() : height(); }
-inline const Style::MarginBox& RenderStyle::marginBox() const { return m_nonInheritedData->surroundData->margin; }
-inline const Style::MarginEdge& RenderStyle::marginAfter() const { return marginAfter(writingMode()); }
-inline const Style::MarginEdge& RenderStyle::marginAfter(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.after(writingMode); }
-inline const Style::MarginEdge& RenderStyle::marginBefore() const { return marginBefore(writingMode()); }
-inline const Style::MarginEdge& RenderStyle::marginBefore(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.before(writingMode); }
-inline const Style::MarginEdge& RenderStyle::marginBottom() const { return m_nonInheritedData->surroundData->margin.bottom(); }
-inline const Style::MarginEdge& RenderStyle::marginEnd() const { return marginEnd(writingMode()); }
-inline const Style::MarginEdge& RenderStyle::marginEnd(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.end(writingMode); }
-inline const Style::MarginEdge& RenderStyle::marginLeft() const { return m_nonInheritedData->surroundData->margin.left(); }
-inline const Style::MarginEdge& RenderStyle::marginRight() const { return m_nonInheritedData->surroundData->margin.right(); }
-inline const Style::MarginEdge& RenderStyle::marginStart() const { return marginStart(writingMode()); }
-inline const Style::MarginEdge& RenderStyle::marginStart(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.start(writingMode); }
-inline const Style::MarginEdge& RenderStyle::marginTop() const { return m_nonInheritedData->surroundData->margin.top(); }
-inline Style::MarginTrim RenderStyle::marginTrim() const { return Style::MarginTrim::fromRaw(m_nonInheritedData->rareData->marginTrim); }
-inline MarqueeBehavior RenderStyle::marqueeBehavior() const { return static_cast<MarqueeBehavior>(m_nonInheritedData->rareData->marquee->behavior); }
-inline MarqueeDirection RenderStyle::marqueeDirection() const { return static_cast<MarqueeDirection>(m_nonInheritedData->rareData->marquee->direction); }
-inline const Style::WebkitMarqueeIncrement& RenderStyle::marqueeIncrement() const { return m_nonInheritedData->rareData->marquee->increment; }
-inline Style::WebkitMarqueeRepetition RenderStyle::marqueeRepetition() const { return m_nonInheritedData->rareData->marquee->repetition; }
-inline Style::WebkitMarqueeSpeed RenderStyle::marqueeSpeed() const { return m_nonInheritedData->rareData->marquee->speed; }
-inline const Style::MaskBorder& RenderStyle::maskBorder() const { return m_nonInheritedData->rareData->maskBorder; }
-inline NinePieceImageRule RenderStyle::maskBorderHorizontalRule() const { return maskBorderRepeat().horizontalRule(); }
-inline const Style::MaskBorderOutset& RenderStyle::maskBorderOutset() const { return maskBorder().outset(); }
-inline LayoutBoxExtent RenderStyle::maskBorderOutsets() const { return imageOutsets(maskBorder()); }
-inline const Style::MaskBorderRepeat& RenderStyle::maskBorderRepeat() const { return maskBorder().repeat(); }
-inline const Style::MaskBorderSlice& RenderStyle::maskBorderSlice() const { return maskBorder().slice(); }
-inline const Style::MaskBorderSource& RenderStyle::maskBorderSource() const { return maskBorder().source(); }
-inline NinePieceImageRule RenderStyle::maskBorderVerticalRule() const { return maskBorderRepeat().verticalRule(); }
-inline const Style::MaskBorderWidth& RenderStyle::maskBorderWidth() const { return maskBorder().width(); }
-inline const Style::MaskLayers& RenderStyle::maskLayers() const { return m_nonInheritedData->miscData->mask; }
-inline Style::MathDepth RenderStyle::mathDepth() const { return m_rareInheritedData->mathDepth; }
-inline MathShift RenderStyle::mathShift() const { return static_cast<MathShift>(m_rareInheritedData->mathShift); }
-inline MathStyle RenderStyle::mathStyle() const { return static_cast<MathStyle>(m_rareInheritedData->mathStyle); }
-inline const Style::MaximumSize& RenderStyle::maxHeight() const { return m_nonInheritedData->boxData->maxHeight(); }
-inline Style::MaximumLines RenderStyle::maxLines() const { return m_nonInheritedData->rareData->maxLines; }
-inline const Style::MaximumSize& RenderStyle::maxWidth() const { return m_nonInheritedData->boxData->maxWidth(); }
-inline const Style::MinimumSize& RenderStyle::minHeight() const { return m_nonInheritedData->boxData->minHeight(); }
-inline const Style::MinimumSize& RenderStyle::minWidth() const { return m_nonInheritedData->boxData->minWidth(); }
-inline NBSPMode RenderStyle::nbspMode() const { return static_cast<NBSPMode>(m_rareInheritedData->nbspMode); }
-inline const Style::CustomPropertyData& RenderStyle::nonInheritedCustomProperties() const { return m_nonInheritedData->rareData->customProperties.get(); }
-inline ObjectFit RenderStyle::objectFit() const { return static_cast<ObjectFit>(m_nonInheritedData->miscData->objectFit); }
-inline const Style::ObjectPosition& RenderStyle::objectPosition() const { return m_nonInheritedData->miscData->objectPosition; }
-inline const Style::OffsetAnchor& RenderStyle::offsetAnchor() const { return m_nonInheritedData->rareData->offsetAnchor; }
-inline const Style::OffsetDistance& RenderStyle::offsetDistance() const { return m_nonInheritedData->rareData->offsetDistance; }
-inline const Style::OffsetPath& RenderStyle::offsetPath() const { return m_nonInheritedData->rareData->offsetPath; }
-inline const Style::OffsetPosition& RenderStyle::offsetPosition() const { return m_nonInheritedData->rareData->offsetPosition; }
-inline const Style::OffsetRotate& RenderStyle::offsetRotate() const { return m_nonInheritedData->rareData->offsetRotate; }
-inline Style::Opacity RenderStyle::opacity() const { return m_nonInheritedData->miscData->opacity; }
-inline Style::Order RenderStyle::order() const { return m_nonInheritedData->miscData->order; }
-inline Style::Orphans RenderStyle::orphans() const { return m_rareInheritedData->orphans; }
-inline const OutlineValue& RenderStyle::outline() const { return m_nonInheritedData->backgroundData->outline; }
-inline const Style::Color& RenderStyle::outlineColor() const { return outline().color(); }
-inline OutlineStyle RenderStyle::outlineStyle() const { return outline().style(); }
-inline OverflowAnchor RenderStyle::overflowAnchor() const { return static_cast<OverflowAnchor>(m_nonInheritedData->rareData->overflowAnchor); }
-inline OverflowContinue RenderStyle::overflowContinue() const { return m_nonInheritedData->rareData->overflowContinue; }
-inline OverflowWrap RenderStyle::overflowWrap() const { return static_cast<OverflowWrap>(m_rareInheritedData->overflowWrap); }
-inline OverscrollBehavior RenderStyle::overscrollBehaviorX() const { return static_cast<OverscrollBehavior>(m_nonInheritedData->rareData->overscrollBehaviorX); }
-inline OverscrollBehavior RenderStyle::overscrollBehaviorY() const { return static_cast<OverscrollBehavior>(m_nonInheritedData->rareData->overscrollBehaviorY); }
-inline const Style::PaddingEdge& RenderStyle::paddingAfter() const { return paddingAfter(writingMode()); }
-inline const Style::PaddingEdge& RenderStyle::paddingAfter(const WritingMode writingMode) const { return paddingBox().after(writingMode); }
-inline const Style::PaddingEdge& RenderStyle::paddingBefore() const { return paddingBefore(writingMode()); }
-inline const Style::PaddingEdge& RenderStyle::paddingBefore(const WritingMode writingMode) const { return paddingBox().before(writingMode); }
-inline const Style::PaddingEdge& RenderStyle::paddingBottom() const { return paddingBox().bottom(); }
-inline const Style::PaddingBox& RenderStyle::paddingBox() const { return m_nonInheritedData->surroundData->padding; }
-inline const Style::PaddingEdge& RenderStyle::paddingEnd() const { return paddingEnd(writingMode()); }
-inline const Style::PaddingEdge& RenderStyle::paddingEnd(const WritingMode writingMode) const { return paddingBox().end(writingMode); }
-inline const Style::PaddingEdge& RenderStyle::paddingLeft() const { return paddingBox().left(); }
-inline const Style::PaddingEdge& RenderStyle::paddingRight() const { return paddingBox().right(); }
-inline const Style::PaddingEdge& RenderStyle::paddingStart() const { return paddingStart(writingMode()); }
-inline const Style::PaddingEdge& RenderStyle::paddingStart(const WritingMode writingMode) const { return paddingBox().start(writingMode); }
-inline const Style::PaddingEdge& RenderStyle::paddingTop() const { return paddingBox().top(); }
-inline const Style::PageSize& RenderStyle::pageSize() const { return m_nonInheritedData->rareData->pageSize; }
-inline Style::SVGPaintOrder RenderStyle::paintOrder() const { return Style::SVGPaintOrder::fromRaw(m_rareInheritedData->paintOrder); }
-inline const Style::Perspective& RenderStyle::perspective() const { return m_nonInheritedData->rareData->perspective; }
-inline const Style::PerspectiveOrigin& RenderStyle::perspectiveOrigin() const { return m_nonInheritedData->rareData->perspectiveOrigin; }
-inline const Style::PerspectiveOriginX& RenderStyle::perspectiveOriginX() const { return m_nonInheritedData->rareData->perspectiveOrigin.x; }
-inline const Style::PerspectiveOriginY& RenderStyle::perspectiveOriginY() const { return m_nonInheritedData->rareData->perspectiveOrigin.y; }
-inline const Style::PositionAnchor& RenderStyle::positionAnchor() const { return m_nonInheritedData->rareData->positionAnchor; }
-inline Style::PositionArea RenderStyle::positionArea() const { return m_nonInheritedData->rareData->positionArea; }
-inline const Style::PositionTryFallbacks& RenderStyle::positionTryFallbacks() const { return m_nonInheritedData->rareData->positionTryFallbacks; }
-inline Style::PositionTryOrder RenderStyle::positionTryOrder() const { return static_cast<Style::PositionTryOrder>(m_nonInheritedData->rareData->positionTryOrder); }
-inline Style::PositionVisibility RenderStyle::positionVisibility() const { return Style::PositionVisibility::fromRaw(m_nonInheritedData->rareData->positionVisibility); }
-inline bool RenderStyle::preserveNewline() const { return preserveNewline(whiteSpaceCollapse()); }
-inline bool RenderStyle::preserves3D() const { return usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
-inline const Style::Quotes& RenderStyle::quotes() const { return m_rareInheritedData->quotes; }
-inline Style::Resize RenderStyle::resize() const { return static_cast<Style::Resize>(m_nonInheritedData->miscData->resize); }
-inline const Style::InsetEdge& RenderStyle::right() const { return m_nonInheritedData->surroundData->inset.right(); }
-inline const Style::Rotate& RenderStyle::rotate() const { return m_nonInheritedData->rareData->rotate; }
-inline const Style::GapGutter& RenderStyle::rowGap() const { return m_nonInheritedData->rareData->rowGap; }
-inline RubyPosition RenderStyle::rubyPosition() const { return static_cast<RubyPosition>(m_rareInheritedData->rubyPosition); }
-inline RubyAlign RenderStyle::rubyAlign() const { return static_cast<RubyAlign>(m_rareInheritedData->rubyAlign); }
-inline RubyOverhang RenderStyle::rubyOverhang() const { return static_cast<RubyOverhang>(m_rareInheritedData->rubyOverhang); }
-inline const Style::Scale& RenderStyle::scale() const { return m_nonInheritedData->rareData->scale; }
-inline const Style::ScrollSnapAlign& RenderStyle::scrollSnapAlign() const { return m_nonInheritedData->rareData->scrollSnapAlign; }
-inline ScrollSnapStop RenderStyle::scrollSnapStop() const { return m_nonInheritedData->rareData->scrollSnapStop; }
-inline const Style::ScrollSnapType& RenderStyle::scrollSnapType() const { return m_nonInheritedData->rareData->scrollSnapType; }
-inline bool RenderStyle::hasSnapPosition() const { return !scrollSnapAlign().isNone(); }
-inline const Style::ScrollTimelines& RenderStyle::scrollTimelines() const { return m_nonInheritedData->rareData->scrollTimelines; }
-inline const Style::ProgressTimelineAxes& RenderStyle::scrollTimelineAxes() const { return m_nonInheritedData->rareData->scrollTimelineAxes; }
-inline const Style::ProgressTimelineNames& RenderStyle::scrollTimelineNames() const { return m_nonInheritedData->rareData->scrollTimelineNames; }
-inline bool RenderStyle::hasScrollTimelines() const { return m_nonInheritedData->rareData->hasScrollTimelines(); }
-inline const Style::ViewTimelines& RenderStyle::viewTimelines() const { return m_nonInheritedData->rareData->viewTimelines; }
-inline const Style::ProgressTimelineAxes& RenderStyle::viewTimelineAxes() const { return m_nonInheritedData->rareData->viewTimelineAxes; }
-inline const Style::ViewTimelineInsets& RenderStyle::viewTimelineInsets() const { return m_nonInheritedData->rareData->viewTimelineInsets; }
-inline const Style::ProgressTimelineNames& RenderStyle::viewTimelineNames() const { return m_nonInheritedData->rareData->viewTimelineNames; }
-inline bool RenderStyle::hasViewTimelines() const { return m_nonInheritedData->rareData->hasViewTimelines(); }
-inline const Style::NameScope& RenderStyle::timelineScope() const { return m_nonInheritedData->rareData->timelineScope; }
-inline const Style::ScrollbarColor& RenderStyle::scrollbarColor() const { return m_rareInheritedData->scrollbarColor; }
-inline const Style::ScrollbarGutter& RenderStyle::scrollbarGutter() const { return m_nonInheritedData->rareData->scrollbarGutter; }
-inline Style::ScrollbarWidth RenderStyle::scrollbarWidth() const { return static_cast<ScrollbarWidth>(m_nonInheritedData->rareData->scrollbarWidth); }
-inline Style::ShapeImageThreshold RenderStyle::shapeImageThreshold() const { return m_nonInheritedData->rareData->shapeImageThreshold; }
-inline const Style::ShapeMargin& RenderStyle::shapeMargin() const { return m_nonInheritedData->rareData->shapeMargin; }
-inline const Style::ShapeOutside& RenderStyle::shapeOutside() const { return m_nonInheritedData->rareData->shapeOutside; }
-inline ContentVisibility RenderStyle::usedContentVisibility() const { return static_cast<ContentVisibility>(m_rareInheritedData->usedContentVisibility); }
-inline bool RenderStyle::isSkippedRootOrSkippedContent() const { return usedContentVisibility() != ContentVisibility::Visible; }
-inline Style::SpeakAs RenderStyle::speakAs() const { return Style::SpeakAs::fromRaw(m_rareInheritedData->speakAs); }
-inline Style::ZIndex RenderStyle::specifiedZIndex() const { return m_nonInheritedData->boxData->specifiedZIndex(); }
-inline bool RenderStyle::specifiesColumns() const { return !columnCount().isAuto() || !columnWidth().isAuto() || !hasInlineColumnAxis(); }
-inline const Style::Color& RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
-inline Style::StrokeMiterlimit RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }
-inline std::optional<PseudoElementType> RenderStyle::pseudoElementType() const
-{
-    if (!m_nonInheritedFlags.pseudoElementType)
-        return { };
-    return static_cast<PseudoElementType>(m_nonInheritedFlags.pseudoElementType - 1);
-}
-inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return m_nonInheritedData->rareData->pseudoElementNameArgument; }
-inline const Style::TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }
-inline TableLayoutType RenderStyle::tableLayout() const { return static_cast<TableLayoutType>(m_nonInheritedData->miscData->tableLayout); }
-inline Style::TextAlignLast RenderStyle::textAlignLast() const { return static_cast<Style::TextAlignLast>(m_rareInheritedData->textAlignLast); }
-inline Style::TextAutospace RenderStyle::textAutospace() const { return fontDescription().textAutospace(); }
-inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }
-inline Style::TextBoxEdge RenderStyle::textBoxEdge() const { return m_rareInheritedData->textBoxEdge; }
-inline Style::LineFitEdge RenderStyle::lineFitEdge() const { return m_rareInheritedData->lineFitEdge; }
-inline TextCombine RenderStyle::textCombine() const { return static_cast<TextCombine>(m_rareInheritedData->textCombine); }
-inline const Style::Color& RenderStyle::textDecorationColor() const { return m_nonInheritedData->rareData->textDecorationColor; }
-inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return Style::TextDecorationLine::fromRaw(m_nonInheritedFlags.textDecorationLine); }
-inline TextDecorationSkipInk RenderStyle::textDecorationSkipInk() const { return static_cast<TextDecorationSkipInk>(m_rareInheritedData->textDecorationSkipInk); }
-inline TextDecorationStyle RenderStyle::textDecorationStyle() const { return static_cast<TextDecorationStyle>(m_nonInheritedData->rareData->textDecorationStyle); }
-inline const Style::TextDecorationThickness& RenderStyle::textDecorationThickness() const { return m_nonInheritedData->rareData->textDecorationThickness; }
-inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return Style::TextDecorationLine::fromRaw(m_inheritedFlags.textDecorationLineInEffect); }
-inline const Style::Color& RenderStyle::textEmphasisColor() const { return m_rareInheritedData->textEmphasisColor; }
-inline const Style::TextEmphasisStyle& RenderStyle::textEmphasisStyle() const { return m_rareInheritedData->textEmphasisStyle; }
-inline Style::TextEmphasisPosition RenderStyle::textEmphasisPosition() const { return Style::TextEmphasisPosition::fromRaw(m_rareInheritedData->textEmphasisPosition); }
-inline const Style::Color& RenderStyle::textFillColor() const { return m_rareInheritedData->textFillColor; }
-inline TextGroupAlign RenderStyle::textGroupAlign() const { return static_cast<TextGroupAlign>(m_nonInheritedData->rareData->textGroupAlign); }
-inline const Style::TextIndent& RenderStyle::textIndent() const { return m_rareInheritedData->textIndent; }
-inline TextJustify RenderStyle::textJustify() const { return static_cast<TextJustify>(m_rareInheritedData->textJustify); }
-inline TextOverflow RenderStyle::textOverflow() const { return static_cast<TextOverflow>(m_nonInheritedData->miscData->textOverflow); }
-inline TextSecurity RenderStyle::textSecurity() const { return static_cast<TextSecurity>(m_rareInheritedData->textSecurity); }
-inline const Style::TextShadows& RenderStyle::textShadow() const { return m_rareInheritedData->textShadow; }
-inline bool RenderStyle::hasTextShadow() const { return !textShadow().isNone(); }
-inline Style::TextSpacingTrim RenderStyle::textSpacingTrim() const { return fontDescription().textSpacingTrim(); }
-inline const Style::Color& RenderStyle::textStrokeColor() const { return m_rareInheritedData->textStrokeColor; }
-inline Style::WebkitTextStrokeWidth RenderStyle::textStrokeWidth() const { return m_rareInheritedData->textStrokeWidth; }
-inline Style::TextTransform RenderStyle::textTransform() const { return Style::TextTransform::fromRaw(m_inheritedFlags.textTransform); }
-inline const Style::TextUnderlineOffset& RenderStyle::textUnderlineOffset() const { return m_rareInheritedData->textUnderlineOffset; }
-inline Style::TextUnderlinePosition RenderStyle::textUnderlinePosition() const { return Style::TextUnderlinePosition::fromRaw(m_rareInheritedData->textUnderlinePosition); }
-inline TextZoom RenderStyle::textZoom() const { return static_cast<TextZoom>(m_rareInheritedData->textZoom); }
-inline const Style::InsetEdge& RenderStyle::top() const { return m_nonInheritedData->surroundData->inset.top(); }
-inline Style::TouchAction RenderStyle::touchAction() const { return m_nonInheritedData->rareData->touchAction; }
-inline const Style::Transform& RenderStyle::transform() const { return m_nonInheritedData->miscData->transform->transform; }
-inline TransformBox RenderStyle::transformBox() const { return m_nonInheritedData->miscData->transform->transformBox; }
-inline const Style::TransformOrigin& RenderStyle::transformOrigin() const { return m_nonInheritedData->miscData->transform->origin; }
-inline const Style::TransformOriginX& RenderStyle::transformOriginX() const { return transformOrigin().x; }
-inline const Style::TransformOriginY& RenderStyle::transformOriginY() const { return transformOrigin().y; }
-inline const Style::TransformOriginZ& RenderStyle::transformOriginZ() const { return transformOrigin().z; }
-inline TransformStyle3D RenderStyle::transformStyle3D() const { return static_cast<TransformStyle3D>(m_nonInheritedData->rareData->transformStyle3D); }
-inline const Style::Transitions& RenderStyle::transitions() const { return m_nonInheritedData->miscData->transitions; }
-inline const Style::Translate& RenderStyle::translate() const { return m_nonInheritedData->rareData->translate; }
-inline Style::ScrollBehavior RenderStyle::scrollBehavior() const { return static_cast<Style::ScrollBehavior>(m_nonInheritedData->rareData->scrollBehavior); }
-inline float RenderStyle::usedPerspective() const { return perspective().usedPerspective(); }
+inline PointerEvents RenderStyle::usedPointerEvents() const { return effectiveInert() ? PointerEvents::None : pointerEvents(); }
 inline TransformStyle3D RenderStyle::usedTransformStyle3D() const { return static_cast<bool>(m_nonInheritedData->rareData->transformStyleForcedToFlat) ? TransformStyle3D::Flat : transformStyle3D(); }
-inline Style::ZIndex RenderStyle::usedZIndex() const { return m_nonInheritedData->boxData->usedZIndex(); }
-inline UserDrag RenderStyle::userDrag() const { return static_cast<UserDrag>(m_nonInheritedData->miscData->userDrag); }
-inline UserModify RenderStyle::userModify() const { return static_cast<UserModify>(m_rareInheritedData->userModify); }
-inline UserSelect RenderStyle::userSelect() const { return static_cast<UserSelect>(m_rareInheritedData->userSelect); }
-inline const Style::VerticalAlign& RenderStyle::verticalAlign() const { return m_nonInheritedData->boxData->verticalAlign(); }
-inline const Style::ViewTransitionClasses& RenderStyle::viewTransitionClasses() const { return m_nonInheritedData->rareData->viewTransitionClasses; }
-inline const Style::ViewTransitionName& RenderStyle::viewTransitionName() const { return m_nonInheritedData->rareData->viewTransitionName; }
-inline const Style::Color& RenderStyle::visitedLinkBackgroundColor() const { return m_nonInheritedData->miscData->visitedLinkColor->background; }
-inline const Style::Color& RenderStyle::visitedLinkBorderBottomColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderBottom; }
-inline const Style::Color& RenderStyle::visitedLinkBorderLeftColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderLeft; }
-inline const Style::Color& RenderStyle::visitedLinkBorderRightColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderRight; }
-inline const Style::Color& RenderStyle::visitedLinkBorderTopColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderTop; }
-inline const Style::Color& RenderStyle::visitedLinkCaretColor() const { return m_rareInheritedData->visitedLinkCaretColor; }
-inline const Style::Color& RenderStyle::visitedLinkColumnRuleColor() const { return m_nonInheritedData->miscData->multiCol->visitedLinkColumnRuleColor; }
-inline const Style::Color& RenderStyle::visitedLinkOutlineColor() const { return m_nonInheritedData->miscData->visitedLinkColor->outline; }
-inline const Style::Color& RenderStyle::visitedLinkStrokeColor() const { return m_rareInheritedData->visitedLinkStrokeColor; }
-inline const Style::Color& RenderStyle::visitedLinkTextDecorationColor() const { return m_nonInheritedData->miscData->visitedLinkColor->textDecoration; }
-inline const Style::Color& RenderStyle::visitedLinkTextEmphasisColor() const { return m_rareInheritedData->visitedLinkTextEmphasisColor; }
-inline const Style::Color& RenderStyle::visitedLinkTextFillColor() const { return m_rareInheritedData->visitedLinkTextFillColor; }
-inline const Style::Color& RenderStyle::visitedLinkTextStrokeColor() const { return m_rareInheritedData->visitedLinkTextStrokeColor; }
-inline Style::Widows RenderStyle::widows() const { return m_rareInheritedData->widows; }
-inline const Style::PreferredSize& RenderStyle::width() const { return m_nonInheritedData->boxData->width(); }
-inline const Style::WillChange& RenderStyle::willChange() const { return m_nonInheritedData->rareData->willChange; }
-inline WordBreak RenderStyle::wordBreak() const { return static_cast<WordBreak>(m_rareInheritedData->wordBreak); }
-inline float RenderStyle::usedWordSpacing() const { return m_inheritedData->fontData->fontCascade.wordSpacing(); }
-inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
-
-inline bool RenderStyle::nativeAppearanceDisabled() const { return m_nonInheritedData->rareData->nativeAppearanceDisabled; }
-
-inline const Style::CornerShapeValue& RenderStyle::cornerBottomLeftShape() const { return border().bottomLeftCornerShape(); }
-inline const Style::CornerShapeValue& RenderStyle::cornerBottomRightShape() const { return border().bottomRightCornerShape(); }
-inline const Style::CornerShapeValue& RenderStyle::cornerTopLeftShape() const { return border().topLeftCornerShape(); }
-inline const Style::CornerShapeValue& RenderStyle::cornerTopRightShape() const { return border().topRightCornerShape(); }
-
-// ignore non-standard ::-webkit-scrollbar when standard properties are in use
-inline bool RenderStyle::usesStandardScrollbarStyle() const { return !scrollbarWidth().isAuto() || !scrollbarColor().isAuto(); }
-inline bool RenderStyle::usesLegacyScrollbarStyle() const { return hasPseudoStyle(PseudoElementType::WebKitScrollbar) && !usesStandardScrollbarStyle(); }
-
-#if ENABLE(APPLE_PAY)
-inline ApplePayButtonStyle RenderStyle::applePayButtonStyle() const { return static_cast<ApplePayButtonStyle>(m_nonInheritedData->rareData->applePayButtonStyle); }
-inline ApplePayButtonType RenderStyle::applePayButtonType() const { return static_cast<ApplePayButtonType>(m_nonInheritedData->rareData->applePayButtonType); }
-constexpr ApplePayButtonStyle RenderStyle::initialApplePayButtonStyle() { return ApplePayButtonStyle::Black; }
-constexpr ApplePayButtonType RenderStyle::initialApplePayButtonType() { return ApplePayButtonType::Plain; }
-#endif
-
-inline BoxDecorationBreak RenderStyle::boxDecorationBreak() const { return m_nonInheritedData->boxData->boxDecorationBreak(); }
-
-inline BlendMode RenderStyle::blendMode() const { return static_cast<BlendMode>(m_nonInheritedData->rareData->effectiveBlendMode); }
-constexpr BlendMode RenderStyle::initialBlendMode() { return BlendMode::Normal; }
-constexpr Isolation RenderStyle::initialIsolation() { return Isolation::Auto; }
-inline bool RenderStyle::isInSubtreeWithBlendMode() const { return m_rareInheritedData->isInSubtreeWithBlendMode; }
-inline bool RenderStyle::isForceHidden() const { return m_rareInheritedData->isForceHidden; }
-inline Isolation RenderStyle::isolation() const { return static_cast<Isolation>(m_nonInheritedData->rareData->isolation); }
-inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData->rareData->usesAnchorFunctions; }
-inline EnumSet<BoxAxis> RenderStyle::anchorFunctionScrollCompensatedAxes() const { return EnumSet<BoxAxis>::fromRaw(m_nonInheritedData->rareData->anchorFunctionScrollCompensatedAxes); }
-
-inline bool RenderStyle::isPopoverInvoker() const { return m_nonInheritedData->rareData->isPopoverInvoker; }
-
+inline float RenderStyle::usedPerspective() const { return perspective().usedPerspective(); }
 inline Visibility RenderStyle::usedVisibility() const
 {
     if (isForceHidden()) [[unlikely]]
         return Visibility::Hidden;
     return static_cast<Visibility>(m_inheritedFlags.visibility);
 }
-
-inline bool RenderStyle::autoRevealsWhenFound() const { return m_rareInheritedData->autoRevealsWhenFound; }
-
-#if ENABLE(CURSOR_VISIBILITY)
-constexpr CursorVisibility RenderStyle::initialCursorVisibility() { return CursorVisibility::Auto; }
-#endif
-
-#if ENABLE(DARK_MODE_CSS)
-inline Style::ColorScheme RenderStyle::colorScheme() const { return m_rareInheritedData->colorScheme; }
-inline Style::ColorScheme RenderStyle::initialColorScheme() { return Style::ColorScheme { .schemes = { }, .only = { } }; }
-inline bool RenderStyle::hasExplicitlySetColorScheme() const { return m_nonInheritedData->miscData->hasExplicitlySetColorScheme; }
-#endif
-
-inline const Style::Filter& RenderStyle::backdropFilter() const { return m_nonInheritedData->rareData->backdropFilter->filter; }
-inline bool RenderStyle::hasBackdropFilter() const { return !backdropFilter().isNone(); }
-inline Style::Filter RenderStyle::initialBackdropFilter() { return CSS::Keyword::None { }; }
-
-inline bool RenderStyle::hasExplicitlySetDirection() const { return m_nonInheritedData->miscData->hasExplicitlySetDirection; }
-inline bool RenderStyle::hasExplicitlySetWritingMode() const { return m_nonInheritedData->miscData->hasExplicitlySetWritingMode; }
-
-inline const Style::DynamicRangeLimit& RenderStyle::dynamicRangeLimit() const { return m_rareInheritedData->dynamicRangeLimit; }
-inline Style::DynamicRangeLimit RenderStyle::initialDynamicRangeLimit() { return CSS::Keyword::NoLimit { }; }
-
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-inline Style::WebkitOverflowScrolling RenderStyle::overflowScrolling() const { return static_cast<Style::WebkitOverflowScrolling>(m_rareInheritedData->webkitOverflowScrolling); }
-constexpr Style::WebkitOverflowScrolling RenderStyle::initialOverflowScrolling() { return Style::WebkitOverflowScrolling::Auto; }
-#endif
-
-#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-inline Style::WebkitTouchCallout RenderStyle::touchCallout() const { return static_cast<Style::WebkitTouchCallout>(m_rareInheritedData->webkitTouchCallout); }
-constexpr Style::WebkitTouchCallout RenderStyle::initialTouchCallout() { return Style::WebkitTouchCallout::Default; }
-#endif
-
-#if ENABLE(TEXT_AUTOSIZING)
-inline Style::LineHeight RenderStyle::initialSpecifiedLineHeight() { return CSS::Keyword::Normal { }; }
-constexpr Style::TextSizeAdjust RenderStyle::initialTextSizeAdjust() { return CSS::Keyword::Auto { }; }
-inline Style::TextSizeAdjust RenderStyle::textSizeAdjust() const { return m_rareInheritedData->textSizeAdjust; }
-#endif
-
-#if ENABLE(TOUCH_EVENTS)
-inline Style::Color RenderStyle::tapHighlightColor() const { return m_rareInheritedData->tapHighlightColor; }
-#endif
-
-inline bool RenderStyle::insideDefaultButton() const { return m_rareInheritedData->insideDefaultButton; }
-inline bool RenderStyle::insideSubmitButton() const { return m_rareInheritedData->insideSubmitButton; }
-
-inline const Style::StrokeWidth& RenderStyle::strokeWidth() const { return m_rareInheritedData->strokeWidth; }
-inline bool RenderStyle::hasExplicitlySetStrokeWidth() const { return m_rareInheritedData->hasSetStrokeWidth; }
-inline bool RenderStyle::hasStroke() const { return !stroke().isNone(); }
-inline bool RenderStyle::hasFill() const { return !fill().isNone(); }
-inline bool RenderStyle::hasMarkers() const { return !markerStart().isNone() || !markerMid().isNone() || !markerEnd().isNone(); }
-
-inline AlignmentBaseline RenderStyle::alignmentBaseline() const { return static_cast<AlignmentBaseline>(m_svgStyle->nonInheritedFlags.alignmentBaseline); }
-inline DominantBaseline RenderStyle::dominantBaseline() const { return static_cast<DominantBaseline>(m_svgStyle->nonInheritedFlags.dominantBaseline); }
-inline VectorEffect RenderStyle::vectorEffect() const { return static_cast<VectorEffect>(m_svgStyle->nonInheritedFlags.vectorEffect); }
-inline BufferedRendering RenderStyle::bufferedRendering() const { return static_cast<BufferedRendering>(m_svgStyle->nonInheritedFlags.bufferedRendering); }
-inline WindRule RenderStyle::clipRule() const { return static_cast<WindRule>(m_svgStyle->inheritedFlags.clipRule); }
-inline ColorInterpolation RenderStyle::colorInterpolation() const { return static_cast<ColorInterpolation>(m_svgStyle->inheritedFlags.colorInterpolation); }
-inline ColorInterpolation RenderStyle::colorInterpolationFilters() const { return static_cast<ColorInterpolation>(m_svgStyle->inheritedFlags.colorInterpolationFilters); }
-inline WindRule RenderStyle::fillRule() const { return static_cast<WindRule>(m_svgStyle->inheritedFlags.fillRule); }
-inline ShapeRendering RenderStyle::shapeRendering() const { return static_cast<ShapeRendering>(m_svgStyle->inheritedFlags.shapeRendering); }
-inline TextAnchor RenderStyle::textAnchor() const { return static_cast<TextAnchor>(m_svgStyle->inheritedFlags.textAnchor); }
-inline Style::SVGGlyphOrientationHorizontal RenderStyle::glyphOrientationHorizontal() const { return static_cast<Style::SVGGlyphOrientationHorizontal>(m_svgStyle->inheritedFlags.glyphOrientationHorizontal); }
-inline Style::SVGGlyphOrientationVertical RenderStyle::glyphOrientationVertical() const { return static_cast<Style::SVGGlyphOrientationVertical>(m_svgStyle->inheritedFlags.glyphOrientationVertical); }
-inline const Style::SVGPaint& RenderStyle::fill() const { return m_svgStyle->fillData->paint; }
-inline Style::Opacity RenderStyle::fillOpacity() const { return m_svgStyle->fillData->opacity; }
-inline const Style::SVGPaint& RenderStyle::stroke() const { return m_svgStyle->strokeData->paint; }
-inline Style::Opacity RenderStyle::strokeOpacity() const { return m_svgStyle->strokeData->opacity; }
-inline const Style::SVGStrokeDasharray& RenderStyle::strokeDashArray() const { return m_svgStyle->strokeData->dashArray; }
-inline const Style::SVGStrokeDashoffset& RenderStyle::strokeDashOffset() const { return m_svgStyle->strokeData->dashOffset; }
-inline Style::Opacity RenderStyle::stopOpacity() const { return m_svgStyle->stopData->opacity; }
-inline const Style::Color& RenderStyle::stopColor() const { return m_svgStyle->stopData->color; }
-inline Style::Opacity RenderStyle::floodOpacity() const { return m_svgStyle->miscData->floodOpacity; }
-inline const Style::Color& RenderStyle::floodColor() const { return m_svgStyle->miscData->floodColor; }
-inline const Style::Color& RenderStyle::lightingColor() const { return m_svgStyle->miscData->lightingColor; }
-inline const Style::SVGBaselineShift& RenderStyle::baselineShift() const { return m_svgStyle->miscData->baselineShift; }
-inline const Style::SVGCenterCoordinateComponent& RenderStyle::cx() const { return m_svgStyle->layoutData->cx; }
-inline const Style::SVGCenterCoordinateComponent& RenderStyle::cy() const { return m_svgStyle->layoutData->cy; }
-inline const Style::SVGRadius& RenderStyle::r() const { return m_svgStyle->layoutData->r; }
-inline const Style::SVGRadiusComponent& RenderStyle::rx() const { return m_svgStyle->layoutData->rx; }
-inline const Style::SVGRadiusComponent& RenderStyle::ry() const { return m_svgStyle->layoutData->ry; }
-inline const Style::SVGCoordinateComponent& RenderStyle::x() const { return m_svgStyle->layoutData->x; }
-inline const Style::SVGCoordinateComponent& RenderStyle::y() const { return m_svgStyle->layoutData->y; }
-inline const Style::SVGPathData& RenderStyle::d() const { return m_svgStyle->layoutData->d; }
-inline const Style::SVGMarkerResource& RenderStyle::markerStart() const { return m_svgStyle->inheritedResourceData->markerStart; }
-inline const Style::SVGMarkerResource& RenderStyle::markerMid() const { return m_svgStyle->inheritedResourceData->markerMid; }
-inline const Style::SVGMarkerResource& RenderStyle::markerEnd() const { return m_svgStyle->inheritedResourceData->markerEnd; }
-inline MaskType RenderStyle::maskType() const { return static_cast<MaskType>(m_svgStyle->nonInheritedFlags.maskType); }
-inline const Style::SVGPaint& RenderStyle::visitedLinkFill() const { return m_svgStyle->fillData->visitedLinkPaint; }
-inline const Style::SVGPaint& RenderStyle::visitedLinkStroke() const { return m_svgStyle->strokeData->visitedLinkPaint; }
-
-inline Style::Color RenderStyle::initialBorderBottomColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::Color RenderStyle::initialBorderLeftColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::Color RenderStyle::initialBorderRightColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::Color RenderStyle::initialBorderTopColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::Color RenderStyle::initialColumnRuleColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::Color RenderStyle::initialOutlineColor() { return CSS::Keyword::Currentcolor { }; }
-inline Style::AccentColor RenderStyle::initialAccentColor() { return CSS::Keyword::Auto { }; }
-inline Style::SVGCenterCoordinateComponent RenderStyle::initialCx() { return 0_css_px; }
-inline Style::SVGCenterCoordinateComponent RenderStyle::initialCy() { return 0_css_px; }
-inline Style::SVGPathData RenderStyle::initialD() { return CSS::Keyword::None { }; }
-inline Style::SVGRadius RenderStyle::initialR() { return 0_css_px; }
-inline Style::SVGRadiusComponent RenderStyle::initialRx() { return CSS::Keyword::Auto { }; }
-inline Style::SVGRadiusComponent RenderStyle::initialRy() { return CSS::Keyword::Auto { }; }
-inline Style::SVGCoordinateComponent RenderStyle::initialX() { return 0_css_px; }
-inline Style::SVGCoordinateComponent RenderStyle::initialY() { return 0_css_px; }
-inline Style::SVGStrokeDasharray RenderStyle::initialStrokeDashArray() { return CSS::Keyword::None { }; }
-inline Style::SVGStrokeDashoffset RenderStyle::initialStrokeDashOffset() { return 0_css_px; }
-constexpr Style::Opacity RenderStyle::initialFillOpacity() { return 1_css_number; }
-constexpr Style::Opacity RenderStyle::initialStrokeOpacity() { return 1_css_number; }
-constexpr Style::Opacity RenderStyle::initialStopOpacity() { return 1_css_number; }
-constexpr Style::Opacity RenderStyle::initialFloodOpacity() { return 1_css_number; }
-constexpr AlignmentBaseline RenderStyle::initialAlignmentBaseline() { return AlignmentBaseline::Baseline; }
-constexpr DominantBaseline RenderStyle::initialDominantBaseline() { return DominantBaseline::Auto; }
-constexpr VectorEffect RenderStyle::initialVectorEffect() { return VectorEffect::None; }
-constexpr BufferedRendering RenderStyle::initialBufferedRendering() { return BufferedRendering::Auto; }
-constexpr WindRule RenderStyle::initialClipRule() { return WindRule::NonZero; }
-constexpr ColorInterpolation RenderStyle::initialColorInterpolation() { return ColorInterpolation::SRGB; }
-constexpr ColorInterpolation RenderStyle::initialColorInterpolationFilters() { return ColorInterpolation::LinearRGB; }
-constexpr WindRule RenderStyle::initialFillRule() { return WindRule::NonZero; }
-constexpr ShapeRendering RenderStyle::initialShapeRendering() { return ShapeRendering::Auto; }
-constexpr TextAnchor RenderStyle::initialTextAnchor() { return TextAnchor::Start; }
-constexpr Style::SVGGlyphOrientationHorizontal RenderStyle::initialGlyphOrientationHorizontal() { return Style::SVGGlyphOrientationHorizontal::Degrees0; }
-constexpr Style::SVGGlyphOrientationVertical RenderStyle::initialGlyphOrientationVertical() { return Style::SVGGlyphOrientationVertical::Auto; }
-inline Style::SVGPaint RenderStyle::initialFill() { return Style::Color { Color::black }; }
-inline Style::SVGPaint RenderStyle::initialStroke() { return CSS::Keyword::None { }; }
-inline Style::Color RenderStyle::initialStopColor() { return Color::black; }
-inline Style::Color RenderStyle::initialFloodColor() { return Color::black; }
-inline Style::Color RenderStyle::initialLightingColor() { return Color::white; }
-inline Style::SVGMarkerResource RenderStyle::initialMarkerStart() { return CSS::Keyword::None { }; }
-inline Style::SVGMarkerResource RenderStyle::initialMarkerMid() { return CSS::Keyword::None { }; }
-inline Style::SVGMarkerResource RenderStyle::initialMarkerEnd() { return CSS::Keyword::None { }; }
-constexpr MaskType RenderStyle::initialMaskType() { return MaskType::Luminance; }
-inline Style::SVGBaselineShift RenderStyle::initialBaselineShift() { return CSS::Keyword::Baseline { }; }
 
 inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoElementType pseudo) const
 {
@@ -1156,16 +271,6 @@ constexpr bool RenderStyle::doesDisplayGenerateBlockContainer() const
         || display == DisplayType::ListItem
         || display == DisplayType::TableCell
         || display == DisplayType::TableCaption);
-}
-
-inline double RenderStyle::logicalAspectRatio() const
-{
-    auto ratio = this->aspectRatio().tryRatio();
-    ASSERT(ratio);
-
-    if (writingMode().isHorizontal())
-        return ratio->numerator.value / ratio->denominator.value;
-    return ratio->denominator.value / ratio->numerator.value;
 }
 
 constexpr bool RenderStyle::preserveNewline(WhiteSpaceCollapse mode)
@@ -1429,5 +534,724 @@ inline Style::ZoomFactor RenderStyle::usedZoomForLength() const
 
     return Style::ZoomFactor(1.0f, deviceScaleFactor());
 }
+
+
+// MARK: has*() functions
+
+inline bool RenderStyle::hasAnimations() const { return !animations().isInitial(); }
+inline bool RenderStyle::hasAnimationsOrTransitions() const { return hasAnimations() || hasTransitions(); }
+// FIXME: Rename this function.
+inline bool RenderStyle::hasAppearance() const { return appearance() != StyleAppearance::None && appearance() != StyleAppearance::Base; }
+inline bool RenderStyle::hasAppleColorFilter() const { return !appleColorFilter().isNone(); }
+#if HAVE(CORE_MATERIAL)
+inline bool RenderStyle::hasAppleVisualEffect() const { return appleVisualEffect() != AppleVisualEffect::None; }
+inline bool RenderStyle::hasAppleVisualEffectRequiringBackdropFilter() const { return appleVisualEffectNeedsBackdrop(appleVisualEffect()); }
+#endif
+inline bool RenderStyle::hasAspectRatio() const { return aspectRatio().hasRatio(); }
+inline bool RenderStyle::hasAttrContent() const { return m_nonInheritedData->miscData->hasAttrContent; }
+inline bool RenderStyle::hasAutoLeftAndRight() const { return left().isAuto() && right().isAuto(); }
+inline bool RenderStyle::hasAutoLengthContainIntrinsicSize() const { return containIntrinsicWidth().hasAuto() || containIntrinsicHeight().hasAuto(); }
+inline bool RenderStyle::hasAutoTopAndBottom() const { return top().isAuto() && bottom().isAuto(); }
+inline bool RenderStyle::hasBackdropFilter() const { return !backdropFilter().isNone(); }
+inline bool RenderStyle::hasBackground() const { return visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || hasBackgroundImage(); }
+inline bool RenderStyle::hasBackgroundImage() const { return Style::hasImageInAnyLayer(backgroundLayers()); }
+inline bool RenderStyle::hasBlendMode() const { return blendMode() != BlendMode::Normal; }
+inline bool RenderStyle::hasBorder() const { return border().hasBorder(); }
+inline bool RenderStyle::hasBorderImage() const { return border().hasBorderImage(); }
+inline bool RenderStyle::hasBorderImageOutsets() const { return borderImage().hasSource() && !borderImage().outset().isZero(); }
+inline bool RenderStyle::hasBorderRadius() const { return border().hasBorderRadius(); }
+inline bool RenderStyle::hasBoxReflect() const { return !boxReflect().isNone(); }
+inline bool RenderStyle::hasBoxShadow() const { return !boxShadow().isNone(); }
+inline bool RenderStyle::hasClip() const { return !clip().isAuto(); }
+inline bool RenderStyle::hasClipPath() const { return !clipPath().isNone(); }
+inline bool RenderStyle::hasContent() const { return content().isData(); }
+inline bool RenderStyle::hasDisplayAffectedByAnimations() const { return m_nonInheritedData->miscData->hasDisplayAffectedByAnimations; }
+inline bool RenderStyle::hasFill() const { return !fill().isNone(); }
+inline bool RenderStyle::hasFilter() const { return !filter().isNone(); }
+inline bool RenderStyle::hasInFlowPosition() const { return position() == PositionType::Relative || position() == PositionType::Sticky; }
+inline bool RenderStyle::hasIsolation() const { return isolation() != Isolation::Auto; }
+inline bool RenderStyle::hasMarkers() const { return !markerStart().isNone() || !markerMid().isNone() || !markerEnd().isNone(); }
+inline bool RenderStyle::hasMask() const { return Style::hasImageInAnyLayer(maskLayers()) || maskBorder().hasSource(); }
+inline bool RenderStyle::hasOffsetPath() const { return !WTF::holdsAlternative<CSS::Keyword::None>(m_nonInheritedData->rareData->offsetPath); }
+inline bool RenderStyle::hasOpacity() const { return !opacity().isOpaque(); }
+inline bool RenderStyle::hasOutline() const { return outlineStyle() != OutlineStyle::None && outlineWidth().isPositive(); }
+inline bool RenderStyle::hasOutlineInVisualOverflow() const { return hasOutline() && outlineSize() > 0; }
+inline bool RenderStyle::hasOutOfFlowPosition() const { return position() == PositionType::Absolute || position() == PositionType::Fixed; }
+inline bool RenderStyle::hasPerspective() const { return !perspective().isNone(); }
+inline bool RenderStyle::hasPositionedMask() const { return Style::hasImageInAnyLayer(maskLayers()); }
+inline bool RenderStyle::hasPseudoStyle(PseudoElementType pseudo) const { return m_nonInheritedFlags.hasPseudoStyle(pseudo); }
+inline bool RenderStyle::hasRotate() const { return !rotate().isNone(); }
+inline bool RenderStyle::hasScale() const { return !scale().isNone(); }
+inline bool RenderStyle::hasScrollTimelines() const { return m_nonInheritedData->rareData->hasScrollTimelines(); }
+inline bool RenderStyle::hasSnapPosition() const { return !scrollSnapAlign().isNone(); }
+inline bool RenderStyle::hasStaticBlockPosition(bool horizontal) const { return horizontal ? hasAutoTopAndBottom() : hasAutoLeftAndRight(); }
+inline bool RenderStyle::hasStaticInlinePosition(bool horizontal) const { return horizontal ? hasAutoLeftAndRight() : hasAutoTopAndBottom(); }
+inline bool RenderStyle::hasStroke() const { return !stroke().isNone(); }
+inline bool RenderStyle::hasTextCombine() const { return textCombine() != TextCombine::None; }
+inline bool RenderStyle::hasTextShadow() const { return !textShadow().isNone(); }
+inline bool RenderStyle::hasTransform() const { return !transform().isNone() || hasOffsetPath(); }
+inline bool RenderStyle::hasTransformRelatedProperty() const { return hasTransform() || hasRotate() || hasScale() || hasTranslate() || transformStyle3D() == TransformStyle3D::Preserve3D || hasPerspective(); }
+inline bool RenderStyle::hasTransitions() const { return !transitions().isInitial(); }
+inline bool RenderStyle::hasTranslate() const { return !translate().isNone(); }
+inline bool RenderStyle::hasUsedAppearance() const { return usedAppearance() != StyleAppearance::None && usedAppearance() != StyleAppearance::Base; }
+inline bool RenderStyle::hasUsedContentNone() const { return content().isNone() || (content().isNormal() && (pseudoElementType() == PseudoElementType::Before || pseudoElementType() == PseudoElementType::After)); }
+inline bool RenderStyle::hasViewportConstrainedPosition() const { return position() == PositionType::Fixed || position() == PositionType::Sticky; }
+inline bool RenderStyle::hasViewTimelines() const { return m_nonInheritedData->rareData->hasViewTimelines(); }
+inline bool RenderStyle::hasVisibleBorder() const { return border().hasVisibleBorder(); }
+inline bool RenderStyle::hasVisibleBorderDecoration() const { return hasVisibleBorder() || hasBorderImage(); }
+
+// MARK: is*() functions
+
+inline bool RenderStyle::isColumnFlexDirection() const { return flexDirection() == FlexDirection::Column || flexDirection() == FlexDirection::ColumnReverse; }
+inline bool RenderStyle::isRowFlexDirection() const { return flexDirection() == FlexDirection::Row || flexDirection() == FlexDirection::RowReverse; }
+constexpr bool RenderStyle::isDisplayBlockLevel() const { return isDisplayBlockType(display()); }
+constexpr bool RenderStyle::isDisplayDeprecatedFlexibleBox(DisplayType display) { return display == DisplayType::Box || display == DisplayType::InlineBox; }
+constexpr bool RenderStyle::isDisplayFlexibleBox(DisplayType display) { return display == DisplayType::Flex || display == DisplayType::InlineFlex; }
+constexpr bool RenderStyle::isDisplayDeprecatedFlexibleBox() const { return isDisplayDeprecatedFlexibleBox(display()); }
+constexpr bool RenderStyle::isDisplayFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox() const { return isDisplayFlexibleOrGridFormattingContextBox() || isDisplayDeprecatedFlexibleBox(); }
+constexpr bool RenderStyle::isDisplayFlexibleOrGridFormattingContextBox() const { return isDisplayFlexibleOrGridFormattingContextBox(display()); }
+constexpr bool RenderStyle::isDisplayFlexibleOrGridFormattingContextBox(DisplayType display) { return isDisplayFlexibleBox(display) || isDisplayGridFormattingContextBox(display); }
+constexpr bool RenderStyle::isDisplayGridFormattingContextBox(DisplayType display) { return isDisplayGridBox(display) || isDisplayGridLanesBox(display); }
+constexpr bool RenderStyle::isDisplayGridBox(DisplayType display) { return display == DisplayType::Grid || display == DisplayType::InlineGrid; }
+constexpr bool RenderStyle::isDisplayGridLanesBox(DisplayType display) { return display == DisplayType::GridLanes || display == DisplayType::InlineGridLanes; }
+constexpr bool RenderStyle::isDisplayInlineType() const { return isDisplayInlineType(display()); }
+constexpr bool RenderStyle::isDisplayListItemType(DisplayType display) { return display == DisplayType::ListItem; }
+constexpr bool RenderStyle::isDisplayTableOrTablePart() const { return isDisplayTableOrTablePart(display()); }
+constexpr bool RenderStyle::isInternalTableBox() const { return isInternalTableBox(display()); }
+constexpr bool RenderStyle::isRubyContainerOrInternalRubyBox() const { return isRubyContainerOrInternalRubyBox(display()); }
+inline bool RenderStyle::isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && (logicalWidth().isSpecified() || logicalWidth().isFitContent() || logicalWidth().isFillAvailable() || logicalWidth().isMinContent()); }
+inline bool RenderStyle::isFloating() const { return floating() != Float::None; }
+constexpr bool RenderStyle::isOriginalDisplayBlockType() const { return isDisplayBlockType(originalDisplay()); }
+constexpr bool RenderStyle::isOriginalDisplayInlineType() const { return isDisplayInlineType(originalDisplay()); }
+constexpr bool RenderStyle::isOriginalDisplayListItemType() const { return isDisplayListItemType(originalDisplay()); }
+inline bool RenderStyle::isOverflowVisible() const { return overflowX() == Overflow::Visible || overflowY() == Overflow::Visible; }
+inline bool RenderStyle::isReverseFlexDirection() const { return flexDirection() == FlexDirection::RowReverse || flexDirection() == FlexDirection::ColumnReverse; }
+inline bool RenderStyle::isSkippedRootOrSkippedContent() const { return usedContentVisibility() != ContentVisibility::Visible; }
+
+// MARK: - Logical getters
+
+// MARK: sizing logical
+inline const Style::PreferredSize& RenderStyle::logicalHeight() const { return logicalHeight(writingMode()); }
+inline const Style::PreferredSize& RenderStyle::logicalHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? height() : width(); }
+inline const Style::MaximumSize& RenderStyle::logicalMaxHeight() const { return logicalMaxHeight(writingMode()); }
+inline const Style::MaximumSize& RenderStyle::logicalMaxHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? maxHeight() : maxWidth(); }
+inline const Style::MaximumSize& RenderStyle::logicalMaxWidth() const { return logicalMaxWidth(writingMode()); }
+inline const Style::MaximumSize& RenderStyle::logicalMaxWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? maxWidth() : maxHeight(); }
+inline const Style::MinimumSize& RenderStyle::logicalMinHeight() const { return logicalMinHeight(writingMode()); }
+inline const Style::MinimumSize& RenderStyle::logicalMinHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? minHeight() : minWidth(); }
+inline const Style::MinimumSize& RenderStyle::logicalMinWidth() const { return logicalMinWidth(writingMode()); }
+inline const Style::MinimumSize& RenderStyle::logicalMinWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? minWidth() : minHeight(); }
+inline const Style::PreferredSize& RenderStyle::logicalWidth() const { return logicalWidth(writingMode()); }
+inline const Style::PreferredSize& RenderStyle::logicalWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? width() : height(); }
+
+// MARK: inset logical
+inline const Style::InsetEdge& RenderStyle::logicalTop() const { return m_nonInheritedData->surroundData->inset.before(writingMode()); }
+inline const Style::InsetEdge& RenderStyle::logicalRight() const { return m_nonInheritedData->surroundData->inset.logicalRight(writingMode()); }
+inline const Style::InsetEdge& RenderStyle::logicalBottom() const { return m_nonInheritedData->surroundData->inset.after(writingMode()); }
+inline const Style::InsetEdge& RenderStyle::logicalLeft() const { return m_nonInheritedData->surroundData->inset.logicalLeft(writingMode()); }
+
+// MARK: margin logical
+inline const Style::MarginEdge& RenderStyle::marginAfter() const { return marginAfter(writingMode()); }
+inline const Style::MarginEdge& RenderStyle::marginAfter(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.after(writingMode); }
+inline const Style::MarginEdge& RenderStyle::marginBefore() const { return marginBefore(writingMode()); }
+inline const Style::MarginEdge& RenderStyle::marginBefore(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.before(writingMode); }
+inline const Style::MarginEdge& RenderStyle::marginEnd() const { return marginEnd(writingMode()); }
+inline const Style::MarginEdge& RenderStyle::marginEnd(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.end(writingMode); }
+inline const Style::MarginEdge& RenderStyle::marginStart() const { return marginStart(writingMode()); }
+inline const Style::MarginEdge& RenderStyle::marginStart(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.start(writingMode); }
+
+// MARK: padding logical
+inline const Style::PaddingEdge& RenderStyle::paddingAfter() const { return paddingAfter(writingMode()); }
+inline const Style::PaddingEdge& RenderStyle::paddingAfter(const WritingMode writingMode) const { return paddingBox().after(writingMode); }
+inline const Style::PaddingEdge& RenderStyle::paddingBefore() const { return paddingBefore(writingMode()); }
+inline const Style::PaddingEdge& RenderStyle::paddingBefore(const WritingMode writingMode) const { return paddingBox().before(writingMode); }
+inline const Style::PaddingEdge& RenderStyle::paddingEnd() const { return paddingEnd(writingMode()); }
+inline const Style::PaddingEdge& RenderStyle::paddingEnd(const WritingMode writingMode) const { return paddingBox().end(writingMode); }
+inline const Style::PaddingEdge& RenderStyle::paddingStart() const { return paddingStart(writingMode()); }
+inline const Style::PaddingEdge& RenderStyle::paddingStart(const WritingMode writingMode) const { return paddingBox().start(writingMode); }
+
+// MARK: grid logical
+inline const Style::GapGutter& RenderStyle::gap(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? columnGap() : rowGap(); }
+inline const Style::GridTrackSizes& RenderStyle::gridAutoList(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridAutoColumns() : gridAutoRows(); }
+inline const Style::GridPosition& RenderStyle::gridItemEnd(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridItemColumnEnd() : gridItemRowEnd(); }
+inline const Style::GridPosition& RenderStyle::gridItemStart(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridItemColumnStart() : gridItemRowStart(); }
+inline const Style::GridTemplateList& RenderStyle::gridTemplateList(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridTemplateColumns() : gridTemplateRows(); }
+
+// MARK: contain-intrinsic-* logical
+inline const Style::ContainIntrinsicSize& RenderStyle::containIntrinsicLogicalHeight() const { return writingMode().isHorizontal() ? containIntrinsicHeight() : containIntrinsicWidth(); }
+inline const Style::ContainIntrinsicSize& RenderStyle::containIntrinsicLogicalWidth() const { return writingMode().isHorizontal() ? containIntrinsicWidth() : containIntrinsicHeight(); }
+
+// MARK: aspect-ratio logical
+inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioLogicalHeight() const { return writingMode().isHorizontal() ? aspectRatio().height() : aspectRatio().width(); }
+inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioLogicalWidth() const { return writingMode().isHorizontal() ? aspectRatio().width() : aspectRatio().height(); }
+inline double RenderStyle::logicalAspectRatio() const
+{
+    auto ratio = this->aspectRatio().tryRatio();
+    ASSERT(ratio);
+
+    if (writingMode().isHorizontal())
+        return ratio->numerator.value / ratio->denominator.value;
+    return ratio->denominator.value / ratio->numerator.value;
+}
+
+// MARK: border-width logical
+inline Style::LineWidth RenderStyle::borderAfterWidth() const { return borderAfterWidth(writingMode()); }
+inline Style::LineWidth RenderStyle::borderBeforeWidth() const { return borderBeforeWidth(writingMode()); }
+inline Style::LineWidth RenderStyle::borderEndWidth() const { return borderEndWidth(writingMode()); }
+inline Style::LineWidth RenderStyle::borderStartWidth() const { return borderStartWidth(writingMode()); }
+
+// MARK: - Aggregate getters
+
+inline const Style::InsetBox& RenderStyle::insetBox() const { return m_nonInheritedData->surroundData->inset; }
+inline const Style::MarginBox& RenderStyle::marginBox() const { return m_nonInheritedData->surroundData->margin; }
+inline const Style::PaddingBox& RenderStyle::paddingBox() const { return m_nonInheritedData->surroundData->padding; }
+inline const Style::ScrollTimelines& RenderStyle::scrollTimelines() const { return m_nonInheritedData->rareData->scrollTimelines; }
+inline const Style::ViewTimelines& RenderStyle::viewTimelines() const { return m_nonInheritedData->rareData->viewTimelines; }
+inline const Style::Animations& RenderStyle::animations() const { return m_nonInheritedData->miscData->animations; }
+inline const Style::Transitions& RenderStyle::transitions() const { return m_nonInheritedData->miscData->transitions; }
+inline const Style::BackgroundLayers& RenderStyle::backgroundLayers() const { return m_nonInheritedData->backgroundData->background; }
+inline const Style::MaskLayers& RenderStyle::maskLayers() const { return m_nonInheritedData->miscData->mask; }
+inline const Style::MaskBorder& RenderStyle::maskBorder() const { return m_nonInheritedData->rareData->maskBorder; }
+inline const Style::BorderImage& RenderStyle::borderImage() const { return border().image(); }
+inline const Style::TransformOrigin& RenderStyle::transformOrigin() const { return m_nonInheritedData->miscData->transform->origin; }
+inline const Style::PerspectiveOrigin& RenderStyle::perspectiveOrigin() const { return m_nonInheritedData->rareData->perspectiveOrigin; }
+inline const OutlineValue& RenderStyle::outline() const { return m_nonInheritedData->backgroundData->outline; }
+inline const BorderData& RenderStyle::border() const { return m_nonInheritedData->surroundData->border; }
+inline const Style::BorderRadius& RenderStyle::borderRadii() const { return border().radii(); }
+
+// MARK: - Property initial values
+
+constexpr Style::AlignContent RenderStyle::initialAlignContent() { return CSS::Keyword::Normal { }; }
+constexpr Style::AlignItems RenderStyle::initialAlignItems() { return CSS::Keyword::Normal { }; }
+constexpr Style::AlignSelf RenderStyle::initialAlignSelf() { return CSS::Keyword::Auto { }; }
+inline Style::AnchorNames RenderStyle::initialAnchorNames() { return CSS::Keyword::None { }; }
+inline Style::NameScope RenderStyle::initialAnchorScope() { return CSS::Keyword::None { }; }
+inline Style::Animations RenderStyle::initialAnimations() { return CSS::Keyword::None { }; }
+constexpr StyleAppearance RenderStyle::initialAppearance() { return StyleAppearance::None; }
+#if HAVE(CORE_MATERIAL)
+constexpr AppleVisualEffect RenderStyle::initialAppleVisualEffect() { return AppleVisualEffect::None; }
+#endif
+inline Style::AppleColorFilter RenderStyle::initialAppleColorFilter() { return CSS::Keyword::None { }; }
+inline Style::AspectRatio RenderStyle::initialAspectRatio() { return CSS::Keyword::Auto { }; }
+constexpr BackfaceVisibility RenderStyle::initialBackfaceVisibility() { return BackfaceVisibility::Visible; }
+inline Style::Color RenderStyle::initialBackgroundColor() { return Color::transparentBlack; }
+inline Style::BackgroundLayers RenderStyle::initialBackgroundLayers() { return CSS::Keyword::None { }; }
+inline Style::BlockEllipsis RenderStyle::initialBlockEllipsis() { return CSS::Keyword::None { }; }
+constexpr BlockStepAlign RenderStyle::initialBlockStepAlign() { return BlockStepAlign::Auto; }
+constexpr BlockStepInsert RenderStyle::initialBlockStepInsert() { return BlockStepInsert::MarginBox; }
+constexpr BlockStepRound RenderStyle::initialBlockStepRound() { return BlockStepRound::Up; }
+inline Style::BlockStepSize RenderStyle::initialBlockStepSize() { return CSS::Keyword::None { }; }
+constexpr BorderCollapse RenderStyle::initialBorderCollapse() { return BorderCollapse::Separate; }
+constexpr Style::WebkitBorderSpacing RenderStyle::initialBorderHorizontalSpacing() { return 0_css_px; }
+inline Style::BorderImage RenderStyle::initialBorderImage() { return Style::BorderImage { }; }
+inline Style::BorderImageSource RenderStyle::initialBorderImageSource() { return CSS::Keyword::None { }; }
+inline Style::BorderRadiusValue RenderStyle::initialBorderRadius() { return { 0_css_px, 0_css_px }; }
+constexpr BorderStyle RenderStyle::initialBorderStyle() { return BorderStyle::None; }
+constexpr Style::WebkitBorderSpacing RenderStyle::initialBorderVerticalSpacing() { return 0_css_px; }
+constexpr Style::LineWidth RenderStyle::initialBorderWidth() { return Style::LineWidth { 3.0f }; }
+constexpr BoxAlignment RenderStyle::initialBoxAlign() { return BoxAlignment::Stretch; }
+constexpr BoxDecorationBreak RenderStyle::initialBoxDecorationBreak() { return BoxDecorationBreak::Slice; }
+constexpr BoxDirection RenderStyle::initialBoxDirection() { return BoxDirection::Normal; }
+constexpr Style::WebkitBoxFlex RenderStyle::initialBoxFlex() { return 0; }
+constexpr Style::WebkitBoxFlexGroup RenderStyle::initialBoxFlexGroup() { return 1; }
+constexpr BoxLines RenderStyle::initialBoxLines() { return BoxLines::Single; }
+constexpr Style::WebkitBoxOrdinalGroup RenderStyle::initialBoxOrdinalGroup() { return 1; }
+constexpr BoxOrient RenderStyle::initialBoxOrient() { return BoxOrient::Horizontal; }
+constexpr BoxPack RenderStyle::initialBoxPack() { return BoxPack::Start; }
+inline Style::BoxShadows RenderStyle::initialBoxShadow() { return CSS::Keyword::None { }; }
+constexpr BoxSizing RenderStyle::initialBoxSizing() { return BoxSizing::ContentBox; }
+inline Style::WebkitBoxReflect RenderStyle::initialBoxReflect() { return CSS::Keyword::None { }; }
+constexpr BreakBetween RenderStyle::initialBreakBetween() { return BreakBetween::Auto; }
+constexpr BreakInside RenderStyle::initialBreakInside() { return BreakInside::Auto; }
+constexpr LineCap RenderStyle::initialCapStyle() { return LineCap::Butt; }
+constexpr CaptionSide RenderStyle::initialCaptionSide() { return CaptionSide::Top; }
+constexpr Clear RenderStyle::initialClear() { return Clear::None; }
+inline Style::Clip RenderStyle::initialClip() { return CSS::Keyword::Auto { }; }
+inline Style::ClipPath RenderStyle::initialClipPath() { return CSS::Keyword::None { }; }
+inline Color RenderStyle::initialColor() { return Color::black; }
+constexpr ColumnAxis RenderStyle::initialColumnAxis() { return ColumnAxis::Auto; }
+constexpr Style::ColumnCount RenderStyle::initialColumnCount() { return CSS::Keyword::Auto { }; }
+constexpr ColumnFill RenderStyle::initialColumnFill() { return ColumnFill::Balance; }
+inline Style::GapGutter RenderStyle::initialColumnGap() { return CSS::Keyword::Normal { }; }
+inline Style::ItemTolerance RenderStyle::initialItemTolerance() { return CSS::Keyword::Normal { }; }
+constexpr ColumnProgression RenderStyle::initialColumnProgression() { return ColumnProgression::Normal; }
+constexpr Style::LineWidth RenderStyle::initialColumnRuleWidth() { return Style::LineWidth { 3.0f }; }
+constexpr ColumnSpan RenderStyle::initialColumnSpan() { return ColumnSpan::None; }
+constexpr Style::ColumnWidth RenderStyle::initialColumnWidth() { return CSS::Keyword::Auto { }; }
+inline Style::ContainIntrinsicSize RenderStyle::initialContainIntrinsicHeight() { return CSS::Keyword::None { }; }
+inline Style::ContainIntrinsicSize RenderStyle::initialContainIntrinsicWidth() { return CSS::Keyword::None { }; }
+inline Style::ContainerNames RenderStyle::initialContainerNames() { return CSS::Keyword::None { }; }
+constexpr ContainerType RenderStyle::initialContainerType() { return ContainerType::Normal; }
+constexpr Style::Contain RenderStyle::initialContain() { return CSS::Keyword::None { }; }
+inline Style::Content RenderStyle::initialContent() { return CSS::Keyword::Normal { }; }
+constexpr ContentVisibility RenderStyle::initialContentVisibility() { return ContentVisibility::Visible; }
+constexpr Style::CornerShapeValue RenderStyle::initialCornerShapeValue() { return Style::CornerShapeValue::round(); }
+inline Style::Cursor RenderStyle::initialCursor() { return CSS::Keyword::Auto { }; }
+constexpr TextDirection RenderStyle::initialDirection() { return TextDirection::LTR; }
+constexpr DisplayType RenderStyle::initialDisplay() { return DisplayType::Inline; }
+constexpr EmptyCell RenderStyle::initialEmptyCells() { return EmptyCell::Show; }
+constexpr FieldSizing RenderStyle::initialFieldSizing() { return FieldSizing::Fixed; }
+inline Style::Filter RenderStyle::initialFilter() { return CSS::Keyword::None { }; }
+inline Style::FlexBasis RenderStyle::initialFlexBasis() { return CSS::Keyword::Auto { }; }
+constexpr FlexDirection RenderStyle::initialFlexDirection() { return FlexDirection::Row; }
+constexpr Style::FlexGrow RenderStyle::initialFlexGrow() { return 0_css_number; }
+constexpr Style::FlexShrink RenderStyle::initialFlexShrink() { return 1_css_number; }
+constexpr FlexWrap RenderStyle::initialFlexWrap() { return FlexWrap::NoWrap; }
+constexpr Float RenderStyle::initialFloating() { return Float::None; }
+constexpr FontOpticalSizing RenderStyle::initialFontOpticalSizing() { return FontOpticalSizing::Enabled; }
+inline Style::FontFeatureSettings RenderStyle::initialFontFeatureSettings() { return CSS::Keyword::Normal { }; }
+inline Style::FontVariationSettings RenderStyle::initialFontVariationSettings() { return CSS::Keyword::Normal { }; }
+inline Style::FontPalette RenderStyle::initialFontPalette() { return CSS::Keyword::Normal { }; }
+inline Style::FontSizeAdjust RenderStyle::initialFontSizeAdjust() { return CSS::Keyword::None { }; }
+inline Style::FontStyle RenderStyle::initialFontStyle() { return CSS::Keyword::Normal { }; }
+inline Style::FontWeight RenderStyle::initialFontWeight() { return CSS::Keyword::Normal { }; }
+inline Style::FontWidth RenderStyle::initialFontWidth() { return CSS::Keyword::Normal { }; }
+constexpr Kerning RenderStyle::initialFontKerning() { return Kerning::Auto; }
+constexpr FontSmoothingMode RenderStyle::initialFontSmoothing() { return FontSmoothingMode::AutoSmoothing; }
+constexpr FontSynthesisLonghandValue RenderStyle::initialFontSynthesisSmallCaps() { return FontSynthesisLonghandValue::Auto; }
+constexpr FontSynthesisLonghandValue RenderStyle::initialFontSynthesisStyle() { return FontSynthesisLonghandValue::Auto; }
+constexpr FontSynthesisLonghandValue RenderStyle::initialFontSynthesisWeight() { return FontSynthesisLonghandValue::Auto; }
+inline Style::FontVariantAlternates RenderStyle::initialFontVariantAlternates() { return CSS::Keyword::Normal { }; }
+constexpr FontVariantCaps RenderStyle::initialFontVariantCaps() { return FontVariantCaps::Normal; }
+constexpr Style::FontVariantEastAsian RenderStyle::initialFontVariantEastAsian() { return CSS::Keyword::Normal { }; }
+constexpr FontVariantEmoji RenderStyle::initialFontVariantEmoji() { return FontVariantEmoji::Normal; }
+constexpr Style::FontVariantLigatures RenderStyle::initialFontVariantLigatures() { return CSS::Keyword::Normal { }; }
+constexpr Style::FontVariantNumeric RenderStyle::initialFontVariantNumeric() { return CSS::Keyword::Normal { }; }
+constexpr FontVariantPosition RenderStyle::initialFontVariantPosition() { return FontVariantPosition::Normal; }
+inline Style::WebkitLocale RenderStyle::initialLocale() { return CSS::Keyword::Auto { }; }
+constexpr Style::TextAutospace RenderStyle::initialTextAutospace() { return CSS::Keyword::NoAutospace { }; }
+constexpr TextRenderingMode RenderStyle::initialTextRendering() { return TextRenderingMode::AutoTextRendering; }
+constexpr Style::TextSpacingTrim RenderStyle::initialTextSpacingTrim() { return CSS::Keyword::SpaceAll { }; }
+inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }
+constexpr Style::GridAutoFlow RenderStyle::initialGridAutoFlow() { return CSS::Keyword::Row { }; }
+inline Style::GridTrackSizes RenderStyle::initialGridAutoRows() { return CSS::Keyword::Auto { }; }
+inline Style::GridPosition RenderStyle::initialGridItemColumnEnd() { return CSS::Keyword::Auto { }; }
+inline Style::GridPosition RenderStyle::initialGridItemColumnStart() { return CSS::Keyword::Auto { }; }
+inline Style::GridPosition RenderStyle::initialGridItemRowEnd() { return CSS::Keyword::Auto { }; }
+inline Style::GridPosition RenderStyle::initialGridItemRowStart() { return CSS::Keyword::Auto { }; }
+inline Style::GridTemplateList RenderStyle::initialGridTemplateColumns() { return CSS::Keyword::None { }; }
+inline Style::GridTemplateList RenderStyle::initialGridTemplateRows() { return CSS::Keyword::None { }; }
+inline Style::GridTemplateAreas RenderStyle::initialGridTemplateAreas() { return CSS::Keyword::None { }; }
+constexpr Style::HangingPunctuation RenderStyle::initialHangingPunctuation() { return CSS::Keyword::None { }; }
+constexpr Style::HyphenateLimitEdge RenderStyle::initialHyphenateLimitAfter() { return CSS::Keyword::Auto { }; }
+constexpr Style::HyphenateLimitEdge RenderStyle::initialHyphenateLimitBefore() { return CSS::Keyword::Auto { }; }
+constexpr Style::HyphenateLimitLines RenderStyle::initialHyphenateLimitLines() { return CSS::Keyword::NoLimit { }; }
+inline Style::HyphenateCharacter RenderStyle::initialHyphenateCharacter() { return CSS::Keyword::Auto { }; }
+constexpr Hyphens RenderStyle::initialHyphens() { return Hyphens::Manual; }
+constexpr Style::ImageOrientation RenderStyle::initialImageOrientation() { return Style::ImageOrientation::FromImage; }
+constexpr ImageRendering RenderStyle::initialImageRendering() { return ImageRendering::Auto; }
+inline Style::InsetEdge RenderStyle::initialInset() { return CSS::Keyword::Auto { }; }
+constexpr Style::WebkitInitialLetter RenderStyle::initialInitialLetter() { return CSS::Keyword::Normal { }; }
+constexpr InputSecurity RenderStyle::initialInputSecurity() { return InputSecurity::Auto; }
+constexpr LineJoin RenderStyle::initialJoinStyle() { return LineJoin::Miter; }
+constexpr Style::JustifyContent RenderStyle::initialJustifyContent() { return CSS::Keyword::Normal { }; }
+constexpr Style::JustifyItems RenderStyle::initialJustifyItems() { return CSS::Keyword::Legacy { }; }
+constexpr Style::JustifySelf RenderStyle::initialJustifySelf() { return CSS::Keyword::Auto { }; }
+inline Style::LetterSpacing RenderStyle::initialLetterSpacing() { return CSS::Keyword::Normal { }; }
+constexpr LineAlign RenderStyle::initialLineAlign() { return LineAlign::None; }
+constexpr Style::WebkitLineBoxContain RenderStyle::initialLineBoxContain() { return { Style::WebkitLineBoxContainValue::Block, Style::WebkitLineBoxContainValue::Inline, Style::WebkitLineBoxContainValue::Replaced }; }
+constexpr LineBreak RenderStyle::initialLineBreak() { return LineBreak::Auto; }
+constexpr Style::WebkitLineClamp RenderStyle::initialLineClamp() { return CSS::Keyword::None { }; }
+inline Style::WebkitLineGrid RenderStyle::initialLineGrid() { return CSS::Keyword::None { }; }
+inline Style::LineHeight RenderStyle::initialLineHeight() { return CSS::Keyword::Normal { }; }
+constexpr LineSnap RenderStyle::initialLineSnap() { return LineSnap::None; }
+inline Style::ImageOrNone RenderStyle::initialListStyleImage() { return CSS::Keyword::None { }; }
+constexpr ListStylePosition RenderStyle::initialListStylePosition() { return ListStylePosition::Outside; }
+inline Style::ListStyleType RenderStyle::initialListStyleType() { return CSS::Keyword::Disc { }; }
+inline Style::MarginEdge RenderStyle::initialMargin() { return 0_css_px; }
+constexpr Style::MarginTrim RenderStyle::initialMarginTrim() { return CSS::Keyword::None { }; }
+constexpr MarqueeBehavior RenderStyle::initialMarqueeBehavior() { return MarqueeBehavior::Scroll; }
+constexpr MarqueeDirection RenderStyle::initialMarqueeDirection() { return MarqueeDirection::Auto; }
+inline Style::WebkitMarqueeIncrement RenderStyle::initialMarqueeIncrement() { return 6_css_px; }
+constexpr Style::WebkitMarqueeRepetition RenderStyle::initialMarqueeRepetition() { return CSS::Keyword::Infinite { }; }
+constexpr Style::WebkitMarqueeSpeed RenderStyle::initialMarqueeSpeed() { return 85_css_ms; }
+inline Style::MaskBorder RenderStyle::initialMaskBorder() { return Style::MaskBorder { }; }
+inline Style::MaskBorderSource RenderStyle::initialMaskBorderSource() { return CSS::Keyword::None { }; }
+inline Style::MaskLayers RenderStyle::initialMaskLayers() { return CSS::Keyword::None { }; }
+constexpr Style::MathDepth RenderStyle::initialMathDepth() { return 0_css_integer; }
+constexpr MathShift RenderStyle::initialMathShift() { return MathShift::Normal; }
+constexpr MathStyle RenderStyle::initialMathStyle() { return MathStyle::Normal; }
+constexpr Style::MaximumLines RenderStyle::initialMaxLines() { return CSS::Keyword::None { }; }
+inline Style::MaximumSize RenderStyle::initialMaxSize() { return CSS::Keyword::None { }; }
+inline Style::MinimumSize RenderStyle::initialMinSize() { return CSS::Keyword::Auto { }; }
+constexpr NBSPMode RenderStyle::initialNBSPMode() { return NBSPMode::Normal; }
+constexpr ObjectFit RenderStyle::initialObjectFit() { return ObjectFit::Fill; }
+inline Style::ObjectPosition RenderStyle::initialObjectPosition() { return { 50_css_percentage, 50_css_percentage }; }
+inline Style::OffsetAnchor RenderStyle::initialOffsetAnchor() { return CSS::Keyword::Auto { }; }
+inline Style::OffsetDistance RenderStyle::initialOffsetDistance() { return 0_css_px; }
+inline Style::OffsetPath RenderStyle::initialOffsetPath() { return CSS::Keyword::None { }; }
+inline Style::OffsetPosition RenderStyle::initialOffsetPosition() { return CSS::Keyword::Normal { }; }
+constexpr Style::OffsetRotate RenderStyle::initialOffsetRotate() { return CSS::Keyword::Auto { }; }
+constexpr Style::Opacity RenderStyle::initialOpacity() { return 1_css_number; }
+constexpr Style::Order RenderStyle::initialOrder() { return 0_css_integer; }
+constexpr Style::Orphans RenderStyle::initialOrphans() { return CSS::Keyword::Auto { }; }
+constexpr OverflowAnchor RenderStyle::initialOverflowAnchor() { return OverflowAnchor::Auto; }
+inline OverflowContinue RenderStyle::initialOverflowContinue() { return OverflowContinue::Auto; }
+constexpr Style::Length<> RenderStyle::initialOutlineOffset() { return 0_css_px; }
+constexpr OutlineStyle RenderStyle::initialOutlineStyle() { return OutlineStyle::None; }
+constexpr Style::LineWidth RenderStyle::initialOutlineWidth() { return Style::LineWidth { 3.0f }; }
+constexpr OverflowWrap RenderStyle::initialOverflowWrap() { return OverflowWrap::Normal; }
+constexpr Overflow RenderStyle::initialOverflowX() { return Overflow::Visible; }
+constexpr Overflow RenderStyle::initialOverflowY() { return Overflow::Visible; }
+constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorX() { return OverscrollBehavior::Auto; }
+constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorY() { return OverscrollBehavior::Auto; }
+inline Style::PaddingEdge RenderStyle::initialPadding() { return 0_css_px; }
+inline Style::PageSize RenderStyle::initialPageSize() { return CSS::Keyword::Auto { }; }
+constexpr Style::SVGPaintOrder RenderStyle::initialPaintOrder() { return CSS::Keyword::Normal { }; }
+inline Style::Perspective RenderStyle::initialPerspective() { return CSS::Keyword::None { }; }
+inline Style::PerspectiveOrigin RenderStyle::initialPerspectiveOrigin() { return { initialPerspectiveOriginX(), initialPerspectiveOriginY() }; }
+inline Style::PerspectiveOriginX RenderStyle::initialPerspectiveOriginX() { return 50_css_percentage; }
+inline Style::PerspectiveOriginY RenderStyle::initialPerspectiveOriginY() { return 50_css_percentage; }
+constexpr PointerEvents RenderStyle::initialPointerEvents() { return PointerEvents::Auto; }
+constexpr PositionType RenderStyle::initialPosition() { return PositionType::Static; }
+inline Style::PositionAnchor RenderStyle::initialPositionAnchor() { return CSS::Keyword::Auto { }; }
+inline Style::PositionArea RenderStyle::initialPositionArea() { return CSS::Keyword::None { }; }
+inline Style::PositionTryFallbacks RenderStyle::initialPositionTryFallbacks() { return CSS::Keyword::None { }; }
+constexpr Style::PositionTryOrder RenderStyle::initialPositionTryOrder() { return Style::PositionTryOrder::Normal; }
+constexpr Style::PositionVisibility RenderStyle::initialPositionVisibility() { return Style::PositionVisibilityValue::AnchorsVisible; }
+constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
+inline Style::Quotes RenderStyle::initialQuotes() { return CSS::Keyword::Auto { }; }
+constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
+constexpr Style::Resize RenderStyle::initialResize() { return Style::Resize::None; }
+inline Style::GapGutter RenderStyle::initialRowGap() { return CSS::Keyword::Normal { }; }
+constexpr RubyPosition RenderStyle::initialRubyPosition() { return RubyPosition::Over; }
+constexpr RubyAlign RenderStyle::initialRubyAlign() { return RubyAlign::SpaceAround; }
+constexpr RubyOverhang RenderStyle::initialRubyOverhang() { return RubyOverhang::Auto; }
+constexpr Style::ScrollBehavior RenderStyle::initialScrollBehavior() { return Style::ScrollBehavior::Auto; }
+inline Style::ScrollMarginEdge RenderStyle::initialScrollMargin() { return 0_css_px; }
+inline Style::ScrollPaddingEdge RenderStyle::initialScrollPadding() { return CSS::Keyword::Auto { }; }
+constexpr Style::ScrollSnapAlign RenderStyle::initialScrollSnapAlign() { return CSS::Keyword::None { }; }
+constexpr ScrollSnapStop RenderStyle::initialScrollSnapStop() { return ScrollSnapStop::Normal; }
+constexpr Style::ScrollSnapType RenderStyle::initialScrollSnapType() { return CSS::Keyword::None { }; }
+inline Style::ProgressTimelineAxes RenderStyle::initialScrollTimelineAxes() { return CSS::Keyword::Block { }; }
+inline Style::ProgressTimelineNames RenderStyle::initialScrollTimelineNames() { return CSS::Keyword::None { }; }
+inline Style::ScrollbarColor RenderStyle::initialScrollbarColor() { return CSS::Keyword::Auto { }; }
+constexpr Style::ScrollbarGutter RenderStyle::initialScrollbarGutter() { return CSS::Keyword::Auto { }; }
+constexpr Style::ScrollbarWidth RenderStyle::initialScrollbarWidth() { return Style::ScrollbarWidth::Auto; }
+constexpr Style::ShapeImageThreshold RenderStyle::initialShapeImageThreshold() { return 0_css_number; }
+inline Style::ShapeMargin RenderStyle::initialShapeMargin() { return 0_css_px; }
+inline Style::ShapeOutside RenderStyle::initialShapeOutside() { return CSS::Keyword::None { }; }
+inline Style::PreferredSize RenderStyle::initialSize() { return CSS::Keyword::Auto { }; }
+constexpr Style::SpeakAs RenderStyle::initialSpeakAs() { return CSS::Keyword::Normal { }; }
+constexpr Style::ZIndex RenderStyle::initialSpecifiedZIndex() { return CSS::Keyword::Auto { }; }
+inline Style::Color RenderStyle::initialStrokeColor() { return { Color::transparentBlack }; }
+constexpr Style::StrokeMiterlimit RenderStyle::initialStrokeMiterLimit() { return 4_css_number; }
+inline Style::StrokeWidth RenderStyle::initialStrokeWidth() { return 1_css_px; }
+constexpr Style::TabSize RenderStyle::initialTabSize() { return 8_css_number; }
+constexpr TableLayoutType RenderStyle::initialTableLayout() { return TableLayoutType::Auto; }
+constexpr Style::TextAlign RenderStyle::initialTextAlign() { return Style::TextAlign::Start; }
+constexpr Style::TextAlignLast RenderStyle::initialTextAlignLast() { return Style::TextAlignLast::Auto; }
+constexpr TextBoxTrim RenderStyle::initialTextBoxTrim() { return TextBoxTrim::None; }
+constexpr Style::TextBoxEdge RenderStyle::initialTextBoxEdge() { return CSS::Keyword::Auto { }; }
+constexpr Style::LineFitEdge RenderStyle::initialLineFitEdge() { return CSS::Keyword::Leading { }; }
+constexpr TextCombine RenderStyle::initialTextCombine() { return TextCombine::None; }
+inline Style::Color RenderStyle::initialTextDecorationColor() { return CSS::Keyword::Currentcolor { }; }
+constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLine() { return CSS::Keyword::None { }; }
+constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLineInEffect() { return initialTextDecorationLine(); }
+constexpr TextDecorationSkipInk RenderStyle::initialTextDecorationSkipInk() { return TextDecorationSkipInk::Auto; }
+constexpr TextDecorationStyle RenderStyle::initialTextDecorationStyle() { return TextDecorationStyle::Solid; }
+inline Style::TextDecorationThickness RenderStyle::initialTextDecorationThickness() { return CSS::Keyword::Auto { }; }
+inline Style::Color RenderStyle::initialTextEmphasisColor() { return CSS::Keyword::Currentcolor { }; }
+inline Style::TextEmphasisStyle RenderStyle::initialTextEmphasisStyle() { return CSS::Keyword::None { }; }
+constexpr Style::TextEmphasisPosition RenderStyle::initialTextEmphasisPosition() { return { Style::TextEmphasisPositionValue::Over, Style::TextEmphasisPositionValue::Right }; }
+inline Style::Color RenderStyle::initialTextFillColor() { return CSS::Keyword::Currentcolor { }; }
+constexpr TextGroupAlign RenderStyle::initialTextGroupAlign() { return TextGroupAlign::None; }
+inline Style::TextIndent RenderStyle::initialTextIndent() { return 0_css_px; }
+constexpr TextJustify RenderStyle::initialTextJustify() { return TextJustify::Auto; }
+constexpr TextOrientation RenderStyle::initialTextOrientation() { return TextOrientation::Mixed; }
+constexpr TextOverflow RenderStyle::initialTextOverflow() { return TextOverflow::Clip; }
+constexpr TextSecurity RenderStyle::initialTextSecurity() { return TextSecurity::None; }
+inline Style::TextShadows RenderStyle::initialTextShadow() { return CSS::Keyword::None { }; }
+inline Style::Color RenderStyle::initialTextStrokeColor() { return CSS::Keyword::Currentcolor { }; }
+constexpr Style::WebkitTextStrokeWidth RenderStyle::initialTextStrokeWidth() { return 0_css_px; }
+constexpr Style::TextTransform RenderStyle::initialTextTransform() { return CSS::Keyword::None { }; }
+inline Style::TextUnderlineOffset RenderStyle::initialTextUnderlineOffset() { return CSS::Keyword::Auto { }; }
+constexpr Style::TextUnderlinePosition RenderStyle::initialTextUnderlinePosition() { return CSS::Keyword::Auto { }; }
+constexpr TextWrapMode RenderStyle::initialTextWrapMode() { return TextWrapMode::Wrap; }
+constexpr TextWrapStyle RenderStyle::initialTextWrapStyle() { return TextWrapStyle::Auto; }
+constexpr TextZoom RenderStyle::initialTextZoom() { return TextZoom::Normal; }
+constexpr Style::TouchAction RenderStyle::initialTouchAction() { return CSS::Keyword::Auto { }; }
+inline Style::Transform RenderStyle::initialTransform() { return CSS::Keyword::None { }; }
+constexpr TransformBox RenderStyle::initialTransformBox() { return TransformBox::ViewBox; }
+inline Style::Transitions RenderStyle::initialTransitions() { return CSS::Keyword::All { }; }
+inline Style::Rotate RenderStyle::initialRotate() { return CSS::Keyword::None { }; }
+inline Style::Scale RenderStyle::initialScale() { return CSS::Keyword::None { }; }
+inline Style::Translate RenderStyle::initialTranslate() { return CSS::Keyword::None { }; }
+inline Style::TransformOrigin RenderStyle::initialTransformOrigin() { return { initialTransformOriginX(), initialTransformOriginY(), initialTransformOriginZ() }; }
+inline Style::TransformOriginX RenderStyle::initialTransformOriginX() { return 50_css_percentage; }
+inline Style::TransformOriginY RenderStyle::initialTransformOriginY() { return 50_css_percentage; }
+inline Style::TransformOriginZ RenderStyle::initialTransformOriginZ() { return 0_css_px; }
+constexpr TransformStyle3D RenderStyle::initialTransformStyle3D() { return TransformStyle3D::Flat; }
+constexpr UnicodeBidi RenderStyle::initialUnicodeBidi() { return UnicodeBidi::Normal; }
+constexpr Style::ZIndex RenderStyle::initialUsedZIndex() { return CSS::Keyword::Auto { }; }
+constexpr UserDrag RenderStyle::initialUserDrag() { return UserDrag::Auto; }
+constexpr UserModify RenderStyle::initialUserModify() { return UserModify::ReadOnly; }
+constexpr UserSelect RenderStyle::initialUserSelect() { return UserSelect::Text; }
+inline Style::VerticalAlign RenderStyle::initialVerticalAlign() { return CSS::Keyword::Baseline { }; }
+inline Style::ProgressTimelineAxes RenderStyle::initialViewTimelineAxes() { return CSS::Keyword::Block { }; }
+inline Style::ViewTimelineInsets RenderStyle::initialViewTimelineInsets() { return CSS::Keyword::Auto { }; }
+inline Style::ProgressTimelineNames RenderStyle::initialViewTimelineNames() { return CSS::Keyword::None { }; }
+inline Style::ViewTransitionClasses RenderStyle::initialViewTransitionClasses() { return CSS::Keyword::None { }; }
+inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { return CSS::Keyword::None { }; }
+constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
+inline Style::NameScope RenderStyle::initialTimelineScope() { return CSS::Keyword::None { }; }
+constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
+constexpr Style::Widows RenderStyle::initialWidows() { return CSS::Keyword::Auto { }; }
+inline Style::WillChange RenderStyle::initialWillChange() { return CSS::Keyword::Auto { }; }
+constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
+inline Style::WordSpacing RenderStyle::initialWordSpacing() { return CSS::Keyword::Normal { }; }
+constexpr StyleWritingMode RenderStyle::initialWritingMode() { return StyleWritingMode::HorizontalTb; }
+inline Style::Color RenderStyle::initialBorderBottomColor() { return CSS::Keyword::Currentcolor { }; }
+inline Style::Color RenderStyle::initialBorderLeftColor() { return CSS::Keyword::Currentcolor { }; }
+inline Style::Color RenderStyle::initialBorderRightColor() { return CSS::Keyword::Currentcolor { }; }
+inline Style::Color RenderStyle::initialBorderTopColor() { return CSS::Keyword::Currentcolor { }; }
+inline Style::Color RenderStyle::initialColumnRuleColor() { return CSS::Keyword::Currentcolor { }; }
+inline Style::Color RenderStyle::initialOutlineColor() { return CSS::Keyword::Currentcolor { }; }
+inline Style::AccentColor RenderStyle::initialAccentColor() { return CSS::Keyword::Auto { }; }
+inline Style::SVGCenterCoordinateComponent RenderStyle::initialCx() { return 0_css_px; }
+inline Style::SVGCenterCoordinateComponent RenderStyle::initialCy() { return 0_css_px; }
+inline Style::SVGPathData RenderStyle::initialD() { return CSS::Keyword::None { }; }
+inline Style::SVGRadius RenderStyle::initialR() { return 0_css_px; }
+inline Style::SVGRadiusComponent RenderStyle::initialRx() { return CSS::Keyword::Auto { }; }
+inline Style::SVGRadiusComponent RenderStyle::initialRy() { return CSS::Keyword::Auto { }; }
+inline Style::SVGCoordinateComponent RenderStyle::initialX() { return 0_css_px; }
+inline Style::SVGCoordinateComponent RenderStyle::initialY() { return 0_css_px; }
+inline Style::SVGStrokeDasharray RenderStyle::initialStrokeDashArray() { return CSS::Keyword::None { }; }
+inline Style::SVGStrokeDashoffset RenderStyle::initialStrokeDashOffset() { return 0_css_px; }
+constexpr Style::Opacity RenderStyle::initialFillOpacity() { return 1_css_number; }
+constexpr Style::Opacity RenderStyle::initialStrokeOpacity() { return 1_css_number; }
+constexpr Style::Opacity RenderStyle::initialStopOpacity() { return 1_css_number; }
+constexpr Style::Opacity RenderStyle::initialFloodOpacity() { return 1_css_number; }
+constexpr AlignmentBaseline RenderStyle::initialAlignmentBaseline() { return AlignmentBaseline::Baseline; }
+constexpr DominantBaseline RenderStyle::initialDominantBaseline() { return DominantBaseline::Auto; }
+constexpr VectorEffect RenderStyle::initialVectorEffect() { return VectorEffect::None; }
+constexpr BufferedRendering RenderStyle::initialBufferedRendering() { return BufferedRendering::Auto; }
+constexpr WindRule RenderStyle::initialClipRule() { return WindRule::NonZero; }
+constexpr ColorInterpolation RenderStyle::initialColorInterpolation() { return ColorInterpolation::SRGB; }
+constexpr ColorInterpolation RenderStyle::initialColorInterpolationFilters() { return ColorInterpolation::LinearRGB; }
+constexpr WindRule RenderStyle::initialFillRule() { return WindRule::NonZero; }
+constexpr ShapeRendering RenderStyle::initialShapeRendering() { return ShapeRendering::Auto; }
+constexpr TextAnchor RenderStyle::initialTextAnchor() { return TextAnchor::Start; }
+constexpr Style::SVGGlyphOrientationHorizontal RenderStyle::initialGlyphOrientationHorizontal() { return Style::SVGGlyphOrientationHorizontal::Degrees0; }
+constexpr Style::SVGGlyphOrientationVertical RenderStyle::initialGlyphOrientationVertical() { return Style::SVGGlyphOrientationVertical::Auto; }
+inline Style::SVGPaint RenderStyle::initialFill() { return Style::Color { Color::black }; }
+inline Style::SVGPaint RenderStyle::initialStroke() { return CSS::Keyword::None { }; }
+inline Style::Color RenderStyle::initialStopColor() { return Color::black; }
+inline Style::Color RenderStyle::initialFloodColor() { return Color::black; }
+inline Style::Color RenderStyle::initialLightingColor() { return Color::white; }
+inline Style::SVGMarkerResource RenderStyle::initialMarkerStart() { return CSS::Keyword::None { }; }
+inline Style::SVGMarkerResource RenderStyle::initialMarkerMid() { return CSS::Keyword::None { }; }
+inline Style::SVGMarkerResource RenderStyle::initialMarkerEnd() { return CSS::Keyword::None { }; }
+constexpr MaskType RenderStyle::initialMaskType() { return MaskType::Luminance; }
+inline Style::SVGBaselineShift RenderStyle::initialBaselineShift() { return CSS::Keyword::Baseline { }; }
+constexpr BlendMode RenderStyle::initialBlendMode() { return BlendMode::Normal; }
+constexpr Isolation RenderStyle::initialIsolation() { return Isolation::Auto; }
+inline Style::Filter RenderStyle::initialBackdropFilter() { return CSS::Keyword::None { }; }
+inline Style::DynamicRangeLimit RenderStyle::initialDynamicRangeLimit() { return CSS::Keyword::NoLimit { }; }
+#if ENABLE(APPLE_PAY)
+constexpr ApplePayButtonStyle RenderStyle::initialApplePayButtonStyle() { return ApplePayButtonStyle::Black; }
+constexpr ApplePayButtonType RenderStyle::initialApplePayButtonType() { return ApplePayButtonType::Plain; }
+#endif
+#if ENABLE(CURSOR_VISIBILITY)
+constexpr CursorVisibility RenderStyle::initialCursorVisibility() { return CursorVisibility::Auto; }
+#endif
+#if ENABLE(DARK_MODE_CSS)
+inline Style::ColorScheme RenderStyle::initialColorScheme() { return Style::ColorScheme { .schemes = { }, .only = { } }; }
+#endif
+#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
+constexpr Style::WebkitOverflowScrolling RenderStyle::initialOverflowScrolling() { return Style::WebkitOverflowScrolling::Auto; }
+#endif
+#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
+constexpr Style::WebkitTouchCallout RenderStyle::initialTouchCallout() { return Style::WebkitTouchCallout::Default; }
+#endif
+#if ENABLE(TEXT_AUTOSIZING)
+inline Style::LineHeight RenderStyle::initialSpecifiedLineHeight() { return CSS::Keyword::Normal { }; }
+constexpr Style::TextSizeAdjust RenderStyle::initialTextSizeAdjust() { return CSS::Keyword::Auto { }; }
+#endif
+
+// MARK: - Property getters
+
+// FIXME: - Below are property getters that are not yet generated
+
+// MARK: FIXME - Support generated properties that use "fromRaw/toRaw" conversions.
+inline Style::HangingPunctuation RenderStyle::hangingPunctuation() const { return Style::HangingPunctuation::fromRaw(m_rareInheritedData->hangingPunctuation); }
+inline Style::WebkitLineBoxContain RenderStyle::lineBoxContain() const { return Style::WebkitLineBoxContain::fromRaw(m_rareInheritedData->lineBoxContain); }
+inline Style::MarginTrim RenderStyle::marginTrim() const { return Style::MarginTrim::fromRaw(m_nonInheritedData->rareData->marginTrim); }
+inline Style::SVGPaintOrder RenderStyle::paintOrder() const { return Style::SVGPaintOrder::fromRaw(m_rareInheritedData->paintOrder); }
+inline Style::PositionVisibility RenderStyle::positionVisibility() const { return Style::PositionVisibility::fromRaw(m_nonInheritedData->rareData->positionVisibility); }
+inline Style::SpeakAs RenderStyle::speakAs() const { return Style::SpeakAs::fromRaw(m_rareInheritedData->speakAs); }
+inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return Style::TextDecorationLine::fromRaw(m_nonInheritedFlags.textDecorationLine); }
+inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return Style::TextDecorationLine::fromRaw(m_inheritedFlags.textDecorationLineInEffect); }
+inline Style::TextEmphasisPosition RenderStyle::textEmphasisPosition() const { return Style::TextEmphasisPosition::fromRaw(m_rareInheritedData->textEmphasisPosition); }
+inline Style::TextTransform RenderStyle::textTransform() const { return Style::TextTransform::fromRaw(m_inheritedFlags.textTransform); }
+inline Style::TextUnderlinePosition RenderStyle::textUnderlinePosition() const { return Style::TextUnderlinePosition::fromRaw(m_rareInheritedData->textUnderlinePosition); }
+inline Style::Contain RenderStyle::contain() const { return Style::Contain::fromRaw(m_nonInheritedData->rareData->contain); }
+
+// FIXME: Support properties that set more than one value when set.
+inline StyleAppearance RenderStyle::appearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->appearance); }
+inline BlendMode RenderStyle::blendMode() const { return static_cast<BlendMode>(m_nonInheritedData->rareData->effectiveBlendMode); }
+inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
+
+// FIXME: Add a type that encapsulates both caretColor() and hasAutoCaretColor().
+inline const Style::Color& RenderStyle::caretColor() const { return m_rareInheritedData->caretColor; }
+inline bool RenderStyle::hasAutoCaretColor() const { return m_rareInheritedData->hasAutoCaretColor; }
+inline bool RenderStyle::hasVisitedLinkAutoCaretColor() const { return m_rareInheritedData->hasVisitedLinkAutoCaretColor; }
+
+// FIXME: Support generating properties that have their storage spread out
+inline Style::Cursor RenderStyle::cursor() const { return { m_rareInheritedData->cursorImages, cursorType() }; }
+inline Style::ZIndex RenderStyle::specifiedZIndex() const { return m_nonInheritedData->boxData->specifiedZIndex(); }
+
+// FIXME: Support descriptors
+inline const Style::PageSize& RenderStyle::pageSize() const { return m_nonInheritedData->rareData->pageSize; }
+
+// FIXME: Support generating getter and setter with different names (or rename computedLetterSpacing() to letterSpacing() and computedWordSpacing() to wordSpacing())
+inline const Style::LetterSpacing& RenderStyle::computedLetterSpacing() const { return m_inheritedData->fontData->letterSpacing; }
+inline const Style::WordSpacing& RenderStyle::computedWordSpacing() const { return m_inheritedData->fontData->wordSpacing; }
+
+// FIXME: Support properties stored in structs
+inline NinePieceImageRule RenderStyle::maskBorderHorizontalRule() const { return maskBorderRepeat().horizontalRule(); }
+inline const Style::MaskBorderOutset& RenderStyle::maskBorderOutset() const { return maskBorder().outset(); }
+inline const Style::MaskBorderRepeat& RenderStyle::maskBorderRepeat() const { return maskBorder().repeat(); }
+inline const Style::MaskBorderSlice& RenderStyle::maskBorderSlice() const { return maskBorder().slice(); }
+inline const Style::MaskBorderSource& RenderStyle::maskBorderSource() const { return maskBorder().source(); }
+inline NinePieceImageRule RenderStyle::maskBorderVerticalRule() const { return maskBorderRepeat().verticalRule(); }
+inline const Style::MaskBorderWidth& RenderStyle::maskBorderWidth() const { return maskBorder().width(); }
+inline const Style::BorderImageOutset& RenderStyle::borderImageOutset() const { return borderImage().outset(); }
+inline const Style::BorderImageRepeat& RenderStyle::borderImageRepeat() const { return borderImage().repeat(); }
+inline const Style::BorderImageSlice& RenderStyle::borderImageSlice() const { return borderImage().slice(); }
+inline const Style::BorderImageSource& RenderStyle::borderImageSource() const { return borderImage().source(); }
+inline const Style::BorderImageWidth& RenderStyle::borderImageWidth() const { return borderImage().width(); }
+inline const Style::TransformOriginX& RenderStyle::transformOriginX() const { return transformOrigin().x; }
+inline const Style::TransformOriginY& RenderStyle::transformOriginY() const { return transformOrigin().y; }
+inline const Style::TransformOriginZ& RenderStyle::transformOriginZ() const { return transformOrigin().z; }
+inline const Style::PerspectiveOriginX& RenderStyle::perspectiveOriginX() const { return m_nonInheritedData->rareData->perspectiveOrigin.x; }
+inline const Style::PerspectiveOriginY& RenderStyle::perspectiveOriginY() const { return m_nonInheritedData->rareData->perspectiveOrigin.y; }
+inline const Style::Color& RenderStyle::columnRuleColor() const { return m_nonInheritedData->miscData->multiCol->columnRule.color(); }
+inline BorderStyle RenderStyle::columnRuleStyle() const { return m_nonInheritedData->miscData->multiCol->columnRule.style(); }
+inline Style::LineWidth RenderStyle::columnRuleWidth() const { return m_nonInheritedData->miscData->multiCol->columnRuleWidth(); }
+inline const Style::Color& RenderStyle::outlineColor() const { return outline().color(); }
+inline OutlineStyle RenderStyle::outlineStyle() const { return outline().style(); }
+inline Style::LineWidthBox RenderStyle::borderWidth() const { return border().borderWidth(); }
+inline BorderStyle RenderStyle::borderBottomStyle() const { return border().bottom().style(); }
+inline BorderStyle RenderStyle::borderLeftStyle() const { return border().left().style(); }
+inline BorderStyle RenderStyle::borderRightStyle() const { return border().right().style(); }
+inline BorderStyle RenderStyle::borderTopStyle() const { return border().top().style(); }
+inline const BorderValue& RenderStyle::borderBottom() const { return border().bottom(); }
+inline const BorderValue& RenderStyle::borderLeft() const { return border().left(); }
+inline const BorderValue& RenderStyle::borderRight() const { return border().right(); }
+inline const BorderValue& RenderStyle::borderTop() const { return border().top(); }
+inline const Style::BorderRadiusValue& RenderStyle::borderBottomLeftRadius() const { return border().bottomLeftRadius(); }
+inline const Style::BorderRadiusValue& RenderStyle::borderBottomRightRadius() const { return border().bottomRightRadius(); }
+inline const Style::BorderRadiusValue& RenderStyle::borderTopLeftRadius() const { return border().topLeftRadius(); }
+inline const Style::BorderRadiusValue& RenderStyle::borderTopRightRadius() const { return border().topRightRadius(); }
+inline const Style::Color& RenderStyle::borderBottomColor() const { return border().bottom().color(); }
+inline const Style::Color& RenderStyle::borderLeftColor() const { return border().left().color(); }
+inline const Style::Color& RenderStyle::borderRightColor() const { return border().right().color(); }
+inline const Style::Color& RenderStyle::borderTopColor() const { return border().top().color(); }
+inline const Style::CornerShapeValue& RenderStyle::cornerBottomLeftShape() const { return border().bottomLeftCornerShape(); }
+inline const Style::CornerShapeValue& RenderStyle::cornerBottomRightShape() const { return border().bottomRightCornerShape(); }
+inline const Style::CornerShapeValue& RenderStyle::cornerTopLeftShape() const { return border().topLeftCornerShape(); }
+inline const Style::CornerShapeValue& RenderStyle::cornerTopRightShape() const { return border().topRightCornerShape(); }
+inline NinePieceImageRule RenderStyle::borderImageHorizontalRule() const { return borderImageRepeat().horizontalRule(); }
+inline NinePieceImageRule RenderStyle::borderImageVerticalRule() const { return borderImageRepeat().verticalRule(); }
+inline Style::LineWidth RenderStyle::borderBottomWidth() const { return border().borderBottomWidth(); }
+inline Style::LineWidth RenderStyle::borderLeftWidth() const { return border().borderLeftWidth(); }
+inline Style::LineWidth RenderStyle::borderRightWidth() const { return border().borderRightWidth(); }
+inline Style::LineWidth RenderStyle::borderTopWidth() const { return border().borderTopWidth(); }
+inline MaskType RenderStyle::maskType() const { return static_cast<MaskType>(m_svgStyle->nonInheritedFlags.maskType); }
+inline AlignmentBaseline RenderStyle::alignmentBaseline() const { return static_cast<AlignmentBaseline>(m_svgStyle->nonInheritedFlags.alignmentBaseline); }
+inline DominantBaseline RenderStyle::dominantBaseline() const { return static_cast<DominantBaseline>(m_svgStyle->nonInheritedFlags.dominantBaseline); }
+inline VectorEffect RenderStyle::vectorEffect() const { return static_cast<VectorEffect>(m_svgStyle->nonInheritedFlags.vectorEffect); }
+inline BufferedRendering RenderStyle::bufferedRendering() const { return static_cast<BufferedRendering>(m_svgStyle->nonInheritedFlags.bufferedRendering); }
+inline WindRule RenderStyle::clipRule() const { return static_cast<WindRule>(m_svgStyle->inheritedFlags.clipRule); }
+inline ColorInterpolation RenderStyle::colorInterpolation() const { return static_cast<ColorInterpolation>(m_svgStyle->inheritedFlags.colorInterpolation); }
+inline ColorInterpolation RenderStyle::colorInterpolationFilters() const { return static_cast<ColorInterpolation>(m_svgStyle->inheritedFlags.colorInterpolationFilters); }
+inline WindRule RenderStyle::fillRule() const { return static_cast<WindRule>(m_svgStyle->inheritedFlags.fillRule); }
+inline ShapeRendering RenderStyle::shapeRendering() const { return static_cast<ShapeRendering>(m_svgStyle->inheritedFlags.shapeRendering); }
+inline TextAnchor RenderStyle::textAnchor() const { return static_cast<TextAnchor>(m_svgStyle->inheritedFlags.textAnchor); }
+inline Style::SVGGlyphOrientationHorizontal RenderStyle::glyphOrientationHorizontal() const { return static_cast<Style::SVGGlyphOrientationHorizontal>(m_svgStyle->inheritedFlags.glyphOrientationHorizontal); }
+inline Style::SVGGlyphOrientationVertical RenderStyle::glyphOrientationVertical() const { return static_cast<Style::SVGGlyphOrientationVertical>(m_svgStyle->inheritedFlags.glyphOrientationVertical); }
+
+// FIXME: Support properties stored in RectEdge<>.
+inline const Style::InsetEdge& RenderStyle::top() const { return m_nonInheritedData->surroundData->inset.top(); }
+inline const Style::InsetEdge& RenderStyle::right() const { return m_nonInheritedData->surroundData->inset.right(); }
+inline const Style::InsetEdge& RenderStyle::bottom() const { return m_nonInheritedData->surroundData->inset.bottom(); }
+inline const Style::InsetEdge& RenderStyle::left() const { return m_nonInheritedData->surroundData->inset.left(); }
+inline const Style::MarginEdge& RenderStyle::marginTop() const { return m_nonInheritedData->surroundData->margin.top(); }
+inline const Style::MarginEdge& RenderStyle::marginBottom() const { return m_nonInheritedData->surroundData->margin.bottom(); }
+inline const Style::MarginEdge& RenderStyle::marginLeft() const { return m_nonInheritedData->surroundData->margin.left(); }
+inline const Style::MarginEdge& RenderStyle::marginRight() const { return m_nonInheritedData->surroundData->margin.right(); }
+inline const Style::PaddingEdge& RenderStyle::paddingTop() const { return paddingBox().top(); }
+inline const Style::PaddingEdge& RenderStyle::paddingRight() const { return paddingBox().right(); }
+inline const Style::PaddingEdge& RenderStyle::paddingBottom() const { return paddingBox().bottom(); }
+inline const Style::PaddingEdge& RenderStyle::paddingLeft() const { return paddingBox().left(); }
+
+// FIXME: Support generated font-property getters
+inline Style::FontFamilies RenderStyle::fontFamily() const { return { fontDescription().families(), fontDescription().isSpecifiedFont() }; }
+inline Style::FontPalette RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
+inline Style::FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
+inline Style::FontStyle RenderStyle::fontStyle() const { return { fontDescription().fontStyleSlope(), fontDescription().fontStyleAxis() }; }
+inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
+inline Style::FontFeatureSettings RenderStyle::fontFeatureSettings() const { return fontDescription().featureSettings(); }
+inline Style::FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
+inline Style::FontWeight RenderStyle::fontWeight() const { return fontDescription().weight(); }
+inline Style::FontWidth RenderStyle::fontWidth() const { return fontDescription().width(); }
+inline Kerning RenderStyle::fontKerning() const { return fontDescription().kerning(); }
+inline FontSmoothingMode RenderStyle::fontSmoothing() const { return fontDescription().fontSmoothing(); }
+inline FontSynthesisLonghandValue RenderStyle::fontSynthesisSmallCaps() const { return fontDescription().fontSynthesisSmallCaps(); }
+inline FontSynthesisLonghandValue RenderStyle::fontSynthesisStyle() const { return fontDescription().fontSynthesisStyle(); }
+inline FontSynthesisLonghandValue RenderStyle::fontSynthesisWeight() const { return fontDescription().fontSynthesisWeight(); }
+inline Style::FontVariantAlternates RenderStyle::fontVariantAlternates() const { return fontDescription().variantAlternates(); }
+inline FontVariantCaps RenderStyle::fontVariantCaps() const { return fontDescription().variantCaps(); }
+inline Style::FontVariantEastAsian RenderStyle::fontVariantEastAsian() const { return fontDescription().variantEastAsian(); }
+inline FontVariantEmoji RenderStyle::fontVariantEmoji() const { return fontDescription().variantEmoji(); }
+inline Style::FontVariantLigatures RenderStyle::fontVariantLigatures() const { return fontDescription().variantLigatures(); }
+inline Style::FontVariantNumeric RenderStyle::fontVariantNumeric() const { return fontDescription().variantNumeric(); }
+inline FontVariantPosition RenderStyle::fontVariantPosition() const { return fontDescription().variantPosition(); }
+inline Style::WebkitLocale RenderStyle::locale() const { return fontDescription().specifiedLocale(); }
+inline TextRenderingMode RenderStyle::textRendering() const { return fontDescription().textRenderingMode(); }
+inline Style::TextAutospace RenderStyle::textAutospace() const { return fontDescription().textAutospace(); }
+inline Style::TextSpacingTrim RenderStyle::textSpacingTrim() const { return fontDescription().textSpacingTrim(); }
+inline float RenderStyle::usedLetterSpacing() const { return m_inheritedData->fontData->fontCascade.letterSpacing(); }
+inline const FontCascade& RenderStyle::fontCascade() const { return m_inheritedData->fontData->fontCascade; }
+inline Style::WebkitLocale RenderStyle::computedLocale() const { return fontDescription().computedLocale(); }
+inline float RenderStyle::usedWordSpacing() const { return m_inheritedData->fontData->fontCascade.wordSpacing(); }
+
+// FIXME: Support generating visited link variants
+inline const Style::Color& RenderStyle::visitedLinkBackgroundColor() const { return m_nonInheritedData->miscData->visitedLinkColor->background; }
+inline const Style::Color& RenderStyle::visitedLinkBorderBottomColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderBottom; }
+inline const Style::Color& RenderStyle::visitedLinkBorderLeftColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderLeft; }
+inline const Style::Color& RenderStyle::visitedLinkBorderRightColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderRight; }
+inline const Style::Color& RenderStyle::visitedLinkBorderTopColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderTop; }
+inline const Style::Color& RenderStyle::visitedLinkCaretColor() const { return m_rareInheritedData->visitedLinkCaretColor; }
+inline const Style::Color& RenderStyle::visitedLinkColumnRuleColor() const { return m_nonInheritedData->miscData->multiCol->visitedLinkColumnRuleColor; }
+inline const Style::Color& RenderStyle::visitedLinkOutlineColor() const { return m_nonInheritedData->miscData->visitedLinkColor->outline; }
+inline const Style::Color& RenderStyle::visitedLinkStrokeColor() const { return m_rareInheritedData->visitedLinkStrokeColor; }
+inline const Style::Color& RenderStyle::visitedLinkTextDecorationColor() const { return m_nonInheritedData->miscData->visitedLinkColor->textDecoration; }
+inline const Style::Color& RenderStyle::visitedLinkTextEmphasisColor() const { return m_rareInheritedData->visitedLinkTextEmphasisColor; }
+inline const Style::Color& RenderStyle::visitedLinkTextFillColor() const { return m_rareInheritedData->visitedLinkTextFillColor; }
+inline const Style::Color& RenderStyle::visitedLinkTextStrokeColor() const { return m_rareInheritedData->visitedLinkTextStrokeColor; }
+inline const Style::SVGPaint& RenderStyle::visitedLinkFill() const { return m_svgStyle->fillData->visitedLinkFill; }
+inline const Style::SVGPaint& RenderStyle::visitedLinkStroke() const { return m_svgStyle->strokeData->visitedLinkStroke; }
+
+// FIXME: Support generating "ExplicitlySet" setters
+inline bool RenderStyle::hasExplicitlySetBorderBottomLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomLeftRadius; }
+inline bool RenderStyle::hasExplicitlySetBorderBottomRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomRightRadius; }
+inline bool RenderStyle::hasExplicitlySetBorderRadius() const { return hasExplicitlySetBorderBottomLeftRadius() || hasExplicitlySetBorderBottomRightRadius() || hasExplicitlySetBorderTopLeftRadius() || hasExplicitlySetBorderTopRightRadius(); }
+inline bool RenderStyle::hasExplicitlySetBorderTopLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopLeftRadius; }
+inline bool RenderStyle::hasExplicitlySetBorderTopRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopRightRadius; }
+inline bool RenderStyle::hasExplicitlySetColor() const { return m_inheritedFlags.hasExplicitlySetColor; }
+inline bool RenderStyle::hasExplicitlySetDirection() const { return m_nonInheritedData->miscData->hasExplicitlySetDirection; }
+inline bool RenderStyle::hasExplicitlySetPadding() const { return hasExplicitlySetPaddingBottom() || hasExplicitlySetPaddingLeft() || hasExplicitlySetPaddingRight() || hasExplicitlySetPaddingTop(); }
+inline bool RenderStyle::hasExplicitlySetPaddingBottom() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingBottom; }
+inline bool RenderStyle::hasExplicitlySetPaddingLeft() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingLeft; }
+inline bool RenderStyle::hasExplicitlySetPaddingRight() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingRight; }
+inline bool RenderStyle::hasExplicitlySetPaddingTop() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingTop; }
+inline bool RenderStyle::hasExplicitlySetStrokeColor() const { return m_rareInheritedData->hasSetStrokeColor; }
+inline bool RenderStyle::hasExplicitlySetStrokeWidth() const { return m_rareInheritedData->hasSetStrokeWidth; }
+inline bool RenderStyle::hasExplicitlySetWritingMode() const { return m_nonInheritedData->miscData->hasExplicitlySetWritingMode; }
+#if ENABLE(DARK_MODE_CSS)
+inline bool RenderStyle::hasExplicitlySetColorScheme() const { return m_nonInheritedData->miscData->hasExplicitlySetColorScheme; }
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -190,12 +190,12 @@ bool SVGRenderStyle::changeRequiresLayout(const SVGRenderStyle& other) const
         return true; 
 
     // Some stroke properties, requires relayouts, as the cached stroke boundaries need to be recalculated.
-    if (!strokeData->paint.hasSameType(other.strokeData->paint)
-        || strokeData->paint.urlDisregardingType() != other.strokeData->paint.urlDisregardingType()
-        || strokeData->dashArray != other.strokeData->dashArray
-        || strokeData->dashOffset != other.strokeData->dashOffset
-        || !strokeData->visitedLinkPaint.hasSameType(other.strokeData->visitedLinkPaint)
-        || strokeData->visitedLinkPaint.urlDisregardingType() != other.strokeData->visitedLinkPaint.urlDisregardingType())
+    if (!strokeData->stroke.hasSameType(other.strokeData->stroke)
+        || strokeData->stroke.urlDisregardingType() != other.strokeData->stroke.urlDisregardingType()
+        || strokeData->strokeDashArray != other.strokeData->strokeDashArray
+        || strokeData->strokeDashOffset != other.strokeData->strokeDashOffset
+        || !strokeData->visitedLinkStroke.hasSameType(other.strokeData->visitedLinkStroke)
+        || strokeData->visitedLinkStroke.urlDisregardingType() != other.strokeData->visitedLinkStroke.urlDisregardingType())
         return true;
 
     // vector-effect changes require a re-layout.
@@ -209,16 +209,16 @@ bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool cur
 {
     if (this == &other) {
         ASSERT(currentColorDiffers);
-        return containsCurrentColor(strokeData->paint)
-            || containsCurrentColor(strokeData->visitedLinkPaint)
+        return containsCurrentColor(strokeData->stroke)
+            || containsCurrentColor(strokeData->visitedLinkStroke)
             || containsCurrentColor(miscData->floodColor)
             || containsCurrentColor(miscData->lightingColor)
-            || containsCurrentColor(fillData->paint); // FIXME: Should this be checking fillData->visitedLinkPaint.color as well?
+            || containsCurrentColor(fillData->fill); // FIXME: Should this be checking fillData->visitedLinkFill as well?
     }
 
-    if (strokeData->opacity != other.strokeData->opacity
-        || colorChangeRequiresRepaint(strokeData->paint.colorDisregardingType(), other.strokeData->paint.colorDisregardingType(), currentColorDiffers)
-        || colorChangeRequiresRepaint(strokeData->visitedLinkPaint.colorDisregardingType(), other.strokeData->visitedLinkPaint.colorDisregardingType(), currentColorDiffers))
+    if (strokeData->strokeOpacity != other.strokeData->strokeOpacity
+        || colorChangeRequiresRepaint(strokeData->stroke.colorDisregardingType(), other.strokeData->stroke.colorDisregardingType(), currentColorDiffers)
+        || colorChangeRequiresRepaint(strokeData->visitedLinkStroke.colorDisregardingType(), other.strokeData->visitedLinkStroke.colorDisregardingType(), currentColorDiffers))
         return true;
 
     // Painting related properties only need repaints. 
@@ -228,10 +228,10 @@ bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool cur
         return true;
 
     // If fill data changes, we just need to repaint. Fill boundaries are not influenced by this, only by the Path, that RenderSVGPath contains.
-    if (!fillData->paint.hasSameType(other.fillData->paint)
-        || colorChangeRequiresRepaint(fillData->paint.colorDisregardingType(), other.fillData->paint.colorDisregardingType(), currentColorDiffers)
-        || fillData->paint.urlDisregardingType() != other.fillData->paint.urlDisregardingType()
-        || fillData->opacity != other.fillData->opacity)
+    if (!fillData->fill.hasSameType(other.fillData->fill)
+        || colorChangeRequiresRepaint(fillData->fill.colorDisregardingType(), other.fillData->fill.colorDisregardingType(), currentColorDiffers)
+        || fillData->fill.urlDisregardingType() != other.fillData->fill.urlDisregardingType()
+        || fillData->fillOpacity != other.fillData->fillOpacity)
         return true;
 
     // If gradient stops change, we just need to repaint. Style updates are already handled through RenderSVGGradientStop.
@@ -260,27 +260,27 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
     // FIXME: Consider auto-generating this function from CSSProperties.json.
 
     auto conservativelyCollectChangedAnimatablePropertiesViaFillData = [&](auto& first, auto& second) {
-        if (first.opacity != second.opacity)
+        if (first.fillOpacity != second.fillOpacity)
             changingProperties.m_properties.set(CSSPropertyFillOpacity);
-        if (first.paint != second.paint || first.visitedLinkPaint != second.visitedLinkPaint)
+        if (first.fill != second.fill || first.visitedLinkFill != second.visitedLinkFill)
             changingProperties.m_properties.set(CSSPropertyFill);
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaStrokeData = [&](auto& first, auto& second) {
-        if (first.opacity != second.opacity)
+        if (first.strokeOpacity != second.strokeOpacity)
             changingProperties.m_properties.set(CSSPropertyStrokeOpacity);
-        if (first.dashOffset != second.dashOffset)
+        if (first.strokeDashOffset != second.strokeDashOffset)
             changingProperties.m_properties.set(CSSPropertyStrokeDashoffset);
-        if (first.dashArray != second.dashArray)
+        if (first.strokeDashArray != second.strokeDashArray)
             changingProperties.m_properties.set(CSSPropertyStrokeDasharray);
-        if (first.paint != second.paint || first.visitedLinkPaint != second.visitedLinkPaint)
+        if (first.stroke != second.stroke || first.visitedLinkStroke != second.visitedLinkStroke)
             changingProperties.m_properties.set(CSSPropertyStroke);
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaStopData = [&](auto& first, auto& second) {
-        if (first.opacity != second.opacity)
+        if (first.stopOpacity != second.stopOpacity)
             changingProperties.m_properties.set(CSSPropertyStopOpacity);
-        if (first.color != second.color)
+        if (first.stopColor != second.stopColor)
             changingProperties.m_properties.set(CSSPropertyStopColor);
     };
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
@@ -42,17 +42,17 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleFillData);
 
 StyleFillData::StyleFillData()
-    : opacity(RenderStyle::initialFillOpacity())
-    , paint(RenderStyle::initialFill())
-    , visitedLinkPaint(RenderStyle::initialFill())
+    : fillOpacity(RenderStyle::initialFillOpacity())
+    , fill(RenderStyle::initialFill())
+    , visitedLinkFill(RenderStyle::initialFill())
 {
 }
 
 inline StyleFillData::StyleFillData(const StyleFillData& other)
     : RefCounted<StyleFillData>()
-    , opacity(other.opacity)
-    , paint(other.paint)
-    , visitedLinkPaint(other.visitedLinkPaint)
+    , fillOpacity(other.fillOpacity)
+    , fill(other.fill)
+    , visitedLinkFill(other.visitedLinkFill)
 {
 }
 
@@ -64,37 +64,37 @@ Ref<StyleFillData> StyleFillData::copy() const
 #if !LOG_DISABLED
 void StyleFillData::dumpDifferences(TextStream& ts, const StyleFillData& other) const
 {
-    LOG_IF_DIFFERENT(opacity);
-    LOG_IF_DIFFERENT(paint);
-    LOG_IF_DIFFERENT(visitedLinkPaint);
+    LOG_IF_DIFFERENT(fillOpacity);
+    LOG_IF_DIFFERENT(fill);
+    LOG_IF_DIFFERENT(visitedLinkFill);
 }
 #endif
 
 bool StyleFillData::operator==(const StyleFillData& other) const
 {
-    return opacity == other.opacity
-        && paint == other.paint
-        && visitedLinkPaint == other.visitedLinkPaint;
+    return fillOpacity == other.fillOpacity
+        && fill == other.fill
+        && visitedLinkFill == other.visitedLinkFill;
 }
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStrokeData);
 
 StyleStrokeData::StyleStrokeData()
-    : opacity(RenderStyle::initialStrokeOpacity())
-    , paint(RenderStyle::initialStroke())
-    , visitedLinkPaint(RenderStyle::initialStroke())
-    , dashOffset(RenderStyle::initialStrokeDashOffset())
-    , dashArray(RenderStyle::initialStrokeDashArray())
+    : strokeOpacity(RenderStyle::initialStrokeOpacity())
+    , stroke(RenderStyle::initialStroke())
+    , visitedLinkStroke(RenderStyle::initialStroke())
+    , strokeDashOffset(RenderStyle::initialStrokeDashOffset())
+    , strokeDashArray(RenderStyle::initialStrokeDashArray())
 {
 }
 
 inline StyleStrokeData::StyleStrokeData(const StyleStrokeData& other)
     : RefCounted<StyleStrokeData>()
-    , opacity(other.opacity)
-    , paint(other.paint)
-    , visitedLinkPaint(other.visitedLinkPaint)
-    , dashOffset(other.dashOffset)
-    , dashArray(other.dashArray)
+    , strokeOpacity(other.strokeOpacity)
+    , stroke(other.stroke)
+    , visitedLinkStroke(other.visitedLinkStroke)
+    , strokeDashOffset(other.strokeDashOffset)
+    , strokeDashArray(other.strokeDashArray)
 {
 }
 
@@ -105,36 +105,36 @@ Ref<StyleStrokeData> StyleStrokeData::copy() const
 
 bool StyleStrokeData::operator==(const StyleStrokeData& other) const
 {
-    return opacity == other.opacity
-        && paint == other.paint
-        && visitedLinkPaint == other.visitedLinkPaint
-        && dashOffset == other.dashOffset
-        && dashArray == other.dashArray;
+    return strokeOpacity == other.strokeOpacity
+        && stroke == other.stroke
+        && visitedLinkStroke == other.visitedLinkStroke
+        && strokeDashOffset == other.strokeDashOffset
+        && strokeDashArray == other.strokeDashArray;
 }
 
 #if !LOG_DISABLED
 void StyleStrokeData::dumpDifferences(TextStream& ts, const StyleStrokeData& other) const
 {
-    LOG_IF_DIFFERENT(opacity);
-    LOG_IF_DIFFERENT(paint);
-    LOG_IF_DIFFERENT(visitedLinkPaint);
-    LOG_IF_DIFFERENT(dashOffset);
-    LOG_IF_DIFFERENT(dashArray);
+    LOG_IF_DIFFERENT(strokeOpacity);
+    LOG_IF_DIFFERENT(stroke);
+    LOG_IF_DIFFERENT(visitedLinkStroke);
+    LOG_IF_DIFFERENT(strokeDashOffset);
+    LOG_IF_DIFFERENT(strokeDashArray);
 }
 #endif
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStopData);
 
 StyleStopData::StyleStopData()
-    : opacity(RenderStyle::initialStopOpacity())
-    , color(RenderStyle::initialStopColor())
+    : stopOpacity(RenderStyle::initialStopOpacity())
+    , stopColor(RenderStyle::initialStopColor())
 {
 }
 
 inline StyleStopData::StyleStopData(const StyleStopData& other)
     : RefCounted<StyleStopData>()
-    , opacity(other.opacity)
-    , color(other.color)
+    , stopOpacity(other.stopOpacity)
+    , stopColor(other.stopColor)
 {
 }
 
@@ -145,15 +145,15 @@ Ref<StyleStopData> StyleStopData::copy() const
 
 bool StyleStopData::operator==(const StyleStopData& other) const
 {
-    return opacity == other.opacity
-        && color == other.color;
+    return stopOpacity == other.stopOpacity
+        && stopColor == other.stopColor;
 }
 
 #if !LOG_DISABLED
 void StyleStopData::dumpDifferences(TextStream& ts, const StyleStopData& other) const
 {
-    LOG_IF_DIFFERENT(opacity);
-    LOG_IF_DIFFERENT(color);
+    LOG_IF_DIFFERENT(stopOpacity);
+    LOG_IF_DIFFERENT(stopColor);
 }
 #endif
 
@@ -327,26 +327,26 @@ void StyleLayoutData::dumpDifferences(TextStream& ts, const StyleLayoutData& oth
 
 TextStream& operator<<(TextStream& ts, const StyleFillData& data)
 {
-    ts.dumpProperty("opacity"_s, data.opacity);
-    ts.dumpProperty("paint"_s, data.paint);
-    ts.dumpProperty("visited link paint"_s, data.visitedLinkPaint);
+    ts.dumpProperty("opacity"_s, data.fillOpacity);
+    ts.dumpProperty("paint"_s, data.fill);
+    ts.dumpProperty("visited link paint"_s, data.visitedLinkFill);
     return ts;
 }
 
 TextStream& operator<<(TextStream& ts, const StyleStrokeData& data)
 {
-    ts.dumpProperty("opacity"_s, data.opacity);
-    ts.dumpProperty("paint"_s, data.paint);
-    ts.dumpProperty("visited link paint"_s, data.visitedLinkPaint);
-    ts.dumpProperty("dashOffset"_s, data.dashOffset);
-    ts.dumpProperty("dash array"_s, data.dashArray);
+    ts.dumpProperty("opacity"_s, data.strokeOpacity);
+    ts.dumpProperty("paint"_s, data.stroke);
+    ts.dumpProperty("visited link paint"_s, data.visitedLinkStroke);
+    ts.dumpProperty("dashOffset"_s, data.strokeDashOffset);
+    ts.dumpProperty("dash array"_s, data.strokeDashArray);
     return ts;
 }
 
 TextStream& operator<<(TextStream& ts, const StyleStopData& data)
 {
-    ts.dumpProperty("opacity"_s, data.opacity);
-    ts.dumpProperty("color"_s, data.color);
+    ts.dumpProperty("opacity"_s, data.stopOpacity);
+    ts.dumpProperty("color"_s, data.stopColor);
     return ts;
 }
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -71,9 +71,9 @@ public:
     void dumpDifferences(TextStream&, const StyleFillData&) const;
 #endif
 
-    Style::Opacity opacity;
-    Style::SVGPaint paint;
-    Style::SVGPaint visitedLinkPaint;
+    Style::Opacity fillOpacity;
+    Style::SVGPaint fill;
+    Style::SVGPaint visitedLinkFill;
 
 private:
     StyleFillData();
@@ -93,11 +93,11 @@ public:
     void dumpDifferences(TextStream&, const StyleStrokeData&) const;
 #endif
 
-    Style::Opacity opacity;
-    Style::SVGPaint paint;
-    Style::SVGPaint visitedLinkPaint;
-    Style::SVGStrokeDashoffset dashOffset;
-    Style::SVGStrokeDasharray dashArray;
+    Style::Opacity strokeOpacity;
+    Style::SVGPaint stroke;
+    Style::SVGPaint visitedLinkStroke;
+    Style::SVGStrokeDashoffset strokeDashOffset;
+    Style::SVGStrokeDasharray strokeDashArray;
 
 private:
     StyleStrokeData();
@@ -117,8 +117,8 @@ public:
     void dumpDifferences(TextStream&, const StyleStopData&) const;
 #endif
 
-    Style::Opacity opacity;
-    Style::Color color;
+    Style::Opacity stopOpacity;
+    Style::Color stopColor;
 
 private:
     StyleStopData();

--- a/Source/WebCore/rendering/style/StyleAppleColorFilterData.h
+++ b/Source/WebCore/rendering/style/StyleAppleColorFilterData.h
@@ -30,10 +30,6 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
-namespace WTF {
-class TextStream;
-}
-
 namespace WebCore {
 
 class StyleAppleColorFilterData : public RefCounted<StyleAppleColorFilterData> {

--- a/Source/WebCore/rendering/style/StyleBackdropFilterData.cpp
+++ b/Source/WebCore/rendering/style/StyleBackdropFilterData.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "StyleBackdropFilterData.h"
+
+#include "RenderStyleDifference.h"
+#include "RenderStyleInlines.h"
+#include "StylePrimitiveKeyword+Logging.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+
+namespace WebCore {
+
+StyleBackdropFilterData::StyleBackdropFilterData()
+    : backdropFilter(RenderStyle::initialBackdropFilter())
+{
+}
+
+StyleBackdropFilterData::StyleBackdropFilterData(const StyleBackdropFilterData& other)
+    : RefCounted<StyleBackdropFilterData>()
+    , backdropFilter(other.backdropFilter)
+{
+}
+
+Ref<StyleBackdropFilterData> StyleBackdropFilterData::copy() const
+{
+    return adoptRef(*new StyleBackdropFilterData(*this));
+}
+
+bool StyleBackdropFilterData::operator==(const StyleBackdropFilterData& other) const
+{
+    return backdropFilter == other.backdropFilter;
+}
+
+#if !LOG_DISABLED
+void StyleBackdropFilterData::dumpDifferences(TextStream& ts, const StyleBackdropFilterData& other) const
+{
+    LOG_IF_DIFFERENT(backdropFilter);
+}
+#endif // !LOG_DISABLED
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleBackdropFilterData.h
+++ b/Source/WebCore/rendering/style/StyleBackdropFilterData.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include <WebCore/StyleFilter.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class StyleBackdropFilterData : public RefCounted<StyleBackdropFilterData> {
+public:
+    static Ref<StyleBackdropFilterData> create() { return adoptRef(*new StyleBackdropFilterData); }
+    Ref<StyleBackdropFilterData> copy() const;
+
+    bool operator==(const StyleBackdropFilterData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleBackdropFilterData&) const;
+#endif
+
+    Style::Filter backdropFilter;
+
+private:
+    StyleBackdropFilterData();
+    StyleBackdropFilterData(const StyleBackdropFilterData&);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleBackgroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.cpp
@@ -34,14 +34,14 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleBackgroundData);
 
 StyleBackgroundData::StyleBackgroundData()
     : background(RenderStyle::initialBackgroundLayers())
-    , color(RenderStyle::initialBackgroundColor())
+    , backgroundColor(RenderStyle::initialBackgroundColor())
 {
 }
 
 inline StyleBackgroundData::StyleBackgroundData(const StyleBackgroundData& other)
     : RefCounted<StyleBackgroundData>()
     , background(other.background)
-    , color(other.color)
+    , backgroundColor(other.backgroundColor)
     , outline(other.outline)
 {
 }
@@ -54,7 +54,7 @@ Ref<StyleBackgroundData> StyleBackgroundData::copy() const
 bool StyleBackgroundData::operator==(const StyleBackgroundData& other) const
 {
     return background == other.background
-        && color == other.color
+        && backgroundColor == other.backgroundColor
         && outline == other.outline;
 }
 
@@ -65,9 +65,9 @@ bool StyleBackgroundData::isEquivalentForPainting(const StyleBackgroundData& oth
         return !containsCurrentColor();
     }
 
-    if (background != other.background || color != other.color)
+    if (background != other.background || backgroundColor != other.backgroundColor)
         return false;
-    if (currentColorDiffers && color.containsCurrentColor())
+    if (currentColorDiffers && backgroundColor.containsCurrentColor())
         return false;
     if (!outline.isVisible() && !other.outline.isVisible())
         return true;
@@ -78,7 +78,7 @@ bool StyleBackgroundData::isEquivalentForPainting(const StyleBackgroundData& oth
 
 bool StyleBackgroundData::containsCurrentColor() const
 {
-    return color.containsCurrentColor()
+    return backgroundColor.containsCurrentColor()
         || outline.color().containsCurrentColor();
 }
 
@@ -86,8 +86,8 @@ void StyleBackgroundData::dump(TextStream& ts, DumpStyleValues behavior) const
 {
     if (behavior == DumpStyleValues::All || background != RenderStyle::initialBackgroundLayers())
         ts.dumpProperty("background-image"_s, background);
-    if (behavior == DumpStyleValues::All || color != RenderStyle::initialBackgroundColor())
-        ts.dumpProperty("background-color"_s, color);
+    if (behavior == DumpStyleValues::All || backgroundColor != RenderStyle::initialBackgroundColor())
+        ts.dumpProperty("background-color"_s, backgroundColor);
     if (behavior == DumpStyleValues::All || outline != OutlineValue())
         ts.dumpProperty("outline"_s, outline);
 }
@@ -96,7 +96,7 @@ void StyleBackgroundData::dump(TextStream& ts, DumpStyleValues behavior) const
 void StyleBackgroundData::dumpDifferences(TextStream& ts, const StyleBackgroundData& other) const
 {
     LOG_IF_DIFFERENT(background);
-    LOG_IF_DIFFERENT(color);
+    LOG_IF_DIFFERENT(backgroundColor);
     LOG_IF_DIFFERENT(outline);
 }
 #endif

--- a/Source/WebCore/rendering/style/StyleBackgroundData.h
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.h
@@ -54,7 +54,7 @@ public:
     bool isEquivalentForPainting(const StyleBackgroundData&, bool currentColorDiffers) const;
 
     Style::BackgroundLayers background;
-    Style::Color color;
+    Style::Color backgroundColor;
     OutlineValue outline;
 
     void dump(TextStream&, DumpStyleValues = DumpStyleValues::All) const;

--- a/Source/WebCore/rendering/style/StyleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleBoxData.cpp
@@ -42,37 +42,37 @@ static_assert(sizeof(StyleBoxData) == sizeof(SameSizeAsStyleBoxData), "StyleBoxD
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleBoxData);
 
 StyleBoxData::StyleBoxData()
-    : m_width(RenderStyle::initialSize())
-    , m_height(RenderStyle::initialSize())
-    , m_minWidth(RenderStyle::initialMinSize())
-    , m_maxWidth(RenderStyle::initialMaxSize())
-    , m_minHeight(RenderStyle::initialMinSize())
-    , m_maxHeight(RenderStyle::initialMaxSize())
-    , m_verticalAlign(RenderStyle::initialVerticalAlign())
-    , m_hasAutoSpecifiedZIndex(static_cast<uint8_t>(RenderStyle::initialSpecifiedZIndex().m_isAuto))
-    , m_hasAutoUsedZIndex(static_cast<uint8_t>(RenderStyle::initialUsedZIndex().m_isAuto))
-    , m_boxSizing(static_cast<uint8_t>(BoxSizing::ContentBox))
-    , m_boxDecorationBreak(static_cast<uint8_t>(BoxDecorationBreak::Slice))
-    , m_specifiedZIndexValue(RenderStyle::initialSpecifiedZIndex().m_value)
-    , m_usedZIndexValue(RenderStyle::initialUsedZIndex().m_value)
+    : width(RenderStyle::initialSize())
+    , height(RenderStyle::initialSize())
+    , minWidth(RenderStyle::initialMinSize())
+    , maxWidth(RenderStyle::initialMaxSize())
+    , minHeight(RenderStyle::initialMinSize())
+    , maxHeight(RenderStyle::initialMaxSize())
+    , verticalAlign(RenderStyle::initialVerticalAlign())
+    , hasAutoSpecifiedZIndex(static_cast<uint8_t>(RenderStyle::initialSpecifiedZIndex().m_isAuto))
+    , hasAutoUsedZIndex(static_cast<uint8_t>(RenderStyle::initialUsedZIndex().m_isAuto))
+    , boxSizing(static_cast<uint8_t>(BoxSizing::ContentBox))
+    , boxDecorationBreak(static_cast<uint8_t>(BoxDecorationBreak::Slice))
+    , specifiedZIndexValue(RenderStyle::initialSpecifiedZIndex().m_value)
+    , usedZIndexValue(RenderStyle::initialUsedZIndex().m_value)
 {
 }
 
 inline StyleBoxData::StyleBoxData(const StyleBoxData& o)
     : RefCounted<StyleBoxData>()
-    , m_width(o.m_width)
-    , m_height(o.m_height)
-    , m_minWidth(o.m_minWidth)
-    , m_maxWidth(o.m_maxWidth)
-    , m_minHeight(o.m_minHeight)
-    , m_maxHeight(o.m_maxHeight)
-    , m_verticalAlign(o.m_verticalAlign)
-    , m_hasAutoSpecifiedZIndex(o.m_hasAutoSpecifiedZIndex)
-    , m_hasAutoUsedZIndex(o.m_hasAutoUsedZIndex)
-    , m_boxSizing(o.m_boxSizing)
-    , m_boxDecorationBreak(o.m_boxDecorationBreak)
-    , m_specifiedZIndexValue(o.m_specifiedZIndexValue)
-    , m_usedZIndexValue(o.m_usedZIndexValue)
+    , width(o.width)
+    , height(o.height)
+    , minWidth(o.minWidth)
+    , maxWidth(o.maxWidth)
+    , minHeight(o.minHeight)
+    , maxHeight(o.maxHeight)
+    , verticalAlign(o.verticalAlign)
+    , hasAutoSpecifiedZIndex(o.hasAutoSpecifiedZIndex)
+    , hasAutoUsedZIndex(o.hasAutoUsedZIndex)
+    , boxSizing(o.boxSizing)
+    , boxDecorationBreak(o.boxDecorationBreak)
+    , specifiedZIndexValue(o.specifiedZIndexValue)
+    , usedZIndexValue(o.usedZIndexValue)
 {
 }
 
@@ -83,43 +83,43 @@ Ref<StyleBoxData> StyleBoxData::copy() const
 
 bool StyleBoxData::operator==(const StyleBoxData& o) const
 {
-    return m_width == o.m_width
-        && m_height == o.m_height
-        && m_minWidth == o.m_minWidth
-        && m_maxWidth == o.m_maxWidth
-        && m_minHeight == o.m_minHeight
-        && m_maxHeight == o.m_maxHeight
-        && m_verticalAlign == o.m_verticalAlign
-        && m_usedZIndexValue == o.m_usedZIndexValue
-        && m_hasAutoUsedZIndex == o.m_hasAutoUsedZIndex
-        && m_boxSizing == o.m_boxSizing
-        && m_boxDecorationBreak == o.m_boxDecorationBreak
-        && m_specifiedZIndexValue == o.m_specifiedZIndexValue
-        && m_hasAutoSpecifiedZIndex == o.m_hasAutoSpecifiedZIndex;
+    return width == o.width
+        && height == o.height
+        && minWidth == o.minWidth
+        && maxWidth == o.maxWidth
+        && minHeight == o.minHeight
+        && maxHeight == o.maxHeight
+        && verticalAlign == o.verticalAlign
+        && usedZIndexValue == o.usedZIndexValue
+        && hasAutoUsedZIndex == o.hasAutoUsedZIndex
+        && boxSizing == o.boxSizing
+        && boxDecorationBreak == o.boxDecorationBreak
+        && specifiedZIndexValue == o.specifiedZIndexValue
+        && hasAutoSpecifiedZIndex == o.hasAutoSpecifiedZIndex;
 }
 
 #if !LOG_DISABLED
 void StyleBoxData::dumpDifferences(TextStream& ts, const StyleBoxData& other) const
 {
-    LOG_IF_DIFFERENT(m_width);
-    LOG_IF_DIFFERENT(m_height);
+    LOG_IF_DIFFERENT(width);
+    LOG_IF_DIFFERENT(height);
 
-    LOG_IF_DIFFERENT(m_minWidth);
-    LOG_IF_DIFFERENT(m_maxWidth);
+    LOG_IF_DIFFERENT(minWidth);
+    LOG_IF_DIFFERENT(maxWidth);
 
-    LOG_IF_DIFFERENT(m_minHeight);
-    LOG_IF_DIFFERENT(m_maxHeight);
+    LOG_IF_DIFFERENT(minHeight);
+    LOG_IF_DIFFERENT(maxHeight);
 
-    LOG_IF_DIFFERENT(m_verticalAlign);
+    LOG_IF_DIFFERENT(verticalAlign);
 
-    LOG_IF_DIFFERENT_WITH_CAST(bool, m_hasAutoSpecifiedZIndex);
-    LOG_IF_DIFFERENT_WITH_CAST(bool, m_hasAutoUsedZIndex);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoSpecifiedZIndex);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoUsedZIndex);
 
-    LOG_IF_DIFFERENT_WITH_CAST(BoxSizing, m_boxSizing);
-    LOG_IF_DIFFERENT_WITH_CAST(BoxDecorationBreak, m_boxDecorationBreak);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxSizing, boxSizing);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxDecorationBreak, boxDecorationBreak);
 
-    LOG_IF_DIFFERENT(m_specifiedZIndexValue);
-    LOG_IF_DIFFERENT(m_usedZIndexValue);
+    LOG_IF_DIFFERENT(specifiedZIndexValue);
+    LOG_IF_DIFFERENT(usedZIndexValue);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/StyleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleBoxData.h
@@ -53,47 +53,31 @@ public:
     void dumpDifferences(TextStream&, const StyleBoxData&) const;
 #endif
 
-    const Style::PreferredSize& width() const { return m_width; }
-    const Style::PreferredSize& height() const { return m_height; }
+    Style::PreferredSize width;
+    Style::PreferredSize height;
 
-    const Style::MinimumSize& minWidth() const { return m_minWidth; }
-    const Style::MinimumSize& minHeight() const { return m_minHeight; }
+    Style::MinimumSize minWidth;
+    Style::MaximumSize maxWidth;
 
-    const Style::MaximumSize& maxWidth() const { return m_maxWidth; }
-    const Style::MaximumSize& maxHeight() const { return m_maxHeight; }
-    
-    const Style::VerticalAlign& verticalAlign() const { return m_verticalAlign; }
+    Style::MinimumSize minHeight;
+    Style::MaximumSize maxHeight;
 
-    Style::ZIndex specifiedZIndex() const { return { static_cast<bool>(m_hasAutoSpecifiedZIndex), m_specifiedZIndexValue }; }
-    Style::ZIndex usedZIndex() const { return { static_cast<bool>(m_hasAutoUsedZIndex), m_usedZIndexValue }; }
+    Style::VerticalAlign verticalAlign;
 
-    BoxSizing boxSizing() const { return static_cast<BoxSizing>(m_boxSizing); }
-    BoxDecorationBreak boxDecorationBreak() const { return static_cast<BoxDecorationBreak>(m_boxDecorationBreak); }
+    PREFERRED_TYPE(bool) uint8_t hasAutoSpecifiedZIndex : 1;
+    PREFERRED_TYPE(bool) uint8_t hasAutoUsedZIndex : 1;
+    PREFERRED_TYPE(BoxSizing) uint8_t boxSizing : 1;
+    PREFERRED_TYPE(BoxDecorationBreak) uint8_t boxDecorationBreak : 1;
+
+    Style::ZIndex::Value specifiedZIndexValue;
+    Style::ZIndex::Value usedZIndexValue;
+
+    Style::ZIndex specifiedZIndex() const { return { static_cast<bool>(hasAutoSpecifiedZIndex), specifiedZIndexValue }; }
+    Style::ZIndex usedZIndex() const { return { static_cast<bool>(hasAutoUsedZIndex), usedZIndexValue }; }
 
 private:
-    friend class RenderStyle;
-
     StyleBoxData();
     StyleBoxData(const StyleBoxData&);
-
-    Style::PreferredSize m_width;
-    Style::PreferredSize m_height;
-
-    Style::MinimumSize m_minWidth;
-    Style::MaximumSize m_maxWidth;
-
-    Style::MinimumSize m_minHeight;
-    Style::MaximumSize m_maxHeight;
-
-    Style::VerticalAlign m_verticalAlign;
-
-    PREFERRED_TYPE(bool) uint8_t m_hasAutoSpecifiedZIndex : 1;
-    PREFERRED_TYPE(bool) uint8_t m_hasAutoUsedZIndex : 1;
-    PREFERRED_TYPE(BoxSizing) uint8_t m_boxSizing : 1;
-    PREFERRED_TYPE(BoxDecorationBreak) uint8_t m_boxDecorationBreak : 1;
-
-    Style::ZIndex::Value m_specifiedZIndexValue;
-    Style::ZIndex::Value m_usedZIndexValue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp
@@ -32,25 +32,25 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleDeprecatedFlexibleBoxData);
 
 StyleDeprecatedFlexibleBoxData::StyleDeprecatedFlexibleBoxData()
-    : flex(RenderStyle::initialBoxFlex())
-    , flexGroup(RenderStyle::initialBoxFlexGroup())
-    , ordinalGroup(RenderStyle::initialBoxOrdinalGroup())
-    , align(static_cast<unsigned>(RenderStyle::initialBoxAlign()))
-    , pack(static_cast<unsigned>(RenderStyle::initialBoxPack()))
-    , orient(static_cast<unsigned>(RenderStyle::initialBoxOrient()))
-    , lines(static_cast<unsigned>(RenderStyle::initialBoxLines()))
+    : boxFlex(RenderStyle::initialBoxFlex())
+    , boxFlexGroup(RenderStyle::initialBoxFlexGroup())
+    , boxOrdinalGroup(RenderStyle::initialBoxOrdinalGroup())
+    , boxAlign(static_cast<unsigned>(RenderStyle::initialBoxAlign()))
+    , boxPack(static_cast<unsigned>(RenderStyle::initialBoxPack()))
+    , boxOrient(static_cast<unsigned>(RenderStyle::initialBoxOrient()))
+    , boxLines(static_cast<unsigned>(RenderStyle::initialBoxLines()))
 {
 }
 
 inline StyleDeprecatedFlexibleBoxData::StyleDeprecatedFlexibleBoxData(const StyleDeprecatedFlexibleBoxData& other)
     : RefCounted<StyleDeprecatedFlexibleBoxData>()
-    , flex(other.flex)
-    , flexGroup(other.flexGroup)
-    , ordinalGroup(other.ordinalGroup)
-    , align(other.align)
-    , pack(other.pack)
-    , orient(other.orient)
-    , lines(other.lines)
+    , boxFlex(other.boxFlex)
+    , boxFlexGroup(other.boxFlexGroup)
+    , boxOrdinalGroup(other.boxOrdinalGroup)
+    , boxAlign(other.boxAlign)
+    , boxPack(other.boxPack)
+    , boxOrient(other.boxOrient)
+    , boxLines(other.boxLines)
 {
 }
 
@@ -61,26 +61,26 @@ Ref<StyleDeprecatedFlexibleBoxData> StyleDeprecatedFlexibleBoxData::copy() const
 
 bool StyleDeprecatedFlexibleBoxData::operator==(const StyleDeprecatedFlexibleBoxData& other) const
 {
-    return flex == other.flex
-        && flexGroup == other.flexGroup
-        && ordinalGroup == other.ordinalGroup
-        && align == other.align
-        && pack == other.pack
-        && orient == other.orient
-        && lines == other.lines;
+    return boxFlex == other.boxFlex
+        && boxFlexGroup == other.boxFlexGroup
+        && boxOrdinalGroup == other.boxOrdinalGroup
+        && boxAlign == other.boxAlign
+        && boxPack == other.boxPack
+        && boxOrient == other.boxOrient
+        && boxLines == other.boxLines;
 }
 
 #if !LOG_DISABLED
 void StyleDeprecatedFlexibleBoxData::dumpDifferences(TextStream& ts, const StyleDeprecatedFlexibleBoxData& other) const
 {
-    LOG_IF_DIFFERENT(flex);
-    LOG_IF_DIFFERENT(flexGroup);
-    LOG_IF_DIFFERENT(ordinalGroup);
+    LOG_IF_DIFFERENT(boxFlex);
+    LOG_IF_DIFFERENT(boxFlexGroup);
+    LOG_IF_DIFFERENT(boxOrdinalGroup);
 
-    LOG_IF_DIFFERENT_WITH_CAST(BoxAlignment, align);
-    LOG_IF_DIFFERENT_WITH_CAST(BoxPack, pack);
-    LOG_IF_DIFFERENT_WITH_CAST(BoxOrient, orient);
-    LOG_IF_DIFFERENT_WITH_CAST(BoxLines, lines);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxAlignment, boxAlign);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxPack, boxPack);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxOrient, boxOrient);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxLines, boxLines);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h
@@ -46,14 +46,14 @@ public:
     void dumpDifferences(TextStream&, const StyleDeprecatedFlexibleBoxData&) const;
 #endif
 
-    Style::WebkitBoxFlex flex;
-    Style::WebkitBoxFlexGroup flexGroup;
-    Style::WebkitBoxOrdinalGroup ordinalGroup;
+    Style::WebkitBoxFlex boxFlex;
+    Style::WebkitBoxFlexGroup boxFlexGroup;
+    Style::WebkitBoxOrdinalGroup boxOrdinalGroup;
 
-    PREFERRED_TYPE(BoxAlignment) unsigned align : 3;
-    PREFERRED_TYPE(BoxPack) unsigned pack: 2;
-    PREFERRED_TYPE(BoxOrient) unsigned orient: 1;
-    PREFERRED_TYPE(BoxLines) unsigned lines : 1;
+    PREFERRED_TYPE(BoxAlignment) unsigned boxAlign : 3;
+    PREFERRED_TYPE(BoxPack) unsigned boxPack: 2;
+    PREFERRED_TYPE(BoxOrient) unsigned boxOrient: 1;
+    PREFERRED_TYPE(BoxLines) unsigned boxLines : 1;
 
 private:
     StyleDeprecatedFlexibleBoxData();

--- a/Source/WebCore/rendering/style/StyleFilterData.h
+++ b/Source/WebCore/rendering/style/StyleFilterData.h
@@ -30,10 +30,6 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
-namespace WTF {
-class TextStream;
-}
-
 namespace WebCore {
 
 class StyleFilterData : public RefCounted<StyleFilterData> {

--- a/Source/WebCore/rendering/style/StyleGridData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridData.cpp
@@ -36,34 +36,34 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridData);
 
 StyleGridData::StyleGridData()
-    : m_gridAutoFlow(RenderStyle::initialGridAutoFlow())
-    , m_gridAutoColumns(RenderStyle::initialGridAutoColumns())
-    , m_gridAutoRows(RenderStyle::initialGridAutoRows())
-    , m_gridTemplateAreas(RenderStyle::initialGridTemplateAreas())
-    , m_gridTemplateColumns(RenderStyle::initialGridTemplateColumns())
-    , m_gridTemplateRows(RenderStyle::initialGridTemplateRows())
+    : gridAutoFlow(RenderStyle::initialGridAutoFlow())
+    , gridAutoColumns(RenderStyle::initialGridAutoColumns())
+    , gridAutoRows(RenderStyle::initialGridAutoRows())
+    , gridTemplateAreas(RenderStyle::initialGridTemplateAreas())
+    , gridTemplateColumns(RenderStyle::initialGridTemplateColumns())
+    , gridTemplateRows(RenderStyle::initialGridTemplateRows())
 {
 }
 
 inline StyleGridData::StyleGridData(const StyleGridData& o)
     : RefCounted<StyleGridData>()
-    , m_gridAutoFlow(o.m_gridAutoFlow)
-    , m_gridAutoColumns(o.m_gridAutoColumns)
-    , m_gridAutoRows(o.m_gridAutoRows)
-    , m_gridTemplateAreas(o.m_gridTemplateAreas)
-    , m_gridTemplateColumns(o.m_gridTemplateColumns)
-    , m_gridTemplateRows(o.m_gridTemplateRows)
+    , gridAutoFlow(o.gridAutoFlow)
+    , gridAutoColumns(o.gridAutoColumns)
+    , gridAutoRows(o.gridAutoRows)
+    , gridTemplateAreas(o.gridTemplateAreas)
+    , gridTemplateColumns(o.gridTemplateColumns)
+    , gridTemplateRows(o.gridTemplateRows)
 {
 }
 
 bool StyleGridData::operator==(const StyleGridData& o) const
 {
-    return m_gridAutoFlow == o.m_gridAutoFlow
-        && m_gridAutoColumns == o.m_gridAutoColumns
-        && m_gridAutoRows == o.m_gridAutoRows
-        && m_gridTemplateAreas == o.m_gridTemplateAreas
-        && m_gridTemplateColumns == o.m_gridTemplateColumns
-        && m_gridTemplateRows == o.m_gridTemplateRows;
+    return gridAutoFlow == o.gridAutoFlow
+        && gridAutoColumns == o.gridAutoColumns
+        && gridAutoRows == o.gridAutoRows
+        && gridTemplateAreas == o.gridTemplateAreas
+        && gridTemplateColumns == o.gridTemplateColumns
+        && gridTemplateRows == o.gridTemplateRows;
 }
 
 Ref<StyleGridData> StyleGridData::copy() const
@@ -74,12 +74,12 @@ Ref<StyleGridData> StyleGridData::copy() const
 #if !LOG_DISABLED
 void StyleGridData::dumpDifferences(TextStream& ts, const StyleGridData& other) const
 {
-    LOG_IF_DIFFERENT(m_gridAutoFlow);
-    LOG_IF_DIFFERENT(m_gridAutoColumns);
-    LOG_IF_DIFFERENT(m_gridAutoRows);
-    LOG_IF_DIFFERENT(m_gridTemplateAreas);
-    LOG_IF_DIFFERENT(m_gridTemplateColumns);
-    LOG_IF_DIFFERENT(m_gridTemplateRows);
+    LOG_IF_DIFFERENT(gridAutoFlow);
+    LOG_IF_DIFFERENT(gridAutoColumns);
+    LOG_IF_DIFFERENT(gridAutoRows);
+    LOG_IF_DIFFERENT(gridTemplateAreas);
+    LOG_IF_DIFFERENT(gridTemplateColumns);
+    LOG_IF_DIFFERENT(gridTemplateRows);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -51,23 +51,14 @@ public:
     void dumpDifferences(TextStream&, const StyleGridData&) const;
 #endif
 
-    Style::GridAutoFlow gridAutoFlow() const { return m_gridAutoFlow; }
-    const Style::GridTrackSizes& gridAutoColumns() const { return m_gridAutoColumns; }
-    const Style::GridTrackSizes& gridAutoRows() const { return m_gridAutoRows; }
-    const Style::GridTemplateAreas& gridTemplateAreas() { return m_gridTemplateAreas; }
-    const Style::GridTemplateList& gridTemplateColumns() const { return m_gridTemplateColumns; }
-    const Style::GridTemplateList& gridTemplateRows() const { return m_gridTemplateRows; }
+    Style::GridAutoFlow gridAutoFlow;
+    Style::GridTrackSizes gridAutoColumns;
+    Style::GridTrackSizes gridAutoRows;
+    Style::GridTemplateAreas gridTemplateAreas;
+    Style::GridTemplateList gridTemplateColumns;
+    Style::GridTemplateList gridTemplateRows;
 
 private:
-    friend class RenderStyle;
-
-    Style::GridAutoFlow m_gridAutoFlow;
-    Style::GridTrackSizes m_gridAutoColumns;
-    Style::GridTrackSizes m_gridAutoRows;
-    Style::GridTemplateAreas m_gridTemplateAreas;
-    Style::GridTemplateList m_gridTemplateColumns;
-    Style::GridTemplateList m_gridTemplateRows;
-
     StyleGridData();
     StyleGridData(const StyleGridData&);
 };

--- a/Source/WebCore/rendering/style/StyleGridItemData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridItemData.cpp
@@ -39,19 +39,19 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridItemData);
 
 StyleGridItemData::StyleGridItemData()
-    : gridColumnStart(RenderStyle::initialGridItemColumnStart())
-    , gridColumnEnd(RenderStyle::initialGridItemColumnEnd())
-    , gridRowStart(RenderStyle::initialGridItemRowStart())
-    , gridRowEnd(RenderStyle::initialGridItemRowEnd())
+    : gridItemColumnStart(RenderStyle::initialGridItemColumnStart())
+    , gridItemColumnEnd(RenderStyle::initialGridItemColumnEnd())
+    , gridItemRowStart(RenderStyle::initialGridItemRowStart())
+    , gridItemRowEnd(RenderStyle::initialGridItemRowEnd())
 {
 }
 
 inline StyleGridItemData::StyleGridItemData(const StyleGridItemData& o)
     : RefCounted<StyleGridItemData>()
-    , gridColumnStart(o.gridColumnStart)
-    , gridColumnEnd(o.gridColumnEnd)
-    , gridRowStart(o.gridRowStart)
-    , gridRowEnd(o.gridRowEnd)
+    , gridItemColumnStart(o.gridItemColumnStart)
+    , gridItemColumnEnd(o.gridItemColumnEnd)
+    , gridItemRowStart(o.gridItemRowStart)
+    , gridItemRowEnd(o.gridItemRowEnd)
 {
 }
 
@@ -63,10 +63,10 @@ Ref<StyleGridItemData> StyleGridItemData::copy() const
 #if !LOG_DISABLED
 void StyleGridItemData::dumpDifferences(TextStream& ts, const StyleGridItemData& other) const
 {
-    LOG_IF_DIFFERENT(gridColumnStart);
-    LOG_IF_DIFFERENT(gridColumnEnd);
-    LOG_IF_DIFFERENT(gridRowStart);
-    LOG_IF_DIFFERENT(gridRowEnd);
+    LOG_IF_DIFFERENT(gridItemColumnStart);
+    LOG_IF_DIFFERENT(gridItemColumnEnd);
+    LOG_IF_DIFFERENT(gridItemRowStart);
+    LOG_IF_DIFFERENT(gridItemRowEnd);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/StyleGridItemData.h
+++ b/Source/WebCore/rendering/style/StyleGridItemData.h
@@ -45,20 +45,20 @@ public:
 
     bool operator==(const StyleGridItemData& o) const
     {
-        return gridColumnStart == o.gridColumnStart
-            && gridColumnEnd == o.gridColumnEnd
-            && gridRowStart == o.gridRowStart
-            && gridRowEnd == o.gridRowEnd;
+        return gridItemColumnStart == o.gridItemColumnStart
+            && gridItemColumnEnd == o.gridItemColumnEnd
+            && gridItemRowStart == o.gridItemRowStart
+            && gridItemRowEnd == o.gridItemRowEnd;
     }
 
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const StyleGridItemData&) const;
 #endif
 
-    Style::GridPosition gridColumnStart;
-    Style::GridPosition gridColumnEnd;
-    Style::GridPosition gridRowStart;
-    Style::GridPosition gridRowEnd;
+    Style::GridPosition gridItemColumnStart;
+    Style::GridPosition gridItemColumnEnd;
+    Style::GridPosition gridItemRowStart;
+    Style::GridPosition gridItemRowEnd;
 
 private:
     StyleGridItemData();

--- a/Source/WebCore/rendering/style/StyleMarqueeData.cpp
+++ b/Source/WebCore/rendering/style/StyleMarqueeData.cpp
@@ -31,21 +31,21 @@
 namespace WebCore {
 
 StyleMarqueeData::StyleMarqueeData()
-    : increment(RenderStyle::initialMarqueeIncrement())
-    , speed(RenderStyle::initialMarqueeSpeed())
-    , repetition(RenderStyle::initialMarqueeRepetition())
-    , behavior(static_cast<unsigned>(RenderStyle::initialMarqueeBehavior()))
-    , direction(static_cast<unsigned>(RenderStyle::initialMarqueeDirection()))
+    : marqueeIncrement(RenderStyle::initialMarqueeIncrement())
+    , marqueeSpeed(RenderStyle::initialMarqueeSpeed())
+    , marqueeRepetition(RenderStyle::initialMarqueeRepetition())
+    , marqueeBehavior(static_cast<unsigned>(RenderStyle::initialMarqueeBehavior()))
+    , marqueeDirection(static_cast<unsigned>(RenderStyle::initialMarqueeDirection()))
 {
 }
 
 inline StyleMarqueeData::StyleMarqueeData(const StyleMarqueeData& o)
     : RefCounted<StyleMarqueeData>()
-    , increment(o.increment)
-    , speed(o.speed)
-    , repetition(o.repetition)
-    , behavior(o.behavior)
-    , direction(o.direction) 
+    , marqueeIncrement(o.marqueeIncrement)
+    , marqueeSpeed(o.marqueeSpeed)
+    , marqueeRepetition(o.marqueeRepetition)
+    , marqueeBehavior(o.marqueeBehavior)
+    , marqueeDirection(o.marqueeDirection)
 {
 }
 
@@ -61,21 +61,21 @@ Ref<StyleMarqueeData> StyleMarqueeData::copy() const
 
 bool StyleMarqueeData::operator==(const StyleMarqueeData& o) const
 {
-    return increment == o.increment
-        && speed == o.speed
-        && repetition == o.repetition
-        && behavior == o.behavior
-        && direction == o.direction;
+    return marqueeIncrement == o.marqueeIncrement
+        && marqueeSpeed == o.marqueeSpeed
+        && marqueeRepetition == o.marqueeRepetition
+        && marqueeBehavior == o.marqueeBehavior
+        && marqueeDirection == o.marqueeDirection;
 }
 
 #if !LOG_DISABLED
 void StyleMarqueeData::dumpDifferences(TextStream& ts, const StyleMarqueeData& other) const
 {
-    LOG_IF_DIFFERENT(increment);
-    LOG_IF_DIFFERENT(speed);
-    LOG_IF_DIFFERENT(repetition);
-    LOG_IF_DIFFERENT_WITH_CAST(MarqueeBehavior, behavior);
-    LOG_IF_DIFFERENT_WITH_CAST(MarqueeDirection, direction);
+    LOG_IF_DIFFERENT(marqueeIncrement);
+    LOG_IF_DIFFERENT(marqueeSpeed);
+    LOG_IF_DIFFERENT(marqueeRepetition);
+    LOG_IF_DIFFERENT_WITH_CAST(MarqueeBehavior, marqueeBehavior);
+    LOG_IF_DIFFERENT_WITH_CAST(MarqueeDirection, marqueeDirection);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleMarqueeData.h
+++ b/Source/WebCore/rendering/style/StyleMarqueeData.h
@@ -46,12 +46,12 @@ struct StyleMarqueeData : RefCounted<StyleMarqueeData> {
     void dumpDifferences(TextStream&, const StyleMarqueeData&) const;
 #endif
 
-    Style::WebkitMarqueeIncrement increment;
-    Style::WebkitMarqueeSpeed speed;
-    Style::WebkitMarqueeRepetition repetition;
+    Style::WebkitMarqueeIncrement marqueeIncrement;
+    Style::WebkitMarqueeSpeed marqueeSpeed;
+    Style::WebkitMarqueeRepetition marqueeRepetition;
 
-    PREFERRED_TYPE(MarqueeBehavior) unsigned behavior : 2;
-    PREFERRED_TYPE(MarqueeDirection) unsigned direction : 3;
+    PREFERRED_TYPE(MarqueeBehavior) unsigned marqueeBehavior : 2;
+    PREFERRED_TYPE(MarqueeDirection) unsigned marqueeDirection : 3;
 
 private:
     StyleMarqueeData();

--- a/Source/WebCore/rendering/style/StyleMultiColData.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiColData.cpp
@@ -33,25 +33,25 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMultiColData);
 
 StyleMultiColData::StyleMultiColData()
-    : width(RenderStyle::initialColumnWidth())
-    , count(RenderStyle::initialColumnCount())
-    , fill(static_cast<unsigned>(RenderStyle::initialColumnFill()))
+    : columnWidth(RenderStyle::initialColumnWidth())
+    , columnCount(RenderStyle::initialColumnCount())
+    , columnFill(static_cast<unsigned>(RenderStyle::initialColumnFill()))
     , columnSpan(static_cast<unsigned>(RenderStyle::initialColumnSpan()))
-    , axis(static_cast<unsigned>(RenderStyle::initialColumnAxis()))
-    , progression(static_cast<unsigned>(RenderStyle::initialColumnProgression()))
+    , columnAxis(static_cast<unsigned>(RenderStyle::initialColumnAxis()))
+    , columnProgression(static_cast<unsigned>(RenderStyle::initialColumnProgression()))
 {
 }
 
 inline StyleMultiColData::StyleMultiColData(const StyleMultiColData& other)
     : RefCounted<StyleMultiColData>()
-    , width(other.width)
-    , count(other.count)
-    , rule(other.rule)
+    , columnWidth(other.columnWidth)
+    , columnCount(other.columnCount)
+    , columnRule(other.columnRule)
     , visitedLinkColumnRuleColor(other.visitedLinkColumnRuleColor)
-    , fill(other.fill)
+    , columnFill(other.columnFill)
     , columnSpan(other.columnSpan)
-    , axis(other.axis)
-    , progression(other.progression)
+    , columnAxis(other.columnAxis)
+    , columnProgression(other.columnProgression)
 {
 }
 
@@ -62,36 +62,36 @@ Ref<StyleMultiColData> StyleMultiColData::copy() const
 
 bool StyleMultiColData::operator==(const StyleMultiColData& other) const
 {
-    return width == other.width
-        && count == other.count
-        && rule == other.rule
+    return columnWidth == other.columnWidth
+        && columnCount == other.columnCount
+        && columnRule == other.columnRule
         && visitedLinkColumnRuleColor == other.visitedLinkColumnRuleColor
-        && fill == other.fill
+        && columnFill == other.columnFill
         && columnSpan == other.columnSpan
-        && axis == other.axis
-        && progression == other.progression;
+        && columnAxis == other.columnAxis
+        && columnProgression == other.columnProgression;
 }
 
 #if !LOG_DISABLED
 void StyleMultiColData::dumpDifferences(TextStream& ts, const StyleMultiColData& other) const
 {
-    LOG_IF_DIFFERENT(width);
-    LOG_IF_DIFFERENT(count);
-    LOG_IF_DIFFERENT(rule);
+    LOG_IF_DIFFERENT(columnWidth);
+    LOG_IF_DIFFERENT(columnCount);
+    LOG_IF_DIFFERENT(columnRule);
     LOG_IF_DIFFERENT(visitedLinkColumnRuleColor);
 
-    LOG_IF_DIFFERENT_WITH_CAST(ColumnFill, fill);
+    LOG_IF_DIFFERENT_WITH_CAST(ColumnFill, columnFill);
     LOG_IF_DIFFERENT_WITH_CAST(ColumnSpan, columnSpan);
-    LOG_IF_DIFFERENT_WITH_CAST(ColumnAxis, axis);
-    LOG_IF_DIFFERENT_WITH_CAST(ColumnProgression, progression);
+    LOG_IF_DIFFERENT_WITH_CAST(ColumnAxis, columnAxis);
+    LOG_IF_DIFFERENT_WITH_CAST(ColumnProgression, columnProgression);
 }
 #endif // !LOG_DISABLED
 
-Style::LineWidth StyleMultiColData::ruleWidth() const
+Style::LineWidth StyleMultiColData::columnRuleWidth() const
 {
-    if (rule.style() == BorderStyle::None || rule.style() == BorderStyle::Hidden)
+    if (columnRule.style() == BorderStyle::None || columnRule.style() == BorderStyle::Hidden)
         return Style::LineWidth { 0_css_px };
-    return rule.width();
+    return columnRule.width();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleMultiColData.h
+++ b/Source/WebCore/rendering/style/StyleMultiColData.h
@@ -53,17 +53,17 @@ public:
     void dumpDifferences(TextStream&, const StyleMultiColData&) const;
 #endif
 
-    Style::LineWidth ruleWidth() const;
+    Style::LineWidth columnRuleWidth() const;
 
-    Style::ColumnWidth width { CSS::Keyword::Auto { } };
-    Style::ColumnCount count { CSS::Keyword::Auto { } };
-    BorderValue rule;
+    Style::ColumnWidth columnWidth { CSS::Keyword::Auto { } };
+    Style::ColumnCount columnCount { CSS::Keyword::Auto { } };
+    BorderValue columnRule;
     Style::Color visitedLinkColumnRuleColor;
 
-    PREFERRED_TYPE(ColumnFill) unsigned fill : 1;
+    PREFERRED_TYPE(ColumnFill) unsigned columnFill : 1;
     PREFERRED_TYPE(ColumnSpan) unsigned columnSpan : 1;
-    PREFERRED_TYPE(ColumnAxis) unsigned axis : 2;
-    PREFERRED_TYPE(ColumnProgression) unsigned progression : 2;
+    PREFERRED_TYPE(ColumnAxis) unsigned columnAxis : 2;
+    PREFERRED_TYPE(ColumnProgression) unsigned columnProgression : 2;
 
 private:
     StyleMultiColData();

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -75,7 +75,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , appleColorFilter(StyleAppleColorFilterData::create())
     , lineGrid(RenderStyle::initialLineGrid())
     , tabSize(RenderStyle::initialTabSize())
-    , miterLimit(RenderStyle::initialStrokeMiterLimit())
+    , strokeMiterLimit(RenderStyle::initialStrokeMiterLimit())
 #if ENABLE(TEXT_AUTOSIZING)
     , textSizeAdjust(RenderStyle::initialTextSizeAdjust())
 #endif
@@ -106,7 +106,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , lineSnap(static_cast<unsigned>(RenderStyle::initialLineSnap()))
     , lineAlign(static_cast<unsigned>(RenderStyle::initialLineAlign()))
 #if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    , webkitOverflowScrolling(static_cast<unsigned>(RenderStyle::initialOverflowScrolling()))
+    , overflowScrolling(static_cast<unsigned>(RenderStyle::initialOverflowScrolling()))
 #endif
     , textAlignLast(static_cast<unsigned>(RenderStyle::initialTextAlignLast()))
     , textJustify(static_cast<unsigned>(RenderStyle::initialTextJustify()))
@@ -118,7 +118,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , rubyOverhang(static_cast<unsigned>(RenderStyle::initialRubyOverhang()))
     , textZoom(static_cast<unsigned>(RenderStyle::initialTextZoom()))
 #if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    , webkitTouchCallout(static_cast<unsigned>(RenderStyle::initialTouchCallout()))
+    , touchCallout(static_cast<unsigned>(RenderStyle::initialTouchCallout()))
 #endif
     , hangingPunctuation(RenderStyle::initialHangingPunctuation().toRaw())
     , paintOrder(static_cast<unsigned>(RenderStyle::initialPaintOrder().type()))
@@ -183,7 +183,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , appleColorFilter(o.appleColorFilter)
     , lineGrid(o.lineGrid)
     , tabSize(o.tabSize)
-    , miterLimit(o.miterLimit)
+    , strokeMiterLimit(o.strokeMiterLimit)
 #if ENABLE(TEXT_AUTOSIZING)
     , textSizeAdjust(o.textSizeAdjust)
 #endif
@@ -214,7 +214,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , lineSnap(o.lineSnap)
     , lineAlign(o.lineAlign)
 #if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    , webkitOverflowScrolling(o.webkitOverflowScrolling)
+    , overflowScrolling(o.overflowScrolling)
 #endif
     , textAlignLast(o.textAlignLast)
     , textJustify(o.textJustify)
@@ -226,7 +226,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , rubyOverhang(o.rubyOverhang)
     , textZoom(o.textZoom)
 #if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    , webkitTouchCallout(o.webkitTouchCallout)
+    , touchCallout(o.touchCallout)
 #endif
     , hangingPunctuation(o.hangingPunctuation)
     , paintOrder(o.paintOrder)
@@ -284,7 +284,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && textUnderlineOffset == o.textUnderlineOffset
         && textBoxEdge == o.textBoxEdge
         && lineFitEdge == o.lineFitEdge
-        && miterLimit == o.miterLimit
+        && strokeMiterLimit == o.strokeMiterLimit
         && widows == o.widows
         && orphans == o.orphans
         && textSecurity == o.textSecurity
@@ -294,7 +294,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && nbspMode == o.nbspMode
         && lineBreak == o.lineBreak
 #if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-        && webkitOverflowScrolling == o.webkitOverflowScrolling
+        && overflowScrolling == o.overflowScrolling
 #endif
 #if ENABLE(TEXT_AUTOSIZING)
         && textSizeAdjust == o.textSizeAdjust
@@ -312,7 +312,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && textEmphasisPosition == o.textEmphasisPosition
         && lineBoxContain == o.lineBoxContain
 #if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-        && webkitTouchCallout == o.webkitTouchCallout
+        && touchCallout == o.touchCallout
 #endif
         && hyphenateCharacter == o.hyphenateCharacter
         && quotes == o.quotes
@@ -411,7 +411,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT(textBoxEdge);
     LOG_IF_DIFFERENT(lineFitEdge);
 
-    LOG_IF_DIFFERENT(miterLimit);
+    LOG_IF_DIFFERENT(strokeMiterLimit);
 
     LOG_IF_DIFFERENT(widows);
     LOG_IF_DIFFERENT(orphans);
@@ -441,7 +441,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(LineAlign, lineAlign);
 
 #if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    LOG_IF_DIFFERENT_WITH_CAST(Style::WebkitOverflowScrolling, webkitOverflowScrolling);
+    LOG_IF_DIFFERENT_WITH_CAST(Style::WebkitOverflowScrolling, overflowScrolling);
 #endif
 
     LOG_IF_DIFFERENT_WITH_CAST(Style::TextAlignLast, textAlignLast);
@@ -455,7 +455,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(TextZoom, textZoom);
 
 #if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    LOG_IF_DIFFERENT_WITH_CAST(Style::WebkitTouchCallout, webkitTouchCallout);
+    LOG_IF_DIFFERENT_WITH_CAST(Style::WebkitTouchCallout, touchCallout);
 #endif
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(Style::HangingPunctuation, hangingPunctuation);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -161,7 +161,7 @@ public:
     Style::WebkitLineGrid lineGrid;
     Style::TabSize tabSize;
 
-    Style::StrokeMiterlimit miterLimit;
+    Style::StrokeMiterlimit strokeMiterLimit;
 
 #if ENABLE(TEXT_AUTOSIZING)
     Style::TextSizeAdjust textSizeAdjust;
@@ -199,7 +199,7 @@ public:
     PREFERRED_TYPE(LineSnap) unsigned lineSnap : 2;
     PREFERRED_TYPE(LineAlign) unsigned lineAlign : 1;
 #if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    PREFERRED_TYPE(Style::WebkitOverflowScrolling) unsigned webkitOverflowScrolling: 1;
+    PREFERRED_TYPE(Style::WebkitOverflowScrolling) unsigned overflowScrolling: 1;
 #endif
     PREFERRED_TYPE(Style::TextAlignLast) unsigned textAlignLast : 3;
     PREFERRED_TYPE(TextJustify) unsigned textJustify : 2;
@@ -211,7 +211,7 @@ public:
     PREFERRED_TYPE(RubyOverhang) unsigned rubyOverhang : 1;
     PREFERRED_TYPE(TextZoom) unsigned textZoom: 1;
 #if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    PREFERRED_TYPE(Style::WebkitTouchCallout) unsigned webkitTouchCallout : 1;
+    PREFERRED_TYPE(Style::WebkitTouchCallout) unsigned touchCallout : 1;
 #endif
     PREFERRED_TYPE(Style::HangingPunctuation) unsigned hangingPunctuation : 4;
     PREFERRED_TYPE(Style::SVGPaintOrder::Type) unsigned paintOrder : 3;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -50,7 +50,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , touchAction(RenderStyle::initialTouchAction())
     , initialLetter(RenderStyle::initialInitialLetter())
     , marquee(StyleMarqueeData::create())
-    , backdropFilter(StyleFilterData::create())
+    , backdropFilter(StyleBackdropFilterData::create())
     , grid(StyleGridData::create())
     , gridItem(StyleGridItemData::create())
     , clip(RenderStyle::initialClip())
@@ -137,7 +137,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
 #if HAVE(CORE_MATERIAL)
     , appleVisualEffect(static_cast<unsigned>(RenderStyle::initialAppleVisualEffect()))
 #endif
-    , scrollbarWidth(static_cast<unsigned>(RenderStyle::initialScrollbarWidth().platform()))
+    , scrollbarWidth(static_cast<unsigned>(RenderStyle::initialScrollbarWidth()))
     , usesAnchorFunctions(false)
     , anchorFunctionScrollCompensatedAxes(0)
     , isPopoverInvoker(false)
@@ -389,7 +389,7 @@ Style::Contain StyleRareNonInheritedData::usedContain() const
 
 bool StyleRareNonInheritedData::hasBackdropFilters() const
 {
-    return !backdropFilter->filter.isNone();
+    return !backdropFilter->backdropFilter.isNone();
 }
 
 #if !LOG_DISABLED

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -96,9 +96,9 @@ namespace WebCore {
 using namespace CSS::Literals;
 
 class PathOperation;
+class StyleBackdropFilterData;
 class StyleCustomPropertyData;
 class StyleDeprecatedFlexibleBoxData;
-class StyleFilterData;
 class StyleFlexibleBoxData;
 class StyleGridData;
 class StyleGridItemData;
@@ -152,7 +152,7 @@ public:
 
     DataRef<StyleMarqueeData> marquee; // Marquee properties
 
-    DataRef<StyleFilterData> backdropFilter; // Filter operations (url, sepia, blur, etc.)
+    DataRef<StyleBackdropFilterData> backdropFilter; // Filter operations (url, sepia, blur, etc.)
 
     DataRef<StyleGridData> grid;
     DataRef<StyleGridItemData> gridItem;

--- a/Source/WebCore/rendering/style/StyleTransformData.cpp
+++ b/Source/WebCore/rendering/style/StyleTransformData.cpp
@@ -34,7 +34,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleTransformData);
 StyleTransformData::StyleTransformData()
     : transform(RenderStyle::initialTransform())
     , origin(RenderStyle::initialTransformOrigin())
-    , transformBox(RenderStyle::initialTransformBox())
+    , transformBox(static_cast<unsigned>(RenderStyle::initialTransformBox()))
 {
 }
 
@@ -63,7 +63,7 @@ void StyleTransformData::dumpDifferences(TextStream& ts, const StyleTransformDat
 {
     LOG_IF_DIFFERENT(transform);
     LOG_IF_DIFFERENT(origin);
-    LOG_IF_DIFFERENT(transformBox);
+    LOG_IF_DIFFERENT_WITH_CAST(TransformBox, transformBox);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleTransformData.h
+++ b/Source/WebCore/rendering/style/StyleTransformData.h
@@ -49,7 +49,7 @@ public:
 
     Style::Transform transform;
     Style::TransformOrigin origin;
-    TransformBox transformBox;
+    PREFERRED_TYPE(TransformBox) unsigned transformBox : 3;
 
 private:
     StyleTransformData();

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1021,8 +1021,8 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         return;
 
     if (documentQuirks.needsBodyScrollbarWidthNoneDisabledQuirk() && is<HTMLBodyElement>(*m_element)) {
-        if (style.scrollbarWidth().isNone())
-            style.setScrollbarWidth(CSS::Keyword::Auto { });
+        if (style.scrollbarWidth() == ScrollbarWidth::None)
+            style.setScrollbarWidth(ScrollbarWidth::Auto);
     }
 
     if (documentQuirks.needsYouTubeOverflowScrollQuirk()) {

--- a/Source/WebCore/style/values/scrollbars/StyleScrollbarWidth.h
+++ b/Source/WebCore/style/values/scrollbars/StyleScrollbarWidth.h
@@ -33,30 +33,33 @@ namespace Style {
 
 // <'scrollbar-width'> = auto | thin | none
 // https://drafts.csswg.org/css-scrollbars/#propdef-scrollbar-width
-struct ScrollbarWidth {
-    constexpr ScrollbarWidth(CSS::Keyword::Auto) : value { WebCore::ScrollbarWidth::Auto } { }
-    constexpr ScrollbarWidth(CSS::Keyword::Thin) : value { WebCore::ScrollbarWidth::Thin } { }
-    constexpr ScrollbarWidth(CSS::Keyword::None) : value { WebCore::ScrollbarWidth::None } { }
-
-    constexpr ScrollbarWidth(WebCore::ScrollbarWidth platform) : value { platform } { }
-    constexpr WebCore::ScrollbarWidth platform() const { return value; }
-
-    constexpr bool isAuto() const { return value == WebCore::ScrollbarWidth::Auto; }
-    constexpr bool isThin() const { return value == WebCore::ScrollbarWidth::Thin; }
-    constexpr bool isNone() const { return value == WebCore::ScrollbarWidth::None; }
-
-    constexpr bool operator==(const ScrollbarWidth&) const = default;
-
-    WebCore::ScrollbarWidth value;
+enum class ScrollbarWidth : uint8_t {
+    Auto,
+    Thin,
+    None
 };
-DEFINE_TYPE_WRAPPER_GET(ScrollbarWidth, value);
 
 // MARK: - Conversion
 
 // `ScrollbarWidth` is special-cased to apply `needsScrollbarWidthThinDisabledQuirk` quirk.
 template<> struct CSSValueConversion<ScrollbarWidth> { auto operator()(BuilderState&, const CSSValue&) -> ScrollbarWidth; };
 
+// MARK: - Platform
+
+template<> struct ToPlatform<ScrollbarWidth> {
+    auto operator()(ScrollbarWidth value) -> WebCore::ScrollbarWidth
+    {
+        switch (value) {
+        case ScrollbarWidth::Auto:
+            return WebCore::ScrollbarWidth::Auto;
+        case ScrollbarWidth::Thin:
+            return WebCore::ScrollbarWidth::Thin;
+        case ScrollbarWidth::None:
+            return WebCore::ScrollbarWidth::None;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+};
+
 } // namespace Style
 } // namespace WebCore
-
-DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::ScrollbarWidth);

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -6262,7 +6262,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!frame || !frame->document() || !frame->document()->documentElement() || !frame->document()->documentElement()->renderer())
         return WebCore::ScrollbarWidth::Auto;
 
-    return frame->document()->documentElement()->renderer()->style().scrollbarWidth().platform();
+    return WebCore::Style::toPlatform(frame->document()->documentElement()->renderer()->style().scrollbarWidth());
 }
 
 @end


### PR DESCRIPTION
#### b59b7d45815ea9c0532af8ae529053c61da1abe4
<pre>
[RenderStyleGen] Extend getter/setter generation to all non-special cased properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=303151">https://bugs.webkit.org/show_bug.cgi?id=303151</a>

Reviewed by Darin Adler.

Extends RenderStyle getter/setter function implementation generation
to all properties except ones that still need additional special casing.

The remaining special cases are:
    - properties that use fromRaw/toRaw conversions (e.g. `hanging-punctuation`)
    - properties that have setters that set multiple values (e.g. `appearance`)
    - properties that don&apos;t have a single strong style type representing them (e.g. `caret-color`)
    - properties that have a getter name that doesn&apos;t match the setter name (e.g. `computedWordSpacing` / `setWordSpacing`)
    - properties that are not stored directly in a data class, but rather within a struct (e.g. `border-bottom-color`)
    - @page descriptors (e.g. `page-size`)

A few changes were need to conform all the properties that are being generated
including:
    - update the names of storage members to match the property name.
    - adding a data class for `backdrop-filter` to ensure we can have a matching storage member name.
    - converting `Style::ScrollbarWidth` from a struct to an enum, and using a ToPlatform interface
      to implement the platform conversion.
    - Updating the signatures of getters/setters in RenderStyle to match conventions

Additionally, a few member functions of RenderStyle were easily removable:
    - aspectRatioWidth()/aspectRatioHeight() were replaced by aspectRatio().width()/aspectRatio().height()
    - clearAnimations()/clearTransitions() were unused.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/RenderTextControl.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/style/StyleBackdropFilterData.cpp: Added.
* Source/WebCore/rendering/style/StyleBackdropFilterData.h: Added.
* Source/WebCore/rendering/style/StyleBackgroundData.cpp:
* Source/WebCore/rendering/style/StyleBackgroundData.h:
* Source/WebCore/rendering/style/StyleBoxData.cpp:
* Source/WebCore/rendering/style/StyleBoxData.h:
* Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp:
* Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h:
* Source/WebCore/rendering/style/StyleGridData.cpp:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/rendering/style/StyleGridItemData.cpp:
* Source/WebCore/rendering/style/StyleGridItemData.h:
* Source/WebCore/rendering/style/StyleMarqueeData.cpp:
* Source/WebCore/rendering/style/StyleMarqueeData.h:
* Source/WebCore/rendering/style/StyleMultiColData.cpp:
* Source/WebCore/rendering/style/StyleMultiColData.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/style/StyleTransformData.cpp:
* Source/WebCore/rendering/style/StyleTransformData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/values/scrollbars/StyleScrollbarWidth.cpp:
* Source/WebCore/style/values/scrollbars/StyleScrollbarWidth.h:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:

Canonical link: <a href="https://commits.webkit.org/303585@main">https://commits.webkit.org/303585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8216652e309cde1b8307df7465861fbd26d87b5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132906 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84937 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101627 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135852 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82426 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83674 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143093 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5076 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27934 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3890 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58627 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5130 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4970 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68582 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->