### PR TITLE
left and right arrows don't look right on hover on https://tickets.compagnie-oceane.fr

### DIFF
--- a/LayoutTests/css3/images/cross-fade-svg-fragments-expected.html
+++ b/LayoutTests/css3/images/cross-fade-svg-fragments-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Test SVG fragments in -webkit-cross-fade image</title>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+</style>
+<div></div>
+<p>There should be one green square above and one green square below.
+<div></div>

--- a/LayoutTests/css3/images/cross-fade-svg-fragments.html
+++ b/LayoutTests/css3/images/cross-fade-svg-fragments.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test SVG fragments in -webkit-cross-fade image</title>
+<style>
+    #tst1 {
+        width: 100px;
+        height: 100px;
+        background-image: -webkit-cross-fade(
+            url("../../svg/css/resources/fragment-identifiers.svg#green"),
+            url("../../svg/css/resources/fragment-identifiers.svg#red"), 0);
+    }
+    #tst2 {
+        width: 100px;
+        height: 100px;
+        background-image: -webkit-cross-fade(
+            url("../../svg/css/resources/fragment-identifiers.svg#red"),
+            url("../../svg/css/resources/fragment-identifiers.svg#green"), 1);
+    }
+</style>
+<div id=tst1></div>
+<p>There should be one green square above and one green square below.
+<div id=tst2></div>

--- a/LayoutTests/css3/images/cross-fade-svg-size-diff-expected.html
+++ b/LayoutTests/css3/images/cross-fade-svg-size-diff-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Test SVG in -webkit-cross-fade image with identical but differently sized SVG elsewhere</title>
+<style>
+    div {
+        background-image: url("data:image/svg+xml,<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><circle cx='50' cy='50' r='35' fill='green'/></svg>");
+    }
+    .tst {
+        width: 100px;
+        height: 100px;
+    }
+    #ref {
+        width: 300px;
+        height: 300px;
+    }
+</style>
+<p>There should be three circles below. One big and two small ones.
+<div id=ref></div>
+<div class=tst></div>
+<div class=tst></div>

--- a/LayoutTests/css3/images/cross-fade-svg-size-diff.html
+++ b/LayoutTests/css3/images/cross-fade-svg-size-diff.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>Test SVG in -webkit-cross-fade image with identical but differently sized SVG elsewhere</title>
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=5-300" />
+<style>
+    #tst1 {
+        width: 100px;
+        height: 100px;
+        background-image: -webkit-cross-fade(
+            url("data:image/svg+xml,<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><circle cx='50' cy='50' r='35' fill='green'/></svg>"), 
+            url("data:image/svg+xml,<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><circle cx='50' cy='50' r='25' fill='red'/></svg>"),
+            0);
+    }
+    #tst2 {
+        width: 100px;
+        height: 100px;
+        background-image: -webkit-cross-fade(
+            url("data:image/svg+xml,<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><circle cx='50' cy='50' r='25' fill='red'/></svg>"),
+            url("data:image/svg+xml,<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><circle cx='50' cy='50' r='35' fill='green'/></svg>"),
+            1);
+    }
+    #ref {
+        background-image: url("data:image/svg+xml,<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><circle cx='50' cy='50' r='35' fill='green'/></svg>");
+        width: 300px;
+        height: 300px;
+    }
+</style>
+<p>There should be three circles below. One big and two small ones.
+<div id=ref></div>
+<div id=tst1></div>
+<div id=tst2></div>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3308,3 +3308,6 @@ imported/w3c/web-platform-tests/css/CSS2/abspos/abspos-containing-block-initial-
 
 # List buttons no longer have tint color.
 fast/css/accent-color/datalist.html [ Skip ]
+
+# Flaky test on WK1
+css3/images/cross-fade-svg-fragments.html [ Skip ]


### PR DESCRIPTION
#### c4cfd9698b72688674a1818f0b5731c6980024d3
<pre>
left and right arrows don&apos;t look right on hover on <a href="https://tickets.compagnie-oceane.fr">https://tickets.compagnie-oceane.fr</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=253427">https://bugs.webkit.org/show_bug.cgi?id=253427</a>
<a href="https://rdar.apple.com/106633417">rdar://106633417</a>

Reviewed by Antoine Quint.

This patch aligns WebKit with Blink / Chromium.

Merge (Test): <a href="https://chromium.googlesource.com/chromium/src.git/+/3ca78bf60493da8b2b7ad63f59bd169cb00a4947">https://chromium.googlesource.com/chromium/src.git/+/3ca78bf60493da8b2b7ad63f59bd169cb00a4947</a> &amp;
<a href="https://chromium.googlesource.com/chromium/src.git/+/ece900bafe8d6ff3346ed364a5d3fd13799b8620">https://chromium.googlesource.com/chromium/src.git/+/ece900bafe8d6ff3346ed364a5d3fd13799b8620</a>

When SVG images are used in CSS crossfade functions, they need to be
wrapped in SVGImageForContainer objects to ensure proper sizing and to
support fragment identifiers (e.g., image.svg#view1).

Without this fix, SVG images in crossfades would render at incorrect
sizes and fragment URLs would not work properly.

Further, I manually confirmed that it fixes the issue observed on website.

Tests: css3/images/cross-fade-svg-fragments.html
       css3/images/cross-fade-svg-size-diff.html
* LayoutTests/css3/images/cross-fade-svg-fragments-expected.html: Added.
* LayoutTests/css3/images/cross-fade-svg-fragments.html: Added.
* LayoutTests/css3/images/cross-fade-svg-size-diff-expected.html: Added.
* LayoutTests/css3/images/cross-fade-svg-size-diff.html: Added.
* Source/WebCore/rendering/style/StyleCrossfadeImage.cpp:
(WebCore::StyleCrossfadeImage::image const):
* LayoutTests/platform/mac-wk1/TestExpectations: Add Platform Specific Expectation

Canonical link: <a href="https://commits.webkit.org/303593@main">https://commits.webkit.org/303593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/753912e35da86f74faec52a105a4a32e35c48ec7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84950 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db1e14c8-5892-441b-8e53-fb769fbdecb9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101637 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68958 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b236b902-eb93-48b6-b92e-923f2de21c6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82438 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3dd07610-e773-4703-8796-65dd4a7cc3a7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83687 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143106 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110015 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3902 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58648 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5143 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33707 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5101 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->