### PR TITLE
WebTransport should be able to cancel reads or writes for a stream

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
@@ -77,6 +77,12 @@ void ReadableStreamSource::cancel(JSC::JSValue value)
     doCancel(value);
 }
 
+void ReadableStreamSource::error(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+{
+    if (m_controller)
+        m_controller->error(globalObject, value);
+}
+
 void ReadableStreamSource::clean()
 {
     if (m_promise) {

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -43,6 +43,7 @@ public:
     void start(ReadableStreamDefaultController&&, DOMPromiseDeferred<void>&&);
     void pull(DOMPromiseDeferred<void>&&);
     void cancel(JSC::JSValue);
+    void error(JSC::JSGlobalObject&, JSC::JSValue);
 
     bool isPulling() const { return !!m_promise; }
 

--- a/Source/WebCore/Modules/streams/WritableStream.cpp
+++ b/Source/WebCore/Modules/streams/WritableStream.cpp
@@ -102,6 +102,11 @@ void WritableStream::errorIfPossible(Exception&& e)
     m_internalWritableStream->errorIfPossible(WTFMove(e));
 }
 
+void WritableStream::errorIfPossible(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
+{
+    m_internalWritableStream->errorIfPossible(globalObject, reason);
+}
+
 WritableStream::State WritableStream::state() const
 {
     auto* globalObject = m_internalWritableStream->globalObject();

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -52,6 +52,7 @@ public:
 
     void closeIfPossible();
     void errorIfPossible(Exception&&);
+    void errorIfPossible(JSC::JSGlobalObject&, JSC::JSValue);
 
     InternalWritableStream& internalWritableStream();
     enum class Type : uint8_t {

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DatagramByteSource.h"
 
+#include "JSDOMGlobalObject.h"
 #include "JSDOMPromiseDeferred.h"
 #include "ReadableByteStreamController.h"
 #include "ReadableStream.h"
@@ -184,4 +185,11 @@ void DatagramByteSource::tryEnqueuing(JSC::ArrayBuffer& buffer, ReadableByteStre
         promise->resolve();
 }
 
+void DatagramByteSource::error(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+{
+    if (RefPtr controller = m_controller) {
+        auto& jsDOMGlobalObject = *JSC::jsCast<JSDOMGlobalObject*>(&globalObject);
+        controller->error(jsDOMGlobalObject, value);
+    }
+}
 }

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.h
@@ -49,6 +49,7 @@ public:
 
     void pull(JSDOMGlobalObject&, ReadableByteStreamController&, Ref<DeferredPromise>&&);
     void cancel(Ref<DeferredPromise>&&);
+    void error(JSC::JSGlobalObject&, JSC::JSValue) final;
 
 private:
     DatagramByteSource();

--- a/Source/WebCore/Modules/webtransport/DatagramSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.cpp
@@ -63,4 +63,9 @@ void DatagramDefaultSource::doCancel()
     m_isCancelled = true;
 }
 
+void DatagramDefaultSource::error(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+{
+    ReadableStreamSource::error(globalObject, value);
+}
+
 }

--- a/Source/WebCore/Modules/webtransport/DatagramSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.h
@@ -28,6 +28,11 @@
 #include "ReadableStreamSource.h"
 #include <wtf/AbstractRefCounted.h>
 
+namespace JSC {
+class JSGlobalObject;
+class JSValue;
+}
+
 namespace WebCore {
 
 class WebTransport;
@@ -38,6 +43,7 @@ public:
     DatagramSource() = default;
     virtual ~DatagramSource() = default;
     virtual void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) = 0;
+    virtual void error(JSC::JSGlobalObject&, JSC::JSValue) = 0;
 };
 
 class DatagramDefaultSource final : public DatagramSource, public RefCountedReadableStreamSource {
@@ -52,6 +58,7 @@ private:
     DatagramDefaultSource();
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
+    void error(JSC::JSGlobalObject&, JSC::JSValue) final;
 
     void setActive() final { }
     void setInactive() final { }

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -57,6 +57,7 @@ class WebTransportDatagramsWritable;
 class WebTransportError;
 class WebTransportReceiveStreamSource;
 class WebTransportSendGroup;
+class WebTransportSendStream;
 class WebTransportSendStreamSink;
 class WebTransportSession;
 class WorkerWebTransportSession;
@@ -116,7 +117,9 @@ private:
     void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) final;
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
-    void didFail(std::optional<unsigned>&&, String&&) final;
+    void streamReceiveError(WebTransportStreamIdentifier, uint64_t) final;
+    void streamSendError(WebTransportStreamIdentifier, uint64_t) final;
+    void didFail(std::optional<uint32_t>&&, String&&) final;
     void didDrain() final;
 
     RefPtr<WebTransportSession> protectedSession();
@@ -151,6 +154,7 @@ private:
     const Ref<WebTransportReceiveStreamSource> m_receiveStreamSource;
     const Ref<WebTransportBidirectionalStreamSource> m_bidirectionalStreamSource;
     HashMap<WebTransportStreamIdentifier, Ref<WebTransportReceiveStreamSource>> m_readStreamSources;
+    HashMap<WebTransportStreamIdentifier, Ref<WebTransportSendStream>> m_writeStreams;
     WeakHashSet<WebTransportDatagramsWritable> m_datagramsWritables;
 };
 

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
@@ -43,6 +43,7 @@ public:
     static Ref<WebTransportReceiveStreamSource> createIncomingDataSource(WebTransport& transport, WebTransportStreamIdentifier identifier) { return adoptRef(*new WebTransportReceiveStreamSource(transport, identifier)); }
     bool receiveIncomingStream(JSC::JSGlobalObject&, Ref<WebTransportReceiveStream>&);
     void receiveBytes(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
+    void receiveError(JSC::JSGlobalObject&, uint64_t errorCode);
 private:
     WebTransportReceiveStreamSource();
     WebTransportReceiveStreamSource(WebTransport&, WebTransportStreamIdentifier);

--- a/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
@@ -46,7 +46,9 @@ public:
     virtual void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) = 0;
     virtual void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) = 0;
     virtual void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) = 0;
-    virtual void didFail(std::optional<unsigned>&&, String&&) = 0;
+    virtual void streamReceiveError(WebTransportStreamIdentifier, uint64_t) = 0;
+    virtual void streamSendError(WebTransportStreamIdentifier, uint64_t) = 0;
+    virtual void didFail(std::optional<uint32_t>&&, String&&) = 0;
     virtual void didDrain() = 0;
 };
 

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -68,7 +68,7 @@ void WorkerWebTransportSession::receiveDatagram(std::span<const uint8_t> span, b
     });
 }
 
-void WorkerWebTransportSession::didFail(std::optional<unsigned>&& code, String&& message)
+void WorkerWebTransportSession::didFail(std::optional<uint32_t>&& code, String&& message)
 {
     ASSERT(RunLoop::isMain());
     ScriptExecutionContext::postTaskTo(m_contextID, [weakClient = m_client, code = WTFMove(code), message = WTFMove(message)] (auto&) mutable {
@@ -120,6 +120,28 @@ void WorkerWebTransportSession::streamReceiveBytes(WebTransportStreamIdentifier 
         if (!client)
             return;
         client->streamReceiveBytes(identifier, data.span(), withFin, WTFMove(exception));
+    });
+}
+
+void WorkerWebTransportSession::streamReceiveError(WebTransportStreamIdentifier identifier, uint64_t errorCode)
+{
+    ASSERT(RunLoop::isMain());
+    ScriptExecutionContext::postTaskTo(m_contextID, [identifier, errorCode, weakClient = m_client] (auto&) mutable {
+        RefPtr client = weakClient.get();
+        if (!client)
+            return;
+        client->streamReceiveError(identifier, errorCode);
+    });
+}
+
+void WorkerWebTransportSession::streamSendError(WebTransportStreamIdentifier identifier, uint64_t errorCode)
+{
+    ASSERT(RunLoop::isMain());
+    ScriptExecutionContext::postTaskTo(m_contextID, [identifier, errorCode, weakClient = m_client] (auto&) mutable {
+        RefPtr client = weakClient.get();
+        if (!client)
+            return;
+        client->streamSendError(identifier, errorCode);
     });
 }
 

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -50,7 +50,9 @@ private:
     void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) final;
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
-    void didFail(std::optional<unsigned>&&, String&&) final;
+    void streamReceiveError(WebTransportStreamIdentifier, uint64_t) final;
+    void streamSendError(WebTransportStreamIdentifier, uint64_t) final;
+    void didFail(std::optional<uint32_t>&&, String&&) final;
     void didDrain() final;
 
     Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final;

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -30,6 +30,8 @@ DECLARE_SYSTEM_HEADER
 #import <Network/Network.h>
 
 typedef void (^nw_webtransport_drain_handler_t)(void);
+typedef void (^nw_webtransport_receive_error_handler_t)(uint64_t receive_error_code);
+typedef void (^nw_webtransport_send_error_handler_t)(uint64_t send_error_code);
 typedef void (^nw_http_optional_string_accessor_t)(const char * _Nullable string);
 
 #if OS_OBJECT_USE_OBJC
@@ -120,6 +122,11 @@ void nw_webtransport_metadata_set_remote_drain_handler(nw_protocol_metadata_t, n
 void nw_webtransport_metadata_set_local_draining(nw_protocol_metadata_t);
 OS_OBJECT_RETURNS_RETAINED nw_http_response_t nw_webtransport_metadata_copy_connect_response(nw_protocol_metadata_t);
 nw_webtransport_transport_mode_t nw_webtransport_metadata_get_transport_mode(nw_protocol_metadata_t);
+void nw_webtransport_metadata_set_remote_receive_error_handler(nw_protocol_metadata_t, nw_webtransport_receive_error_handler_t, dispatch_queue_t);
+void nw_webtransport_metadata_set_remote_send_error_handler(nw_protocol_metadata_t, nw_webtransport_send_error_handler_t, dispatch_queue_t);
+
+void nw_connection_abort_reads(nw_connection_t, uint64_t);
+void nw_connection_abort_writes(nw_connection_t, uint64_t);
 
 void nw_http_fields_access_value_by_name(nw_http_fields_t, const char*, nw_http_optional_string_accessor_t);
 

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -244,6 +244,23 @@ void InternalWritableStream::errorIfPossible(Exception&& exception)
         scope.clearException();
 }
 
+JSC::JSValue InternalWritableStream::errorIfPossible(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
+{
+    auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamErrorIfPossiblePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(guardedObject());
+    arguments.append(reason);
+    ASSERT(!arguments.hasOverflowed());
+
+    auto result = invokeWritableStreamFunction(globalObject, privateName, arguments);
+    if (result.hasException())
+        return { };
+
+    return result.returnValue();
+}
+
 JSC::JSValue InternalWritableStream::getWriter(JSC::JSGlobalObject& globalObject)
 {
     auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);

--- a/Source/WebCore/bindings/js/InternalWritableStream.h
+++ b/Source/WebCore/bindings/js/InternalWritableStream.h
@@ -49,6 +49,7 @@ public:
 
     void closeIfPossible();
     void errorIfPossible(Exception&&);
+    JSC::JSValue errorIfPossible(JSC::JSGlobalObject&, JSC::JSValue);
 
     JSC::JSValue abort(JSC::JSGlobalObject&, JSC::JSValue);
     String state(JSC::JSGlobalObject& globalObject) const;

--- a/Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp
+++ b/Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp
@@ -95,6 +95,22 @@ void ReadableStreamDefaultController::error(const Exception& exception)
     invokeReadableStreamDefaultControllerFunction(globalObject(), privateName, arguments);
 }
 
+void ReadableStreamDefaultController::error(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
+{
+    auto& vm = lexicalGlobalObject.vm();
+    JSC::JSLockHolder lock(vm);
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(&jsController());
+    arguments.append(value);
+    ASSERT(!arguments.hasOverflowed());
+
+    auto* clientData = downcast<JSVMClientData>(vm.clientData);
+    auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamDefaultControllerErrorPrivateName();
+
+    invokeReadableStreamDefaultControllerFunction(globalObject(), privateName, arguments);
+}
+
 bool ReadableStreamDefaultController::enqueue(JSC::JSValue value)
 {
     JSC::JSGlobalObject& lexicalGlobalObject = this->globalObject();

--- a/Source/WebCore/bindings/js/ReadableStreamDefaultController.h
+++ b/Source/WebCore/bindings/js/ReadableStreamDefaultController.h
@@ -46,6 +46,7 @@ public:
     WEBCORE_EXPORT bool enqueue(RefPtr<JSC::ArrayBuffer>&&);
     bool enqueue(JSC::JSValue);
     WEBCORE_EXPORT void error(const Exception&);
+    WEBCORE_EXPORT void error(JSC::JSGlobalObject&, JSC::JSValue);
     WEBCORE_EXPORT void close();
 
 private:

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -83,6 +83,8 @@ selectors = [
     { name = "_setServerTrust:", class = "?" },
 ]
 symbols = [
+    "nw_connection_abort_reads",
+    "nw_connection_abort_writes",
     "nw_http_fields_access_value_by_name",
     "nw_parameters_create_webtransport_http",
     "nw_protocol_copy_webtransport_definition",
@@ -94,6 +96,8 @@ symbols = [
     "nw_webtransport_metadata_set_session_error_message",
     "nw_webtransport_metadata_get_session_closed",
     "nw_webtransport_metadata_set_remote_drain_handler",
+    "nw_webtransport_metadata_set_remote_receive_error_handler",
+    "nw_webtransport_metadata_set_remote_send_error_handler",
     "nw_webtransport_metadata_copy_connect_response",
     "nw_webtransport_metadata_get_transport_mode",
     "nw_webtransport_options_add_connect_request_header",

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
@@ -53,4 +53,16 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER_WITH_NS_RETURNS_RETAINED(WebKit, Network,
 // FIXME: Replace this soft linking with a HAVE macro once rdar://164917448 is available on all tested OS builds.
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_get_transport_mode, nw_webtransport_transport_mode_t, (nw_protocol_metadata_t metadata), (metadata))
 
+// FIXME: Replace this soft linking with a HAVE macro once rdar://141886375 is available on all tested OS builds.
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_set_remote_receive_error_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_receive_error_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
+
+// FIXME: Replace this soft linking with a HAVE macro once rdar://141886375 is available on all tested OS builds.
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_set_remote_send_error_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_send_error_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
+
+// FIXME: Replace this soft linking with a HAVE macro once rdar://141886375 is available on all tested OS builds.
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_connection_abort_reads, void, (nw_connection_t connection, uint64_t error_code), (connection, error_code))
+
+// FIXME: Replace this soft linking with a HAVE macro once rdar://141886375 is available on all tested OS builds.
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_connection_abort_writes, void, (nw_connection_t connection, uint64_t error_code), (connection, error_code))
+
 #endif // HAVE(WEB_TRANSPORT)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
@@ -46,5 +46,12 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_get_transport_mode, nw_webtransport_transport_mode_t, (nw_protocol_metadata_t metadata), (metadata))
 
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_set_remote_receive_error_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_receive_error_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
 
-#endif // HAVE(AVAUDIOAPPLICATION)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_set_remote_send_error_handler, void, (nw_protocol_metadata_t metadata, nw_webtransport_send_error_handler_t handler, dispatch_queue_t queue), (metadata, handler, queue))
+
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_connection_abort_reads, void, (nw_connection_t connection, uint64_t error_code), (connection, error_code))
+
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_connection_abort_writes, void, (nw_connection_t connection, uint64_t error_code), (connection, error_code))
+
+#endif // HAVE(WEB_TRANSPORT)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -71,6 +71,16 @@ void NetworkTransportSession::streamReceiveBytes(WebCore::WebTransportStreamIden
     send(Messages::WebTransportSession::StreamReceiveBytes(identifier, bytes, withFin, WTFMove(exception)));
 }
 
+void NetworkTransportSession::streamReceiveError(WebCore::WebTransportStreamIdentifier identifier, uint64_t errorCode)
+{
+    send(Messages::WebTransportSession::StreamReceiveError(identifier, errorCode));
+}
+
+void NetworkTransportSession::streamSendError(WebCore::WebTransportStreamIdentifier identifier, uint64_t errorCode)
+{
+    send(Messages::WebTransportSession::StreamSendError(identifier, errorCode));
+}
+
 void NetworkTransportSession::receiveIncomingUnidirectionalStream(WebCore::WebTransportStreamIdentifier identifier)
 {
     send(Messages::WebTransportSession::ReceiveIncomingUnidirectionalStream(identifier));

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -95,6 +95,8 @@ public:
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
+    void streamReceiveError(WebCore::WebTransportStreamIdentifier, uint64_t);
+    void streamSendError(WebCore::WebTransportStreamIdentifier, uint64_t);
     void receiveIncomingUnidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void receiveBidirectionalStream(WebCore::WebTransportStreamIdentifier);
 

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h
@@ -76,7 +76,6 @@ protected:
 
 private:
     void receiveLoop();
-    void setErrorCodeForStream(std::optional<WebCore::WebTransportStreamErrorCode>);
 
     const WebCore::WebTransportStreamIdentifier m_identifier;
     WeakPtr<NetworkTransportSession> m_session;

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -118,7 +118,25 @@ void WebTransportSession::streamReceiveBytes(WebCore::WebTransportStreamIdentifi
         ASSERT_NOT_REACHED();
 }
 
-void WebTransportSession::didFail(std::optional<unsigned>&& code, String&& message)
+void WebTransportSession::streamReceiveError(WebCore::WebTransportStreamIdentifier identifier, uint64_t errorCode)
+{
+    ASSERT(RunLoop::isMain());
+    if (RefPtr strongClient = m_client.get())
+        strongClient->streamReceiveError(identifier, errorCode);
+    else
+        ASSERT_NOT_REACHED();
+}
+
+void WebTransportSession::streamSendError(WebCore::WebTransportStreamIdentifier identifier, uint64_t errorCode)
+{
+    ASSERT(RunLoop::isMain());
+    if (RefPtr strongClient = m_client.get())
+        strongClient->streamSendError(identifier, errorCode);
+    else
+        ASSERT_NOT_REACHED();
+}
+
+void WebTransportSession::didFail(std::optional<uint32_t>&& code, String&& message)
 {
     ASSERT(RunLoop::isMain());
     if (RefPtr strongClient = m_client.get())

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -72,7 +72,9 @@ public:
     void receiveIncomingUnidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void receiveBidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
-    void didFail(std::optional<unsigned>&&, String&&);
+    void streamReceiveError(WebCore::WebTransportStreamIdentifier, uint64_t);
+    void streamSendError(WebCore::WebTransportStreamIdentifier, uint64_t);
+    void didFail(std::optional<uint32_t>&&, String&&);
     void didDrain();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
@@ -29,6 +29,8 @@ messages -> WebTransportSession {
     ReceiveIncomingUnidirectionalStream(WebCore::WebTransportStreamIdentifier identifier)
     ReceiveBidirectionalStream(WebCore::WebTransportStreamIdentifier identifier)
     StreamReceiveBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, std::optional<WebCore::Exception> exception)
-    DidFail(std::optional<unsigned> code, String message)
+    StreamReceiveError(WebCore::WebTransportStreamIdentifier identifier, uint64_t errorCode)
+    StreamSendError(WebCore::WebTransportStreamIdentifier identifier, uint64_t errorCode)
+    DidFail(std::optional<uint32_t> code, String message)
     DidDrain()
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -422,27 +422,33 @@ TEST(WebTransport, NetworkProcessCrash)
 
     obj = [webView objectByCallingAsyncFunction:@"return await getIncomingBidiStream()" withArguments:@{ } error:&error];
     EXPECT_EQ(obj, nil);
-    EXPECT_NULL(error);
+    EXPECT_NOT_NULL(error);
+    error = nil;
 
     obj = [webView objectByCallingAsyncFunction:@"return await getIncomingUniStream()" withArguments:@{ } error:&error];
     EXPECT_EQ(obj, nil);
-    EXPECT_NULL(error);
+    EXPECT_NOT_NULL(error);
+    error = nil;
 
     obj = [webView objectByCallingAsyncFunction:@"return await readFromBidiStream()" withArguments:@{ } error:&error];
     EXPECT_EQ(obj, nil);
-    EXPECT_NULL(error);
+    EXPECT_NOT_NULL(error);
+    error = nil;
 
     obj = [webView objectByCallingAsyncFunction:@"return await readFromIncomingBidiStream()" withArguments:@{ } error:&error];
     EXPECT_EQ(obj, nil);
-    EXPECT_NULL(error);
+    EXPECT_NOT_NULL(error);
+    error = nil;
 
     obj = [webView objectByCallingAsyncFunction:@"return await readFromIncomingUniStream()" withArguments:@{ } error:&error];
     EXPECT_EQ(obj, nil);
-    EXPECT_NULL(error);
+    EXPECT_NOT_NULL(error);
+    error = nil;
 
     obj = [webView objectByCallingAsyncFunction:@"return await readDatagram()" withArguments:@{ } error:&error];
     EXPECT_EQ(obj, nil);
-    EXPECT_NULL(error);
+    EXPECT_NOT_NULL(error);
+    error = nil;
 
     obj = [webView objectByCallingAsyncFunction:@"return await writeOnBidiStream()" withArguments:@{ } error:&error];
     EXPECT_EQ(obj, nil);


### PR DESCRIPTION
#### c9f3e1d327891574fc0d8b5fa734f0e7153a6ce3
<pre>
WebTransport should be able to cancel reads or writes for a stream
<a href="https://bugs.webkit.org/show_bug.cgi?id=303152">https://bugs.webkit.org/show_bug.cgi?id=303152</a>
<a href="https://rdar.apple.com/160150325">rdar://160150325</a>

Reviewed by Alex Christensen.

This PR plumbs sending and receiving RESET_STREAM_AT and STOP_SENDING signals on the streams.

The sending flow does not take the stream error code into account right now.
This is tracked by existing FIXMEs in `WebTransportReceiveStreamSource::doCancel` and `WebTransportSendStreamSink::error`.

It also fixes the cleanup procedure for WebTransport, using the correct exception to terminate the readable and writable streams.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm

* Source/WebCore/Modules/streams/ReadableStreamSource.cpp:
(WebCore::ReadableStreamSource::error):
* Source/WebCore/Modules/streams/ReadableStreamSource.h:
* Source/WebCore/Modules/streams/WritableStream.cpp:
(WebCore::WritableStream::errorIfPossible):
* Source/WebCore/Modules/streams/WritableStream.h:
* Source/WebCore/Modules/webtransport/DatagramByteSource.cpp:
(WebCore::DatagramByteSource::error):
* Source/WebCore/Modules/webtransport/DatagramByteSource.h:
* Source/WebCore/Modules/webtransport/DatagramSource.cpp:
(WebCore::DatagramDefaultSource::error):
* Source/WebCore/Modules/webtransport/DatagramSource.h:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::receiveBidirectionalStream):
(WebCore::WebTransport::streamReceiveError):
(WebCore::WebTransport::streamSendError):
(WebCore::WebTransport::cleanup):
(WebCore::WebTransport::createBidirectionalStream):
(WebCore::WebTransport::createUnidirectionalStream):
(WebCore::WebTransport::didFail):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp:
(WebCore::WebTransportReceiveStreamSource::receiveError):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h:
* Source/WebCore/Modules/webtransport/WebTransportSessionClient.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::didFail):
(WebCore::WorkerWebTransportSession::streamReceiveError):
(WebCore::WorkerWebTransportSession::streamSendError):
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
(WebCore::InternalWritableStream::errorIfPossible):
* Source/WebCore/bindings/js/InternalWritableStream.h:
* Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp:
(WebCore::ReadableStreamDefaultController::error):
* Source/WebCore/bindings/js/ReadableStreamDefaultController.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::streamReceiveError):
(WebKit::NetworkTransportSession::streamSendError):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::setupConnectionHandler):
(WebKit::NetworkTransportSession::createStream):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm:
(WebKit::NetworkTransportStream::sendBytes):
(WebKit::NetworkTransportStream::receiveLoop):
(WebKit::NetworkTransportStream::cancel):
(WebKit::NetworkTransportStream::cancelReceive):
(WebKit::NetworkTransportStream::cancelSend):
(WebKit::NetworkTransportStream::setErrorCodeForStream): Deleted.
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::streamReceiveError):
(WebKit::WebTransportSession::streamSendError):
(WebKit::WebTransportSession::didFail):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKit/WebProcess/Network/WebTransportSession.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, NetworkProcessCrash)):

Canonical link: <a href="https://commits.webkit.org/303774@main">https://commits.webkit.org/303774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25fe9cc48f173258b39622de43cd6ed0dcbf058a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69481 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4428 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2025 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110425 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110607 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4290 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115840 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59328 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20648 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5633 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34166 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69085 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->