### PR TITLE
`:visited` link color does not propagate to SVG through `currentColor`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS test: propagate `:visited` link color to an SVG element thorough `fill="currentColor"`</title>
+<link rel="help" href="https://www.w3.org/TR/selectors-4/#link">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#currentcolor-color">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#resolving-other-colors">
+<link rel="help" href="https://www.w3.org/TR/SVG2/painting.html#SpecifyingFillPaint">
+<link rel="author" title="Masataka Yakura" href="mailto:masataka.yakura@gmail.com">
+<link rel="match" href="../../css/reference/ref-filled-green-100px-square.xht">
+<style>
+:any-link {
+  color: red;
+}
+:visited {
+  color: green;
+}
+</style>
+<body>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<a href="">
+  <svg width="100" height="100">
+    <rect width="100%" height="100%" fill="currentColor"/>
+  </svg>
+</a>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Property fill value 'currentColor' should not leak :visited for SVG fill with currentColor
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG paint servers with :visited don't leak information via getComputedStyle</title>
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#currentcolor-color">
+<link rel="help" href="https://www.w3.org/TR/SVG2/painting.html#SpecifyingFillPaint">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<style>
+a:link { color: red; }
+a:visited { color: green; }
+</style>
+
+<a href="">
+  <svg width="100" height="100">
+    <rect id="target" width="100%" height="100%" fill="currentColor"/>
+  </svg>
+</a>
+
+<script>
+test_computed_value("fill", "currentColor", "rgb(255, 0, 0)", "should not leak :visited for SVG fill with currentColor");
+</script>

--- a/Source/WebCore/rendering/svg/SVGPaintServerHandlingInlines.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerHandlingInlines.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2023, 2024 Igalia S.L.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -163,9 +164,10 @@ inline Color SVGPaintServerHandling::resolveColorFromStyle(const RenderStyle& st
     auto color = colorResolver.colorResolvingCurrentColor(paint.colorDisregardingType());
     if (style.insideLink() == InsideLink::InsideVisited) {
         // FIXME: This code doesn't support the uri component of the visited link paint, https://bugs.webkit.org/show_bug.cgi?id=70006
-        // FIXME: This code is resolving the visit link paint color with RenderStyle::color(), rather than the more commonly used RenderStyle::visitedLinkColor(). If this is intentional, we should document that, otherwise, we should use RenderStyle::visitedLinkColor().
         if (auto visitedLinkPaintColor = visitedLinkPaint.tryColor()) {
-            if (auto visitedColor = colorResolver.colorResolvingCurrentColor(*visitedLinkPaintColor); visitedColor.isValid())
+            if (visitedLinkPaintColor->isCurrentColor())
+                color = style.visitedLinkColor();
+            else if (auto visitedColor = colorResolver.colorResolvingCurrentColor(*visitedLinkPaintColor); visitedColor.isValid())
                 color = visitedColor.colorWithAlpha(color.alphaAsFloat());
         }
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2008 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -80,9 +80,10 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
         // FIXME: This code doesn't support the uri component of the visited link paint, https://bugs.webkit.org/show_bug.cgi?id=70006
         auto& visitedPaint = applyToFill ? style.visitedLinkFill() : style.visitedLinkStroke();
 
-        // For `currentcolor`, 'color' already contains the 'visitedColor'.
-        if (auto visitedPaintColor = visitedPaint.tryColor(); visitedPaintColor && !visitedPaintColor->isCurrentColor()) {
-            if (auto visitedColor = colorResolver.colorResolvingCurrentColor(*visitedPaintColor); visitedColor.isValid())
+        if (auto visitedPaintColor = visitedPaint.tryColor()) {
+            if (visitedPaintColor->isCurrentColor())
+                color = style.visitedLinkColor();
+            else if (auto visitedColor = colorResolver.colorResolvingCurrentColor(*visitedPaintColor); visitedColor.isValid())
                 color = visitedColor.colorWithAlpha(color.alphaAsFloat());
         }
     }


### PR DESCRIPTION
#### 8be100449e659f802ebf29f1ba426182693d230e
<pre>
`:visited` link color does not propagate to SVG through `currentColor`
<a href="https://bugs.webkit.org/show_bug.cgi?id=244025">https://bugs.webkit.org/show_bug.cgi?id=244025</a>
<a href="https://rdar.apple.com/98776770">rdar://98776770</a>

Reviewed by Nikolas Zimmermann and Antti Koivisto.

This patch aligns WebKit with Blink / Chromium.

When an SVG element uses fill=&quot;currentColor&quot; or stroke=&quot;currentColor&quot;
inside a :visited link, the color should resolve to the visited link
color, not the unvisited link color.

Previously, the code would skip currentColor handling in the visited
link block because it assumed the color was already resolved correctly.
However, the initial color resolution always used the non-visited style,
causing currentColor to resolve to the wrong color for visited links.

This fix explicitly handles the currentColor case within the visited
link block, ensuring it resolves to style.visitedLinkColor() for both
fill and stroke attributes.

Credits to `Masataka Yakura` for Test Case.

NOTE: This patch fixes the bug in both LegacySVG and Layer Based SVG engine.

Test: imported/w3c/web-platform-tests/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill.html
    imported/w3c/web-platform-tests/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle.html

* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle.html: Added.
* Source/WebCore/rendering/svg/SVGPaintServerHandlingInlines.h:
(WebCore::SVGPaintServerHandling::resolveColorFromStyle):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::requestPaintingResource):

Canonical link: <a href="https://commits.webkit.org/306387@main">https://commits.webkit.org/306387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01689d823f45801a7654bb14ae2f8989fb5e0009

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149826 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71fec440-ad78-41b1-80a8-b23a5b1d39b1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108518 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/198bb484-ff37-4898-a347-4f84f2b89ed1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11064 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba33764b-47cd-4ce6-ba99-e8307e08a7af) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8253 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152220 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13322 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116617 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/basic/error-after-response.any.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116957 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13007 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123068 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21788 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13365 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13104 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->