### PR TITLE
[threaded-animations] make `AnimationTimeline::createAcceleratedRepresentation()` const

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -133,7 +133,7 @@ AcceleratedTimeline& AnimationTimeline::acceleratedRepresentation()
     return *m_acceleratedRepresentation;
 }
 
-Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation()
+Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation() const
 {
     ASSERT_NOT_REACHED();
     return AcceleratedTimeline::create(m_acceleratedTimelineIdentifier, 0_s);

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -90,7 +90,7 @@ protected:
     AnimationTimeline(std::optional<WebAnimationTime> = std::nullopt);
 
 #if ENABLE(THREADED_ANIMATIONS)
-    virtual Ref<AcceleratedTimeline> createAcceleratedRepresentation();
+    virtual Ref<AcceleratedTimeline> createAcceleratedRepresentation() const;
 #endif
 
     AnimationCollection m_animations;

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -536,7 +536,7 @@ Seconds DocumentTimeline::convertTimelineTimeToOriginRelativeTime(Seconds timeli
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
-Ref<AcceleratedTimeline> DocumentTimeline::createAcceleratedRepresentation()
+Ref<AcceleratedTimeline> DocumentTimeline::createAcceleratedRepresentation() const
 {
     // The origin time of a document timeline is relative to the time origin
     // of the document's associated performance object. We must convert this

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -99,7 +99,7 @@ private:
     AnimationTimelinesController* controller() const override;
 #if ENABLE(THREADED_ANIMATIONS)
     bool computeCanBeAccelerated() const final { return true; }
-    Ref<AcceleratedTimeline> createAcceleratedRepresentation() override;
+    Ref<AcceleratedTimeline> createAcceleratedRepresentation() const final;
 #endif
 
     void applyPendingAcceleratedAnimations();

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -403,7 +403,7 @@ bool ScrollTimeline::computeCanBeAccelerated() const
     return sourceScrollableArea && !!sourceScrollableArea->scrollingNodeID();
 }
 
-Ref<AcceleratedTimeline> ScrollTimeline::createAcceleratedRepresentation()
+Ref<AcceleratedTimeline> ScrollTimeline::createAcceleratedRepresentation() const
 {
     ASSERT(this->source());
     ASSERT(this->source()->document().settings().threadedScrollDrivenAnimationsEnabled());

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -105,7 +105,7 @@ private:
     bool isScrollTimeline() const final { return true; }
 #if ENABLE(THREADED_ANIMATIONS)
     bool computeCanBeAccelerated() const final;
-    Ref<AcceleratedTimeline> createAcceleratedRepresentation() override;
+    Ref<AcceleratedTimeline> createAcceleratedRepresentation() const final;
 #endif
 
     void animationTimingDidChange(WebAnimation&) override;


### PR DESCRIPTION
#### 4007389c11159d5897c715f3870e65ba3189f5d9
<pre>
[threaded-animations] make `AnimationTimeline::createAcceleratedRepresentation()` const
<a href="https://bugs.webkit.org/show_bug.cgi?id=303158">https://bugs.webkit.org/show_bug.cgi?id=303158</a>
<a href="https://rdar.apple.com/165466087">rdar://165466087</a>

Reviewed by Anne van Kesteren.

The `AnimationTimeline::createAcceleratedRepresentation()` method should not need
to modify its members, so codify this by making it `const`.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::createAcceleratedRepresentation const):
(WebCore::AnimationTimeline::createAcceleratedRepresentation): Deleted.
* Source/WebCore/animation/AnimationTimeline.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::createAcceleratedRepresentation const):
(WebCore::DocumentTimeline::createAcceleratedRepresentation): Deleted.
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::createAcceleratedRepresentation const):
(WebCore::ScrollTimeline::createAcceleratedRepresentation): Deleted.
* Source/WebCore/animation/ScrollTimeline.h:

Canonical link: <a href="https://commits.webkit.org/303592@main">https://commits.webkit.org/303592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baf6d6bd6445dac3b0b52b37910c782ab074271e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84945 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00f2cead-9b7c-4c2d-b58b-be99db0e2013) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101633 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68954 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be0cbc65-e519-43e8-a68b-e3f5c4824edd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135860 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82432 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5b716c9-8806-435c-8775-ab9031a4f147) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83682 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143101 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110010 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110190 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3896 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115350 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58641 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20598 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5138 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33704 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68590 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5228 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->