### PR TITLE
Remove non-standard webkitconvertPoint* API usage from modern media controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016, 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -217,7 +217,7 @@ class SliderBase extends LayoutNode
 
         if (this._allowsRelativeScrubbing) {
             this._startValue = parseFloat(this._input.element.value);
-            this._startPosition = this._playbackProgress(event.pageX);
+            this._startPosition = this._playbackProgress(event.clientX);
         }
 
         if (this.uiDelegate && typeof this.uiDelegate.controlValueWillStartChanging === "function")
@@ -250,7 +250,7 @@ class SliderBase extends LayoutNode
         if (!this._allowsRelativeScrubbing || isNaN(this._startValue) || isNaN(this._startPosition))
             return;
 
-        let value = this._startValue + this._playbackProgress(event.pageX) - this._startPosition;
+        let value = this._startValue + this._playbackProgress(event.clientX) - this._startPosition;
         this._input.element.value = Math.min(Math.max(0, value), 1);
         this._valueDidChange();
     }
@@ -273,9 +273,11 @@ class SliderBase extends LayoutNode
         this.needsLayout = true;
     }
 
-    _playbackProgress(pageX)
+    _playbackProgress(clientX)
     {
-        let x = window.webkitConvertPointFromPageToNode(this.element, new WebKitPoint(pageX, 0)).x;
+        const rect = this.element.getBoundingClientRect();
+        let x = clientX - rect.left;
+        
         if (this._layoutDelegate?.scaleFactor)
             x *= this._layoutDelegate.scaleFactor;
 

--- a/Source/WebCore/Modules/modern-media-controls/gesture-recognizers/gesture-recognizer.js
+++ b/Source/WebCore/Modules/modern-media-controls/gesture-recognizers/gesture-recognizer.js
@@ -99,9 +99,8 @@ class GestureRecognizer
         if (!element)
             return p;
 
-        // FIXME: are WebKitPoint and DOMPoint interchangeable?
-        const wkPoint = window.webkitConvertPointFromPageToNode(element, new WebKitPoint(p.x, p.y));
-        return new DOMPoint(wkPoint.x, wkPoint.y);
+        const rect = element.getBoundingClientRect();
+        return new DOMPoint(p.x - rect.left - window.scrollX, p.y - rect.top - window.scrollY);
     }
 
     locationInClient()

--- a/Source/WebCore/Modules/modern-media-controls/gesture-recognizers/tap.js
+++ b/Source/WebCore/Modules/modern-media-controls/gesture-recognizers/tap.js
@@ -75,9 +75,8 @@ class TapGestureRecognizer extends GestureRecognizer
         if (!element)
             return p;
 
-        // FIXME: are WebKitPoint and DOMPoint interchangeable?
-        const wkPoint = window.webkitConvertPointFromPageToNode(element, new WebKitPoint(p.x, p.y));
-        return new DOMPoint(wkPoint.x, wkPoint.y);
+        const rect = element.getBoundingClientRect();
+        return new DOMPoint(p.x - rect.left - window.scrollX, p.y - rect.top - window.scrollY);
     }
 
     locationInClient()


### PR DESCRIPTION
#### 5b3e698248701560db234c3b5c569bd66d02a768
<pre>
Remove non-standard webkitconvertPoint* API usage from modern media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=298160">https://bugs.webkit.org/show_bug.cgi?id=298160</a>
<a href="https://rdar.apple.com/159527307">rdar://159527307</a>

Reviewed by NOBODY (OOPS!).

This patch removes non-standard `webkitconvertPoint*` API usage from
media controls.

It is covered by existing tests.

* Source/WebCore/Modules/modern-media-controls/controls/slider-base.js:
(SliderBase.prototype._handlePointerdownEvent):
(SliderBase.prototype._handlePointermoveEvent):
(SliderBase.prototype._playbackProgress):
* Source/WebCore/Modules/modern-media-controls/gesture-recognizers/gesture-recognizer.js:
(GestureRecognizer.prototype.locationInElement):
* Source/WebCore/Modules/modern-media-controls/gesture-recognizers/tap.js:
(TapGestureRecognizer.prototype.locationInElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b3e698248701560db234c3b5c569bd66d02a768

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84969 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/da742024-66c1-4264-85d6-b09ed8d1a42b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101652 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68983 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/698fbfa6-9d27-4e56-acdb-597e20947795) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d7e177b3-ee2b-4def-8f41-19d5a42138fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4123 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1616 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83706 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143126 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5108 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110029 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110210 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3920 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115369 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58674 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5162 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33723 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5252 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5120 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->