### PR TITLE
[Tools][GTK][browserperfdash-benchmark] browser-binary-size plan plugin fails to find the browser libraries in the GTK performance bot

### DIFF
--- a/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
@@ -62,8 +62,8 @@ def get_browser_relevant_objects_glib(browser_driver):
         raise ValueError(f"The browser path does not exist: {browser_path}")
     libraries, interpreter = SharedObjectResolver('ldd', browser_env).get_libs_and_interpreter(browser_path)
     browser_build_dir = port_driver._build_path()
-    for library in libraries:
-        if library.startswith(browser_build_dir):
+    for library in sorted(libraries):
+        if library.startswith(browser_build_dir) or os.path.realpath(library).startswith(browser_build_dir):
             browser_relevant_objects.append(library)
     return browser_relevant_objects
 


### PR DESCRIPTION
#### c120510bb21592e5ee3f596bedae127cebb96749
<pre>
[Tools][GTK][browserperfdash-benchmark] browser-binary-size plan plugin fails to find the browser libraries in the GTK performance bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=303174">https://bugs.webkit.org/show_bug.cgi?id=303174</a>

Reviewed by Nikolas Zimmermann and Carlos Garcia Campos.

If the DT_NEEDED entries for WebKit libraries in the MiniBrowser binary contain full paths,
and those paths point to symlinks outside the build directory that ultimately resolve to
locations inside the build directory, then the browser-binary-size plugin incorrectly
classifies those libraries as external when they should be considered part of the build.

This is a corner case that occurs when you build WebKit in one directory, then move the
WebKit checkout to another location and create a symlink from the original directory to
the new one. In this scenario, the LD_LIBRARY_PATH environment variable set by the test
cannot override DT_NEEDED entries with full paths. In practice, this isn&apos;t a functional
issue because the correct library still gets loaded, but it causes the plugin to
incorrectly identify the library as being outside the build directory.

Fix this by also checking whether the resolved path belongs to the build directory.

* Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py:
(get_browser_relevant_objects_glib):

Canonical link: <a href="https://commits.webkit.org/303603@main">https://commits.webkit.org/303603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4cbcbe27b7a2fe55875e198a32ba67bbd912262

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135904 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82471 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132307 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83726 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143146 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110049 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110229 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3936 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58699 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20600 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5182 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33746 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->