### PR TITLE
[WPE] Implement non-composited page rendering

### DIFF
--- a/LayoutTests/platform/glib/non-compositing/simple-dom-expected.html
+++ b/LayoutTests/platform/glib/non-compositing/simple-dom-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AcceleratedCompositingEnabled=true ] -->
+<html lang="en">
+  <body>
+    This is a text.
+    <div style="background-color: yellow;">This is a text in block</div>
+    <b>This is a text in bold</b>
+    <div style="width: 50px; height: 50px; border: 2px solid blue;"></div>
+  </body>
+</html>
+

--- a/LayoutTests/platform/glib/non-compositing/simple-dom.html
+++ b/LayoutTests/platform/glib/non-compositing/simple-dom.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AcceleratedCompositingEnabled=false ] -->
+<html lang="en">
+  <head>
+    <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-14" />
+  </head>
+  <body>
+    This is a text.
+    <div style="background-color: yellow;">This is a text in block</div>
+    <b>This is a text in bold</b>
+    <div style="width: 50px; height: 50px; border: 2px solid blue;"></div>
+  </body>
+</html>
+

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -328,6 +328,7 @@ WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
 WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
 WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
 WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
 
 WebProcess/WebPage/glib/WebPageGLib.cpp

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -56,6 +56,10 @@ typedef struct AHardwareBuffer AHardwareBuffer;
 typedef void *EGLImage;
 #endif
 
+#if USE(SKIA)
+#include <WebCore/GraphicsContextSkia.h>
+#endif
+
 #if USE(WPE_RENDERER)
 struct wpe_renderer_backend_egl_target;
 #endif
@@ -66,6 +70,7 @@ class RunLoop;
 
 namespace WebCore {
 class GLFence;
+class GraphicsContext;
 class ShareableBitmap;
 class ShareableBitmapHandle;
 }
@@ -103,6 +108,8 @@ public:
         return true;
 #endif
     }
+
+    WebCore::GraphicsContext* graphicsContext();
 
     void willDestroyGLContext();
     void willRenderFrame(const WebCore::IntSize&);
@@ -143,6 +150,8 @@ private:
 
         uint64_t id() const { return m_id; }
 
+        virtual WebCore::GraphicsContext* graphicsContext() { RELEASE_ASSERT_NOT_REACHED(); }
+
         virtual void willRenderFrame() { }
         virtual void didRenderFrame(Vector<WebCore::IntRect, 1>&&) { }
 
@@ -177,6 +186,8 @@ private:
     protected:
         RenderTargetShareableBuffer(uint64_t, const WebCore::IntSize&);
 
+        WebCore::GraphicsContext* graphicsContext() override;
+
         void willRenderFrame() override;
         void didRenderFrame(Vector<WebCore::IntRect, 1>&&) override;
 
@@ -188,6 +199,13 @@ private:
         unsigned m_depthStencilBuffer { 0 };
         UnixFileDescriptor m_renderingFenceFD;
         UnixFileDescriptor m_releaseFenceFD;
+#if USE(SKIA)
+        struct {
+            sk_sp<SkSurface> surface;
+            std::unique_ptr<WebCore::GraphicsContextSkia> context;
+        } m_graphicsContext;
+#endif
+        WebCore::IntSize m_initialSize;
     };
 
 #if USE(GBM) || OS(ANDROID)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -36,6 +36,7 @@ class GraphicsContext;
 }
 
 namespace WebKit {
+class NonCompositedFrameRenderer;
 struct RenderProcessInfo;
 struct UpdateInfo;
 
@@ -148,6 +149,11 @@ private:
 
     // The layer tree host that handles accelerated compositing.
     std::unique_ptr<LayerTreeHost> m_layerTreeHost;
+
+#if PLATFORM(WPE)
+    // Frame renderer used in non-composited mode.
+    std::unique_ptr<NonCompositedFrameRenderer> m_nonCompositedFrameRenderer;
+#endif
 
     WebCore::Region m_dirtyRegion;
     WebCore::IntRect m_scrollRect;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NonCompositedFrameRenderer.h"
+
+#if USE(COORDINATED_GRAPHICS)
+
+namespace WebKit {
+using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NonCompositedFrameRenderer);
+
+std::unique_ptr<NonCompositedFrameRenderer> NonCompositedFrameRenderer::create(WebPage& webPage)
+{
+    auto instance = makeUnique<NonCompositedFrameRenderer>(webPage);
+    return instance->initialize() ? WTFMove(instance) : nullptr;
+}
+
+NonCompositedFrameRenderer::NonCompositedFrameRenderer(WebPage& webPage)
+    : m_webPage(webPage)
+    , m_surface(AcceleratedSurface::create(m_webPage, [this] {
+        m_canRenderNextFrame = true;
+        if (m_shouldRenderFollowupFrame) {
+            m_shouldRenderFollowupFrame = false;
+            display();
+        }
+    }))
+{
+}
+
+bool NonCompositedFrameRenderer::initialize()
+{
+    static_assert(sizeof(GLNativeWindowType) <= sizeof(uint64_t), "GLNativeWindowType must not be longer than 64 bits.");
+    m_context = GLContext::create(PlatformDisplay::sharedDisplay(), m_surface->window());
+    if (!m_context || !m_context->makeContextCurrent())
+        return false;
+
+    m_surface->didCreateCompositingRunLoop(RunLoop::mainSingleton());
+    LayerTreeContext layerTreeContext;
+    layerTreeContext.contextID = m_surface->surfaceID();
+    m_webPage.get().send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(0, layerTreeContext), m_webPage.get().drawingArea()->identifier().toUInt64(), { });
+    return true;
+}
+
+NonCompositedFrameRenderer::~NonCompositedFrameRenderer()
+{
+    m_surface->willDestroyGLContext();
+    m_surface->willDestroyCompositingRunLoop();
+}
+
+void NonCompositedFrameRenderer::display()
+{
+    if (!m_canRenderNextFrame) {
+        m_shouldRenderFollowupFrame = true;
+        return;
+    }
+
+    Ref webPage = m_webPage.get();
+    webPage->updateRendering();
+    webPage->finalizeRenderingUpdate({ });
+    webPage->flushPendingEditorStateUpdate();
+
+    m_surface->willRenderFrame(webPage->size());
+    auto* graphicsContext = m_surface->graphicsContext();
+    if (!graphicsContext || !m_context->makeContextCurrent())
+        return;
+
+    // FIXME: Use render target damage not to re-paint whole rect.
+    webPage->drawRect(*graphicsContext, webPage->bounds());
+
+    m_canRenderNextFrame = false;
+    m_surface->didRenderFrame();
+
+    webPage->didUpdateRendering();
+}
+
+} // namespace WebKit
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+#include "AcceleratedSurface.h"
+#include <WebCore/GLContext.h>
+
+namespace WebKit {
+class WebPage;
+
+class NonCompositedFrameRenderer {
+    WTF_MAKE_TZONE_ALLOCATED(NonCompositedFrameRenderer);
+public:
+    static std::unique_ptr<NonCompositedFrameRenderer> create(WebPage&);
+
+    NonCompositedFrameRenderer(WebPage&);
+    ~NonCompositedFrameRenderer();
+
+    void display();
+
+private:
+    bool initialize();
+
+    WeakRef<WebPage> m_webPage;
+    Ref<AcceleratedSurface> m_surface;
+    std::unique_ptr<WebCore::GLContext> m_context;
+    bool m_canRenderNextFrame { true };
+    bool m_shouldRenderFollowupFrame { false };
+};
+
+} // namespace WebKit
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4792,7 +4792,7 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 
     updateSettingsGenerated(store, settings);
 
-#if !PLATFORM(GTK) && !PLATFORM(WIN) && !PLATFORM(PLAYSTATION)
+#if !PLATFORM(GTK) && !PLATFORM(WIN) && !PLATFORM(PLAYSTATION) && !PLATFORM(WPE)
     if (!settings.acceleratedCompositingEnabled()) {
         WEBPAGE_RELEASE_LOG(Layers, "updatePreferences: acceleratedCompositingEnabled setting was false. WebKit cannot function in this mode; changing setting to true");
         settings.setAcceleratedCompositingEnabled(true);


### PR DESCRIPTION
#### f47827c7c3aa15647991c6ec44a94ae3552e35f2
<pre>
[WPE] Implement non-composited page rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=303170">https://bugs.webkit.org/show_bug.cgi?id=303170</a>

Reviewed by Carlos Garcia Campos.

This change implements the non-composited page rendering for WPE.

With this change, it&apos;s possible to utilize a simplified frame rendering
that does not use compositor at all. It&apos;s useful especially on low-end
embedded devices where GPU is not powerful or not present at all.

The non-composited mode implemented in this change can be enabled using
a -AcceleratedCompositing preference.

Additionally, this change adds a layout ref-test that protects the new
implementation as well as existing, GTK&apos;s implementation from
regressions.

Canonical link: <a href="https://commits.webkit.org/304678@main">https://commits.webkit.org/304678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07c56e294097fe9e5084ef3d0f8887ffa0084596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143967 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104184 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6412 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4072 "Found 2 new API test failures: TestWebKitAPI.MessagePort.MessageToClosedPort, TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4560 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8296 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112524 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112867 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6340 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118400 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8344 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36457 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71903 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8136 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->