### PR TITLE
[bfcache] Update WebSocket's WPT expectations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Testing BFCache support for page with closed WebSocket connection and "Cache-Control: no-store" header. BFCache not supported.
+FAIL Testing BFCache support for page with closed WebSocket connection and "Cache-Control: no-store" header. assert_equals: document unexpectedly BFCached expected (undefined) undefined but got (boolean) true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection.window-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Testing BFCache support for page with closed WebSocket connection. BFCache not supported.
+PASS Testing BFCache support for page with closed WebSocket connection.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Testing BFCache support for page with open WebSocket connection and "Cache-Control: no-store" header. BFCache not supported.
+FAIL Testing BFCache support for page with open WebSocket connection and "Cache-Control: no-store" header. assert_equals: document unexpectedly BFCached expected (undefined) undefined but got (boolean) true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection.window-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Testing BFCache support for page with open WebSocket connection.
+FAIL Testing BFCache support for page with open WebSocket connection. assert_equals: document unexpectedly BFCached expected (undefined) undefined but got (boolean) true
 

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -142,7 +142,8 @@ static bool shouldEnableEnhancedSecurity(const std::string& pathOrURL)
 
 static bool shouldUseBackForwardCache(const std::string& pathOrURL)
 {
-    return pathContains(pathOrURL, "navigation-api/");
+    return pathContains(pathOrURL, "navigation-api/")
+        || pathContains(pathOrURL, "websockets/back-forward-cache");
 }
 
 static bool shouldEnableBlocksInInline(const std::string& pathOrURL)


### PR DESCRIPTION
#### 43b242582bf341c9be81bf2e892e14b478f14913
<pre>
[bfcache] Update WebSocket&apos;s WPT expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=303176">https://bugs.webkit.org/show_bug.cgi?id=303176</a>

Reviewed by Alexey Proskuryakov.

The WPT expectations for WebSockets BFCache behaviour were incorrect as
BFCache was not used by the runner.
This enables BFCache for that specific test subset and resets the test
results.

Test failures are expected, as B/F cache is intentionally supported in
this case. Please see <a href="https://webkit.org/b/143505">https://webkit.org/b/143505</a> for additional
context.

* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection.window-expected.txt:
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::shouldUseBackForwardCache):

Canonical link: <a href="https://commits.webkit.org/303822@main">https://commits.webkit.org/303822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c2a49071fb4e2411613ee631d7688dab783cfff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102179 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69555 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2156 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143770 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110557 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4405 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59487 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5790 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34311 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->