### PR TITLE
[MSE] imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-av-audio-bitrate.html is a constant timeout.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-play-terminate-worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-play-terminate-worker-expected.txt
@@ -1,7 +1,5 @@
 
 
-Harness Error (TIMEOUT), message = null
-
 PASS Test worker MediaSource termination after at least 0 main thread setTimeouts, starting counting before setting srcObject
 PASS Test worker MediaSource termination after at least 1 main thread setTimeouts, starting counting before setting srcObject
 PASS Test worker MediaSource termination after at least 2 main thread setTimeouts, starting counting before setting srcObject
@@ -22,14 +20,14 @@ PASS Test worker MediaSource termination after at least 6 main thread setTimeout
 PASS Test worker MediaSource termination after at least 7 main thread setTimeouts, starting counting after setting srcObject
 PASS Test worker MediaSource termination after at least 8 main thread setTimeouts, starting counting after setting srcObject
 PASS Test worker MediaSource termination after at least 9 main thread setTimeouts, starting counting after setting srcObject
-TIMEOUT Test worker MediaSource termination after at least 0 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 1 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 2 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 3 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 4 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 5 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 6 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 7 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 8 main thread setTimeouts, starting counting after first ended event Test timed out
-TIMEOUT Test worker MediaSource termination after at least 9 main thread setTimeouts, starting counting after first ended event Test timed out
+PASS Test worker MediaSource termination after at least 0 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 1 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 2 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 3 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 4 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 5 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 6 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 7 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 8 main thread setTimeouts, starting counting after first ended event
+PASS Test worker MediaSource termination after at least 9 main thread setTimeouts, starting counting after first ended event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-append-buffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-append-buffer-expected.txt
@@ -12,12 +12,14 @@ PASS Test appending an empty ArrayBufferView.
 PASS Test appending a neutered ArrayBufferView.
 PASS Test appending an empty ArrayBuffer.
 PASS Test appending a neutered ArrayBuffer.
-FAIL Test appendBuffer with partial init segments. assert_equals: expected 6.0756 but got 0
-FAIL Test appendBuffer with partial media segments. assert_equals: expected 6.0756 but got 0
+PASS Test appendBuffer with partial init segments.
+PASS Test appendBuffer with partial media segments.
+FAIL Test appendBuffer events order. assert_true: expected true got false
 PASS Test abort in the middle of an initialization segment.
 PASS Test abort after removing sourcebuffer.
 PASS Test abort after readyState is ended following init segment and media segment.
 PASS Test abort after appendBuffer update ends.
 PASS Test appending null.
 PASS Test appending after removeSourceBuffer().
+PASS Test slow appending does not trigger stalled events.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-endofstream-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-endofstream-expected.txt
@@ -1,6 +1,5 @@
 
 PASS MediaSource.endOfStream(): duration truncated to 0 when there are no buffered coded frames
 PASS MediaSource.endOfStream(): media element notified that it now has all of the media data
-PASS MediaSource.endOfStream(): buffered data not modified when endOfStream is called
-PASS MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute
+PASS MediaSource.endOfStream(): duration and buffered range end time before and after endOfStream
 

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-errors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-errors-expected.txt
@@ -2,7 +2,8 @@
 PASS Appending media segment before the first initialization segment.
 PASS Signaling 'decode' error via endOfStream() before initialization segment has been appended.
 PASS Signaling 'network' error via endOfStream() before initialization segment has been appended.
-PASS Signaling 'decode' error via endOfStream() after initialization segment has been appended and the HTMLMediaElement has reached HAVE_METADATA.
-PASS Signaling 'network' error via endOfStream() after initialization segment has been appended and the HTMLMediaElement has reached HAVE_METADATA.
-PASS Signaling 'decode' error via segment parser loop algorithm after initialization segment and partial media segment has been appended.
+FAIL Signaling 'decode' error via endOfStream() after initialization segment has been appended and the HTMLMediaElement has reached HAVE_METADATA. assert_equals: expected "ended" but got "closed"
+FAIL Signaling 'network' error via endOfStream() after initialization segment has been appended and the HTMLMediaElement has reached HAVE_METADATA. assert_equals: expected "ended" but got "closed"
+PASS Signaling 'decode' error via segment parser loop algorithm after initialization segment has been appended.
+PASS Signaling 'decode' error via segment parser loop algorithm of append containing init plus corrupted media segment.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality-expected.txt
@@ -1,4 +1,3 @@
 
 PASS Test HTMLVideoElement.getVideoPlaybackQuality() with MediaSource API
-PASS Test the totalFrameDelay attribute of HTMLVideoElement.getVideoPlaybackQuality() with MediaSource API
 

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-removesourcebuffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-removesourcebuffer-expected.txt
@@ -2,6 +2,7 @@
 PASS Test addSourceBuffer(), removeSourceBuffer(), addSourceBuffer() sequence.
 PASS Test removeSourceBuffer() with null
 PASS Test calling removeSourceBuffer() twice with the same object.
+PASS Test calling removeSourceBuffer() for a sourceBuffer belonging to a different mediaSource instance.
 PASS Test calling removeSourceBuffer() in ended state.
 PASS Test removesourcebuffer event on activeSourceBuffers.
 PASS Test abort event when removeSourceBuffer() called while SourceBuffer is updating

--- a/LayoutTests/media/media-source/media-source-rendering-update-count-expected.txt
+++ b/LayoutTests/media/media-source/media-source-rendering-update-count-expected.txt
@@ -11,18 +11,15 @@ Wait for the rendering count to settle down
 Append first media segment
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
 EVENT(update)
-EVENT(progress)
 EXPECTED (internals.renderingUpdateCount() > '0') OK
 
 Append second media segment
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
 EVENT(update)
-EVENT(progress)
 EXPECTED (Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout == 'true') OK
 
 Append third media segment
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(2)))
 EVENT(update)
-EVENT(progress)
 EXPECTED (Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout == 'true') OK
 

--- a/LayoutTests/media/media-source/media-source-rendering-update-count.html
+++ b/LayoutTests/media/media-source/media-source-rendering-update-count.html
@@ -57,10 +57,7 @@
         consoleWrite('<br>Append first media segment')
         run(`sourceBuffer.appendBuffer(loader.mediaSegment(0))`);
 
-        await Promise.all([
-            waitFor(video, 'progress'),
-            waitFor(sourceBuffer, 'update')
-            ]);
+        await waitFor(sourceBuffer, 'update');
 
         await testExpectedEventually('internals.renderingUpdateCount()', initialRenderingUpdateCount, '>');
         initialRenderingUpdateCount = internals.renderingUpdateCount();
@@ -68,20 +65,14 @@
         consoleWrite('<br>Append second media segment')
         run(`sourceBuffer.appendBuffer(loader.mediaSegment(1))`);
 
-        await Promise.all([
-            waitFor(video, 'progress'),
-            waitFor(sourceBuffer, 'update')
-            ]);
+        await waitFor(sourceBuffer, 'update');
 
         testExpected('Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout', true,);
 
         consoleWrite('<br>Append third media segment')
         run(`sourceBuffer.appendBuffer(loader.mediaSegment(2))`);
 
-        await Promise.all([
-            waitFor(video, 'progress'),
-            waitFor(sourceBuffer, 'update')
-            ]);
+        await waitFor(sourceBuffer, 'update');
 
         testExpected('Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout', true);
     }

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1310,6 +1310,15 @@ media/media-source/media-source-ended.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play.html [ Skip ]
+imported/w3c/web-platform-tests/media-source/mediasource-video-is-visible.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html [ Skip ]
+imported/w3c/web-platform-tests/media-source/mediasource-endofstream.html [ Skip ]
+
+# Requires WebM
+imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-a-bitrate.html [ Skip ]
+imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-audio-bitrate.html [ Skip ]
+imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-framesize.html [ Skip ]
+imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-video-bitrate.html [ Skip ]
 
 # Managed MediaSource isn't enabled on WK1
 media/media-source/media-managedmse-append.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -721,26 +721,14 @@ imported/w3c/web-platform-tests/media-source/ [ Pass ]
 imported/w3c/web-platform-tests/media-source/dedicated-worker/ [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/URL-createObjectURL-revoke.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-append-buffer.html [ Skip ]
-webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-appendbuffer-quota-exceeded.html [ Skip ]
-webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-av-framesize.html [ Skip ]
-webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-endofstream.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-errors.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-is-type-supported.html [ Skip ]
-webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-removesourcebuffer.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-seek-beyond-duration.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html [ Skip ]
-webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sourcebuffer-mode-timestamps.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sourcebuffer-mode.html [ Skip ]
 webkit.org/b/214166 imported/w3c/web-platform-tests/media-source/idlharness.window.html [ Skip ]
 
-# Requires WebM
-imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-a-bitrate.html [ Skip ]
-imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-audio-bitrate.html [ Skip ]
-imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-framesize.html [ Skip ]
-imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-video-bitrate.html [ Skip ]
-
 # Skipped in W3C Web Platform Test manifest
-imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-sourcebuffer-trackdefaults.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-trackdefault.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-trackdefaultlist.html [ Skip ]
@@ -1060,10 +1048,6 @@ webkit.org/b/168087 media/video-zoom.html [ Pass Failure ]
 
 # rdar://problem/23643423
 [ Debug ] fast/frames/exponential-frames.html [ Skip ]
-
-webkit.org/b/168094 imported/w3c/web-platform-tests/media-source/SourceBuffer-abort.html [ Pass Failure ]
-webkit.org/b/167975 imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-removed.html [ Pass Failure ]
-webkit.org/b/187911 imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-readyState.html [ Pass Failure ]
 
 [ Debug ] imported/w3c/web-platform-tests/hr-time/idlharness.any.html [ Slow ]
 
@@ -1418,9 +1402,6 @@ webkit.org/b/200128 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 
 # See bug 232916; this test can't pass as we do not support mid-stream resolution change.
 webkit.org/b/231084 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/resize-during-playback.html [ Skip ]
-
-# The test runner is failing in an unrelated, unexplained, invisible to the human eye, 2 pixels difference.
-webkit.org/b/201401 imported/w3c/web-platform-tests/media-source/mediasource-video-is-visible.html [ Skip ]
 
 webkit.org/b/198867 webgl/many-contexts.html [ Skip ]
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-expected.txt
@@ -1,4 +1,0 @@
-
-FAIL SourceBuffer#abort() (video/webm; codecs="vorbis,vp8"): Check the values of appendWindowStart and appendWindowEnd. assert_true: Browser doesn't support the MIME used in this test: video/webm; codecs="vorbis,vp8" expected true got false
-PASS SourceBuffer#abort() (video/mp4): Check the values of appendWindowStart and appendWindowEnd.
-

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-readyState-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-readyState-expected.txt
@@ -1,4 +1,0 @@
-
-FAIL SourceBuffer#abort() (video/webm; codecs="vorbis,vp8") : If the readyState attribute of the parent media source is not in the "open" state then throw an INVALID_STATE_ERR exception and abort these steps. assert_unreached: Browser doesn't support the MIME used in this test: video/webm; codecs="vorbis,vp8" Reached unreachable code
-PASS SourceBuffer#abort() (video/mp4) : If the readyState attribute of the parent media source is not in the "open" state then throw an INVALID_STATE_ERR exception and abort these steps.
-

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-removed-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-removed-expected.txt
@@ -1,4 +1,0 @@
-
-FAIL SourceBuffer#abort (video/webm; codecs="vorbis,vp8") : if this object has been removed from the sourceBuffers attribute of the parent media source, then throw an INVALID_STATE_ERR exception and abort these steps. assert_unreached: Browser doesn't support the MIME used in this test: video/webm; codecs="vorbis,vp8" Reached unreachable code
-PASS SourceBuffer#abort (video/mp4) : if this object has been removed from the sourceBuffers attribute of the parent media source, then throw an INVALID_STATE_ERR exception and abort these steps.
-

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -787,6 +787,8 @@ void MediaSource::streamEndedWithError(std::optional<EndOfStreamError> error)
         setDurationInternal(maxEndTime);
 
         // 2. Notify the media element that it now has all of the media data.
+        // Once the entire media resource has been fetched (but potentially before any of it has been decoded)
+        // Fire an event named progress at the media element.
         msp->markEndOfStream(MediaSourcePrivate::EndOfStreamStatus::NoError);
         return;
     }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -179,6 +179,10 @@ public:
     virtual MediaPlayer::NetworkState networkState() const = 0;
     virtual MediaPlayer::ReadyState readyState() const = 0;
 
+#if ENABLE(MEDIA_SOURCE)
+    virtual void mediaSourceHasRetrievedAllData() { };
+#endif
+
     WEBCORE_EXPORT virtual const PlatformTimeRanges& seekable() const;
     virtual MediaTime maxTimeSeekable() const { return MediaTime::zeroTime(); }
     virtual MediaTime minTimeSeekable() const { return MediaTime::zeroTime(); }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -267,6 +267,20 @@ void MediaSourcePrivate::setMediaPlayerReadyState(MediaPlayer::ReadyState readyS
     });
 }
 
+void MediaSourcePrivate::markEndOfStream(EndOfStreamStatus status)
+{
+    m_isEnded = true;
+    if (status != EndOfStreamStatus::NoError)
+        return;
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (RefPtr player = protectedThis->player())
+            player->mediaSourceHasRetrievedAllData();
+    });
+}
+
 PlatformTimeRanges MediaSourcePrivate::seekable() const
 {
     MediaTime duration;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -94,7 +94,7 @@ public:
 
     MediaPlayer::ReadyState mediaPlayerReadyState() const;
     virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState);
-    virtual void markEndOfStream(EndOfStreamStatus) { m_isEnded = true; }
+    virtual void markEndOfStream(EndOfStreamStatus);
     virtual void unmarkEndOfStream() { m_isEnded = false; }
     bool isEnded() const { return m_isEnded; }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -307,6 +307,9 @@ private:
 
     void readyStateFromMediaSourceChanged() final;
     void updateStateFromReadyState();
+    void mediaSourceHasRetrievedAllData() final;
+
+    bool supportsProgressMonitoring() const final { return false; }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const final { return true; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1089,6 +1089,12 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setNetworkState(MediaPlayer::NetworkS
         player->networkStateChanged();
 }
 
+void MediaPlayerPrivateMediaSourceAVFObjC::mediaSourceHasRetrievedAllData()
+{
+    assertIsMainThread();
+    setNetworkState(MediaPlayer::NetworkState::Loaded);
+}
+
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 void MediaPlayerPrivateMediaSourceAVFObjC::addAudioTrack(TrackIdentifier audioTrack)
 ALLOW_NEW_API_WITHOUT_GUARDS_END

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -73,7 +73,6 @@ public:
 
     AddStatus addSourceBuffer(const ContentType&, const MediaSourceConfiguration&, RefPtr<SourceBufferPrivate>&) final;
     void durationChanged(const MediaTime&) final;
-    void markEndOfStream(EndOfStreamStatus) final;
 
     FloatSize naturalSize() const;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -174,16 +174,6 @@ void MediaSourcePrivateAVFObjC::durationChanged(const MediaTime& duration)
     });
 }
 
-void MediaSourcePrivateAVFObjC::markEndOfStream(EndOfStreamStatus status)
-{
-    if (status != EndOfStreamStatus::NoError)
-        return;
-    callOnMainThreadWithPlayer([](auto& player) {
-        player.setNetworkState(MediaPlayer::NetworkState::Loaded);
-    });
-    MediaSourcePrivate::markEndOfStream(status);
-}
-
 FloatSize MediaSourcePrivateAVFObjC::naturalSize() const
 {
     assertIsCurrent(m_dispatcher.get());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -412,6 +412,11 @@ void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
         player->timeChanged();
 }
 
+void MediaPlayerPrivateGStreamerMSE::mediaSourceHasRetrievedAllData()
+{
+    setNetworkState(MediaPlayer::NetworkState::Loaded);
+}
+
 void MediaPlayerPrivateGStreamerMSE::didPreroll()
 {
     ASSERT(GST_STATE(m_pipeline.get()) >= GST_STATE_PAUSED);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -79,6 +79,7 @@ public:
 
     void setNetworkState(MediaPlayer::NetworkState);
     void readyStateFromMediaSourceChanged() final;
+    void mediaSourceHasRetrievedAllData() final;
 
     void setInitialVideoSize(const FloatSize&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -132,6 +132,7 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
 {
     ASSERT(isMainThread());
 
+    MediaSourcePrivate::markEndOfStream(endOfStreamStatus);
     RefPtr player = platformPlayer();
     if (!player)
         return;
@@ -152,15 +153,12 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
     GST_DEBUG_OBJECT(player->pipeline(), "Marking EOS, status is %s", statusString);
 #endif
     if (endOfStreamStatus == EndOfStreamStatus::NoError) {
-        player->setNetworkState(MediaPlayer::NetworkState::Loaded);
-
         auto bufferedRanges = buffered();
         if (!bufferedRanges.length()) {
             GST_DEBUG("EOS with no buffers");
             player->setEosWithNoBuffers(true);
         }
     }
-    MediaSourcePrivate::markEndOfStream(endOfStreamStatus);
 }
 
 void MediaSourcePrivateGStreamer::unmarkEndOfStream()

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -188,6 +188,11 @@ void MockMediaPlayerMediaSource::readyStateFromMediaSourceChanged()
         player->readyStateChanged();
 }
 
+void MockMediaPlayerMediaSource::mediaSourceHasRetrievedAllData()
+{
+    setNetworkState(MediaPlayer::NetworkState::Loaded);
+}
+
 MediaTime MockMediaPlayerMediaSource::maxTimeSeekable() const
 {
     return m_duration;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -91,6 +91,7 @@ private:
     bool seeking() const final;
     bool paused() const override;
     MediaPlayer::NetworkState networkState() const override;
+    void mediaSourceHasRetrievedAllData() final;
     MediaTime maxTimeSeekable() const override;
     const PlatformTimeRanges& buffered() const override;
     bool didLoadingProgress() const override;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -93,13 +93,6 @@ void MockMediaSourcePrivate::durationChanged(const MediaTime& duration)
         m_player->updateDuration(duration);
 }
 
-void MockMediaSourcePrivate::markEndOfStream(EndOfStreamStatus status)
-{
-    if (m_player && status == EndOfStreamStatus::NoError)
-        m_player->setNetworkState(MediaPlayer::NetworkState::Loaded);
-    MediaSourcePrivate::markEndOfStream(status);
-}
-
 void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
 {
     if (m_player)

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -73,7 +73,6 @@ private:
     // MediaSourcePrivate Overrides
     AddStatus addSourceBuffer(const ContentType&, const MediaSourceConfiguration&, RefPtr<SourceBufferPrivate>&) override;
     void durationChanged(const MediaTime&) override;
-    void markEndOfStream(EndOfStreamStatus) override;
 
     void notifyActiveSourceBuffersChanged() final;
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -189,7 +189,6 @@ void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffere
 
 void MediaSourcePrivateRemote::markEndOfStream(EndOfStreamStatus status)
 {
-    MediaSourcePrivate::markEndOfStream(status);
     ensureOnDispatcher([protectedThis = Ref { *this }, this, status] {
         auto gpuProcessConnection = m_gpuProcessConnection.get();
         if (!isGPURunning() || !gpuProcessConnection)


### PR DESCRIPTION
#### 9a97db3ec439cfd792a342618a43ce274654a514
<pre>
[MSE] imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-av-audio-bitrate.html is a constant timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302695">https://bugs.webkit.org/show_bug.cgi?id=302695</a>
<a href="https://rdar.apple.com/164943486">rdar://164943486</a>

Reviewed by Youenn Fablet.

Many tests has been marked as failed during a 2020 WPT re-sync, mostly due to
a failure to update the expected files.
We update all tests as required and remove the incorrect TestExpectations.
This increase our test coverage of MSE by over 50%

Fly-By: We move the responsability from notifying the MediaPlayerPrivateClient
that all data has been received following a call to MediaSource.endOfStream()
from the MediaSourcePrivate to the MediaPlayerPrivate and use a more clear
nomenclature to indicate what is happening.

Covered by existing tests.
* LayoutTests/imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-play-terminate-worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-append-buffer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-endofstream-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-errors-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-removesourcebuffer-expected.txt:
* LayoutTests/media/media-source/media-source-rendering-update-count-expected.txt:
* LayoutTests/media/media-source/media-source-rendering-update-count.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-expected.txt: Removed.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-readyState-expected.txt: Removed.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-removed-expected.txt: Removed.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::streamEndedWithError):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::mediaSourceHasRetrievedAllData):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::markEndOfStream):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h: The HTMLMediaElement shouldn&apos;t emit `stalled` or `progress` event
as when MSE is in use, the user agent never fetches data on behalf of the player.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::mediaSourceHasRetrievedAllData):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::markEndOfStream): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamer::mediaSourceHasRetrievedAllData):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::markEndOfStream):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::mediaSourceHasRetrievedAllData):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::markEndOfStream): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::markEndOfStream):

Canonical link: <a href="https://commits.webkit.org/303737@main">https://commits.webkit.org/303737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e081fa0979026e95746ad48cc3b6df244de773ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141028 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7aebd005-f766-4771-83f0-943a99d5b0de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136419 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82898 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db178be6-2847-4b33-a8d6-741a61a4ed8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4472 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2070 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143675 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5643 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110473 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28047 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4332 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115906 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5698 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34223 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5787 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->