### PR TITLE
Allow const calls to CompletionHandler from Swift

### DIFF
--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -94,6 +94,14 @@ public:
         return std::exchange(m_function, nullptr)(std::forward<In>(in)...);
     }
 
+#ifdef __swift__
+    Out operator()(In... in) const
+    {
+        // Likely to be called using Cell.pointee so needs to be const.
+        return (*(const_cast<CompletionHandler<Out(In...)>*>(this)))(std::forward<In>(in)...);
+    }
+#endif
+
 private:
     Function<Out(In...)> m_function;
     NO_UNIQUE_ADDRESS ThreadLikeAssertion m_callThread;


### PR DESCRIPTION
#### 07715855f4bc56dd9c0b47eac06904ea1311297f
<pre>
Allow const calls to CompletionHandler from Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=303180">https://bugs.webkit.org/show_bug.cgi?id=303180</a>
<a href="https://rdar.apple.com/165483404">rdar://165483404</a>

Reviewed by NOBODY (OOPS!).

Upcoming work to use Swift for CoreIPC message recievers will require us to
pass WTF::CompletionHandlers across the language boundary from C++ to Swift.
These are move-only types, and thus are not directly supported by current
Swift/C++ interop (this is <a href="https://rdar.apple.com/162361370">rdar://162361370</a>). Instead, we&apos;ll need to wrap them
in a WTF::Cell (being introduced in
<a href="https://github.com/WebKit/WebKit/pull/54517)">https://github.com/WebKit/WebKit/pull/54517)</a> or some similar reference-counted
container.

We can then use two Swift/C++ interop features to call methods on the CompletionHandler:
* .pointee allows access to the operator* of the Cell;
* thing() calls the operator() of the thing.
So, we can do box.pointee(). Almost. The problem is the &apos;const&apos;ness, because
.pointee only allows const access to the contents.

In the case of CompletionHandler, the object is updated to ensure that the
handler is called exactly once, so the current operator() is not const. In
Swift, we add a const version to allow Box&lt;CompletionHandler&gt; to be used across
the language boundary like this. Although it&apos;s obviously slightly messy
to cast away the &apos;const&apos; like this, the pattern is in keeping with the way the
same type is used in C++, and it should be tempoary pending a fix for
<a href="https://rdar.apple.com/162361370">rdar://162361370</a>.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07715855f4bc56dd9c0b47eac06904ea1311297f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85005 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d26d655-44fc-4aa5-8fef-78f23ec2b776) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101683 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69014 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135920 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4140 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; 2 new passes 36 flakes; Compiled WebKit (cancelled)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/98828deb-6a71-499b-945f-4188f0555988) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83744 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125044 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143162 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131482 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5144 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110063 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110243 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3950 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58715 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5198 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33766 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164449 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68650 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42763 "Found unexpected failure with change (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5288 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->