### PR TITLE
[JSC] General improvements to the ARMv7 backend

### DIFF
--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -1463,6 +1463,7 @@ public:
         ASSERT(!BadReg(rt));
         ASSERT(!BadReg(rt2));
         ASSERT(rn != ARMRegisters::pc);
+        ASSERT(rt != rt2); // Rt and Rt2 must not be the same register
         m_formatter.twoWordOp12Reg4FourFours(OP_LDREXD_T1, rn, FourFours(rt, rt2, 0x7, 0xf));
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -851,36 +851,22 @@ public:
     void compare64(RelationalCondition cond, RegisterID lhsHi, RegisterID lhsLo, RegisterID rhsHi, RegisterID rhsLo, RegisterID dest)
     {
         if (cond == RelationalCondition::Equal || cond == RelationalCondition::NotEqual) {
-            // For Equal/NotEqual, we can optimize to only set one value conditionally
-            // NotEqual: default to 1, change to 0 only if both parts equal
-            // Equal: default to 0, change to 1 only if both parts equal
-            if (dest != lhsHi && dest != rhsHi && dest != lhsLo && dest != rhsLo) {
-                m_assembler.mov(dest, ARMThumbImmediate::makeEncodedImm(cond == RelationalCondition::NotEqual ? 1 : 0));
-                m_assembler.cmp(lhsHi, rhsHi);
-                Jump done = makeBranch(ARMv7Assembler::ConditionNE);
-                m_assembler.cmp(lhsLo, rhsLo);
-                // Only need to set the "opposite" value when both parts match
-                m_assembler.it(ARMv7Assembler::ConditionEQ);
-                m_assembler.mov(dest, ARMThumbImmediate::makeEncodedImm(cond == RelationalCondition::NotEqual ? 0 : 1));
-                done.link(this);
-            } else {
-                RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
-                m_assembler.mov(scratch, ARMThumbImmediate::makeEncodedImm(cond == RelationalCondition::NotEqual ? 1 : 0));
-                m_assembler.cmp(lhsHi, rhsHi);
-                Jump done = makeBranch(ARMv7Assembler::ConditionNE);
-                m_assembler.cmp(lhsLo, rhsLo);
-                m_assembler.it(ARMv7Assembler::ConditionEQ);
-                m_assembler.mov(scratch, ARMThumbImmediate::makeEncodedImm(cond == RelationalCondition::NotEqual ? 0 : 1));
-                done.link(this);
-                move(scratch, dest);
-            }
+            RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+            m_assembler.eor(scratch, lhsHi, rhsHi);
+            m_assembler.eor(dest, lhsLo, rhsLo);
+            m_assembler.orr(dest, dest, scratch);
+            m_assembler.clz(dest, dest);
+            m_assembler.lsr(dest, dest, 5);
+
+            if (cond == RelationalCondition::NotEqual)
+                m_assembler.eor(dest, dest, ARMThumbImmediate::makeEncodedImm(1));
             return;
         }
 
         ARMv7Assembler::Condition hiCondition = armV7ConditionForHigh32(cond);
         ARMv7Assembler::Condition loCondition = armV7ConditionForLow32(cond);
 
-        if (dest != lhsLo && dest != rhsLo && dest != lhsHi && dest != rhsHi) {
+        if (dest != lhsLo && dest != rhsLo) {
             // No aliasing - use ITE blocks with 1 branch
             m_assembler.cmp(lhsHi, rhsHi);
             m_assembler.it(hiCondition, false);
@@ -3066,6 +3052,21 @@ public:
         return static_cast<ResultCondition>(cond ^ 1);
     }
 
+    static RelationalCondition commute(RelationalCondition cond)
+    {
+        switch (cond) {
+        case Above: return Below;
+        case AboveOrEqual: return BelowOrEqual;
+        case Below: return Above;
+        case BelowOrEqual: return AboveOrEqual;
+        case GreaterThan: return LessThan;
+        case GreaterThanOrEqual: return LessThanOrEqual;
+        case LessThan: return GreaterThan;
+        case LessThanOrEqual: return GreaterThanOrEqual;
+        default: return cond; // Equal and NotEqual are symmetric
+        }
+    }
+
     static std::optional<ResultCondition> commuteCompareToZeroIntoTest(RelationalCondition cond)
     {
         switch (cond) {
@@ -3255,28 +3256,13 @@ public:
 
     Jump branch32(RelationalCondition cond, RegisterID left, RegisterID right)
     {
-        if (left == ARMRegisters::sp && right == addressTempRegister && cond == Equal) {
-            m_assembler.sub_S(addressTempRegister, left, addressTempRegister);
-            return Jump(makeBranch(Zero));
-        } else if (left == ARMRegisters::sp && right == addressTempRegister && cond == NotEqual) {
-            m_assembler.sub_S(addressTempRegister, left, addressTempRegister);
-            return Jump(makeBranch(NonZero));
-        } else if (right == ARMRegisters::sp && left == addressTempRegister && cond == Equal) {
-            m_assembler.sub_S(addressTempRegister, right, addressTempRegister);
-            return Jump(makeBranch(Zero));
-        } else if (right == ARMRegisters::sp && left == addressTempRegister && cond == NotEqual) {
-            m_assembler.sub_S(addressTempRegister, right, addressTempRegister);
-            return Jump(makeBranch(NonZero));
-        } else if (left == ARMRegisters::sp) {
-            ASSERT(right != addressTempRegister);
-            move(left, addressTempRegister);
-            m_assembler.cmp(addressTempRegister, right);
-        } else if (right == ARMRegisters::sp) {
-            ASSERT(left != addressTempRegister);
-            move(right, addressTempRegister);
-            m_assembler.cmp(left, addressTempRegister);
+        // ARM CMP T3 encoding: allows SP as first operand but not second
+        if (right == ARMRegisters::sp) {
+            m_assembler.cmp(right, left);
+            cond = commute(cond);
         } else
             m_assembler.cmp(left, right);
+
         return Jump(makeBranch(cond));
     }
 
@@ -3305,23 +3291,20 @@ public:
 
     Jump branch32(RelationalCondition cond, Address left, TrustedImm32 right)
     {
-        // use addressTempRegister incase the branch32 we call uses dataTempRegister. :-/
-        load32(left, addressTempRegister);
-        return branch32(cond, addressTempRegister, right);
+        load32(left, dataTempRegister);
+        return branch32(cond, dataTempRegister, right);
     }
 
     Jump branch32(RelationalCondition cond, BaseIndex left, TrustedImm32 right)
     {
-        // use addressTempRegister incase the branch32 we call uses dataTempRegister. :-/
-        load32(left, addressTempRegister);
-        return branch32(cond, addressTempRegister, right);
+        load32(left, dataTempRegister);
+        return branch32(cond, dataTempRegister, right);
     }
 
     Jump branch32WithUnalignedHalfWords(RelationalCondition cond, BaseIndex left, TrustedImm32 right)
     {
-        // use addressTempRegister incase the branch32 we call uses dataTempRegister. :-/
-        load32WithUnalignedHalfWords(left, addressTempRegister);
-        return branch32(cond, addressTempRegister, right);
+        load32WithUnalignedHalfWords(left, dataTempRegister);
+        return branch32(cond, dataTempRegister, right);
     }
 
     Jump branch32WithMemory16(RelationalCondition cond, Address left, RegisterID right)
@@ -3357,8 +3340,7 @@ public:
 
     Jump branch8(RelationalCondition cond, Address left, TrustedImm32 right)
     {
-        // use addressTempRegister incase the branch8 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 right8 = MacroAssemblerHelpers::mask8OnCondition(*this, cond, right);
         MacroAssemblerHelpers::load8OnCondition(*this, cond, left, scratch);
         return branch8(cond, scratch, right8);
@@ -3366,8 +3348,7 @@ public:
 
     Jump branch8(RelationalCondition cond, BaseIndex left, TrustedImm32 right)
     {
-        // use addressTempRegister incase the branch32 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 right8 = MacroAssemblerHelpers::mask8OnCondition(*this, cond, right);
         MacroAssemblerHelpers::load8OnCondition(*this, cond, left, scratch);
         return branch32(cond, scratch, right8);
@@ -3375,11 +3356,10 @@ public:
 
     Jump branch8(RelationalCondition cond, AbsoluteAddress address, TrustedImm32 right)
     {
-        // Use addressTempRegister instead of dataTempRegister, since branch32 uses dataTempRegister.
         TrustedImm32 right8 = MacroAssemblerHelpers::mask8OnCondition(*this, cond, right);
         ArmAddress armAddress = setupArmAddress(address);
-        MacroAssemblerHelpers::load8OnCondition(*this, cond, armAddress, addressTempRegister);
-        return branch32(cond, addressTempRegister, right8);
+        MacroAssemblerHelpers::load8OnCondition(*this, cond, armAddress, dataTempRegister);
+        return branch32(cond, dataTempRegister, right8);
     }
 
     Jump branch16(RelationalCondition cond, RegisterID left, TrustedImm32 right)
@@ -3391,8 +3371,7 @@ public:
 
     Jump branch16(RelationalCondition cond, Address left, TrustedImm32 right)
     {
-        // use addressTempRegister incase the branch16 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 right16 = MacroAssemblerHelpers::mask16OnCondition(*this, cond, right);
         MacroAssemblerHelpers::load16OnCondition(*this, cond, left, scratch);
         return branch16(cond, scratch, right16);
@@ -3400,8 +3379,7 @@ public:
 
     Jump branch16(RelationalCondition cond, BaseIndex left, TrustedImm32 right)
     {
-        // use addressTempRegister incase the branch32 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 right16 = MacroAssemblerHelpers::mask16OnCondition(*this, cond, right);
         MacroAssemblerHelpers::load16OnCondition(*this, cond, left, scratch);
         return branch32(cond, scratch, right16);
@@ -3409,11 +3387,10 @@ public:
 
     Jump branch16(RelationalCondition cond, AbsoluteAddress address, TrustedImm32 right)
     {
-        // Use addressTempRegister instead of dataTempRegister, since branch32 uses dataTempRegister.
         TrustedImm32 right16 = MacroAssemblerHelpers::mask16OnCondition(*this, cond, right);
         ArmAddress armAddress = setupArmAddress(address);
-        MacroAssemblerHelpers::load16OnCondition(*this, cond, armAddress, addressTempRegister);
-        return branch32(cond, addressTempRegister, right16);
+        MacroAssemblerHelpers::load16OnCondition(*this, cond, armAddress, dataTempRegister);
+        return branch32(cond, dataTempRegister, right16);
     }
 
 private:
@@ -3517,29 +3494,25 @@ public:
 
     Jump branchTest32(ResultCondition cond, Address address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
-        load32(address, addressTempRegister);
-        return branchTest32(cond, addressTempRegister, mask);
+        load32(address, dataTempRegister);
+        return branchTest32(cond, dataTempRegister, mask);
     }
 
     Jump branchTest32(ResultCondition cond, BaseIndex address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
-        load32(address, addressTempRegister);
-        return branchTest32(cond, addressTempRegister, mask);
+        load32(address, dataTempRegister);
+        return branchTest32(cond, dataTempRegister, mask);
     }
 
     Jump branchTest32(ResultCondition cond, AbsoluteAddress address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
-        load32(setupArmAddress(address), addressTempRegister);
-        return branchTest32(cond, addressTempRegister, mask);
+        load32(setupArmAddress(address), dataTempRegister);
+        return branchTest32(cond, dataTempRegister, mask);
     }
 
     Jump branchTest8(ResultCondition cond, BaseIndex address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 mask8 = MacroAssemblerHelpers::mask8OnCondition(*this, cond, mask);
         MacroAssemblerHelpers::load8OnCondition(*this, cond, address, scratch);
         return branchTest32(cond, scratch, mask8);
@@ -3547,8 +3520,7 @@ public:
 
     Jump branchTest8(ResultCondition cond, Address address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 mask8 = MacroAssemblerHelpers::mask8OnCondition(*this, cond, mask);
         MacroAssemblerHelpers::load8OnCondition(*this, cond, address, scratch);
         return branchTest32(cond, scratch, mask8);
@@ -3556,17 +3528,15 @@ public:
 
     Jump branchTest8(ResultCondition cond, AbsoluteAddress address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
         TrustedImm32 mask8 = MacroAssemblerHelpers::mask8OnCondition(*this, cond, mask);
         ArmAddress armAddress = setupArmAddress(address);
-        MacroAssemblerHelpers::load8OnCondition(*this, cond, armAddress, addressTempRegister);
-        return branchTest32(cond, addressTempRegister, mask8);
+        MacroAssemblerHelpers::load8OnCondition(*this, cond, armAddress, dataTempRegister);
+        return branchTest32(cond, dataTempRegister, mask8);
     }
 
     Jump branchTest16(ResultCondition cond, BaseIndex address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 mask16 = MacroAssemblerHelpers::mask16OnCondition(*this, cond, mask);
         MacroAssemblerHelpers::load16OnCondition(*this, cond, address, scratch);
         return branchTest32(cond, scratch, mask16);
@@ -3574,8 +3544,7 @@ public:
 
     Jump branchTest16(ResultCondition cond, Address address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
-        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         TrustedImm32 mask16 = MacroAssemblerHelpers::mask16OnCondition(*this, cond, mask);
         MacroAssemblerHelpers::load16OnCondition(*this, cond, address, scratch);
         return branchTest32(cond, scratch, mask16);
@@ -3583,11 +3552,10 @@ public:
 
     Jump branchTest16(ResultCondition cond, AbsoluteAddress address, TrustedImm32 mask = TrustedImm32(-1))
     {
-        // use addressTempRegister incase the branchTest32 we call uses dataTempRegister. :-/
         TrustedImm32 mask16 = MacroAssemblerHelpers::mask16OnCondition(*this, cond, mask);
         ArmAddress armAddress = setupArmAddress(address);
-        MacroAssemblerHelpers::load16OnCondition(*this, cond, armAddress, addressTempRegister);
-        return branchTest32(cond, addressTempRegister, mask16);
+        MacroAssemblerHelpers::load16OnCondition(*this, cond, armAddress, dataTempRegister);
+        return branchTest32(cond, dataTempRegister, mask16);
     }
 
     void farJump(RegisterID target, PtrTag)


### PR DESCRIPTION
#### 97688f4cc91563d2d8f39f6248a85ba61e33ae92
<pre>
[JSC] General improvements to the ARMv7 backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=303194">https://bugs.webkit.org/show_bug.cgi?id=303194</a>

Reviewed by NOBODY (OOPS!).

This PR bundles a few small changes to the ARMv7 backend that would be kinda
small to send separately:

* Added missing constraint to ldrexd
* Remove branches from NotEqual/Equal comparisons in compare64
* Relax a overlap check in compare64
* Simplify branch32 main codegen function
* Simplify all other branch calls that use branch32 to use dataTempRegister

* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::ldrexd):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::compare64):
(JSC::MacroAssemblerARMv7::commute):
(JSC::MacroAssemblerARMv7::branch32):
(JSC::MacroAssemblerARMv7::branch32WithUnalignedHalfWords):
(JSC::MacroAssemblerARMv7::branch8):
(JSC::MacroAssemblerARMv7::branch16):
(JSC::MacroAssemblerARMv7::branchTest32):
(JSC::MacroAssemblerARMv7::branchTest8):
(JSC::MacroAssemblerARMv7::branchTest16):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97688f4cc91563d2d8f39f6248a85ba61e33ae92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85016 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101691 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69019 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4140 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1653 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125055 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143174 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131493 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5155 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110070 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110250 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3955 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115419 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58726 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5209 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33772 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164460 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68661 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43348 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->