### PR TITLE
Add operator<=> to CompositionHighlight and CompositionUnderline for natural ordering

### DIFF
--- a/Source/WebCore/editing/CompositionHighlight.h
+++ b/Source/WebCore/editing/CompositionHighlight.h
@@ -50,6 +50,13 @@ struct CompositionHighlight {
     unsigned endOffset { 0 };
     std::optional<Color> backgroundColor;
     std::optional<Color> foregroundColor;
+
+    friend std::strong_ordering operator<=>(const CompositionHighlight& a, const CompositionHighlight& b)
+    {
+        return std::make_pair(a.startOffset, a.endOffset) <=> std::make_pair(b.startOffset, b.endOffset);
+    }
+
+    friend bool operator==(const CompositionHighlight&, const CompositionHighlight&) = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/CompositionUnderline.h
+++ b/Source/WebCore/editing/CompositionUnderline.h
@@ -51,6 +51,13 @@ struct CompositionUnderline {
     CompositionUnderlineColor compositionUnderlineColor { CompositionUnderlineColor::TextColor };
     Color color;
     bool thick { false };
+
+    friend std::strong_ordering operator<=>(const CompositionUnderline& a, const CompositionUnderline& b)
+    {
+        return std::make_pair(a.startOffset, a.endOffset) <=> std::make_pair(b.startOffset, b.endOffset);
+    }
+
+    friend bool operator==(const CompositionUnderline&, const CompositionUnderline&) = default;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6631,13 +6631,7 @@ static Vector<WebCore::CompositionUnderline> extractUnderlines(NSAttributedStrin
         });
     }];
 
-    std::ranges::sort(underlines, [](auto& a, auto& b) {
-        if (a.startOffset < b.startOffset)
-            return true;
-        if (a.startOffset > b.startOffset)
-            return false;
-        return a.endOffset < b.endOffset;
-    });
+    std::ranges::sort(underlines);
 
     Vector<WebCore::CompositionUnderline> mergedUnderlines;
     if (!underlines.isEmpty())
@@ -6670,13 +6664,7 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
         highlights.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), backgroundHighlightColor, foregroundHighlightColor });
     }];
 
-    std::ranges::sort(highlights, [](auto& a, auto& b) {
-        if (a.startOffset < b.startOffset)
-            return true;
-        if (a.startOffset > b.startOffset)
-            return false;
-        return a.endOffset < b.endOffset;
-    });
+    std::ranges::sort(highlights);
 
     Vector<WebCore::CompositionHighlight> mergedHighlights;
     mergedHighlights.reserveInitialCapacity(highlights.size());

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5574,13 +5574,7 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
         highlights.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), backgroundHighlightColor, foregroundHighlightColor });
     }];
 
-    std::ranges::sort(highlights, [](auto& a, auto& b) {
-        if (a.startOffset < b.startOffset)
-            return true;
-        if (a.startOffset > b.startOffset)
-            return false;
-        return a.endOffset < b.endOffset;
-    });
+    std::ranges::sort(highlights);
 
     Vector<WebCore::CompositionHighlight> mergedHighlights;
     mergedHighlights.reserveInitialCapacity(highlights.size());
@@ -5618,13 +5612,7 @@ static Vector<WebCore::CompositionUnderline> compositionUnderlines(NSAttributedS
             underlines.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), WebCore::CompositionUnderlineColor::GivenColor, WebCore::Color::black, style.get().intValue > 1 });
     }];
 
-    std::ranges::sort(underlines, [](auto& a, auto& b) {
-        if (a.startOffset < b.startOffset)
-            return true;
-        if (a.startOffset > b.startOffset)
-            return false;
-        return a.endOffset < b.endOffset;
-    });
+    std::ranges::sort(underlines);
 
     if (!underlines.isEmpty())
         mergedUnderlines.append({ underlines.first().startOffset, underlines.last().endOffset, WebCore::CompositionUnderlineColor::GivenColor, WebCore::Color::black, false });


### PR DESCRIPTION
#### 443314896cd23eb23412a812145d1becd8a2d542
<pre>
Add operator&lt;=&gt; to CompositionHighlight and CompositionUnderline for natural ordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=303195">https://bugs.webkit.org/show_bug.cgi?id=303195</a>
<a href="https://rdar.apple.com/problem/165485853">rdar://problem/165485853</a>

Reviewed by Sam Weinig.

Replace lambdas in std::ranges::sort calls with operator&lt;=&gt; definitions on CompositionHighlight and CompositionUnderline.
This removes the multi-line comparison logic in the lambdas.

* Source/WebCore/editing/CompositionHighlight.h:
(WebCore::CompositionHighlight::operator&lt;=&gt;):
* Source/WebCore/editing/CompositionUnderline.h:
(WebCore::CompositionUnderline::operator&lt;=&gt;):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(extractUnderlines):
(compositionHighlights):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::compositionHighlights):
(WebKit::compositionUnderlines):

Canonical link: <a href="https://commits.webkit.org/303640@main">https://commits.webkit.org/303640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f503b5a76603c6ae861ab0139812f9bde0f3255c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85157 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09fa50a5-e523-4fdd-aea8-5afca429ea17) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101806 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69183 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/997f6ec9-54ad-469c-acd5-a4dadbdf6ebc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82603 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/daf1776c-7dbf-4203-bf4d-534a4939fc3e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4203 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1784 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143309 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110185 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110365 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27969 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4080 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58945 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5344 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33913 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5433 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5300 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->