### PR TITLE
[iOS] Introduce MediaDeviceRoute

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -285,6 +285,7 @@ platform/audio/cocoa/SpatialAudioExperienceHelper.mm @nonARC
 platform/audio/cocoa/WebAudioBufferList.cpp
 platform/audio/ios/AudioOutputUnitAdaptorIOS.cpp @no-unify
 platform/audio/ios/AudioSessionIOS.mm @nonARC @no-unify
+platform/audio/ios/MediaDeviceRoute.mm @nonARC
 platform/audio/ios/MediaSessionHelperIOS.mm @nonARC @no-unify
 platform/audio/ios/MediaSessionManagerIOS.mm @nonARC @no-unify
 platform/audio/mac/AudioBusMac.mm @nonARC

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#include <WebKitAdditions/MediaDeviceRouteInterfaceAdditions.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+
+OBJC_CLASS WebMediaDeviceRoute;
+
+namespace WebCore {
+
+struct MediaTimelineSegment {
+    enum class Type : uint8_t {
+        Primary,
+        Secondary,
+    };
+
+    const Type type;
+    const bool isMarked;
+    const bool requiresLinearPlayback;
+    const MediaTimeRange timeRange;
+    const String identifier;
+};
+
+enum class MediaPlaybackSourceState : uint8_t {
+    Ready,
+    Loading,
+    Seeking,
+    Scanning,
+    Scrubbing,
+};
+
+enum class MediaPlaybackSourceSupportedMode : uint8_t {
+    ScanForward = 1 << 0,
+    ScanBackward = 1 << 1,
+    Seek = 1 << 2,
+};
+
+enum class MediaPlaybackSourcePlaybackType : uint8_t {
+    Regular = 1 << 0,
+    Live = 1 << 1,
+};
+
+struct MediaPlaybackSourceError {
+    const long code;
+    const String domain;
+    const String localizedDescription;
+};
+
+struct MediaSelectionOption {
+    enum class Type : uint8_t {
+        Audio,
+        Legible,
+    };
+
+    const String displayName;
+    const String identifier;
+    const Type type;
+    const String extendedLanguageTag;
+};
+
+class MediaDeviceRoute;
+
+class MediaDeviceRouteClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaDeviceRouteClient> {
+public:
+    virtual ~MediaDeviceRouteClient() = default;
+
+    virtual void minValueDidChange(MediaDeviceRoute&) = 0;
+    virtual void maxValueDidChange(MediaDeviceRoute&) = 0;
+    virtual void currentValueDidChange(MediaDeviceRoute&) = 0;
+    virtual void segmentsDidChange(MediaDeviceRoute&) = 0;
+    virtual void currentSegmentDidChange(MediaDeviceRoute&) = 0;
+    virtual void isPlayingDidChange(MediaDeviceRoute&) = 0;
+    virtual void playbackSpeedDidChange(MediaDeviceRoute&) = 0;
+    virtual void scanSpeedDidChange(MediaDeviceRoute&) = 0;
+    virtual void stateDidChange(MediaDeviceRoute&) = 0;
+    virtual void supportedModesDidChange(MediaDeviceRoute&) = 0;
+    virtual void playbackTypeDidChange(MediaDeviceRoute&) = 0;
+    virtual void playbackErrorDidChange(MediaDeviceRoute&) = 0;
+    virtual void currentAudioOptionDidChange(MediaDeviceRoute&) = 0;
+    virtual void currentSubtitleOptionDidChange(MediaDeviceRoute&) = 0;
+    virtual void optionsDidChange(MediaDeviceRoute&) = 0;
+    virtual void hasAudioDidChange(MediaDeviceRoute&) = 0;
+    virtual void mutedDidChange(MediaDeviceRoute&) = 0;
+    virtual void volumeDidChange(MediaDeviceRoute&) = 0;
+};
+
+class MediaDeviceRoute : public RefCountedAndCanMakeWeakPtr<MediaDeviceRoute> {
+    WTF_MAKE_TZONE_ALLOCATED(MediaDeviceRoute);
+public:
+    static Ref<MediaDeviceRoute> create(WebMediaDevicePlatformRoute *);
+
+    ~MediaDeviceRoute();
+
+    MediaDeviceRouteClient* client() const { return m_client.get(); }
+    void setClient(MediaDeviceRouteClient* client) { m_client = client; }
+
+    float minValue() const;
+    float maxValue() const;
+    float currentValue() const;
+    Vector<MediaTimelineSegment> segments() const;
+    std::optional<MediaTimelineSegment> currentSegment() const;
+    bool isPlaying() const;
+    double playbackSpeed() const;
+    double scanSpeed() const;
+    MediaPlaybackSourceState state() const;
+    OptionSet<MediaPlaybackSourceSupportedMode> supportedModes() const;
+    OptionSet<MediaPlaybackSourcePlaybackType> playbackType() const;
+    std::optional<MediaPlaybackSourceError> playbackError() const;
+    std::optional<MediaSelectionOption> currentAudioOption() const;
+    std::optional<MediaSelectionOption> currentSubtitleOption() const;
+    Vector<MediaSelectionOption> options() const;
+    bool hasAudio() const;
+    bool muted() const;
+    double volume() const;
+
+    void setCurrentValue(float);
+    void setIsPlaying(bool);
+    void setPlaybackSpeed(double);
+    void setScanSpeed(double);
+    void setCurrentAudioOption(std::optional<MediaSelectionOption>);
+    void setCurrentSubtitleOption(std::optional<MediaSelectionOption>);
+    void setMuted(bool);
+    void setVolume(double);
+
+private:
+    explicit MediaDeviceRoute(WebMediaDevicePlatformRoute *);
+
+    RetainPtr<WebMediaDeviceRoute> m_route;
+    WeakPtr<MediaDeviceRouteClient> m_client;
+};
+
+} // namespace WebCore
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "MediaDeviceRoute.h"
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#include <WebKitAdditions/MediaDeviceRouteImplementationAdditions.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#define FOR_EACH_READONLY_KEY_PATH(Macro) \
+    Macro(minValue, MinValue, float) \
+    Macro(maxValue, MinValue, float) \
+    Macro(segments, Segments, Vector<MediaTimelineSegment>) \
+    Macro(currentSegment, CurrentSegment, std::optional<MediaTimelineSegment>) \
+    Macro(state, State, MediaPlaybackSourceState) \
+    Macro(supportedModes, SupportedModes, OptionSet<MediaPlaybackSourceSupportedMode>) \
+    Macro(playbackType, PlaybackType, OptionSet<MediaPlaybackSourcePlaybackType>) \
+    Macro(playbackError, PlaybackError, std::optional<MediaPlaybackSourceError>) \
+    Macro(options, Options, Vector<MediaSelectionOption>) \
+    Macro(hasAudio, HasAudio, bool) \
+\
+
+#define FOR_EACH_READWRITE_KEY_PATH(Macro) \
+    Macro(currentValue, CurrentValue, float) \
+    Macro(isPlaying, IsPlaying, bool) \
+    Macro(playbackSpeed, PlaybackSpeed, double) \
+    Macro(scanSpeed, ScanSpeed, double) \
+    Macro(currentAudioOption, CurrentAudioOption, std::optional<MediaSelectionOption>) \
+    Macro(currentSubtitleOption, CurrentSubtitleOption, std::optional<MediaSelectionOption>) \
+    Macro(muted, Muted, bool) \
+    Macro(volume, Volume, double) \
+\
+
+#define FOR_EACH_KEY_PATH(Macro) \
+    FOR_EACH_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_READWRITE_KEY_PATH(Macro) \
+\
+
+#define ADD_OBSERVER(KeyPath, SetterSuffix, Type) \
+    [_platformRoute addObserver:self forKeyPath:@#KeyPath options:0 context:WebMediaDeviceRouteObserverContext]; \
+\
+
+#define REMOVE_OBSERVER(KeyPath, SetterSuffix, Type) \
+    [_platformRoute removeObserver:self forKeyPath:@#KeyPath context:WebMediaDeviceRouteObserverContext]; \
+\
+
+#define OBSERVE_VALUE(KeyPath, SetterSuffix, Type) \
+    if ([keyPath isEqualToString:@#KeyPath]) { \
+        if (RefPtr route = _route.get()) { \
+            if (RefPtr client = route->client()) \
+                client->KeyPath##DidChange(*route); \
+        } \
+        return; \
+    } \
+\
+
+#define DEFINE_GETTER(KeyPath, SetterSuffix, Type) \
+    Type MediaDeviceRoute::KeyPath() const \
+    { \
+        return convert([[m_route platformRoute] KeyPath]); \
+    } \
+\
+
+#define DEFINE_SETTER(KeyPath, SetterSuffix, Type) \
+    void MediaDeviceRoute::set##SetterSuffix(Type KeyPath) \
+    { \
+        [[m_route platformRoute] set##SetterSuffix:convert(WTFMove(KeyPath))]; \
+    } \
+\
+
+NS_ASSUME_NONNULL_BEGIN
+
+static void* WebMediaDeviceRouteObserverContext = &WebMediaDeviceRouteObserverContext;
+
+@interface WebMediaSelectionOption : NSObject <AVMediaSelectionOptionSource>
+@end
+
+@interface WebMediaSelectionOption ()
+@property (nonatomic, copy) NSString *displayName;
+@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic) AVMediaOptionType type;
+@property (nonatomic, copy) NSString *extendedLanguageTag;
+@end
+
+@implementation WebMediaSelectionOption
+@end
+
+@interface WebMediaDeviceRoute : NSObject
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route platformRoute:(WebMediaDevicePlatformRoute *)platformRoute NS_DESIGNATED_INITIALIZER;
+@property (nonatomic, readonly, strong) WebMediaDevicePlatformRoute *platformRoute;
+@end
+
+@implementation WebMediaDeviceRoute {
+    WeakPtr<WebCore::MediaDeviceRoute> _route;
+    RetainPtr<WebMediaDevicePlatformRoute> _platformRoute;
+}
+
+- (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route platformRoute:(WebMediaDevicePlatformRoute *)platformRoute
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _route = route;
+    _platformRoute = platformRoute;
+    FOR_EACH_KEY_PATH(ADD_OBSERVER)
+    return self;
+}
+
+- (WebMediaDevicePlatformRoute *)platformRoute
+{
+    return _platformRoute.get();
+}
+
+- (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context
+{
+    if (context != WebMediaDeviceRouteObserverContext) {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+        return;
+    }
+
+    FOR_EACH_KEY_PATH(OBSERVE_VALUE)
+    ASSERT_NOT_REACHED();
+}
+
+- (void)dealloc
+{
+    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
+    [super dealloc];
+}
+
+@end
+
+namespace WebCore {
+
+static double convert(double value)
+{
+    return value;
+}
+
+static bool convert(bool value)
+{
+    return value;
+}
+
+static MediaTimelineSegment::Type convert(AVMediaTimelineSegmentType segmentType)
+{
+    switch (segmentType) {
+    case AVMediaTimelineSegmentTypePrimary:
+        return MediaTimelineSegment::Type::Primary;
+    case AVMediaTimelineSegmentTypeSecondary:
+        return MediaTimelineSegment::Type::Secondary;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static MediaTimeRange convert(CMTimeRange timeRange)
+{
+    MediaTime start = PAL::toMediaTime(timeRange.start);
+    return { WTFMove(start), start + PAL::toMediaTime(timeRange.duration) };
+}
+
+static std::optional<MediaTimelineSegment> convert(id<AVMediaTimelineSegment> _Nullable segment)
+{
+    if (!segment)
+        return std::nullopt;
+
+    return MediaTimelineSegment {
+        convert(segment.type),
+        segment.isMarked,
+        segment.requiresLinearPlayback,
+        convert(segment.timeRange),
+        segment.identifier,
+    };
+}
+
+static Vector<MediaTimelineSegment> convert(NSArray<AVMediaTimelineSegment> * _Nullable segments)
+{
+    Vector<MediaTimelineSegment> result;
+
+    for (id<AVMediaTimelineSegment> segment in segments)
+        result.append(*convert(segment));
+
+    return result;
+}
+
+static MediaPlaybackSourceState convert(AVMediaPlaybackSourceState state)
+{
+    switch (state) {
+    case AVMediaPlaybackSourceStateReady:
+        return MediaPlaybackSourceState::Ready;
+    case AVMediaPlaybackSourceStateLoading:
+        return MediaPlaybackSourceState::Loading;
+    case AVMediaPlaybackSourceStateSeeking:
+        return MediaPlaybackSourceState::Seeking;
+    case AVMediaPlaybackSourceStateScanning:
+        return MediaPlaybackSourceState::Scanning;
+    case AVMediaPlaybackSourceStateScrubbing:
+        return MediaPlaybackSourceState::Scrubbing;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static OptionSet<MediaPlaybackSourceSupportedMode> convert(AVMediaPlaybackSourceSupportedMode supportedModes)
+{
+    OptionSet<MediaPlaybackSourceSupportedMode> result;
+
+    if (supportedModes & AVMediaPlaybackSourceSupportedModeScanForward)
+        result.add(MediaPlaybackSourceSupportedMode::ScanForward);
+    if (supportedModes & AVMediaPlaybackSourceSupportedModeScanBackward)
+        result.add(MediaPlaybackSourceSupportedMode::ScanBackward);
+    if (supportedModes & AVMediaPlaybackSourceSupportedModeSeek)
+        result.add(MediaPlaybackSourceSupportedMode::Seek);
+
+    return result;
+}
+
+static OptionSet<MediaPlaybackSourcePlaybackType> convert(AVMediaPlaybackSourcePlaybackType playbackType)
+{
+    OptionSet<MediaPlaybackSourcePlaybackType> result;
+
+    if (playbackType & AVMediaPlaybackSourcePlaybackTypeRegular)
+        result.add(MediaPlaybackSourcePlaybackType::Regular);
+    if (playbackType & AVMediaPlaybackSourcePlaybackTypeLive)
+        result.add(MediaPlaybackSourcePlaybackType::Live);
+
+    return result;
+}
+
+static std::optional<MediaPlaybackSourceError> convert(NSError * _Nullable error)
+{
+    if (!error)
+        return std::nullopt;
+
+    return MediaPlaybackSourceError {
+        error.code,
+        error.domain,
+        error.localizedDescription,
+    };
+}
+
+static MediaSelectionOption::Type convert(AVMediaOptionType type)
+{
+    switch (type) {
+    case AVMediaOptionTypeAudio:
+        return MediaSelectionOption::Type::Audio;
+    case AVMediaOptionTypeLegible:
+        return MediaSelectionOption::Type::Legible;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static AVMediaOptionType convert(MediaSelectionOption::Type type)
+{
+    switch (type) {
+    case MediaSelectionOption::Type::Audio:
+        return AVMediaOptionTypeAudio;
+    case MediaSelectionOption::Type::Legible:
+        return AVMediaOptionTypeLegible;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static std::optional<MediaSelectionOption> convert(id<AVMediaSelectionOptionSource> _Nullable option)
+{
+    if (!option)
+        return std::nullopt;
+
+    return MediaSelectionOption {
+        option.displayName,
+        option.identifier,
+        convert(option.type),
+        option.extendedLanguageTag,
+    };
+}
+
+static id<AVMediaSelectionOptionSource> _Nullable convert(const std::optional<MediaSelectionOption>& option)
+{
+    if (!option)
+        return nil;
+
+    RetainPtr result = adoptNS([[WebMediaSelectionOption alloc] init]);
+    [result setDisplayName:option->displayName.createNSString().get()];
+    [result setIdentifier:option->identifier.createNSString().get()];
+    [result setType:convert(option->type)];
+    [result setExtendedLanguageTag:option->extendedLanguageTag.createNSString().get()];
+
+    return result.autorelease();
+}
+
+static Vector<MediaSelectionOption> convert(NSArray<AVMediaSelectionOptionSource> * _Nullable options)
+{
+    Vector<MediaSelectionOption> result;
+
+    for (id<AVMediaSelectionOptionSource> option in options)
+        result.append(*convert(option));
+
+    return result;
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaDeviceRoute);
+
+Ref<MediaDeviceRoute> MediaDeviceRoute::create(WebMediaDevicePlatformRoute *platformRoute)
+{
+    return adoptRef(*new MediaDeviceRoute(platformRoute));
+}
+
+MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
+    : m_route { adoptNS([[WebMediaDeviceRoute alloc] initWithRoute:*this platformRoute:platformRoute]) }
+{
+}
+
+MediaDeviceRoute::~MediaDeviceRoute() = default;
+
+FOR_EACH_KEY_PATH(DEFINE_GETTER)
+FOR_EACH_READWRITE_KEY_PATH(DEFINE_SETTER)
+
+} // namespace WebCore
+
+NS_ASSUME_NONNULL_END
+
+#undef FOR_EACH_READONLY_KEY_PATH
+#undef FOR_EACH_READWRITE_KEY_PATH
+#undef FOR_EACH_KEY_PATH
+#undef ADD_OBSERVER
+#undef OBSERVE_VALUE
+#undef DEFINE_GETTER
+#undef DEFINE_SETTER
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
+++ b/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
@@ -191,7 +191,7 @@ String keyForCharCode(unichar charCode)
     case NSNextFunctionKey:
         return "Unidentified"_s;
     default:
-        return span(*reinterpret_cast<const char16_t*>(&charCode));
+        return singleElementSpan(*reinterpret_cast<const char16_t*>(&charCode));
     }
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -47,6 +47,7 @@ namespace WebCore {
 class AudioVideoRenderer;
 class LegacyCDMPrivateAVFObjC;
 class MediaSampleAVFObjC;
+class SharedBuffer;
 
 class CDMSessionAVContentKeySession final : public LegacyCDMSession, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CDMSessionAVContentKeySession> {
     WTF_MAKE_TZONE_ALLOCATED(CDMSessionAVContentKeySession);

--- a/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBGL)
 #import "GraphicsContextGLCocoa.h" // NOLINT
+#import "GraphicsLayer.h"
 #import "GraphicsLayerContentsDisplayDelegate.h"
 #import "PlatformCALayer.h"
 #import "PlatformCALayerDelegatedContents.h"

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
@@ -28,6 +28,7 @@
 
 #if USE(LIBWEBRTC)
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 


### PR DESCRIPTION
#### cbd19cda5899cc9b5b8f220e398b307e7bb02c8b
<pre>
[iOS] Introduce MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=303214">https://bugs.webkit.org/show_bug.cgi?id=303214</a>
<a href="https://rdar.apple.com/165498830">rdar://165498830</a>

Reviewed by Jean-Yves Avenard.

Introduced MediaDeviceRoute. In a follow-on change it will be used by
MediaPlayerPrivateWirelessPlayback for playing media to AirPlay routes. MediaDeviceRoute&apos;s job is
to wrap a WebMediaDevicePlatformRoute, observing its properties and dispatching
MediaDeviceRouteClient callbacks when values change. It also exposes a C++ interface for getting
and setting route properties.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h: Added.
(WebCore::MediaDeviceRoute::client const):
(WebCore::MediaDeviceRoute::setClient):
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm: Added.
(-[WebMediaDeviceRoute initWithRoute:platformRoute:]):
(-[WebMediaDeviceRoute platformRoute]):
(-[WebMediaDeviceRoute observeValueForKeyPath:ofObject:change:context:]):
(-[WebMediaDeviceRoute dealloc]):
(WebCore::convert):
(WebCore::MediaDeviceRoute::create):
(WebCore::MediaDeviceRoute::MediaDeviceRoute):
* Source/WebCore/platform/cocoa/KeyEventCocoa.mm:
(WebCore::keyForCharCode):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
* Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp:

Canonical link: <a href="https://commits.webkit.org/303660@main">https://commits.webkit.org/303660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5bcfbaa53323270bb2bccf7a66ffc5cecff3d0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140558 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e0fffb7-a082-4654-9f78-2eb156676e85) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101725 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69040 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3bb61972-ded8-4d1b-9334-f0201d571295) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1686 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83793 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143211 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5192 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110103 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110285 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3987 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58779 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5246 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33808 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5204 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->